### PR TITLE
Joyent merge/2017070502

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,7 +2,7 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull). LX-for-OmniOS-specific notes follow.
 
-Last illumos-joyent commit:  b29bd3a941d640162496a2ab849fd84ca5dd6cf5
+Last illumos-joyent commit:  75647a92265dde475f2caca5f9d959ecf9f8b633
 
 LX zones can be installed using ZFS send streams (gzipped or uncompressed) from
 Joyent's images (-s /full/path/to/file), from ZFS datasets or snapshots

--- a/usr/src/lib/brand/lx/testing/ltp_skiplist
+++ b/usr/src/lib/brand/lx/testing/ltp_skiplist
@@ -239,6 +239,8 @@ shmget05		# OS-3326
 splice01
 splice02
 splice03
+splice04
+splice05
 ssetmask01
 sync_file_range01
 sysconf01		# OS-3305

--- a/usr/src/uts/common/brand/lx/autofs/lx_autofs.c
+++ b/usr/src/uts/common/brand/lx/autofs/lx_autofs.c
@@ -2242,10 +2242,21 @@ lx_autofs_lookup(vnode_t *dvp, char *nm, vnode_t **vpp, struct pathname *pnp,
 		 * will also do a rele on the original dvp and that would leave
 		 * us one ref short on our autofs root vnode.
 		 */
+		vnode_t *orig_dvp = dvp;
+
 		VN_HOLD(dvp);
 		if ((error = traverse(&dvp)) != 0) {
 			VN_RELE(dvp);
 			return (error);
+		}
+
+		if (dvp == orig_dvp) {
+			/*
+			 * For some reason the automountd did not actually
+			 * mount the new filesystem. Return an error.
+			 */
+			VN_RELE(dvp);
+			return (ENOENT);
 		}
 
 		error = VOP_LOOKUP(dvp, nm, vpp, pnp, flags, rdir, cr, ctp,

--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -1218,6 +1218,7 @@ lx_init_brand_data(zone_t *zone, kmutex_t *zsl)
 	    LX_KERN_RELEASE_MAX);
 	(void) strlcpy(data->lxzd_kernel_version, "BrandZ virtual linux",
 	    LX_KERN_VERSION_MAX);
+	data->lxzd_pipe_max_sz = lx_pipe_max_default;
 
 	zone->zone_brand_data = data;
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -211,6 +211,7 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_FS_INOTIFY_MAX_QUEUED_EVENTS,	/* inotify/max_queued_events */
 	LXPR_SYS_FS_INOTIFY_MAX_USER_INSTANCES,	/* inotify/max_user_instances */
 	LXPR_SYS_FS_INOTIFY_MAX_USER_WATCHES,	/* inotify/max_user_watches */
+	LXPR_SYS_FS_PIPE_MAX,	/* /proc/sys/fs/pipe-max-size	*/
 	LXPR_SYS_KERNELDIR,	/* /proc/sys/kernel/	*/
 	LXPR_SYS_KERNEL_CAPLCAP,	/* /proc/sys/kernel/cap_last_cap */
 	LXPR_SYS_KERNEL_COREPATT,	/* /proc/sys/kernel/core_pattern */

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -231,6 +231,7 @@ static void lxpr_read_sys_fs_inotify_max_user_instances(lxpr_node_t *,
     lxpr_uiobuf_t *);
 static void lxpr_read_sys_fs_inotify_max_user_watches(lxpr_node_t *,
     lxpr_uiobuf_t *);
+static void lxpr_read_sys_fs_pipe_max(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_caplcap(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_corepatt(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_hostname(lxpr_node_t *, lxpr_uiobuf_t *);
@@ -263,6 +264,8 @@ static void lxpr_read_sys_vm_overcommit_mem(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_vm_swappiness(lxpr_node_t *, lxpr_uiobuf_t *);
 
 static int lxpr_write_pid_loginuid(lxpr_node_t *, uio_t *, cred_t *,
+    caller_context_t *);
+static int lxpr_write_sys_fs_pipe_max(lxpr_node_t *, uio_t *, cred_t *,
     caller_context_t *);
 static int lxpr_write_sys_net_core_somaxc(lxpr_node_t *, uio_t *, cred_t *,
     caller_context_t *);
@@ -517,6 +520,7 @@ static lxpr_dirent_t sys_fsdir[] = {
 	{ LXPR_SYS_FS_FILEMAX,		"file-max" },
 	{ LXPR_SYS_FS_FILENR,		"file-nr" },
 	{ LXPR_SYS_FS_INOTIFYDIR,	"inotify" },
+	{ LXPR_SYS_FS_PIPE_MAX,		"pipe-max-size" },
 };
 
 #define	SYS_FSDIRFILES (sizeof (sys_fsdir) / sizeof (sys_fsdir[0]))
@@ -640,6 +644,7 @@ static wftab_t wr_tab[] = {
 	{LXPR_SYS_KERNEL_COREPATT, lxpr_write_sys_kernel_corepatt},
 	{LXPR_SYS_KERNEL_SHMALL, NULL},
 	{LXPR_SYS_KERNEL_SHMMAX, NULL},
+	{LXPR_SYS_FS_PIPE_MAX, lxpr_write_sys_fs_pipe_max},
 	{LXPR_SYS_NET_CORE_SOMAXCON, lxpr_write_sys_net_core_somaxc},
 	{LXPR_SYS_NET_IPV4_IP_LPORT_RANGE,
 	    lxpr_write_sys_net_ipv4_ip_lport_range},
@@ -859,6 +864,7 @@ static void (*lxpr_read_function[LXPR_NFILES])() = {
 	lxpr_read_sys_fs_inotify_max_queued_events, /* max_queued_events */
 	lxpr_read_sys_fs_inotify_max_user_instances, /* max_user_instances */
 	lxpr_read_sys_fs_inotify_max_user_watches, /* max_user_watches */
+	lxpr_read_sys_fs_pipe_max,	/* /proc/sys/fs/pipe-max-size */
 	lxpr_read_invalid,		/* /proc/sys/kernel	*/
 	lxpr_read_sys_kernel_caplcap,	/* /proc/sys/kernel/cap_last_cap */
 	lxpr_read_sys_kernel_corepatt,	/* /proc/sys/kernel/core_pattern */
@@ -1007,6 +1013,7 @@ static vnode_t *(*lxpr_lookup_function[LXPR_NFILES])() = {
 	lxpr_lookup_not_a_dir,		/* .../inotify/max_queued_events */
 	lxpr_lookup_not_a_dir,		/* .../inotify/max_user_instances */
 	lxpr_lookup_not_a_dir,		/* .../inotify/max_user_watches */
+	lxpr_lookup_not_a_dir,		/* /proc/sys/fs/pipe-max-size */
 	lxpr_lookup_sys_kerneldir,	/* /proc/sys/kernel	*/
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/cap_last_cap */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/core_pattern */
@@ -1155,6 +1162,7 @@ static int (*lxpr_readdir_function[LXPR_NFILES])() = {
 	lxpr_readdir_not_a_dir,		/* .../inotify/max_queued_events */
 	lxpr_readdir_not_a_dir,		/* .../inotify/max_user_instances */
 	lxpr_readdir_not_a_dir,		/* .../inotify/max_user_watches	*/
+	lxpr_readdir_not_a_dir,		/* /proc/sys/fs/pipe-max-size */
 	lxpr_readdir_sys_kerneldir,	/* /proc/sys/kernel	*/
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/cap_last_cap */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/core_pattern */
@@ -4460,6 +4468,23 @@ lxpr_read_sys_fs_inotify_max_user_watches(lxpr_node_t *lxpnp,
 
 /* ARGSUSED */
 static void
+lxpr_read_sys_fs_pipe_max(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	lx_zone_data_t *lxzd = ztolxzd(LXPTOZ(lxpnp));
+	uint_t pipe_max;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_FS_PIPE_MAX);
+	ASSERT(lxzd != NULL);
+
+	mutex_enter(&lxzd->lxzd_lock);
+	pipe_max = lxzd->lxzd_pipe_max_sz;
+	mutex_exit(&lxzd->lxzd_lock);
+
+	lxpr_uiobuf_printf(uiobuf, "%u\n", pipe_max);
+}
+
+/* ARGSUSED */
+static void
 lxpr_read_sys_kernel_caplcap(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 {
 	ASSERT(lxpnp->lxpr_type == LXPR_SYS_KERNEL_CAPLCAP);
@@ -7248,6 +7273,59 @@ lxpr_write_sys_net_ipv4_tcp_winscale(lxpr_node_t *lxpnp, struct uio *uio,
 	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_TCP_WINSCALE);
 	return (lxpr_write_tcp_property(lxpnp, uio, cr, ct, "_wscale_always",
 	    NULL));
+}
+
+/* ARGSUSED */
+static int
+lxpr_write_sys_fs_pipe_max(lxpr_node_t *lxpnp, struct uio *uio,
+    struct cred *cr, caller_context_t *ct)
+{
+	int error;
+	size_t olen;
+	char val[16];	/* big enough for a uint numeric string */
+	char *ep;
+	long u;
+	size_t size;
+	lx_zone_data_t *lxzd = ztolxzd(LXPTOZ(lxpnp));
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_FS_PIPE_MAX);
+
+	if (uio->uio_loffset != 0)
+		return (EINVAL);
+
+	if (uio->uio_resid == 0)
+		return (0);
+
+	olen = uio->uio_resid;
+	if (olen > sizeof (val) - 1)
+		return (EINVAL);
+
+	bzero(val, sizeof (val));
+	error = uiomove(val, olen, UIO_WRITE, uio);
+	if (error != 0)
+		return (error);
+
+	if (lxpr_tokenize_num(val, &u, &ep) != 0)
+		return (EINVAL);
+	if (*ep != '\0')
+		return (EINVAL);
+
+	/*
+	 * Bound to PAGESIZE <= input <= lx_pipe_max_limit, then round to the
+	 * nearest page.  Linux is a little more picky, rounding to the nearest
+	 * power-of-two pages.  Such strengthened behavior can be added later
+	 * if needed.
+	 */
+	size = (size_t)u;
+	size = P2ROUNDUP(MIN(MAX(PAGESIZE, size), lx_pipe_max_limit), PAGESIZE);
+
+	ASSERT(size <= lx_pipe_max_limit);
+
+	mutex_enter(&lxzd->lxzd_lock);
+	lxzd->lxzd_pipe_max_sz = size;
+	mutex_exit(&lxzd->lxzd_lock);
+
+	return (0);
 }
 
 /* ARGSUSED */

--- a/usr/src/uts/common/brand/lx/sys/lx_brand.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_brand.h
@@ -621,6 +621,7 @@ typedef struct lx_zone_data {
 	list_t *lxzd_vdisks;			/* virtual disks (zvols) */
 	dev_t lxzd_zfs_dev;			/* major num for zfs */
 	uint_t lxzd_aio_nr;			/* see lx_aio.c */
+	uint_t lxzd_pipe_max_sz;		/* pipe-max-size sysctl val */
 } lx_zone_data_t;
 
 /* LWP br_lwp_flags values */
@@ -709,6 +710,9 @@ extern int lx_lpid_lock(pid_t, zone_t *, lx_pid_flag_t, proc_t **,
 extern pid_t lx_lwp_ppid(klwp_t *, pid_t *, id_t *);
 extern void lx_pid_init(void);
 extern void lx_pid_fini(void);
+
+extern uint_t lx_pipe_max_limit;
+extern uint_t lx_pipe_max_default;
 
 /*
  * In-Kernel Linux System Call Description.

--- a/usr/src/uts/common/brand/lx/syscall/lx_getpid.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_getpid.c
@@ -23,7 +23,7 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/zone.h>
@@ -71,5 +71,5 @@ lx_gettid(void)
 {
 	lx_lwp_data_t *lwpd = ttolxlwp(curthread);
 
-	return (lwpd->br_pid);
+	return (lwpd->br_pid == curzone->zone_proc_initpid ? 1 : lwpd->br_pid);
 }


### PR DESCRIPTION
This PR merges latest LX-related changes from Joyent.

I suggest backporting:

* OS-6202 fdisk -l core dumps in CentOS 7

Comments on the others?

mail_msg:

```
==== Nightly distributed build started:   Wed Jul  5 14:05:11 UTC 2017 ====
==== Nightly distributed build completed: Wed Jul  5 14:48:29 UTC 2017 ====

==== Total build time ====

real    0:43:18

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-f9693432c2 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   670348

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-merge-2017070502-841c15fd73

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    16:42.0
user  1:33:19.4
sys     11:11.8

==== Build noise differences (DEBUG) ====

12,15c12
---
>     printf("\t.globl %s\n\t.type %s,@function\n%s:\n", \
32,45d28
98,112d80

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:19.0
user    52:01.3
sys      6:41.7

==== lint warnings src ====

"/data/omnios-build/omniosorg/illumos-omnios/usr/src/uts/common/io/iwn/if_iwn.c", line 2052: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/illumos-omnios/usr/src/uts/common/os/sysent.c", line 1213: warning: function returns value which is always ignored: yield (E_FUNC_RET_ALWAYS_IGNOR2)

==== lint noise differences src ====

==== cstyle/hdrchk errors ====

dmake: Warning: Command failed for target `lx.5.check'
dmake: Warning: Command failed for target `man'
dmake: Warning: Command failed for target `man5'
dmake: Warning: Command failed for target `man7d'
dmake: Warning: Command failed for target `zfd.7d.check'
dmake: Warning: Target `check' not remade because of errors
mandoc: lx.5:124:57: WARNING: new sentence, new line
mandoc: lx.5:130:49: WARNING: new sentence, new line
mandoc: lx.5:132:7: WARNING: new sentence, new line
mandoc: lx.5:139:70: WARNING: new sentence, new line
mandoc: lx.5:28:14: WARNING: new sentence, new line
mandoc: lx.5:29:20: WARNING: new sentence, new line
mandoc: lx.5:29:71: WARNING: new sentence, new line
mandoc: lx.5:43:26: WARNING: new sentence, new line
mandoc: lx.5:67:12: WARNING: new sentence, new line
mandoc: lx.5:72:32: WARNING: new sentence, new line
mandoc: lx.5:81:74: WARNING: new sentence, new line
mandoc: lx.5:88:50: WARNING: new sentence, new line
mandoc: zfd.7d:41:62: WARNING: new sentence, new line
mandoc: zfd.7d:64:61: WARNING: new sentence, new line
mandoc: zfd.7d:70:7: WARNING: new sentence, new line
mandoc: zfd.7d:73:35: WARNING: new sentence, new line
mandoc: zfd.7d:74:38: WARNING: new sentence, new line

==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```