### PR TITLE
Joyent merge/2017080301

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,7 +2,7 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull). LX-for-OmniOS-specific notes follow.
 
-Last illumos-joyent commit:  ad734d51547cf4bbcdc0baaef0bf8e9297afabb4
+Last illumos-joyent commit:  70fe2b10487a1b0dfe11ed0378b4f835ff133884
 
 LX zones can be installed using ZFS send streams (gzipped or uncompressed) from
 Joyent's images (-s /full/path/to/file), from ZFS datasets or snapshots

--- a/usr/src/lib/brand/lx/testing/ltp_skiplist
+++ b/usr/src/lib/brand/lx/testing/ltp_skiplist
@@ -192,6 +192,7 @@ mq_timedsend01
 mq_unlink01
 msgctl12
 msgrcv07
+msync04
 open02
 open10
 perf_event_open01

--- a/usr/src/uts/common/brand/lx/os/lx_pid.c
+++ b/usr/src/uts/common/brand/lx/os/lx_pid.c
@@ -284,7 +284,7 @@ int
 lx_lpid_lock(pid_t lpid, zone_t *zone, lx_pid_flag_t flag, proc_t **pp,
     kthread_t **tp)
 {
-	proc_t *p = NULL;
+	proc_t *p;
 	kthread_t *t;
 	id_t tid = 0;
 
@@ -293,6 +293,7 @@ lx_lpid_lock(pid_t lpid, zone_t *zone, lx_pid_flag_t flag, proc_t **pp,
 	ASSERT(zone != NULL && zone->zone_brand == &lx_brand);
 
 retry:
+	p = NULL;
 	if (lpid == 1) {
 		pid_t initpid;
 

--- a/usr/src/uts/common/brand/lx/syscall/lx_aio.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_aio.c
@@ -221,7 +221,7 @@ typedef struct lx_io_elem {
 	int64_t		lxioelem_offset;	/* offset in file */
 	uint64_t	lxioelem_data;
 	ssize_t		lxioelem_res;
-	lx_iocb_t	*lxioelem_cbp;
+	void		*lxioelem_cbp;		/* ptr to iocb in userspace */
 } lx_io_elem_t;
 
 /* From lx_rw.c */
@@ -1240,7 +1240,7 @@ lx_io_cancel(lx_aio_context_t cid, lx_iocb_t *iocbp, lx_io_event_t *result)
 		ep->lxioelem_resfp = NULL;
 	}
 
-	ev.lxioe_data = ep->lxioelem_cbp->lxiocb_data;
+	ev.lxioe_data = ep->lxioelem_data;
 	ev.lxioe_object = (uint64_t)(uintptr_t)ep->lxioelem_cbp;
 	ev.lxioe_res = 0;
 	ev.lxioe_res2 = 0;


### PR DESCRIPTION
Upstream merge from `illumos-joyent`.

### Backports

* OS-6238 panic in lxpr\_access

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent-merge-2017080301-aaae3d8be9 i86pc i386 i86pc
hadfl@mars:~$ zoneadm list -cv
  ID NAME             STATUS     PATH                           BRAND    IP    
   0 global           running    /                              ipkg     shared
   1 ubuntu-16        running    /zones/ubuntu-16               lx       excl  
```

### mail_msg

```
==== Nightly distributed build started:   Thu Aug  3 18:25:36 CEST 2017 ====
==== Nightly distributed build completed: Thu Aug  3 19:06:48 CEST 2017 ====

==== Total build time ====

real    0:41:12

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-79a0d1a8fc i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-merge-2017080301-aaae3d8be9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:02.4
user  1:07:56.1
sys      4:54.0

==== Build noise differences (DEBUG) ====

83,84c83,84
< maximum offset: 1d52
< maximum offset: 23ae
---
> maximum offset: 1d50
> maximum offset: 23ac

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    17:54.6
user    44:52.7
sys      4:45.8

==== lint warnings src ====


==== lint noise differences src ====

1d0
< "../../common/os/acct.c", line 438: warning: assignment causes implicit narrowing conversion (E_ASSIGN_NARROW_CONV)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```