### PR TITLE
Joyent merge/2017072701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,7 +2,7 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull). LX-for-OmniOS-specific notes follow.
 
-Last illumos-joyent commit:  2bcd0c2213ad2567e05837f2b5406447e005a44b
+Last illumos-joyent commit:  ad734d51547cf4bbcdc0baaef0bf8e9297afabb4
 
 LX zones can be installed using ZFS send streams (gzipped or uncompressed) from
 Joyent's images (-s /full/path/to/file), from ZFS datasets or snapshots

--- a/usr/src/lib/brand/lx/lx_brand/common/sysv_ipc.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/sysv_ipc.c
@@ -579,7 +579,7 @@ lx_msgctl_ipcinfo(int cmd, void *buf)
 	 * in the Linux header file.  We're lying, but trying to be
 	 * coherent about it.
 	 */
-	m.msgmax = m.msgmnb;
+	m.msgmax = LX_MSGMAX;
 	m.msgssz = 16;
 	msgseg = (m.msgpool * 1024) / m.msgssz;
 	m.msgseg = (msgseg > 0xffff) ? 0xffff : msgseg;

--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -216,6 +216,8 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_KERNEL_CAPLCAP,	/* /proc/sys/kernel/cap_last_cap */
 	LXPR_SYS_KERNEL_COREPATT,	/* /proc/sys/kernel/core_pattern */
 	LXPR_SYS_KERNEL_HOSTNAME,	/* /proc/sys/kernel/hostname */
