### PR TITLE
Upstream merge/2017091401

### DIFF
--- a/usr/src/cmd/cmd-inet/etc/dhcp/inittab
+++ b/usr/src/cmd/cmd-inet/etc/dhcp/inittab
@@ -1,6 +1,7 @@
 #
 # Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 # CDDL HEADER START
 #
@@ -22,7 +23,6 @@
 #
 # CDDL HEADER END
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
 #
 # This file provides information about all supported DHCP options, for
 # use by DHCP-related programs.  This file should only be modified to
@@ -114,6 +114,7 @@ STDAservs	STANDARD,	76,	IP,	   1,	0,	sdmi
 UserClas	STANDARD,	77,	ASCII,	   1,	0,	sdi
 SLP_DA		STANDARD,	78,	OCTET,	   1,	0,	sdmi
 SLP_SS		STANDARD,	79,	OCTET,	   1,	0,	sdmi
+ClientFQDN	STANDARD,	81,	OCTET,	   1,	0,	sdmi
 AgentOpt	STANDARD,	82,	OCTET,	   1,	0,	sdi
 FQDN		STANDARD,	89,	OCTET,	   1,	0,	sdmi
 
@@ -177,7 +178,7 @@ SHTTPproxy	VENDOR,		17,	ASCII,	   1,	0,	smi
 # The following option describes an option named ipPairs, that is in
 # the  SITE category, meaning it is defined by each individual site.
 # It is option code 132, which is of type IP Address, consisting of
-# a potentially infinite number of pairs of IP addresses.  (See 
+# a potentially infinite number of pairs of IP addresses.  (See
 # dhcp_inittab(4) for details)
 #
 # ipPairs     SITE,           132,    IP,     2,      0,      sdmi

--- a/usr/src/cmd/cmd-inet/lib/ipmgmtd/ipmgmt_door.c
+++ b/usr/src/cmd/cmd-inet/lib/ipmgmtd/ipmgmt_door.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -236,8 +237,6 @@ i_ipmgmt_nvl2aobjnode(nvlist_t *nvl, ipmgmt_aobjmap_t *nodep)
 	char			*aobjname = NULL, *ifname = NULL;
 	int32_t			lnum;
 	nvlist_t		*nvladdr;
-	struct sockaddr_storage	addr;
-	uint_t			n;
 	sa_family_t		af = AF_UNSPEC;
 	ipadm_addr_type_t	addrtype = IPADM_ADDR_NONE;
 	int			err = 0;
@@ -255,16 +254,37 @@ i_ipmgmt_nvl2aobjnode(nvlist_t *nvl, ipmgmt_aobjmap_t *nodep)
 	if (nvlist_exists(nvl, IPADM_NVP_IPV4ADDR)) {
 		af = AF_INET;
 		addrtype = IPADM_ADDR_STATIC;
-	} else if (nvlist_exists(nvl, IPADM_NVP_DHCP)) {
+	} else if (nvlist_lookup_nvlist(nvl, IPADM_NVP_DHCP, &nvladdr) == 0) {
+		char	*reqhost;
+
 		af = AF_INET;
 		addrtype = IPADM_ADDR_DHCP;
+
+		/*
+		 * ipmgmt_am_reqhost comes through in `nvl' for purposes of
+		 * updating the cached representation, but it is persisted as
+		 * a stand-alone DB line; so remove it after copying it.
+		 */
+		if (!nvlist_exists(nvl, IPADM_NVP_REQHOST)) {
+			*nodep->ipmgmt_am_reqhost = '\0';
+		} else {
+			if ((err = nvlist_lookup_string(nvl, IPADM_NVP_REQHOST,
+			    &reqhost)) != 0)
+				return (err);
+
+			(void) strlcpy(nodep->ipmgmt_am_reqhost, reqhost,
+			    sizeof (nodep->ipmgmt_am_reqhost));
+			(void) nvlist_remove(nvl, IPADM_NVP_REQHOST,
+			    DATA_TYPE_STRING);
+		}
 	} else if (nvlist_exists(nvl, IPADM_NVP_IPV6ADDR)) {
 		af = AF_INET6;
 		addrtype = IPADM_ADDR_STATIC;
 	} else if (nvlist_lookup_nvlist(nvl, IPADM_NVP_INTFID, &nvladdr) == 0) {
-		struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&addr;
+		struct sockaddr_in6		sin6 = {0};
 		uint8_t	*addr6;
 		uint32_t plen;
+		uint_t	n;
 
 		af = AF_INET6;
 		addrtype = IPADM_ADDR_IPV6_ADDRCONF;
@@ -275,14 +295,15 @@ i_ipmgmt_nvl2aobjnode(nvlist_t *nvl, ipmgmt_aobjmap_t *nodep)
 			if (nvlist_lookup_uint8_array(nvladdr,
 			    IPADM_NVP_IPNUMADDR, &addr6, &n) != 0)
 				return (EINVAL);
-			bcopy(addr6, &sin6->sin6_addr, n);
-		} else {
-			bzero(&sin6->sin6_addr, sizeof (sin6->sin6_addr));
+			bcopy(addr6, &sin6.sin6_addr, n);
 		}
+
+		nodep->ipmgmt_am_linklocal = B_TRUE;
+		nodep->ipmgmt_am_ifid = sin6;
 	}
 
 	/*
-	 * populate the `*nodep' with retrieved values.
+	 * populate the non-addrtype-specific `*nodep' with retrieved values.
 	 */
 	(void) strlcpy(nodep->am_ifname, ifname, sizeof (nodep->am_ifname));
 	(void) strlcpy(nodep->am_aobjname, aobjname,
@@ -290,10 +311,6 @@ i_ipmgmt_nvl2aobjnode(nvlist_t *nvl, ipmgmt_aobjmap_t *nodep)
 	nodep->am_lnum = lnum;
 	nodep->am_family = af;
 	nodep->am_atype = addrtype;
-	if (addrtype == IPADM_ADDR_IPV6_ADDRCONF) {
-		nodep->am_linklocal = B_TRUE;
-		nodep->am_ifid = addr;
-	}
 	nodep->am_next = NULL;
 
 	/*
@@ -308,15 +325,15 @@ i_ipmgmt_nvl2aobjnode(nvlist_t *nvl, ipmgmt_aobjmap_t *nodep)
 
 /*
  * Handles the door command IPMGMT_CMD_SETADDR. It adds a new address object
- * node to the list `aobjmap' and then persists the address information in the
- * DB.
+ * node to the list `aobjmap' and optionally persists the address
+ * information in the DB.
  */
 static void
 ipmgmt_setaddr_handler(void *argp)
 {
 	ipmgmt_setaddr_arg_t	*sargp = argp;
 	ipmgmt_retval_t		rval;
-	ipmgmt_aobjmap_t	node;
+	ipmgmt_aobjmap_t	node = {0};
 	nvlist_t		*nvl = NULL;
 	char			*nvlbuf;
 	size_t			nvlsize = sargp->ia_nvlsize;
@@ -332,11 +349,11 @@ ipmgmt_setaddr_handler(void *argp)
 		if (flags & IPMGMT_INIT)
 			node.am_flags = (IPMGMT_ACTIVE|IPMGMT_PERSIST);
 		else
-			node.am_flags = flags;
+			node.am_flags = flags & ~IPMGMT_PROPS_ONLY;
 		if ((err = ipmgmt_aobjmap_op(&node, ADDROBJ_ADD)) != 0)
 			goto ret;
 	}
-	if (flags & IPMGMT_PERSIST) {
+	if ((flags & IPMGMT_PERSIST) && !(flags & IPMGMT_PROPS_ONLY)) {
 		ipadm_dbwrite_cbarg_t	cb;
 
 		cb.dbw_nvl = nvl;
@@ -350,7 +367,7 @@ ret:
 }
 
 /*
- * Handles the door commands that modify the `aobjmap' structure.
+ * Handles the door commands that read or modify the `aobjmap' structure.
  *
  * IPMGMT_CMD_ADDROBJ_LOOKUPADD - places a stub address object in `aobjmap'
  *	after ensuring that the namespace is not taken. If required, also
@@ -452,7 +469,7 @@ ipmgmt_aobjop_handler(void *argp)
 			 * have am_ifid set.
 			 */
 			if (head->am_atype != IPADM_ADDR_IPV6_ADDRCONF ||
-			    head->am_linklocal) {
+			    head->ipmgmt_am_linklocal) {
 				break;
 			}
 		}
@@ -467,9 +484,7 @@ ipmgmt_aobjop_handler(void *argp)
 		aobjrval.ir_family = head->am_family;
 		aobjrval.ir_flags = head->am_flags;
 		aobjrval.ir_atype = head->am_atype;
-		if (head->am_atype == IPADM_ADDR_IPV6_ADDRCONF &&
-		    head->am_linklocal)
-			aobjrval.ir_ifid = head->am_ifid;
+		aobjrval.ir_atype_cache = head->am_atype_cache;
 		(void) pthread_rwlock_unlock(&aobjmap.aobjmap_rwlock);
 		break;
 	case IPMGMT_CMD_LIF2ADDROBJ:
@@ -498,6 +513,7 @@ ipmgmt_aobjop_handler(void *argp)
 		    sizeof (aobjrval.ir_aobjname));
 		aobjrval.ir_atype = head->am_atype;
 		aobjrval.ir_flags = head->am_flags;
+		aobjrval.ir_atype_cache = head->am_atype_cache;
 		(void) pthread_rwlock_unlock(&aobjmap.aobjmap_rwlock);
 		break;
 	default:

--- a/usr/src/cmd/cmd-inet/lib/ipmgmtd/ipmgmt_impl.h
+++ b/usr/src/cmd/cmd-inet/lib/ipmgmtd/ipmgmt_impl.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Joyent, Inc.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef	_IPMGMT_IMPL_H
@@ -104,8 +105,11 @@ extern db_wfunc_t	ipmgmt_db_initif;
  *	  of `aobjname'.
  *	- address type (static, dhcp or addrconf)
  *	- `am_flags' indicates if this addrobj in active and/or persist config
- *	- if `am_atype' is IPADM_ADDR_IPV6_ADDRCONF then `am_ifid' holds the
- *	  interface-id used to configure auto-configured addresses
+ *	- other, ipadm_addr_type_t-specific values are cached in
+ *	  am_addr_cache (see type ipmgmt_addr_cache_u):
+ *	  -	ipv6: ipmgmt_am_linklocal (macro)
+ *	  -	ipv6: ipmgmt_am_ifid (macro)
+ *	  -	dhcp: ipmgmt_am_reqhost (macro)
  */
 typedef struct ipmgmt_aobjmap_s {
 	struct ipmgmt_aobjmap_s	*am_next;
@@ -116,9 +120,15 @@ typedef struct ipmgmt_aobjmap_s {
 	ipadm_addr_type_t	am_atype;
 	uint32_t		am_nextnum;
 	uint32_t		am_flags;
-	boolean_t		am_linklocal;
-	struct sockaddr_storage	am_ifid;
+	ipmgmt_addr_type_cache_u	am_atype_cache;
 } ipmgmt_aobjmap_t;
+
+#define	ipmgmt_am_linklocal \
+    am_atype_cache.ipmgmt_ipv6_cache_s.ipmgmt_linklocal
+#define	ipmgmt_am_ifid \
+    am_atype_cache.ipmgmt_ipv6_cache_s.ipmgmt_ifid
+#define	ipmgmt_am_reqhost \
+    am_atype_cache.ipmgmt_dhcp_cache_s.ipmgmt_reqhost
 
 /* linked list of `aobjmap' nodes, protected by RW lock */
 typedef struct ipmgmt_aobjmap_list_s {

--- a/usr/src/cmd/cmd-inet/lib/ipmgmtd/ipmgmt_persist.c
+++ b/usr/src/cmd/cmd-inet/lib/ipmgmtd/ipmgmt_persist.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Joyent, Inc.
  * Copyright 2016 Argo Technologie SA.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -918,7 +919,8 @@ ipmgmt_aobjmap_op(ipmgmt_aobjmap_t *nodep, uint32_t op)
 			if (strcmp(head->am_aobjname,
 			    nodep->am_aobjname) == 0 &&
 			    (head->am_atype != IPADM_ADDR_IPV6_ADDRCONF ||
-			    head->am_linklocal == nodep->am_linklocal))
+			    head->ipmgmt_am_linklocal ==
+			    nodep->ipmgmt_am_linklocal))
 				break;
 		}
 
