### PR TITLE
Add mountpoint=true attribute to /lib/libc.so.1

### DIFF
--- a/usr/src/pkg/manifests/system-library.mf
+++ b/usr/src/pkg/manifests/system-library.mf
@@ -261,7 +261,7 @@ file path=lib/libadm.so.1
 file path=lib/libaio.so.1
 file path=lib/libavl.so.1
 file path=lib/libbsm.so.1
-file path=lib/libc.so.1 reboot-needed=true
+file path=lib/libc.so.1 reboot-needed=true mountpoint=true
 file path=lib/libc_db.so.1
 file path=lib/libcmdutils.so.1
 file path=lib/libcontract.so.1


### PR DESCRIPTION
Used by pkg(5) to handle the hardware capability mounts.

Without this attribute, `pkg verify` always detects a problem in libc.so.1 and `pkg repair` always creates a new BE.

```
% pkg verify system/library
PACKAGE                                                                 STATUS
pkg://omnios/system/library                                              ERROR
     file: lib/libc.so.1
        ERROR: ELF content hash: aca8a62ca6198278c21c57931632d504d95d05f6 should be aab836b8552af9e009dbddffdb303881626222c1
```