### PR TITLE
Joyent merge/2017082401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 088d69f878cf3fb57556357236ef8e1c8f9d893e
+Last illumos-joyent commit: 6ce43f2a6fa2b7afc12a8d8d72313305ff468356
 

--- a/usr/src/uts/common/brand/lx/syscall/lx_pipe.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_pipe.c
@@ -180,6 +180,15 @@ lx_hd_pipe(intptr_t arg, int flags)
 	(void) lx_pipe_setsz(str, LX_DEFAULT_PIPE_SIZE, B_TRUE);
 
 	/*
+	 * Because we're using streams to increase the capacity of the pipe
+	 * up to the default Linux capacity, we have to switch the pipe
+	 * out of FIFOFAST mode and back to a normal stream. In fast mode
+	 * the pipe capacity is limited to "Fifohiwat" which is a compile-time
+	 * limit set to FIFOHIWAT.
+	 */
+	fifo_fastoff(VTOF(vp1));
+
+	/*
 	 * Set the O_NONBLOCK flag if requested.
 	 */
 	if (flags & FNONBLOCK) {


### PR DESCRIPTION
## Backport candidates

None

## mail_msg

```
==== Nightly distributed build started:   Thu Aug 24 14:22:46 UTC 2017 ====
==== Nightly distributed build completed: Thu Aug 24 15:32:57 UTC 2017 ====

==== Total build time ====

real    1:10:11

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-5e982daae6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_101-b00"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   156328

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-merge-2017082401-b2ae00b267

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:28.2
user  1:36:17.3
sys     12:50.2

==== Build noise differences (non-DEBUG) ====

83,84c83,84
< maximum offset: 1d0f
< maximum offset: 236b
---
> maximum offset: 1d0d
> maximum offset: 2369

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:16.2
user  1:25:46.1
sys      9:01.3

==== Build noise differences (DEBUG) ====

48,49c48,49
< maximum offset: 1d4e
< maximum offset: 23aa
---
> maximum offset: 1d4c
> maximum offset: 23a8

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    20:18.7
user    55:51.4
sys      7:10.4

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```

Given the small change, I haven't `onu`d this build.