### PR TITLE
Keys must be in alphabetical order

### DIFF
--- a/usr/src/pkg/manifests/system-library.mf
+++ b/usr/src/pkg/manifests/system-library.mf
@@ -261,7 +261,7 @@ file path=lib/libadm.so.1
 file path=lib/libaio.so.1
 file path=lib/libavl.so.1
 file path=lib/libbsm.so.1
-file path=lib/libc.so.1 reboot-needed=true mountpoint=true
+file path=lib/libc.so.1 mountpoint=true reboot-needed=true
 file path=lib/libc_db.so.1
 file path=lib/libcmdutils.so.1
 file path=lib/libcontract.so.1


### PR DESCRIPTION
Nightly failed..
`pkgfmt: error: manifests/system-library.mf is not in pkgfmt form`