### PR TITLE
r151022 backport/2017071401

### DIFF
--- a/usr/src/lib/brand/lx/lx_brand/common/mount.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/mount.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <assert.h>
@@ -405,7 +405,7 @@ lx_mount(uintptr_t p1, uintptr_t p2, uintptr_t p3, uintptr_t p4,
 	lx_debug("\tlinux mount fstype: %s", fstype);
 
 	/* The in-kernel mount code should only call us for an NFS mount. */
-	assert(strcmp(fstype, "nfs") == 0);
+	assert(strcmp(fstype, "nfs") == 0 || strcmp(fstype, "nfs4") == 0);
 
 	/*
 	 * While SunOS is picky about mount(2) target paths being absolute,

--- a/usr/src/lib/brand/lx/lx_brand/common/mount_nfs.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/mount_nfs.c
@@ -1364,7 +1364,6 @@ convert_nfs_arg_str(char *srcp, char *mntopts, nfs_mnt_data_t *nmdp)
 	return (0);
 }
 
-/* ARGSUSED2 */
 int
 lx_nfs_mount(char *srcp, char *mntp, char *fst, int lx_flags, char *opts)
 {
@@ -1390,6 +1389,9 @@ lx_nfs_mount(char *srcp, char *mntp, char *fst, int lx_flags, char *opts)
 	if ((r = convert_nfs_arg_str(srcp, opts, nmdp)) < 0) {
 		return (r);
 	}
+
+	if (strcmp(fst, "nfs4") == 0)
+		nmdp->nmd_nfsvers = NFS_V4;
 
 	/* Linux seems to always allow overlay mounts */
 	il_flags |= MS_OVERLAY;
@@ -1443,7 +1445,7 @@ lx_nfs_mount(char *srcp, char *mntp, char *fst, int lx_flags, char *opts)
 	if ((r = set_args(&il_flags, argp, host, opts, nmdp)) != 0)
 		goto out;
 
-	if (nmdp->nmd_nfsvers == 4) {
+	if (nmdp->nmd_nfsvers == NFS_V4) {
 		/*
 		 * In the case of version 4 there is no MOUNT program, thus no
 		 * need for an RPC to get a file handle.

--- a/usr/src/lib/libsocket/inet/getifaddrs.c
+++ b/usr/src/lib/libsocket/inet/getifaddrs.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 RackTop Systems.
  */
 
 #include <netdb.h>
@@ -102,6 +103,14 @@ getallifaddrs(sa_family_t af, struct ifaddrs **ifap, int64_t flags)
 	int sock6;
 	int err;
 
+	/*
+	 * Initialize ifap to NULL so we can safely call freeifaddrs
+	 * on it in case of error.
+	 */
+	if (ifap == NULL)
+		return (EINVAL);
+	*ifap = NULL;
+
 	if ((sock4 = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
 		return (-1);
 	if ((sock6 = socket(AF_INET6, SOCK_DGRAM, 0)) < 0) {
@@ -123,7 +132,6 @@ retry:
 	 */
 	prev = NULL;
 	lifrp = buf;
-	*ifap = NULL;
 	for (n = 0; n < numifs; n++, lifrp++) {
 
 		/* Prepare for the ioctl call */

--- a/usr/src/uts/common/brand/lx/syscall/lx_lseek.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_lseek.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -46,6 +46,7 @@ long
 lx_lseek32(int fd, off32_t offset, int whence)
 {
 	offset_t res;
+	const uint32_t hival = (offset < 0) ? (uint32_t)-1 : 0;
 
 	/*
 	 * When returning EOVERFLOW for an offset which is outside the bounds
@@ -57,7 +58,7 @@ lx_lseek32(int fd, off32_t offset, int whence)
 	 * successful seek.
 	 */
 	ASSERT(get_udatamodel() == DATAMODEL_ILP32);
-	res = llseek32(fd, (uint32_t)offset, 0, whence);
+	res = llseek32(fd, (uint32_t)offset, hival, whence);
 	if (ttolwp(curthread)->lwp_errno == 0 && res > MAXOFF32_T) {
 		return (set_errno(EOVERFLOW));
 	}

--- a/usr/src/uts/common/brand/lx/syscall/lx_mount.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_mount.c
@@ -415,7 +415,7 @@ lx_mount(const char *sourcep, const char *targetp, const char *fstypep,
 	/*
 	 * Vector back out to userland emulation for NFS.
 	 */
-	if (strcmp(fstype, "nfs") == 0) {
+	if (strcmp(fstype, "nfs") == 0 || strcmp(fstype, "nfs4") == 0) {
 		uintptr_t uargs[5] = {(uintptr_t)sourcep, (uintptr_t)targetp,
 		    (uintptr_t)fstypep, (uintptr_t)flags, (uintptr_t)datap};
 


### PR DESCRIPTION
reference upstream PR: https://github.com/omniosorg/illumos-omnios/pull/12 https://github.com/omniosorg/illumos-omnios/pull/14

```
hadfl@mars-stable:~$ uname -a
SunOS mars-stable 5.11 omnios-r151022-backport-2017071401-57b4c3978e i86pc i386 i86pc
```

mail_msg:
```
==== Nightly distributed build started:   Fri Jul 14 14:38:11 CEST 2017 ====
==== Nightly distributed build completed: Fri Jul 14 15:19:34 CEST 2017 ====

==== Total build time ====

real    0:41:22

==== Build environment ====

/usr/bin/uname
SunOS mars-stable 5.11 omnios-r151022-f9693432c2 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   90

==== Nightly argument issues ====


==== Build version ====

omnios-r151022-backport-2017071401-57b4c3978e

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:47.2
user  1:07:02.4
sys      4:59.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:38.7
user    46:21.6
sys      4:50.7

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```