### PR TITLE
Cleanup man pages to fix lint warnings

### DIFF
--- a/usr/src/man/man5/lx.5
+++ b/usr/src/man/man5/lx.5
@@ -25,9 +25,11 @@ brand
 uses the
 .Xr brands 5
 framework to provide an environment for running binary applications built
-for GNU/Linux. User-level code, including an entire Linux distribution, can
-run inside the zone. Both 32-bit and 64-bit applications are supported. The
-majority of Linux system calls are provided, along with emulation for a
+for GNU/Linux.
+User-level code, including an entire Linux distribution, can run inside the
+zone.
+Both 32-bit and 64-bit applications are supported.
+The majority of Linux system calls are provided, along with emulation for a
 variety of Linux file systems, such as
 .Em proc ,
 .Em cgroup
@@ -40,8 +42,9 @@ file system within the zone is a subset of a full Linux
 .Em /proc .
 Most kernel-level tuning applied to
 .Em /proc
-is unavailable or ignored. Some tuning can be performed, but only to reduce
-the overall limits that have been specified on the zone's configuration.
+is unavailable or ignored.
+Some tuning can be performed, but only to reduce the overall limits that have
+been specified on the zone's configuration.
 That is, within the zone there is no way to increase the resource limits set
 on the zone itself.
 .Pp
@@ -64,13 +67,14 @@ Examples:
 Applications provided by the base SunOS operating system are also available
 within the zone under the
 .Em /native
-mount point. This allows the use of various native tools such as
+mount point.
+This allows the use of various native tools such as
 .Xr dtrace 1m ,
 .Xr mdb 1 ,
 or the
 .Xr proc 1
-tools on GNU/Linux applications. However, not every native tool will work
-properly within an
+tools on GNU/Linux applications.
+However, not every native tool will work properly within an
 .Em lx
 zone.
 .Sh CONFIGURATION
@@ -78,15 +82,15 @@ The
 .Em kernel-version
 attribute can be included in the zone's
 .Xr zonecfg 1m
-settings as a way to specify the Linux version that the zone is emulating. For
-example, the value could be
+settings as a way to specify the Linux version that the zone is emulating.
+For example, the value could be
 .Em 3.13.0 .
 .Pp
 Persistent network configuration (including DNS resolver information) can be
 configured using
 .Xr zonecfg 1m
-as well, as attributes under the network property.  An example LX zone
-configured with vNIC "lx1" using DHCP is below:
+as well, as attributes under the network property.
+An example LX zone configured with vNIC "lx1" using DHCP is below:
 .sp
 .Dl create -b
 .Dl set zonepath=/zones/lx1
@@ -121,24 +125,26 @@ The brand only supports the exclusive IP stack zone configuration.
 Most modern GNU/Linux application software runs on
 .Em lx ,
 but because there are some system calls or file systems which are not currently
-implemented, it's possible that an application won't run. This does not
-preclude the application running in the future as the
+implemented, it's possible that an application won't run.
+This does not preclude the application running in the future as the
 .Em lx
 brand adds new capabilities.
 .Pp
 Because there is only the single SunOS kernel running on the system, there
-is no support for any Linux kernel-level modules. That is, there is no support
-for add-on drivers or any other modules that are part of the Linux kernel
-itself. If that is required, a full virtual machine should be used instead of
+is no support for any Linux kernel-level modules.
+That is, there is no support for add-on drivers or any other modules that are
+part of the Linux kernel itself.
+If that is required, a full virtual machine should be used instead of
 an
 .Em lx
 branded zone.
 .Pp
 Any core files produced within the zone are in the native SunOS format.
 .Pp
-As with any zone, the normal security mechanisms and privileges apply. Thus,
-certain operations (for example, changing the system time), will not be allowed
-unless the zone has been configured with the appropriate additional privileges.
+As with any zone, the normal security mechanisms and privileges apply.
+Thus, certain operations (for example, changing the system time), will not be
+allowed unless the zone has been configured with the appropriate additional
+privileges.
 .Sh SEE ALSO
 .Xr mdb 1 ,
 .Xr proc 1 ,

--- a/usr/src/man/man7d/zfd.7d
+++ b/usr/src/man/man7d/zfd.7d
@@ -38,10 +38,10 @@ The zone's zfd device configuration is driven by
 .Nm zoneadmd
 and a zone attribute
 .Nm zlog-mode
