### PR TITLE
Upstream merge/2017071301

### DIFF
--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2017.6.11.1
+BOOT_VERSION = $(LOADER_VERSION)-2017.6.29.1

--- a/usr/src/boot/sys/boot/i386/libi386/libi386.h
+++ b/usr/src/boot/sys/boot/i386/libi386/libi386.h
@@ -70,7 +70,10 @@ struct relocate_data {
 
 extern void relocater(void);
 
-extern uint32_t relocater_data;
+/*
+ * The relocater_data[] is fixed size array allocated in relocater_tramp.S
+ */
+extern struct relocate_data relocater_data[];
 extern uint32_t relocater_size;
 
 extern uint16_t relocator_ip;

--- a/usr/src/boot/sys/boot/i386/loader/chain.c
+++ b/usr/src/boot/sys/boot/i386/loader/chain.c
@@ -45,7 +45,6 @@ command_chain(int argc, char *argv[])
 	int fd, len, size = SECTOR_SIZE;
 	struct stat st;
 	vm_offset_t mem = 0x100000;
-	uint32_t *uintptr = &relocater_data;
 	struct i386_devdesc *rootdev;
 
 	if (argc == 1) {
@@ -97,9 +96,9 @@ command_chain(int argc, char *argv[])
 		return (CMD_ERROR);
 	}
 
-	uintptr[0] = mem;
-	uintptr[1] = 0x7C00;
-	uintptr[2] = size;
+	relocater_data[0].src = mem;
+	relocater_data[0].dest = 0x7C00;
+	relocater_data[0].size = size;
 
 	relocator_edx = bd_unit2bios(rootdev->d_unit);
 	relocator_esi = relocater_size;

--- a/usr/src/cmd/col/col.c
+++ b/usr/src/cmd/col/col.c
@@ -27,8 +27,6 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 /*
  *	col - filter reverse carraige motions
  *
@@ -311,22 +309,22 @@ outc(wchar_t c)
 		if (*line != '\b')
 			if (esc_chars)
 				esc_chars = '\0';
-			switch (*line)	{
-			case ESC:
-				incr_line(1);
-				esc_chars = 1;
-				break;
-			case '\0':
-				*line = ' ';
-				lp++;
-				break;
-			case '\b':
-				/* if ( ! esc_chars ) */
-					lp--;
-				break;
-			default:
-				lp += wcscrwidth(*line);
-			}
+		switch (*line)	{
+		case ESC:
+			incr_line(1);
+			esc_chars = 1;
+			break;
+		case '\0':
+			*line = ' ';
+			lp++;
+			break;
+		case '\b':
+			/* if ( ! esc_chars ) */
+			lp--;
+			break;
+		default:
+			lp += wcscrwidth(*line);
+		}
 		incr_line(1);
 	}
 	while (*line == '\b') {
@@ -468,7 +466,7 @@ store(int lno)
 	if (page[lno] != 0)
 		free((char *)page[lno]);
 	page[lno] = (wchar_t *)malloc((unsigned)(wcslen(lbuff) + 2)
-		* sizeof (wchar_t));
+	    * sizeof (wchar_t));
 	if (page[lno] == 0) {
 		/* fprintf(stderr, "%s: no storage\n", pgmname); */
 		exit(2);

--- a/usr/src/cmd/dlmgmtd/dlmgmt_door.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_door.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -1258,8 +1259,7 @@ dlmgmt_setzoneid(void *argp, void *retp, size_t *sz, zoneid_t zoneid,
 	 * Before we remove the link from its current zone, make sure that
 	 * there isn't a link with the same name in the destination zone.
 	 */
-	if (zoneid != GLOBAL_ZONEID &&
-	    link_by_name(linkp->ll_link, newzoneid) != NULL) {
+	if (link_by_name(linkp->ll_link, newzoneid) != NULL) {
 		err = EEXIST;
 		goto done;
 	}

--- a/usr/src/cmd/fs.d/nfs/mount/Makefile
+++ b/usr/src/cmd/fs.d/nfs/mount/Makefile
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2017, Joyent, Inc. All rights reserved.
 #
 # cmd/fs.d/nfs/mount/Makefile
 
@@ -107,7 +108,7 @@ webnfs.x:	../lib/webnfs.x
 #
 catalog: $(POFILE)
 
-$(POFILE): $(SRCS)
+$(POFILE): $(SRCS) webnfs.h
 	$(RM) $@
 	$(COMPILE.cpp) $(SRCS)   > $(POFILE).i
 	$(XGETTEXT)     $(XGETFLAGS) $(POFILE).i

--- a/usr/src/cmd/fs.d/udfs/fsdb/Makefile
+++ b/usr/src/cmd/fs.d/udfs/fsdb/Makefile
@@ -22,6 +22,8 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2017, Joyent Inc.
+#
 
 FSTYPE=		udfs
 LIBPROG=	fsdb
@@ -100,7 +102,7 @@ catalog:        $(POFILE)
 
 CATSRCS=	$(SRCS) lex.yy.c y.tab.c
 
-$(POFILE):      $(CATSRCS)
+$(POFILE):      $(CATSRCS) ud_lib.h
 	$(RM) $@
 	$(COMPILE.cpp) $(CATSRCS)   > $(POFILE).i
 	$(XGETTEXT) $(XGETFLAGS)        $(POFILE).i

--- a/usr/src/cmd/fs.d/udfs/labelit/Makefile
+++ b/usr/src/cmd/fs.d/udfs/labelit/Makefile
@@ -22,6 +22,8 @@
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2017 Joyent, Inc.
+#
 
 FSTYPE=		udfs
 LIBPROG=	labelit
@@ -63,7 +65,7 @@ POFILE= labelit.po
 #
 catalog:	$(POFILE)
 
-$(POFILE):	$(SRCS)
+$(POFILE):	$(SRCS) ud_lib.h
 	$(RM) $@
 	$(COMPILE.cpp) $(SRCS) > $(POFILE).i
 	$(XGETTEXT) $(XGETFLAGS) $(POFILE).i

--- a/usr/src/cmd/iconv/Makefile
+++ b/usr/src/cmd/iconv/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2017 Joyent Inc.
 #
 
 PROG=iconv
@@ -44,6 +45,7 @@ $(PROG): $(OBJS)
 	$(POST_PROCESS)
 
 $(OBJS):	parser.tab.h
+$(PIFILES):	parser.tab.h
 
 parser.tab.c parser.tab.h: parser.y
 	$(YACC) $(YFLAGS) parser.y

--- a/usr/src/cmd/isns/isnsd/Makefile
+++ b/usr/src/cmd/isns/isnsd/Makefile
@@ -25,6 +25,7 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2017 Joyent, Inc.
 #
 
 PROG = isns
@@ -93,6 +94,8 @@ clean:
 	$(RM) $(OBJS)
 
 lint:	lint_SRCS
+
+$(POFILES): $(DTRACE_HEADER)
 
 $(POFILE): $(POFILES)
 	$(RM) $@

--- a/usr/src/cmd/msgfmt/Makefile
+++ b/usr/src/cmd/msgfmt/Makefile
@@ -25,6 +25,8 @@
 #       Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T
 #         All Rights Reserved
 #
+# Copyright 2017 Joyent, Inc.
+#
 
 # cmd/msgfmt/Makefile
 
@@ -89,6 +91,8 @@ gmsgfmt_rev:	$(GOBJS) $(YOBJS) $(LOBJS) $(COBJS)
 xgettext: $(XOBJS) $(LXOBJS)
 	$(LINK.c) $(XOBJS) $(LXOBJS) -o $@ $(LDLIBS)
 	$(POST_PROCESS)
+
+$(POFILES): y.tab.h
 
 $(POFILE):	$(POFILES)
 	$(RM) $@

--- a/usr/src/cmd/sgs/Makefile
+++ b/usr/src/cmd/sgs/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2016 RackTop Systems.
+# Copyright 2017 Joyent, Inc.
 #
 
 include		$(SRC)/cmd/Makefile.cmd
@@ -123,7 +124,8 @@ _msg: _msg_gettext _msg_sgsmsg
 
 _msg_gettext: $(MSGDOMAIN)/$(POFILE)
 
-_msg_sgsmsg: $(MSGDIR)
+# $(MACH)/sgsmsg must be built before we can descend into $(MSGDIR)
+_msg_sgsmsg: native-add .WAIT $(MSGDIR)
 
 $(MSGDOMAIN)/$(POFILE): \
 		$(MSGDOMAIN) $(POFILE)

--- a/usr/src/cmd/svc/svccfg/Makefile
+++ b/usr/src/cmd/svc/svccfg/Makefile
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2017 Joyent, Inc.
 #
 
 MYPROG =	svccfg
@@ -133,6 +134,8 @@ native: FRC
 $(PROG): $(OBJS) $(MAPFILES)
 	$(LINK.c) -o $@ $(OBJS) $(LDLIBS)
 	$(POST_PROCESS)
+
+$(POFILES): svccfg_grammar.h
 
 $(POFILE): $(POFILES)
 	cat $(POFILES) > $(POFILE)

--- a/usr/src/cmd/xargs/xargs.c
+++ b/usr/src/cmd/xargs/xargs.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2014 Garrett D'Amore <garrett@damore.org>
  * Copyright 2012 DEY Storage Systems, Inc.
+ * Copyright (c) 2017, Joyent, Inc.
  *
  * Portions of this file developed by DEY Storage Systems, Inc. are licensed
  * under the terms of the Common Development and Distribution License (CDDL)
@@ -54,6 +55,7 @@
 #include <poll.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <sys/fork.h>
 #include "getresponse.h"
 
 #define	HEAD	0
@@ -90,6 +92,7 @@
 #define	MISSQUOTE	"Missing quote"
 #define	BADESCAPE	"Incomplete escape"
 #define	IBUFOVERFLOW	"Insert buffer overflow"
+#define	NOCHILDSLOT	"No free child slot available"
 
 #define	_(x)	gettext(x)
 
@@ -110,6 +113,7 @@ static struct inserts {
 
 static int	PROMPT = -1;
 static int	BUFLIM = BUFSIZE;
+static int	MAXPROCS = 1;
 static int	N_ARGS = 0;
 static int	N_args = 0;
 static int	N_lines = 0;
@@ -130,15 +134,17 @@ static int	exitstat = 0;	/* our exit status			*/
 static int	mac;		/* modified argc, after parsing		*/
 static char	**mav;		/* modified argv, after parsing		*/
 static int	n_inserts;	/* # of insertions.			*/
+static pid_t	*procs;		/* pids of children			*/
+static int	n_procs;	/* # of child processes.		*/
 
 /* our usage message:							*/
 #define	USAGEMSG "Usage: xargs: [-t] [-p] [-0] [-e[eofstr]] [-E eofstr] "\
-	"[-I replstr] [-i[replstr]] [-L #] [-l[#]] [-n # [-x]] [-s size] "\
-	"[cmd [args ...]]\n"
+	"[-I replstr] [-i[replstr]] [-L #] [-l[#]] [-n # [-x]] [-P maxprocs] "\
+	"[-s size] [cmd [args ...]]\n"
 
 static int	echoargs();
 static wint_t	getwchr(char *, size_t *);
-static int	lcall(char *sub, char **subargs);
+static void	lcall(char *sub, char **subargs);
 static void	addibuf(struct inserts *p);
 static void	ermsg(char *messages, ...);
 static char	*addarg(char *arg);
@@ -147,17 +153,24 @@ static char	*getarg(char *);
 static char	*insert(char *pattern, char *subst);
 static void	usage();
 static void	parseargs();
+static int	procs_find(pid_t child);
+static void	procs_store(pid_t child);
+static boolean_t procs_delete(pid_t child);
+static pid_t	procs_waitpid(boolean_t blocking, int *stat_loc);
+static void	procs_wait(boolean_t blocking);
 
 int
 main(int argc, char **argv)
 {
 	int	j;
+	unsigned long	l;
 	struct inserts *psave;
 	int c;
 	int	initsize;
 	char	*cmdname, **initlist;
 	char	*arg;
 	char	*next;
+	char	*eptr;
 
 	/* initialization */
 	blank = wctype("blank");
@@ -176,7 +189,7 @@ main(int argc, char **argv)
 	parseargs(argc, argv);
 
 	/* handling all of xargs arguments:				*/
-	while ((c = getopt(mac, mav, "0tpe:E:I:i:L:l:n:s:x")) != EOF) {
+	while ((c = getopt(mac, mav, "0tpe:E:I:i:L:l:n:P:s:x")) != EOF) {
 		switch (c) {
 		case '0':
 			ZERO = TRUE;
@@ -301,6 +314,25 @@ main(int argc, char **argv)
 			}
 			break;
 
+		case 'P':	/* -P maxprocs: # of child processses	*/
+			errno = 0;
+			l = strtoul(optarg, &eptr, 10);
+			if (*eptr != '\0' || errno != 0) {
+				ermsg(_("failed to parse maxprocs (-P): %s\n"),
+				    optarg);
+				break;
+			}
+
+			/*
+			 * Come up with an upper bound that'll probably fit in
+			 * memory.
+			 */
+			if (l == 0 || l > ((INT_MAX / sizeof (pid_t) >> 1))) {
+				l = INT_MAX / sizeof (pid_t) >> 1;
+			}
+			MAXPROCS = (int)l;
+			break;
+
 		case 's':	/* -s size: set max size of each arg list */
 			BUFLIM = atoi(optarg);
 			if (BUFLIM > BUFSIZE || BUFLIM <= 0) {
@@ -340,6 +372,12 @@ main(int argc, char **argv)
 
 	mac -= optind;	/* dec arg count by what we've processed 	*/
 	mav += optind;	/* inc to current mav				*/
+
+	procs = calloc(MAXPROCS, sizeof (pid_t));
+	if (procs == NULL) {
+		PERR(MALLOCFAIL);
+		exit(1);
+	}
 
 	if (mac <= 0) {	/* if there're no more args to process,	*/
 		cmdname = "/usr/bin/echo";	/* our default command	*/
@@ -411,6 +449,7 @@ main(int argc, char **argv)
 				 */
 				if (LEGAL || N_args == 0) {
 					EMSG(LIST2LONG);
+					procs_wait(B_TRUE);
 					exit(2);
 					/* NOTREACHED */
 				}
@@ -440,7 +479,7 @@ main(int argc, char **argv)
 		*ARGV = NULL;
 		if (N_args == 0) {
 			/* Reached the end with no more work. */
-			exit(exitstat);
+			break;
 		}
 
 		/* insert arg if requested */
@@ -469,6 +508,7 @@ main(int argc, char **argv)
 			}
 			if (linesize >= BUFLIM) {
 				EMSG(LIST2LONG);
+				procs_wait(B_TRUE);
 				exit(2);
 				/* NOTREACHED */
 			}
@@ -489,10 +529,12 @@ main(int argc, char **argv)
 				 * so if we have a non-zero status here,
 				 * quit immediately.
 				 */
-				exitstat |= lcall(cmdname, arglist);
+				(void) lcall(cmdname, arglist);
 			}
 		}
 	}
+
+	procs_wait(B_TRUE);
 
 	if (OK)
 		return (exitstat);
@@ -863,34 +905,22 @@ getwchr(char *mbc, size_t *sz)
 }
 
 
-static int
+static void
 lcall(char *sub, char **subargs)
 {
-	int retcode, retry = 0;
-	pid_t iwait, child;
+	int	retry = 0;
+	pid_t	child;
 
 	for (;;) {
-		switch (child = fork()) {
+		switch (child = forkx(FORK_NOSIGCHLD)) {
 		default:
-			while ((iwait = wait(&retcode)) != child &&
-			    iwait != (pid_t)-1)
-				;
-			if (iwait == (pid_t)-1) {
-				PERR(WAITFAIL);
-				exit(122);
-				/* NOTREACHED */
-			}
-			if (WIFSIGNALED(retcode)) {
-				EMSG2(CHILDSIG, WTERMSIG(retcode));
-				exit(125);
-				/* NOTREACHED */
-			}
-			if ((WEXITSTATUS(retcode) & 0377) == 0377) {
-				EMSG(CHILDFAIL);
-				exit(124);
-				/* NOTREACHED */
-			}
-			return (WEXITSTATUS(retcode));
+			procs_store(child);
+			/*
+			 * Note, if we have used up all of our slots, then this
+			 * call may end up blocking.
+			 */
+			procs_wait(B_FALSE);
+			return;
 		case 0:
 			(void) execvp(sub, subargs);
 			PERR(EXECFAIL);
@@ -908,6 +938,110 @@ lcall(char *sub, char **subargs)
 	}
 }
 
+/*
+ * Return the index of child in the procs array.
+ */
+static int
+procs_find(pid_t child)
+{
+	int	i;
+
+	for (i = 0; i < MAXPROCS; i++) {
+		if (procs[i] == child) {
+			return (i);
+		}
+	}
+
+	return (-1);
+}
+
+static void
+procs_store(pid_t child)
+{
+	int	i;
+
+	i = procs_find(0);
+	if (i < 0) {
+		EMSG(NOCHILDSLOT);
+		exit(1);
+	}
+	procs[i] = child;
+	n_procs++;
+}
+
+static boolean_t
+procs_delete(pid_t child)
+{
+	int	i;
+
+	i = procs_find(child);
+	if (i < 0) {
+		return (B_FALSE);
+	}
+
+	procs[i] = (pid_t)0;
+	n_procs--;
+
+	return (B_TRUE);
+}
+
+static pid_t
+procs_waitpid(boolean_t blocking, int *stat_loc)
+{
+	pid_t	child;
+	int	options;
+
+	if (n_procs == 0) {
+		errno = ECHILD;
+		return (-1);
+	}
+
+	options = 0;
+	if (!blocking) {
+		options |= WNOHANG;
+	}
+
+	while ((child = waitpid((pid_t)-1, stat_loc, options)) > 0) {
+		if (procs_delete(child)) {
+			break;
+		}
+	}
+
+	return (child);
+}
+
+static void
+procs_wait(boolean_t blocking)
+{
+	pid_t	child;
+	int	stat_loc;
+
+	/*
+	 * If we currently have filled all of our slots, then we need to block
+	 * further execution.
+	 */
+	if (n_procs >= MAXPROCS)
+		blocking = B_TRUE;
+	while ((child = procs_waitpid(blocking, &stat_loc)) > 0) {
+		if (WIFSIGNALED(stat_loc)) {
+			EMSG2(CHILDSIG, WTERMSIG(stat_loc));
+			exit(125);
+			/* NOTREACHED */
+		} else if ((WEXITSTATUS(stat_loc) & 0377) == 0377) {
+			EMSG(CHILDFAIL);
+			exit(124);
+			/* NOTREACHED */
+		} else {
+			exitstat |= WEXITSTATUS(stat_loc);
+		}
+	}
+
+	if (child == (pid_t)(-1) && errno != ECHILD) {
+		EMSG(WAITFAIL);
+		exit(122);
+		/* NOTREACHED */
+	}
+}
 
 static void
 usage()
@@ -1006,6 +1140,7 @@ process_special:
 			 * and the new XCU4 way of handling things are allowed.
 			 */
 			case	'n':	/* FALLTHROUGH			*/
+			case	'P':	/* FALLTHROUGH			*/
 			case	's':	/* FALLTHROUGH			*/
 			case	'E':	/* FALLTHROUGH			*/
 			case	'I':	/* FALLTHROUGH			*/

--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -61,6 +61,7 @@
 #include <sys/ddt.h>
 #include <sys/zfeature.h>
 #include <sys/abd.h>
+#include <sys/blkptr.h>
 #include <zfs_comutil.h>
 #undef verify
 #include <libzfs.h>
@@ -134,10 +135,11 @@ usage(void)
 	    "\t%s -O <dataset> <path>\n"
 	    "\t%s -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]\n"
 	    "\t\t<poolname> <vdev>:<offset>:<size>[:<flags>]\n"
+	    "\t%s -E [-A] word0:word1:...:word15\n"
 	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
 	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
-	    cmdname);
+	    cmdname, cmdname);
 
 	(void) fprintf(stderr, "    Dataset name must include at least one "
 	    "separator character '/' or '@'\n");
@@ -152,6 +154,8 @@ usage(void)
 	(void) fprintf(stderr, "        -C config (or cachefile if alone)\n");
 	(void) fprintf(stderr, "        -d dataset(s)\n");
 	(void) fprintf(stderr, "        -D dedup statistics\n");
+	(void) fprintf(stderr, "        -E decode and display block from an "
+	    "embedded block pointer\n");
 	(void) fprintf(stderr, "        -h pool history\n");
 	(void) fprintf(stderr, "        -i intent logs\n");
 	(void) fprintf(stderr, "        -l read label contents\n");
@@ -3628,6 +3632,33 @@ out:
 	free(dup);
 }
 
+static void
+zdb_embedded_block(char *thing)
+{
+	blkptr_t bp = { 0 };
+	unsigned long long *words = (void *)&bp;
+	char buf[SPA_MAXBLOCKSIZE];
+	int err;
+
+	err = sscanf(thing, "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx:"
+	    "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx",
+	    words + 0, words + 1, words + 2, words + 3,
+	    words + 4, words + 5, words + 6, words + 7,
+	    words + 8, words + 9, words + 10, words + 11,
+	    words + 12, words + 13, words + 14, words + 15);
+	if (err != 16) {
+		(void) printf("invalid input format\n");
+		exit(1);
+	}
+	ASSERT3U(BPE_GET_LSIZE(&bp), <=, SPA_MAXBLOCKSIZE);
+	err = decode_embedded_bp(&bp, buf, BPE_GET_LSIZE(&bp));
+	if (err != 0) {
+		(void) printf("decode failed: %u\n", err);
+		exit(1);
+	}
+	zdb_dump_block_raw(buf, BPE_GET_LSIZE(&bp), 0);
+}
+
 static boolean_t
 pool_match(nvlist_t *cfg, char *tgt)
 {
@@ -3746,13 +3777,14 @@ main(int argc, char **argv)
 		spa_config_path = spa_config_path_env;
 
 	while ((c = getopt(argc, argv,
-	    "AbcCdDeFGhiI:lLmMo:Op:PqRsSt:uU:vVx:X")) != -1) {
+	    "AbcCdDeEFGhiI:lLmMo:Op:PqRsSt:uU:vVx:X")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
 		case 'C':
 		case 'd':
 		case 'D':
+		case 'E':
 		case 'G':
 		case 'h':
 		case 'i':
@@ -3816,6 +3848,12 @@ main(int argc, char **argv)
 			break;
 		case 'U':
 			spa_config_path = optarg;
+			if (spa_config_path[0] != '/') {
+				(void) fprintf(stderr,
+				    "cachefile must be an absolute path "
+				    "(i.e. start with a slash)\n");
+				usage();
+			}
 			break;
 		case 'v':
 			verbose++;
@@ -3863,7 +3901,7 @@ main(int argc, char **argv)
 		verbose = MAX(verbose, 1);
 
 	for (c = 0; c < 256; c++) {
-		if (dump_all && strchr("AeFlLOPRSX", c) == NULL)
+		if (dump_all && strchr("AeEFlLOPRSX", c) == NULL)
 			dump_opt[c] = 1;
 		if (dump_opt[c])
 			dump_opt[c] += verbose;
@@ -3877,6 +3915,14 @@ main(int argc, char **argv)
 
 	if (argc < 2 && dump_opt['R'])
 		usage();
+
+	if (dump_opt['E']) {
+		if (argc != 1)
+			usage();
+		zdb_embedded_block(argv[0]);
+		return (0);
+	}
+
 	if (argc < 1) {
 		if (!dump_opt['e'] && dump_opt['C']) {
 			dump_cachefile(spa_config_path);

--- a/usr/src/lib/auditd_plugins/binfile/binfile.c
+++ b/usr/src/lib/auditd_plugins/binfile/binfile.c
@@ -263,7 +263,7 @@ loadauditlist(char *dirstr, char *minfreestr)
 	dirlist_t	*thisdir;
 	int		node_count = 0;
 	int		rc;
-	int		temp_minfree;
+	int		temp_minfree = 0;
 
 	static dirlist_t	*activeList = NULL;	/* directory list */
 
@@ -691,7 +691,8 @@ spacecheck(dirlist_t *thisdir, int test_limit, size_t next_buf_size)
  * INT_MAX.  Defaults to 0 if the value is invalid or is missing.
  */
 static void
-save_maxsize(char *maxsize) {
+save_maxsize(char *maxsize)
+{
 	/*
 	 * strtol() returns a long which could be larger than int so
 	 * store here for sanity checking first
@@ -713,11 +714,11 @@ save_maxsize(char *maxsize) {
 		 */
 		if ((errno == ERANGE) ||
 		    ((proposed_maxsize != 0) &&
-			(proposed_maxsize < FSIZE_MIN)) ||
+		    (proposed_maxsize < FSIZE_MIN)) ||
 		    (proposed_maxsize > INT_MAX)) {
 			binfile_maxsize = 0;
 			DPRINT((dbfp, "binfile: p_fsize parameter out of "
-					"range: %s\n", maxsize));
+			    "range: %s\n", maxsize));
 			/*
 			 * Inform administrator of the error via
 			 * syslog

--- a/usr/src/lib/fm/topo/modules/common/disk/disk.h
+++ b/usr/src/lib/fm/topo/modules/common/disk/disk.h
@@ -23,7 +23,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc.
  */
 
 #ifndef _DISK_H
@@ -106,6 +106,8 @@ extern int disk_declare_non_enumerated(topo_mod_t *, tnode_t *, tnode_t **);
 extern int disk_declare_path(topo_mod_t *, tnode_t *,
     struct topo_list *, const char *);
 extern int disk_declare_addr(topo_mod_t *, tnode_t *,
+    struct topo_list *, const char *, tnode_t **);
+extern int disk_declare_bridge(topo_mod_t *, tnode_t *,
     struct topo_list *, const char *, tnode_t **);
 extern char *disk_auth_clean(topo_mod_t *, const char *);
 

--- a/usr/src/lib/libipsecutil/common/ipsec_util.c
+++ b/usr/src/lib/libipsecutil/common/ipsec_util.c
@@ -696,9 +696,9 @@ do_interactive(FILE *infile, char *configfile, char *promptstring,
     char *my_fmri, parse_cmdln_fn parseit, CplMatchFn *match_fn)
 {
 	char		ibuf[IBUF_SIZE], holder[IBUF_SIZE];
-	char		*hptr, **thisargv, *ebuf;
+	char		*volatile hptr, **thisargv, *ebuf;
 	int		thisargc;
-	boolean_t	continue_in_progress = B_FALSE;
+	volatile boolean_t	continue_in_progress = B_FALSE;
 	char		*s;
 
 	(void) setjmp(env);
@@ -2296,7 +2296,7 @@ ipsec_convert_sl_to_sens(int doi, bslabel_t *sl, sadb_sens_t *sens)
  */
 void
 print_sens(FILE *file, char *prefix, const struct sadb_sens *sens,
-	boolean_t ignore_nss)
+    boolean_t ignore_nss)
 {
 	char *plabel;
 	char *hlabel;

--- a/usr/src/lib/libsocket/inet/getifaddrs.c
+++ b/usr/src/lib/libsocket/inet/getifaddrs.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 RackTop Systems.
  */
 
 #include <netdb.h>
@@ -102,6 +103,14 @@ getallifaddrs(sa_family_t af, struct ifaddrs **ifap, int64_t flags)
 	int sock6;
 	int err;
 
+	/*
+	 * Initialize ifap to NULL so we can safely call freeifaddrs
+	 * on it in case of error.
+	 */
+	if (ifap == NULL)
+		return (EINVAL);
+	*ifap = NULL;
+
 	if ((sock4 = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
 		return (-1);
 	if ((sock6 = socket(AF_INET6, SOCK_DGRAM, 0)) < 0) {
@@ -123,7 +132,6 @@ retry:
 	 */
 	prev = NULL;
 	lifrp = buf;
-	*ifap = NULL;
 	for (n = 0; n < numifs; n++, lifrp++) {
 
 		/* Prepare for the ioctl call */

--- a/usr/src/man/man1/xargs.1
+++ b/usr/src/man/man1/xargs.1
@@ -7,7 +7,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH XARGS 1 "November 24, 2012"
+.TH XARGS 1 "May 28, 2017"
 .SH NAME
 xargs \- construct argument lists and invoke utility
 .SH SYNOPSIS
@@ -15,11 +15,11 @@ xargs \- construct argument lists and invoke utility
 .nf
 \fBxargs\fR [\fB-t\fR] [\fB-0\fR] [\fB-p\fR] [\fB-e\fR[\fIeofstr\fR]] [\fB-E\fR \fIeofstr\fR]
      [\fB-I\fR \fIreplstr\fR] [\fB-i\fR[\fIreplstr\fR]] [\fB-L\fR \fInumber\fR] [\fB-l\fR[\fInumber\fR]]
-     [\fB-n\fR \fInumber\fR [\fB-x\fR]] [\fB-s\fR \fIsize\fR] [\fIutility\fR [\fIargument\fR...]]
+     [\fB-n\fR \fInumber\fR [\fB-x\fR]] [\fB-P\fR \fImaxprocs\fR] [\fB-s\fR \fIsize\fR]
+     [\fIutility\fR [\fIargument\fR...]]
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBxargs\fR utility constructs a command line consisting of the
 \fIutility\fR and \fIargument\fR operands specified followed by as many
@@ -49,7 +49,6 @@ argument and environment lists can not exceed \fB{ARG_MAX}\(mi2048\fR bytes.
 Within this constraint, if neither the \fB-n\fR nor the \fB-s\fR option is
 specified, the default command line length is at least \fB{LINE_MAX}\fR.
 .SH OPTIONS
-.sp
 .LP
 The following options are supported:
 .sp
@@ -171,6 +170,16 @@ otherwise, that particular invocation of \fIutility\fR is skipped.
 .sp
 .ne 2
 .na
+\fB\fB-P\fR \fImaxprocs\fR\fR
+.ad
+.RS 15n
+Invokes \fIutility\fR using at most \fImaxprocs\fR (a positive decimal integer)
+parallel child processes.
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fB-s\fR \fIsize\fR\fR
 .ad
 .RS 15n
@@ -236,7 +245,6 @@ the -print0 argument to \fBfind\fR(1).
 .RE
 
 .SH OPERANDS
-.sp
 .LP
 The following operands are supported:
 .sp
@@ -262,7 +270,6 @@ An initial option or operand for the invocation of \fIutility\fR.
 .RE
 
 .SH USAGE
-.sp
 .LP
 The \fB255\fR exit status allows a utility being used by \fBxargs\fR to tell
 \fBxargs\fR to terminate if it knows no further invocations using the current
@@ -371,7 +378,6 @@ example% \fBecho $* | xargs -n 2 diff\fR
 .sp
 
 .SH ENVIRONMENT VARIABLES
-.sp
 .LP
 See \fBenviron\fR(5) for descriptions of the following environment variables
 that affect the execution of \fBxargs\fR: \fBLANG\fR, \fBLC_ALL\fR,
@@ -396,7 +402,6 @@ in \fBLC_CTYPE\fR determines the locale for interpretation of sequences of
 bytes of text data a characters, the behavior of character classes used in the
 expression defined for the \fByesexpr\fR. See \fBlocale\fR(5).
 .SH EXIT STATUS
-.sp
 .LP
 The following exit values are returned:
 .sp
@@ -445,7 +450,6 @@ signal, or an invocation of the utility exits with exit status \fB255\fR, the
 \fBxargs\fR utility writes a diagnostic message and exit without processing any
 remaining input.
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -463,7 +467,6 @@ Interface Stability	Standard
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBecho\fR(1), \fBshell_builtins\fR(1), \fBattributes\fR(5), \fBenviron\fR(5),
 \fBstandards\fR(5)

--- a/usr/src/man/man1m/zdb.1m
+++ b/usr/src/man/man1m/zdb.1m
@@ -10,10 +10,10 @@
 .\"
 .\"
 .\" Copyright 2012, Richard Lowe.
-.\" Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+.\" Copyright (c) 2012, 2017 by Delphix. All rights reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\"
-.Dd January 14, 2017
+.Dd April 14, 2017
 .Dt ZDB 1M
 .Os
 .Sh NAME
@@ -38,6 +38,10 @@
 .Fl C
 .Op Fl A
 .Op Fl U Ar cache
+.Nm
+.Fl E
+.Op Fl A
+.Ar word0 Ns : Ns Ar word1 Ns :...: Ns Ar word15
 .Nm
 .Fl l
 .Op Fl Aqu
@@ -153,6 +157,10 @@ Display the statistics independently for each deduplication table.
 Dump the contents of the deduplication tables describing duplicate blocks.
 .It Fl DDDDD
 Also dump the contents of the deduplication tables describing unique blocks.
+.It Fl E Ar word0 Ns : Ns Ar word1 Ns :...: Ns Ar word15
+Decode and display block from an embedded block pointer specified by the
+.Ar word
+arguments.
 .It Fl h
 Display pool history similar to
 .Nm zpool Cm history ,

--- a/usr/src/test/util-tests/tests/xargs/xargs_test.ksh
+++ b/usr/src/test/util-tests/tests/xargs/xargs_test.ksh
@@ -13,6 +13,7 @@
 
 #
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
+# Copyright (c) 2017, Joyent, Inc.
 #
 
 XARGS=${XARGS:=/usr/bin/xargs}
@@ -242,6 +243,39 @@ test18() {
 	test_pass $t
 }
 
+test19() {
+	t=test19
+	test_start $t "bad -P option (negative value)"
+	$XARGS -P -3 </dev/null 2>/dev/null
+	if [[ $? -eq 2 ]]; then
+		test_pass $t
+	else
+		test_fail $t
+	fi
+}
+
+test20() {
+	t=test20
+	test_start $t "bad -P option (bad string)"
+	$XARGS -P as3f </dev/null 2>/dev/null
+	if [[ $? -eq 2 ]]; then
+		test_pass $t
+	else
+		test_fail $t
+	fi
+}
+
+test21() {
+	t=test21
+	test_start $t "bad -P option (extraneous characters)"
+	$XARGS -P 2c </dev/null 2>/dev/null
+	if [[ $? -eq 2 ]]; then
+		test_pass $t
+	else
+		test_fail $t
+	fi
+}
+
 test1
 test2
 test3
@@ -260,3 +294,6 @@ test15
 test16
 test17
 test18
+test19
+test20
+test21

--- a/usr/src/tools/scripts/git-pbchk.py
+++ b/usr/src/tools/scripts/git-pbchk.py
@@ -20,6 +20,7 @@
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
 # Copyright (c) 2014, Joyent, Inc.
 # Copyright (c) 2015, 2016 by Delphix. All rights reserved.
+# Copyright 2016 Nexenta Systems, Inc.
 #
 
 import getopt
@@ -121,8 +122,8 @@ def git_parent_branch(branch):
     if not branch:
         return None
 
-    p = git("for-each-ref --format=%(refname:short) %(upstream:short) " +
-            "refs/heads/")
+    p = git(["for-each-ref", "--format=%(refname:short) %(upstream:short)", 
+            "refs/heads/"])
 
     if not p:
         sys.stderr.write("Failed finding git parent branch\n")

--- a/usr/src/tools/scripts/nightly.1onbld
+++ b/usr/src/tools/scripts/nightly.1onbld
@@ -19,7 +19,7 @@
 .\" "Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
 .\" "Copyright 2012 Joshua M. Clulow <josh@sysmgr.org>
 .\" "
-.TH NIGHTLY 1ONBLD "Jan 28, 2014"
+.TH NIGHTLY 1ONBLD "Jul 2, 2017"
 .SH NAME
 .I nightly
 \- build an OS-Net consolidation overnight
@@ -284,18 +284,6 @@ build.  If $MULTI_PROTO is "yes", $ROOT contains the DEBUG build and
 $ROOT-nd contains the non-DEBUG build.
 .RE
 .LP
-.B TOOLS_ROOT
-.RS 5
-Root of the tools proto area for the build.  The makefiles direct
-installation of tools build products to this area.  Unless \fB+t\fR
-is part of $NIGHTLY_OPTIONS, these tools will be used during the
-build.
-.LP
-As built by nightly, this will always contain non-DEBUG objects.
-Therefore, this will always have a -nd suffix, regardless of
-$MULTI_PROTO.
-.RE
-.LP
 .B MACH
 .RS 5
 The instruction set architecture of the build machine as given
@@ -442,16 +430,6 @@ The gate-defined default location of things formerly in /opt; e.g.,
 /ws/onnv-tools.  This is used by nightly, but not the makefiles.
 .RE
 .LP
-.B TEAMWARE
-.RS 5
-The gate-defined default location for the Teamware tools; e.g.,
-/ws/onnv-tools/SUNWspro.  By default, it is derived from
-.BR OPTHOME .
-This is used by nightly, but not the makefiles.  There is no
-corresponding variable for Mercurial or Subversion, which are assumed
-to be installed in the default path.
-.RE
-.LP
 .B ON_CLOSED_BINS
 .RS 5
 OpenSolaris builds do not contain the closed source tree.  Instead,
@@ -468,13 +446,6 @@ Normally, nightly runs the 'checkpaths' script to check for
 discrepancies among the files that list paths to other files, such as
 exception lists and req.flg.  Set this flag to 'n' to disable this
 check, which appears in the nightly output as "Check lists of files."
-.RE
-.LP
-.B CHECK_DMAKE
-.RS 5
-Nightly validates that the version of dmake encountered is known to be
-safe to use.  Set this flag to 'n' to disable this test, allowing any
-version of dmake to be used.
 .RE
 .LP
 .B MULTI_PROTO

--- a/usr/src/uts/common/fs/zfs/blkptr.c
+++ b/usr/src/uts/common/fs/zfs/blkptr.c
@@ -117,3 +117,36 @@ decode_embedded_bp_compressed(const blkptr_t *bp, void *buf)
 		buf8[i] = BF64_GET(w, (i % sizeof (w)) * NBBY, NBBY);
 	}
 }
+
+/*
+ * Fill in the buffer with the (decompressed) payload of the embedded
+ * blkptr_t.  Takes into account compression and byteorder (the payload is
+ * treated as a stream of bytes).
+ * Return 0 on success, or ENOSPC if it won't fit in the buffer.
+ */
+int
+decode_embedded_bp(const blkptr_t *bp, void *buf, int buflen)
+{
+	int lsize, psize;
+
+	ASSERT(BP_IS_EMBEDDED(bp));
+
+	lsize = BPE_GET_LSIZE(bp);
+	psize = BPE_GET_PSIZE(bp);
+
+	if (lsize > buflen)
+		return (ENOSPC);
+	ASSERT3U(lsize, ==, buflen);
+
+	if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_OFF) {
+		uint8_t dstbuf[BPE_PAYLOAD_SIZE];
+		decode_embedded_bp_compressed(bp, dstbuf);
+		VERIFY0(zio_decompress_data_buf(BP_GET_COMPRESS(bp),
+		    dstbuf, buf, psize, buflen));
+	} else {
+		ASSERT3U(lsize, ==, psize);
+		decode_embedded_bp_compressed(bp, buf);
+	}
+
+	return (0);
+}

--- a/usr/src/uts/common/fs/zfs/dbuf.c
+++ b/usr/src/uts/common/fs/zfs/dbuf.c
@@ -1542,11 +1542,6 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	    (dmu_tx_is_syncing(tx) ? DN_DIRTY_SYNC : DN_DIRTY_OPEN));
 
 	ASSERT3U(dn->dn_nlevels, >, db->db_level);
-	ASSERT((dn->dn_phys->dn_nlevels == 0 && db->db_level == 0) ||
-	    dn->dn_phys->dn_nlevels > db->db_level ||
-	    dn->dn_next_nlevels[txgoff] > db->db_level ||
-	    dn->dn_next_nlevels[(tx->tx_txg-1) & TXG_MASK] > db->db_level ||
-	    dn->dn_next_nlevels[(tx->tx_txg-2) & TXG_MASK] > db->db_level);
 
 	/*
 	 * We should only be dirtying in syncing context if it's the
@@ -1662,6 +1657,16 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 		rw_enter(&dn->dn_struct_rwlock, RW_READER);
 		drop_struct_lock = TRUE;
 	}
+
+	/*
+	 * We need to hold the dn_struct_rwlock to make this assertion,
+	 * because it protects dn_phys / dn_next_nlevels from changing.
+	 */
+	ASSERT((dn->dn_phys->dn_nlevels == 0 && db->db_level == 0) ||
+	    dn->dn_phys->dn_nlevels > db->db_level ||
+	    dn->dn_next_nlevels[txgoff] > db->db_level ||
+	    dn->dn_next_nlevels[(tx->tx_txg-1) & TXG_MASK] > db->db_level ||
+	    dn->dn_next_nlevels[(tx->tx_txg-2) & TXG_MASK] > db->db_level);
 
 	/*
 	 * If we are overwriting a dedup BP, then unless it is snapshotted,

--- a/usr/src/uts/common/fs/zfs/sys/blkptr.h
+++ b/usr/src/uts/common/fs/zfs/sys/blkptr.h
@@ -30,6 +30,7 @@ extern "C" {
 void encode_embedded_bp_compressed(blkptr_t *, void *,
     enum zio_compress, int, int);
 void decode_embedded_bp_compressed(const blkptr_t *, void *);
+int decode_embedded_bp(const blkptr_t *, void *, int);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/io/nvme/nvme.c
+++ b/usr/src/uts/common/io/nvme/nvme.c
@@ -2191,6 +2191,7 @@ nvme_init_ns(nvme_t *nvme, int nsid)
 		dev_err(nvme->n_dip, CE_WARN,
 		    "!ignoring namespace %d, unsupported block size %"PRIu64,
 		    nsid, (uint64_t)ns->ns_block_size);
+		ns->ns_ignore = B_TRUE;
 	} else {
 		ns->ns_ignore = B_FALSE;
 	}

--- a/usr/src/uts/common/sys/scsi/scsi_address.h
+++ b/usr/src/uts/common/sys/scsi/scsi_address.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2017, Joyent, Inc.
  */
 
 #ifndef	_SYS_SCSI_SCSI_ADDRESS_H
@@ -171,6 +172,17 @@ char		*scsi_wwn_to_wwnstr(uint64_t wwn,
 void		scsi_wwnstr_hexcase(char *wwnstr, int lower_case);
 const char	*scsi_wwnstr_skip_ua_prefix(const char *wwnstr);
 void		scsi_free_wwnstr(char *wwnstr);
+
+/*
+ * Buffer lengths for SCSI strings. SCSI_WWN_STRLEN is the length of a WWN
+ * that's not in unit-address form. SCSI_WWN_UA_STRLEN includes the
+ * unit-address. SCSI_WWN_BUFLEN provides a buffer that's large enough for all
+ * of these.
+ */
+#define	SCSI_WWN_STRLEN	16
+#define	SCSI_WWN_UA_STRLEN	17
+#define	SCSI_WWN_BUFLEN	SCSI_MAXNAMELEN
+
 #endif	/* _KERNEL */
 
 #ifdef	__cplusplus

--- a/usr/src/uts/i86pc/io/pci/pci_tools.c
+++ b/usr/src/uts/i86pc/io/pci/pci_tools.c
@@ -675,9 +675,9 @@ pcitool_io_access(pcitool_reg_t *prg, boolean_t write_flag)
 	int port = (int)prg->phys_addr;
 	size_t size = PCITOOL_ACC_ATTR_SIZE(prg->acc_attr);
 	boolean_t big_endian = PCITOOL_ACC_IS_BIG_ENDIAN(prg->acc_attr);
-	int rval = SUCCESS;
+	volatile int rval = SUCCESS;
 	on_trap_data_t otd;
-	uint64_t local_data;
+	volatile uint64_t local_data;
 
 
 	/*
@@ -763,9 +763,9 @@ pcitool_mem_access(pcitool_reg_t *prg, uint64_t virt_addr, boolean_t write_flag)
 {
 	size_t size = PCITOOL_ACC_ATTR_SIZE(prg->acc_attr);
 	boolean_t big_endian = PCITOOL_ACC_IS_BIG_ENDIAN(prg->acc_attr);
-	int rval = DDI_SUCCESS;
+	volatile int rval = DDI_SUCCESS;
 	on_trap_data_t otd;
-	uint64_t local_data;
+	volatile uint64_t local_data;
 
 	/*
 	 * on_trap works like setjmp.


### PR DESCRIPTION
Backport candidates:

- 8429 getallifaddrs dereferences invalid pointer causing SIGSEGV

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream-merge-2017071301-31f6ed2876 i86pc i386 i86pc
```

mail_msg:
```
==== Nightly distributed build started:   Thu Jul 13 14:16:00 CEST 2017 ====
==== Nightly distributed build completed: Thu Jul 13 14:58:14 CEST 2017 ====

==== Total build time ====

real    0:42:14

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-8b31933c62 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   76

==== Nightly argument issues ====


==== Build version ====

omnios-upstream-merge-2017071301-31f6ed2876

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:25.6
user  1:08:30.4
sys      5:33.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:43.7
user    46:37.2
sys      4:54.8

==== lint warnings src ====

"/omniosorg/build/bloody/illumos-omnios/usr/src/uts/common/io/iwn/if_iwn.c", line 2052: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
"/omniosorg/build/bloody/illumos-omnios/usr/src/uts/common/os/sysent.c", line 1213: warning: function returns value which is always ignored: yield (E_FUNC_RET_ALWAYS_IGNOR2)

==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```

