### PR TITLE
Joyent upstream/2017071301

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,7 +2,7 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull). LX-for-OmniOS-specific notes follow.
 
-Last illumos-joyent commit:  75647a92265dde475f2caca5f9d959ecf9f8b633
+Last illumos-joyent commit:  a752e24f3ca79ca5b9a9c035721c4cbfd7c8576f
 
 LX zones can be installed using ZFS send streams (gzipped or uncompressed) from
 Joyent's images (-s /full/path/to/file), from ZFS datasets or snapshots

--- a/usr/src/lib/brand/lx/lx_brand/common/mount.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/mount.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <assert.h>
@@ -405,7 +405,7 @@ lx_mount(uintptr_t p1, uintptr_t p2, uintptr_t p3, uintptr_t p4,
 	lx_debug("\tlinux mount fstype: %s", fstype);
 
 	/* The in-kernel mount code should only call us for an NFS mount. */
-	assert(strcmp(fstype, "nfs") == 0);
+	assert(strcmp(fstype, "nfs") == 0 || strcmp(fstype, "nfs4") == 0);
 
 	/*
 	 * While SunOS is picky about mount(2) target paths being absolute,

--- a/usr/src/lib/brand/lx/lx_brand/common/mount_nfs.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/mount_nfs.c
@@ -1364,7 +1364,6 @@ convert_nfs_arg_str(char *srcp, char *mntopts, nfs_mnt_data_t *nmdp)
 	return (0);
 }
 
-/* ARGSUSED2 */
 int
 lx_nfs_mount(char *srcp, char *mntp, char *fst, int lx_flags, char *opts)
 {
@@ -1390,6 +1389,9 @@ lx_nfs_mount(char *srcp, char *mntp, char *fst, int lx_flags, char *opts)
 	if ((r = convert_nfs_arg_str(srcp, opts, nmdp)) < 0) {
 		return (r);
 	}
+
+	if (strcmp(fst, "nfs4") == 0)
+		nmdp->nmd_nfsvers = NFS_V4;
 
 	/* Linux seems to always allow overlay mounts */
 	il_flags |= MS_OVERLAY;
@@ -1443,7 +1445,7 @@ lx_nfs_mount(char *srcp, char *mntp, char *fst, int lx_flags, char *opts)
 	if ((r = set_args(&il_flags, argp, host, opts, nmdp)) != 0)
 		goto out;
 
-	if (nmdp->nmd_nfsvers == 4) {
+	if (nmdp->nmd_nfsvers == NFS_V4) {
 		/*
 		 * In the case of version 4 there is no MOUNT program, thus no
 		 * need for an RPC to get a file handle.

--- a/usr/src/uts/common/brand/lx/os/lx_acct.c
+++ b/usr/src/uts/common/brand/lx/os/lx_acct.c
@@ -1,0 +1,198 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Joyent, Inc.
+ */
+
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/systm.h>
+#include <sys/acct.h>
+#include <sys/proc.h>
+#include <sys/user.h>
+#include <sys/cred.h>
+#include <sys/file.h>
+#include <sys/vnode.h>
+#include <sys/session.h>
+#include <sys/wait.h>
+#include <sys/ddi.h>
+#include <sys/zone.h>
+#include <sys/lx_types.h>
+
+/*
+ * Based on the Linux acct(5) man page, their comp_t definition is the same
+ * as ours. lxac_etime is encoded as a float for v3 accounting records.
+ */
+
+#define	LX_ACCT_VERSION	3
+
+/*
+ * Bit flags in lxac_flag. The Linux AFORK and ASU match native. The rest of
+ * the flags diverge.
+ */
+#define	LX_AFORK	0x01	/* executed fork, but no exec */
+#define	LX_ASU		0x02	/* used superuser privileges */
+#define	LX_ACORE	0x08	/* dumped core */
+#define	LX_AXSIG	0x10	/* killed by a signal */
+
+typedef struct lx_acct {
+	char		lxac_flag;
+	char		lxac_version;
+	uint16_t	lxac_tty;
+	uint32_t	lxac_exitcode;
+	uint32_t	lxac_uid;
+	uint32_t	lxac_gid;
+	uint32_t	lxac_pid;
+	uint32_t	lxac_ppid;
+	uint32_t	lxac_btime;	/* seconds since the epoch */
+	uint32_t	lxac_etime;	/* float representation of ticks */
+	comp_t		lxac_utime;
+	comp_t		lxac_stime;
+	comp_t		lxac_mem;	/* kb */
+	comp_t		lxac_io;	/* unused */
+	comp_t		lxac_rw;	/* unused */
+	comp_t		lxac_minflt;
+	comp_t		lxac_majflt;
+	comp_t		lxac_swaps;	/* unused */
+	char		lxac_comm[16];
+} lx_acct_t;
+
+/*
+ * Same functionality as acct_compress(). Produce a pseudo-floating point
+ * representation with 3 bits base-8 exponent, 13 bits fraction.
+ */
+static comp_t
+lx_acct_compt(ulong_t t)
+{
+	int exp = 0, round = 0;
+
+	while (t >= 8192) {
+		exp++;
+		round = t & 04;
+		t >>= 3;
+	}
+	if (round) {
+		t++;
+		if (t >= 8192) {
+			t >>= 3;
+			exp++;
+		}
+	}
+#ifdef _LP64
+	if (exp > 7) {
+		/* prevent wraparound */
+		t = 8191;
+		exp = 7;
+	}
+#endif
+	return ((exp << 13) + t);
+}
+
+/*
+ * 32-bit IEEE float encoding as-per Linux.
+ */
+static uint32_t
+lx_acct_float(int64_t t)
+{
+	uint32_t val, exp = 190;
+
+	if (t == 0)
+		return (0);
+
+	while (t > 0) {
+		t <<= 1;
+		exp--;
+	}
+	val = (uint32_t)(t >> 40) & 0x7fffffu;
+
+	return (val | (exp << 23));
+}
+
+/*
+ * Write a Linux-formatted record to the accounting file.
+ */
+void
+lx_acct_out(vnode_t *vp, int exit_status)
+{
+	struct proc *p;
+	user_t *ua;
+	struct cred *cr;
+	dev_t d;
+	pid_t pid, ppid;
+	struct vattr va;
+	ssize_t resid = 0;
+	int err;
+	lx_acct_t a;
+
+	p = curproc;
+	ua = PTOU(p);
+	cr = CRED();
+
+	bzero(&a, sizeof (a));
+
+	a.lxac_flag = ua->u_acflag & (LX_AFORK | LX_ASU);
+	a.lxac_version = LX_ACCT_VERSION;
+	d = cttydev(p);
+	a.lxac_tty = LX_MAKEDEVICE(getmajor(d), getminor(d));
+	if (WIFEXITED(exit_status)) {
+		a.lxac_exitcode = WEXITSTATUS(exit_status);
+	} else if (WIFSIGNALED(exit_status)) {
+		a.lxac_flag |= LX_AXSIG;
+		if (WCOREDUMP(exit_status)) {
+			a.lxac_flag |= LX_ACORE;
+		}
+	}
+	a.lxac_uid = crgetruid(cr);
+	a.lxac_gid = crgetrgid(cr);
+	pid = p->p_pid;
+	ppid = p->p_ppid;
+	/* Perform pid translation ala lxpr_fixpid(). */
+	if (pid == curzone->zone_proc_initpid) {
+		pid = 1;
+		ppid = 0;
+	} else {
+		if (ppid == curzone->zone_proc_initpid) {
+			ppid = 1;
+		} else if (ppid == curzone->zone_zsched->p_pid ||
+		    (p->p_flag & SZONETOP) != 0) {
+			ppid = 1;
+		}
+	}
+	a.lxac_pid = pid;
+	a.lxac_ppid = ppid;
+	a.lxac_btime = ua->u_start.tv_sec;
+	/* For Linux v3 accounting record, this is an encoded float. */
+	a.lxac_etime = lx_acct_float(ddi_get_lbolt() - ua->u_ticks);
+	a.lxac_utime = lx_acct_compt(NSEC_TO_TICK(p->p_acct[LMS_USER]));
+	a.lxac_stime = lx_acct_compt(
+	    NSEC_TO_TICK(p->p_acct[LMS_SYSTEM] + p->p_acct[LMS_TRAP]));
+	a.lxac_mem = lx_acct_compt((ulong_t)(ptob(ua->u_mem) / 1024));
+	/* a.lxac_io		unused */
+	/* a.lxac_rw		unused */
+	a.lxac_minflt = lx_acct_compt((ulong_t)p->p_ru.minflt);
+	a.lxac_majflt = lx_acct_compt((ulong_t)p->p_ru.majflt);
+	/* a.lxac_swaps		unused */
+	bcopy(ua->u_comm, a.lxac_comm, sizeof (a.lxac_comm));
+
+	/*
+	 * As with the native acct() handling, we save the size so that if the
+	 * write fails, we can reset the size to avoid corrupting the accounting
+	 * file.
+	 */
+	va.va_mask = AT_SIZE;
+	if (VOP_GETATTR(vp, &va, 0, kcred, NULL) == 0) {
+		err = vn_rdwr(UIO_WRITE, vp, (caddr_t)&a, sizeof (a), 0LL,
+		    UIO_SYSSPACE, FAPPEND, (rlim64_t)MAXOFF_T, kcred, &resid);
+		if (err != 0 || resid != 0)
+			(void) VOP_SETATTR(vp, &va, 0, kcred, NULL);
+	}
+}

--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -307,7 +307,8 @@ struct brand_ops lx_brops = {
 #endif
 	B_FALSE,			/* b_intp_parse_arg */
 	lx_clearbrand,			/* b_clearbrand */
-	lx_upcall_statd			/* b_rpc_statd */
+	lx_upcall_statd,		/* b_rpc_statd */
+	lx_acct_out			/* b_acct_out */
 };
 
 struct brand_mach_ops lx_mops = {

--- a/usr/src/uts/common/brand/lx/os/lx_syscall.c
+++ b/usr/src/uts/common/brand/lx/os/lx_syscall.c
@@ -570,7 +570,7 @@ lx_sysent_t lx_sysent32[] = {
 	{"signal",	NULL,			0,		2}, /* 48 */
 	{"geteuid16",	lx_geteuid16,		0,		0}, /* 49 */
 	{"getegid16",	lx_getegid16,		0,		0}, /* 50 */
-	{"acct",	NULL,			NOSYS_NO_EQUIV,	0}, /* 51 */
+	{"acct",	lx_acct,		0,		1}, /* 51 */
 	{"umount2",	lx_umount2,		0,		2}, /* 52 */
 	{"lock",	NULL,			NOSYS_OBSOLETE,	0}, /* 53 */
 	{"ioctl",	lx_ioctl,		0,		3}, /* 54 */
@@ -1053,7 +1053,7 @@ lx_sysent_t lx_sysent64[] = {
 	{"setrlimit",	lx_setrlimit,		0,		2}, /* 160 */
 	{"chroot",	lx_chroot,		0,		1}, /* 161 */
 	{"sync",	lx_sync,		0,		0}, /* 162 */
-	{"acct",	NULL,			NOSYS_NO_EQUIV,	0}, /* 163 */
+	{"acct",	lx_acct,		0,		1}, /* 163 */
 	{"settimeofday", NULL,			0,		2}, /* 164 */
 	{"mount",	lx_mount,		0,		5}, /* 165 */
 	{"umount2",	lx_umount2,		0,		2}, /* 166 */

--- a/usr/src/uts/common/brand/lx/sys/lx_brand.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_brand.h
@@ -710,6 +710,7 @@ extern int lx_lpid_lock(pid_t, zone_t *, lx_pid_flag_t, proc_t **,
 extern pid_t lx_lwp_ppid(klwp_t *, pid_t *, id_t *);
 extern void lx_pid_init(void);
 extern void lx_pid_fini(void);
+extern void lx_acct_out(vnode_t *, int);
 
 extern uint_t lx_pipe_max_limit;
 extern uint_t lx_pipe_max_default;

--- a/usr/src/uts/common/brand/lx/sys/lx_syscalls.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_syscalls.h
@@ -37,6 +37,7 @@ extern "C" {
 extern long lx_accept();
 extern long lx_accept4();
 extern long lx_access();
+extern long lx_acct();
 extern long lx_alarm();
 extern long lx_arch_prctl();
 extern long lx_bind();

--- a/usr/src/uts/common/brand/lx/syscall/lx_lseek.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_lseek.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -46,6 +46,7 @@ long
 lx_lseek32(int fd, off32_t offset, int whence)
 {
 	offset_t res;
+	const uint32_t hival = (offset < 0) ? (uint32_t)-1 : 0;
 
 	/*
 	 * When returning EOVERFLOW for an offset which is outside the bounds
@@ -57,7 +58,7 @@ lx_lseek32(int fd, off32_t offset, int whence)
 	 * successful seek.
 	 */
 	ASSERT(get_udatamodel() == DATAMODEL_ILP32);
-	res = llseek32(fd, (uint32_t)offset, 0, whence);
+	res = llseek32(fd, (uint32_t)offset, hival, whence);
 	if (ttolwp(curthread)->lwp_errno == 0 && res > MAXOFF32_T) {
 		return (set_errno(EOVERFLOW));
 	}

--- a/usr/src/uts/common/brand/lx/syscall/lx_miscsys.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_miscsys.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/systeminfo.h>
@@ -75,6 +75,8 @@ extern int chdir_proc(proc_t *, vnode_t *, boolean_t, boolean_t);
 extern int lookupname(char *, enum uio_seg, int, vnode_t **, vnode_t **);
 /* From uts/common/fs/fs_subr.c */
 extern int fs_need_estale_retry(int);
+/* From uts/common/os/acct.c */
+extern int sysacct(char *);
 
 /* The callback arguments when handling a FS clone group. */
 typedef struct {
@@ -410,4 +412,10 @@ lx_vhangup(void)
 	 * already checked that our process is root, just succeed.
 	 */
 	return (0);
+}
+
+long
+lx_acct(char *p)
+{
+	return (sysacct(p));
 }

--- a/usr/src/uts/common/brand/lx/syscall/lx_mount.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_mount.c
@@ -415,7 +415,7 @@ lx_mount(const char *sourcep, const char *targetp, const char *fstypep,
 	/*
 	 * Vector back out to userland emulation for NFS.
 	 */
-	if (strcmp(fstype, "nfs") == 0) {
+	if (strcmp(fstype, "nfs") == 0 || strcmp(fstype, "nfs4") == 0) {
 		uintptr_t uargs[5] = {(uintptr_t)sourcep, (uintptr_t)targetp,
 		    (uintptr_t)fstypep, (uintptr_t)flags, (uintptr_t)datap};
 

--- a/usr/src/uts/common/brand/sn1/sn1_brand.c
+++ b/usr/src/uts/common/brand/sn1/sn1_brand.c
@@ -104,7 +104,8 @@ struct brand_ops sn1_brops = {
 	NULL,				/* b_pagefault */
 	B_TRUE,				/* b_intp_parse_arg */
 	NULL,				/* b_clearbrand */
-	NULL				/* b_rpc_statd */
+	NULL,				/* b_rpc_statd */
+	NULL				/* b_acct_out */
 };
 
 #ifdef	sparc

--- a/usr/src/uts/common/brand/solaris10/s10_brand.c
+++ b/usr/src/uts/common/brand/solaris10/s10_brand.c
@@ -109,7 +109,8 @@ struct brand_ops s10_brops = {
 	NULL,				/* b_pagefault */
 	B_TRUE,				/* b_intp_parse_arg */
 	NULL,				/* b_clearbrand */
-	NULL				/* b_rpc_statd */
+	NULL,				/* b_rpc_statd */
+	NULL				/* b_acct_out */
 };
 
 #ifdef	sparc

--- a/usr/src/uts/common/os/exit.c
+++ b/usr/src/uts/common/os/exit.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2014 Joyent, Inc. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -601,7 +601,7 @@ proc_exit(int why, int what)
 		semexit(p);
 	rv = wstat(why, what);
 
-	acct(rv & 0xff);
+	acct(rv);
 	exacct_commit_proc(p, rv);
 
 	/*

--- a/usr/src/uts/common/sys/acct.h
+++ b/usr/src/uts/common/sys/acct.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2014 Garrett D'Amore <garrett@damore.org>
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -88,7 +89,7 @@ extern int acct(const char *);
 
 #if defined(_KERNEL)
 
-void	acct(char);
+void	acct(int);
 int	sysacct(char *);
 
 struct vnode;

--- a/usr/src/uts/common/sys/brand.h
+++ b/usr/src/uts/common/sys/brand.h
@@ -151,6 +151,7 @@ struct execa;
  * b_intp_parse_arg - Controls interpreter argument handling (allow 1 or all)
  * b_clearbrand - Perform any actions necessary when clearing the brand.
  * b_rpc_statd - Upcall to rpc.statd running within the zone
+ * b_acct_out - Output properly formatted accounting record
  */
 struct brand_ops {
 	void	(*b_init_brand_data)(zone_t *, kmutex_t *);
@@ -202,6 +203,7 @@ struct brand_ops {
 	boolean_t b_intp_parse_arg;
 	void	(*b_clearbrand)(proc_t *, boolean_t);
 	void	(*b_rpc_statd)(int, void *, void *);
+	void	(*b_acct_out)(struct vnode *, int);
 };
 
 /*

--- a/usr/src/uts/intel/Makefile.files
+++ b/usr/src/uts/intel/Makefile.files
@@ -300,6 +300,7 @@ SN1_BRAND_OBJS	=	sn1_brand.o sn1_brand_asm.o
 S10_BRAND_OBJS	=	s10_brand.o s10_brand_asm.o
 LX_BRAND_OBJS  =		\
 	lx_access.o		\
+	lx_acct.o		\
 	lx_acl.o		\
 	lx_aio.o		\
 	lx_archdep.o		\

--- a/usr/src/uts/intel/lx_brand/Makefile
+++ b/usr/src/uts/intel/lx_brand/Makefile
@@ -69,7 +69,7 @@ AS_INC_PATH	+= -I$(UTSBASE)/i86pc/genassym/$(OBJS_DIR)
 CFLAGS		+= $(CCVERBOSE)
 
 LDFLAGS		+= -dy -Nexec/elfexec -Nfs/fifofs -Nfs/sockfs -Ndrv/ip \
-		    -Nfs/zfs -Nmisc/klmmod
+		    -Nfs/zfs -Nmisc/klmmod -Nsys/sysacct
 
 #
 # For now, disable these lint checks; maintainers should endeavor


### PR DESCRIPTION
This PR merges latest lx-related changes from Joyent and an updated last commit in `README.OmniOS`

I suggest backporting:
- OS-6222 lxbrand lseek32 mishandles negative offsets

Possible other backport candidates (open for discussion):
- ~~OS-6223 lxbrand aio failures under ltp~~
- OS-5028 mount -t nfs4 not working

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent-upstream-2017071301-8d6929d204 i86pc i386 i86pc
hadfl@mars:~$ zoneadm list -v
  ID NAME             STATUS     PATH                           BRAND    IP
   0 global           running    /                              ipkg     shared
   1 ubuntu-16        running    /zones/ubuntu-16               lx       excl
```

mail_msg:
```
==== Nightly distributed build started:   Thu Jul 13 20:20:46 CEST 2017 ====
==== Nightly distributed build completed: Thu Jul 13 21:04:10 CEST 2017 ====

==== Total build time ====

real    0:43:24

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-8b31933c62 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-upstream-2017071301-8d6929d204

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:58.5
user  1:11:46.3
sys      5:42.8

==== Build noise differences (DEBUG) ====

83,84c83,84
< maximum offset: 1d50
< maximum offset: 23ac
---
> maximum offset: 1d51
> maximum offset: 23ad

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:15.8
user    47:52.5
sys      5:07.9

==== lint warnings src ====

"../../common/os/acct.c", line 438: warning: assignment causes implicit narrowing conversion (E_ASSIGN_NARROW_CONV)
"/omniosorg/build/bloody/illumos-omnios/usr/src/uts/common/io/iwn/if_iwn.c", line 2052: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
"/omniosorg/build/bloody/illumos-omnios/usr/src/uts/common/os/sysent.c", line 1213: warning: function returns value which is always ignored: yield (E_FUNC_RET_ALWAYS_IGNOR2)

==== lint noise differences src ====

0a1
> "../../common/os/acct.c", line 438: warning: assignment causes implicit narrowing conversion (E_ASSIGN_NARROW_CONV)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```