### PR TITLE
Joyent merge/2017083101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 6ce43f2a6fa2b7afc12a8d8d72313305ff468356
+Last illumos-joyent commit: 630e04903d53ad768c332359548d2fa6d50bf572
 

--- a/usr/src/lib/brand/lx/testing/ltp_skiplist
+++ b/usr/src/lib/brand/lx/testing/ltp_skiplist
@@ -172,6 +172,10 @@ ioctl04
 ioctl05
 ioctl06
 keyctl01
+keyctl02
+keyctl03
+keyctl04
+keyctl05
 kcmp01
 kcmp02
 kcmp03

--- a/usr/src/uts/common/brand/lx/syscall/lx_pipe.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_pipe.c
@@ -186,7 +186,9 @@ lx_hd_pipe(intptr_t arg, int flags)
 	 * the pipe capacity is limited to "Fifohiwat" which is a compile-time
 	 * limit set to FIFOHIWAT.
 	 */
+	mutex_enter(&VTOF(vp1)->fn_lock->flk_lock);
 	fifo_fastoff(VTOF(vp1));
+	mutex_exit(&VTOF(vp1)->fn_lock->flk_lock);
 
 	/*
 	 * Set the O_NONBLOCK flag if requested.

--- a/usr/src/uts/common/brand/lx/syscall/lx_pipe.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_pipe.c
@@ -180,17 +180,6 @@ lx_hd_pipe(intptr_t arg, int flags)
 	(void) lx_pipe_setsz(str, LX_DEFAULT_PIPE_SIZE, B_TRUE);
 
 	/*
-	 * Because we're using streams to increase the capacity of the pipe
-	 * up to the default Linux capacity, we have to switch the pipe
-	 * out of FIFOFAST mode and back to a normal stream. In fast mode
-	 * the pipe capacity is limited to "Fifohiwat" which is a compile-time
-	 * limit set to FIFOHIWAT.
-	 */
-	mutex_enter(&VTOF(vp1)->fn_lock->flk_lock);
-	fifo_fastoff(VTOF(vp1));
-	mutex_exit(&VTOF(vp1)->fn_lock->flk_lock);
-
-	/*
 	 * Set the O_NONBLOCK flag if requested.
 	 */
 	if (flags & FNONBLOCK) {


### PR DESCRIPTION
Upstream merge from `illumos-joyent`.

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent-merge-2017083101-a9d1b8e6ee i86pc i386 i86pc
hadfl@mars:~$ zoneadm list -cv
  ID NAME             STATUS     PATH                           BRAND    IP
   0 global           running    /                              ipkg     shared
   1 ubuntu-16        running    /zones/ubuntu-16               lx       excl
```

### mail_msg

```
==== Nightly distributed build started:   Thu Aug 31 16:00:44 CEST 2017 ====
==== Nightly distributed build completed: Thu Aug 31 16:42:54 CEST 2017 ====

==== Total build time ====

real    0:42:10

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-d667e00233 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   93

==== Nightly argument issues ====


==== Build version ====

omnios-joyent-merge-2017083101-a9d1b8e6ee

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:22.5
user  1:08:49.9
sys      5:12.6

==== Build noise differences (DEBUG) ====

83,84c83,84
< maximum offset: 1d52
< maximum offset: 23ae
---
> maximum offset: 1d50
> maximum offset: 23ac

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:34.6
user    46:19.1
sys      5:00.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```