### PR TITLE
Fix lint warnings

### DIFF
--- a/usr/src/uts/common/brand/lx/syscall/lx_sched.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_sched.c
@@ -132,9 +132,7 @@ typedef struct lx_sched_attr {
 long
 lx_sched_yield(void)
 {
-	yield();
-
-	return (0);
+	return (yield());
 }
 
 static void

--- a/usr/src/uts/common/os/acct.c
+++ b/usr/src/uts/common/os/acct.c
@@ -412,13 +412,6 @@ acct(int st)
 		return;
 	}
 
-	/*
-	 * The 'st' status value was traditionally masked this way by our
-	 * caller, but we now accept the unmasked value for brand handling.
-	 * Zones not using the brand hook mask the status here.
-	 */
-	st &= 0xff;
-
 	p = curproc;
 	ua = PTOU(p);
 	bcopy(ua->u_comm, ag->acctbuf.ac_comm, sizeof (ag->acctbuf.ac_comm));
@@ -435,7 +428,12 @@ acct(int st)
 	ag->acctbuf.ac_uid = crgetruid(cr);
 	ag->acctbuf.ac_gid = crgetrgid(cr);
 	(void) cmpldev(&ag->acctbuf.ac_tty, cttydev(p));
-	ag->acctbuf.ac_stat = st;
+	/*
+	 * The 'st' status value was traditionally masked this way by our
+	 * caller, but we now accept the unmasked value for brand handling.
+	 * Zones not using the brand hook mask the status here.
+	 */
+	ag->acctbuf.ac_stat = (char)(st & 0xff);
 	ag->acctbuf.ac_flag = (ua->u_acflag | AEXPND);
 
 	/*

--- a/usr/src/uts/intel/Makefile
+++ b/usr/src/uts/intel/Makefile
@@ -144,7 +144,7 @@ install_h check:	FRC
 #
 # Work-around to disable acpica global crosscheck lint warnings
 #
-LGREP.intel =	grep -v 'intel/io/acpica'
+LGREP.intel =	egrep -v 'intel/io/acpica|iwn/if_iwn.c.*E_FUNC_RET_MAYBE_IGNORED2'
 
 #
 #	Full kernel lint target.


### PR DESCRIPTION
This commit fixes/suppresses the lint warnings in the bloody build, see https://github.com/omniosorg/illumos-omnios/issues/20

Grepping out the specific warning for `iwn/if_iwn.c.*E_FUNC_RET_MAYBE_IGNORED2` isn't ideal but I can't find any other way to avoid this other than to pepper the code with (void) casts which would complicate keeping up-to-date with upstream. Any other suggestions for this one would be appreciated!

This gets us back to a build that succeeds cleanly.