@@ -930,10 +932,7 @@ ipmgmt_aobjmap_op(ipmgmt_aobjmap_t *nodep, uint32_t op)
 			head->am_family = nodep->am_family;
 			head->am_flags = nodep->am_flags;
 			head->am_atype = nodep->am_atype;
-			if (head->am_atype == IPADM_ADDR_IPV6_ADDRCONF) {
-				head->am_ifid = nodep->am_ifid;
-				head->am_linklocal = nodep->am_linklocal;
-			}
+			head->am_atype_cache = nodep->am_atype_cache;
 		} else {
 			for (head = aobjmap.aobjmap_head; head != NULL;
 			    head = head->am_next) {
@@ -1078,29 +1077,43 @@ i_ipmgmt_node2nvl(nvlist_t **nvl, ipmgmt_aobjmap_t *np)
 	if ((err = nvlist_add_string(*nvl, ATYPE, strval)) != 0)
 		goto fail;
 
-	if (np->am_atype == IPADM_ADDR_IPV6_ADDRCONF) {
-		struct sockaddr_in6	*in6;
+	switch (np->am_atype) {
+		case IPADM_ADDR_IPV6_ADDRCONF: {
+			struct sockaddr_in6	*in6;
 
-		in6 = (struct sockaddr_in6 *)&np->am_ifid;
-		if (np->am_linklocal &&
-		    IN6_IS_ADDR_UNSPECIFIED(&in6->sin6_addr)) {
-			if ((err = nvlist_add_string(*nvl, IPADM_NVP_IPNUMADDR,
-			    "default")) != 0)
-				goto fail;
-		} else {
-			if (inet_ntop(AF_INET6, &in6->sin6_addr, strval,
-			    IPMGMT_STRSIZE) == NULL) {
-				err = errno;
-				goto fail;
+			in6 = &np->ipmgmt_am_ifid;
+			if (np->ipmgmt_am_linklocal &&
+			    IN6_IS_ADDR_UNSPECIFIED(&in6->sin6_addr)) {
+				if ((err = nvlist_add_string(*nvl,
+				    IPADM_NVP_IPNUMADDR, "default")) != 0) {
+					goto fail;
+				}
+			} else {
+				if (inet_ntop(AF_INET6, &in6->sin6_addr, strval,
+				    IPMGMT_STRSIZE) == NULL) {
+					err = errno;
+					goto fail;
+				}
+				if ((err = nvlist_add_string(*nvl,
+				    IPADM_NVP_IPNUMADDR, strval)) != 0) {
+					goto fail;
+				}
 			}
-			if ((err = nvlist_add_string(*nvl, IPADM_NVP_IPNUMADDR,
-			    strval)) != 0)
+		}
+			break;
+		case IPADM_ADDR_DHCP: {
+			if (np->ipmgmt_am_reqhost &&
+			    *np->ipmgmt_am_reqhost != '\0' &&
+			    (err = nvlist_add_string(*nvl, IPADM_NVP_REQHOST,
+			    np->ipmgmt_am_reqhost)) != 0)
 				goto fail;
 		}
-	} else {
-		if ((err = nvlist_add_string(*nvl, IPADM_NVP_IPNUMADDR,
-		    "")) != 0)
-			goto fail;
+			/* FALLTHRU */
+		default:
+			if ((err = nvlist_add_string(*nvl, IPADM_NVP_IPNUMADDR,
+			    "")) != 0)
+				goto fail;
+			break;
 	}
 	return (err);
 fail:
@@ -1148,16 +1161,18 @@ ipmgmt_aobjmap_init(void *arg, nvlist_t *db_nvl, char *buf, size_t buflen,
 			node.am_atype = (ipadm_addr_type_t)atoi(strval);
 		} else if (strcmp(IPADM_NVP_IPNUMADDR, name) == 0) {
 			if (node.am_atype == IPADM_ADDR_IPV6_ADDRCONF) {
-				in6 = (struct sockaddr_in6 *)&node.am_ifid;
+				in6 = &node.ipmgmt_am_ifid;
 				if (strcmp(strval, "default") == 0) {
-					bzero(in6, sizeof (node.am_ifid));
-					node.am_linklocal = B_TRUE;
+					bzero(in6,
+					    sizeof (node.ipmgmt_am_ifid));
+					node.ipmgmt_am_linklocal = B_TRUE;
 				} else {
 					(void) inet_pton(AF_INET6, strval,
 					    &in6->sin6_addr);
 					if (IN6_IS_ADDR_UNSPECIFIED(
 					    &in6->sin6_addr))
-						node.am_linklocal = B_TRUE;
+						node.ipmgmt_am_linklocal =
+						    B_TRUE;
 				}
 			}
 		}

--- a/usr/src/cmd/cmd-inet/lib/nwamd/ncu.h
+++ b/usr/src/cmd/cmd-inet/lib/nwamd/ncu.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef _NCU_H
@@ -225,6 +226,8 @@ extern nwam_error_t nwamd_get_ncu_uint(nwam_ncu_handle_t, nwam_value_t *,
     uint64_t **, uint_t *, const char *);
 extern nwam_error_t nwamd_get_ncu_string(nwam_ncu_handle_t, nwam_value_t *,
     char ***, uint_t *, const char *);
+extern nwam_error_t nwamd_get_ncu_boolean(nwam_ncu_handle_t, nwam_value_t *,
+    boolean_t **, uint_t *, const char *);
 
 extern void nwamd_walk_physical_configuration(void);
 

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/Makefile
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 
 PROG    = dhcpagent
@@ -45,7 +46,8 @@ CERRWARN += -_gcc=-Wno-parentheses
 #
 
 CPPFLAGS  += -D_XOPEN_SOURCE=500 -D__EXTENSIONS__
-LDLIBS    += -lxnet -lnvpair -ldhcpagent -ldhcputil -linetutil -ldevinfo -ldlpi
+LDLIBS    += -lxnet -lnvpair -ldhcpagent -ldhcputil -linetutil -ldevinfo \
+	-ldlpi -lresolv -lsocket -lipadm
 
 # Disable warnings that affect all XPG applications.
 LINTFLAGS += -erroff=E_INCONS_ARG_DECL2 -erroff=E_INCONS_VAL_TYPE_DECL2

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/bound.c
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/bound.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  *
  * BOUND state of the DHCP client state machine.
  */
@@ -106,6 +107,8 @@ dhcp_bound(dhcp_smach_t *dsmp, PKT_LIST *ack)
 		/* Save the first ack as the original */
 		if (dsmp->dsm_orig_ack == NULL)
 			dsmp->dsm_orig_ack = ack;
+
+		save_domainname(dsmp, ack);
 	}
 
 	oldstate = dsmp->dsm_state;

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/defaults.c
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/defaults.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 #include <sys/types.h>
@@ -60,7 +61,11 @@ static struct dhcp_default defaults[] = {
 	{ "DEBUG_LEVEL",	 "0",	 0,   3   },
 	{ "VERBOSE",		 "0",	 0,   0   },
 	{ "VERIFIED_LEASE_ONLY", "0",	 0,   0	  },
-	{ "PARAM_IGNORE_LIST",	 NULL,	 0,   0   }
+	{ "PARAM_IGNORE_LIST",	 NULL,	 0,   0   },
+	{ "REQUEST_FQDN",	 "1",	 0,   0	  },
+	{ "V4_DEFAULT_IAID_DUID",  "0",	 0,   0	  },
+	{ "DNS_DOMAINNAME",  NULL,	 0,   0	  },
+	{ "ADOPT_DOMAINNAME",	 "0",	 0,   0	  },
 };
 
 

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/defaults.h
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/defaults.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef	DEFAULTS_H
@@ -54,7 +55,11 @@ enum {
 	DF_DEBUG_LEVEL,		/* set debug level (undocumented) */
 	DF_VERBOSE,		/* set verbose mode (undocumented) */
 	DF_VERIFIED_LEASE_ONLY,	/* send RELEASE on SIGTERM and need verify */
-	DF_PARAM_IGNORE_LIST	/* our parameter ignore list */
+	DF_PARAM_IGNORE_LIST,	/* our parameter ignore list */
+	DF_REQUEST_FQDN,	/* request FQDN associated with interface */
+	DF_V4_DEFAULT_IAID_DUID,	/* IAID/DUID if no DF_CLIENT_ID */
+	DF_DNS_DOMAINNAME,	/* static domain name if not in --reqhost */
+	DF_ADOPT_DOMAINNAME	/* adopt DHCP domain if not in --reqhost */
 };
 
 #define	DHCP_AGENT_DEFAULTS	"/etc/default/dhcpagent"

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/dhcpagent.dfl
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/dhcpagent.dfl
@@ -22,6 +22,7 @@
 #
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
 #
 
 #
@@ -90,16 +91,73 @@
 #
 # CLIENT_ID=
 
+# By default, for an IPv4 interface that is not in an IP network
+# multipathing (IPMP) group, that is not IP over InfiniBand (IPoIB), and
+# that is not a logical interface, the DHCP agent will forgo sending a
+# client identifier unless CLIENT_ID is defined.
+#
+# To use a system-managed, RFC 3315-style (i.e., DHCPv6-style) binding
+# identifier as documented in RFC 4361, "Node-specific Client Identifiers
+# for DHCPv4," for all IPv4 interfaces (unless CLIENT_ID is defined),
+# uncomment the following line.
+#
+# V4_DEFAULT_IAID_DUID=yes
+
+# By default, the DHCP agent will try to request the Fully Qualified Domain
+# Name (FQDN) currently associated with the interface performing DHCP.  The
+# hostname is defined by using the -h,--reqhost option of ipadm(1M) or the
+# ncu ip-reqhost property of nwamcfg(1M) or by flagging the interface as
+# primary so that nodename(4) is used as the hostname.
+#
+# A defined hostname will be used as the FQDN if it is "rooted" (i.e., if
+# it ends with a '.') or if it consists of at least three DNS labels (e.g.,
+# srv.example.com).  If the hostname is not an FQDN, then DNS_DOMAINNAME
+# will be appended if defined or ADOPT_DOMAINNAME discernment will be used
+# if active.  If no FQDN can be determined, the option will not be used.
+#
+# If this REQUEST_FQDN option is enabled, an FQDN will be sent in messages
+# to the DHCP server along with RFC 4702 options to request that a
+# collaborating DNS server perform DNS updates for A and PTR resource
+# records.  To prevent sending FQDN and DNS options, uncomment the line
+# below.
+#
+# If an FQDN is sent, REQUEST_HOSTNAME processing will not be done, per RFC
+# 4702 (3.1):  "clients that send the Client FQDN option in their messages
+# MUST NOT also send the Host Name."
+#
+# REQUEST_FQDN=no
+
+# By default, the DHCP agent will not attempt to construct an FQDN from a
+# PQDN specified by the -h,--reqhost option of ipadm(1M), by the ncu
+# ip-reqhost property of nwamcfg(1M), or by nodename(4).  Set and
+# uncomment the following parameter to indicate a domain name to be used by
+# the DHCP agent to construct if necessary an FQDN.
+#
+# DNS_DOMAINNAME=
+
+# By default, the DHCP agent will not attempt to use a domain name returned
+# by the DHCP server or the domain in resolv.conf(4) to construct an FQDN
+# from a PQDN specified by the -h,--reqhost option of ipadm(1M), by the ncu
+# ip-reqhost property of nwamcfg(1M), or by nodename(4).  Set and uncomment
+# the following parameter to indicate that a returned DHCPv4 DNSdmain or the
+# domain from resolv.conf(4) should be adopted by the DHCP agent to
+# construct if necessary an FQDN.
+#
+# ADOPT_DOMAINNAME=yes
+
 # By default, the DHCP agent will try to request the hostname currently
 # associated with the interface performing DHCP.  If this option is
-# enabled, the agent will attempt to find a host name in /etc/hostname.<if>,
-# which must contain a line of the form
+# enabled, the agent will attempt to use an -h,--reqhost option saved with
+# ipadm(1M) or an ncu ip-reqhost property set with nwamcfg(1M); or else
+# attempt to find a host name in /etc/hostname.<if>, which must contain a
+# line of the form
 #
 #	inet name
 #
-# where "name" is a single RFC 1101-compliant token.  If found, the token
-# will be used to request that host name from the DHCP server.  To prevent
-# this, uncomment the following line.
+# where "name" is a single RFC 1101-compliant token; or else use
+# nodename(4) for a DHCP interface flagged as primary.  If found in any of
+# these configurations, the token will be used to request that host name
+# from the DHCP server.  To prevent this, uncomment the following line.
 #
 # REQUEST_HOSTNAME=no
 

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/ipc_action.c
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/ipc_action.c
@@ -21,9 +21,8 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <stdlib.h>
 #include <sys/types.h>
@@ -106,8 +105,10 @@ ipc_action_start(dhcp_smach_t *dsmp, ipc_action_t *iareq)
 	/* We've taken ownership, so the input request is now invalid */
 	ipc_action_init(iareq);
 
-	dhcpmsg(MSG_DEBUG, "ipc_action_start: started %s (command %d) on %s",
-	    dhcp_ipc_type_to_string(ia->ia_cmd), ia->ia_cmd, dsmp->dsm_name);
+	dhcpmsg(MSG_DEBUG, "ipc_action_start: started %s (command %d) on %s,"
+	    " buffer length %u",
+	    dhcp_ipc_type_to_string(ia->ia_cmd), ia->ia_cmd, dsmp->dsm_name,
+	    ia->ia_request == NULL ? 0 : ia->ia_request->data_length);
 
 	dsmp->dsm_dflags |= DHCP_IF_BUSY;
 

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/packet.h
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/packet.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef	_PACKET_H
 #define	_PACKET_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <sys/types.h>
 #include <netinet/in.h>
@@ -122,6 +121,8 @@ dhcp_pkt_t	*init_pkt(dhcp_smach_t *, uchar_t);
 boolean_t	remove_pkt_opt(dhcp_pkt_t *, uint_t);
 boolean_t	update_v6opt_len(dhcpv6_option_t *, int);
 void		*add_pkt_opt(dhcp_pkt_t *, uint_t, const void *, uint_t);
+size_t		encode_dhcp_opt(void *, boolean_t, uint_t, const void *,
+			uint_t);
 void		*add_pkt_subopt(dhcp_pkt_t *, dhcpv6_option_t *, uint_t,
 		    const void *, uint_t);
 void		*add_pkt_opt16(dhcp_pkt_t *, uint_t, uint16_t);

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/renew.c
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/renew.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 #include <sys/types.h>
@@ -490,7 +491,8 @@ dhcp_extending(dhcp_smach_t *dsmp)
 		 * dhcp_selecting() if the REQUEST_HOSTNAME option was set and
 		 * a host name was found.
 		 */
-		if (dsmp->dsm_reqhost != NULL) {
+		if (!dhcp_add_fqdn_opt(dpkt, dsmp) &&
+		    dsmp->dsm_reqhost != NULL) {
 			(void) add_pkt_opt(dpkt, CD_HOSTNAME, dsmp->dsm_reqhost,
 			    strlen(dsmp->dsm_reqhost));
 		}

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/request.c
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/request.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  *
  * REQUESTING state of the client state machine.
  */
@@ -245,6 +246,8 @@ dhcp_requesting(iu_tq_t *tqp, void *arg)
 		return;
 	}
 
+	save_domainname(dsmp, offer);
+
 	if (isv6) {
 		const char *estr, *msg;
 		const dhcpv6_option_t *d6o;
@@ -313,7 +316,8 @@ dhcp_requesting(iu_tq_t *tqp, void *arg)
 		 * dhcp_selecting() if the DF_REQUEST_HOSTNAME option set and a
 		 * host name was found
 		 */
-		if (dsmp->dsm_reqhost != NULL) {
+		if (!dhcp_add_fqdn_opt(dpkt, dsmp) &&
+		    dsmp->dsm_reqhost != NULL) {
 			(void) add_pkt_opt(dpkt, CD_HOSTNAME, dsmp->dsm_reqhost,
 			    strlen(dsmp->dsm_reqhost));
 		}

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/select.c
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/select.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  *
  * SELECTING state of the client state machine.
  */
@@ -29,7 +30,6 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <time.h>
-#include <limits.h>
 #include <netinet/in.h>
 #include <net/route.h>
 #include <net/if.h>
@@ -106,8 +106,6 @@ void
 dhcp_selecting(dhcp_smach_t *dsmp)
 {
 	dhcp_pkt_t		*dpkt;
-	const char		*reqhost;
-	char			hostfile[PATH_MAX + 1];
 
 	/*
 	 * We first set up to collect OFFER/Advertise packets as they arrive.
@@ -201,27 +199,9 @@ dhcp_selecting(dhcp_smach_t *dsmp)
 		}
 		(void) add_pkt_prl(dpkt, dsmp);
 
-		if (df_get_bool(dsmp->dsm_name, dsmp->dsm_isv6,
-		    DF_REQUEST_HOSTNAME)) {
-			dhcpmsg(MSG_DEBUG,
-			    "dhcp_selecting: DF_REQUEST_HOSTNAME");
-			(void) snprintf(hostfile, sizeof (hostfile),
-			    "/etc/hostname.%s", dsmp->dsm_name);
+		if (!dhcp_add_fqdn_opt(dpkt, dsmp))
+			(void) dhcp_add_hostname_opt(dpkt, dsmp);
 
-			if ((reqhost = iffile_to_hostname(hostfile)) != NULL) {
-				dhcpmsg(MSG_DEBUG, "dhcp_selecting: host %s",
-				    reqhost);
-				dsmp->dsm_reqhost = strdup(reqhost);
-				if (dsmp->dsm_reqhost != NULL)
-					(void) add_pkt_opt(dpkt, CD_HOSTNAME,
-					    dsmp->dsm_reqhost,
-					    strlen(dsmp->dsm_reqhost));
-				else
-					dhcpmsg(MSG_WARNING,
-					    "dhcp_selecting: cannot allocate "
-					    "memory for host name option");
-			}
-		}
 		(void) add_pkt_opt(dpkt, CD_END, NULL, 0);
 
 		(void) send_pkt(dsmp, dpkt, htonl(INADDR_BROADCAST),

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/states.h
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/states.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef	STATES_H
@@ -199,6 +200,19 @@ struct dhcp_smach_s {
 	 * here between the DISCOVER and the REQUEST.  (v4 only)
 	 */
 	char		*dsm_reqhost;
+
+	/*
+	 * The host name we've been asked by IPC message (e.g.,
+	 * `ipadm -T dhcp -h ...') to request is remembered here until it is
+	 * reset by another external message.
+	 */
+	char		*dsm_msg_reqhost;
+
+	/*
+	 * The domain name returned for v4 DNSdmain is decoded here for use
+	 * (if configured and needed) to determine an FQDN.
+	 */
+	char		*dsm_dhcp_domainname;
 
 	/*
 	 * V4 and V6 use slightly different timers.  For v4, we must count

--- a/usr/src/cmd/cmd-inet/sbin/dhcpagent/util.h
+++ b/usr/src/cmd/cmd-inet/sbin/dhcpagent/util.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef	UTIL_H
@@ -33,6 +34,7 @@
 #include <dhcpagent_ipc.h>
 
 #include "common.h"
+#include "packet.h"
 
 /*
  * general utility functions which have no better home.  see util.c
@@ -75,6 +77,9 @@ const char	*iffile_to_hostname(const char *);
 int		dhcpv6_status_code(const dhcpv6_option_t *, uint_t,
     const char **, const char **, uint_t *);
 void		write_lease_to_hostconf(dhcp_smach_t *);
+boolean_t	dhcp_add_hostname_opt(dhcp_pkt_t *, dhcp_smach_t *);
+boolean_t	dhcp_add_fqdn_opt(dhcp_pkt_t *, dhcp_smach_t *);
+void		save_domainname(dhcp_smach_t *, PKT_LIST *);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/cmd/cmd-inet/usr.sbin/ipadm/ipadm.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/ipadm/ipadm.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2017 Gary Mills
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #include <arpa/inet.h>
@@ -91,7 +92,8 @@ static cmd_t	cmds[] = {
 	{ "create-addr", do_create_addr,
 	    "\tcreate-addr\t[-t] -T static [-d] "
 	    "-a{local|remote}=addr[/prefixlen]\n\t\t\t<addrobj>\n"
-	    "\tcreate-addr\t[-t] -T dhcp [-w <seconds> | forever] <addrobj>\n"
+	    "\tcreate-addr\t[-t] -T dhcp [-w <seconds> | forever]\n"
+	    "\t\t\t[-1] [-h <hostname>] <addrobj>\n"
 	    "\tcreate-addr\t[-t] -T addrconf [-i interface-id]\n"
 	    "\t\t\t[-p {stateful|stateless}={yes|no}] <addrobj>" },
 	{ "down-addr",	do_down_addr,	"\tdown-addr\t[-t] <addrobj>"	},
@@ -164,7 +166,9 @@ static const struct option addr_longopts[] = {
 	{"address",	required_argument,	0, 'a'	},
 	{"down",	no_argument,		0, 'd'	},
 	{"interface-id", required_argument,	0, 'i'	},
+	{"primary",	no_argument,		0, '1'	},
 	{"prop",	required_argument,	0, 'p'	},
+	{"reqhost", required_argument,	0, 'h'	},
 	{"temporary",	no_argument,		0, 't'	},
 	{"type",	required_argument,	0, 'T'	},
 	{"wait",	required_argument,	0, 'w'	},
@@ -615,8 +619,8 @@ show_property(void *arg, const char *pname, uint_t proto)
 
 /*
  * Properties to be displayed is in `statep->sps_proplist'. If it is NULL,
- * for all the properties for the specified object, relavant information, will
- * be displayed. Otherwise, for the selected property set, display relevant
+ * for all the properties for the specified object, display relevant
+ * information. Otherwise, for the selected property set, display relevant
  * information
  */
 static void
@@ -1241,14 +1245,19 @@ do_create_addr(int argc, char *argv[], const char *use)
 	char		*addrconf_arg = NULL;
 	char		*interface_id = NULL;
 	char		*wait = NULL;
+	char		*reqhost = NULL;
 	boolean_t	s_opt = _B_FALSE;	/* static addr options */
 	boolean_t	auto_opt = _B_FALSE;	/* Addrconf options */
 	boolean_t	dhcp_opt = _B_FALSE;	/* dhcp options */
+	boolean_t	primary_opt = _B_FALSE;	/* dhcp primary option */
 
 	opterr = 0;
-	while ((option = getopt_long(argc, argv, ":T:a:di:p:w:t",
+	while ((option = getopt_long(argc, argv, ":1T:a:dh:i:p:w:t",
 	    addr_longopts, NULL)) != -1) {
 		switch (option) {
+		case '1':
+			primary_opt = _B_TRUE;
+			break;
 		case 'T':
 			atype = optarg;
 			break;
@@ -1259,6 +1268,9 @@ do_create_addr(int argc, char *argv[], const char *use)
 		case 'd':
 			flags &= ~IPADM_OPT_UP;
 			s_opt = _B_TRUE;
+			break;
+		case 'h':
+			reqhost = optarg;
 			break;
 		case 'i':
 			interface_id = optarg;
@@ -1291,7 +1303,8 @@ do_create_addr(int argc, char *argv[], const char *use)
 	 * Allocate and initialize the addrobj based on the address type.
 	 */
 	if (strcmp(atype, "static") == 0) {
-		if (static_arg == NULL || auto_opt || dhcp_opt) {
+		if (static_arg == NULL || auto_opt || dhcp_opt ||
+		    reqhost != NULL || primary_opt) {
 			die("Invalid arguments for type %s\nusage: %s",
 			    atype, use);
 		}
@@ -1328,13 +1341,27 @@ do_create_addr(int argc, char *argv[], const char *use)
 				    ipadm_status2str(status));
 			}
 		}
+		if (primary_opt) {
+			status = ipadm_set_primary(ipaddr, _B_TRUE);
+			if (status != IPADM_SUCCESS) {
+				die("Error in setting primary flag: %s",
+				    ipadm_status2str(status));
+			}
+		}
+		if (reqhost != NULL) {
+			status = ipadm_set_reqhost(ipaddr, reqhost);
+			if (status != IPADM_SUCCESS) {
+				die("Error in setting reqhost: %s",
+				    ipadm_status2str(status));
+			}
+		}
 	} else if (strcmp(atype, "addrconf") == 0) {
-		if (dhcp_opt || s_opt) {
+		if (dhcp_opt || s_opt || reqhost != NULL || primary_opt) {
 			die("Invalid arguments for type %s\nusage: %s",
 			    atype, use);
 		}
 
-		/* Initialize the addrobj for dhcp addresses. */
+		/* Initialize the addrobj for ipv6-addrconf addresses. */
 		status = ipadm_create_addrobj(IPADM_ADDR_IPV6_ADDRCONF,
 		    argv[optind], &ipaddr);
 		if (status != IPADM_SUCCESS) {

--- a/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/Makefile
+++ b/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 # cmd/cmd-inet/usr.sbin/nwamcfg/Makefile
 
@@ -56,7 +57,7 @@ install: all $(ROOTUSRSBINPROG)
 nwamcfg_lex.c:	nwamcfg_lex.l nwamcfg_grammar.tab.h nwamcfg.h
 	$(LEX) $(LFLAGS) nwamcfg_lex.l > $@
 
-nwamcfg_grammar.tab.h nwamcfg_grammar.tab.c:	nwamcfg_grammar.y nwamcfg.h
+nwamcfg_grammar.tab.h + nwamcfg_grammar.tab.c:	nwamcfg_grammar.y nwamcfg.h
 	$(YACC) $(YFLAGS) nwamcfg_grammar.y
 
 nwamcfg_lex.o nwamcfg_grammar.tab.o := CCVERBOSE =

--- a/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -198,7 +199,9 @@ static char *pt_types[] = {
 	NWAM_KNOWN_WLAN_PROP_PRIORITY,
 	NWAM_KNOWN_WLAN_PROP_KEYNAME,
 	NWAM_KNOWN_WLAN_PROP_KEYSLOT,
-	NWAM_KNOWN_WLAN_PROP_SECURITY_MODE
+	NWAM_KNOWN_WLAN_PROP_SECURITY_MODE,
+	NWAM_NCU_PROP_IP_PRIMARY,
+	NWAM_NCU_PROP_IP_REQHOST
 };
 
 /* properties table: maps PT_* constants to property names */
@@ -226,6 +229,8 @@ static prop_table_entry_t ncu_prop_table[] = {
 	{ PT_IPV6_ADDRSRC, 		NWAM_NCU_PROP_IPV6_ADDRSRC },
 	{ PT_IPV6_ADDR, 		NWAM_NCU_PROP_IPV6_ADDR },
 	{ PT_IPV6_DEFAULT_ROUTE,	NWAM_NCU_PROP_IPV6_DEFAULT_ROUTE },
+	{ PT_IP_PRIMARY,		NWAM_NCU_PROP_IP_PRIMARY },
+	{ PT_IP_REQHOST,		NWAM_NCU_PROP_IP_REQHOST },
 	{ 0, NULL }
 };
 
@@ -626,7 +631,8 @@ rt2_to_str(int res_type)
 
 /* Returns "ncp, "ncu", "loc", "enm", or "wlan" according to the scope */
 static const char *
-scope_to_str(int scope) {
+scope_to_str(int scope)
+{
 	switch (scope) {
 	case NWAM_SCOPE_GBL:
 		return ("global");
@@ -664,11 +670,15 @@ pt_to_str(int prop_type)
 	return (pt_types[prop_type]);
 }
 
-/* Return B_TRUE if string starts with "t" or is 1, B_FALSE otherwise */
+/*
+ * Return B_TRUE if string starts with "t" or "on" or is 1;
+ * B_FALSE otherwise
+ */
 static boolean_t
 str_to_boolean(const char *str)
 {
-	if (strncasecmp(str, "t", 1) == 0 || atoi(str) == 1)
+	if (strncasecmp(str, "t", 1) == 0 || strncasecmp(str, "on", 2) == 0 ||
+	    atoi(str) == 1)
 		return (B_TRUE);
 	else
 		return (B_FALSE);
@@ -2197,6 +2207,12 @@ static prop_display_entry_t ncu_prop_display_entry_table[] = {
 	/* show ipv6-default-route if ip-version == ipv6 */
 	{ NWAM_NCU_PROP_IPV6_DEFAULT_ROUTE, NWAM_NCU_PROP_IP_VERSION,
 	    { IPV6_VERSION, -1 } },
+	/* show ip-primary if ipv4-addrsrc == dhcp */
+	{ NWAM_NCU_PROP_IP_PRIMARY, NWAM_NCU_PROP_IPV4_ADDRSRC,
+	    { NWAM_ADDRSRC_DHCP, -1 } },
+	/* show ip-reqhost if ipv4-addrsrc == dhcp */
+	{ NWAM_NCU_PROP_IP_REQHOST, NWAM_NCU_PROP_IPV4_ADDRSRC,
+	    { NWAM_ADDRSRC_DHCP, -1 } },
 	{ NULL, NULL, { -1 } }
 };
 

--- a/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg.h
+++ b/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef _NWAMCFG_H
@@ -133,12 +134,14 @@ extern "C" {
 #define	PT_WLAN_KEYNAME		42
 #define	PT_WLAN_KEYSLOT		43
 #define	PT_WLAN_SECURITY_MODE	44
+#define	PT_IP_PRIMARY		45
+#define	PT_IP_REQHOST		46
 /*
  * If any new PT_ are defined here, make sure it is added in the same
  * order into the pt_types array in nwamcfg.c
  */
 #define	PT_MIN			PT_UNKNOWN
-#define	PT_MAX			PT_WLAN_SECURITY_MODE
+#define	PT_MAX			PT_IP_REQHOST
 
 #define	MAX_SUBCMD_ARGS	3
 

--- a/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg_grammar.y
+++ b/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg_grammar.y
@@ -23,6 +23,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #include <stdio.h>
@@ -67,6 +68,7 @@ extern boolean_t newline_terminated;
 %token LOC_IPF_CONFIG LOC_IPF_V6_CONFIG
 %token LOC_IPNAT_CONFIG LOC_IPPOOL_CONFIG LOC_IKE_CONFIG LOC_IPSECPOL_CONFIG
 %token WLAN_BSSIDS WLAN_PRIORITY WLAN_KEYNAME WLAN_KEYSLOT WLAN_SECURITY_MODE
+%token IP_PRIMARY IP_REQHOST
 
 %type <strval> TOKEN EQUAL OPTION
 %type <ival> resource1_type LOC NCP ENM WLAN
@@ -86,6 +88,7 @@ extern boolean_t newline_terminated;
     LOC_IPF_CONFIG LOC_IPF_V6_CONFIG
     LOC_IPNAT_CONFIG LOC_IPPOOL_CONFIG LOC_IKE_CONFIG LOC_IPSECPOL_CONFIG
     WLAN_BSSIDS WLAN_PRIORITY WLAN_KEYNAME WLAN_KEYSLOT WLAN_SECURITY_MODE
+    IP_PRIMARY IP_REQHOST
 %type <cmd> command
 %type <cmd> cancel_command CANCEL
 %type <cmd> clear_command CLEAR
@@ -617,7 +620,22 @@ list_command:	LIST
 		command_usage(CMD_LIST);
 		YYERROR;
 	}
+	|	LIST OPTION resource1_type
+	{
+		command_usage(CMD_LIST);
+		YYERROR;
+	}
 	|	LIST resource2_type
+	{
+		command_usage(CMD_LIST);
+		YYERROR;
+	}
+	|	LIST OPTION resource2_type
+	{
+		command_usage(CMD_LIST);
+		YYERROR;
+	}
+	|	LIST OPTION resource2_type ncu_class_type
 	{
 		command_usage(CMD_LIST);
 		YYERROR;
@@ -739,6 +757,11 @@ select_command:	SELECT
 		YYERROR;
 	}
 	|	SELECT resource2_type
+	{
+		command_usage(CMD_SELECT);
+		YYERROR;
+	}
+	|	SELECT resource2_type ncu_class_type
 	{
 		command_usage(CMD_SELECT);
 		YYERROR;
@@ -900,5 +923,7 @@ property_type:	UNKNOWN			{ $$ = PT_UNKNOWN; }
 	|	WLAN_KEYNAME		{ $$ = PT_WLAN_KEYNAME; }
 	|	WLAN_KEYSLOT		{ $$ = PT_WLAN_KEYSLOT; }
 	|	WLAN_SECURITY_MODE	{ $$ = PT_WLAN_SECURITY_MODE; }
+	|	IP_PRIMARY		{ $$ = PT_IP_PRIMARY; }
+	|	IP_REQHOST		{ $$ = PT_IP_REQHOST; }
 
 %%

--- a/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg_lex.l
+++ b/usr/src/cmd/cmd-inet/usr.sbin/nwamcfg/nwamcfg_lex.l
@@ -23,6 +23,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #include <string.h>
@@ -182,6 +183,8 @@ char *safe_strdup(char *s);
 <TSTATE>ipv6-addrsrc		{ return IPV6_ADDRSRC; }
 <TSTATE>ipv6-addr		{ return IPV6_ADDR; }
 <TSTATE>ipv6-default-route	{ return IPV6_DEFAULT_ROUTE; }
+<TSTATE>ip-primary		{ return IP_PRIMARY; }
+<TSTATE>ip-reqhost		{ return IP_REQHOST; }
 
 <TSTATE>state		{ return ENM_STATE; }
 <TSTATE>fmri		{ return ENM_FMRI; }

--- a/usr/src/cmd/sgs/libld/common/args.c
+++ b/usr/src/cmd/sgs/libld/common/args.c
@@ -27,6 +27,7 @@
  */
 /*
  * Copyright (c) 2012, Joyent, Inc.  All rights reserved.
+ * Copyright 2017 RackTop Systems.
  */
 
 /*
@@ -1235,6 +1236,14 @@ parseopt_pass1(Ofl_desc *ofl, int argc, char **argv, int *usage)
 
 		case 'z':
 			DBG_CALL(Dbg_args_option(ofl->ofl_lml, ndx, c, optarg));
+
+			/*
+			 * Skip comma that might be present between -z and its
+			 * argument (e.g. if -Wl,-z,assert-deflib was passed).
+			 */
+			if (strncmp(optarg, MSG_ORIG(MSG_STR_COMMA),
+			    MSG_STR_COMMA_SIZE) == 0)
+				optarg++;
 
 			/*
 			 * For specific help, print our usage message and exit

--- a/usr/src/cmd/sgs/libld/common/libld.msg
+++ b/usr/src/cmd/sgs/libld/common/libld.msg
@@ -25,6 +25,7 @@
 
 #
 # Copyright (c) 2012, Joyent, Inc.  All rights reserved.
+# Copyright 2017 RackTop Systems.
 #
 
 @ _START_
@@ -730,6 +731,7 @@
 @ MSG_QSTR_STAR		"'*'"
 @ MSG_STR_DOT		"."
 @ MSG_STR_SLASH		"/"
+@ MSG_STR_COMMA		","
 @ MSG_STR_DYNAMIC	"(.dynamic)"
 @ MSG_STR_ORIGIN	"$ORIGIN"
 @ MSG_STR_MACHINE	"$MACHINE"

--- a/usr/src/cmd/sgs/packages/common/SUNWonld-README
+++ b/usr/src/cmd/sgs/packages/common/SUNWonld-README
@@ -1660,3 +1660,4 @@ Bugid   Risk Synopsis
 6252	ld should merge function/data-sections in the same manner as GNU ld
 7323	ld(1) -zignore can erroneously discard init and fini arrays as unreferenced
 7594	ld -zaslr should accept Solaris-compatible values
+8616	ld has trouble parsing -z options specified with -Wl

--- a/usr/src/common/net/dhcp/dhcp_impl.h
+++ b/usr/src/common/net/dhcp/dhcp_impl.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef	_DHCP_IMPL_H
 #define	_DHCP_IMPL_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
  * Common definitions used by Sun DHCP implementations
@@ -93,6 +92,11 @@ typedef struct {
 	uint8_t    len;
 	uint8_t    value[1];
 } DHCP_OPT;
+
+/*
+ * Defines the size of DHCP_OPT code + len
+ */
+#define	DHCP_OPT_META_LEN	2
 
 typedef union sockaddr46_s {
 	struct sockaddr_in v4;

--- a/usr/src/head/arpa/nameser.h
+++ b/usr/src/head/arpa/nameser.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -576,6 +577,7 @@ typedef enum __ns_cert_types {
 #define	ns_name_ntol		__ns_name_ntol
 #define	ns_name_ntop		__ns_name_ntop
 #define	ns_name_pton		__ns_name_pton
+#define	ns_name_pton2		__ns_name_pton2
 #define	ns_name_unpack		__ns_name_unpack
 #define	ns_name_pack		__ns_name_pack
 #define	ns_name_compress	__ns_name_compress
@@ -632,6 +634,7 @@ uint32_t	ns_datetosecs(const char *cp, int *errp);
 int		ns_name_ntol(const uchar_t *, uchar_t *, size_t);
 int		ns_name_ntop(const uchar_t *, char *, size_t);
 int		ns_name_pton(const char *, uchar_t *, size_t);
+int		ns_name_pton2(const char *, uchar_t *, size_t, size_t *);
 int		ns_name_unpack(const uchar_t *, const uchar_t *,
 				    const uchar_t *, uchar_t *, size_t);
 int		ns_name_pack(const uchar_t *, uchar_t *, int,

--- a/usr/src/lib/Makefile
+++ b/usr/src/lib/Makefile
@@ -28,6 +28,7 @@
 # Copyright (c) 2015 Gary Mills
 # Copyright 2016 Toomas Soome <tsoome@me.com>
 # Copyright 2017 Nexenta Systems, Inc.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 
 include ../Makefile.master
@@ -619,7 +620,7 @@ $(INTEL_BLD)libgrubmgmt: libfdisk
 libidmap:	libavl libuutil
 libinetsvc:	libscf
 libinstzones:	libzonecfg libcontract
-libipadm:	libinetutil libdlpi libdhcpagent libdladm libsecdb
+libipadm:	libinetutil libdlpi libdhcpagent libdladm libsecdb libdhcputil
 libipmp:	libinetutil
 libipsecutil:	libtecla libtsol
 libiscsit:	libstmf libuuid
@@ -629,7 +630,7 @@ libldap5:	libsasl
 libmapid:	libresolv2 libscf
 libndmp:	libscf
 libnisdb:	libldap5
-libnwam:	libscf libbsm libdladm
+libnwam:	libscf libbsm libdladm libipadm
 libpcp:		libumem libdevinfo
 libpctx:	libproc
 libpkg:		libwanboot libscf libadm

--- a/usr/src/lib/libipadm/Makefile.com
+++ b/usr/src/lib/libipadm/Makefile.com
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 #
 
@@ -35,7 +36,7 @@ include ../../Makefile.rootfs
 
 LIBS =		$(DYNLIB) $(LINTLIB)
 LDLIBS +=	-lc -lnsl -linetutil -lsocket -ldlpi -lnvpair -ldhcpagent \
-	        -ldladm -lsecdb
+	        -ldladm -lsecdb -ldhcputil
 
 SRCDIR =	../common
 $(LINTLIB) :=	SRCS = $(SRCDIR)/$(LINTSRC)

--- a/usr/src/lib/libipadm/common/ipadm_ndpd.c
+++ b/usr/src/lib/libipadm/common/ipadm_ndpd.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -107,7 +108,7 @@ i_ipadm_create_ipv6addrs(ipadm_handle_t iph, ipadm_addrobj_t addr,
 	}
 
 	/* Persist the intfid. */
-	status = i_ipadm_addr_persist(iph, addr, B_FALSE, i_flags);
+	status = i_ipadm_addr_persist(iph, addr, B_FALSE, i_flags, NULL);
 	if (status != IPADM_SUCCESS) {
 		(void) i_ipadm_delete_addr(iph, addr);
 		(void) i_ipadm_send_ndpd_cmd(addr->ipadm_ifname, addr,

--- a/usr/src/lib/libipadm/common/libipadm.c
+++ b/usr/src/lib/libipadm/common/libipadm.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Joyent, Inc.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #include <stdio.h>
@@ -737,12 +738,13 @@ i_ipadm_init_ifobj(ipadm_handle_t iph, const char *ifname, nvlist_t *ifnvl)
 		} else if (nvlist_lookup_string(nvl, IPADM_NVP_AOBJNAME,
 		    &aobjstr) == 0) {
 			/*
-			 * For a static address, we need to search for
-			 * the prefixlen in the nvlist `ifnvl'.
+			 * For addresses, we need to relocate addrprops from the
+			 * nvlist `ifnvl'.
 			 */
 			if (nvlist_exists(nvl, IPADM_NVP_IPV4ADDR) ||
-			    nvlist_exists(nvl, IPADM_NVP_IPV6ADDR)) {
-				status = i_ipadm_merge_prefixlen_from_nvl(ifnvl,
+			    nvlist_exists(nvl, IPADM_NVP_IPV6ADDR) ||
+			    nvlist_exists(nvl, IPADM_NVP_DHCP)) {
+				status = i_ipadm_merge_addrprops_from_nvl(ifnvl,
 				    nvl, aobjstr);
 				if (status != IPADM_SUCCESS)
 					continue;
@@ -976,4 +978,81 @@ reopen:
 			err = EBADE;
 	}
 	return (err);
+}
+
+/*
+ * ipadm_is_nil_hostname() : Determine if the `hostname' is nil: i.e.,
+ *			NULL, empty, or a single space (e.g., as returned by
+ *			domainname(1M)/sysinfo).
+ *
+ *   input: const char *: the hostname to inspect;
+ *  output: boolean_t: B_TRUE if `hostname' is not NULL satisfies the
+ *			criteria above; otherwise, B_FALSE;
+ */
+
+boolean_t
+ipadm_is_nil_hostname(const char *hostname)
+{
+	return (hostname == NULL || *hostname == '\0' ||
+	    (*hostname == ' ' && hostname[1] == '\0'));
+}
+
+/*
+ * ipadm_is_valid_hostname(): check whether a string is a valid hostname
+ *
+ *   input: const char *: the string to verify as a hostname
+ *  output: boolean_t: B_TRUE if the string is a valid hostname
+ *
+ * Note that we accept host names beginning with a digit, which is not
+ * strictly legal according to the RFCs but is in common practice, so we
+ * endeavour to not break what customers are using.
+ *
+ * RFC 1035 limits a wire-format domain name to 255 octets. For a printable
+ * `hostname' as we have, the limit is therefore 253 characters (excluding
+ * the terminating '\0'--or 254 characters if the last character of
+ * `hostname' is a '.'.
+ *
+ * Excerpt from section 2.3.1., Preferred name syntax:
+ *
+ * <domain> ::= <subdomain> | " "
+ * <subdomain> ::= <label> | <subdomain> "." <label>
+ * <label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]
+ * <ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+ * <let-dig-hyp> ::= <let-dig> | "-"
+ * <let-dig> ::= <letter> | <digit>
+ */
+boolean_t
+ipadm_is_valid_hostname(const char *hostname)
+{
+	const size_t MAX_READABLE_NAME_LEN = 253;
+	char last_char;
+	size_t has_last_dot, namelen, i;
+
+	if (hostname == NULL)
+		return (B_FALSE);
+
+	namelen = strlen(hostname);
+	if (namelen < 1)
+		return (B_FALSE);
+
+	last_char = hostname[namelen - 1];
+	has_last_dot = last_char == '.';
+
+	if (namelen > MAX_READABLE_NAME_LEN + has_last_dot ||
+	    last_char == '-')
+		return (B_FALSE);
+
+	for (i = 0; hostname[i] != '\0'; i++) {
+		/*
+		 * As noted above, this deviates from RFC 1035 in that it
+		 * allows a leading digit.
+		 */
+		if (isalpha(hostname[i]) || isdigit(hostname[i]) ||
+		    (((hostname[i] == '-') || (hostname[i] == '.')) && (i > 0)))
+			continue;
+
+		return (B_FALSE);
+	}
+
+	return (B_TRUE);
 }

--- a/usr/src/lib/libipadm/common/libipadm.h
+++ b/usr/src/lib/libipadm/common/libipadm.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 #ifndef _LIBIPADM_H
 #define	_LIBIPADM_H
@@ -29,6 +30,7 @@ extern "C" {
 #endif
 
 #include <sys/types.h>
+#include <sys/param.h>
 #include <sys/socket.h>
 #include <net/if.h>
 #include <netdb.h>
@@ -100,8 +102,8 @@ typedef enum {
  *
  *  - IPADM_OPT_PERSIST:
  *	For all the create/delete/up/down/set/get functions,
- * 	requests to persist the configuration so that it can be
- *	re-enabled or reapplied on boot.
+ *	requests to persist the configuration so that it can be
+ *	re-enabled or re-applied on boot.
  *
  *  - IPADM_OPT_ACTIVE:
  *	Requests to apply configuration without persisting it and
@@ -141,7 +143,17 @@ typedef enum {
  *	Used to bring up a static address on creation
  *
  *  - IPADM_OPT_V46
- *      Used to plumb both IPv4 and IPv6 interfaces by ipadm_create_addr()
+ *	Used to plumb both IPv4 and IPv6 interfaces by ipadm_create_addr()
+ *
+ *  - IPADM_OPT_SET_PROPS
+ *	Used to indicate the update changes the running configuration of
+ *	"props" data on the object. The props are cached there on the parent,
+ *	but the PROPS_ONLY change does not affect the ACTIVE/PERSIST state of
+ *	the parent.
+ *
+ *  - IPADM_OPT_PERSIST_PROPS
+ *	Used when IPADM_OPT_SET_PROPS is active to indicate the update changes
+ *  the persistent configuration of the "props" data on the object.
  */
 #define	IPADM_OPT_PERSIST	0x00000001
 #define	IPADM_OPT_ACTIVE	0x00000002
@@ -157,6 +169,8 @@ typedef enum {
 #define	IPADM_OPT_INFORM	0x00000800
 #define	IPADM_OPT_UP		0x00001000
 #define	IPADM_OPT_V46		0x00002000
+#define	IPADM_OPT_SET_PROPS	0x00004000
+#define	IPADM_OPT_PERSIST_PROPS		0x00008000
 
 /* IPADM property class */
 #define	IPADMPROP_CLASS_MODULE	0x00000001	/* on 'protocol' only */
@@ -257,7 +271,7 @@ extern void		ipadm_close(ipadm_handle_t);
 /* Check authorization for network configuration */
 extern boolean_t	ipadm_check_auth(void);
 /*
- * Interface mangement functions
+ * Interface management functions
  */
 extern ipadm_status_t	ipadm_create_if(ipadm_handle_t, char *, sa_family_t,
 			    uint32_t);
@@ -315,6 +329,7 @@ extern ipadm_status_t	ipadm_set_stateful(ipadm_addrobj_t, boolean_t);
 /* Functions to set fields in addrobj for DHCP */
 extern ipadm_status_t	ipadm_set_primary(ipadm_addrobj_t, boolean_t);
 extern ipadm_status_t	ipadm_set_wait_time(ipadm_addrobj_t, int32_t);
+extern ipadm_status_t	ipadm_set_reqhost(ipadm_addrobj_t, const char *);
 
 /*
  * Property management functions
@@ -357,6 +372,8 @@ extern int		ipadm_legacy2new_propname(const char *, char *,
 			    uint_t, uint_t *);
 extern int		ipadm_new2legacy_propname(const char *, char *,
 			    uint_t, uint_t);
+extern boolean_t	ipadm_is_valid_hostname(const char *hostname);
+extern boolean_t	ipadm_is_nil_hostname(const char *hostname);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/lib/libipadm/common/libipadm_impl.h
+++ b/usr/src/lib/libipadm/common/libipadm_impl.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 #ifndef _LIBIPADM_IMPL_H
@@ -87,6 +88,7 @@ struct ipadm_addrobj_s {
 		struct {
 			boolean_t		ipadm_primary;
 			int32_t			ipadm_wait;
+			char			ipadm_reqhost[MAXNAMELEN];
 		} ipadm_dhcp_s;
 	} ipadm_addr_u;
 };
@@ -102,6 +104,7 @@ struct ipadm_addrobj_s {
 #define	ipadm_stateful		ipadm_addr_u.ipadm_ipv6_intfid_s.ipadm_stateful
 #define	ipadm_primary		ipadm_addr_u.ipadm_dhcp_s.ipadm_primary
 #define	ipadm_wait		ipadm_addr_u.ipadm_dhcp_s.ipadm_wait
+#define	ipadm_reqhost	ipadm_addr_u.ipadm_dhcp_s.ipadm_reqhost
 
 /*
  * Data structures and callback functions related to property management
@@ -145,7 +148,8 @@ extern ipadm_status_t	i_ipadm_init_ifobj(ipadm_handle_t, const char *,
 			    nvlist_t *);
 extern ipadm_status_t	i_ipadm_init_addrobj(ipadm_handle_t, nvlist_t *);
 extern ipadm_status_t	i_ipadm_addr_persist(ipadm_handle_t,
-			    const ipadm_addrobj_t, boolean_t, uint32_t);
+			    const ipadm_addrobj_t, boolean_t, uint32_t,
+			    const char *);
 extern ipadm_status_t	i_ipadm_delete_addr(ipadm_handle_t, ipadm_addrobj_t);
 extern int		i_ipadm_strioctl(int, int, char *, int);
 extern boolean_t	i_ipadm_is_loopback(const char *);
@@ -185,7 +189,7 @@ extern ipadm_status_t	i_ipadm_get_persist_propval(ipadm_handle_t,
 /* ipadm_addr.c */
 extern void		i_ipadm_init_addr(ipadm_addrobj_t, const char *,
 			    const char *, ipadm_addr_type_t);
-extern ipadm_status_t	i_ipadm_merge_prefixlen_from_nvl(nvlist_t *, nvlist_t *,
+extern ipadm_status_t	i_ipadm_merge_addrprops_from_nvl(nvlist_t *, nvlist_t *,
 			    const char *);
 extern ipadm_status_t	i_ipadm_get_addrobj(ipadm_handle_t, ipadm_addrobj_t);
 extern ipadm_status_t	i_ipadm_enable_static(ipadm_handle_t, const char *,

--- a/usr/src/lib/libipadm/common/mapfile-vers
+++ b/usr/src/lib/libipadm/common/mapfile-vers
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 
 #
@@ -67,6 +68,8 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	ipadm_if_info;
 	ipadm_if_move;
 	ipadm_init_net_from_gz;
+	ipadm_is_nil_hostname;
+	ipadm_is_valid_hostname;
 	ipadm_legacy2new_propname;
 	ipadm_ndpd_read;
 	ipadm_ndpd_write;
@@ -80,6 +83,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	ipadm_set_addr;
 	ipadm_set_addrprop;
 	ipadm_set_dst_addr;
+	ipadm_set_reqhost;
 	ipadm_set_ifprop;
 	ipadm_set_interface_id;
 	ipadm_set_primary;

--- a/usr/src/lib/libnwam/Makefile.com
+++ b/usr/src/lib/libnwam/Makefile.com
@@ -21,6 +21,7 @@
 #
 # Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 
 LIBRARY=	libnwam.a
@@ -43,7 +44,8 @@ include ../../Makefile.lib
 include ../../Makefile.rootfs
 
 LIBS =		$(DYNLIB) $(LINTLIB)
-LDLIBS +=	-lbsm -lc -ldladm -lnsl -lnvpair -lscf -lsecdb -lsocket
+LDLIBS +=	-lbsm -lc -ldladm -lnsl -lnvpair -lscf -lsecdb -lsocket \
+		-lipadm
 
 SRCDIR =	../common
 $(LINTLIB) := SRCS=	$(SRCDIR)/$(LINTSRC)

--- a/usr/src/lib/libnwam/common/libnwam.h
+++ b/usr/src/lib/libnwam/common/libnwam.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -447,6 +448,8 @@ typedef enum {
 #define	NWAM_NCU_PROP_IPV6_ADDRSRC		"ipv6-addrsrc"
 #define	NWAM_NCU_PROP_IPV6_ADDR			"ipv6-addr"
 #define	NWAM_NCU_PROP_IPV6_DEFAULT_ROUTE	"ipv6-default-route"
+#define	NWAM_NCU_PROP_IP_PRIMARY		"ip-primary"
+#define	NWAM_NCU_PROP_IP_REQHOST		"ip-reqhost"
 
 /* Some properties should only be set on creation */
 #define	NWAM_NCU_PROP_SETONCE(prop)	\

--- a/usr/src/lib/libresolv2/common/mapfile-vers
+++ b/usr/src/lib/libresolv2/common/mapfile-vers
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 #
 
 #
@@ -104,6 +105,7 @@ SYMBOL_VERSION SUNWprivate_2.2 {
 	isc_puthexstring;
 	__log_close_debug_channels;
 	__memactive;
+	__ns_name_pton2;
 	p_sockun;
 	res_gethostbyname2;
 	res_getservers;

--- a/usr/src/man/man1m/dhcpagent.1m
+++ b/usr/src/man/man1m/dhcpagent.1m
@@ -1,9 +1,10 @@
 '\" te
 .\"  Copyright (c) 1992-1996 Competitive Automation, Inc. Copyright (c) 2009 Sun Microsystems, Inc. All Rights Reserved.
+.\"  Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License"). You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\" See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE. If applicable, add the following below this CDDL HEADER, with the
 .\" fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH DHCPAGENT 1M "Dec 11, 2015"
+.TH DHCPAGENT 1M "Jun 30, 2017"
 .SH NAME
 dhcpagent \- Dynamic Host Configuration Protocol (DHCP) client daemon
 .SH SYNOPSIS
@@ -15,7 +16,7 @@ dhcpagent \- Dynamic Host Configuration Protocol (DHCP) client daemon
 .SH DESCRIPTION
 .LP
 \fBdhcpagent\fR implements the client half of the Dynamic Host Configuration
-Protocol \fB(DHCP)\fR for machines running Solaris software.
+Protocol \fB(DHCP)\fR for machines running illumos software.
 .sp
 .LP
 The \fBdhcpagent\fR daemon obtains configuration parameters for the client
@@ -28,11 +29,12 @@ it must negotiate an extension using \fBDHCP\fR. For this reason,
 powers down.
 .sp
 .LP
-For IPv4, the \fBdhcpagent\fR daemon is controlled through \fBifconfig\fR(1M)
-in much the same way that the \fBinit\fR(1M) daemon is controlled by
-\fBtelinit\fR(1M). \fBdhcpagent\fR can be invoked as a user process, albeit one
-requiring root privileges, but this is not necessary, as \fBifconfig\fR(1M)
-will start it automatically.
+For IPv4, the \fBdhcpagent\fR daemon is controlled through \fBipadm\fR(1M),
+\fBnwamcfg\fR(1M), or \fBifconfig\fR(1M) in much the same way that the
+\fBinit\fR(1M) daemon is controlled by \fBtelinit\fR(1M). \fBdhcpagent\fR can
+be invoked as a user process, albeit one requiring root privileges, but this is
+not necessary, as \fBipadm\fR(1M), \fBnwamcfg\fR(1M), or \fBifconfig\fR(1M)
+will start \fBdhcpagent\fR automatically.
 .sp
 .LP
 For IPv6, the \fBdhcpagent\fR daemon is invoked automatically by
@@ -41,16 +43,20 @@ necessary.
 .sp
 .LP
 When invoked, \fBdhcpagent\fR enters a passive state while it awaits
-instructions from \fBifconfig\fR(1M) or \fBin.ndpd\fR(1M). When it receives a
-command to configure an interface, it brings up the interface (if necessary)
-and starts DHCP. Once DHCP is complete, \fBdhcpagent\fR can be queried for the
-values of the various network parameters. In addition, if DHCP was used to
-obtain a lease on an address for an interface, it configures the address for
-use. When a lease is obtained, it is automatically renewed as necessary. If the
+instructions from \fBipadm\fR(1M), \fBnwamcfg\fR(1M), \fBifconfig\fR(1M), or
+\fBin.ndpd\fR(1M). When \fBdhcpagent\fR receives a command to configure an
+interface, \fBdhcpagent\fR brings up the interface (if necessary) and starts
+DHCP. Once DHCP is complete, \fBdhcpagent\fR can be queried for the values of
+the various network parameters. In addition, if DHCP was used to obtain a lease
+on an address for an interface, \fBdhcpagent\fR configures the address for use.
+When a lease is obtained, it is automatically renewed as necessary. If the
 lease cannot be renewed, \fBdhcpagent\fR will unconfigure the address, but the
-interface will be left up and \fBdhcpagent\fR will attempt to acquire a new
-address lease. \fBdhcpagent\fR monitors system suspend/resume events and will
-validate any non-permanent leases with the DHCP server upon resume. Similarly,
+interface will be left up, and \fBdhcpagent\fR will attempt to acquire a new
+address lease.
+.sp
+.LP
+\fBdhcpagent\fR monitors system suspend/resume events and will validate any
+non-permanent leases with the DHCP server upon resume. Similarly,
 \fBdhcpagent\fR monitors link up/down events and will validate any
 non-permanent leases with the DHCP server when the downed link is brought back
 up. The lease validation mechanism will restart DHCP if the server indicates
@@ -102,10 +108,10 @@ parameters in the case where no specific interface is requested. See
 .sp
 .LP
 For IPv4, the \fBdhcpagent\fR daemon can be configured to request a particular
-host name. See the \fBREQUEST_HOSTNAME\fR description in the \fBFILES\fR
-section. When first configuring a client to request a host name, you must
-perform the following steps as root to ensure that the full DHCP negotiation
-takes place:
+Fully Qualified Domain Name (FQDN) or host name. See the \fBREQUEST_FQDN\fR or
+\fBREQUEST_HOSTNAME\fR description in the \fBFILES\fR section. When first
+configuring a client to request an FQDN or host name, you must perform the
+following steps as root to ensure that the full DHCP negotiation takes place:
 .sp
 .in +2
 .nf
@@ -494,9 +500,14 @@ using REQUEST (for DHCPv4) or Confirm (DHCPv6).
 .ad
 .sp .6
 .RS 4n
-Contains persistent storage for DUID (DHCP Unique Identifier) and IAID
-(Identity Association Identifier) values. The format of these files is
-undocumented, and applications should not read from or write to them.
+Contains persistent storage for system-generated DUID (DHCP Unique Identifier)
+and interface-specific IAID (Identity Association Identifier) values which are
+used if no \fBCLIENT_ID\fR is defined (see below). The format of these files is
+undocumented, and applications should not read from or write to them.  Instead,
+\fBdhcpinfo\fR(1) can be used to query the \fBdhcpagent\fR for \fIClientID\fR.
+For DHCPv6 interfaces, the result will contain the DUID. For DHCPv4 interfaces
+with \fBV4_DEFAULT_IAID_DUID\fR enabled (see below), the result will contain
+the IAID and DUID.
 .RE
 
 .sp
@@ -536,6 +547,8 @@ remaining) and a new one obtained.
 .sp
 Enabling this option is often desirable on mobile systems, such as laptops, to
 allow the system to recover quickly from moves.
+.sp
+Default value of this option is \fIno\fR.
 .RE
 
 .sp
@@ -545,9 +558,11 @@ allow the system to recover quickly from moves.
 .ad
 .sp .6
 .RS 4n
-Indicates how long to wait between checking for valid \fBOFFER\fRs after
-sending a \fBDISCOVER\fR. For DHCPv6, sets the time to wait between checking
-for valid Advertisements after sending a Solicit.
+Indicates how long to wait in seconds between checking for valid
+\fBOFFER\fRs after sending a \fBDISCOVER\fR. For DHCPv6, sets the time to
+wait between checking for valid Advertisements after sending a Solicit.
+.sp
+Default value of this option is \fI3\fR.
 .RE
 
 .sp
@@ -630,6 +645,26 @@ format. Thus, "\fBSun\fR" and \fB0x53756E\fR are equivalent.
 .sp
 .ne 2
 .na
+\fB\fBV4_DEFAULT_IAID_DUID\fR\fR
+.ad
+.sp .6
+.RS 4n
+Indicates whether to use, when CLIENT_ID is not defined, a system-managed,
+RFC 3315-style (i.e., DHCPv6-style) binding identifier as documented in
+RFC 4361, "Node-specific Client Identifiers for DHCPv4," for IPv4
+interfaces which for purposes of backward compatibility do not normally get
+default binding identifiers.
+.sp
+An IPv4 interface that is not in an IP network multipathing (IPMP) group,
+that is not IP over InfiniBand (IPoIB), and that is not a logical interface
+does not normally get a default binding identifier.
+.sp
+Default value of this option is \fIno\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fBPARAM_REQUEST_LIST\fR\fR
 .ad
 .sp .6
@@ -658,13 +693,106 @@ default router.
 .sp
 .ne 2
 .na
+\fB\fBREQUEST_FQDN\fR\fR
+.ad
+.sp .6
+.RS 4n
+Indicates the client requests the DHCP server to map the client's leased
+IPv4 address to the Fully Qualified Domain Name (FQDN) associated with the
+network interface that performs DHCP on the client and to collaborate with
+a compatible DNS server to manage A and PTR resource records for the FQDN
+for the life of the lease.
+.sp .6
+The \fIhostname\fR in the FQDN is determined from the following possible
+configurations:
+.sp
+.ne 2
+.na
+1.  \fBipadm\fR(1M): include the \fB-1,--primary\fR flag when creating an
+address that uses DHCP so that \fBnodename\fR(4) is used as the
+\fIhostname\fR.
+.ad
+.sp
+.ne 2
+.na
+2.  \fBipadm\fR(1M): include the \fB-h,--reqhost\fR \fIhostname\fR switch
+when executing the \fBcreate-addr -T dhcp\fR subcommand, or use the
+\fBset-addrprop -p reqhost=\fR\fIhostname\fR subcommand for any existing
+DHCP address.
+.ad
+.sp
+.ne 2
+.na
+3.  \fBnwamcfg\fR(1M): set a property,
+\fBip-primary=\fR\fIon\fR, for an ncu ip that uses DHCP so that
+\fBnodename\fR(4) is used as the \fIhostname\fR.
+.ad
+.sp
+.ne 2
+.na
+4.  \fBnwamcfg\fR(1M): set a property,
+\fBip-reqhost=\fR\fIhostname\fR, for an ncu ip that uses DHCP.
+.ad
+.sp
+The \fIhostname\fR value is either a Partially Qualified Domain Name (PQDN)
+or an FQDN (i.e., a "rooted" domain name ending with a '.' or one inferred
+to be an FQDN if it contains at least three DNS labels such as
+srv.example.com).  If a PQDN is specified, then an FQDN is constructed if
+\fBDNS_DOMAINNAME\fR is defined or if \fBADOPT_DOMAINNAME\fR is set to
+\fIyes\fR and an eligible domain name (as described below) is available.
+.sp
+If an FQDN is sent, \fBREQUEST_HOSTNAME\fR processing will not be done,
+per RFC 4702 (3.1):  "clients that send the Client FQDN option in their
+messages MUST NOT also send the Host Name."
+.sp
+Default value of this option is \fIyes\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBDNS_DOMAINNAME\fR\fR
+.ad
+.sp .6
+.RS 4n
+Indicates the value that should be appended to a PQDN specified by the
+\fB-h,--reqhost\fR option of \fBipadm\fR(1M), by the ncu \fBip-reqhost\fR
+property of \fBnwamcfg\fR(1M), or by \fBnodename\fR(4) to construct an FQDN
+for \fBREQUEST_FQDN\fR processing.
+If the \fIhostname\fR value is already an FQDN, then the value of this
+option is not used.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBADOPT_DOMAINNAME\fR\fR
+.ad
+.sp .6
+.RS 4n
+Indicates that a domain name returned by the DHCP server or the \fBdomain\fR
+from \fBresolv.conf\fR(4) should be adopted if needed to construct an FQDN
+from a PQDN specified by the \fB-h,--reqhost\fR option of \fBipadm\fR(1M),
+by the ncu \fBip-reqhost\fR property of \fBnwamcfg\fR(1M), or by
+\fBnodename\fR(4).
+If the \fIhostname\fR value is already an FQDN, then the value of this
+option is not applicable.
+The eligible DHCP option for domain name is DHCPv4 \fBDNSdmain\fR.
+.sp
+Default value of this option is \fIno\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fBREQUEST_HOSTNAME\fR\fR
 .ad
 .sp .6
 .RS 4n
 Indicates the client requests the DHCP server to map the client's leased IPv4
 address to the host name associated with the network interface that performs
-DHCP on the client. The host name must be specified in the
+DHCP on the client. The host name must be specified as documented for a
+PQDN in \fBREQUEST_FQDN\fR above or specified in the
 \fB/etc/hostname.\fIinterface\fR\fR file for the relevant interface on a line
 of the form
 .sp
@@ -678,6 +806,8 @@ inet \fIhostname\fR
 where \fIhostname\fR is the host name requested.
 .sp
 This option works with DHCPv4 only.
+.sp
+Default value of this option is \fIyes\fR.
 .RE
 
 .RE
@@ -710,7 +840,8 @@ Interface Stability	Committed
 .SH SEE ALSO
 .LP
 \fBdhcpinfo\fR(1), \fBifconfig\fR(1M), \fBinit\fR(1M), \fBin.mpathd\fR(1M),
-\fBin.ndpd\fR(1M), \fBsyslog\fR(3C), \fBattributes\fR(5), \fBdhcp\fR(5)
+\fBin.ndpd\fR(1M), \fBipadm\fR(1M), \fBnwamcfg\fR(1M), \fBsyslog\fR(3C),
+\fBnodename\fR(4), \fBresolv.conf\fR(4), \fBattributes\fR(5), \fBdhcp\fR(5)
 .sp
 .LP
 \fI\fR

--- a/usr/src/man/man1m/ipadm.1m
+++ b/usr/src/man/man1m/ipadm.1m
@@ -12,8 +12,9 @@
 .\" Copyright (c) 2012, Joyent, Inc. All Rights Reserved
 .\" Copyright (c) 2013 by Delphix. All rights reserved.
 .\" Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+.\" Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
 .\"
-.Dd April 9, 2016
+.Dd June 16, 2017
 .Dt IPADM 1M
 .Os
 .Sh NAME
@@ -70,6 +71,8 @@
 .Op Fl t
 .Fl T Cm dhcp
 .Op Fl w Ar seconds Ns | Ns Cm forever
+.Op Fl 1
+.Op Fl h Ar hostname
 .Ar addrobj
 .Nm
 .Ic create-addr
@@ -418,6 +421,8 @@ subcommand for the list of property names.
 .Op Fl t
 .Fl T Cm dhcp
 .Op Fl w Ar seconds Ns | Ns Cm forever
+.Op Fl 1
+.Op Fl h Ar hostname
 .Ar addrobj
 .br
 .Nm
@@ -466,7 +471,32 @@ Obtain the address via DHCP.
 This takes the following options:
 .Bl -tag -width ""
 .It Fl w Ns \&, Ns Fl -wait
-Specify the time, in seconds, that the command should wait to obtain an address.
+Specify the time, in seconds, that the command should wait to obtain an
+address; or specify
+.Cm forever
+to wait without interruption.
+The default value is 120.
+.It Fl 1 Ns \&, Ns Fl -primary
+Specify that the interface is primary.
+One effect will be that
+.Xr nodename 4
+will serve as
+.Fl h Ns \&, Ns Fl -reqhost
+if that switch is not otherwise specified.
+.It Fl h Ns \&, Ns Fl -reqhost
+Specify the host name to send to the DHCP server in order to request an
+association of a Fully Qualified Domain Name to the interface.
+An FQDN is determined from
+.Ar hostname
+if it is "rooted" (ending in a '.'), or if it consists of at least three
+DNS labels, or by appending to
+.Ar hostname
+the DNS domain name value configured in
+.Pa /etc/default/dhcpagent
+for
+.Xr dhcpagent 1m .
+N.b. that the DHCP server implementation ultimately determines whether and
+how the client-sent FQDN is used.
 .El
 .It Fl T Cm addrconf
 Create an auto-configured address.
@@ -647,14 +677,29 @@ The address should not be used to send packets but can still receive packets
 .Pq Cm on Ns / Ns Cm off .
 .It Cm prefixlen
 The number of bits in the IPv4 netmask or IPv6 prefix.
+.It Cm primary
+The DHCP primary interface flag (read-only).
 .It Cm private
 The address is not advertised to routing
 .Pq Cm on Ns / Ns Cm off .
+.It Cm reqhost
+The host name to send to the DHCP server in order to request an association
+of an FQDN to the interface.
+For a primary DHCP interface,
+.Xr nodename 4
+is sent if this property is not defined.
+See the
+.Nm
+.Ic create-addr
+.Fl T Cm dhcp
+subcommand for an explanation of how an FQDN is determined.
 .It Cm transmit
 Packets can be transmitted
 .Pq Cm on Ns / Ns Cm off .
 .It Cm zone
-The zone the addrobj is in.
+The zone the addrobj is in (temporary-only--use
+.Xr zonecfg 1M
+to make persistent).
 .El
 .It Fl t Ns \&, Ns Fl -temporary
 Temporary, not persistent across reboots.
@@ -847,10 +892,12 @@ subcommand for the list of property names.
 .Sh SEE ALSO
 .Xr arp 1M ,
 .Xr cfgadm 1M ,
+.Xr dhcpagent 1M ,
 .Xr dladm 1M ,
 .Xr if_mpadm 1M ,
 .Xr ifconfig 1M ,
 .Xr ndd 1M ,
 .Xr zonecfg 1M ,
+.Xr nodename 4 ,
 .Xr nsswitch.conf 4 ,
 .Xr dhcp 5

--- a/usr/src/man/man4/dhcp_inittab.4
+++ b/usr/src/man/man4/dhcp_inittab.4
@@ -1,13 +1,13 @@
 '\" te
 .\" Copyright (C) 2009, Sun Microsystems, Inc. All Rights Reserved
+.\" Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\"  See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with
 .\" the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH DHCP_INITTAB 4 "Aug 31, 2009"
+.TH DHCP_INITTAB 4 "Oct 31, 2016"
 .SH NAME
 dhcp_inittab \- information repository for DHCP options
 .SH DESCRIPTION
-.sp
 .LP
 The \fB/etc/dhcp/inittab\fR and the \fB/etc/dhcp/inittab6\fR files contain
 information about the Dynamic Host Configuration Protocol (\fBDHCP\fR) options,
@@ -123,7 +123,6 @@ be further defined.
 .RE
 
 .SS "DHCP \fBinittab\fR and \fBinittab6\fR Format"
-.sp
 .LP
 Data entries are written one per line and have seven fields; each entry
 provides information for one option. Each field is separated by a comma, except
@@ -361,7 +360,6 @@ this information, and should always be defined as \fBsdmi\fR for newly added
 options.
 .RE
 .SS "Mnemonic Identifiers for IPv4 Options"
-.sp
 .LP
 The following table maps the mnemonic identifiers used in Solaris DHCP to
 \fIRFC 2132\fR options:
@@ -377,7 +375,7 @@ _
 Subnet Mask, dotted Internet address (IP).
 T}
 \fBUTCoffst\fR	\fB2\fR	T{
-Coordinated Universal time offset (seconds).
+Coordinated Universal time offset (seconds) [deprecated].
 T}
 \fBRouter\fR	\fB3\fR	List of Routers, IP.
 \fBTimeserv\fR	\fB4\fR	List of RFC-868 servers, IP.
@@ -475,6 +473,7 @@ T}
 \fBUserClas\fR	\fB77\fR	User class information, ASCII.
 \fBSLP_DA\fR	\fB78\fR	Directory agent, OCTET.
 \fBSLP_SS\fR	\fB79\fR	Service scope, OCTET.
+\fBClientFQDN\fR	\fB81\fR	Fully Qualified Domain Name, OCTET.
 \fBAgentOpt\fR	\fB82\fR	Agent circuit ID, OCTET.
 \fBFQDN\fR	\fB89\fR	Fully Qualified Domain Name, OCTET.
 \fBPXEarch\fR	\fB93\fR	Client system architecture, NUMBER.
@@ -491,7 +490,6 @@ T}
 .TE
 
 .SS "Mnemonic Identifiers for IPv6 Options"
-.sp
 .LP
 The following table maps the mnemonic identifiers used in Solaris DHCP to RFC
 3315, 3319, 3646, 3898, 4075, and 4280 options:
@@ -559,7 +557,6 @@ is of type \fBIP\fR Address, consisting  of a potentially infinite number of
 pairs of \fBIP\fR addresses.
 
 .SH FILES
-.br
 .in +2
 \fB/etc/dhcp/inittab\fR
 .in -2
@@ -568,7 +565,6 @@ pairs of \fBIP\fR addresses.
 \fB/etc/dhcp/inittabv6\fR
 .in -2
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5)  for descriptions of the following attributes:
 .sp
@@ -584,7 +580,6 @@ Interface Stability	Committed
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBdhcpinfo\fR(1), \fBdhcpagent\fR(1M), \fBisspace\fR(3C), \fBdhcptab\fR(4),
 \fBattributes\fR(5), \fBdhcp\fR(5), \fBdhcp_modules\fR(5)

--- a/usr/src/uts/common/io/nvme/nvme.c
+++ b/usr/src/uts/common/io/nvme/nvme.c
@@ -320,7 +320,7 @@ static int nvme_open(dev_t *, int, int, cred_t *);
 static int nvme_close(dev_t, int, int, cred_t *);
 static int nvme_ioctl(dev_t, int, intptr_t, int, cred_t *, int *);
 
-#define	NVME_MINOR_INST_SHIFT	14
+#define	NVME_MINOR_INST_SHIFT	9
 #define	NVME_MINOR(inst, nsid)	(((inst) << NVME_MINOR_INST_SHIFT) | (nsid))
 #define	NVME_MINOR_INST(minor)	((minor) >> NVME_MINOR_INST_SHIFT)
 #define	NVME_MINOR_NSID(minor)	((minor) & ((1 << NVME_MINOR_INST_SHIFT) - 1))

--- a/usr/src/uts/common/netinet/dhcp.h
+++ b/usr/src/uts/common/netinet/dhcp.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 1996-2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -30,8 +31,6 @@
 
 #ifndef	_DHCP_H
 #define	_DHCP_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #ifdef	__cplusplus
 extern "C" {
@@ -157,8 +156,15 @@ extern "C" {
 
 #define	CD_SLPDA		78
 #define	CD_SLPSS		79
+#define	CD_CLIENTFQDN		81
 #define	CD_AGENTOPT		82
+
+/*
+ * Per RFC 3679, option 89 was "Never published as standard and [is] not in
+ * general use". See active CD_CLIENTFQDN and RFC 4702.
+ */
 #define	CD_FQDN			89
+
 #define	CD_PXEARCHi		93
 #define	CD_PXENIIi		94
 #define	CD_PXECID		95

--- a/usr/src/uts/common/sys/scsi/targets/sddef.h
+++ b/usr/src/uts/common/sys/scsi/targets/sddef.h
@@ -1746,12 +1746,6 @@ struct sd_fm_internal {
 #endif
 
 /*
- * 60 seconds is what we will wait for to reset the
- * throttle back to it SD_MAX_THROTTLE.
- */
-#define	SD_RESET_THROTTLE_TIMEOUT	60
-
-/*
  * Number of times we'll retry a normal operation.
  *
  * This includes retries due to transport failure


### PR DESCRIPTION
Weekly merge from `illumos-gate`

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2017091401-5c2987b8c8 i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Sep 14 06:52:32 CEST 2017 ====
==== Nightly distributed build completed: Thu Sep 14 07:54:18 CEST 2017 ====

==== Total build time ====

real    1:01:45

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-5480e1c069 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2017091401-5c2987b8c8

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:08.0
user  1:06:52.8
sys      5:06.7

==== Build noise differences (non-DEBUG) ====

83,84c83,84
< maximum offset: 1cff
< maximum offset: 235b
---
> maximum offset: 1d12
> maximum offset: 236e

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:55.6
user    58:36.2
sys      3:29.5

==== Build noise differences (DEBUG) ====

48,49c48,49
< maximum offset: 1d42
< maximum offset: 239e
---
> maximum offset: 1d55
> maximum offset: 23b1

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====

10362a10363
> lib/libipadm.so.1: NEEDED=libdhcputil.so.1
12578a12580
> lib/libnwam.so.1: NEEDED=libipadm.so.1
14525a14528
> sbin/dhcpagent: NEEDED=libipadm.so.1
14526a14530,14531
> sbin/dhcpagent: NEEDED=libresolv.so.2
> sbin/dhcpagent: NEEDED=libsocket.so.1

==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:18.8
user    46:55.0
sys      5:36.3

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```