### PR TITLE
Joyent merge/2017070501

### DIFF
--- a/usr/src/cmd/svc/svcs/svcs.c
+++ b/usr/src/cmd/svc/svcs/svcs.c
@@ -3664,6 +3664,24 @@ again:
 		assert(opt_zone == NULL || zids == NULL);
 
 		if (opt_zone == NULL) {
+			zone_status_t status;
+
+			if (zone_getattr(zids[zent], ZONE_ATTR_STATUS,
+			    &status, sizeof (status)) < 0 ||
+			    status != ZONE_IS_RUNNING) {
+				/*
+				 * If this zone is not running or we cannot
+				 * get its status, we do not want to attempt
+				 * to bind an SCF handle to it, lest we
+				 * accidentally interfere with a zone that
+				 * is not yet running by looking up a door
+				 * to its svc.configd (which could potentially
+				 * block a mount with an EBUSY).
+				 */
+				zent++;
+				goto nextzone;
+			}
+
 			if (getzonenamebyid(zids[zent++],
 			    zonename, sizeof (zonename)) < 0) {
 				uu_warn(gettext("could not get name for "

--- a/usr/src/cmd/svc/svcs/svcs.c
+++ b/usr/src/cmd/svc/svcs/svcs.c
@@ -3772,7 +3772,7 @@ again:
 
 	if (opt_mode == 'L') {
 		if ((err = scf_walk_fmri(h, argc, argv, SCF_WALK_MULTIPLE,
-		    print_log, NULL, &exit_status, uu_warn)) != 0) {
+		    print_log, NULL, errarg, errfunc)) != 0) {
 			uu_warn(gettext("failed to iterate over "
 			    "instances: %s\n"), scf_strerror(err));
 			exit_status = UU_EXIT_FATAL;

--- a/usr/src/cmd/svc/svcs/svcs.c
+++ b/usr/src/cmd/svc/svcs/svcs.c
@@ -3690,14 +3690,12 @@ again:
 
 	if (scf_handle_bind(h) == -1) {
 		if (g_zonename != NULL) {
-			uu_warn(gettext("Could not bind to repository "
+			if (show_zones)
+				goto nextzone;
+
+			uu_die(gettext("Could not bind to repository "
 			    "server for zone %s: %s\n"), g_zonename,
 			    scf_strerror(scf_error()));
-
-			if (!show_zones)
-				return (UU_EXIT_FATAL);
-
-			goto nextzone;
 		}
 
 		uu_die(gettext("Could not bind to repository server: %s.  "


### PR DESCRIPTION
backport candidates:
- fbc3b3a OS-569 svcs -Z should not emit an error message for zones without SMF
- 55371c7 OS-601 svcs -Z in GZ should skip zones in ready state
- 20f2d84 OS-1634 svcs -ZL does not work when a pattern is specified

not a critical fix but i think it could still be backported as it is very unlikely it will break anything nor requires a reboot. opinions?

before:
```
hadfl@mars:~$ sudo svcs -Z
svcs: Could not bind to repository server for zone ubuntu-16: repository server unavailable
ZONE             STATE          STIME    FMRI
[...]
```

after:
```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream-joyent-merge-2017070501-20f2d84f9a i86pc i386 i86pc
hadfl@mars:~$ sudo svcs -Z
ZONE             STATE          STIME    FMRI
[...]
```

mail_msg:
```
==== Nightly distributed build started:   Wed Jul  5 14:55:47 CEST 2017 ====
==== Nightly distributed build completed: Wed Jul  5 15:37:03 CEST 2017 ====

==== Total build time ====

real    0:41:16

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-upstream-merge-2017070301-8a5908ecf9 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-upstream-joyent-merge-2017070501-20f2d84f9a

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:59.6
user  1:08:03.1
sys      4:54.2

==== Build noise differences (DEBUG) ====

0a1
> 	-classpath /export/home/hadfl/build/illumos-omnios/usr/src/lib/libdtrace_jni/java/classes:/export/home/hadfl/build/illumos-omnios/usr/src/lib/libdtrace_jni/java/src -d /export/home/hadfl/build/illumos-omnios/proto/root_i386/usr/share/lib/java/javadoc/dtrace/api \
4a6
> 	print "export PATH=/usr/ast/bin:/usr/xpg6/bin:/usr/xpg4/bin:/usr/bin:\${PATH}" ; \
43a46,48
> : libcommon.a
> : libdrivers.a
> : libgrub.a
45a51,80
> Note: /export/home/hadfl/build/illumos-omnios/usr/src/cmd/pools/poold/com/sun/solaris/domain/pools/ResourceMonitor.java uses unchecked or unsafe operations.
> Note: /export/home/hadfl/build/illumos-omnios/usr/src/cmd/print/printmgr/com/sun/admin/pm/server/Debug.java uses unchecked or unsafe operations.
> Note: BST.java uses unchecked or unsafe operations.
> Note: Configuration.java uses unchecked or unsafe operations.
> Note: Debug.java uses unchecked or unsafe operations.
> Note: DecisionHistory.java uses unchecked or unsafe operations.
> Note: Element.java uses unchecked or unsafe operations.
> Note: LocalityGroup.java uses unchecked or unsafe operations.
> Note: Move.java uses unchecked or unsafe operations.
> Note: Pool.java uses unchecked or unsafe operations.
> Note: Recompile with -Xlint:unchecked for details.
> Note: Resource.java uses unchecked or unsafe operations.
> Note: ResourceMonitor.java uses unchecked or unsafe operations.
> Note: Severity.java uses unchecked or unsafe operations.
> Note: Some input files use unchecked or unsafe operations.
> Note: StatisticList.java uses unchecked or unsafe operations.
> Note: SysloglikeFormatter.java uses unchecked or unsafe operations.
> Note: SystemMonitor.java uses unchecked or unsafe operations.
> Note: SystemSolver.java uses unchecked or unsafe operations.
> Note: helptools/parseMain.java uses unchecked or unsafe operations.
> Note: pmButton.java uses unchecked or unsafe operations.
> Note: pmHelpDetailPanel.java uses unchecked or unsafe operations.
> Note: pmHelpIndexPanel.java uses unchecked or unsafe operations.
> Note: pmHelpRepository.java uses unchecked or unsafe operations.
> Note: pmHelpSearchPanel.java uses unchecked or unsafe operations.
> Note: pmInstallPrinter.java uses unchecked or unsafe operations.
> Note: pmInstallScreen.java uses unchecked or unsafe operations.
> Note: pmLoad.java uses unchecked or unsafe operations.
> Note: pmMessageDialog.java uses unchecked or unsafe operations.
> Note: pmTop.java uses unchecked or unsafe operations.
48,49c83,84
< maximum offset: 1d52
< maximum offset: 23ae
---
> maximum offset: 1d59
> maximum offset: 23b5
51a87,90
> sed 's/.c:#define/,/'                   |\
> sed -e '/^.include/s:\.\..*/rpcsvc:rpcsvc:' < nlm_prot_xdr.c.tmp > nlm_prot_xdr.c
> sed -e '/^.include/s:\.\..*/rpcsvc:rpcsvc:' < nsm_addr_xdr.c.tmp > nsm_addr_xdr.c
> sed -e '/^.include/s:\.\..*/rpcsvc:rpcsvc:' < sm_inter_xdr.c.tmp > sm_inter_xdr.c

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:19.2
user    45:56.0
sys      4:46.4

==== lint warnings src ====

"/export/home/hadfl/build/illumos-omnios/usr/src/uts/common/io/iwn/if_iwn.c", line 2052: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
"/export/home/hadfl/build/illumos-omnios/usr/src/uts/common/os/sysent.c", line 1213: warning: function returns value which is always ignored: yield (E_FUNC_RET_ALWAYS_IGNOR2)

==== lint noise differences src ====


==== cstyle/hdrchk errors ====

dmake: Warning: Command failed for target `lx.5.check'
dmake: Warning: Command failed for target `man'
dmake: Warning: Command failed for target `man5'
dmake: Warning: Command failed for target `man7d'
dmake: Warning: Command failed for target `zfd.7d.check'
dmake: Warning: Target `check' not remade because of errors
mandoc: lx.5:124:57: WARNING: new sentence, new line
mandoc: lx.5:130:49: WARNING: new sentence, new line
mandoc: lx.5:132:7: WARNING: new sentence, new line
mandoc: lx.5:139:70: WARNING: new sentence, new line
mandoc: lx.5:28:14: WARNING: new sentence, new line
mandoc: lx.5:29:20: WARNING: new sentence, new line
mandoc: lx.5:29:71: WARNING: new sentence, new line
mandoc: lx.5:43:26: WARNING: new sentence, new line
mandoc: lx.5:67:12: WARNING: new sentence, new line
mandoc: lx.5:72:32: WARNING: new sentence, new line
mandoc: lx.5:81:74: WARNING: new sentence, new line
mandoc: lx.5:88:50: WARNING: new sentence, new line
mandoc: zfd.7d:41:62: WARNING: new sentence, new line
mandoc: zfd.7d:64:61: WARNING: new sentence, new line
mandoc: zfd.7d:70:7: WARNING: new sentence, new line
mandoc: zfd.7d:73:35: WARNING: new sentence, new line
mandoc: zfd.7d:74:38: WARNING: new sentence, new line

==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```