### PR TITLE
Upstream merge/2017083101

### DIFF
--- a/usr/src/boot/lib/libstand/bootp.h
+++ b/usr/src/boot/lib/libstand/bootp.h
@@ -20,6 +20,8 @@
  * without express or implied warranty.
  */
 
+#include <netinet/in.h>
+
 #ifndef _BOOTP_H_
 #define	_BOOTP_H_
 
@@ -144,6 +146,9 @@ struct cmu_vend {
 
 /* v_flags values */
 #define VF_SMASK	1	/* Subnet mask field contains valid data */
+
+/* cached bootp response/dhcp ack */
+extern struct bootp *bootp_response;
 
 int	dhcp_try_rfc1048(uint8_t *cp, size_t len);
 

--- a/usr/src/boot/sys/boot/common/bootstrap.h
+++ b/usr/src/boot/sys/boot/common/bootstrap.h
@@ -245,15 +245,17 @@ extern u_int64_t __elfN(relocation_offset);
 struct elf_file;
 typedef Elf_Addr (symaddr_fn)(struct elf_file *ef, Elf_Size symidx);
 
-int	__elfN(loadfile)(char *filename, u_int64_t dest, struct preloaded_file **result);
-int	__elfN(obj_loadfile)(char *filename, u_int64_t dest,
-	    struct preloaded_file **result);
+int	elf64_loadfile(char *, uint64_t, struct preloaded_file **);
+int	elf32_loadfile(char *, uint64_t, struct preloaded_file **);
+int	elf64_obj_loadfile(char *, uint64_t, struct preloaded_file **);
+int	elf32_obj_loadfile(char *, uint64_t, struct preloaded_file **);
 int	__elfN(reloc)(struct elf_file *ef, symaddr_fn *symaddr,
 	    const void *reldata, int reltype, Elf_Addr relbase,
 	    Elf_Addr dataaddr, void *data, size_t len);
-int __elfN(loadfile_raw)(char *filename, u_int64_t dest,
-	    struct preloaded_file **result, int multiboot);
-int __elfN(load_modmetadata)(struct preloaded_file *fp, u_int64_t dest);
+int	elf64_loadfile_raw(char *, uint64_t, struct preloaded_file **, int);
+int	elf32_loadfile_raw(char *, uint64_t, struct preloaded_file **, int);
+int	elf64_load_modmetadata(struct preloaded_file *, uint64_t);
+int	elf32_load_modmetadata(struct preloaded_file *, uint64_t);
 #endif
 
 /*

--- a/usr/src/boot/sys/boot/common/multiboot2.c
+++ b/usr/src/boot/sys/boot/common/multiboot2.c
@@ -18,6 +18,7 @@
  * kernel. This code is only built to support the illumos kernel, it does
  * not support xen.
  */
+
 #include <sys/cdefs.h>
 #include <sys/stddef.h>
 
@@ -29,6 +30,7 @@
 #include <sys/multiboot2.h>
 #include <stand.h>
 #include <stdbool.h>
+#include <machine/elf.h>
 #include "libzfs.h"
 
 #include "bootstrap.h"
@@ -36,12 +38,20 @@
 #include <machine/metadata.h>
 #include <machine/pc/bios.h>
 
+#define	SUPPORT_DHCP
+#include <bootp.h>
+
+#if !defined(EFI)
 #include "../i386/libi386/libi386.h"
 #include "../i386/btx/lib/btxv86.h"
-#include "pxe.h"
 
-extern BOOTPLAYER bootplayer;	/* dhcp info */
-extern void multiboot_tramp();
+#else
+#include <efi.h>
+#include <efilib.h>
+#include "loader_efi.h"
+
+static void (*trampoline)(uint32_t, struct relocator *, uint64_t);
+#endif
 
 #include "platform/acfreebsd.h"
 #include "acconfig.h"
@@ -55,8 +65,6 @@ extern ACPI_TABLE_RSDP *rsdp;
 static vm_offset_t last_addr;
 extern char bootprog_info[];
 
-extern int elf32_loadfile_raw(char *filename, u_int64_t dest,
-    struct preloaded_file **result, int multiboot);
 static int multiboot2_loadfile(char *, u_int64_t, struct preloaded_file **);
 static int multiboot2_exec(struct preloaded_file *);
 
@@ -276,6 +284,12 @@ multiboot2_loadfile(char *filename, u_int64_t dest,
 		fp->f_metadata = NULL;
 		error = 0;
 	} else {
+#if defined(EFI)
+		/* 32-bit kernel is not yet supported for EFI */
+		printf("32-bit kernel is not supported by UEFI loader\n");
+		error = ENOTSUP;
+		goto out;
+#endif
 		/* elf32_loadfile_raw will fill the attributes in fp. */
 		error = elf32_loadfile_raw(filename, dest, &fp, 2);
 		if (error != 0) {
@@ -295,7 +309,11 @@ multiboot2_loadfile(char *filename, u_int64_t dest,
 	}
 
 	setenv("kernelname", fp->f_name, 1);
+#if defined(EFI)
+	efi_addsmapdata(fp);
+#else
 	bios_addsmapdata(fp);
+#endif
 	*result = fp;
 out:
 	free(header_search);
@@ -656,6 +674,42 @@ module_size(struct preloaded_file *fp)
 	return (size);
 }
 
+#if defined (EFI)
+/*
+ * Calculate size for UEFI memory map tag.
+ */
+static int
+efimemmap_size(void)
+{
+	UINTN size, cur_size, desc_size;
+	EFI_MEMORY_DESCRIPTOR *mmap;
+	EFI_STATUS ret;
+
+	size = EFI_PAGE_SIZE;		/* Start with 4k. */
+	while (1) {
+		cur_size = size;
+		mmap = malloc(cur_size);
+		if (mmap == NULL)
+			return (0);
+		ret = BS->GetMemoryMap(&cur_size, mmap, NULL, &desc_size, NULL);
+		free(mmap);
+		if (ret == EFI_SUCCESS)
+			break;
+		if (ret == EFI_BUFFER_TOO_SMALL) {
+			if (size < cur_size)
+				size = cur_size;
+			size += (EFI_PAGE_SIZE);
+		} else
+			return (0);
+	}
+
+	/* EFI MMAP will grow when we allocate MBI, set some buffer. */
+	size += (3 << EFI_PAGE_SHIFT);
+	size = roundup(size, desc_size);
+	return (sizeof (multiboot_tag_efi_mmap_t) + size);
+}
+#endif
+
 /*
  * Calculate size for bios smap tag.
  */
@@ -684,15 +738,29 @@ mbi_size(struct preloaded_file *fp, char *cmdline)
 	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
 	size += sizeof (multiboot_tag_string_t) + strlen(bootprog_info) + 1;
 	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
+#if !defined (EFI)
 	size += sizeof (multiboot_tag_basic_meminfo_t);
 	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
+#endif
 	size += module_size(fp);
 	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
+#if defined (EFI)
+	size += sizeof (multiboot_tag_efi64_t);
+	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
+	size += efimemmap_size();
+	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
+
+	if (have_framebuffer == true) {
+		size += sizeof (multiboot_tag_framebuffer_t);
+		size = roundup2(size, MULTIBOOT_TAG_ALIGN);
+	}
+#endif
 	size += biossmap_size(fp);
 	size = roundup2(size, MULTIBOOT_TAG_ALIGN);
 
-	if (strstr(getenv("loaddev"), "pxe") != NULL) {
-		size += sizeof(multiboot_tag_network_t) + sizeof (BOOTPLAYER);
+	if (bootp_response != NULL) {
+		size += sizeof(multiboot_tag_network_t) +
+		    sizeof (*bootp_response);
 		size = roundup2(size, MULTIBOOT_TAG_ALIGN);
 	}
 
@@ -724,7 +792,17 @@ multiboot2_exec(struct preloaded_file *fp)
 	size_t size;
 	struct bios_smap *smap;
 	vm_offset_t tmp;
+#if defined (EFI)
+	multiboot_tag_module_t *module;
+	EFI_MEMORY_DESCRIPTOR *map;
+	struct relocator *relocator;
+	struct chunk_head *head;
+	struct chunk *chunk;
+
+	efi_getdev((void **)(&rootdev), NULL, NULL);
+#else
 	i386_getdev((void **)(&rootdev), NULL, NULL);
+#endif
 
 	error = EINVAL;
 	if (rootdev == NULL) {
@@ -756,8 +834,28 @@ multiboot2_exec(struct preloaded_file *fp)
 	size = mbi_size(fp, cmdline);	/* Get the size for MBI. */
 
 	/* Set up the base for mb_malloc. */
-	for (mfp = fp; mfp->f_next != NULL; mfp = mfp->f_next);
+	i = 0;
+	for (mfp = fp; mfp->f_next != NULL; mfp = mfp->f_next)
+		i++;
 
+#if defined (EFI)
+	/* We need space for kernel + MBI + # modules */
+	num = (EFI_PAGE_SIZE - offsetof(struct relocator, rel_chunklist)) /
+	    sizeof (struct chunk);
+	if (i + 2 >= num) {
+		printf("Too many modules, do not have space for relocator.\n");
+		error = ENOMEM;
+		goto error;
+	}
+
+	last_addr = efi_loadaddr(LOAD_MEM, &size, mfp->f_addr + mfp->f_size);
+	mbi = (multiboot2_info_header_t *)last_addr;
+	if (mbi == NULL) {
+		error = ENOMEM;
+		goto error;
+	}
+	last_addr = (vm_offset_t)mbi->mbi_tags;
+#else
 	/* Start info block from the new page. */
 	last_addr = roundup(mfp->f_addr + mfp->f_size, MULTIBOOT_MOD_ALIGN);
 
@@ -769,6 +867,7 @@ multiboot2_exec(struct preloaded_file *fp)
 
 	mbi = (multiboot2_info_header_t *)PTOV(last_addr);
 	last_addr = (vm_offset_t)mbi->mbi_tags;
+#endif	/* EFI */
 
 	{
 		multiboot_tag_string_t *tag;
@@ -793,6 +892,8 @@ multiboot2_exec(struct preloaded_file *fp)
 		    strlen(bootprog_info) + 1);
 	}
 
+#if !defined (EFI)
+	/* Only set in case of BIOS. */
 	{
 		multiboot_tag_basic_meminfo_t *tag;
 		tag = (multiboot_tag_basic_meminfo_t *)
@@ -803,6 +904,7 @@ multiboot2_exec(struct preloaded_file *fp)
 		tag->mb_mem_lower = bios_basemem / 1024;
 		tag->mb_mem_upper = bios_extmem / 1024;
 	}
+#endif
 
 	num = 0;
 	for (mfp = fp->f_next; mfp != NULL; mfp = mfp->f_next) {
@@ -824,8 +926,12 @@ multiboot2_exec(struct preloaded_file *fp)
 	 * - Modules are aligned to page boundary.
 	 * - MBI is aligned to page boundary.
 	 * - Set the tmp to point to physical address of the first module.
+	 * - tmp != mfp->f_addr only in case of EFI.
 	 */
 	tmp = roundup2(load_addr + fp->f_size, MULTIBOOT_MOD_ALIGN);
+#if defined (EFI)
+	module = (multiboot_tag_module_t *)last_addr;
+#endif
 
 	for (mfp = fp->f_next; mfp != NULL; mfp = mfp->f_next) {
 		multiboot_tag_module_t *tag;
@@ -893,14 +999,15 @@ multiboot2_exec(struct preloaded_file *fp)
 		}
 	}
 
-	if (strstr(getenv("loaddev"), "pxe") != NULL) {
+	if (bootp_response != NULL) {
 		multiboot_tag_network_t *tag;
 		tag = (multiboot_tag_network_t *)
-		    mb_malloc(sizeof(*tag) + sizeof (BOOTPLAYER));
+		    mb_malloc(sizeof (*tag) + sizeof (*bootp_response));
 
 		tag->mb_type = MULTIBOOT_TAG_TYPE_NETWORK;
-		tag->mb_size = sizeof(*tag) + sizeof (BOOTPLAYER);
-		memcpy(tag->mb_dhcpack, &bootplayer, sizeof (BOOTPLAYER));
+		tag->mb_size = sizeof (*tag) + sizeof (*bootp_response);
+		memcpy(tag->mb_dhcpack, bootp_response,
+		    sizeof (*bootp_response));
 	}
 
 	if (rsdp != NULL) {
@@ -923,6 +1030,132 @@ multiboot2_exec(struct preloaded_file *fp)
 		}
 	}
 
+#if defined (EFI)
+	{
+		multiboot_tag_efi64_t *tag;
+		tag = (multiboot_tag_efi64_t *)
+		    mb_malloc(sizeof (*tag));
+
+		tag->mb_type = MULTIBOOT_TAG_TYPE_EFI64;
+		tag->mb_size = sizeof (*tag);
+		tag->mb_pointer = (uint64_t)(uintptr_t)ST;
+	}
+
+	if (have_framebuffer == true) {
+		multiboot_tag_framebuffer_t *tag;
+		int bpp;
+		struct efi_fb fb;
+		extern int efi_find_framebuffer(struct efi_fb *efifb);
+
+		if (efi_find_framebuffer(&fb) == 0) {
+			tag = (multiboot_tag_framebuffer_t *)
+			    mb_malloc(sizeof (*tag));
+
+			/*
+			 * We assume contiguous color bitmap, and use
+			 * the msb for bits per pixel calculation.
+			 */
+			bpp = fls(fb.fb_mask_red | fb.fb_mask_green |
+			    fb.fb_mask_blue | fb.fb_mask_reserved);
+
+			tag->framebuffer_common.mb_type =
+			    MULTIBOOT_TAG_TYPE_FRAMEBUFFER;
+			tag->framebuffer_common.mb_size =
+			    sizeof (multiboot_tag_framebuffer_t);
+			tag->framebuffer_common.framebuffer_addr = fb.fb_addr;
+			tag->framebuffer_common.framebuffer_width = fb.fb_width;
+			tag->framebuffer_common.framebuffer_height =
+			    fb.fb_height;
+			tag->framebuffer_common.framebuffer_bpp = bpp;
+			/*
+			 * Pitch is stride * bytes per pixel.
+			 * Stride is pixels per scanline.
+			 */
+			tag->framebuffer_common.framebuffer_pitch =
+			    fb.fb_stride * (bpp / 8);
+			tag->framebuffer_common.framebuffer_type =
+			    MULTIBOOT_FRAMEBUFFER_TYPE_RGB;
+			tag->framebuffer_common.mb_reserved = 0;
+
+			/*
+			 * The RGB or BGR color ordering.
+			 */
+			if (fb.fb_mask_red & 0x000000ff) {
+				tag->u.fb2.framebuffer_red_field_position = 0;
+				tag->u.fb2.framebuffer_blue_field_position = 16;
+			} else {
+				tag->u.fb2.framebuffer_red_field_position = 16;
+				tag->u.fb2.framebuffer_blue_field_position = 0;
+			}
+			tag->u.fb2.framebuffer_red_mask_size = 8;
+			tag->u.fb2.framebuffer_green_field_position = 8;
+			tag->u.fb2.framebuffer_green_mask_size = 8;
+			tag->u.fb2.framebuffer_blue_mask_size = 8;
+		}
+	}
+
+	/* Leave EFI memmap last as we will also switch off the BS. */
+	{
+		multiboot_tag_efi_mmap_t *tag;
+		UINTN size, desc_size, key;
+		EFI_STATUS status;
+
+		tag = (multiboot_tag_efi_mmap_t *)
+		    mb_malloc(sizeof (*tag));
+
+		size = 0;
+		status = BS->GetMemoryMap(&size,
+		    (EFI_MEMORY_DESCRIPTOR *)tag->mb_efi_mmap, &key,
+		    &desc_size, &tag->mb_descr_vers);
+		if (status != EFI_BUFFER_TOO_SMALL) {
+			error = EINVAL;
+			goto error;
+		}
+		status = BS->GetMemoryMap(&size,
+		    (EFI_MEMORY_DESCRIPTOR *)tag->mb_efi_mmap, &key,
+		    &desc_size, &tag->mb_descr_vers);
+		if (EFI_ERROR(status)) {
+			error = EINVAL;
+			goto error;
+		}
+		tag->mb_type = MULTIBOOT_TAG_TYPE_EFI_MMAP;
+		tag->mb_size = sizeof (*tag) + size;
+		tag->mb_descr_size = (uint32_t) desc_size;
+
+		/*
+		 * Find relocater pages. We assume we have free pages
+		 * below kernel load address.
+		 * In this version we are using 5 pages:
+		 * relocator data, trampoline, copy, memmove, stack.
+		 */
+		for (i = 0, map = (EFI_MEMORY_DESCRIPTOR *)tag->mb_efi_mmap;
+		    i < size / desc_size;
+		    i++, map = NextMemoryDescriptor(map, desc_size)) {
+			if (map->PhysicalStart == 0)
+				continue;
+			if (map->Type != EfiConventionalMemory)
+				continue;
+			if (map->PhysicalStart < load_addr &&
+			    map->NumberOfPages > 5)
+				break;
+		}
+		if (map->PhysicalStart == 0)
+			panic("Could not find memory for relocater\n");
+
+		if (keep_bs == 0) {
+			status = BS->ExitBootServices(IH, key);
+			if (EFI_ERROR(status)) {
+				printf("Call to ExitBootServices failed\n");
+				error = EINVAL;
+				goto error;
+			}
+		}
+
+		last_addr += size;
+		last_addr = roundup2(last_addr, MULTIBOOT_TAG_ALIGN);
+	}
+#endif
+
 	/*
 	 * MB tag list end marker.
 	 */
@@ -936,13 +1169,66 @@ multiboot2_exec(struct preloaded_file *fp)
 	mbi->mbi_total_size = last_addr - (vm_offset_t)mbi;
 	mbi->mbi_reserved = 0;
 
+#if defined (EFI)
+	/* At this point we have load_addr pointing to kernel load
+	 * address, module list in MBI having physical addresses,
+	 * module list in fp having logical addresses and tmp pointing to
+	 * physical address for MBI.
+	 * Now we must move all pieces to place and start the kernel.
+	 */
+	relocator = (struct relocator *)(uintptr_t)map->PhysicalStart;
+	head = &relocator->rel_chunk_head;
+	STAILQ_INIT(head);
+
+	i = 0;
+	chunk = &relocator->rel_chunklist[i++];
+	chunk->chunk_vaddr = fp->f_addr;
+	chunk->chunk_paddr = load_addr;
+	chunk->chunk_size = fp->f_size;
+
+	STAILQ_INSERT_TAIL(head, chunk, chunk_next);
+
+	for (mfp = fp->f_next; mfp != NULL; mfp = mfp->f_next) {
+		chunk = &relocator->rel_chunklist[i++];
+		chunk->chunk_vaddr = mfp->f_addr;
+		chunk->chunk_paddr = module->mb_mod_start;
+		chunk->chunk_size = mfp->f_size;
+		STAILQ_INSERT_TAIL(head, chunk, chunk_next);
+
+		module = (multiboot_tag_module_t *)
+		    roundup2((uintptr_t)module + module->mb_size,
+		    MULTIBOOT_TAG_ALIGN);
+	}
+	chunk = &relocator->rel_chunklist[i++];
+	chunk->chunk_vaddr = (EFI_VIRTUAL_ADDRESS)mbi;
+	chunk->chunk_paddr = tmp;
+	chunk->chunk_size = mbi->mbi_total_size;
+	STAILQ_INSERT_TAIL(head, chunk, chunk_next);
+
+	trampoline = (void *)(uintptr_t)relocator + EFI_PAGE_SIZE;
+	memmove(trampoline, multiboot_tramp, EFI_PAGE_SIZE);
+
+	relocator->rel_copy = (uintptr_t)trampoline + EFI_PAGE_SIZE;
+	memmove((void *)relocator->rel_copy, efi_copy_finish, EFI_PAGE_SIZE);
+
+	relocator->rel_memmove = (uintptr_t)relocator->rel_copy + EFI_PAGE_SIZE;
+	memmove((void *)relocator->rel_memmove, memmove, EFI_PAGE_SIZE);
+	relocator->rel_stack = relocator->rel_memmove + EFI_PAGE_SIZE - 8;
+
+	trampoline(MULTIBOOT2_BOOTLOADER_MAGIC, relocator, entry_addr);
+#else
 	dev_cleanup();
 	__exec((void *)VTOP(multiboot_tramp), MULTIBOOT2_BOOTLOADER_MAGIC,
 	    (void *)entry_addr, (void *)VTOP(mbi));
+#endif
 	panic("exec returned");
 
 error:
 	if (cmdline != NULL)
 		free(cmdline);
+#if defined (EFI)
+	if (mbi != NULL)
+		efi_free_loadaddr((uint64_t)mbi, EFI_SIZE_TO_PAGES(size));
+#endif
 	return (error);
 }

--- a/usr/src/boot/sys/boot/efi/boot1/Makefile
+++ b/usr/src/boot/sys/boot/efi/boot1/Makefile
@@ -40,7 +40,7 @@ CPPFLAGS +=	-I./../../../../include
 CPPFLAGS +=	-I./../../../sys
 CPPFLAGS +=	-I./../../..
 CPPFLAGS +=	-I../../../../lib/libstand
-CPPFLAGS +=	-DEFI_UFS_BOOT
+CPPFLAGS +=	-DEFI_UFS_BOOT -DUFS1_ONLY
 # CPPFLAGS +=	-DEFI_DEBUG
 
 CPPFLAGS +=	-I./../../zfs/

--- a/usr/src/boot/sys/boot/efi/loader/Makefile
+++ b/usr/src/boot/sys/boot/efi/loader/Makefile
@@ -27,9 +27,9 @@ MACHINE=	$(MACH64)
 
 # architecture-specific loader code
 SRCS=	autoload.c bootinfo.c conf.c copy.c devicename.c main.c self_reloc.c \
-	smbios.c acpi.c vers.c
+	smbios.c acpi.c vers.c memmap.c multiboot2.c
 OBJS= autoload.o bootinfo.o conf.o copy.o devicename.o main.o self_reloc.o \
-	smbios.o acpi.o vers.o
+	smbios.o acpi.o vers.o memmap.o multiboot2.o
 
 ASFLAGS=-m64 -fPIC
 CFLAGS=	-O2
@@ -82,6 +82,9 @@ LIBZFSBOOT=	../../zfs/${MACHINE}/libzfsboot.a
 # Always add MI sources
 include	./Makefile.common
 CPPFLAGS +=	-I../../common
+
+# For multiboot2.h, must be last, to avoid conflicts
+CPPFLAGS +=	-I$(SRC)/uts/common
 
 FILES=	loader.efi
 FILEMODE=	0555

--- a/usr/src/boot/sys/boot/efi/loader/arch/amd64/Makefile.inc
+++ b/usr/src/boot/sys/boot/efi/loader/arch/amd64/Makefile.inc
@@ -1,15 +1,13 @@
 
-SRCS +=	amd64_tramp.S \
+SRCS +=	multiboot_tramp.S \
 	start.S \
 	framebuffer.c \
-	elf64_freebsd.c \
 	trap.c \
 	exc.S
 
-OBJS += amd64_tramp.o \
+OBJS += multiboot_tramp.o \
 	start.o \
 	framebuffer.o \
-	elf64_freebsd.o \
 	trap.o \
 	exc.o
 

--- a/usr/src/boot/sys/boot/efi/loader/arch/amd64/multiboot_tramp.S
+++ b/usr/src/boot/sys/boot/efi/loader/arch/amd64/multiboot_tramp.S
@@ -1,0 +1,119 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2016 Toomas Soome <tsoome@me.com>
+ */
+
+#include <x86/specialreg.h>
+
+	.file	"multiboot_tramp.s"
+
+/*
+ * The current dboot in illumos kernel is running in 32bit mode
+ * and expecting following 32-bit multiboot execution environment:
+ *
+ * EAX: MB magic
+ * EBX: 32-bit physical address of MBI
+ * CS: 32-bit read/execute code segment with offset 0 and limit 0xFFFFFFFF
+ * DS: 32-bit read/write code segment with offset 0 and limit 0xFFFFFFFF
+ * ES: 32-bit read/write code segment with offset 0 and limit 0xFFFFFFFF
+ * FS: 32-bit read/write code segment with offset 0 and limit 0xFFFFFFFF
+ * GS: 32-bit read/write code segment with offset 0 and limit 0xFFFFFFFF
+ * SS: 32-bit read/write data segment with offset 0 and limit 0xFFFFFFFF
+ * A20 enabled
+ * CR0: PG cleared, PE set
+ * EFLAGS: VM cleared, IF cleared
+ * interrupts disabled
+ */
+
+		.set	SEL_SCODE,0x8
+		.set	SEL_SDATA,0x10
+
+		.text
+		.p2align 4
+		.globl	multiboot_tramp
+		.type	multiboot_tramp, STT_FUNC
+
+/*
+ * void multiboot_tramp(uint32_t magic, struct relocator *relocator,
+ *    uint64_t entry)
+ */
+multiboot_tramp:
+		cli
+		movq	(%rsi), %rax
+		movq	%rax, %rsp		/* Switch to temporary stack. */
+		movq	0x8(%rsi), %rax		/* relocator->copy */
+		pushq	%rdi			/* save magic */
+		pushq	%rdx			/* save entry */
+		movq	%rsi, %rdi
+		callq	*%rax
+		movq	%rax, %rbx		/* MBI */
+		popq	%rsi			/* entry to rsi */
+		popq	%rdi			/* restore magic */
+		movq	gdt@GOTPCREL(%rip), %rax
+		movq	gdtaddr@GOTPCREL(%rip), %rdx
+		movq	%rax, (%rdx)
+		movq	gdtdesc@GOTPCREL(%rip), %rax
+		lgdt	(%rax)
+
+		/* record the address */
+		movq	multiboot_tramp_2@GOTPCREL(%rip), %rcx
+		movq	%rsp, %rax
+		pushq	$SEL_SDATA
+		pushq	%rax
+		pushf
+		pushq	$SEL_SCODE
+		movq	multiboot_tramp_1@GOTPCREL(%rip), %rax
+		pushq	%rax
+		iretq
+
+		.code32
+multiboot_tramp_1:
+		movl	$SEL_SDATA, %eax
+		movw	%ax, %ss
+		movw	%ax, %ds
+		movw	%ax, %es
+		movw	%ax, %fs
+		movw	%ax, %gs
+
+		movl	%cr0, %eax		/* disable paging */
+		btrl	$31, %eax
+		movl	%eax, %cr0
+		jmp	*%ecx
+multiboot_tramp_2:
+		movl	%cr4, %eax		/* disable PAE, PGE, PSE */
+		andl	$~(CR4_PGE | CR4_PAE | CR4_PSE), %eax
+		movl	%eax, %cr4
+		movl	$MSR_EFER, %ecx
+		rdmsr				/* updates %edx:%eax */
+		btcl	$8, %eax		/* clear long mode */
+		wrmsr
+		movl	%edi, %eax		/* magic */
+		jmp	*%esi			/* jump to kernel */
+
+/* GDT record */
+		.p2align 4
+gdt:
+		.word	0x0, 0x0		/* NULL entry */
+		.byte	0x0, 0x0, 0x0, 0x0
+		.word	0xffff, 0x0		/* code segment */
+		.byte	0x0, 0x9a, 0xcf, 0x0
+		.word	0xffff, 0x0		/* data segment */
+		.byte	0x0, 0x92, 0xcf, 0x0
+gdt_end:
+
+		.p2align 4
+gdtdesc:	.word	gdt_end - gdt - 1	/* limit */
+gdtaddr:	.long	0			/* base */
+		.long	0
+
+multiboot_tramp_end:

--- a/usr/src/boot/sys/boot/efi/loader/conf.c
+++ b/usr/src/boot/sys/boot/efi/loader/conf.c
@@ -88,3 +88,14 @@ struct console *consoles[] = {
 #endif
 	NULL
 };
+
+#if defined(__amd64__) || defined(__i386__)
+extern struct file_format multiboot2;
+#endif
+
+struct file_format *file_formats[] = {
+#if defined(__amd64__) || defined(__i386__)
+        &multiboot2,
+#endif
+        NULL
+};

--- a/usr/src/boot/sys/boot/efi/loader/copy.c
+++ b/usr/src/boot/sys/boot/efi/loader/copy.c
@@ -27,91 +27,91 @@
  */
 
 #include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
 #include <sys/param.h>
+#include <sys/multiboot2.h>
 
 #include <stand.h>
 #include <bootstrap.h>
 
 #include <efi.h>
 #include <efilib.h>
+#include <assert.h>
 
 #include "loader_efi.h"
 
-#ifndef EFI_STAGING_SIZE
-#define	EFI_STAGING_SIZE	48
-#endif
-
-#define	STAGE_PAGES	EFI_SIZE_TO_PAGES((EFI_STAGING_SIZE) * 1024 * 1024)
-
-EFI_PHYSICAL_ADDRESS	staging, staging_end;
-int			stage_offset_set = 0;
-ssize_t			stage_offset;
-
-int
-efi_copy_init(void)
+/*
+ * Allocate pages for data to be loaded. As we can not expect AllocateAddress
+ * to succeed, we allocate using AllocateMaxAddress from 4GB limit.
+ * 4GB limit is because reportedly some 64bit systems are reported to have
+ * issues with memory above 4GB. It should be quite enough anyhow.
+ * Note: AllocateMaxAddress will only make sure we are below the specified
+ * address, we can not make any assumptions about actual location or
+ * about the order of the allocated blocks.
+ */
+uint64_t
+efi_loadaddr(u_int type, void *data, uint64_t addr)
 {
-	EFI_STATUS	status;
+	EFI_PHYSICAL_ADDRESS paddr;
+	struct stat st;
+	int size;
+	uint64_t pages;
+	EFI_STATUS status;
 
-	status = BS->AllocatePages(AllocateAnyPages, EfiLoaderData,
-	    STAGE_PAGES, &staging);
-	if (EFI_ERROR(status)) {
-		printf("failed to allocate staging area: %lu\n",
-		    EFI_ERROR_CODE(status));
-		return (status);
+	if (addr == 0)
+		return (addr);	/* nothing to do */
+
+	if (type == LOAD_ELF)
+		return (0);	/* not supported */
+
+	if (type == LOAD_MEM)
+		size = *(int *)data;
+	else {
+		stat(data, &st);
+		size = st.st_size;
 	}
-	staging_end = staging + STAGE_PAGES * EFI_PAGE_SIZE;
 
-#if defined(__aarch64__) || defined(__arm__)
-	/*
-	 * Round the kernel load address to a 2MiB value. This is needed
-	 * because the kernel builds a page table based on where it has
-	 * been loaded in physical address space. As the kernel will use
-	 * either a 1MiB or 2MiB page for this we need to make sure it
-	 * is correctly aligned for both cases.
-	 */
-	staging = roundup2(staging, 2 * 1024 * 1024);
-#endif
+	pages = EFI_SIZE_TO_PAGES(size);
+	/* 4GB upper limit */
+	paddr = 0x0000000100000000;
 
-	return (0);
+	status = BS->AllocatePages(AllocateMaxAddress, EfiLoaderData,
+	    pages, &paddr);
+
+	if (EFI_ERROR(status)) {
+		printf("failed to allocate %d bytes for staging area: %lu\n",
+		    size, EFI_ERROR_CODE(status));
+		return (0);
+	}
+
+	return (paddr);
+}
+
+void
+efi_free_loadaddr(uint64_t addr, uint64_t pages)
+{
+	(void) BS->FreePages(addr, pages);
 }
 
 void *
 efi_translate(vm_offset_t ptr)
 {
-
-	return ((void *)(ptr + stage_offset));
+	return ((void *)ptr);
 }
 
 ssize_t
 efi_copyin(const void *src, vm_offset_t dest, const size_t len)
 {
-
-	if (!stage_offset_set) {
-		stage_offset = (vm_offset_t)staging - dest;
-		stage_offset_set = 1;
-	}
-
-	/* XXX: Callers do not check for failure. */
-	if (dest + stage_offset + len > staging_end) {
-		errno = ENOMEM;
-		return (-1);
-	}
-	bcopy(src, (void *)(dest + stage_offset), len);
+	assert(dest < 0x100000000);
+	bcopy(src, (void *)(uintptr_t)dest, len);
 	return (len);
 }
 
 ssize_t
 efi_copyout(const vm_offset_t src, void *dest, const size_t len)
 {
-
-	/* XXX: Callers do not check for failure. */
-	if (src + stage_offset + len > staging_end) {
-		errno = ENOMEM;
-		return (-1);
-	}
-	bcopy((void *)(src + stage_offset), dest, len);
+	assert(src < 0x100000000);
+	bcopy((void *)(uintptr_t)src, dest, len);
 	return (len);
 }
 
@@ -119,23 +119,86 @@ efi_copyout(const vm_offset_t src, void *dest, const size_t len)
 ssize_t
 efi_readin(const int fd, vm_offset_t dest, const size_t len)
 {
-
-	if (dest + stage_offset + len > staging_end) {
-		errno = ENOMEM;
-		return (-1);
-	}
-	return (read(fd, (void *)(dest + stage_offset), len));
+	return (read(fd, (void *)dest, len));
 }
 
-void
-efi_copy_finish(void)
+/*
+ * Relocate chunks and return pointer to MBI.
+ * This function is relocated before being called and we only have
+ * memmove() available, as most likely moving chunks into the final
+ * destination will destroy the rest of the loader code.
+ *
+ * In safe area we have relocator data, multiboot_tramp, efi_copy_finish,
+ * memmove and stack.
+ */
+multiboot2_info_header_t *
+efi_copy_finish(struct relocator *relocator)
 {
-	uint64_t	*src, *dst, *last;
+	multiboot2_info_header_t *mbi;
+	struct chunk *chunk, *c;
+	struct chunk_head *head;
+	UINT64 size;
+	int done = 0;
+	void (*move)(void *s1, const void *s2, size_t n);
 
-	src = (uint64_t *)staging;
-	dst = (uint64_t *)(staging - stage_offset);
-	last = (uint64_t *)staging_end;
+	move = (void *)relocator->rel_memmove;
 
-	while (src < last)
-		*dst++ = *src++;
+	/* MBI is the last chunk in the list. */
+	head = &relocator->rel_chunk_head;
+	chunk = STAILQ_LAST(head, chunk, chunk_next);
+	mbi = (multiboot2_info_header_t *)chunk->chunk_paddr;
+
+	/*
+	 * If chunk paddr == vaddr, the chunk is in place.
+	 * If all chunks are in place, we are done.
+	 */
+	chunk = NULL;
+	while (done == 0) {
+		/* First check if we have anything to do. */
+		if (chunk == NULL) {
+			done = 1;
+			STAILQ_FOREACH(chunk, head, chunk_next) {
+				if (chunk->chunk_paddr != chunk->chunk_vaddr) {
+					done = 0;
+					break;
+				}
+			}
+		}
+		if (done == 1)
+			break;
+
+		/*
+		 * Make sure the destination is not conflicting
+		 * with rest of the modules.
+		 */
+		STAILQ_FOREACH(c, head, chunk_next) {
+			/* Moved already? */
+			if (c->chunk_vaddr == c->chunk_paddr)
+				continue;
+			/* Is it the chunk itself? */
+			if (c->chunk_vaddr == chunk->chunk_vaddr &&
+			    c->chunk_size == chunk->chunk_size)
+				continue;
+			if ((c->chunk_vaddr >= chunk->chunk_paddr &&
+			    c->chunk_vaddr <=
+			    chunk->chunk_paddr + chunk->chunk_size) ||
+			    (c->chunk_vaddr + c->chunk_size >=
+			    chunk->chunk_paddr &&
+			    c->chunk_vaddr + c->chunk_size <=
+			    chunk->chunk_paddr + chunk->chunk_size))
+				break;
+		}
+		/* If there are no conflicts, move to place and restart. */
+		if (c == NULL) {
+			move((void *)chunk->chunk_paddr,
+			    (void *)chunk->chunk_vaddr,
+			    chunk->chunk_size);
+			chunk->chunk_vaddr = chunk->chunk_paddr;
+			chunk = NULL;
+			continue;
+		}
+		chunk = STAILQ_NEXT(chunk, chunk_next);
+	}
+
+	return (mbi);
 }

--- a/usr/src/boot/sys/boot/efi/loader/loader_efi.h
+++ b/usr/src/boot/sys/boot/efi/loader/loader_efi.h
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 2013 The FreeBSD Foundation
  * All rights reserved.
  *
@@ -24,28 +24,51 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * $FreeBSD$
  */
 
-#ifndef	_LOADER_EFI_COPY_H_
-#define	_LOADER_EFI_COPY_H_
+#ifndef	_LOADER_EFI_H
+#define	_LOADER_EFI_H
 
 #include <stand.h>
+#include <efi.h>
+#include <efilib.h>
+#include <sys/multiboot2.h>
+#include <sys/queue.h>
+#include <bootstrap.h>
+
+struct chunk {
+	EFI_VIRTUAL_ADDRESS chunk_vaddr;
+	EFI_PHYSICAL_ADDRESS chunk_paddr;
+	UINT64 chunk_size;
+	STAILQ_ENTRY(chunk) chunk_next;
+};
+
+STAILQ_HEAD(chunk_head, chunk);
+
+struct relocator {
+	UINT64 rel_stack;
+	UINT64 rel_copy;
+	UINT64 rel_memmove;
+	struct chunk_head rel_chunk_head;
+	struct chunk rel_chunklist[];
+};
 
 int	efi_autoload(void);
 
-int	efi_getdev(void **vdev, const char *devspec, const char **path);
-char	*efi_fmtdev(void *vdev);
-int	efi_setcurrdev(struct env_var *ev, int flags, const void *value);
+int	efi_getdev(void **, const char *, const char **);
+char	*efi_fmtdev(void *);
+int	efi_setcurrdev(struct env_var *, int, const void *);
 
-int	efi_copy_init(void);
+ssize_t	efi_copyin(const void *, vm_offset_t, const size_t);
+ssize_t	efi_copyout(const vm_offset_t, void *, const size_t);
+ssize_t	efi_readin(const int, vm_offset_t, const size_t);
+uint64_t efi_loadaddr(u_int, void *, uint64_t);
+void efi_free_loadaddr(uint64_t, uint64_t);
+void * efi_translate(vm_offset_t);
 
-ssize_t	efi_copyin(const void *src, vm_offset_t dest, const size_t len);
-ssize_t	efi_copyout(const vm_offset_t src, void *dest, const size_t len);
-ssize_t	efi_readin(const int fd, vm_offset_t dest, const size_t len);
-void * efi_translate(vm_offset_t ptr);
+multiboot2_info_header_t *efi_copy_finish(struct relocator *);
+void multiboot_tramp(uint32_t, struct relocator *, uint64_t);
 
-void	efi_copy_finish(void);
+void efi_addsmapdata(struct preloaded_file *);
 
-#endif	/* _LOADER_EFI_COPY_H_ */
+#endif	/* _LOADER_EFI_H */

--- a/usr/src/boot/sys/boot/efi/loader/main.c
+++ b/usr/src/boot/sys/boot/efi/loader/main.c
@@ -65,6 +65,7 @@ EFI_GUID serial_io = SERIAL_IO_PROTOCOL;
 
 extern void acpi_detect(void);
 void efi_serial_init(void);
+extern void efi_getsmap(void);
 #ifdef EFI_ZFS_BOOT
 static void efi_zfs_probe(void);
 #endif
@@ -209,6 +210,8 @@ main(int argc, CHAR16 *argv[])
 	archsw.arch_copyin = efi_copyin;
 	archsw.arch_copyout = efi_copyout;
 	archsw.arch_readin = efi_readin;
+	archsw.arch_loadaddr = efi_loadaddr;
+	archsw.arch_free_loadaddr = efi_free_loadaddr;
 #ifdef EFI_ZFS_BOOT
 	/* Note this needs to be set before ZFS init. */
 	archsw.arch_zfs_probe = efi_zfs_probe;
@@ -226,6 +229,7 @@ main(int argc, CHAR16 *argv[])
 	 * printf() etc. once this is done.
 	 */
 	cons_probe();
+	efi_getsmap();
 
 	/*
 	 * Initialise the block cache. Set the upper limit.
@@ -327,11 +331,6 @@ main(int argc, CHAR16 *argv[])
 			setenv("console", "text ttya" , 1);
 	} else if (howto & RB_SERIAL) {
 		setenv("console", "ttya" , 1);
-	}
-
-	if (efi_copy_init()) {
-		printf("failed to allocate staging area\n");
-		return (EFI_BUFFER_TOO_SMALL);
 	}
 
 	/*
@@ -795,6 +794,104 @@ command_fdt(int argc, char *argv[])
 
 COMMAND_SET(fdt, "fdt", "flattened device tree handling", command_fdt);
 #endif
+
+/*
+ * Chain load another efi loader.
+ */
+static int
+command_chain(int argc, char *argv[])
+{
+	EFI_GUID LoadedImageGUID = LOADED_IMAGE_PROTOCOL;
+	EFI_HANDLE loaderhandle;
+	EFI_LOADED_IMAGE *loaded_image;
+	EFI_STATUS status;
+	struct stat st;
+	struct devdesc *dev;
+	char *name, *path;
+	void *buf;
+	int fd;
+
+	if (argc < 2) {
+		command_errmsg = "wrong number of arguments";
+		return (CMD_ERROR);
+	}
+
+	name = argv[1];
+
+	if ((fd = open(name, O_RDONLY)) < 0) {
+		command_errmsg = "no such file";
+		return (CMD_ERROR);
+	}
+
+	if (fstat(fd, &st) < -1) {
+		command_errmsg = "stat failed";
+		close(fd);
+		return (CMD_ERROR);
+	}
+
+	status = BS->AllocatePool(EfiLoaderCode, (UINTN)st.st_size, &buf);
+	if (status != EFI_SUCCESS) {
+		command_errmsg = "failed to allocate buffer";
+		close(fd);
+		return (CMD_ERROR);
+	}
+	if (read(fd, buf, st.st_size) != st.st_size) {
+		command_errmsg = "error while reading the file";
+		(void)BS->FreePool(buf);
+		close(fd);
+		return (CMD_ERROR);
+	}
+	close(fd);
+	status = BS->LoadImage(FALSE, IH, NULL, buf, st.st_size, &loaderhandle);
+	(void)BS->FreePool(buf);
+	if (status != EFI_SUCCESS) {
+		command_errmsg = "LoadImage failed";
+		return (CMD_ERROR);
+	}
+	status = BS->HandleProtocol(loaderhandle, &LoadedImageGUID,
+	    (void **)&loaded_image);
+
+	if (argc > 2) {
+		int i, len = 0;
+		CHAR16 *argp;
+
+		for (i = 2; i < argc; i++)
+			len += strlen(argv[i]) + 1;
+
+		len *= sizeof (*argp);
+		loaded_image->LoadOptions = argp = malloc (len);
+		if (loaded_image->LoadOptions == NULL) {
+			(void) BS->UnloadImage(loaded_image);
+			return (CMD_ERROR);
+		}
+		loaded_image->LoadOptionsSize = len;
+		for (i = 2; i < argc; i++) {
+			char *ptr = argv[i];
+			while (*ptr)
+				*(argp++) = *(ptr++);
+			*(argp++) = ' ';
+		}
+		*(--argv) = 0;
+	}
+
+	if (efi_getdev((void **)&dev, name, (const char **)&path) == 0)
+		loaded_image->DeviceHandle =
+		    efi_find_handle(dev->d_dev, dev->d_unit);
+
+	dev_cleanup();
+	status = BS->StartImage(loaderhandle, NULL, NULL);
+	if (status != EFI_SUCCESS) {
+		command_errmsg = "StartImage failed";
+		free(loaded_image->LoadOptions);
+		loaded_image->LoadOptions = NULL;
+		status = BS->UnloadImage(loaded_image);
+		return (CMD_ERROR);
+	}
+
+	return (CMD_ERROR);	/* not reached */
+}
+
+COMMAND_SET(chain, "chain", "chain load file", command_chain);
 
 #ifdef EFI_ZFS_BOOT
 static void

--- a/usr/src/boot/sys/boot/efi/loader/memmap.c
+++ b/usr/src/boot/sys/boot/efi/loader/memmap.c
@@ -1,0 +1,180 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2016 Toomas Soome <tsoome@me.com>
+ */
+
+/*
+ * Build smap like memory map from efi memmap.
+ */
+
+#include <stand.h>
+#include <inttypes.h>
+#include <efi.h>
+#include <efilib.h>
+#include <sys/param.h>
+#include <sys/linker.h>
+#include <sys/queue.h>
+#include <sys/stddef.h>
+#include <machine/metadata.h>
+#include <machine/pc/bios.h>
+#include "bootstrap.h"
+
+struct smap_buf {
+	struct bios_smap	sb_smap;
+	STAILQ_ENTRY(smap_buf)	sb_bufs;
+};
+
+static struct bios_smap *smapbase;
+static int smaplen;
+
+/*
+ * See ACPI 6.1 Table 15-330 UEFI Memory Types and mapping to ACPI address
+ * range types.
+ */
+static int
+smap_type(int type)
+{
+	switch (type) {
+	case EfiLoaderCode:
+	case EfiLoaderData:
+	case EfiBootServicesCode:
+	case EfiBootServicesData:
+	case EfiConventionalMemory:
+		return (SMAP_TYPE_MEMORY);
+	case EfiReservedMemoryType:
+	case EfiRuntimeServicesCode:
+	case EfiRuntimeServicesData:
+	case EfiMemoryMappedIO:
+	case EfiMemoryMappedIOPortSpace:
+	case EfiPalCode:
+	case EfiUnusableMemory:
+		return (SMAP_TYPE_RESERVED);
+	case EfiACPIReclaimMemory:
+		return (SMAP_TYPE_ACPI_RECLAIM);
+	case EfiACPIMemoryNVS:
+		return (SMAP_TYPE_ACPI_NVS);
+	}
+	return (SMAP_TYPE_RESERVED);
+}
+
+void
+efi_getsmap(void)
+{
+	UINTN size, desc_size, key;
+	EFI_MEMORY_DESCRIPTOR *efi_mmap, *p;
+	EFI_PHYSICAL_ADDRESS addr;
+	EFI_STATUS status;
+	STAILQ_HEAD(smap_head, smap_buf) head =
+	    STAILQ_HEAD_INITIALIZER(head);
+	struct smap_buf *cur, *next;
+	int i, n, ndesc;
+	int type = -1;
+
+	size = 0;
+	status = BS->GetMemoryMap(&size, efi_mmap, &key, &desc_size, NULL);
+	efi_mmap = malloc(size);
+	status = BS->GetMemoryMap(&size, efi_mmap, &key, &desc_size, NULL);
+	if (EFI_ERROR(status)) {
+		printf("GetMemoryMap: error %lu\n", EFI_ERROR_CODE(status));
+		free(efi_mmap);
+		return;
+	}
+
+	STAILQ_INIT(&head);
+	n = 0;
+	i = 0;
+	p = efi_mmap;
+	next = NULL;
+	ndesc = size / desc_size;
+	while (i < ndesc) {
+		if (next == NULL) {
+			next = malloc(sizeof(*next));
+			if (next == NULL)
+				break;
+
+			next->sb_smap.base = p->PhysicalStart;
+			next->sb_smap.length =
+			    p->NumberOfPages << EFI_PAGE_SHIFT;
+			/*
+			 * ACPI 6.1 tells the lower memory should be
+			 * reported as normal memory, so we enforce
+			 * page 0 type even as vmware maps it as
+			 * acpi reclaimable.
+			 */
+			if (next->sb_smap.base == 0)
+				type = SMAP_TYPE_MEMORY;
+			else
+				type = smap_type(p->Type);
+			next->sb_smap.type = type;
+
+			STAILQ_INSERT_TAIL(&head, next, sb_bufs);
+			n++;
+			p = NextMemoryDescriptor(p, desc_size);
+			i++;
+			continue;
+		}
+		addr = next->sb_smap.base + next->sb_smap.length;
+		if ((smap_type(p->Type) == type) &&
+		    (p->PhysicalStart == addr)) {
+			next->sb_smap.length +=
+			    (p->NumberOfPages << EFI_PAGE_SHIFT);
+			p = NextMemoryDescriptor(p, desc_size);
+			i++;
+		} else
+			next = NULL;
+	}
+	smaplen = n;
+	if (smaplen > 0) {
+		smapbase = malloc(smaplen * sizeof(*smapbase));
+		if (smapbase != NULL) {
+			n = 0;
+			STAILQ_FOREACH(cur, &head, sb_bufs)
+				smapbase[n++] = cur->sb_smap;
+		}
+		cur = STAILQ_FIRST(&head);
+		while (cur != NULL) {
+			next = STAILQ_NEXT(cur, sb_bufs);
+			free(cur);
+			cur = next;
+		}
+	}
+	free(efi_mmap);
+}
+
+void
+efi_addsmapdata(struct preloaded_file *kfp)
+{
+	size_t size;
+
+	if (smapbase == NULL || smaplen == 0)
+		return;
+	size = smaplen * sizeof(*smapbase);
+	file_addmetadata(kfp, MODINFOMD_SMAP, size, smapbase);
+}
+
+COMMAND_SET(smap, "smap", "show BIOS SMAP", command_smap);
+
+static int
+command_smap(int argc, char *argv[])
+{
+	u_int i;
+
+	if (smapbase == NULL || smaplen == 0)
+		return (CMD_ERROR);
+
+	for (i = 0; i < smaplen; i++)
+		printf("SMAP type=%02" PRIx32 " base=%016" PRIx64
+		    " len=%016" PRIx64 "\n", smapbase[i].type,
+		    smapbase[i].base, smapbase[i].length);
+	return (CMD_OK);
+}

--- a/usr/src/boot/sys/boot/i386/libi386/libi386.h
+++ b/usr/src/boot/sys/boot/i386/libi386/libi386.h
@@ -25,6 +25,8 @@
  *
  */
 
+#ifndef	_LIBI386_H
+#define	_LIBI386_H
 
 /*
  * i386 fully-qualified device descriptor.
@@ -153,4 +155,8 @@ int	bi_load64(char *args, vm_offset_t addr, vm_offset_t *modulep,
 	    vm_offset_t *kernend, int add_smap);
 int	bi_checkcpu(void);
 
+int	mb_kernel_cmdline(struct preloaded_file *, struct devdesc *, char **);
+void	multiboot_tramp(uint32_t, vm_offset_t, vm_offset_t);
 void	pxe_enable(void *pxeinfo);
+
+#endif /* _LIBI386_H */

--- a/usr/src/boot/sys/boot/i386/libi386/pxe.c
+++ b/usr/src/boot/sys/boot/i386/libi386/pxe.c
@@ -58,7 +58,7 @@ static char	data_buffer[PXE_BUFFER_SIZE];
 
 static pxenv_t	*pxenv_p = NULL;        /* PXENV+ */
 static pxe_t	*pxe_p   = NULL;	/* !PXE */
-BOOTPLAYER	bootplayer = {0};	/* PXE Cached information. */
+static BOOTPLAYER	bootplayer = {0};	/* PXE Cached information. */
 
 static int 	pxe_debug = 0;
 static int	pxe_sock = -1;

--- a/usr/src/cmd/bnu/uuglist.c
+++ b/usr/src/cmd/bnu/uuglist.c
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -27,8 +28,6 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include	"uucp.h"
 
@@ -129,13 +128,12 @@ rproc()
 	FILE *cfd;
 	char line[BUFSIZ];
 	char *carray[C_MAX];
-	int na;
 
 	cfd = fopen(GRADES, "r");
 
 	while (rdfulline(cfd, line, BUFSIZ) != 0) {
 
-		na = getargs(line, carray, C_MAX);
+		(void) getargs(line, carray, C_MAX);
 		insert(carray[0]);
 	}
 

--- a/usr/src/cmd/bnu/uustat.c
+++ b/usr/src/cmd/bnu/uustat.c
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -27,7 +28,6 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 #include <time.h>
 #include "uucp.h"
 
@@ -1542,9 +1542,6 @@ friendlytime(uplimit, lolimit)
 char *uplimit, *lolimit;
 {
 
-	char c;
-
-	c = *(uplimit+6);
 	friendlyptr->uhour[0] = *(uplimit+6);
 	friendlyptr->uhour[1] = *(uplimit+7);
 	friendlyptr->lhour[0] = *(lolimit+6);

--- a/usr/src/cmd/cmd-inet/usr.bin/talk/get_names.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/talk/get_names.c
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 1997 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -36,8 +37,6 @@
  * software developed by the University of California, Berkeley, and its
  * contributors.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include "talk.h"
 #include "ctl.h"
@@ -65,7 +64,6 @@ char *argv[];
 	char *my_name;
 	char *my_machine_name;
 	char *rem_machine_name;
-	char *my_tty;
 	char *rem_tty;
 	char *ptr;
 	int name_length;
@@ -101,8 +99,6 @@ char *argv[];
 	name_length = HOST_NAME_LENGTH;
 	(void) sysinfo(SI_HOSTNAME, hostname, name_length);
 	my_machine_name = hostname;
-
-	my_tty = strrchr(ttyname(0), '/') + 1;
 
 	/*
 	 * check for, and strip out, the machine name of the target

--- a/usr/src/cmd/cmd-inet/usr.sbin/ipadm/ipadm.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/ipadm/ipadm.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
+ * Copyright 2017 Gary Mills
  */
 
 #include <arpa/inet.h>
@@ -507,21 +508,17 @@ print_prop(show_prop_state_t *statep, uint_t flags, char *buf, size_t bufsize)
 	char			*propval = statep->sps_propval;
 	uint_t			proto = statep->sps_proto;
 	size_t			propsize = MAXPROPVALLEN;
-	char			*object;
 	ipadm_status_t		status;
 
 	if (statep->sps_ifprop) {
 		status = ipadm_get_ifprop(iph, ifname, prop_name, propval,
 		    &propsize, proto, flags);
-		object = ifname;
 	} else if (statep->sps_modprop) {
 		status = ipadm_get_prop(iph, prop_name, propval, &propsize,
 		    proto, flags);
-		object = ipadm_proto2str(proto);
 	} else {
 		status = ipadm_get_addrprop(iph, prop_name, propval, &propsize,
 		    statep->sps_aobjname, flags);
-		object = statep->sps_aobjname;
 	}
 
 	if (status != IPADM_SUCCESS) {

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_dhcpv6.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_dhcpv6.c
@@ -20,6 +20,7 @@
  */
 
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -584,7 +585,7 @@ static void
 show_options(const uint8_t *data, int len)
 {
 	dhcpv6_option_t d6o;
-	uint_t olen, retlen;
+	uint_t olen;
 	uint16_t val16;
 	uint16_t type;
 	uint32_t val32;
@@ -766,7 +767,7 @@ show_options(const uint8_t *data, int len)
 			if (olen > 0) {
 				oldnest = prot_nest_prefix;
 				prot_nest_prefix = prot_prefix;
-				retlen = interpret_dhcpv6(F_DTAIL, data, olen);
+				(void) interpret_dhcpv6(F_DTAIL, data, olen);
 				prot_prefix = prot_nest_prefix;
 				prot_nest_prefix = oldnest;
 			}

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpcsec.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpcsec.c
@@ -23,6 +23,7 @@
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright 2017 Gary Mills
  */
 
 #include <sys/types.h>
@@ -293,22 +294,20 @@ rpcsec_gss_control_proc(int type, int flags, int xid)
 void
 extract_rpcsec_gss_cred_info(int xid)
 {
-	unsigned int seq_num;
 	unsigned int handle_len;
-	unsigned int flavor_len;
 	unsigned int rpcsec_gss_ver;
 	rpc_gss_service_t rpcsec_gss_service;
 	unsigned int rpcsec_gss_proc;
 	struct cache_struct *x;
 
-	flavor_len = getxdr_u_long();
+	(void) getxdr_u_long();
 	rpcsec_gss_ver = getxdr_u_long();
 	/* see if we know this version or not */
 	if (rpcsec_gss_ver != 1) {
 		longjmp(xdr_err, 1);
 	}
 	rpcsec_gss_proc   = getxdr_u_long();
-	seq_num    = getxdr_u_long();
+	(void) getxdr_u_long();
 	rpcsec_gss_service    = getxdr_enum();
 	/* skip the handle */
 	xdr_skip(RNDUP(getxdr_u_long()));
@@ -327,7 +326,7 @@ static void
 print_rpc_gss_init_arg(int flags, struct cache_struct *x)
 {
 
-	char *token, *line;
+	char  *line;
 	unsigned int token_len;
 	int pos = 0;
 
@@ -348,7 +347,7 @@ print_rpc_gss_init_arg(int flags, struct cache_struct *x)
 
 	pos = getxdr_pos();
 	token_len = getxdr_u_long();
-	token = getxdr_hex(token_len);
+	(void) getxdr_hex(token_len);
 	line = get_line(pos, getxdr_pos());
 	sprintf(line, "   gss token: length = %d, data = [%d bytes]",
 	    token_len, token_len);
@@ -363,7 +362,7 @@ void
 print_rpc_gss_init_res(int flags)
 {
 
-	char *handle, *token, *line;
+	char *handle, *line;
 	unsigned int token_len, handle_len;
 	unsigned int major, minor, seq_window;
 
@@ -395,7 +394,7 @@ print_rpc_gss_init_res(int flags)
 	    "   sequence window  = %u", seq_window);
 	pos = getxdr_pos();
 	token_len = getxdr_u_long();
-	token = getxdr_hex(token_len);
+	(void) getxdr_hex(token_len);
 	line = get_line(pos, getxdr_pos());
 	sprintf(line, "   gss token: length = %d, data = [%d bytes]",
 	    token_len, token_len);

--- a/usr/src/cmd/gss/gssd/gssdtest.c
+++ b/usr/src/cmd/gss/gssd/gssdtest.c
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -1294,9 +1295,7 @@ char **argv;
 	OM_UINT32 status;
 	gss_ctx_id_t *context_handle;
 	OM_uint32 minor_status;
-	uid_t uid;
 
-	uid = (uid_t) getuid();
 
 	/* parse the command line to determine the variable input argument */
 

--- a/usr/src/cmd/hal/addons/network-devices/common.c
+++ b/usr/src/cmd/hal/addons/network-devices/common.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2017 Gary Mills
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Academic Free License version 2.1
@@ -113,7 +114,7 @@ addr_to_string(char *prefix, uchar_t *mac, int mac_len, char *buf, int buf_len)
 static char *
 pseudo_serialno_from_addr(char *name)
 {
-	int sd, rc, errnum;
+	int sd, errnum;
 	char buf[128];
 	struct hostent *hp;
 	struct xarpreq ar;
@@ -140,7 +141,7 @@ pseudo_serialno_from_addr(char *name)
 	sd = socket(AF_INET, SOCK_DGRAM, 0);
 
 	ar.xarp_ha.sdl_family = AF_LINK;
-	rc = ioctl(sd, SIOCGXARP, (caddr_t)&ar);
+	(void) ioctl(sd, SIOCGXARP, (caddr_t)&ar);
 
 	close(sd);
 

--- a/usr/src/cmd/hal/addons/storage/addon-storage.c
+++ b/usr/src/cmd/hal/addons/storage/addon-storage.c
@@ -2,6 +2,7 @@
  *
  * addon-storage.c : watch removable media state changes
  *
+ * Copyright 2017 Gary Mills
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
@@ -318,8 +319,6 @@ main (int argc, char *argv[])
 	char *bus;
 	char *drive_type;
 	int state, last_state;
-	char *support_media_changed_str;
-	int support_media_changed;
 	int fd = -1;
 
 	if ((udi = getenv ("UDI")) == NULL)
@@ -340,12 +339,6 @@ main (int argc, char *argv[])
 	setup_logger ();
 
 	sysevent_init ();
-
-	support_media_changed_str = getenv ("HAL_PROP_STORAGE_CDROM_SUPPORT_MEDIA_CHANGED");
-	if (support_media_changed_str != NULL && strcmp (support_media_changed_str, "true") == 0)
-		support_media_changed = TRUE;
-	else
-		support_media_changed = FALSE;
 
 	dbus_error_init (&error);
 

--- a/usr/src/cmd/ipf/tools/ipfcomp.c
+++ b/usr/src/cmd/ipf/tools/ipfcomp.c
@@ -5,6 +5,7 @@
  *
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2017 Gary Mills
  */
 
 #include "ipf.h"
@@ -62,7 +63,6 @@ static	FILE	*cfile = NULL;
 void printc(fr)
 frentry_t *fr;
 {
-	fripf_t *ipf;
 	u_long *ulp;
 	char *and;
 	FILE *fp;
@@ -75,7 +75,6 @@ frentry_t *fr;
 	if ((fr->fr_type == FR_T_IPF) &&
 	    ((fr->fr_datype != FRI_NORMAL) || (fr->fr_satype != FRI_NORMAL)))
 		return;
-	ipf = fr->fr_ipf;
 
 	if (cfile == NULL)
 		cfile = fopen("ip_rules.c", "w");

--- a/usr/src/cmd/ipf/tools/ippool.c
+++ b/usr/src/cmd/ipf/tools/ippool.c
@@ -7,6 +7,7 @@
  * Use is subject to license terms.
  *
  * Copyright (c) 2014, Joyent, Inc.  All rights reserved.
+ * Copyright 2017 Gary Mills
  */
 
 #include <sys/types.h>
@@ -382,8 +383,8 @@ char *argv[];
 {
 	char *kernel, *core, *poolname;
 	int c, role, type, live_kernel;
-	ip_pool_stat_t *plstp, plstat;
-	iphtstat_t *htstp, htstat;
+	ip_pool_stat_t  plstat;
+	iphtstat_t  htstat;
 	iphtable_t *hptr;
 	iplookupop_t op;
 	ip_pool_t *ptr;
@@ -469,7 +470,6 @@ char *argv[];
 	}
 
 	if (type == IPLT_ALL || type == IPLT_POOL) {
-		plstp = &plstat;
 		op.iplo_type = IPLT_POOL;
 		op.iplo_size = sizeof(plstat);
 		op.iplo_struct = &plstat;
@@ -503,7 +503,6 @@ char *argv[];
 		}
 	}
 	if (type == IPLT_ALL || type == IPLT_HASH) {
-		htstp = &htstat;
 		op.iplo_type = IPLT_HASH;
 		op.iplo_size = sizeof(htstat);
 		op.iplo_struct = &htstat;
@@ -642,15 +641,11 @@ int poolstats(argc, argv)
 int argc;
 char *argv[];
 {
-	int c, type, role, live_kernel;
+	int c, type, role;
 	ip_pool_stat_t plstat;
-	char *kernel, *core;
 	iphtstat_t htstat;
 	iplookupop_t op;
 
-	core = NULL;
-	kernel = NULL;
-	live_kernel = 1;
 	type = IPLT_ALL;
 	role = IPL_LOGALL;
 
@@ -666,12 +661,8 @@ char *argv[];
 			setzonename_global(optarg);
 			break;
 		case 'M' :
-			live_kernel = 0;
-			core = optarg;
 			break;
 		case 'N' :
-			live_kernel = 0;
-			kernel = optarg;
 			break;
 		case 'o' :
 			role = getrole(optarg);

--- a/usr/src/cmd/krb5/ldap_util/kdb5_ldap_list.c
+++ b/usr/src/cmd/krb5/ldap_util/kdb5_ldap_list.c
@@ -1,5 +1,3 @@
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * kadmin/ldap_util/kdb5_ldap_list.c
  */
@@ -164,7 +162,6 @@ void list_modify_str_array(destlist, sourcelist, mode)
     char **dlist = NULL, **tmplist = NULL;
     const char **slist = NULL;
     int dcount = 0, scount = 0, copycount = 0;
-    int found = 0;
 
     if ((destlist == NULL) || (*destlist == NULL) || (sourcelist == NULL))
 	return;
@@ -200,10 +197,8 @@ void list_modify_str_array(destlist, sourcelist, mode)
 	 * from the destination list */
 	for (slist = sourcelist; *slist != NULL; slist++) {
 	    for (dlist = *destlist; *dlist != NULL; dlist++) {
-		found = 0; /* value not found */
 		/* DN is case insensitive string */
 		if (strcasecmp(*dlist, *slist) == 0) {
-		    found = 1;
 		    free(*dlist);
 		    /* Advance the rest of the entries by one */
 		    for (tmplist = dlist; *tmplist != NULL; tmplist++) {

--- a/usr/src/cmd/krb5/ldap_util/kdb5_ldap_realm.c
+++ b/usr/src/cmd/krb5/ldap_util/kdb5_ldap_realm.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -156,21 +157,19 @@ static int get_ticket_policy(rparams,i,argv,argc)
     time_t now;
     int mask = 0;
     krb5_error_code retval = 0;
-    krb5_boolean no_msg = FALSE;
 
-    krb5_boolean print_usage = FALSE;
     /* Solaris Kerberos */
     char *me = progname;
 
     time(&now);
     if (!strcmp(argv[*i], "-maxtktlife")) {
 	if (++(*i) > argc-1)
-	    goto err_usage;
+	    goto err;
 	date = get_date(argv[*i]);
 	if (date == (time_t)(-1)) {
 	    retval = EINVAL;
 	    com_err (me, retval, gettext("while providing time specification"));
-	    goto err_nomsg;
+	    goto err;
 	}
 	rparams->max_life = date-now;
 	mask |= LDAP_REALM_MAXTICKETLIFE;
@@ -179,13 +178,13 @@ static int get_ticket_policy(rparams,i,argv,argc)
 
     else if (!strcmp(argv[*i], "-maxrenewlife")) {
 	if (++(*i) > argc-1)
-	    goto err_usage;
+	    goto err;
 
 	date = get_date(argv[*i]);
 	if (date == (time_t)(-1)) {
 	    retval = EINVAL;
 	    com_err (me, retval, gettext("while providing time specification"));
-	    goto err_nomsg;
+	    goto err;
 	}
 	rparams->max_renewable_life = date-now;
 	mask |= LDAP_REALM_MAXRENEWLIFE;
@@ -195,7 +194,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_POSTDATED;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_forwardable")) {
@@ -205,7 +204,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_FORWARDABLE;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_renewable")) {
@@ -214,7 +213,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_RENEWABLE;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_proxiable")) {
@@ -223,7 +222,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_PROXIABLE;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_dup_skey")) {
@@ -232,7 +231,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_DUP_SKEY;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     }
@@ -243,7 +242,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags &= (int)(~KRB5_KDB_REQUIRES_PRE_AUTH);
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "requires_hwauth")) {
@@ -252,7 +251,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags &= (int)(~KRB5_KDB_REQUIRES_HW_AUTH);
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_svr")) {
@@ -261,7 +260,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_SVR;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_tgs_req")) {
@@ -270,7 +269,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_TGT_BASED;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_tix")) {
@@ -279,7 +278,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags |= KRB5_KDB_DISALLOW_ALL_TIX;
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "needchange")) {
@@ -288,7 +287,7 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags &= (int)(~KRB5_KDB_REQUIRES_PWCHANGE);
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "password_changing_service")) {
@@ -297,15 +296,12 @@ static int get_ticket_policy(rparams,i,argv,argc)
 	else if (*(argv[*i]) == '-')
 	    rparams->tktflags &= (int)(~KRB5_KDB_PWCHANGE_SERVICE);
 	else
-	    goto err_usage;
+	    goto err;
 
 	mask |=LDAP_REALM_KRBTICKETFLAGS;
     }
-err_usage:
-    print_usage = TRUE;
 
-err_nomsg:
-    no_msg = TRUE;
+err:
 
     return mask;
 }

--- a/usr/src/cmd/ldap/common/fileurl.c
+++ b/usr/src/cmd/ldap/common/fileurl.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -360,7 +361,6 @@ berval_from_file( const char *path, struct berval *bvp, int reporterrs )
 {
     FILE	*fp;
     long	rlen;
-    int		eof;
 #if defined( XP_WIN32 )
     char	mode[20] = "r+b";
 #else
@@ -397,7 +397,6 @@ berval_from_file( const char *path, struct berval *bvp, int reporterrs )
     }
 
     rlen = fread( bvp->bv_val, 1, bvp->bv_len, fp );
-    eof = feof( fp );
     fclose( fp );
 
     if ( rlen != (long)bvp->bv_len ) {

--- a/usr/src/cmd/lp/lib/papi/ppd.c
+++ b/usr/src/cmd/lp/lib/papi/ppd.c
@@ -19,11 +19,10 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
  * This file contains an extremely rudimentary implementation of PPD file
@@ -90,7 +89,6 @@ PPDFileToAttributesList(papi_attribute_t ***attributes, char *filename)
 	char capability[256];
 	char def[256];
 	char supported[256];
-	char *current_group_name = NULL;
 
 	int ui = 0;
 
@@ -120,7 +118,6 @@ PPDFileToAttributesList(papi_attribute_t ***attributes, char *filename)
 		if (strcasecmp(key, "OpenGroup") == 0) {
 			if (value == NULL)
 				value = "unknown";
-			current_group_name = strdup(value);
 		} else if (strcasecmp(key, "OpenUI") == 0) {
 			if ((strcasecmp(value, "PageSize") == 0) ||
 			    (strcasecmp(value, "InputSlot") == 0))

--- a/usr/src/cmd/mail/copylet.c
+++ b/usr/src/cmd/mail/copylet.c
@@ -20,14 +20,13 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include "mail.h"
 
@@ -90,7 +89,6 @@ xxxcopylet(int letnum, FILE *f, int type)
 					/* H_RECEIVED lines? */
 	long	clen = -1L;
 	int	htype;			/* header type */
-	int	sav_htype;	/* Header type of last non-H_CONT header line */
 	struct hdrs *hptr;
 
 	if (!sending) {
@@ -296,7 +294,6 @@ xxxcopylet(int letnum, FILE *f, int type)
 			sav_suppress = suppress;
 			suppress = FALSE;
 			print_from_struct = FALSE;
-			sav_htype = htype;
 			htype = isheader (buf, &ctf);
 			Dout(pn, 5, "loop 2: buf = %s, htype= %d/%s\n", buf, htype, header[htype].tag);
 			/* The following order is defined in the MTA documents. */

--- a/usr/src/cmd/print/bsd-sysv-commands/disable.c
+++ b/usr/src/cmd/print/bsd-sysv-commands/disable.c
@@ -21,6 +21,7 @@
  */
 
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
@@ -92,7 +93,6 @@ main(int ac, char *av[])
 	papi_encryption_t encryption = PAPI_ENCRYPT_NEVER;
 	int exit_status = 0;
 	int cancel = 0;
-	int pending = 0;	/* not implemented */
 	char *reason = NULL;
 	int c;
 
@@ -105,7 +105,6 @@ main(int ac, char *av[])
 			cancel = 1;
 			break;
 		case 'W':	/* wait for active request, not implemented */
-			pending = 1;
 			break;
 		case 'r':	/* reason */
 			reason = optarg;

--- a/usr/src/cmd/print/bsd-sysv-commands/lpr.c
+++ b/usr/src/cmd/print/bsd-sysv-commands/lpr.c
@@ -20,14 +20,13 @@
  */
 
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
  */
 
 /* $Id: lpr.c 146 2006-03-24 00:26:54Z njacobs $ */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -75,7 +74,6 @@ main(int ac, char *av[])
 	papi_encryption_t encryption = PAPI_ENCRYPT_NEVER;
 	int dump = 0;
 	int validate = 0;
-	int remove = 0;
 	int copy = 1;	/* default is to copy the data */
 	char *document_format = "text/plain";
 	int c;
@@ -170,7 +168,6 @@ main(int ac, char *av[])
 				"rfc-1179-mail", 1);
 			break;
 		case 'r':
-			remove = 1;
 			break;
 		case 's':
 			copy = 0;

--- a/usr/src/cmd/refer/glue4.c
+++ b/usr/src/cmd/refer/glue4.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -12,8 +13,6 @@
  * specifies the terms and conditions for redistribution.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 
 #include <stdio.h>
 #include <ctype.h>
@@ -26,17 +25,13 @@ grepcall(char *in, char *out, char *arg)
 	char line[200], *s, argig[100], *cv[50];
 	char *inp, inb[500];
 	FILE *qf, *gf;
-	int c, oldc = 0, alph = 0, nv = 0;
+	int c, alph = 0, nv = 0;
 	int sv0, sv1;
 	strcpy(argig, arg);
 	strcat(argig, ".ig");
 	strcpy(inp = inb, in);
 	if (gfile[0] == 0)
 		sprintf(gfile, "/tmp/rj%dg", getpid());
-#if D1
-	fprintf(stderr, "in grepcall, gfile %s in %o out %o\n",
-	    gfile, in, out);
-#endif
 	for (cv[nv++] = "fgrep"; c = *inp; inp++) {
 		if (c == ' ')
 			c = *inp = 0;
@@ -47,11 +42,7 @@ grepcall(char *in, char *out, char *arg)
 			cv[nv++] = inp;
 		if (alph > 6)
 			*inp = 0;
-		oldc = c;
 	}
-#if D1
-	fprintf(stderr, "%d args set up\n", nv);
-#endif
 	{
 		sv0 = dup(0);
 		close(0);
@@ -62,9 +53,6 @@ grepcall(char *in, char *out, char *arg)
 		if (creat(gfile, 0666) != 1)
 			err("Can't write fgrep output %s", gfile);
 		fgrep(nv, cv);
-#if D1
-		fprintf(stderr, "fgrep returned, output is..\n");
-#endif
 		close(0);
 		dup(sv0);
 		close(sv0);
@@ -73,17 +61,11 @@ grepcall(char *in, char *out, char *arg)
 		close(sv1);
 	}
 
-#if D1
-	fprintf(stderr, "back from fgrep\n");
-#endif
 	gf = fopen(gfile, "r");
 	if (gf == NULL)
 		err("can't read fgrep output %s", gfile);
 	while (fgets(line, 100, gf) == line) {
 		line[100] = 0;
-#if D1
-		fprintf(stderr, "read line as //%s//\n", line);
-#endif
 		for (s = line; *s && (*s != '\t'); s++)
 			;
 		if (*s == '\t') {
@@ -92,23 +74,13 @@ grepcall(char *in, char *out, char *arg)
 		}
 		if (line[0])
 			strcat(out, line);
-#if D1
-		fprintf(stderr, "out now /%s/\n", out);
-#endif
 		while (*s) s++;
-#if D1
-		fprintf(stderr, "line %o s %o s-1 %o\n", line, s, s[-1]);
-#endif
 		if (s[-1] != '\n')
 			while (!feof(gf) && getc(gf) != '\n')
 				;
 	}
 	fclose(gf);
-#if D1
-	fprintf(stderr, "back from reading %, out %s\n", out);
-#else
 	unlink(gfile);
-#endif
 }
 
 void

--- a/usr/src/cmd/refer/hunt7.c
+++ b/usr/src/cmd/refer/hunt7.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -11,8 +12,6 @@
  * All rights reserved. The Berkeley software License Agreement
  * specifies the terms and conditions for redistribution.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <stdio.h>
 #include <locale.h>
@@ -37,11 +36,8 @@ findline(char *in, char **out, int outlen, long indexdate)
 	extern long gdate();
 	static FILE *fa = NULL;
 	long lp, llen;
-	int len, k, nofil;
+	int k, nofil;
 
-#if D1
-	fprintf(stderr, "findline: %s\n", in);
-#endif
 	if (mindex(in, '!'))
 		return (0);
 
@@ -51,38 +47,18 @@ findline(char *in, char **out, int outlen, long indexdate)
 	if (*p) *p++ = 0;
 	else p = in;
 	k = sscanf(p, "%ld,%ld", &lp, &llen);
-#ifdef D1
-	fprintf(stderr, "p %s k %d lp %ld llen %ld\n", p, k, lp, llen);
-#endif
 	if (k < 2) {
 		lp = 0;
 		llen = outlen;
 	}
-#ifdef D1
-	fprintf(stderr, "lp %ld llen %ld\n", lp, llen);
-#endif
-#ifdef D1
-	fprintf(stderr, "fa now %o, p %o in %o %s\n", fa, p, in, in);
-#endif
 	if (nofil) {
-#if D1
-		fprintf(stderr, "set fa to stdin\n");
-#endif
 		fa = stdin;
 	} else
 		if (strcmp(name, in) != 0 || 1) {
-#if D1
-			fprintf(stderr, "old: %s new %s not equal\n", name, in);
-#endif
 			if (fa != NULL)
 				fa = freopen(in, "r", fa);
 			else
 				fa = fopen(in, "r");
-#if D1
-			if (fa == NULL)
-				fprintf(stderr, "failed to (re)open *%s*\n",
-				    in);
-#endif
 			if (fa == NULL)
 				return (0);
 			/* err("Can't open %s", in); */
@@ -105,22 +81,14 @@ findline(char *in, char **out, int outlen, long indexdate)
 				    name);
 			}
 		}
-#if D1
-		else
-			fprintf(stderr, "old %s new %s same fa %o\n",
-			    name, in, fa);
-#endif
 	if (fa != NULL) {
 		fseek(fa, lp, 0);
 		*out = (char *)malloc(llen + 1);
 		if (*out == NULL) {
 			return (0);
 		}
-		len = fread(*out, 1, llen, fa);
+		(void) fread(*out, 1, llen, fa);
 		*(*out + llen) = 0;
-#ifdef D1
-		fprintf(stderr, "length as read is %d\n", len);
-#endif
 	}
 	return (llen);
 }

--- a/usr/src/cmd/sh/xec.c
+++ b/usr/src/cmd/sh/xec.c
@@ -20,6 +20,7 @@
  */
 
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -124,7 +125,7 @@ int *pf1, *pf2;
 
 		case TCOM:
 			{
-				unsigned char	*a1, *name;
+				unsigned char	*name;
 				int	argn, internal;
 				struct argnod	*schain = gchain;
 				struct ionod	*io = t->treio;
@@ -136,7 +137,6 @@ int *pf1, *pf2;
 				gchain = 0;
 				argn = getarg(t);
 				com = scan(argn);
-				a1 = com[1];
 				gchain = schain;
 
 				if (argn != 0)

--- a/usr/src/cmd/svr4pkg/pkgremove/special.c
+++ b/usr/src/cmd/svr4pkg/pkgremove/special.c
@@ -20,6 +20,7 @@
  */
 
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -499,7 +500,7 @@ special_contents_remove(int ient, struct cfent **ppcfent, const char *pcroot)
 {
 	int result = 0;		/* Assume we will succeed.  Return result. */
 	char **ppcSC = NULL;	/* The special contents rules, sorted. */
-	int i, j;		/* Indexes into contents & special contents */
+	int i;			/* Index into contents & special contents */
 	FILE *fpi = NULL,	/* Input of contents file */
 	    *fpo = NULL;	/* Output to temp contents file */
 	char cpath[PATH_MAX],	/* Contents file path */
@@ -599,7 +600,7 @@ special_contents_remove(int ient, struct cfent **ppcfent, const char *pcroot)
 	 */
 	(void) memset(line, 0, LINESZ);
 
-	for (i = 0, j = 0; fgets(line, LINESZ, fpi) != NULL; ) {
+	for (i = 0; fgets(line, LINESZ, fpi) != NULL; ) {
 
 		char *pcpath = NULL;
 

--- a/usr/src/cmd/troff/nroff.d/n6.c
+++ b/usr/src/cmd/troff/nroff.d/n6.c
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -201,11 +202,10 @@ setps()
 
 tchar setht()		/* set character height from \H'...' */
 {
-	int	n;
 	tchar c;
 
 	getch();
-	n = inumb(&apts);
+	(void) inumb(&apts);
 	getch();
 	return(0);
 }

--- a/usr/src/cmd/volcheck/volcheck.c
+++ b/usr/src/cmd/volcheck/volcheck.c
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -54,9 +55,6 @@ main(int argc, char **argv)
 {
 	const char	*opts = "itv";
 	int		c;
-	boolean_t	opt_i = B_FALSE;
-	boolean_t	opt_t = B_FALSE;
-	boolean_t	opt_v = B_FALSE;
 	LibHalContext	*hal_ctx;
 	DBusError	error;
 	rmm_error_t	rmm_error;
@@ -67,13 +65,10 @@ main(int argc, char **argv)
 	while ((c = getopt(argc, argv, opts)) != EOF) {
 		switch (c) {
 		case 'i':
-			opt_i = B_TRUE;
 			break;
 		case 't':
-			opt_t = B_TRUE;
 			break;
 		case 'v':
-			opt_v = B_TRUE;
 			break;
 		default:
 			usage();

--- a/usr/src/cmd/ypcmd/ypserv.c
+++ b/usr/src/cmd/ypcmd/ypserv.c
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2017 Gary Mills
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -31,8 +32,6 @@
  * Portions of this source code were derived from Berkeley 4.3 BSD
  * under license from the Regents of the University of California.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
  * This contains the mainline code for the YP server.  Data
@@ -174,7 +173,7 @@ static void
 ypinit(int argc, char **argv)
 {
 	int pid;
-	int stat, t;
+	int stat;
 	struct sigaction act;
 	int ufd, tfd;
 	SVCXPRT *utransp, *ttransp;
@@ -237,7 +236,7 @@ ypinit(int argc, char **argv)
 		    freopen(logfile, "a", stderr);
 		}
 
-		t = open("/dev/tty", 2);
+		(void) open("/dev/tty", 2);
 
 		setpgrp();
 	}

--- a/usr/src/common/bzip2/compress.c
+++ b/usr/src/common/bzip2/compress.c
@@ -241,7 +241,7 @@ void sendMTFValues ( EState* s )
 {
    Int32 v, t, i, j, gs, ge, totc, bt, bc, iter;
    Int32 nSelectors, alphaSize, minLen, maxLen, selCtr;
-   Int32 nGroups, __GNU_UNUSED nBytes;
+   Int32 nGroups, nBytes __unused;
 
    /*--
    UChar  len [BZ_N_GROUPS][BZ_MAX_ALPHA_SIZE];

--- a/usr/src/lib/libmvec/common/__vcos.c
+++ b/usr/src/lib/libmvec/common/__vcos.c
@@ -102,7 +102,7 @@ __vcos(int n, double * restrict x, int stridex, double * restrict y,
 	double		x0, x1, x2, *py0 = 0, *py1 = 0, *py2, *xsave, *ysave;
 	unsigned	hx0, hx1, hx2, xsb0, xsb1 = 0, xsb2;
 	int		i, biguns, nsave, sxsave, sysave;
-	volatile int	v __GNU_UNUSED;
+	volatile int	v __unused;
 	nsave = n;
 	xsave = x;
 	sxsave = stridex;

--- a/usr/src/lib/libmvec/common/__vsin.c
+++ b/usr/src/lib/libmvec/common/__vsin.c
@@ -82,7 +82,7 @@ __vsin(int n, double * restrict x, int stridex, double * restrict y,
 	double		x0, x1, x2, *py0 = 0, *py1 = 0, *py2, *xsave, *ysave;
 	unsigned	hx0, hx1, hx2, xsb0, xsb1 = 0, xsb2;
 	int		i, biguns, nsave, sxsave, sysave;
-	volatile int	v __GNU_UNUSED;
+	volatile int	v __unused;
 	nsave = n;
 	xsave = x;
 	sxsave = stridex;

--- a/usr/src/lib/libmvec/common/__vsincos.c
+++ b/usr/src/lib/libmvec/common/__vsincos.c
@@ -99,7 +99,7 @@ __vsincos(int n, double * restrict x, int stridex,
 			*xsave, *ysave, *csave;
 	unsigned	hx0, hx1, hx2, xsb0, xsb1, xsb2;
 	int		i, biguns, nsave, sxsave, sysave, scsave;
-	volatile int	v __GNU_UNUSED;
+	volatile int	v __unused;
 	nsave = n;
 	xsave = x;
 	sxsave = stridex;

--- a/usr/src/man/man1/chown.1
+++ b/usr/src/man/man1/chown.1
@@ -567,7 +567,7 @@ The built-in interfaces are Uncommitted.
 .SH SEE ALSO
 .sp
 .LP
-\fBchgrp\fR(1), \fBchmod\fR(1),\fBksh93\fR(1),  \fBchown\fR(2),
+\fBchgrp\fR(1), \fBchmod\fR(1), \fBksh93\fR(1), \fBchown\fR(2),
 \fBfpathconf\fR(2), \fBpasswd\fR(4), \fBsystem\fR(4), \fBattributes\fR(5),
 \fBenviron\fR(5), \fBlargefile\fR(5), \fBstandards\fR(5)
 .SH NOTES

--- a/usr/src/man/man1/kbd.1
+++ b/usr/src/man/man1/kbd.1
@@ -102,8 +102,8 @@ sequence is in use.
 .sp
 .LP
 The Alternate Break sequence has no effect on the keyboard abort. For more
-information on the Alternate Break sequence, see \fBzs\fR(7D),\fBse\fR(7D), and
-\fBasy\fR(7D).
+information on the Alternate Break sequence, see \fBzs\fR(7D), \fBse\fR(7D),
+and \fBasy\fR(7D).
 .sp
 .LP
 On many systems, the default effect of the keyboard abort sequence is to

--- a/usr/src/man/man1/kinit.1
+++ b/usr/src/man/man1/kinit.1
@@ -409,7 +409,7 @@ the user's certificate and private key.
 .RS 4n
 All keyword and values are optional. PKCS11 modules (for example,
 \fBopensc-pkcs11.so\fR) must be installed as a crypto provider
-under\fBlibpkcs11\fR(3LIB). \fBslotid=\fR and/or \fBtoken=\fR can be specified
+under \fBlibpkcs11\fR(3LIB). \fBslotid=\fR and/or \fBtoken=\fR can be specified
 to force the use of a particular smard card reader or token if there is more
 than one available. \fBcertid=\fR and/or \fBcertlabel=\fR can be specified to
 force the selection of a particular certificate on the device. See the

--- a/usr/src/man/man1/mandoc.1
+++ b/usr/src/man/man1/mandoc.1
@@ -1003,9 +1003,12 @@ The argument of the first
 macro is not
 .Sq NAME .
 This may confuse
-.Xr makewhatis 8
-and
-.Xr apropos 1 .
+.Xr apropos 1
+or confuse
+.Xr man 1
+when updating the
+.Xr whatis 1
+database.
 .It Sy "NAME section without Nm before Nd"
 .Pq mdoc
 The NAME section does not contain any

--- a/usr/src/man/man1/msgcpp.1
+++ b/usr/src/man/man1/msgcpp.1
@@ -18,7 +18,7 @@ msgcpp \- C language message catalog preprocessor
 \fBmsgcpp\fR is a C language message catalog preprocessor. It accepts
 \fBcpp\fR(1) style options and arguments. \fBmsgcpp\fR preprocesses an input C
 source file and emits keyed lines to the output, usually for further processing
-by\fBmsgcc\fR(1). \fBmsgcc\fR output is in the \fBgencat\fR(1) syntax.
+by \fBmsgcc\fR(1). \fBmsgcc\fR output is in the \fBgencat\fR(1) syntax.
 Candidate message text is determined by arguments to the last \fB<error.h>\fR
 and \fB<option.h>\fR functions. The \fBmsgcpp\fR keyed output lines are:
 .sp

--- a/usr/src/man/man1/pmap.1
+++ b/usr/src/man/man1/pmap.1
@@ -689,7 +689,7 @@ different mapping types. In this example, the mappings are as follows:
          with MAP_NORESERVE
 
 0800000: A DISM shared memory mapping, created with SHM_PAGEABLE
-         with 8MB locked via mlock(2)
+         with 8MB locked via mlock(3C)
 
 0900000: A DISM shared memory mapping, created with SHM_PAGEABLE,
          with 4MB of its pages touched.

--- a/usr/src/man/man1/preap.1
+++ b/usr/src/man/man1/preap.1
@@ -32,7 +32,7 @@ of system memory.
 .sp
 .LP
 \fBpreap\fR forces the parent of the process specified by \fIpid\fR to
-\fBwaitid\fR(3C) for \fIpid\fR, if \fIpid\fR represents a defunct process.
+\fBwaitid\fR(2) for \fIpid\fR, if \fIpid\fR represents a defunct process.
 .sp
 .LP
 \fBpreap\fR attempts to prevent the administrator from unwisely reaping a child

--- a/usr/src/man/man1/rcp.1
+++ b/usr/src/man/man1/rcp.1
@@ -138,8 +138,8 @@ of the remote host's realm as determined by \fBkrb5.conf\fR(4).
 \fB\fB-K\fR \fIrealm\fR\fR
 .ad
 .RS 12n
-This option explicitly disables Kerberos authentication. It canbe used to
-override the \fBautologin\fR variable in\fBkrb5.conf\fR(4).
+This option explicitly disables Kerberos authentication. It can be used to
+override the \fBautologin\fR variable in \fBkrb5.conf\fR(4).
 .RE
 
 .sp

--- a/usr/src/man/man1/rlogin.1
+++ b/usr/src/man/man1/rlogin.1
@@ -369,7 +369,7 @@ Hosts database.
 .sp
 .LP
 \fBrsh\fR(1), \fBstty\fR(1), \fBtty\fR(1), \fBin.rlogind\fR(1M),
-\fBhosts\fR(4),\fBhosts.equiv\fR(4), \fBkrb5.conf\fR(4), \fBnologin\fR(4),
+\fBhosts\fR(4), \fBhosts.equiv\fR(4), \fBkrb5.conf\fR(4), \fBnologin\fR(4),
 \fBattributes\fR(5), \fBkrb5_auth_rules\fR(5)
 .SH DIAGNOSTICS
 .sp

--- a/usr/src/man/man1/telnet.1
+++ b/usr/src/man/man1/telnet.1
@@ -176,7 +176,7 @@ Forwards a forwardable copy of the local credentials to the remote system.
 .RS 4n
 If Kerberos authentication is being used, requests that \fBtelnet\fR obtain
 tickets for the remote host in \fIrealm\fR instead of the remote host's default
-realm as determined in\fBkrb5.conf\fR(4).
+realm as determined in \fBkrb5.conf\fR(4).
 .RE
 
 .sp

--- a/usr/src/man/man1/tftp.1
+++ b/usr/src/man/man1/tftp.1
@@ -258,7 +258,7 @@ Print help information.
 .SH SEE ALSO
 .sp
 .LP
-\fBin.tftpd\fR(1M), \fBhosts\fR(4), \fBattributes\fR(5),\fBinet\fR(7P),
+\fBin.tftpd\fR(1M), \fBhosts\fR(4), \fBattributes\fR(5), \fBinet\fR(7P),
 \fBinet6\fR(7P)
 .sp
 .LP

--- a/usr/src/man/man1/uuidgen.1
+++ b/usr/src/man/man1/uuidgen.1
@@ -60,4 +60,4 @@ Failure.
 .Sh SEE ALSO
 .Xr uuid_generate 3uuid ,
 .Xr uuid_generate_random 3uuid ,
-.Xr uuid_generate_time 3uuidd
+.Xr uuid_generate_time 3uuid

--- a/usr/src/man/man1b/mail.1b
+++ b/usr/src/man/man1b/mail.1b
@@ -29,4 +29,4 @@ these commands.
 .SH SEE ALSO
 .sp
 .LP
-\fBmailx\fR(1),\fBattributes\fR(5)
+\fBmailx\fR(1), \fBattributes\fR(5)

--- a/usr/src/man/man1m/Makefile
+++ b/usr/src/man/man1m/Makefile
@@ -16,6 +16,7 @@
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
 # Copyright 2016 Toomas Soome <tsoome@me.com>
 # Copyright 2017 Nexenta Systems, Inc.
+# Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
 #
 
 include		$(SRC)//Makefile.master
@@ -581,6 +582,7 @@ MANLINKS=	acctcon1.1m			\
 		acctprc1.1m			\
 		acctprc2.1m			\
 		acctwtmp.1m			\
+		audlinks.1m			\
 		bootparamd.1m			\
 		chargefee.1m			\
 		ckpacct.1m			\
@@ -681,6 +683,7 @@ turnacct.1m			:= LINKSRC = acctsh.1m
 
 dcopy.1m			:= LINKSRC = clri.1m
 
+audlinks.1m			:= LINKSRC = devfsadm.1m
 devfsadmd.1m			:= LINKSRC = devfsadm.1m
 
 fcadm.1m			:= LINKSRC = fcinfo.1m

--- a/usr/src/man/man1m/cfgadm.1m
+++ b/usr/src/man/man1m/cfgadm.1m
@@ -806,7 +806,7 @@ Usage error.
 .sp
 .LP
 \fBcfgadm_fp\fR(1M), \fBcfgadm_ib\fR(1M),
-\fBcfgadm_pci\fR(1M),\fBcfgadm_sbd\fR(1M), \fBcfgadm_scsi\fR(1M),
+\fBcfgadm_pci\fR(1M), \fBcfgadm_sbd\fR(1M), \fBcfgadm_scsi\fR(1M),
 \fBcfgadm_usb\fR(1M), \fBifconfig\fR(1M), \fBmount\fR(1M), \fBprtdiag\fR(1M),
 \fBpsradm\fR(1M), \fBsyslogd\fR(1M), \fBconfig_admin\fR(3CFGADM),
 \fBgetopt\fR(3C), \fBgetsubopt\fR(3C), \fBisatty\fR(3C), \fBattributes\fR(5),

--- a/usr/src/man/man1m/cfgadm_sysctrl.1m
+++ b/usr/src/man/man1m/cfgadm_sysctrl.1m
@@ -99,7 +99,7 @@ creates the Solaris device tree nodes, attaching devices as required. For
 \fBCPU\fR/Memory boards, \fBconfigure\fR adds \fBCPU\fRs to the \fBCPU\fR list
 in the \fBpowered-off \fRstate. These are visible to the \fBpsrinfo\fR(1M) and
 \fBpsradm\fR(1M) commands. Two memory attachment points are published for
-CPU/memory boards. Use \fBmount\fR(1M) and\fBifconfig\fR(1M) to use \fBI/O\fR
+CPU/memory boards. Use \fBmount\fR(1M) and \fBifconfig\fR(1M) to use \fBI/O\fR
 devices on the new board. To use \fBCPU\fRs, use \fBpsradm\fR \fB-n\fR to
 on-line the new processors. Use \fBcfgadm_ac\fR(1M) to test and configure the
 memory banks.
@@ -160,7 +160,7 @@ changed to the unconfigured state prior to issuing the board unconfigure
 operation. The \fBCPU\fRs on the board are off-lined, powered off and removed
 from the Solaris \fBCPU\fR list. \fBCPU\fRs that have processes bound to them
 cannot be off-lined. See \fBpsradm\fR(1M), \fBpsrinfo\fR(1M), \fBpbind\fR(1M),
-and\fBp_online\fR(2) for more information on off-lining \fBCPU\fRs.
+and \fBp_online\fR(2) for more information on off-lining \fBCPU\fRs.
 .RE
 
 .RE

--- a/usr/src/man/man1m/dns-sd.1m
+++ b/usr/src/man/man1m/dns-sd.1m
@@ -59,9 +59,9 @@
 The
 .Nm
 command is a network diagnostic tool, much like
-.Xr ping 8
+.Xr ping 1M
 or
-.Xr traceroute 8 .
+.Xr traceroute 1M .
 However, unlike those tools, most of its functionality is not implemented in the
 .Nm
 executable itself, but in library code that is available to any application.

--- a/usr/src/man/man1m/fsdb_udfs.1m
+++ b/usr/src/man/man1m/fsdb_udfs.1m
@@ -404,7 +404,7 @@ on one line by  separating them by a SPACE, TAB, or semicolon (\fB;\fR).
 To view a potentially unmounted disk in a reasonable manner, \fBfsdb\fR
 supports the \fBcd\fR, \fBpwd\fR, \fBls\fR, and \fBfind\fR commands. The
 functionality of each of these commands basically matches that of its UNIX
-counterpart. See \fBcd\fR(1), \fBpwd\fR(1),\fBls\fR(1), and\fBfind\fR(1) for
+counterpart. See \fBcd\fR(1), \fBpwd\fR(1), \fBls\fR(1), and \fBfind\fR(1) for
 details. The \fB*\fR, \fB,\fR, \fB?\fR, and \fB-\fR wildcard characters are
 also supported.
 .sp

--- a/usr/src/man/man1m/in.comsat.1m
+++ b/usr/src/man/man1m/in.comsat.1m
@@ -49,7 +49,7 @@ user access and administration information
 .sp
 .LP
 \fBsvcs\fR(1), \fBinetadm\fR(1M), \fBinetd\fR(1M),
-\fBsvcadm\fR(1M),\fBservices\fR(4), \fBattributes\fR(5), \fBsmf\fR(5)
+\fBsvcadm\fR(1M), \fBservices\fR(4), \fBattributes\fR(5), \fBsmf\fR(5)
 .SH NOTES
 .sp
 .LP

--- a/usr/src/man/man1m/inityp2l.1m
+++ b/usr/src/man/man1m/inityp2l.1m
@@ -17,7 +17,7 @@ inityp2l \- create NIS (YP) to LDAP configuration files
 .sp
 .LP
 The \fBinityp2l\fR utility assists with creation of the \fBNISLDAPmapping\fR
-and \fBypserv\fR files. See \fBNISLDAPmapping\fR(4) and\fBypserv\fR(4).
+and \fBypserv\fR files. See \fBNISLDAPmapping\fR(4) and \fBypserv\fR(4).
 \fBinityp2l\fR examines the NIS maps on a system. and through a dialogue with
 the user, determines which NIS to (and from) LDAP mappings are required. A
 \fBNISLDAPmapping\fR file is then created based on this information. The

--- a/usr/src/man/man1m/ipdadm.1m
+++ b/usr/src/man/man1m/ipdadm.1m
@@ -220,4 +220,4 @@ Interface Stability	Evolving
 .SH SEE ALSO
 .sp
 .LP
-\fBzonename\fR(1),\fBzoneadm\fR(1M), \fBattributes\fR(5), \fBzones(5)\fR
+\fBzonename\fR(1), \fBzoneadm\fR(1M), \fBattributes\fR(5), \fBzones(5)\fR

--- a/usr/src/man/man1m/kdb5_ldap_util.1m
+++ b/usr/src/man/man1m/kdb5_ldap_util.1m
@@ -130,7 +130,7 @@ Specifies maximum renewable life of tickets for principals in this realm.
 .sp .6
 .RS 4n
 Specifies the Kerberos realm of the database; by default the realm returned by
-\fBkrb5_default_local_realm(3)\fR is used.
+\fBkrb5_default_local_realm\fR(3LIB) is used.
 .RE
 
 .SH \fBkdb5_ldap_util\fR COMMANDS

--- a/usr/src/man/man1m/ldapclient.1m
+++ b/usr/src/man/man1m/ldapclient.1m
@@ -1139,7 +1139,7 @@ Interface Stability	Evolving
 \fBchkey\fR(1), \fBldap\fR(1), \fBldapadd\fR(1), \fBldapdelete\fR(1),
 \fBldaplist\fR(1), \fBldapmodify\fR(1), \fBldapmodrdn\fR(1),
 \fBldapsearch\fR(1), \fBidsconfig\fR(1M), \fBldapaddent\fR(1M),
-\fBldap_cachemgr\fR(1M), \fBsuninstall\fR(1M), \fBdefaultdomain\fR(4),
+\fBldap_cachemgr\fR(1M), \fBdefaultdomain\fR(4),
 \fBnsswitch.conf\fR(4), \fBresolv.conf\fR(4), \fBattributes\fR(5)
 .SH CAUTION
 .LP

--- a/usr/src/man/man1m/mkfs_udfs.1m
+++ b/usr/src/man/man1m/mkfs_udfs.1m
@@ -85,7 +85,7 @@ Specify the number of 512-byte blocks in the file system.
 .SH SEE ALSO
 .sp
 .LP
-\fBfsck\fR(1M),\fBmkfs\fR(1M), \fBattributes\fR(5)
+\fBfsck\fR(1M), \fBmkfs\fR(1M), \fBattributes\fR(5)
 .SH DIAGNOSTICS
 .sp
 .in +2

--- a/usr/src/man/man1m/netstat.1m
+++ b/usr/src/man/man1m/netstat.1m
@@ -763,7 +763,7 @@ The statistics use the MIB specified variables. The defined values for
 .sp
 .ne 2
 .na
-\fB\fBforwarding(1)\fR\fR
+\fB\fBforwarding (1)\fR\fR
 .ad
 .RS 21n
 Acting as a gateway.
@@ -772,7 +772,7 @@ Acting as a gateway.
 .sp
 .ne 2
 .na
-\fB\fBnot-forwarding(2)\fR\fR
+\fB\fBnot-forwarding (2)\fR\fR
 .ad
 .RS 21n
 Not acting as a gateway.

--- a/usr/src/man/man1m/ping.1m
+++ b/usr/src/man/man1m/ping.1m
@@ -332,7 +332,7 @@ packets. The default time to live (hop limit) for unicast packets can be set
 with the \fBndd\fR module, \fB/dev/icmp\fR, using the \fBicmp_ipv4_ttl\fR
 variable for IPv4 and the \fBicmp_ipv6_hoplimit\fR variable for IPv6. The
 default time to live (hop limit) for multicast is one hop. See \fBEXAMPLES\fR.
-For further information, see\fBndd\fR(1M).
+For further information, see \fBndd\fR(1M).
 .RE
 
 .sp

--- a/usr/src/man/man1m/pkgask.1m
+++ b/usr/src/man/man1m/pkgask.1m
@@ -107,7 +107,7 @@ An error occurred.
 .LP
 \fBpkginfo\fR(1), \fBpkgmk\fR(1), \fBpkgparam\fR(1), \fBpkgproto\fR(1),
 \fBpkgtrans\fR(1), \fBinstallf\fR(1M), \fBpkgadd\fR(1M), \fBpkgchk\fR(1M),
-\fBpkgrm\fR(1M), \fBremovef\fR(1M), \fBadmin\fR(4),\fBattributes\fR(5)
+\fBpkgrm\fR(1M), \fBremovef\fR(1M), \fBadmin\fR(4), \fBattributes\fR(5)
 .sp
 .LP
 \fI\fR
@@ -128,4 +128,4 @@ command.
 .LP
 If the default \fBadmin\fR file is too restrictive, the administration file may
 need to be modified to allow for total non-interaction during a package
-installation. See\fBadmin\fR(4) for details.
+installation. See \fBadmin\fR(4) for details.

--- a/usr/src/man/man1m/rpc.bootparamd.1m
+++ b/usr/src/man/man1m/rpc.bootparamd.1m
@@ -59,7 +59,7 @@ configuration file for the name-service switch
 .SH SEE ALSO
 .sp
 .LP
-\fBsvcs\fR(1),\fBsvcadm\fR(1M), \fBbootparams\fR(4), \fBnsswitch.conf\fR(4),
+\fBsvcs\fR(1), \fBsvcadm\fR(1M), \fBbootparams\fR(4), \fBnsswitch.conf\fR(4),
 \fBattributes\fR(5), \fBsmf\fR(5)
 .SH NOTES
 .sp

--- a/usr/src/man/man1m/stmsboot.1m
+++ b/usr/src/man/man1m/stmsboot.1m
@@ -218,7 +218,7 @@ controller ports, enter:
 .LP
 To enable Solaris I/O multipathing on specific fibre channel controller ports
 and disable the feature on others, manually edit the \fB/kernel/drv/fp.conf\fR
-file. (See\fBfp\fR(7D).) The following command will update \fBvfstab\fR(4) and
+file. (See \fBfp\fR(7D).) The following command will update \fBvfstab\fR(4) and
 \fBdumpadm\fR(1M) configurations to reflect the changed device names:
 
 .sp

--- a/usr/src/man/man1m/svc.configd.1m
+++ b/usr/src/man/man1m/svc.configd.1m
@@ -21,7 +21,7 @@ if any failures occur. \fBsvc.configd\fR should never be invoked directly.
 .sp
 .LP
 Interaction with \fBsvc.configd\fR is by way of \fBlibscf\fR(3LIB) and the
-command line tools:\fBsvcs\fR(1), \fBsvcprop\fR(1), \fBsvcadm\fR(1M), and
+command line tools: \fBsvcs\fR(1), \fBsvcprop\fR(1), \fBsvcadm\fR(1M), and
 \fBsvccfg\fR(1M).
 .SH SEE ALSO
 .sp

--- a/usr/src/man/man1m/tapes.1m
+++ b/usr/src/man/man1m/tapes.1m
@@ -95,7 +95,8 @@ combination of density, \fBBSD\fR behavior, and no-rewind flags. See
 .LP
 To prevent \fBtapes\fR from attempting to automatically generate links for a
 device, drivers must specify a private node type and refrain from using the
-node type string \fBDDI_NT_TAPE\fR when calling\fBddi_create_minor_node\fR(9F).
+node type string \fBDDI_NT_TAPE\fR when calling
+\fBddi_create_minor_node\fR(9F).
 .SH OPTIONS
 .sp
 .LP

--- a/usr/src/man/man1m/vscand.1m
+++ b/usr/src/man/man1m/vscand.1m
@@ -94,7 +94,7 @@ Interface Stability	Uncommitted
 .sp
 .LP
 \fBps\fR(1), \fBsvcs\fR(1), \fBlogadm\fR(1M), \fBsvcadm\fR(1M),
-\fBsyslogd\fR(1M), \fBvscandadm\fR(1M), \fBzfs\fR(1M), \fBattributes\fR(5),
+\fBsyslogd\fR(1M), \fBvscanadm\fR(1M), \fBzfs\fR(1M), \fBattributes\fR(5),
 \fBsmf\fR(5)
 .SH NOTES
 .sp

--- a/usr/src/man/man1m/zfs-program.1m
+++ b/usr/src/man/man1m/zfs-program.1m
@@ -14,10 +14,10 @@
 .Dt ZFS-PROGRAM 1M
 .Os
 .Sh NAME
-.Nm zfs program
+.Nm "zfs program"
 .Nd executes ZFS channel programs
 .Sh SYNOPSIS
-.Cm zfs program
+.Cm "zfs program"
 .Op Fl t Ar instruction-limit
 .Op Fl m Ar memory-limit
 .Ar pool
@@ -274,7 +274,7 @@ EBADF     EXDEV       EFBIG
 .Ss API Functions
 For detailed descriptions of the exact behavior of any zfs administrative
 operations, see the main
-.Xr zfs 1
+.Xr zfs 1M
 manual page.
 .Bl -tag -width "xx"
 .It Em zfs.debug(msg)

--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -341,7 +341,7 @@ intervals.
 The visibility of the
 .Pa .zfs
 directory can be controlled by the
-snapdir
+.Sy snapdir
 property.
 .Ss Clones
 A clone is a writable volume or file system whose initial contents are the same
@@ -1358,7 +1358,7 @@ bytes in the dataset.
 This property can also be referred to by its shortened column name,
 .Sy refreserv .
 .It Sy reservation Ns = Ns Em size Ns | Ns Sy none
-The minimum amount of space guaranteed to a dataset and its descendents.
+The minimum amount of space guaranteed to a dataset and its descendants.
 When the amount of space used is below this value, the dataset is treated as if
 it were taking up the amount of space specified by its reservation.
 Reservations are accounted for in the parent datasets' space used, and count
@@ -1410,7 +1410,7 @@ command is invoked with options equivalent to the contents of this property.
 Because SMB shares requires a resource name, a unique resource name is
 constructed from the dataset name.
 The constructed name is a copy of the dataset name except that the characters in
-the dataset name, which would be illegal in the resource name, are replaced with
+the dataset name, which would be invalid in the resource name, are replaced with
 underscore
 .Pq Sy _
 characters.
@@ -2116,7 +2116,8 @@ subcommand can be used to rename any conflicting snapshots.
 .Op Fl f
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
-.br
+.Xc
+.It Xo
 .Nm
 .Cm rename
 .Op Fl fp
@@ -2909,7 +2910,8 @@ for more details.
 .Op Fl Fnsuv
 .Op Fl o Sy origin Ns = Ns Ar snapshot
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
-.br
+.Xc
+.It Xo
 .Nm
 .Cm receive
 .Op Fl Fnsuv
@@ -3145,31 +3147,35 @@ property.
 The following permissions are available:
 .Bd -literal
 NAME             TYPE           NOTES
-allow            subcommand     Must also have the permission that is being
-                                allowed
-clone            subcommand     Must also have the 'create' ability and 'mount'
-                                ability in the origin file system
+allow            subcommand     Must also have the permission that is
+                                being allowed
+clone            subcommand     Must also have the 'create' ability and
+                                'mount' ability in the origin file system
 create           subcommand     Must also have the 'mount' ability
 destroy          subcommand     Must also have the 'mount' ability
 diff             subcommand     Allows lookup of paths within a dataset
-                                given an object number, and the ability to
-                                create snapshots necessary to 'zfs diff'.
+                                given an object number, and the ability
+                                to create snapshots necessary to
+                                'zfs diff'.
 mount            subcommand     Allows mount/umount of ZFS datasets
-promote          subcommand     Must also have the 'mount'
-                                and 'promote' ability in the origin file system
-receive          subcommand     Must also have the 'mount' and 'create' ability
+promote          subcommand     Must also have the 'mount' and 'promote'
+                                ability in the origin file system
+receive          subcommand     Must also have the 'mount' and 'create'
+                                ability
 rename           subcommand     Must also have the 'mount' and 'create'
                                 ability in the new parent
 rollback         subcommand     Must also have the 'mount' ability
 send             subcommand
-share            subcommand     Allows sharing file systems over NFS or SMB
-                                protocols
+share            subcommand     Allows sharing file systems over NFS
+                                or SMB protocols
 snapshot         subcommand     Must also have the 'mount' ability
 
-groupquota       other          Allows accessing any groupquota@... property
+groupquota       other          Allows accessing any groupquota@...
+                                property
 groupused        other          Allows reading any groupused@... property
 userprop         other          Allows changing any user property
-userquota        other          Allows accessing any userquota@... property
+userquota        other          Allows accessing any userquota@...
+                                property
 userused         other          Allows reading any userused@... property
 
 aclinherit       property

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -23,8 +23,9 @@
 .\" Copyright (c) 2013 by Delphix. All rights reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Datto Inc.
+.\" Copyright (c) 2017 George Melikov. All Rights Reserved.
 .\"
-.Dd June 21, 2017
+.Dd August 23, 2017
 .Dt ZPOOL 1M
 .Os
 .Sh NAME
@@ -661,7 +662,7 @@ to the enabled state.
 See
 .Xr zpool-features 5
 for details on feature states.
-.It Sy listsnaps Ns = Ns Sy on Ns | Ns Sy off
+.It Sy listsnapshots Ns = Ns Sy on Ns | Ns Sy off
 Controls whether information about snapshots associated with this pool is
 output when
 .Nm zfs Cm list
@@ -670,6 +671,8 @@ is run without the
 option.
 The default value is
 .Sy off .
+This property can also be referred to by its shortened name,
+.Sy listsnaps .
 .It Sy version Ns = Ns Ar version
 The current on-disk version of the pool.
 This can be increased, but never decreased.
@@ -677,7 +680,7 @@ The preferred method of updating pools is with the
 .Nm zpool Cm upgrade
 command, though this property can be used when a specific version is needed for
 backwards compatibility.
-Once feature flags is enabled on a pool this property will no longer have a
+Once feature flags are enabled on a pool this property will no longer have a
 value.
 .El
 .Ss Subcommands
@@ -1541,7 +1544,7 @@ for
 .Ar newpool
 to
 .Ar root
-and automaticaly import it.
+and automatically import it.
 .El
 .It Xo
 .Nm
@@ -1606,7 +1609,7 @@ to enable all features on all pools.
 .Fl v
 .Xc
 Displays legacy ZFS versions supported by the current software.
- See
+See
 .Xr zpool-features 5
 for a description of feature flags features supported by the current software.
 .It Xo
@@ -1746,7 +1749,7 @@ The failed device can be replaced using the following command:
 .Ed
 .Pp
 Once the data has been resilvered, the spare is automatically removed and is
-made available should another device fails.
+made available for use should another device fail.
 The hot spare can be permanently removed from the pool using the following
 command:
 .Bd -literal
@@ -1806,7 +1809,7 @@ is:
 # zpool remove tank mirror-2
 .Ed
 .It Sy Example 15 No Displaying expanded space on a device
-The following command dipslays the detailed information for the pool
+The following command displays the detailed information for the pool
 .Em data .
 This pool is comprised of a single raidz vdev where one of its devices
 increased its capacity by 10GB.

--- a/usr/src/man/man2/setreuid.2
+++ b/usr/src/man/man2/setreuid.2
@@ -31,7 +31,7 @@ set to any legal value.
 If the {\fBPRIV_PROC_SETID\fR} privilege is not asserted in the effective set
 of the calling process, either the real user ID can be set to the effective
 user ID, or the effective user ID can either be set to the saved set-user ID
-from \fBexecve()\fR (see\fBexec\fR(2)) or the real user ID.
+from \fBexecve()\fR (see \fBexec\fR(2)) or the real user ID.
 .sp
 .LP
 In either case, if the real user ID is being changed (that is, if \fIruid\fR is

--- a/usr/src/man/man3c/aligned_alloc.3c
+++ b/usr/src/man/man3c/aligned_alloc.3c
@@ -71,6 +71,6 @@ It is not a power of two multiple of the word size.
 .Sy MT-Safe
 .Sh SEE ALSO
 .Xr malloc 3C ,
-.Xr memalgin 3C ,
+.Xr memalign 3C ,
 .Xr posix_memalign 3C ,
 .Xr attributes 5

--- a/usr/src/man/man3c/arc4random.3c
+++ b/usr/src/man/man3c/arc4random.3c
@@ -69,7 +69,7 @@ to generate a new result.
 One data pool is used for all consumers in a process, so that consumption
 under program flow can act as additional stirring.
 The subsystem is re-seeded from the kernel random number subsystem using
-.Xr getentropy 2
+.Xr getentropy 3C
 on a regular basis, and also upon
 .Xr fork 2 .
 .Pp

--- a/usr/src/man/man3c/cnd.3c
+++ b/usr/src/man/man3c/cnd.3c
@@ -176,12 +176,12 @@ is returned to indicate an error.
 .Sh MT-LEVEL
 .Sy MT-Safe
 .Sh SEE ALSO
-.Xr cond_braodcast 3C ,
+.Xr cond_broadcast 3C ,
 .Xr cond_destroy 3C ,
 .Xr cond_init 3C ,
 .Xr cond_signal 3C ,
 .Xr cond_timedwait 3C ,
 .Xr cond_wait 3C ,
-.Xr threads 3HEAD ,
+.Xr threads.h 3HEAD ,
 .Xr attributes 5 ,
 .Xr threads 5

--- a/usr/src/man/man3c/door_bind.3c
+++ b/usr/src/man/man3c/door_bind.3c
@@ -191,5 +191,5 @@ MT-Level	Safe
 
 .SH SEE ALSO
 .LP
-\fBfork\fR(2),\fBdoor_create\fR(3C), \fBdoor_return\fR(3C),
+\fBfork\fR(2), \fBdoor_create\fR(3C), \fBdoor_return\fR(3C),
 \fBdoor_server_create\fR(3C), \fBattributes\fR(5)

--- a/usr/src/man/man3c/door_getparam.3c
+++ b/usr/src/man/man3c/door_getparam.3c
@@ -193,7 +193,7 @@ if (door_setparam(fd, DOOR_PARAM_DATA_MIN,
  /* handle error */
 
 /*
- * the door will only accept door_call(3DOOR)s with a
+ * the door will only accept door_call(3C)s with a
  * data_size which is exactly sizeof (my_request_t).
  */
 .fi

--- a/usr/src/man/man3c/door_return.3c
+++ b/usr/src/man/man3c/door_return.3c
@@ -92,4 +92,4 @@ MT-Level	Safe
 
 .SH SEE ALSO
 .LP
-\fBdoor_call\fR(3C),\fBattributes\fR(5)
+\fBdoor_call\fR(3C), \fBattributes\fR(5)

--- a/usr/src/man/man3c/econvert.3c
+++ b/usr/src/man/man3c/econvert.3c
@@ -143,4 +143,4 @@ MT-Level	MT-Safe
 
 .SH SEE ALSO
 .LP
-\fBecvt\fR(3C),\fBsprintf\fR(3C), \fBattributes\fR(5)
+\fBecvt\fR(3C), \fBsprintf\fR(3C), \fBattributes\fR(5)

--- a/usr/src/man/man3c/endian.3c
+++ b/usr/src/man/man3c/endian.3c
@@ -177,7 +177,7 @@ To better support extant software, both are provided.
 While these functions are common across multiple platforms, they have
 not been standardized.
 Portable applications should instead use the functions defined in
-.Xr byteorder 3C .
+.Xr byteorder 3SOCKET .
 .Sh RETURN VALUES
 The functions always succeed and return a value that has been properly
 converted.
@@ -186,7 +186,7 @@ converted.
 .Sh MT-LEVEL
 .Sy MT-Safe
 .Sh SEE ALSO
-.Xr byteorder 3C ,
 .Xr endian.h 3HEAD ,
+.Xr byteorder 3SOCKET ,
 .Xr attributes 5 ,
 .Xr byteorder 5

--- a/usr/src/man/man3c/fcloseall.3c
+++ b/usr/src/man/man3c/fcloseall.3c
@@ -48,7 +48,7 @@ Note, portable applications should always check the return value.
 .Sh MT-LEVEL
 .Sy Mt-Safe .
 .Sh SEE ALSO
-.Xr close 3C ,
+.Xr close 2 ,
 .Xr fflush 3C ,
 .Xr attributes 5 ,
 .Xr environ 5 ,

--- a/usr/src/man/man3c/pthread_atfork.3c
+++ b/usr/src/man/man3c/pthread_atfork.3c
@@ -69,7 +69,7 @@ Insufficient table space exists to record the fork handler addresses.
 Solaris threads do not offer \fBpthread_atfork()\fR functionality (there is no
 \fBthr_atfork()\fR interface). However, a Solaris threads application can call
 \fBpthread_atfork()\fR to ensure \fBfork()\fR-safety, since the two thread APIs
-are interoperable. See\fBfork\fR(2) for information relating to \fBfork()\fR in
+are interoperable. See \fBfork\fR(2) for information relating to \fBfork()\fR in
 a Solaris threads environment in Solaris 10 relative to previous releases.
 .SH EXAMPLES
 .LP

--- a/usr/src/man/man3c/quick_exit.3c
+++ b/usr/src/man/man3c/quick_exit.3c
@@ -34,10 +34,10 @@ The
 and
 .Fn at_quick_exit
 functions provide a veneer around
-.Xr _Exit 3C
+.Xr _Exit 2
 that allows for registered functions to be called before terminating.
 Like
-.Xr _Exit 3C ,
+.Xr _Exit 2 ,
 standard library termination is not done.
 .Xr atexit 3C
 functions are not called and various standard termination that occurs
@@ -55,7 +55,7 @@ will not be called at any other time.
 Functions that are registered with
 .Fn at_quick_exit
 should not make use of
-.Xr longjump 3C
+.Xr longjmp 3C
 and related functions.
 .Pp
 After calling all registered functions, the
@@ -86,7 +86,7 @@ Insufficient storage space is available.
 .Sh MT-LEVEL
 .Sy Safe
 .Sh SEE ALSO
-.Xr _Exit 3C ,
+.Xr _Exit 2 ,
 .Xr atexit 3C ,
 .Xr exit 3C ,
 .Xr attributes 5 ,

--- a/usr/src/man/man3c/thr_suspend.3c
+++ b/usr/src/man/man3c/thr_suspend.3c
@@ -36,7 +36,7 @@ have no effect.
 .LP
 A suspended thread will not be awakened by any mechanism other than a call to
 \fBthr_continue()\fR.  Signals and the effect of calls
-to\fBmutex_unlock\fR(3C), \fBrw_unlock\fR(3C), \fBsema_post\fR(3C),
+to \fBmutex_unlock\fR(3C), \fBrw_unlock\fR(3C), \fBsema_post\fR(3C),
 \fBcond_signal\fR(3C), and \fBcond_broadcast\fR(3C) remain pending until the
 execution of the thread is resumed by \fBthr_continue()\fR.
 .SH RETURN VALUES

--- a/usr/src/man/man3c/thrd_create.3c
+++ b/usr/src/man/man3c/thrd_create.3c
@@ -58,7 +58,7 @@ the exit status remains available and the corresponding thread ID will
 not be reused until a process calls
 .Xr thrd_join 3C .
 This is similar to how a parent must call
-.Xr wait 2 ,
+.Xr wait 3C ,
 to clean up a child process that has terminated.
 .Pp
 For a richer interface interface with more control over aspects of the

--- a/usr/src/man/man3c/thrd_join.3c
+++ b/usr/src/man/man3c/thrd_join.3c
@@ -67,7 +67,7 @@ function returns
 and if
 .Fa res
 is a non-null pointer, it will be filled in with the exit status of
-.Xr thrd 3C .
+.Fa thrd .
 If an error occurs,
 .Sy thrd_error
 will be returned.

--- a/usr/src/man/man3c/timerfd_create.3c
+++ b/usr/src/man/man3c/timerfd_create.3c
@@ -199,5 +199,5 @@ is not asserted in the effective set of the calling process.
 .Xr timer_create 3C ,
 .Xr timer_gettime 3C ,
 .Xr timer_settime 3C ,
-.Xr privileages 5 ,
+.Xr privileges 5 ,
 .Xr timerfd 5

--- a/usr/src/man/man3c_db/td_thr_get_info.3c_db
+++ b/usr/src/man/man3c_db/td_thr_get_info.3c_db
@@ -49,11 +49,11 @@ typedef struct td_thrinfo_t {
   short            ti_flags           /* set of special flags used by
                                          libc*/
   int              ti_pri             /* priority of thread returned by
-                                         thr_getprio(3T)*/
+                                         thr_getprio(3C)*/
   lwpid_t          ti_lid             /* id of light weight process (LWP)
                                          executing this thread*/
   sigset_t         ti_sigmask         /* thread's signal mask.  See
-                                         thr_sigsetmask(3T)*/
+                                         thr_sigsetmask(3C)*/
   u_char           ti_traceme         /* non-zero if event tracing is on*/
   u_char_t         ti_preemptflag     /* non-zero if thread preempted when
                                          last active*/

--- a/usr/src/man/man3dat/dat_evd_wait.3dat
+++ b/usr/src/man/man3dat/dat_evd_wait.3dat
@@ -295,6 +295,6 @@ MT-Level	Safe
 .LP
 \fBdat_cr_accept\fR(3DAT), \fBdat_cr_handoff\fR(3DAT),
 \fBdat_cr_reject\fR(3DAT), \fBdat_ep_connect\fR(3DAT),
-\fBdat_ep_dup_connect\fR(3DAT),\fBdat_ep_free\fR(3DAT),
+\fBdat_ep_dup_connect\fR(3DAT), \fBdat_ep_free\fR(3DAT),
 \fBdat_evd_dequeue\fR(3DAT), \fBdat_evd_set_unwaitable\fR(3DAT),
 \fBlibdat\fR(3LIB), \fBattributes\fR(5)

--- a/usr/src/man/man3elf/gelf.3elf
+++ b/usr/src/man/man3elf/gelf.3elf
@@ -284,7 +284,7 @@ table at the given index. \fBdst\fR points to the location where the
 \fB\fBgelf_getphdr()\fR\fR
 .ad
 .RS 26n
-An analog to\fBelf32_getphdr\fR(3ELF) and \fBelf64_getphdr\fR(3ELF). \fBdst\fR
+An analog to \fBelf32_getphdr\fR(3ELF) and \fBelf64_getphdr\fR(3ELF). \fBdst\fR
 points to the location where the \fBGElf_Phdr\fR program header is stored.
 .RE
 

--- a/usr/src/man/man3ext/auto_ef.3ext
+++ b/usr/src/man/man3ext/auto_ef.3ext
@@ -64,7 +64,7 @@ Information about encodings are stored in data type\fBauto_ef_t\fR in the order
 of possibility with the most possible encoding stored first. To examine the
 information, use the \fBauto_ef_get_encoding()\fR and \fBauto_ef_get_score()\fR
 access functions. For a list of encodings with which \fBauto_ef_file()\fR can
-examine text, see \fBauto_ef\fR(1).
+examine text, see \fBauto_ef\fR(3EXT).
 .sp
 .LP
 If \fBauto_ef_file()\fR cannot determine the encoding of text, it returns 0 and
@@ -199,4 +199,4 @@ MT-Level	MT-Safe
 .SH SEE ALSO
 .sp
 .LP
-\fBauto_ef\fR(1), \fBlibauto_ef\fR(3LIB), \fBattributes\fR(5)
+\fBauto_ef\fR(3EXT), \fBlibauto_ef\fR(3LIB), \fBattributes\fR(5)

--- a/usr/src/man/man3head/endian.h.3head
+++ b/usr/src/man/man3head/endian.h.3head
@@ -77,7 +77,7 @@ to one of the aforementioned macros.
 .Pp
 In addition to the routines provided by this header, standardized
 functions may be found in
-.Xr byteorder 3C .
+.Xr byteorder 3SOCKET .
 The header
 .Xr types.h 3HEAD
 also defines additional pre-processor symbols to determine the current

--- a/usr/src/man/man3head/wait.h.3head
+++ b/usr/src/man/man3head/wait.h.3head
@@ -226,4 +226,4 @@ Interface Stability	Standard
 .sp
 .LP
 \fBexit\fR(2), \fBwaitid\fR(2), \fBexit\fR(3C), \fBwait\fR(3C),
-\fBwaitpid\fR(3C),\fBattributes\fR(5), \fBstandards\fR(5)
+\fBwaitpid\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man3kvm/kvm_open.3kvm
+++ b/usr/src/man/man3kvm/kvm_open.3kvm
@@ -160,7 +160,7 @@ MT-Level	Unsafe
 \fBsavecore\fR(1M), \fBexec\fR(2), \fBexit\fR(2), \fBpathconf\fR(2),
 \fBgetloadavg\fR(3C), \fBkstat\fR(3KSTAT), \fBkvm_getu\fR(3KVM),
 \fBkvm_nextproc\fR(3KVM), \fBkvm_nlist\fR(3KVM), \fBkvm_kread\fR(3KVM),
-\fBlibkvm\fR(3LIB),\fBsysconf\fR(3C), \fBproc\fR(4), \fBattributes\fR(5),
+\fBlibkvm\fR(3LIB), \fBsysconf\fR(3C), \fBproc\fR(4), \fBattributes\fR(5),
 \fBlfcompile\fR(5)
 .SH NOTES
 .sp

--- a/usr/src/man/man3ldap/ber_encode.3ldap
+++ b/usr/src/man/man3ldap/ber_encode.3ldap
@@ -103,7 +103,7 @@ The  \fBber_alloc()\fR function is used to allocate a new BER element.
 .sp
 .LP
 The  \fBber_printf()\fR function is used to encode a BER element in much the
-same way that  \fBsprintf(3S)\fR works.  One important difference, though, is
+same way that \fBsprintf(3C)\fR works.  One important difference, though, is
 that some state information is kept with the \fIber\fR parameter so that
 multiple calls can be made to  \fBber_printf()\fR to append things to the end
 of the BER element.   \fBBer_printf()\fR writes to \fIber\fR, a pointer to a

--- a/usr/src/man/man3ldap/ldap_entry2text.3ldap
+++ b/usr/src/man/man3ldap/ldap_entry2text.3ldap
@@ -81,7 +81,7 @@ cc[ \fIflag\fR... ] \fIfile\fR... -lldap[ \fIlibrary\fR... ]
 .sp
 .LP
 These functions use the LDAP display template functions (see
-\fBldap_disptmpl\fR(3LDAP) and  \fBldap_templates.conf(4))\fR to produce a
+\fBldap_disptmpl\fR(3LDAP) and \fBldaptemplates.conf\fR(4)) to produce a
 plain text or an HyperText Markup Language (HTML) display of an entry or a set
 of values.  Typical plain text output produced for an entry might look like:
 .sp

--- a/usr/src/man/man3lib/libSMHBAAPI.3lib
+++ b/usr/src/man/man3lib/libSMHBAAPI.3lib
@@ -31,7 +31,7 @@ cc [ \fIflag\fR\&.\|.\|. ] \fIfile\fR\&.\|.\|. \fB-lSMHBAAPI\fR [ \fIlibrary\fR\
 .SH DESCRIPTION
 .sp
 .LP
-The functions in this library access Fibre Channel and/or Sereal Attached SCSI
+The functions in this library access Fibre Channel and/or Serial Attached SCSI
 HBA data depending on vendor provided implementation underneath.
 .sp
 .LP

--- a/usr/src/man/man3lib/libaio.3lib
+++ b/usr/src/man/man3lib/libaio.3lib
@@ -16,7 +16,7 @@ cc [ \fIflag\fR... ] \fIfile\fR... \fB-laio\fR [ \fIlibrary\fR... ]
 .sp
 .LP
 Historically, functions in this library provided asynchronous I/O operations.
-This functionality now resides in\fBlibc\fR(3LIB)
+This functionality now resides in \fBlibc\fR(3LIB)
 .sp
 .LP
 This library is maintained to provide backward compatibility for both runtime

--- a/usr/src/man/man3lib/libproc.3lib
+++ b/usr/src/man/man3lib/libproc.3lib
@@ -405,7 +405,7 @@ Many functions relating to tracing processes, for example
 .Xr Psignal 3PROC ,
 .Xr Psetsignal 3PROC ,
 .Xr Psetfault 3PROC ,
-.Xr Psetentry 3PROC ,
+.Xr Psysentry 3PROC ,
 and others, mention that they only act upon
 .Em Active Processes .
 This specifically refers to processes whose state are in
@@ -414,8 +414,7 @@ and
 .Dv PS_STOP .
 Process handles in the other states have no notion of settable tracing
 flags, though core files
-.Pf ( type Dv PS_DEAD ) ,
-=======
+.Pf ( type Dv PS_DEAD )
 may have a read-only snapshot of their tracing settings available.
 .Sh TYPES
 The

--- a/usr/src/man/man3m/Makefile
+++ b/usr/src/man/man3m/Makefile
@@ -10,6 +10,7 @@
 #
 
 # Copyright (c) 2012, Igor Kozhukhov <ikozhukhov@gmail.com>
+# Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
 
 include ../../Makefile.master
 
@@ -123,8 +124,18 @@ MANFILES =	acos.3m \
 		trunc.3m \
 		y0.3m
 
+MANLINKS=	fesetenv.3m				\
+		fesetexceptflag.3m			\
+		fesetround.3m
+
+fesetenv.3m				:= LINKSRC = fegetenv.3m
+
+fesetexceptflag.3m			:= LINKSRC = fegetexceptflag.3m
+
+fesetround.3m				:= LINKSRC = fegetround.3m
+
 .KEEP_STATE:
 
 include ../Makefile.man
 
-install: $(ROOTMANFILES)
+install: $(ROOTMANFILES) $(ROOTMANLINKS)

--- a/usr/src/man/man3m/copysign.3m
+++ b/usr/src/man/man3m/copysign.3m
@@ -67,4 +67,4 @@ MT-LevelMT-Safe
 .SH SEE ALSO
 .sp
 .LP
-\fBmath.h\fR(3HEAD), \fBsignbit\fR(3M),\fBattributes\fR(5), \fBstandards\fR(5)
+\fBmath.h\fR(3HEAD), \fBsignbit\fR(3M), \fBattributes\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man3m/pow.3m
+++ b/usr/src/man/man3m/pow.3m
@@ -98,7 +98,7 @@ For \fIy\fR > 0 and not an odd integer, if \fIx\fR is \(+-0, +0 is returned.
 If \fIx\fR is \(+-1 and \fIy\fR is \(+-Inf, and the application was compiled
 with the \fBcc\fR compiler driver, NaN is returned. If, however, the
 application was compiled with the \fBc99\fR compiler driver and is therefore
-SUSv3-conforming (see\fBstandards\fR(5)), 1.0 is returned.
+SUSv3-conforming (see \fBstandards\fR(5)), 1.0 is returned.
 .sp
 .LP
 For |\fIx\fR| < 1, if \fIy\fR is \(miInf, +Inf is returned.

--- a/usr/src/man/man3mail/maillock.3mail
+++ b/usr/src/man/man3mail/maillock.3mail
@@ -105,7 +105,7 @@ MT-Level	Unsafe
 .SH SEE ALSO
 .sp
 .LP
-\fBlibmail\fR(3LIB),\fBattributes\fR(5)
+\fBlibmail\fR(3LIB), \fBattributes\fR(5)
 .SH NOTES
 .sp
 .LP

--- a/usr/src/man/man3nsl/rpc_gss_get_mechanisms.3nsl
+++ b/usr/src/man/man3nsl/rpc_gss_get_mechanisms.3nsl
@@ -156,7 +156,8 @@ MT-Level	MT-Safe
 .SH SEE ALSO
 .sp
 .LP
-\fBrpc\fR(3NSL),\fBrpcsec_gss\fR(3NSL), \fBmech\fR(4), \fBqop\fR(4), \fBattributes\fR(5)
+\fBrpc\fR(3NSL), \fBrpcsec_gss\fR(3NSL), \fBmech\fR(4), \fBqop\fR(4),
+\fBattributes\fR(5)
 .sp
 .LP
 \fIONC+ Developer\&'s Guide\fR

--- a/usr/src/man/man3nsl/t_strerror.3nsl
+++ b/usr/src/man/man3nsl/t_strerror.3nsl
@@ -97,4 +97,4 @@ MT Level	Safe
 .SH SEE ALSO
 .sp
 .LP
-\fBt_errno\fR(3NSL),\fBt_error\fR(3NSL), \fBattributes\fR(5)
+\fBt_errno\fR(3NSL), \fBt_error\fR(3NSL), \fBattributes\fR(5)

--- a/usr/src/man/man3proc/Lprochandle.3proc
+++ b/usr/src/man/man3proc/Lprochandle.3proc
@@ -31,7 +31,7 @@ function returns the process handle to which the thread handle
 .Fa L
 belongs.
 This proccess handle may be used with other
-.Xr libproc 3PROC
+.Xr libproc 3LIB
 functions just as if
 .Xr Pgrab 3PROC was called.
 The returned handle is valid even if

--- a/usr/src/man/man3proc/Lstate.3proc
+++ b/usr/src/man/man3proc/Lstate.3proc
@@ -30,7 +30,7 @@ The
 function returns the state of the thread handle
 .Fa L .
 The list of states is available in the
-.Xr libproc 3PROC .
+.Xr libproc 3LIB .
 .Sh RETURN VALUES
 Upon successful completion, the current state is returned.
 .Sh INTERFACE STABILITY

--- a/usr/src/man/man3proc/Lstatus.3proc
+++ b/usr/src/man/man3proc/Lstatus.3proc
@@ -40,7 +40,7 @@ The returned pointer is only valid as long as the thread handle
 .Fa L
 is valid.
 After a call to
-.Xr Ltree 3PROC ,
+.Xr Lfree 3PROC ,
 the returned data pointer is invalid.
 .Sh RETURN VALUES
 Upon successful completion, the

--- a/usr/src/man/man3proc/Pctlfd.3proc
+++ b/usr/src/man/man3proc/Pctlfd.3proc
@@ -38,7 +38,7 @@ itself.
 .Pp
 Only live processes have a control file descriptor.
 Process handles that correspond to files and cores, created through
-.Xr Prab_file 3PROC
+.Xr Pgrab_file 3PROC
 and
 .Xr Pgrab_core 3PROC ,
 do not have a corresponding file descriptor.

--- a/usr/src/man/man3proc/Pgetareg.3proc
+++ b/usr/src/man/man3proc/Pgetareg.3proc
@@ -55,15 +55,15 @@ and
 functions read and update the registers of the process handle referred
 to by
 .Fa P .
-.Pp
 The getting and setting of registers of the process operates on the
 representative thread (LWP).
 For more information on how the representative is chosen, see
 .Xr proc 4 .
+.Pp
 To change the registers of a specific thread, use the
 .Fn Lgetareg
 and
-.Xr Lsetareg 3PROC
+.Fn Lputareg
 functions.
 .Pp
 The getting and setting of registers only applies to stopped processes.

--- a/usr/src/man/man3proc/Plookup_by_addr.3proc
+++ b/usr/src/man/man3proc/Plookup_by_addr.3proc
@@ -101,7 +101,7 @@ with additional information.
 The definition of the
 .Sy prsyminfo_t
 is found in
-.Xr libproc 3PROC .
+.Xr libproc 3LIB .
 .Pp
 The
 .Fn Pxlookup_by_addr_resolved

--- a/usr/src/man/man3proc/Prd_agent.3proc
+++ b/usr/src/man/man3proc/Prd_agent.3proc
@@ -29,7 +29,7 @@ The
 .Fn Prd_agent
 function returns a pointer to an agent suitable for use with the
 run-time link editing database library,
-.Xr librtld_db 3PROC ,
+.Xr librtld_db 3LIB ,
 corresponding to the process handle
 .Fa P .
 .Pp

--- a/usr/src/man/man3proc/Psysentry.3proc
+++ b/usr/src/man/man3proc/Psysentry.3proc
@@ -35,9 +35,9 @@
 .Fc
 .Sh DESCRIPTION
 The
-.Fn Psetentry
+.Fn Psysentry
 and
-.Fn Psetexit
+.Fn Psysexit
 functions controls what actions the process handle
 .Fa P
 should take upon executing a system call.
@@ -72,9 +72,9 @@ They do not function on handles that refer to core files, zombie processes,
 or ELF objects.
 .Sh RETURN VALUES
 Upon successful completion, the
-.Fn Psetentry
+.Fn Psysentry
 and
-.Fn Psetexit
+.Fn Psysexit
 functions return the previous disposition of the system call --
 .Sy 0
 if it was not set to stop and

--- a/usr/src/man/man3proc/pr_getzoneid.3proc
+++ b/usr/src/man/man3proc/pr_getzoneid.3proc
@@ -28,7 +28,7 @@
 The
 .Fn pr_getzoneid
 function injects the
-.Xr getzoneid 2
+.Xr getzoneid 3C
 system call into the target process
 .Fa P
 by means of the agent LWP.
@@ -37,7 +37,7 @@ If the process handle
 is the value
 .Dv NULL
 then this will be equivalent to calling
-.Xr getzoneid 2
+.Xr getzoneid 3C
 on the currently running process.
 .Pp
 The
@@ -49,7 +49,7 @@ do not support system call injection.
 Upon successful completion, the
 .Fn pr_getzoneid
 function's return value is that described in
-.Xr getzoneid 2 .
+.Xr getzoneid 3C .
 Otherwise,
 .Sy -1
 is returned and
@@ -61,7 +61,7 @@ to indicate that the system call could not be injected.
 For the full list of errors see the
 .Sy ERRORS
 section in
-.Xr getzoneid 2 .
+.Xr getzoneid 3C .
 .Pp
 The
 .Fn pr_getzoneid
@@ -83,6 +83,6 @@ See
 in
 .Xr libproc 3LIB .
 .Sh SEE ALSO
-.Xr getzoneid 2 ,
+.Xr getzoneid 3C ,
 .Xr libproc 3LIB ,
 .Xr proc 4

--- a/usr/src/man/man3project/setproject.3project
+++ b/usr/src/man/man3project/setproject.3project
@@ -221,7 +221,7 @@ enabled with \fBpooladm\fR(1M).
 .sp
 .LP
 The final attribute is used to finalize the task created by \fBsetproject()\fR.
-See\fBsettaskid\fR(2).
+See \fBsettaskid\fR(2).
 .sp
 .in +2
 .nf

--- a/usr/src/man/man3rsm/rsm_memseg_import_putv.3rsm
+++ b/usr/src/man/man3rsm/rsm_memseg_import_putv.3rsm
@@ -26,7 +26,7 @@ cc [ \fIflag\fR... ] \fIfile\fR... -lrsm [ \fIlibrary\fR... ]
 .LP
 The \fBrsm_memseg_import_putv()\fR and \fBrsm_memseg_import_getv()\fR functions
 provide for using a list of I/O requests rather than a single source and
-destination address as is done for the\fBrsm_memseg_import_put\fR(3RSM) and
+destination address as is done for the \fBrsm_memseg_import_put\fR(3RSM) and
 \fBrsm_memseg_import_get\fR(3RSM) functions.
 .sp
 .LP

--- a/usr/src/man/man3slp/SLPUnescape.3slp
+++ b/usr/src/man/man3slp/SLPUnescape.3slp
@@ -92,7 +92,7 @@ When set, use this file for configuration.
 .SH SEE ALSO
 .sp
 .LP
-\fBslpd\fR(1M),\fBSLPFree\fR(3SLP), \fBslp_api\fR(3SLP), \fBslp.conf\fR(4),
+\fBslpd\fR(1M), \fBSLPFree\fR(3SLP), \fBslp_api\fR(3SLP), \fBslp.conf\fR(4),
 \fBslpd.reg\fR(4), \fBattributes\fR(5)
 .sp
 .LP

--- a/usr/src/man/man3socket/sockaddr.3socket
+++ b/usr/src/man/man3socket/sockaddr.3socket
@@ -575,7 +575,7 @@ main(void)
 .Ed
 .Sh SEE ALSO
 .Xr socket 3HEAD ,
-.Xr uh.h 3HEAD ,
+.Xr un.h 3HEAD ,
 .Xr accept 3SOCKET ,
 .Xr bind 3SOCKET ,
 .Xr connect 3SOCKET ,

--- a/usr/src/man/man3socket/socket.3socket
+++ b/usr/src/man/man3socket/socket.3socket
@@ -317,7 +317,7 @@ MT-Level	Safe
 \fBnca\fR(1), \fBclose\fR(2), \fBfcntl\fR(2), \fBioctl\fR(2), \fBread\fR(2),
 \fBwrite\fR(2), \fBaccept\fR(3SOCKET), \fBbind\fR(3SOCKET), \fBexec\fR(2),
 \fBconnect\fR(3SOCKET), \fBgetsockname\fR(3SOCKET), \fBgetsockopt\fR(3SOCKET),
-\fBin.h\fR(3HEAD),\fBlisten\fR(3SOCKET), \fBrecv\fR(3SOCKET), \fBopen\fR(2),
+\fBin.h\fR(3HEAD), \fBlisten\fR(3SOCKET), \fBrecv\fR(3SOCKET), \fBopen\fR(2),
 \fBsetsockopt\fR(3SOCKET), \fBsend\fR(3SOCKET), \fBshutdown\fR(3SOCKET),
 \fBsocket.h\fR(3HEAD), \fBsocketpair\fR(3SOCKET), \fBattributes\fR(5)
 .SH NOTES

--- a/usr/src/man/man3tsol/btohex.3tsol
+++ b/usr/src/man/man3tsol/btohex.3tsol
@@ -140,7 +140,7 @@ multithreaded applications.
 .SH SEE ALSO
 .sp
 .LP
-\fBatohexlabel\fR(1M), \fBhextoalabel\fR(1M),\fBlabel_to_str\fR(3TSOL),
+\fBatohexlabel\fR(1M), \fBhextoalabel\fR(1M), \fBlabel_to_str\fR(3TSOL),
 \fBlibtsol\fR(3LIB), \fBattributes\fR(5), \fBlabels\fR(5)
 .SH NOTES
 .sp

--- a/usr/src/man/man3volmgt/media_getid.3volmgt
+++ b/usr/src/man/man3volmgt/media_getid.3volmgt
@@ -97,5 +97,5 @@ Interface Stability	Obsolete
 .SH SEE ALSO
 .sp
 .LP
-\fBvolmgt_ownspath\fR(3VOLMGT),\fBvolmgt_running\fR(3VOLMGT),\fBattributes\fR(5
-), \fBhal\fR(5)
+\fBvolmgt_ownspath\fR(3VOLMGT), \fBvolmgt_running\fR(3VOLMGT),
+\fBattributes\fR(5), \fBhal\fR(5)

--- a/usr/src/man/man4/contract.4
+++ b/usr/src/man/man4/contract.4
@@ -387,7 +387,6 @@ endpoint file descriptor:
 ct_event_read(3contract)
 ct_event_read_critical(3contract)
 ct_event_reset(3contract)
-ct_event_next(3contract)
 .fi
 .in -2
 .sp

--- a/usr/src/man/man4/core.4
+++ b/usr/src/man/man4/core.4
@@ -457,7 +457,7 @@ more details.
 .RS 15n
 \fBn_type\fR: \fbNT_SECFLAGS\fR.  This entry contains the process
 security-flags, see \fBsecurity-flags\fR(5), \fBproc\fR(4), and
-\fBpsecflags\fR(1M) for more information.
+\fBpsecflags\fR(1) for more information.
 .RE
 
 .sp

--- a/usr/src/man/man4/dhcp_inittab.4
+++ b/usr/src/man/man4/dhcp_inittab.4
@@ -586,7 +586,7 @@ Interface Stability	Committed
 .SH SEE ALSO
 .sp
 .LP
-\fBdhcpinfo\fR(1),\fBdhcpagent\fR(1M), \fBisspace\fR(3C), \fBdhcptab\fR(4),
+\fBdhcpinfo\fR(1), \fBdhcpagent\fR(1M), \fBisspace\fR(3C), \fBdhcptab\fR(4),
 \fBattributes\fR(5), \fBdhcp\fR(5), \fBdhcp_modules\fR(5)
 .sp
 .LP

--- a/usr/src/man/man4/ipf.4
+++ b/usr/src/man/man4/ipf.4
@@ -171,7 +171,7 @@ the filter.
 .B count
 causes the packet to be included in the accounting statistics kept by
 the filter, and has no effect on whether the packet will be allowed through
-the filter. These statistics are viewable with ipfstat(8).
+the filter. These statistics are viewable with ipfstat(1M).
 .TP
 .B call
 this action is used to invoke the named function in the kernel, which
@@ -472,7 +472,7 @@ the default facility being used, will be used to log information about
 this packet using ipmon's -s option.
 .PP
 See ipl(4) for the format of records written
-to this device. The ipmon(8) program can be used to read and format
+to this device. The ipmon(1M) program can be used to read and format
 this log.
 .SH EXAMPLES
 .PP

--- a/usr/src/man/man5/brand.4th.5
+++ b/usr/src/man/man5/brand.4th.5
@@ -100,7 +100,7 @@ The
 .Nm
 itself.
 .It Pa /boot/loader.rc
-.Xr loader 4
+.Xr loader 5
 bootstrapping script.
 .El
 .Sh EXAMPLES

--- a/usr/src/man/man5/byteorder.5
+++ b/usr/src/man/man5/byteorder.5
@@ -202,7 +202,7 @@ check the byte order and convert it appropriately.
 The system provides two different sets of functions to convert values
 between big-endian and little-endian.
 They are defined in
-.Xr byteorder 3C
+.Xr byteorder 3SOCKET
 and
 .Xr endian 3C .
 .Pp
@@ -235,7 +235,7 @@ The second family of functions,
 provide a means to convert between the host's byte order
 and big-endian and little-endian specifically.
 While these functions are similar to those in
-.Xr byteorder 3C ,
+.Xr byteorder 3SOCKET ,
 they more explicitly cover different data conversions.
 Like them, these functions operate on either 16-bit, 32-bit, or 64-bit values.
 When converting from big-endian, to the host's endianness, the functions
@@ -254,7 +254,7 @@ to little-endian respectively.
 These functions are not standardized and the header they appear in varies
 between the BSDs and GNU/Linux.
 Applications that wish to be portable, shoulda instead use the
-.Xr byteorder 3C
+.Xr byteorder 3SOCKET
 functions.
 .Pp
 All of these functions in both families simply return their input when

--- a/usr/src/man/man5/gptzfsboot.5
+++ b/usr/src/man/man5/gptzfsboot.5
@@ -84,7 +84,7 @@ If
 is present in the boot filesystem, boot options are read from it.
 .Pp
 The ZFS GUIDs of the boot pool and boot file system are made available to
-.Xr zfsloader 8 .
+.Xr zfsloader 5 .
 .Ss USAGE
 Normally
 .Nm

--- a/usr/src/man/man5/loader.5
+++ b/usr/src/man/man5/loader.5
@@ -720,7 +720,7 @@ Unspecified error.
 .It Pa /boot/loader.conf.local
 .Nm
 configuration files, as described in
-.Xr loader.conf 5 .
+.Xr loader.conf 4 .
 .It Pa /boot/loader.help
 Loaded by
 .Ic help .
@@ -754,7 +754,7 @@ autoboot 5
 .Sh SEE ALSO
 .Xr boot 1M ,
 .Xr btxld 1onbld ,
-.Xr loader.conf 5
+.Xr loader.conf 4
 .Sh STANDARDS
 For the purposes of ANS Forth compliance, loader is an
 .Bf Em

--- a/usr/src/man/man5/menu.4th.5
+++ b/usr/src/man/man5/menu.4th.5
@@ -113,7 +113,7 @@ process and escaping to the loader prompt.
 Default is
 .Dq Li 10 .
 See
-.Xr loader 8
+.Xr loader 5
 for additional information.
 .It Va menu_timeout_command
 The command to be executed after

--- a/usr/src/man/man5/pam_unix_auth.5
+++ b/usr/src/man/man5/pam_unix_auth.5
@@ -216,7 +216,7 @@ multi-threaded application uses its own \fBPAM\fR handle.
 The \fBpam_unix\fR(5) module is no longer supported. Similar functionality is
 provided by \fBpam_authtok_check\fR(5), \fBpam_authtok_get\fR(5),
 \fBpam_authtok_store\fR(5), \fBpam_dhkeys\fR(5),
-\fBpam_passwd_auth\fR(5),\fBpam_setcred\fR(3PAM), \fBpam_unix_account\fR(5),
+\fBpam_passwd_auth\fR(5), \fBpam_setcred\fR(3PAM), \fBpam_unix_account\fR(5),
 \fBpam_unix_cred\fR(5), \fBpam_unix_session\fR(5).
 .sp
 .LP

--- a/usr/src/man/man5/pam_unix_cred.5
+++ b/usr/src/man/man5/pam_unix_cred.5
@@ -195,7 +195,7 @@ MT Level	MT-Safe with exceptions
 \fBssh\fR(1), \fBsu\fR(1M), \fBsettaskid\fR(2), \fBlibpam\fR(3LIB),
 \fBgetprojent\fR(3PROJECT), \fBpam\fR(3PAM), \fBpam_set_item\fR(3PAM),
 \fBpam_sm_authenticate\fR(3PAM), \fBsyslog\fR(3C),
-\fBsetproject\fR(3PROJECT),\fBpam.conf\fR(4), \fBnsswitch.conf\fR(4),
+\fBsetproject\fR(3PROJECT), \fBpam.conf\fR(4), \fBnsswitch.conf\fR(4),
 \fBproject\fR(4), \fBattributes\fR(5), \fBpam_authtok_check\fR(5),
 \fBpam_authtok_get\fR(5), \fBpam_authtok_store\fR(5), \fBpam_dhkeys\fR(5),
 \fBpam_passwd_auth\fR(5), \fBpam_unix_auth\fR(5), \fBpam_unix_account\fR(5),

--- a/usr/src/man/man5/pam_unix_session.5
+++ b/usr/src/man/man5/pam_unix_session.5
@@ -94,7 +94,7 @@ MT Level	MT-Safe with exceptions
 \fBlibpam\fR(3LIB), \fBpam.conf\fR(4), \fBnsswitch.conf\fR(4),
 \fBattributes\fR(5), \fBpam_authtok_check\fR(5), \fBpam_authtok_get\fR(5),
 \fBpam_authtok_store\fR(5), \fBpam_dhkeys\fR(5), \fBpam_passwd_auth\fR(5),
-\fBpam_unix_account\fR(5),\fBpam_unix_auth\fR(5),
+\fBpam_unix_account\fR(5), \fBpam_unix_auth\fR(5)
 .SH NOTES
 .LP
 The interfaces in \fBlibpam\fR(3LIB) are MT-Safe only if each thread within the

--- a/usr/src/man/man5/version.4th.5
+++ b/usr/src/man/man5/version.4th.5
@@ -104,7 +104,7 @@ bootstrapping script.
 Override
 .Xr loader 5
 version in
-.Xr loader.conf 5 :
+.Xr loader.conf 4 :
 .Pp
 .Bd -literal -offset indent -compact
 loader_version="loader 1.1"

--- a/usr/src/man/man5/zpool-features.5
+++ b/usr/src/man/man5/zpool-features.5
@@ -468,7 +468,7 @@ cannot for whatever reason utilize the faster \fBskein\fR and
 
 When the \fBsha512\fR feature is set to \fBenabled\fR, the administrator
 can turn on the \fBsha512\fR checksum on any dataset using the
-\fBzfs set checksum=sha512\fR(1M) command.  This feature becomes
+\fBzfs set checksum=sha512\fR command.  This feature becomes
 \fBactive\fR once a \fBchecksum\fR property has been set to \fBsha512\fR,
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBsha512\fR are destroyed.
@@ -503,7 +503,7 @@ given pool, preventing hash collision attacks on systems with dedup.
 
 When the \fBskein\fR feature is set to \fBenabled\fR, the administrator
 can turn on the \fBskein\fR checksum on any dataset using the
-\fBzfs set checksum=skein\fR(1M) command.  This feature becomes
+\fBzfs set checksum=skein\fR command.  This feature becomes
 \fBactive\fR once a \fBchecksum\fR property has been set to \fBskein\fR,
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBskein\fR are destroyed.
@@ -545,7 +545,7 @@ pool.
 
 When the \fBedonr\fR feature is set to \fBenabled\fR, the administrator
 can turn on the \fBedonr\fR checksum on any dataset using the
-\fBzfs set checksum=edonr\fR(1M) command.  This feature becomes
+\fBzfs set checksum=edonr\fR command.  This feature becomes
 \fBactive\fR once a \fBchecksum\fR property has been set to \fBedonr\fR,
 and will return to being \fBenabled\fR once all filesystems that have
 ever had their checksum set to \fBedonr\fR are destroyed.
@@ -555,4 +555,4 @@ Booting off of pools using \fBedonr\fR is \fBNOT\fR supported
 error.
 
 .SH "SEE ALSO"
-\fBzpool\fR(1M)
+\fBzfs\fR(1M), \fBzpool\fR(1M)

--- a/usr/src/man/man7d/blkdev.7d
+++ b/usr/src/man/man7d/blkdev.7d
@@ -71,10 +71,10 @@ See
 .El
 .
 .Sh SEE ALSO
+.Xr rmformat 1 ,
 .Xr devinfo 1M ,
 .Xr fdisk 1M ,
 .Xr mount 1M ,
-.Xr rmformat 1M ,
 .Xr umount 1M ,
 .Xr sd 7D ,
 .Xr pcfs 7FS ,

--- a/usr/src/man/man7d/ipmi.7d
+++ b/usr/src/man/man7d/ipmi.7d
@@ -169,7 +169,7 @@ Unregister to receive a specific command
 .SH SEE ALSO
 .sp
 .LP
-\fBipmitool\fR(1M), \fBioctl\fR(2), \fBsmbios\fR(7d)
+\fBipmitool\fR(1), \fBioctl\fR(2), \fBsmbios\fR(7d)
 .sp
 .LP
 \fIIntelligent Platform Management Interface Specification Second

--- a/usr/src/man/man7d/pcn.7d
+++ b/usr/src/man/man7d/pcn.7d
@@ -175,7 +175,7 @@ Special character device\.
 .SH "SEE ALSO"
 .sp
 .LP
-\fBdlpi\fR(1m), \fBattributes\fR(5), \fBstreamio\fR(7I), \fBdlpi\fR(7p)
+\fBattributes\fR(5), \fBstreamio\fR(7I), \fBdlpi\fR(7p)
 .sp
 .LP
 \fIIEEE 802.3\fR \(em Institute of Electrical and Electronics Engineers, 2002

--- a/usr/src/man/man7d/su.7d
+++ b/usr/src/man/man7d/su.7d
@@ -195,7 +195,7 @@ Architecture	 SPARC
 
 .SH SEE ALSO
 .LP
-\fBstrconf\fR(1), \fBkbd\fR(1), \fBtip\fR(1),\fBuucp\fR(1C),
+\fBstrconf\fR(1), \fBkbd\fR(1), \fBtip\fR(1), \fBuucp\fR(1C),
 \fBautopush\fR(1M), \fBkstat\fR(1M), \fBpppd\fR(1M), \fBioctl\fR(2),
 \fBopen\fR(2), \fBtermios\fR(3C), \fBdacf.conf\fR(4), \fBattributes\fR(5),
 \fBkb\fR(7M), \fBldterm\fR(7M), \fBttcompat\fR(7M), \fBtermio\fR(7I)

--- a/usr/src/man/man7d/usbsacm.7d
+++ b/usr/src/man/man7d/usbsacm.7d
@@ -202,7 +202,7 @@ Architecture	 SPARC, x86 PCI-based systems
 .SH SEE ALSO
 .sp
 .LP
-\fBstrconf\fR(1), \fBtip\fR(1),\fBuucp\fR(1C), \fBautopush\fR(1M),
+\fBstrconf\fR(1), \fBtip\fR(1), \fBuucp\fR(1C), \fBautopush\fR(1M),
 \fBpppd\fR(1M), \fBioctl\fR(2), \fBopen\fR(2), \fBtermios\fR(3C),
 \fBattributes\fR(5), \fBusba\fR(7D), \fBtermio\fR(7I), \fBldterm\fR(7M),
 \fBttcompat\fR(7M)

--- a/usr/src/man/man7i/iec61883.7i
+++ b/usr/src/man/man7i/iec61883.7i
@@ -174,7 +174,7 @@ the remaining \fBarq_len - 4\fR bytes should be read and concatenated.
 .LP
 \fBread\fR(2) blocks until the specified amount of data is available, unless
 \fBO_NONBLOCK\fR or \fBO_NDELAY\fR flag was set during \fBopen\fR(2), in which
-case\fBread\fR(2) returns immediately.
+case \fBread\fR(2) returns immediately.
 .SS "poll(2)"
 .sp
 .LP

--- a/usr/src/man/man7i/termio.7i
+++ b/usr/src/man/man7i/termio.7i
@@ -466,7 +466,7 @@ arrives, or the condition is cleared by a program.
 .RS 11n
 (Control-t or \fBASCII DC4\fR) generates a \fBSIGINFO\fR signal. Processes with
 a handler will output status information when they receive \fBSIGINFO\fR, for
-example, \fBdd(1)\fR. If a process does not have a \fBSIGINFO\fR handler, the
+example, \fBdd\fR(1M). If a process does not have a \fBSIGINFO\fR handler, the
 signal will be ignored.
 .RE
 

--- a/usr/src/man/man7p/inet6.7p
+++ b/usr/src/man/man7p/inet6.7p
@@ -372,7 +372,7 @@ specifying an address.
 .LP
 \fBioctl\fR(2), \fBbind\fR(3SOCKET), \fBconnect\fR(3SOCKET),
 \fBgetipnodebyaddr\fR(3SOCKET),
-\fBgetipnodebyname\fR(3SOCKET),\fBgetprotobyname\fR(3SOCKET),
+\fBgetipnodebyname\fR(3SOCKET), \fBgetprotobyname\fR(3SOCKET),
 \fBgetservbyname\fR(3SOCKET), \fBgetsockopt\fR(3SOCKET), \fBinet\fR(3SOCKET),
 \fBsend\fR(3SOCKET), \fBsockaddr\fR(3SOCKET),
 \fBicmp6\fR(7P), \fBip6\fR(7P), \fBtcp\fR(7P), \fBudp\fR(7P)

--- a/usr/src/man/man9e/mac.9e
+++ b/usr/src/man/man9e/mac.9e
@@ -109,7 +109,7 @@ function fails, then the driver must be removed by a call to
 .Xr mac_fini_ops 9F .
 .Pp
 Conversely, in the driver's
-.Xr _fini 9F
+.Xr _fini 9E
 routine, it should call
 .Xr mac_fini_ops 9F
 after it successfully calls
@@ -193,10 +193,10 @@ A device driver should make no assumptions about when the various
 callbacks will be called and whether or not they will be called
 simultaneously.
 For example, a device driver may be asked to transmit data through a call to its
-.Xr mc_tx 9F
+.Xr mc_tx 9E
 entry point while it is being asked to get a device property through a
 call to its
-.Xr mc_getprop 9F
+.Xr mc_getprop 9E
 entry point.
 As such, while some calls may be serialized to the device, such as setting
 properties, the device driver should always presume that all of its data needs
@@ -255,7 +255,7 @@ First check whether or not the frame has errors.
 If errors were detected, then the frame should not be sent to the operating
 system.
 It is recommended that devices keep kstats (see
-.Xr kstat_create 9S
+.Xr kstat_create 9F
 for more information) and bump the counter whenever such an error is
 detected.
 If the device distinguishes between the types of errors, then separate kstats
@@ -1575,7 +1575,7 @@ so as to allow the driver to report issues that it detects.
 If the driver registers with the fault management framework during its
 .Xr attach 9E
 entry point, it must call
-.Xr ddi_fm_fini 9E
+.Xr ddi_fm_fini 9F
 during its
 .Xr detach 9E
 entry point.
@@ -1589,7 +1589,7 @@ and
 or they use direct memory access (DMA).
 New device drivers should always enable checking of the transport layer by
 marking their support in the
-.Xr ddi_device_acc_attr_t 9S
+.Xr ddi_device_acc_attr 9S
 structure and using routines like
 .Xr ddi_fm_acc_err_get 9F
 and
@@ -1745,7 +1745,7 @@ two different cases: copying and binding.
 The first way that device drivers handle interfacing between the two is
 by having two separate regions of memory.
 One part is memory which has been allocated for DMA through a call to
-.Xr ddi_dma_alloc 9F
+.Xr ddi_dma_mem_alloc 9F
 and the other is memory associated with the memory block.
 .Pp
 In this case, a driver will use
@@ -1858,7 +1858,7 @@ a given platform.
 .Xr allocb 9F ,
 .Xr bcopy 9F ,
 .Xr ddi_dma_addr_bind_handle 9F ,
-.Xr ddi_dma_alloc 9F ,
+.Xr ddi_dma_mem_alloc 9F ,
 .Xr ddi_fm_acc_err_get 9F ,
 .Xr ddi_fm_dma_err_get 9F ,
 .Xr ddi_fm_ereport_post 9F ,
@@ -1888,16 +1888,13 @@ a given platform.
 .Xr mac_register 9F ,
 .Xr mac_rx 9F ,
 .Xr mac_unregister 9F ,
-.Xr mc_getprop 9F ,
-.Xr mc_tx 9F ,
 .Xr mod_install 9F ,
 .Xr mod_remove 9F ,
 .Xr strcmp 9F ,
 .Xr timeout 9F ,
 .Xr cb_ops 9S ,
-.Xr ddi_device_acc_attr_t 9S ,
+.Xr ddi_device_acc_attr 9S ,
 .Xr dev_ops 9S ,
-.Xr kstat_create 9S ,
 .Xr mac_callbacks 9S ,
 .Xr mac_register 9S ,
 .Xr mblk 9S ,

--- a/usr/src/man/man9e/mc_getcapab.9e
+++ b/usr/src/man/man9e/mc_getcapab.9e
@@ -107,7 +107,7 @@ It is recommended that any capability that is supported have some form of
 tunable, whether in the form of a
 .Sy MAC_PROP_PRIVATE
 driver-specific property and/or a
-.Xr driver.conf 5
+.Xr driver.conf 4
 property to disable it.
 This way when problems are discovered in the field, they can be worked around
 without requiring initial changes to the device driver.
@@ -135,7 +135,7 @@ entry point.
  * the purpose of this example, we assume that we have a device which
  * has members that indicate whether the various capabilities have been
  * enabled and that they are read-only after the driver has had its
- * mc_start(9F) entry point called.
+ * mc_start(9E) entry point called.
  */
 
 #define	EXAMPLE_LSO_MAX		65535

--- a/usr/src/man/man9e/srv.9e
+++ b/usr/src/man/man9e/srv.9e
@@ -171,5 +171,5 @@ Each stream module must specify a read and a write service \fBsrv()\fR routine.
 If a service routine is not needed (because the \fBput()\fR routine processes
 all messages), a \fBNULL\fR pointer should be placed in module's
 \fBqinit\fR(9S) structure. Do not use \fBnulldev\fR(9F) instead of the
-\fBNULL\fR pointer. Use  of\fBnulldev\fR(9F) for a \fBsrv()\fR routine can
+\fBNULL\fR pointer. Use of \fBnulldev\fR(9F) for a \fBsrv()\fR routine can
 result in flow control errors.

--- a/usr/src/man/man9e/tran_init_pkt.9e
+++ b/usr/src/man/man9e/tran_init_pkt.9e
@@ -132,7 +132,7 @@ allocate and initialize a \fBscsi_pkt\fR structure on behalf of a \fBSCSI
 .LP
 If \fIbp\fR is non-\fINULL\fR, the \fBHBA \fRdriver must allocate appropriate
 \fBDMA \fRresources for the \fIpkt\fR, for example,
-through\fBddi_dma_buf_setup\fR(9F) or \fBddi_dma_buf_bind_handle\fR(9F).
+through \fBddi_dma_buf_setup\fR(9F) or \fBddi_dma_buf_bind_handle\fR(9F).
 .sp
 .LP
 If the \fBPKT_CONSISTENT\fR bit is set in \fIflags\fR, the buffer was allocated
@@ -229,7 +229,7 @@ on success, or \fINULL\fR on failure.
 .sp
 .LP
 If \fIpkt\fR is \fINULL\fR on entry, and \fBtran_init_pkt()\fR allocated a
-packet through\fBscsi_hba_pkt_alloc\fR(9F) but was unable to allocate \fBDMA
+packet through \fBscsi_hba_pkt_alloc\fR(9F) but was unable to allocate \fBDMA
 \fRresources, \fBtran_init_pkt()\fR must free the packet through
 \fBscsi_hba_pkt_free\fR(9F) before returning \fINULL\fR.
 .SH SEE ALSO

--- a/usr/src/man/man9e/usba_hcdi.9e
+++ b/usr/src/man/man9e/usba_hcdi.9e
@@ -186,7 +186,7 @@ For example, open an endpoint, the host controller has to implement
 .Xr usba_hcdi_pipe_open 9E
 and for each transfer type, there is a different transfer function.
 One example is
-.Xr usba_hcdi_bulk_xfer 9E .
+.Xr usba_hcdi_pipe_bulk_xfer 9E .
 See
 .Xr usba_hcdi_ops 9S
 for a full list of the different function endpoints.
@@ -268,7 +268,7 @@ are not packed for this purpose.
 They should not be used as they have gaps added by the compiler for alignment.
 .Pp
 Once assembled, the device driver should call
-.Xr usb_hubdi_bind_root_hub 9F .
+.Xr usba_hubdi_bind_root_hub 9F .
 This will cause an instance of the
 .Xr hubd 7D
 driver to be attached and associated with the root controller.
@@ -276,10 +276,10 @@ As such, driver writers need to ensure that all initialization is done prior to
 loading the root hub.
 Once successfully loaded, driver writers should assume that they'll get other
 calls into the driver's operation vector before the call to
-.Xr usb_hcdi_bind_root_hub 9F.
+.Xr usba_hubdi_bind_root_hub 9F.
 .Pp
 If the call to
-.Xr usb_hcdi_bind_root_hub 9F
+.Xr usba_hubdi_bind_root_hub 9F
 failed for whatever reason, the driver should unregister from USBA (see
 the next section), unwind all of the resources it has allocated, and
 return
@@ -355,7 +355,7 @@ The
 member should be set to the symbol
 .Sy usba_hubdi_busops .
 See
-.Xr usba_hubdi_devops 9F
+.Xr usba_hubdi_dev_ops 9F
 for more information.
 .It Sy devo_power
 The
@@ -363,7 +363,7 @@ The
 member should be set to the symbol
 .Sy usba_hubdi_root_hub_power .
 See
-.Xr usba_hubdi_Devops 9F
+.Xr usba_hubdi_dev_ops 9F
 for more information.
 .El
 .Pp
@@ -832,7 +832,7 @@ The device is running as a super speed device.
 This is a USB 3.0 device.
 .It Vt usb_cr_t
 This is a set of codes that may be returned as a part of the call to
-.Xr usb_hcdi_cb 9F .
+.Xr usba_hcdi_cb 9F .
 The best place for the full set of these is currently in the source
 control headers.
 .El
@@ -859,7 +859,6 @@ file.
 .Xr getinfo 9E ,
 .Xr ioctl 9E ,
 .Xr open 9E ,
-.Xr usba_hcdi_bulk_xfer 9E ,
 .Xr usba_hcdi_cb_close 9E ,
 .Xr usba_hcdi_cb_ioctl 9E ,
 .Xr usba_hcdi_cb_open 9E ,
@@ -875,17 +874,15 @@ file.
 .Xr nochpoll 9F ,
 .Xr nodev 9F ,
 .Xr timeout 9F ,
-.Xr usb_hcdi_bind_root_hub 9F ,
-.Xr usb_hubdi_bind_root_hub 9F ,
 .Xr usba_alloc_hcdi_ops 9F ,
 .Xr usba_hcdi_cb 9F ,
 .Xr usba_hcdi_dup_intr_req 9F ,
 .Xr usba_hcdi_dup_isoc_req 9F ,
 .Xr usba_hcdi_register 9F ,
 .Xr usba_hcdi_unregister 9F ,
+.Xr usba_hubdi_bind_root_hub 9F ,
 .Xr usba_hubdi_close 9F ,
-.Xr usba_hubdi_devops 9F ,
-.Xr usba_hubdi_Devops 9F ,
+.Xr usba_hubdi_dev_ops 9F ,
 .Xr usba_hubdi_ioctl 9F ,
 .Xr usba_hubdi_open 9F ,
 .Xr usba_hubdi_unbind_root_hub 9F ,

--- a/usr/src/man/man9e/usba_hcdi_device_init.9e
+++ b/usr/src/man/man9e/usba_hcdi_device_init.9e
@@ -104,6 +104,6 @@ function should return
 .Sy USB_SUCCESS .
 Otherwise, it should return the appropriate error.
 .Sh SEE ALSO
-.Xr usba_hcd 9E ,
+.Xr usba_hcdi 9E ,
 .Xr usba_hcdi_pipe_close 9E ,
 .Xr usba_hcdi_pipe_open 9E

--- a/usr/src/man/man9e/usba_hcdi_pipe_intr_xfer.9e
+++ b/usr/src/man/man9e/usba_hcdi_pipe_intr_xfer.9e
@@ -178,7 +178,7 @@ conditions:
 .Bl -bullet
 .It
 A pipe reset request came in from the
-.Xr usba_hcdi_pipe_rest 9E
+.Xr usba_hcdi_pipe_reset 9E
 entry point.
 .It
 A request to stop polling came in from the
@@ -263,7 +263,7 @@ If uncertain, use
 .Sh SEE ALSO
 .Xr usba_hcdi 9E ,
 .Xr usba_hcdi_pipe_close 9E ,
-.Xr usba_hcdi_pipe_rest 9E ,
+.Xr usba_hcdi_pipe_reset 9E ,
 .Xr usba_hcdi_pipe_stop_intr_polling 9E ,
 .Xr allocb 9F ,
 .Xr usba_hcdi_cb 9F ,

--- a/usr/src/man/man9e/usba_hcdi_pipe_isoc_xfer.9e
+++ b/usr/src/man/man9e/usba_hcdi_pipe_isoc_xfer.9e
@@ -173,7 +173,7 @@ conditions:
 .Bl -bullet
 .It
 A pipe reset request came in from the
-.Xr usba_hcdi_pipe_rest 9E
+.Xr usba_hcdi_pipe_reset 9E
 entry point.
 .It
 A request to stop polling came in from the
@@ -258,7 +258,7 @@ If uncertain, use
 .Sh SEE ALSO
 .Xr usba_hcdi 9E ,
 .Xr usba_hcdi_pipe_close 9E ,
-.Xr usba_hcdi_pipe_rest 9E ,
+.Xr usba_hcdi_pipe_reset 9E ,
 .Xr usba_hcdi_pipe_stop_isoc_polling 9E ,
 .Xr usba_hcdi_cb 9F ,
 .Xr usba_hcdi_dup_isoc_req 9F ,

--- a/usr/src/man/man9e/usba_hcdi_pipe_reset.9e
+++ b/usr/src/man/man9e/usba_hcdi_pipe_reset.9e
@@ -59,9 +59,9 @@ entry point is designed to take a pipe in an arbitrary state and return
 it to the same state it was in after a call to
 .Xr usba_hcdi_pipe_open 9E .
 While this entry point does some similar things to the
-.Xr usba_hcdi_stop_intr_polling 9E
+.Xr usba_hcdi_pipe_stop_intr_polling 9E
 and
-.Xr usba_hcdi_stop_isoc_polling 9E
+.Xr usba_hcdi_pipe_stop_isoc_polling 9E
 entry points, there are some notable differences.
 .Pp
 This entry point is synchronous.
@@ -95,7 +95,7 @@ If uncertain, use
 .Sy USB_FAILURE .
 .Sh SEE ALSO
 .Xr usba_hcdi_pipe_open 9E ,
-.Xr usba_hcdi_stop_intr_polling 9E ,
-.Xr usba_hcdi_stop_isoc_polling 9E ,
+.Xr usba_hcdi_pipe_stop_intr_polling 9E ,
+.Xr usba_hcdi_pipe_stop_isoc_polling 9E ,
 .Xr usba_hcdi_cb 9F ,
 .Xr usba_pipe_handle_data 9S

--- a/usr/src/man/man9f/STRUCT_DECL.9f
+++ b/usr/src/man/man9f/STRUCT_DECL.9f
@@ -463,7 +463,7 @@ Interface Stability	Evolving
 .SH SEE ALSO
 .sp
 .LP
-\fBdevmap\fR(9E), \fBioctl\fR(9E), \fBmmap\fR(9E),\fBddi_mmap_get_model\fR(9F)
+\fBdevmap\fR(9E), \fBioctl\fR(9E), \fBmmap\fR(9E), \fBddi_mmap_get_model\fR(9F)
 .sp
 .LP
 \fIWriting Device Drivers\fR

--- a/usr/src/man/man9f/ddi_cb_register.9f
+++ b/usr/src/man/man9f/ddi_cb_register.9f
@@ -263,7 +263,7 @@ These functions can be called from kernel, non-interrupt context.
 .in +2
 .nf
 /*
-    * attach(9F) routine.
+    * attach(9E) routine.
     *
     * Creates soft state, registers callback handler, initializes
     * hardware, and sets up interrupt handling for the driver.
@@ -363,7 +363,7 @@ These functions can be called from kernel, non-interrupt context.
     }
 
     /*
-     * detach(9F) routine.
+     * detach(9E) routine.
      *
      * Stops the hardware, disables interrupt handling, unregisters
      * a callback handler, and destroys the soft state for the driver.

--- a/usr/src/man/man9f/ddi_modopen.9f
+++ b/usr/src/man/man9f/ddi_modopen.9f
@@ -98,7 +98,7 @@ Symbol's name as a character string.
 .LP
 The function prototypes for \fBddi_modopen()\fR, \fBddi_modsym()\fR, and
 \fBddi_modclose()\fR are modeled after the userland \fBlibdl\fR(3LIB),
-\fBdlopen\fR(3C), \fBdlsym\fR(3C) , and\fBdlclose\fR(3C) interfaces, however
+\fBdlopen\fR(3C), \fBdlsym\fR(3C), and \fBdlclose\fR(3C) interfaces, however
 not all userland features are available and the kernel symbol resolution is
 different. The \fBdlerror\fR(3C) interface is not appropriate for the kernel
 environment, so the new \fIerrnop\fR return argument was added for
@@ -142,7 +142,7 @@ limited to the module directly associated with the handle.
 .sp
 .LP
 The \fBddi_modopen()\fR function increments the reference count on the named
-kernel module. Upon the first load of a module, the\fB_init\fR(9E)
+kernel module. Upon the first load of a module, the \fB_init\fR(9E)
 initialization code in the module is called; \fBddi_modopen()\fR does not
 return until \fB_init\fR completes.
 .sp
@@ -151,7 +151,7 @@ The \fBddi_modsym()\fR function allows a caller to obtain the address of a
 symbol that is defined within a module. The \fIhandle\fR argument is a valid
 \fBddi_modhandle_t\fR as returned by \fBddi_modopen()\fR, the \fIsymname\fR
 argument is the symbol's name as a character string. The special handle values
-supported by ddi_modsym(3C) are not supported.
+supported by ddi_modsym(9F) are not supported.
 .sp
 .LP
 The \fBddi_modclose()\fR function decrements the reference count of the kernel

--- a/usr/src/man/man9f/mac_hcksum_get.9f
+++ b/usr/src/man/man9f/mac_hcksum_get.9f
@@ -201,5 +201,5 @@ and
 functions may be called from any context.
 .Sh SEE ALSO
 .Xr mac 9E ,
-.Xr mac_getcapab 9E ,
+.Xr mc_getcapab 9E ,
 .Xr mblk 9S

--- a/usr/src/man/man9f/mac_init_ops.9f
+++ b/usr/src/man/man9f/mac_init_ops.9f
@@ -78,7 +78,7 @@ If the call to
 fails, then the device driver should not call
 .Fn mac_fini_ops
 and should fail the call to
-.Xr _fini 9F .
+.Xr _fini 9E .
 .Pp
 In addition, if the call to
 .Xr mod_install 9F

--- a/usr/src/man/man9f/mac_maxsdu_update.9f
+++ b/usr/src/man/man9f/mac_maxsdu_update.9f
@@ -44,7 +44,7 @@ has changed the largest size frame that it can transmit, also known as
 its Send Data Unit (SDU).
 This should be called when the device's MTU has been requested to be changed
 when a driver's
-.Xr mac_setprop 9E
+.Xr mc_setprop 9E
 entry point has been called with the property
 .Sy MAC_PROP_MTU
 or some other device-related event occurring.
@@ -72,7 +72,7 @@ For an example of how a device driver should use the
 function, see the
 .Sx EXAMPLES
 section in
-.Xr mac_setprop 9E .
+.Xr mc_setprop 9E .
 .Sh ERRORS
 The
 .Fn max_maxsdu_update
@@ -85,5 +85,5 @@ is lower than the minimum SDU of the device.
 .El
 .Sh SEE ALSO
 .Xr mac 9E ,
-.Xr mac_setprop 9E ,
+.Xr mc_setprop 9E ,
 .Xr mac_register 9F

--- a/usr/src/man/man9f/mac_tx_update.9f
+++ b/usr/src/man/man9f/mac_tx_update.9f
@@ -66,5 +66,5 @@ or
 context.
 .Sh SEE ALSO
 .Xr mac 9E ,
-.Xr mac_tx 9E ,
+.Xr mc_tx 9E ,
 .Xr mac_register 9F

--- a/usr/src/man/man9f/pm_power_has_changed.9f
+++ b/usr/src/man/man9f/pm_power_has_changed.9f
@@ -51,7 +51,7 @@ Power level to which the indicated component has changed
 .SH DESCRIPTION
 .sp
 .LP
-The \fBpm_power_has_changed\fR(9) function notifies the Power Management
+The \fBpm_power_has_changed\fR(9F) function notifies the Power Management
 framework that the power level of component of \fIdip \fR has changed to
 \fIlevel\fR.
 .sp
@@ -115,7 +115,7 @@ Management function called by the driver.
 .sp
 .LP
 A hypothetical driver might include this code to handle
-\fBpm_power_has_changed\fR(9):
+\fBpm_power_has_changed\fR(9F):
 .sp
 .in +2
 .nf

--- a/usr/src/man/man9f/pollhead_clean.9f
+++ b/usr/src/man/man9f/pollhead_clean.9f
@@ -47,7 +47,7 @@ The \fBpollhead_clean()\fR function informs the kernel that a driver's
 \fBpollhead\fR structure is about to be deallocated, usually as part of
 the driver's \fBclose\fR(9E) entry point before the software state that
 contains the \fBpollhead\fR is deallocated via \fBddi_soft_state_free\fR(9F).
-See \fBchpoll\fR(9E), \fBpollwakeup\fR(9E) and \fBpoll\fR(2) for more detail.
+See \fBchpoll\fR(9E), \fBpollwakeup\fR(9F) and \fBpoll\fR(2) for more detail.
 .SH CONTEXT
 .LP
 The \fBpollhead_clean()\fR function is generally called from the context
@@ -55,5 +55,5 @@ of a \fBclose\fR(9E) entry point, but may be called from user or kernel
 context.
 .SH SEE ALSO
 .LP
-\fBpoll\fR(2), \fBchpoll\fR(9E), \fBpollwakeup\fR(9E)
+\fBpoll\fR(2), \fBchpoll\fR(9E), \fBpollwakeup\fR(9F)
 

--- a/usr/src/man/man9f/usb_pipe_isoc_xfer.9f
+++ b/usr/src/man/man9f/usb_pipe_isoc_xfer.9f
@@ -116,7 +116,7 @@ completed request is returned through a normal callback.
 Allocate room for data when allocating isochronous-OUT requests via
 usb_alloc_isoc_req(9F), by passing a positive value for     the \fIlen\fR
 argument. The data will be divided among the request transactions, each
-transaction represented by a packet descriptor.  (See usb_isoc_request(9F).
+transaction represented by a packet descriptor.  (See usb_isoc_request(9S).
 When all of the data has been sent, regardless of any errors encountered, a
 normal transfer callback will be     made to notify the client driver of
 completion.

--- a/usr/src/man/man9f/usba_hubdi_cb_ops.9f
+++ b/usr/src/man/man9f/usba_hubdi_cb_ops.9f
@@ -107,5 +107,5 @@ entry points.
 .Xr close 9E ,
 .Xr ioctl 9E ,
 .Xr open 9E ,
-.Xr usb_hcdi 9E ,
+.Xr usba_hcdi 9E ,
 .Xr cb_ops 9S

--- a/usr/src/man/man9s/ddi_device_acc_attr.9s
+++ b/usr/src/man/man9s/ddi_device_acc_attr.9s
@@ -215,7 +215,7 @@ The following examples illustrate the use of device register address mapping
 setup functions and different data access functions.
 .LP
 \fBExample 1 \fRUsing \fBddi_device_acc_attr()\fR in
->\fBddi_regs_map_setup\fR(9F)
+\fBddi_regs_map_setup\fR(9F)
 .sp
 .LP
 This example demonstrates the use of the \fBddi_device_acc_attr()\fR structure

--- a/usr/src/man/man9s/usb_bulk_req.9s
+++ b/usr/src/man/man9s/usb_bulk_req.9s
@@ -34,7 +34,7 @@ The usb_bulk_req_t fields are:
 .nf
 uint_t          bulk_len;       /* number of bytes to xfer      */
                                 /* Please see */
-                                /* usb_pipe_get_max_bulk_xfer_size(9F) */
+                                /* usb_pipe_get_max_bulk_transfer_size(9F) */
                                 /* for maximum size */
 mblk_t          *bulk_data;     /* the data for the data phase  */
                                 /* IN or OUT: allocated by client */
@@ -99,7 +99,7 @@ Please see \fBusb_request_attributes\fR(9S) for more information.
 Bulk transfers/requests are subject to the following constraints and caveats:
 .sp
 .LP
-1) The following table indicates combinations of \fBusb_pipe_bulk_xfer()\fR
+1) The following table indicates combinations of \fBusb_pipe_bulk_xfer\fR()
 flags argument and fields of the usb_bulk_req_t request argument (X = don't
 care).
 .br
@@ -216,13 +216,13 @@ is not set is considered a device error.)  An exception callback is made and
 completion_reason will be non-zero.
 .sp
 .LP
-4) Splitting large Bulk xfers: Due to internal constraints, the USBA framework
-can only do a limited size bulk data xfer per request.  A client driver may
-first determine this limitation by calling the USBA interface
-(usb_pipe_get_max_bulk_xfer_size(9F)) and then restrict itself to doing
-transfers in multiples of this fixed size. This forces a client driver to do
-data xfers in a loop for a large request, splitting it into multiple chunks of
-fixed size.
+4) Splitting large bulk transfers: Due to internal constraints, the USBA
+framework can only do a limited size bulk data transfer per request.  A client
+driver may first determine this limitation by calling the USBA interface,
+\fBusb_pipe_get_max_bulk_transfer_size\fR(9F), and then restrict itself to
+doing transfers in multiples of this fixed size. This forces a client driver
+to do data transfers in a loop for a large request, splitting it into multiple
+chunks of fixed size.
 .sp
 .LP
 The bulk_completion_reason indicates the status of the transfer.  See

--- a/usr/src/man/man9s/usb_ep_xdescr.9s
+++ b/usr/src/man/man9s/usb_ep_xdescr.9s
@@ -75,7 +75,7 @@ The
 .Sy uex_version
 member is used to describe the current version of this structure.
 This member will be set to the value passed in by the device driver to
-.Xr usb_ep_xdescr_fil 9F .
+.Xr usb_ep_xdescr_fill 9F .
 Device drivers should ignore this field and should not modify the value
 placed there or modify it.
 .Pp

--- a/usr/src/pkg/manifests/SUNWcs.man1m.inc
+++ b/usr/src/pkg/manifests/SUNWcs.man1m.inc
@@ -13,6 +13,7 @@
 # Copyright 2011, Richard Lowe
 # Copyright 2015 Nexenta Systems, Inc. All rights reserved.
 # Copyright 2016 Toomas Soome <tsoome@me.com>
+# Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
 #
 
 file path=usr/share/man/man1m/6to4relay.1m
@@ -55,6 +56,7 @@ file path=usr/share/man/man1m/dd.1m
 file path=usr/share/man/man1m/devattr.1m
 file path=usr/share/man/man1m/devfree.1m
 file path=usr/share/man/man1m/devfsadm.1m
+link path=usr/share/man/man1m/audlinks.1m target=devfsadm.1m
 file path=usr/share/man/man1m/devinfo.1m
 file path=usr/share/man/man1m/devlinks.1m
 file path=usr/share/man/man1m/devnm.1m

--- a/usr/src/pkg/manifests/system-library-math.man3m.inc
+++ b/usr/src/pkg/manifests/system-library-math.man3m.inc
@@ -10,6 +10,7 @@
 #
 
 # Copyright (c) 2012, Igor Kozhukhov <ikozhukhov@gmail.com>
+# Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
 
 file path=usr/share/man/man3m/acos.3m
 file path=usr/share/man/man3m/acosh.3m
@@ -54,8 +55,11 @@ file path=usr/share/man/man3m/fabs.3m
 file path=usr/share/man/man3m/fdim.3m
 file path=usr/share/man/man3m/feclearexcept.3m
 file path=usr/share/man/man3m/fegetenv.3m
+link path=usr/share/man/man3m/fesetenv.3m target=fegetenv.3m
 file path=usr/share/man/man3m/fegetexceptflag.3m
+link path=usr/share/man/man3m/fesetexceptflag.3m target=fegetexceptflag.3m
 file path=usr/share/man/man3m/fegetround.3m
+link path=usr/share/man/man3m/fesetround.3m target=fegetround.3m
 file path=usr/share/man/man3m/feholdexcept.3m
 file path=usr/share/man/man3m/feraiseexcept.3m
 file path=usr/share/man/man3m/fesetprec.3m

--- a/usr/src/uts/common/fs/zfs/abd.c
+++ b/usr/src/uts/common/fs/zfs/abd.c
@@ -157,6 +157,13 @@ extern vmem_t *zio_alloc_arena;
 kmem_cache_t *abd_chunk_cache;
 static kstat_t *abd_ksp;
 
+extern inline boolean_t abd_is_linear(abd_t *abd);
+extern inline void abd_copy(abd_t *dabd, abd_t *sabd, size_t size);
+extern inline void abd_copy_from_buf(abd_t *abd, const void *buf, size_t size);
+extern inline void abd_copy_to_buf(void* buf, abd_t *abd, size_t size);
+extern inline int abd_cmp_buf(abd_t *abd, const void *buf, size_t size);
+extern inline void abd_zero(abd_t *abd, size_t size);
+
 static void *
 abd_alloc_chunk()
 {

--- a/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
@@ -122,6 +122,8 @@ typedef struct dsl_pool {
 	txg_list_t dp_dirty_dirs;
 	txg_list_t dp_sync_tasks;
 	taskq_t *dp_sync_taskq;
+	taskq_t *dp_zil_clean_taskq;
+	txg_list_t dp_early_sync_tasks;
 
 	/*
 	 * Protects administrative changes (properties, namespace)

--- a/usr/src/uts/common/fs/zfs/sys/zil_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/zil_impl.h
@@ -124,7 +124,6 @@ struct zilog {
 	list_t		zl_lwb_list;	/* in-flight log write list */
 	kmutex_t	zl_vdev_lock;	/* protects zl_vdev_tree */
 	avl_tree_t	zl_vdev_tree;	/* vdevs to flush in zil_commit() */
-	taskq_t		*zl_clean_taskq; /* runs lwb and itx clean tasks */
 	avl_tree_t	zl_bp_tree;	/* track bps during log parse */
 	clock_t		zl_replay_time;	/* lbolt of when replay started */
 	uint64_t	zl_replay_blks;	/* number of log blocks replayed */

--- a/usr/src/uts/common/fs/zfs/zil.c
+++ b/usr/src/uts/common/fs/zfs/zil.c
@@ -1394,8 +1394,7 @@ zil_clean(zilog_t *zilog, uint64_t synced_txg)
 		return;
 	}
 	ASSERT3U(itxg->itxg_txg, <=, synced_txg);
-	ASSERT(itxg->itxg_txg != 0);
-	ASSERT(zilog->zl_clean_taskq != NULL);
+	ASSERT3U(itxg->itxg_txg, !=, 0);
 	clean_me = itxg->itxg_itxs;
 	itxg->itxg_itxs = NULL;
 	itxg->itxg_txg = 0;
@@ -1406,7 +1405,9 @@ zil_clean(zilog_t *zilog, uint64_t synced_txg)
 	 * free it in-line. This should be rare. Note, using TQ_SLEEP
 	 * created a bad performance problem.
 	 */
-	if (taskq_dispatch(zilog->zl_clean_taskq,
+	ASSERT3P(zilog->zl_dmu_pool, !=, NULL);
+	ASSERT3P(zilog->zl_dmu_pool->dp_zil_clean_taskq, !=, NULL);
+	if (taskq_dispatch(zilog->zl_dmu_pool->dp_zil_clean_taskq,
 	    (void (*)(void *))zil_itxg_clean, clean_me, TQ_NOSLEEP) == NULL)
 		zil_itxg_clean(clean_me);
 }
@@ -1835,13 +1836,10 @@ zil_open(objset_t *os, zil_get_data_t *get_data)
 {
 	zilog_t *zilog = dmu_objset_zil(os);
 
-	ASSERT(zilog->zl_clean_taskq == NULL);
 	ASSERT(zilog->zl_get_data == NULL);
 	ASSERT(list_is_empty(&zilog->zl_lwb_list));
 
 	zilog->zl_get_data = get_data;
-	zilog->zl_clean_taskq = taskq_create("zil_clean", 1, minclsyspri,
-	    2, 2, TASKQ_PREPOPULATE);
 
 	return (zilog);
 }
@@ -1875,8 +1873,6 @@ zil_close(zilog_t *zilog)
 		zfs_dbgmsg("zil (%p) is dirty, txg %llu", zilog, txg);
 	VERIFY(!zilog_is_dirty(zilog));
 
-	taskq_destroy(zilog->zl_clean_taskq);
-	zilog->zl_clean_taskq = NULL;
 	zilog->zl_get_data = NULL;
 
 	/*

--- a/usr/src/uts/common/sys/ccompile.h
+++ b/usr/src/uts/common/sys/ccompile.h
@@ -152,7 +152,7 @@ extern "C" {
 #define	__RETURNS_TWICE		__sun_attr__((__returns_twice__))
 #define	__CONST			__sun_attr__((__const__))
 #define	__PURE			__sun_attr__((__pure__))
-#define	__GNU_UNUSED		__sun_attr__((__unused__))
+#define	__unused		__sun_attr__((__unused__))
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/sys/modctl.h
+++ b/usr/src/uts/common/sys/modctl.h
@@ -513,7 +513,7 @@ typedef struct modctl {
 	char		mod_delay_unload;	/* deferred unload */
 
 	struct modctl_list *mod_requisites;	/* mods this one depends on. */
-	void		*__unused;	/* NOTE: reuse (same size) is OK, */
+	void		*mod_unused;	/* NOTE: reuse (same size) is OK, */
 					/* deletion causes mdb.vs.core issues */
 	int		mod_loadcnt;	/* number of times mod was loaded */
 	int		mod_nenabled;	/* # of enabled DTrace probes in mod */

--- a/usr/src/uts/common/sys/taskq_impl.h
+++ b/usr/src/uts/common/sys/taskq_impl.h
@@ -24,6 +24,7 @@
  */
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #ifndef	_SYS_TASKQ_IMPL_H
@@ -66,7 +67,6 @@ typedef struct tqstat {
 	uint_t		tqs_tcreates;	/* threads created 	*/
 	uint_t		tqs_tdeaths;	/* threads died		*/
 	uint_t		tqs_maxthreads;	/* max # of alive threads */
-	uint_t		tqs_nomem;	/* # of times there were no memory */
 	uint_t		tqs_disptcreates;
 } tqstat_t;
 
@@ -142,6 +142,7 @@ struct taskq {
 	 */
 	kstat_t		*tq_kstat;	/* Exported statistics */
 	hrtime_t	tq_totaltime;	/* Time spent processing tasks */
+	uint64_t	tq_nomem;	/* # of times there was no memory */
 	uint64_t	tq_tasks;	/* Total # of tasks posted */
 	uint64_t	tq_executed;	/* Total # of tasks executed */
 	int		tq_maxtasks;	/* Max number of tasks in the queue */


### PR DESCRIPTION
Weekly merge from `illumos-gate`

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream-merge-2017083101-9f6450a0dc i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Aug 31 12:19:28 CEST 2017 ====
==== Nightly distributed build completed: Thu Aug 31 13:01:50 CEST 2017 ====

==== Total build time ====

real    0:42:21

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-d667e00233 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-upstream-merge-2017083101-9f6450a0dc

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:16.1
user  1:08:44.7
sys      5:04.9

==== Build noise differences (DEBUG) ====

0a1
> 	-classpath /omniosorg/build/bloody/illumos-omnios/usr/src/lib/libdtrace_jni/java/classes:/omniosorg/build/bloody/illumos-omnios/usr/src/lib/libdtrace_jni/java/src -d /omniosorg/build/bloody/illumos-omnios/proto/root_i386/usr/share/lib/java/javadoc/dtrace/api \
4a6
> 	print "export PATH=/usr/ast/bin:/usr/xpg6/bin:/usr/xpg4/bin:/usr/bin:\${PATH}" ; \
43a46,48
> : libcommon.a
> : libdrivers.a
> : libgrub.a
45a51,80
> Note: /omniosorg/build/bloody/illumos-omnios/usr/src/cmd/pools/poold/com/sun/solaris/domain/pools/ResourceMonitor.java uses unchecked or unsafe operations.
> Note: /omniosorg/build/bloody/illumos-omnios/usr/src/cmd/print/printmgr/com/sun/admin/pm/server/Debug.java uses unchecked or unsafe operations.
> Note: BST.java uses unchecked or unsafe operations.
> Note: Configuration.java uses unchecked or unsafe operations.
> Note: Debug.java uses unchecked or unsafe operations.
> Note: DecisionHistory.java uses unchecked or unsafe operations.
> Note: Element.java uses unchecked or unsafe operations.
> Note: LocalityGroup.java uses unchecked or unsafe operations.
> Note: Move.java uses unchecked or unsafe operations.
> Note: Pool.java uses unchecked or unsafe operations.
> Note: Recompile with -Xlint:unchecked for details.
> Note: Resource.java uses unchecked or unsafe operations.
> Note: ResourceMonitor.java uses unchecked or unsafe operations.
> Note: Severity.java uses unchecked or unsafe operations.
> Note: Some input files use unchecked or unsafe operations.
> Note: StatisticList.java uses unchecked or unsafe operations.
> Note: SysloglikeFormatter.java uses unchecked or unsafe operations.
> Note: SystemMonitor.java uses unchecked or unsafe operations.
> Note: SystemSolver.java uses unchecked or unsafe operations.
> Note: helptools/parseMain.java uses unchecked or unsafe operations.
> Note: pmButton.java uses unchecked or unsafe operations.
> Note: pmHelpDetailPanel.java uses unchecked or unsafe operations.
> Note: pmHelpIndexPanel.java uses unchecked or unsafe operations.
> Note: pmHelpRepository.java uses unchecked or unsafe operations.
> Note: pmHelpSearchPanel.java uses unchecked or unsafe operations.
> Note: pmInstallPrinter.java uses unchecked or unsafe operations.
> Note: pmInstallScreen.java uses unchecked or unsafe operations.
> Note: pmLoad.java uses unchecked or unsafe operations.
> Note: pmMessageDialog.java uses unchecked or unsafe operations.
> Note: pmTop.java uses unchecked or unsafe operations.
48,49c83,84
< maximum offset: 1d3f
< maximum offset: 239b
---
> maximum offset: 1d52
> maximum offset: 23ae
51a87,90
> sed 's/.c:#define/,/'                   |\
> sed -e '/^.include/s:\.\..*/rpcsvc:rpcsvc:' < nlm_prot_xdr.c.tmp > nlm_prot_xdr.c
> sed -e '/^.include/s:\.\..*/rpcsvc:rpcsvc:' < nsm_addr_xdr.c.tmp > nsm_addr_xdr.c
> sed -e '/^.include/s:\.\..*/rpcsvc:rpcsvc:' < sm_inter_xdr.c.tmp > sm_inter_xdr.c

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:42.2
user    46:29.6
sys      4:56.2

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```