-which is somewhat of a misnomer since its purpose has evolved. The attribute
-can have a variety of values, but the lowest two positions in the value string
-are used to control how many zfd devices are created inside the zone and if the
-primary stream is a tty.
+which is somewhat of a misnomer since its purpose has evolved.
+The attribute can have a variety of values, but the lowest two positions in the
+value string are used to control how many zfd devices are created inside the
+zone and if the primary stream is a tty.
 .sp
 .Dl --
 .Dl -n
@@ -61,18 +61,19 @@ That is,
 .Nm ldterm
 and
 .Nm ttycompat
-are autopushed onto the stream when the slave side is opened. There is only a
-single zfd device (0) needed for the primary stream.
+are autopushed onto the stream when the slave side is opened.
+There is only a single zfd device (0) needed for the primary stream.
 .sp
 When the
 .Nm n
 flag is set, it is assumed that output logging will be done within the zone
-itself. In this configuration 1 or 2 additional zfd devices, depending on tty
-mode
+itself.
+In this configuration 1 or 2 additional zfd devices, depending on tty mode
 .Nm ( t
-flag), are created within the zone. An application can then configure the
-zfd streams driver into a multiplexer. Output from the stdout/stderr zfd(s)
-will be teed into the correspond logging zfd(s) within the zone.
+flag), are created within the zone.
+An application can then configure the zfd streams driver into a multiplexer.
+Output from the stdout/stderr zfd(s) will be teed into the correspond logging
+zfd(s) within the zone.
 .sp
 .Sh SEE ALSO
 .Xr zlogin 1 ,


### PR DESCRIPTION
These are cleanups to the lx.5 and zfd.7d man pages to fix warnings produced by the new lint in gate.
The only fixes are to move sentences so that they start on a new line.

mail_msg:

```

==== Nightly distributed build started:   Thu Jul  6 11:02:05 UTC 2017 ====
==== Nightly distributed build completed: Thu Jul  6 11:47:56 UTC 2017 ====

==== Total build time ====

real    0:45:50

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-f9693432c2 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   688018

==== Nightly argument issues ====


==== Build version ====

omnios-man-lint-6e1a91aa37

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:02.0
user  1:34:19.8
sys     11:09.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    20:38.6
user  1:10:12.8
sys     19:31.0

==== lint warnings src ====

"/data/omnios-build/omniosorg/illumos-omnios/usr/src/uts/common/io/iwn/if_iwn.c", line 2052: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/illumos-omnios/usr/src/uts/common/os/sysent.c", line 1213: warning: function returns value which is always ignored: yield (E_FUNC_RET_ALWAYS_IGNOR2)

==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====

```

Compare this with previous builds which included:

```
==== cstyle/hdrchk errors ====

dmake: Warning: Command failed for target `lx.5.check'
dmake: Warning: Command failed for target `man'
dmake: Warning: Command failed for target `man5'
dmake: Warning: Command failed for target `man7d'
dmake: Warning: Command failed for target `zfd.7d.check'
dmake: Warning: Target `check' not remade because of errors
mandoc: lx.5:124:57: WARNING: new sentence, new line
mandoc: lx.5:130:49: WARNING: new sentence, new line
mandoc: lx.5:132:7: WARNING: new sentence, new line
mandoc: lx.5:139:70: WARNING: new sentence, new line
mandoc: lx.5:28:14: WARNING: new sentence, new line
mandoc: lx.5:29:20: WARNING: new sentence, new line
mandoc: lx.5:29:71: WARNING: new sentence, new line
mandoc: lx.5:43:26: WARNING: new sentence, new line
mandoc: lx.5:67:12: WARNING: new sentence, new line
mandoc: lx.5:72:32: WARNING: new sentence, new line
mandoc: lx.5:81:74: WARNING: new sentence, new line
mandoc: lx.5:88:50: WARNING: new sentence, new line
mandoc: zfd.7d:41:62: WARNING: new sentence, new line
mandoc: zfd.7d:64:61: WARNING: new sentence, new line
mandoc: zfd.7d:70:7: WARNING: new sentence, new line
mandoc: zfd.7d:73:35: WARNING: new sentence, new line
mandoc: zfd.7d:74:38: WARNING: new sentence, new line
```