### PR TITLE
Use omnios as the default package publisher

### DIFF
--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -1008,7 +1008,7 @@ PKGARCHIVE=$(SRC)/../../packages/$(MACH)/nightly$(PKGARCHIVESUFFIX)
 # update an image to the resulting repositories, this must match the
 # publisher name provided to "pkg set-publisher."
 #
-PKGPUBLISHER_REDIST=	on-nightly
+PKGPUBLISHER_REDIST=	omnios
 PKGPUBLISHER_NONREDIST=	on-extra
 
 #	Default build rules which perform comment section post-processing.

--- a/usr/src/tools/scripts/onu.sh.in
+++ b/usr/src/tools/scripts/onu.sh.in
@@ -23,13 +23,14 @@
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2010, Richard Lowe
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 
 PATH=/usr/bin:/usr/sbin
 export PATH
 
-DEFAULTONURI="http://ipkg.sfbay/on-nightly"
-DEFAULTONPUB="on-nightly"
+DEFAULTONURI="https://pkg.omniosce.org/bloody/core"
+DEFAULTONPUB="omnios"
 
 usage()
 {
@@ -116,12 +117,12 @@ update_zone()
 	zone=$1
 
 	name=`echo $zone | cut -d: -f 2`
-	if [ $name = "global" ]; then
+	if [ "$name" = "global" ]; then
 		return
 	fi
 
 	brand=`echo $zone | cut -d: -f 6`
-	if [ $brand != "ipkg" && $brand != "lipkg" ]; then
+	if [ "$brand" != "ipkg" -a "$brand" != "lipkg" ]; then
 		return
 	fi
 
@@ -240,6 +241,8 @@ do_cmd beadm create $createargs $targetbe
 do_cmd beadm mount $targetbe $tmpdir
 update $tmpdir
 do_cmd beadm activate $targetbe
+do_cmd beadm unmount $targetbe
+rmdir $tmpdir
 
 if [ "$no_zones" != 1 ]; then
 	for zone in `do_cmd zoneadm -R $tmpdir list -cip`; do


### PR DESCRIPTION
This change makes `illumos-omnios` publish packages using the `omnios` publisher instead of `on-nightly`.
This means that the post-processing step of changing the publisher can be avoided in `omnios-build` - see https://github.com/omniosorg/omnios-build/pull/169.

ONU is also smoother since all that changes is the origin of the `omnios` publisher and the signature policy.

This also fixes a small bug in `onu` where the brand check did not work.

Example output showing bug:

```
/opt/onbld/bin/onu[128]: [: ']' missing
WARNING: Use of onu(1) will prevent use of zone attach in the new BE
See onu(1)
Updating zone alpine
pkg: No image rooted at '/tmp/onu.g_aW53/data/zone/alpine/root'
pkg: No image rooted at '/tmp/onu.g_aW53/data/zone/alpine/root'
```
