### PR TITLE
dmake clobber leaves lx brand objects behind

### DIFF
--- a/usr/src/lib/brand/lx/lx_support/Makefile
+++ b/usr/src/lib/brand/lx/lx_support/Makefile
@@ -34,7 +34,7 @@ include $(SRC)/cmd/Makefile.cmd
 
 # override the install directory
 ROOTBIN =	$(ROOTBRANDDIR)
-CLOBBERFILES =	$(OBJS) $(ROOTPROGS)
+CLOBBERFILES =	$(OBJS) $(ROOTPROGS) $(OBJS:%=%.po)
 
 UTSBASE =	$(SRC)/uts
 

--- a/usr/src/lib/brand/lx/zone/Makefile
+++ b/usr/src/lib/brand/lx/zone/Makefile
@@ -64,7 +64,8 @@ clean:
 	-$(RM) $(PROGS)
 
 clobber: clean
-	-$(RM) $(ROOTXMLDOCS) $(ROOTPROGS) $(ROOTTEMPLATES)
+	-$(RM) $(ROOTXMLDOCS) $(ROOTPROGS) $(ROOTTEMPLATES) \
+	    $(POFILES) $(POFILE)
 
 FRC:
 


### PR DESCRIPTION
A `dmake clobber` leaves some lx-related .po files behind:

```
?? usr/src/lib/brand/lx/lx_support/lx_support.po
?? usr/src/lib/brand/lx/zone/lx_boot.po
?? usr/src/lib/brand/lx/zone/lx_boot_zone_busybox.po
?? usr/src/lib/brand/lx/zone/lx_boot_zone_debian.po
?? usr/src/lib/brand/lx/zone/lx_boot_zone_redhat.po
?? usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.po
?? usr/src/lib/brand/lx/zone/lx_install.po
?? usr/src/lib/brand/lx/zone/lx_zone.po
```
