### PR TITLE
Joyent merge/2017090701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 630e04903d53ad768c332359548d2fa6d50bf572
+Last illumos-joyent commit: b5921b68e3c3270372dc07d568b4024543b4f957
 

--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -513,6 +513,7 @@ lx_netlink_setsockopt(sock_lower_handle_t handle, int level,
 	}
 }
 
+/*ARGSUSED*/
 static int
 lx_netlink_getsockopt(sock_lower_handle_t handle, int level,
     int option_name, void *optval, socklen_t *optlen, cred_t *cr)

--- a/usr/src/uts/common/brand/lx/procfs/lx_prsubr.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prsubr.c
@@ -530,7 +530,7 @@ lxpr_getnode(vnode_t *dp, lxpr_nodetype_t type, proc_t *p, int desc)
 		 * ignores nodes in the SIDL state so we'll never get a node
 		 * that isn't already in the SRUN state.
 		 */
-		if (p->p_stat == SZOMB) {
+		if (p->p_stat == SZOMB || (p->p_flag & SEXITING) != 0) {
 			lxpnp->lxpr_realvp = NULL;
 		} else {
 			ASSERT(MUTEX_HELD(&p->p_lock));
@@ -546,7 +546,7 @@ lxpr_getnode(vnode_t *dp, lxpr_nodetype_t type, proc_t *p, int desc)
 	case LXPR_PID_ROOTDIR:
 		ASSERT(p != NULL);
 		/* Zombie check.  see locking comment above */
-		if (p->p_stat == SZOMB) {
+		if (p->p_stat == SZOMB || (p->p_flag & SEXITING) != 0) {
 			lxpnp->lxpr_realvp = NULL;
 		} else {
 			ASSERT(MUTEX_HELD(&p->p_lock));

--- a/usr/src/uts/common/fs/proc/prvnops.c
+++ b/usr/src/uts/common/fs/proc/prvnops.c
@@ -3739,7 +3739,7 @@ pr_lookup_procdir(vnode_t *dp, char *comp)
 		/* initialize the new prcommon struct */
 		if ((p->p_flag & SSYS) || p->p_as == &kas)
 			pcp->prc_flags |= PRC_SYS;
-		if (p->p_stat == SZOMB)
+		if (p->p_stat == SZOMB || (p->p_flag & SEXITING) != 0)
 			pcp->prc_flags |= PRC_DESTROY;
 		pcp->prc_proc = p;
 		pcp->prc_datamodel = p->p_model;

--- a/usr/src/uts/common/sys/fs/fifonode.h
+++ b/usr/src/uts/common/sys/fs/fifonode.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -83,6 +84,7 @@ struct fifonode {
 	struct msgb	*fn_tail;	/* last message to read */
 	fifolock_t	*fn_lock;	/* pointer to per fifo lock */
 	uint_t		fn_count;	/* Number of bytes on fn_mp */
+	uint_t		fn_hiwat;	/* pipe (fifofast) high water */
 	kcondvar_t	fn_wait_cv;	/* fifo conditional variable */
 	ushort_t	fn_wcnt;	/* number of writers */
 	ushort_t	fn_rcnt;	/* number of readers */
@@ -146,16 +148,6 @@ typedef struct fifodata {
 #define	FTOV(fp) ((fp)->fn_vnode)
 
 #if defined(_KERNEL)
-
-/*
- * Fifohiwat defined as a variable is to allow tuning of the high
- * water mark if needed. It is not meant to be released.
- */
-#if FIFODEBUG
-extern int Fifohiwat;
-#else /* FIFODEBUG */
-#define	Fifohiwat	FIFOHIWAT
-#endif /* FIFODEBUG */
 
 extern struct vnodeops *fifo_vnodeops;
 extern const struct fs_operation_def fifo_vnodeops_template[];


### PR DESCRIPTION
## Backports

None

## mail_msg

```
==== Nightly distributed build started:   Thu Sep  7 20:39:31 UTC 2017 ====
==== Nightly distributed build completed: Thu Sep  7 21:41:32 UTC 2017 ====

==== Total build time ====

real    1:02:00

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-5e982daae6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   440316

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017090701-3ff5e44fd1

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:45.2
user  1:33:11.9
sys     12:03.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:16.9
user  1:24:35.5
sys      9:25.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    20:24.5
user  1:08:19.5
sys     19:31.1

==== lint warnings src ====


==== lint noise differences src ====

1,3d0
< "../../common/brand/lx/io/lx_netlink.c", line 517: warning: argument unused in function: handle in lx_netlink_getsockopt (E_FUNC_ARG_UNUSED)
< "../../common/brand/lx/io/lx_netlink.c", line 518: warning: argument unused in function: cr in lx_netlink_getsockopt (E_FUNC_ARG_UNUSED)
< "../../common/brand/lx/io/lx_netlink.c", line 518: warning: argument unused in function: optval in lx_netlink_getsockopt (E_FUNC_ARG_UNUSED)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
