### PR TITLE
Joyent merge/2017081001

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,7 +2,7 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull). LX-for-OmniOS-specific notes follow.
 
-Last illumos-joyent commit:  70fe2b10487a1b0dfe11ed0378b4f835ff133884
+Last illumos-joyent commit:  89420cc6448331a712735c3624e5282875879a7d
 
 LX zones can be installed using ZFS send streams (gzipped or uncompressed) from
 Joyent's images (-s /full/path/to/file), from ZFS datasets or snapshots


### PR DESCRIPTION
Weekly merge from `illumos-joyent`.

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent-merge-2017081001-9d5345697f i86pc i386 i86pc
hadfl@mars:~$ zoneadm list -cv
  ID NAME             STATUS     PATH                           BRAND    IP
   0 global           running    /                              ipkg     shared
   1 ubuntu-16        running    /zones/ubuntu-16               lx       excl
```

### mail_msg

```
==== Nightly distributed build started:   Thu Aug 10 16:56:30 CEST 2017 ====
==== Nightly distributed build completed: Thu Aug 10 17:37:44 CEST 2017 ====

==== Total build time ====

real    0:41:13

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-79a0d1a8fc i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-merge-2017081001-9d5345697f

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:07.1
user  1:08:29.8
sys      5:01.9

==== Build noise differences (DEBUG) ====

83,84c83,84
< maximum offset: 1d52
< maximum offset: 23ae
---
> maximum offset: 1d50
> maximum offset: 23ac

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:09.6
user    45:35.2
sys      4:51.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
