### PR TITLE
Revert "8437 dlmgmt_setzoneid() doesn't enforce uniqueness"

### DIFF
--- a/usr/src/cmd/dlmgmtd/dlmgmt_door.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_door.c
@@ -21,7 +21,6 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -1259,7 +1258,8 @@ dlmgmt_setzoneid(void *argp, void *retp, size_t *sz, zoneid_t zoneid,
 	 * Before we remove the link from its current zone, make sure that
 	 * there isn't a link with the same name in the destination zone.
 	 */
-	if (link_by_name(linkp->ll_link, newzoneid) != NULL) {
+	if (zoneid != GLOBAL_ZONEID &&
+	    link_by_name(linkp->ll_link, newzoneid) != NULL) {
 		err = EEXIST;
 		goto done;
 	}


### PR DESCRIPTION
This reverts commit b2519362c825a494fb6e93549e2e32a425011563.

cf. #18 

Requires more investigation.