+	LXPR_SYS_KERNEL_MSGMAX,	/* /proc/sys/kernel/msgmax */
+	LXPR_SYS_KERNEL_MSGMNB,	/* /proc/sys/kernel/msgmnb */
 	LXPR_SYS_KERNEL_MSGMNI,	/* /proc/sys/kernel/msgmni */
 	LXPR_SYS_KERNEL_NGROUPS_MAX,	/* /proc/sys/kernel/ngroups_max */
 	LXPR_SYS_KERNEL_OSREL,	/* /proc/sys/kernel/osrelease */

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -235,6 +235,8 @@ static void lxpr_read_sys_fs_pipe_max(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_caplcap(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_corepatt(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_hostname(lxpr_node_t *, lxpr_uiobuf_t *);
+static void lxpr_read_sys_kernel_msgmax(lxpr_node_t *, lxpr_uiobuf_t *);
+static void lxpr_read_sys_kernel_msgmnb(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_msgmni(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_ngroups_max(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_osrel(lxpr_node_t *, lxpr_uiobuf_t *);
@@ -299,6 +301,7 @@ static int lxpr_write_sys_kernel_corepatt(lxpr_node_t *, uio_t *, cred_t *,
 extern rctl_hndl_t rc_process_semmsl;
 extern rctl_hndl_t rc_process_semopm;
 extern rctl_hndl_t rc_zone_semmni;
+extern rctl_hndl_t rc_process_msgmnb;
 
 extern rctl_hndl_t rc_zone_msgmni;
 extern rctl_hndl_t rc_zone_shmmax;
@@ -544,6 +547,8 @@ static lxpr_dirent_t sys_kerneldir[] = {
 	{ LXPR_SYS_KERNEL_CAPLCAP,	"cap_last_cap" },
 	{ LXPR_SYS_KERNEL_COREPATT,	"core_pattern" },
 	{ LXPR_SYS_KERNEL_HOSTNAME,	"hostname" },
+	{ LXPR_SYS_KERNEL_MSGMAX,	"msgmax" },
+	{ LXPR_SYS_KERNEL_MSGMNB,	"msgmnb" },
 	{ LXPR_SYS_KERNEL_MSGMNI,	"msgmni" },
 	{ LXPR_SYS_KERNEL_NGROUPS_MAX,	"ngroups_max" },
 	{ LXPR_SYS_KERNEL_OSREL,	"osrelease" },
@@ -869,6 +874,8 @@ static void (*lxpr_read_function[LXPR_NFILES])() = {
 	lxpr_read_sys_kernel_caplcap,	/* /proc/sys/kernel/cap_last_cap */
 	lxpr_read_sys_kernel_corepatt,	/* /proc/sys/kernel/core_pattern */
 	lxpr_read_sys_kernel_hostname,	/* /proc/sys/kernel/hostname */
+	lxpr_read_sys_kernel_msgmax,	/* /proc/sys/kernel/msgmax */
+	lxpr_read_sys_kernel_msgmnb,	/* /proc/sys/kernel/msgmnb */
 	lxpr_read_sys_kernel_msgmni,	/* /proc/sys/kernel/msgmni */
 	lxpr_read_sys_kernel_ngroups_max, /* /proc/sys/kernel/ngroups_max */
 	lxpr_read_sys_kernel_osrel,	/* /proc/sys/kernel/osrelease */
@@ -1018,6 +1025,8 @@ static vnode_t *(*lxpr_lookup_function[LXPR_NFILES])() = {
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/cap_last_cap */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/core_pattern */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/hostname */
+	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/msgmax */
+	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/msgmnb */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/msgmni */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/ngroups_max */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/osrelease */
@@ -1167,6 +1176,8 @@ static int (*lxpr_readdir_function[LXPR_NFILES])() = {
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/cap_last_cap */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/core_pattern */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/hostname */
+	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/msgmax */
+	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/msgmnb */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/msgmni */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/ngroups_max */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/osrelease */
@@ -4540,6 +4551,39 @@ lxpr_read_sys_kernel_hostname(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 {
 	ASSERT(lxpnp->lxpr_type == LXPR_SYS_KERNEL_HOSTNAME);
 	lxpr_uiobuf_printf(uiobuf, "%s\n", uts_nodename());
+}
+
+/* ARGSUSED */
+static void
+lxpr_read_sys_kernel_msgmax(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	/*
+	 * We don't have an rctl for this. See our definition for LX_MSGMAX
+	 * in the user-level emulation library. Once that code moves into
+	 * the kernel, we can use a common definition. This matches the
+	 * value on Linux.
+	 */
+	uint_t val = 8192;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_KERNEL_MSGMAX);
+
+	lxpr_uiobuf_printf(uiobuf, "%u\n", val);
+}
+
+/* ARGSUSED */
+static void
+lxpr_read_sys_kernel_msgmnb(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	rctl_qty_t val;
+	proc_t *pp = curproc;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_KERNEL_MSGMNB);
+
+	mutex_enter(&pp->p_lock);
+	val = rctl_enforced_value(rc_process_msgmnb, pp->p_rctls, pp);
+	mutex_exit(&pp->p_lock);
+
+	lxpr_uiobuf_printf(uiobuf, "%u\n", (uint_t)val);
 }
 
 /* ARGSUSED */


### PR DESCRIPTION
Upstream merge from Joyent. No backport candidates here.

mail_msg:

```

==== Nightly distributed build started:   Thu Jul 27 22:11:24 UTC 2017 ====
==== Nightly distributed build completed: Thu Jul 27 23:12:12 UTC 2017 ====

==== Total build time ====

real    1:00:48

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-5e982daae6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   151646

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-merge-2017072701-1479b728af

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:45.0
user  1:32:13.7
sys     11:04.5

==== Build noise differences (non-DEBUG) ====

83,84c83,84
< maximum offset: 1d0d
< maximum offset: 2369
---
> maximum offset: 1d0b
> maximum offset: 2367

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:19.5
user  1:22:19.8
sys      7:49.4

==== Build noise differences (DEBUG) ====

48,49c48,49
< maximum offset: 1d4c
< maximum offset: 23a8
---
> maximum offset: 1d4a
> maximum offset: 23a6

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:14.6
user  1:07:06.2
sys     19:34.6

==== lint warnings src ====

"../../common/os/acct.c", line 438: warning: assignment causes implicit narrowing conversion (E_ASSIGN_NARROW_CONV)
"/data/omnios-build/omniosorg/omnios.bloody/usr/src/uts/common/io/iwn/if_iwn.c", line 2052: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/omnios.bloody/usr/src/uts/common/os/sysent.c", line 1213: warning: function returns value which is always ignored: yield (E_FUNC_RET_ALWAYS_IGNOR2)

==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```