### PR TITLE
Upstream merge/2017092101

### DIFF
--- a/usr/src/boot/sys/boot/i386/libi386/biosmem.c
+++ b/usr/src/boot/sys/boot/i386/libi386/biosmem.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 1998 Michael Smith <msmith@freebsd.org>
  * All rights reserved.
  *
@@ -32,7 +32,6 @@
 #include <stand.h>
 #include <machine/pc/bios.h>
 #include "bootstrap.h"
-#include "smbios.h"
 #include "libi386.h"
 #include "btxv86.h"
 #include "smbios.h"
@@ -63,150 +62,166 @@ static uint8_t b_bios_probed;
  * memory correctly. You need both maker and product as
  * reported by smbios.
  */
-#define BQ_DISTRUST_E820_EXTMEM	0x1	/* e820 might not return useful
-					   extended memory */
+/* e820 might not return useful extended memory */
+#define	BQ_DISTRUST_E820_EXTMEM	0x1
 struct bios_getmem_quirks {
-    const char* bios_vendor;
-    const char*	maker;
-    const char*	product;
-    int		quirk;
+	const char *bios_vendor;
+	const char *maker;
+	const char *product;
+	int quirk;
 };
 
 static struct bios_getmem_quirks quirks[] = {
-    {"coreboot", "Acer", "Peppy", BQ_DISTRUST_E820_EXTMEM},
-    {NULL, NULL, NULL, 0}
+	{"coreboot", "Acer", "Peppy", BQ_DISTRUST_E820_EXTMEM},
+	{NULL, NULL, NULL, 0}
 };
 
 static int
 bios_getquirks(void)
 {
-    int i;
+	int i;
 
-    for (i=0; quirks[i].quirk != 0; ++i)
-	if (smbios_match(quirks[i].bios_vendor, quirks[i].maker,
-	    quirks[i].product))
-	    return (quirks[i].quirk);
+	for (i = 0; quirks[i].quirk != 0; ++i) {
+		if (smbios_match(quirks[i].bios_vendor, quirks[i].maker,
+		    quirks[i].product))
+			return (quirks[i].quirk);
+	}
 
-    return (0);
+	return (0);
 }
 
 void
 bios_getmem(void)
 {
-    uint64_t size;
+	uint64_t size;
 
-    /* Parse system memory map */
-    v86.ebx = 0;
-    do {
-	v86.ctl = V86_FLAGS;
-	v86.addr = 0x15;		/* int 0x15 function 0xe820*/
-	v86.eax = 0xe820;
-	v86.ecx = sizeof(struct bios_smap_xattr);
-	v86.edx = SMAP_SIG;
-	v86.es = VTOPSEG(&smap);
-	v86.edi = VTOPOFF(&smap);
-	v86int();
-	if ((V86_CY(v86.efl)) || (v86.eax != SMAP_SIG))
-	    break;
-	/* look for a low-memory segment that's large enough */
-	if ((smap.type == SMAP_TYPE_MEMORY) && (smap.base == 0) &&
-	    (smap.length >= (512 * 1024))) {
-	    bios_basemem = smap.length;
-	    b_bios_probed |= B_BASEMEM_E820;
-	}
+	/* Parse system memory map */
+	v86.ebx = 0;
+	do {
+		v86.ctl = V86_FLAGS;
+		v86.addr = 0x15;		/* int 0x15 function 0xe820 */
+		v86.eax = 0xe820;
+		v86.ecx = sizeof (struct bios_smap_xattr);
+		v86.edx = SMAP_SIG;
+		v86.es = VTOPSEG(&smap);
+		v86.edi = VTOPOFF(&smap);
+		v86int();
+		if ((V86_CY(v86.efl)) || (v86.eax != SMAP_SIG))
+			break;
+		/* look for a low-memory segment that's large enough */
+		if ((smap.type == SMAP_TYPE_MEMORY) && (smap.base == 0) &&
+		    (smap.length >= (512 * 1024))) {
+			bios_basemem = smap.length;
+			b_bios_probed |= B_BASEMEM_E820;
+		}
 
-	/* look for the first segment in 'extended' memory */
-	if ((smap.type == SMAP_TYPE_MEMORY) && (smap.base == 0x100000) &&
-	    !(bios_getquirks() & BQ_DISTRUST_E820_EXTMEM)) {
-	    bios_extmem = smap.length;
-	    b_bios_probed |= B_EXTMEM_E820;
+		/* look for the first segment in 'extended' memory */
+		if ((smap.type == SMAP_TYPE_MEMORY) &&
+		    (smap.base == 0x100000) &&
+		    !(bios_getquirks() & BQ_DISTRUST_E820_EXTMEM)) {
+			bios_extmem = smap.length;
+			b_bios_probed |= B_EXTMEM_E820;
+		}
+
+		/*
+		 * Look for the highest segment in 'extended' memory beyond
+		 * 1MB but below 4GB.
+		 */
+		if ((smap.type == SMAP_TYPE_MEMORY) &&
+		    (smap.base > 0x100000) &&
+		    (smap.base < 0x100000000ull)) {
+			size = smap.length;
+
+			/*
+			 * If this segment crosses the 4GB boundary,
+			 * truncate it.
+			 */
+			if (smap.base + size > 0x100000000ull)
+				size = 0x100000000ull - smap.base;
+
+			/*
+			 * To make maximum space for the kernel and the modules,
+			 * set heap to use highest HEAP_MIN bytes below 4GB.
+			 */
+			if (high_heap_base < smap.base && size >= HEAP_MIN) {
+				high_heap_base = smap.base + size - HEAP_MIN;
+				high_heap_size = HEAP_MIN;
+			}
+		}
+	} while (v86.ebx != 0);
+
+	/* Fall back to the old compatibility function for base memory */
+	if (bios_basemem == 0) {
+		v86.ctl = 0;
+		v86.addr = 0x12;		/* int 0x12 */
+		v86int();
+
+		bios_basemem = (v86.eax & 0xffff) * 1024;
+		b_bios_probed |= B_BASEMEM_12;
 	}
 
 	/*
-	 * Look for the largest segment in 'extended' memory beyond
-	 * 1MB but below 4GB.
+	 * Fall back through several compatibility functions for extended
+	 * memory.
 	 */
-	if ((smap.type == SMAP_TYPE_MEMORY) && (smap.base > 0x100000) &&
-	    (smap.base < 0x100000000ull)) {
-	    size = smap.length;
+	if (bios_extmem == 0) {
+		v86.ctl = V86_FLAGS;
+		v86.addr = 0x15;		/* int 0x15 function 0xe801 */
+		v86.eax = 0xe801;
+		v86int();
+		if (!(V86_CY(v86.efl))) {
+			/*
+			 * Clear high_heap; it may end up overlapping
+			 * with the segment we're determining here.
+			 * Let the default "steal stuff from top of
+			 * bios_extmem" code below pick up on it.
+			 */
+			high_heap_size = 0;
+			high_heap_base = 0;
 
-	    /*
-	     * If this segment crosses the 4GB boundary, truncate it.
-	     */
-	    if (smap.base + size > 0x100000000ull)
-		size = 0x100000000ull - smap.base;
+			/*
+			 * %cx is the number of 1KiB blocks between 1..16MiB.
+			 * It can only be up to 0x3c00; if it's smaller then
+			 * there's a PC AT memory hole so we can't treat
+			 * it as contiguous.
+			 */
+			bios_extmem = (v86.ecx & 0xffff) * 1024;
+			if (bios_extmem == (1024 * 0x3c00))
+				bios_extmem += (v86.edx & 0xffff) * 64 * 1024;
 
-	    if (size > high_heap_size) {
-		high_heap_size = size;
-		high_heap_base = smap.base;
-	    }
+			/* truncate bios_extmem */
+			if (bios_extmem > 0x3ff00000)
+				bios_extmem = 0x3ff00000;
+
+			b_bios_probed |= B_EXTMEM_E801;
+		}
 	}
-    } while (v86.ebx != 0);
-
-    /* Fall back to the old compatibility function for base memory */
-    if (bios_basemem == 0) {
-	v86.ctl = 0;
-	v86.addr = 0x12;		/* int 0x12 */
-	v86int();
-	
-	bios_basemem = (v86.eax & 0xffff) * 1024;
-	b_bios_probed |= B_BASEMEM_12;
-    }
-
-    /* Fall back through several compatibility functions for extended memory */
-    if (bios_extmem == 0) {
-	v86.ctl = V86_FLAGS;
-	v86.addr = 0x15;		/* int 0x15 function 0xe801*/
-	v86.eax = 0xe801;
-	v86int();
-	if (!(V86_CY(v86.efl))) {
-	    /*
-	     * Clear high_heap; it may end up overlapping
-	     * with the segment we're determining here.
-	     * Let the default "steal stuff from top of
-	     * bios_extmem" code below pick up on it.
-	     */
-	    high_heap_size = 0;
-	    high_heap_base = 0;
-
-	    /*
-	     * %cx is the number of 1KiB blocks between 1..16MiB.
-	     * It can only be up to 0x3c00; if it's smaller then
-	     * there's a PC AT memory hole so we can't treat
-	     * it as contiguous.
-	     */
-	    bios_extmem = (v86.ecx & 0xffff) * 1024;
-	    if (bios_extmem == (1024 * 0x3c00))
-		bios_extmem += (v86.edx & 0xffff) * 64 * 1024;
-
-	    /* truncate bios_extmem */
-	    if (bios_extmem > 0x3ff00000)
-		bios_extmem = 0x3ff00000;
-
-	    b_bios_probed |= B_EXTMEM_E801;
+	if (bios_extmem == 0) {
+		v86.ctl = 0;
+		v86.addr = 0x15;		/* int 0x15 function 0x88 */
+		v86.eax = 0x8800;
+		v86int();
+		bios_extmem = (v86.eax & 0xffff) * 1024;
+		b_bios_probed |= B_EXTMEM_8800;
 	}
-    }
-    if (bios_extmem == 0) {
-	v86.ctl = 0;
-	v86.addr = 0x15;		/* int 0x15 function 0x88*/
-	v86.eax = 0x8800;
-	v86int();
-	bios_extmem = (v86.eax & 0xffff) * 1024;
-	b_bios_probed |= B_EXTMEM_8800;
-    }
 
-    /* Set memtop to actual top of memory */
-    memtop = memtop_copyin = 0x100000 + bios_extmem;
+	/* Set memtop to actual top of memory */
+	if (high_heap_size != 0) {
+		memtop = memtop_copyin = high_heap_base;
+	} else {
+		memtop = memtop_copyin = 0x100000 + bios_extmem;
+	}
 
-    /*
-     * If we have extended memory and did not find a suitable heap
-     * region in the SMAP, use the last 3MB of 'extended' memory as a
-     * high heap candidate.
-     */
-    if (bios_extmem >= HEAP_MIN && high_heap_size < HEAP_MIN) {
-	high_heap_size = HEAP_MIN;
-	high_heap_base = memtop - HEAP_MIN;
-    }
+	/*
+	 * If we have extended memory and did not find a suitable heap
+	 * region in the SMAP, use the last HEAP_MIN of 'extended' memory as a
+	 * high heap candidate.
+	 */
+	if (bios_extmem >= HEAP_MIN && high_heap_size < HEAP_MIN) {
+		high_heap_size = HEAP_MIN;
+		high_heap_base = memtop - HEAP_MIN;
+		memtop = memtop_copyin = high_heap_base;
+	}
 }
 
 #ifndef	BOOT2
@@ -215,16 +230,16 @@ command_biosmem(int argc, char *argv[])
 {
 	int bq = bios_getquirks();
 
-	printf("bios_basemem: 0x%llx\n", (unsigned long long) bios_basemem);
-	printf("bios_extmem: 0x%llx\n", (unsigned long long) bios_extmem);
-	printf("memtop: 0x%llx\n", (unsigned long long) memtop);
-	printf("high_heap_base: 0x%llx\n", (unsigned long long) high_heap_base);
-	printf("high_heap_size: 0x%llx\n", (unsigned long long) high_heap_size);
+	printf("bios_basemem: 0x%llx\n", (unsigned long long)bios_basemem);
+	printf("bios_extmem: 0x%llx\n", (unsigned long long)bios_extmem);
+	printf("memtop: 0x%llx\n", (unsigned long long)memtop);
+	printf("high_heap_base: 0x%llx\n", (unsigned long long)high_heap_base);
+	printf("high_heap_size: 0x%llx\n", (unsigned long long)high_heap_size);
 	printf("bios_quirks: 0x%02x", bq);
 	if (bq & BQ_DISTRUST_E820_EXTMEM)
 		printf(" BQ_DISTRUST_E820_EXTMEM");
 	printf("\n");
-	printf("b_bios_probed: 0x%02x", (int) b_bios_probed);
+	printf("b_bios_probed: 0x%02x", (int)b_bios_probed);
 	if (b_bios_probed & B_BASEMEM_E820)
 		printf(" B_BASEMEM_E820");
 	if (b_bios_probed & B_BASEMEM_12)

--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c
@@ -885,7 +885,7 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
 		/*
 		 * If it has no interface identifier, or if we both
 		 * have same identifier then NAK it with new idea.  In
-		 * particular, if we don't know his identifier, but it
+		 * particular, if we don't know its identifier, but it
 		 * does, then accept that identifier.
 		 */
 		eui64_get(ifaceid, p);

--- a/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c
@@ -1728,7 +1728,7 @@ doaddup(int cmd, int satype, char *argv[], char *ebuf)
 			switch (token) {
 			case TOK_SPI:
 				/*
-				 * If some cretin types in "spi 0" then they
+				 * If they type in "spi 0" then they
 				 * can type in another SPI.
 				 */
 				if (assoc->sadb_sa_spi != 0) {

--- a/usr/src/cmd/format/main.c
+++ b/usr/src/cmd/format/main.c
@@ -492,7 +492,7 @@ init_globals(disk)
 			fmt_print("]");
 		/*
 		 * Drive wasn't formatted.  Tell the user in case they
-		 * disagrees.
+		 * disagree.
 		 */
 		} else if (EMBEDDED_SCSI) {
 			fmt_print("[disk unformatted]");

--- a/usr/src/cmd/fs.d/zfs/fstyp/fstyp.c
+++ b/usr/src/cmd/fs.d/zfs/fstyp/fstyp.c
@@ -89,8 +89,7 @@ fstyp_mod_ident(fstyp_mod_handle_t handle)
 	uint64_t u64;
 	char	buf[64];
 
-	if (zpool_read_label(h->fd, &h->config) != 0 ||
-	    h->config == NULL) {
+	if (zpool_read_label(h->fd, &h->config) != 0) {
 		return (FSTYP_ERR_NO_MATCH);
 	}
 

--- a/usr/src/cmd/tar/tar.c
+++ b/usr/src/cmd/tar/tar.c
@@ -1465,8 +1465,8 @@ dorep(char *argv[])
  *	endtape checks the entry in dblock.dbuf to see if its the
  *	special EOT entry.  Endtape is usually called after getdir().
  *
- *	endtape used to call backtape; it no longer does, it who
- *	wants it backed up must call backtape himself
+ *	endtape used to call backtape; it no longer does. If the caller
+ *	wants the tape backed up, it must call backtape itself
  *	RETURNS:	0 if not EOT, tape position unaffected
  *			1 if	 EOT, tape position unaffected
  */

--- a/usr/src/cmd/vi/port/ex_cmdsub.c
+++ b/usr/src/cmd/vi/port/ex_cmdsub.c
@@ -1621,7 +1621,7 @@ addmac(unsigned char *src, unsigned char *dest, unsigned char *dname,
 		if (src[1] == 0 && src[0] == dest[strlen(dest)-1])
 			error(gettext("No tail recursion"));
 		/*
-		 * We don't let the user rob himself of ":", and making
+		 * We don't let the user rob themself of ":", and making
 		 * multi char words is a bad idea so we don't allow it.
 		 * Note that if user sets mapinput and maps all of return,
 		 * linefeed, and escape, they can hurt themself. This is

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -708,7 +708,7 @@ zpool_do_labelclear(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_read_label(fd, &config) != 0 || config == NULL) {
+	if (zpool_read_label(fd, &config) != 0) {
 		(void) fprintf(stderr,
 		    gettext("failed to read label from %s\n"), vdev);
 		return (1);

--- a/usr/src/head/arpa/telnet.h
+++ b/usr/src/head/arpa/telnet.h
@@ -245,8 +245,8 @@ extern char *slc_names[];
  */
 #define	AUTH_REJECT	0	/* Rejected */
 #define	AUTH_UNKNOWN	1	/* We don't know who it is, but it's okay */
-#define	AUTH_OTHER	2	/* We know it, but not it's name */
-#define	AUTH_USER	3	/* We know it's name */
+#define	AUTH_OTHER	2	/* We know it, but not its name */
+#define	AUTH_USER	3	/* We know its name */
 #define	AUTH_VALID	4	/* We know it, and it needs no password */
 
 /*

--- a/usr/src/lib/libbc/libc/gen/common/ndbm.c
+++ b/usr/src/lib/libbc/libc/gen/common/ndbm.c
@@ -495,10 +495,9 @@ dbm_do_nextkey(DBM *db, datum inkey)
 		else key=nullkey;
 
 	/* the keyptr pagbuf have failed us, the user must
-	be an extra clever moron who depends on
-	these variables and their former meaning.
+	depend on these variables and their former meaning.
 	If we set the variables this would have got
-	us the key for sure! So give him the old algorithm.*/
+	us the key for sure! So give the user the old algorithm.*/
 		if (key.dptr == NULL) return (dbm_slow_nextkey(db));
 	}
 

--- a/usr/src/lib/libc/port/threads/thr.c
+++ b/usr/src/lib/libc/port/threads/thr.c
@@ -1827,7 +1827,7 @@ force_continue(ulwp_t *ulwp)
 		if (error != 0 && error != EINTR)
 			break;
 		error = 0;
-		if (ulwp->ul_stopping) {	/* it is stopping itsself */
+		if (ulwp->ul_stopping) {	/* it is stopping itself */
 			ts.tv_sec = 0;		/* give it a chance to run */
 			ts.tv_nsec = 100000;	/* 100 usecs or clock tick */
 			(void) __nanosleep(&ts, NULL);

--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -841,6 +841,7 @@ label_offset(uint64_t size, int l)
 /*
  * Given a file descriptor, read the label information and return an nvlist
  * describing the configuration, if there is one.
+ * Return 0 on success, or -1 on failure
  */
 int
 zpool_read_label(int fd, nvlist_t **config)
@@ -853,7 +854,7 @@ zpool_read_label(int fd, nvlist_t **config)
 	*config = NULL;
 
 	if (fstat64(fd, &statbuf) == -1)
-		return (0);
+		return (-1);
 	size = P2ALIGN_TYPED(statbuf.st_size, sizeof (vdev_label_t), uint64_t);
 
 	if ((label = malloc(sizeof (vdev_label_t))) == NULL)
@@ -887,7 +888,7 @@ zpool_read_label(int fd, nvlist_t **config)
 
 	free(label);
 	*config = NULL;
-	return (0);
+	return (-1);
 }
 
 typedef struct rdsk_node {
@@ -1052,7 +1053,7 @@ zpool_open_func(void *arg)
 		check_slices(rn->rn_avl, fd, rn->rn_name);
 	}
 
-	if ((zpool_read_label(fd, &config)) != 0) {
+	if ((zpool_read_label(fd, &config)) != 0 && errno == ENOMEM) {
 		(void) close(fd);
 		(void) no_memory(rn->rn_hdl);
 		return;
@@ -1517,7 +1518,7 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
 
 	*inuse = B_FALSE;
 
-	if (zpool_read_label(fd, &config) != 0) {
+	if (zpool_read_label(fd, &config) != 0 && errno == ENOMEM) {
 		(void) no_memory(hdl);
 		return (-1);
 	}

--- a/usr/src/man/man1m/zfs-program.1m
+++ b/usr/src/man/man1m/zfs-program.1m
@@ -289,6 +289,18 @@ msg (string)
 .Bd -ragged -compact -offset "xxxx"
 Debug message to be printed.
 .Ed
+.It Em zfs.exists(dataset)
+Returns true if the given dataset exists, or false if it doesn't.
+A fatal error will be thrown if the dataset is not in the target pool.
+That is, in a channel program running on rpool,
+zfs.exists("rpool/nonexistent_fs") returns false, but
+zfs.exists("somepool/fs_that_may_exist") will error.
+.Pp
+dataset (string)
+.Bd -ragged -compact -offset "xxxx"
+Dataset to check for existence.
+Must be in the target pool.
+.Ed
 .It Em zfs.get_prop(dataset, property)
 Returns two values.
 First, a string, number or table containing the property value for the given

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -403,6 +403,11 @@ file \
 file \
     path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.divide_by_zero.zcp \
     mode=0444
+file path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.exists \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.zcp \
+    mode=0444
 file \
     path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.integer_illegal \
     mode=0555

--- a/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+#
+# DESCRIPTION:
+#       zfs.exists should accurately report whether a dataset exists, and
+#       report an error if a dataset is in another pool.
+
+verify_runnable "global"
+
+# create $TESTSNAP and $TESTCLONE
+create_snapshot
+create_clone
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+	    log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
+}
+
+log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.exists.zcp \
+    $TESTPOOL $TESTPOOL/$TESTFS $TESTPOOL/$TESTFS@$TESTSNAP \
+    $TESTPOOL/$TESTCLONE
+
+log_mustnot_checkerr_program "not in the target pool" \
+    $TESTPOOL - <<-EOF
+	return zfs.exists('rpool')
+EOF
+
+log_pass "zfs.exists() gives correct results"

--- a/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.zcp
+++ b/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.zcp
@@ -1,0 +1,26 @@
+--
+-- This file and its contents are supplied under the terms of the
+-- Common Development and Distribution License ("CDDL"), version 1.0.
+-- You may only use this file in accordance with the terms of version
+-- 1.0 of the CDDL.
+--
+-- A full copy of the text of the CDDL should have accompanied this
+-- source.  A copy of the CDDL is also available via the Internet at
+-- http://www.illumos.org/license/CDDL.
+--
+
+--
+-- Copyright (c) 2017 by Delphix. All rights reserved.
+--
+
+-- ensure zfs.exists works as expected.
+
+args = ...
+argv = args['argv']
+pool = argv[1]
+
+for i = 1,4 do
+	assert(zfs.exists(argv[i]))
+end
+
+assert(not zfs.exists(pool .. '/notadataset'))

--- a/usr/src/uts/common/fs/zfs/dsl_destroy.c
+++ b/usr/src/uts/common/fs/zfs/dsl_destroy.c
@@ -488,23 +488,29 @@ dsl_destroy_snapshots_nvl(nvlist_t *snaps, boolean_t defer,
 	if (nvlist_next_nvpair(snaps, NULL) == NULL)
 		return (0);
 
-	nvlist_t *arg = fnvlist_alloc();
-	nvlist_t *snaps_normalized = fnvlist_alloc();
 	/*
 	 * lzc_destroy_snaps() is documented to take an nvlist whose
-	 * values "don't matter".  We need to convert that nvlist to one
-	 * that we know can be converted to LUA.
+	 * values "don't matter".  We need to convert that nvlist to
+	 * one that we know can be converted to LUA. We also don't
+	 * care about any duplicate entries because the nvlist will
+	 * be converted to a LUA table which should take care of this.
 	 */
+	nvlist_t *snaps_normalized;
+	VERIFY0(nvlist_alloc(&snaps_normalized, 0, KM_SLEEP));
 	for (nvpair_t *pair = nvlist_next_nvpair(snaps, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(snaps, pair)) {
 		fnvlist_add_boolean_value(snaps_normalized,
 		    nvpair_name(pair), B_TRUE);
 	}
+
+	nvlist_t *arg;
+	VERIFY0(nvlist_alloc(&arg, 0, KM_SLEEP));
 	fnvlist_add_nvlist(arg, "snaps", snaps_normalized);
 	fnvlist_free(snaps_normalized);
 	fnvlist_add_boolean_value(arg, "defer", defer);
 
-	nvlist_t *wrapper = fnvlist_alloc();
+	nvlist_t *wrapper;
+	VERIFY0(nvlist_alloc(&wrapper, 0, KM_SLEEP));
 	fnvlist_add_nvlist(wrapper, ZCP_ARG_ARGLIST, arg);
 	fnvlist_free(arg);
 
@@ -538,7 +544,7 @@ dsl_destroy_snapshots_nvl(nvlist_t *snaps, boolean_t defer,
 	    program,
 	    0,
 	    zfs_lua_max_memlimit,
-	    fnvlist_lookup_nvpair(wrapper, ZCP_ARG_ARGLIST), result);
+	    nvlist_next_nvpair(wrapper, NULL), result);
 	if (error != 0) {
 		char *errorstr = NULL;
 		(void) nvlist_lookup_string(result, ZCP_RET_ERROR, &errorstr);

--- a/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
@@ -123,7 +123,6 @@ typedef struct dsl_pool {
 	txg_list_t dp_sync_tasks;
 	taskq_t *dp_sync_taskq;
 	taskq_t *dp_zil_clean_taskq;
-	txg_list_t dp_early_sync_tasks;
 
 	/*
 	 * Protects administrative changes (properties, namespace)

--- a/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h
+++ b/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011-2012 Pawel Jakub Dawidek. All rights reserved.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright 2016 RackTop Systems.
  * Copyright (c) 2014 Integros [integros.com]
  */
@@ -428,9 +428,10 @@ extern int zfs_secpolicy_snapshot_perms(const char *, cred_t *);
 extern int zfs_secpolicy_rename_perms(const char *, const char *, cred_t *);
 extern int zfs_secpolicy_destroy_perms(const char *, cred_t *);
 extern int zfs_busy(void);
-extern int zfs_unmount_snap(const char *);
+extern void zfs_unmount_snap(const char *);
 extern void zfs_destroy_unmount_origin(const char *);
 extern int getzfsvfs_impl(struct objset *, struct zfsvfs **);
+extern int getzfsvfs(const char *, struct zfsvfs **);
 
 /*
  * ZFS minor numbers can refer to either a control device instance or

--- a/usr/src/uts/common/fs/zfs/zcp.c
+++ b/usr/src/uts/common/fs/zfs/zcp.c
@@ -710,7 +710,7 @@ zcp_exists(lua_State *state)
 		return (luaL_error(state, "unexpected error %d", error));
 	}
 
-	return (0);
+	return (1);
 }
 
 /*

--- a/usr/src/uts/common/rpc/xdr_sizeof.c
+++ b/usr/src/uts/common/rpc/xdr_sizeof.c
@@ -25,6 +25,7 @@
  */
 /*
  * Copyright 2012 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2017 RackTop Systems.
  */
 
 #include <rpc/types.h>
@@ -113,10 +114,11 @@ xdr_sizeof(xdrproc_t func, void *data)
 	struct xdr_ops ops;
 	bool_t stat;
 	/* to stop ANSI-C compiler from complaining */
-	typedef  bool_t (* dummyfunc1)(XDR *, long *);
-	typedef  bool_t (* dummyfunc2)(XDR *, caddr_t, int);
+	typedef  bool_t (* dummyfunc1)(XDR *, caddr_t, int);
+	typedef	 bool_t (* dummyfunc2)(XDR *, int, void *);
+#if defined(_LP64) || defined(_KERNEL)
 	typedef  bool_t (* dummyfunc3)(XDR *, int32_t *);
-	typedef	 bool_t (* dummyfunc4)(XDR *, int, void *);
+#endif
 
 	ops.x_putbytes = x_putbytes;
 	ops.x_inline = x_inline;
@@ -130,8 +132,8 @@ xdr_sizeof(xdrproc_t func, void *data)
 #endif
 
 	/* the other harmless ones */
-	ops.x_getbytes = (dummyfunc2)harmless;
-	ops.x_control = (dummyfunc4)harmless;
+	ops.x_getbytes = (dummyfunc1)harmless;
+	ops.x_control = (dummyfunc2)harmless;
 
 	x.x_op = XDR_ENCODE;
 	x.x_ops = &ops;

--- a/usr/src/uts/common/rpc/xdrrdma_sizeof.c
+++ b/usr/src/uts/common/rpc/xdrrdma_sizeof.c
@@ -21,6 +21,8 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2017 RackTop Systems.
  */
 
 #include <rpc/types.h>
@@ -275,9 +277,10 @@ xdrrdma_xops(void)
 	static struct xdr_ops ops;
 
 	/* to stop ANSI-C compiler from complaining */
-	typedef  bool_t (* dummyfunc1)(XDR *, long *);
-	typedef  bool_t (* dummyfunc2)(XDR *, caddr_t, int);
-	typedef  bool_t (* dummyfunc3)(XDR *, int32_t *);
+	typedef  bool_t (* dummyfunc1)(XDR *, caddr_t, int);
+#if defined(_LP64) || defined(_KERNEL)
+	typedef  bool_t (* dummyfunc2)(XDR *, int32_t *);
+#endif
 
 	ops.x_putbytes = x_putbytes;
 	ops.x_inline = x_inline;
@@ -287,12 +290,12 @@ xdrrdma_xops(void)
 	ops.x_control = x_control;
 
 #if defined(_LP64) || defined(_KERNEL)
-	ops.x_getint32 = (dummyfunc3)harmless;
+	ops.x_getint32 = (dummyfunc2)harmless;
 	ops.x_putint32 = x_putint32_t;
 #endif
 
 	/* the other harmless ones */
-	ops.x_getbytes = (dummyfunc2)harmless;
+	ops.x_getbytes = (dummyfunc1)harmless;
 
 	return (&ops);
 }

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -23,7 +23,7 @@
 # Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
 #
 # Copyright (c) 2010, Intel Corporation.
-# Copyright 2016 Joyent, Inc.
+# Copyright 2017 Joyent, Inc.
 #
 #	This Makefile defines file modules in the directory uts/i86pc
 #	and its children. These are the source files which are i86pc
@@ -200,7 +200,7 @@ PCPLUSMP_OBJS += apic.o apic_regops.o psm_common.o apic_introp.o	\
 			hpet_acpi.o apic_common.o apic_timer.o
 APIX_OBJS += apix.o apic_regops.o psm_common.o apix_intr.o apix_utils.o \
 		apix_irm.o mp_platform_common.o hpet_acpi.o apic_common.o \
-		apic_timer.o
+		apic_timer.o apix_regops.o
 
 
 ACPI_DRV_OBJS	+= acpi_drv.o acpi_video.o

--- a/usr/src/uts/i86pc/apix/Makefile
+++ b/usr/src/uts/i86pc/apix/Makefile
@@ -22,12 +22,12 @@
 # uts/i86pc/apix/Makefile
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2016, Joyent, Inc.
+# Copyright 2017, Joyent, Inc.
 #
-#	This makefile drives the production of the pcplusmp "mach"
+#	This makefile drives the production of the apix "mach"
 #	kernel module.
 #
-#	pcplusmp implementation architecture dependent
+#	apix implementation architecture dependent
 #
 
 #
@@ -62,9 +62,6 @@ $(NOT_RELEASE_BUILD)DEBUG_DEFS	+= $(DEBUG_FLGS)
 # Depends on ACPI CA interpreter
 #
 LDFLAGS		+= -dy -N misc/acpica
-
-CERRWARN	+= -_gcc=-Wno-uninitialized
-CERRWARN	+= -_gcc=-Wno-unused-function
 
 #
 #	Default build targets.

--- a/usr/src/uts/i86pc/io/apix/apix.c
+++ b/usr/src/uts/i86pc/io/apix/apix.c
@@ -221,6 +221,9 @@ int apix_nipis = 16;	/* Maximum number of IPIs */
  */
 int apix_cpu_nvectors = APIX_NVECTOR;
 
+/* number of CPUs in power-on transition state */
+static int apic_poweron_cnt = 0;
+
 /* gcpu.h */
 
 extern void apic_do_interrupt(struct regs *rp, trap_trace_rec_t *ttp);
@@ -1606,8 +1609,8 @@ apix_set_cpu(apix_vector_t *vecp, int new_cpu, int *result)
 	ddi_acc_handle_t handle;
 	ddi_intr_msix_t *msix_p = NULL;
 	ushort_t msix_ctrl;
-	uintptr_t off;
-	uint32_t mask;
+	uintptr_t off = 0;
+	uint32_t mask = 0;
 
 	ASSERT(LOCK_HELD(&apix_lock));
 	*result = ENXIO;
@@ -1665,8 +1668,8 @@ apix_grp_set_cpu(apix_vector_t *vecp, int new_cpu, int *result)
 	apix_vector_t *newp, *vp;
 	uint32_t orig_cpu = vecp->v_cpuid;
 	int orig_vect = vecp->v_vector;
-	int i, num_vectors, cap_ptr, msi_mask_off;
-	uint32_t msi_pvm;
+	int i, num_vectors, cap_ptr, msi_mask_off = 0;
+	uint32_t msi_pvm = 0;
 	ushort_t msi_ctrl;
 	ddi_acc_handle_t handle;
 	dev_info_t *dip;
@@ -2558,6 +2561,45 @@ apix_intx_xlate_vector(dev_info_t *dip, int inum, struct intrspec *ispec)
 	vecp = apix_intx_get_vector(irqno);
 
 	return (vecp);
+}
+
+/*
+ * Switch between safe and x2APIC IPI sending method.
+ * The CPU may power on in xapic mode or x2apic mode. If the CPU needs to send
+ * an IPI to other CPUs before entering x2APIC mode, it still needs to use the
+ * xAPIC method. Before sending a StartIPI to the target CPU, psm_send_ipi will
+ * be changed to apic_common_send_ipi, which detects current local APIC mode and
+ * use the right method to send an IPI. If some CPUs fail to start up,
+ * apic_poweron_cnt won't return to zero, so apic_common_send_ipi will always be
+ * used. psm_send_ipi can't be simply changed back to x2apic_send_ipi if some
+ * CPUs failed to start up because those failed CPUs may recover itself later at
+ * unpredictable time.
+ */
+void
+apic_switch_ipi_callback(boolean_t enter)
+{
+	ulong_t iflag;
+	struct psm_ops *pops = psmops;
+
+	iflag = intr_clear();
+	lock_set(&apic_mode_switch_lock);
+	if (enter) {
+		ASSERT(apic_poweron_cnt >= 0);
+		if (apic_poweron_cnt == 0) {
+			pops->psm_send_ipi = apic_common_send_ipi;
+			send_dirintf = pops->psm_send_ipi;
+		}
+		apic_poweron_cnt++;
+	} else {
+		ASSERT(apic_poweron_cnt > 0);
+		apic_poweron_cnt--;
+		if (apic_poweron_cnt == 0) {
+			pops->psm_send_ipi = x2apic_send_ipi;
+			send_dirintf = pops->psm_send_ipi;
+		}
+	}
+	lock_clear(&apic_mode_switch_lock);
+	intr_restore(iflag);
 }
 
 /* stub function */

--- a/usr/src/uts/i86pc/io/apix/apix_regops.c
+++ b/usr/src/uts/i86pc/io/apix/apix_regops.c
@@ -1,0 +1,252 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2014 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
+ */
+
+#include <sys/cpuvar.h>
+#include <sys/psm.h>
+#include <sys/archsystm.h>
+#include <sys/apic.h>
+#include <sys/sunddi.h>
+#include <sys/ddi_impldefs.h>
+#include <sys/mach_intr.h>
+#include <sys/sysmacros.h>
+#include <sys/trap.h>
+#include <sys/x86_archext.h>
+#include <sys/privregs.h>
+#include <sys/psm_common.h>
+
+/* Function prototypes of X2APIC */
+static uint64_t local_x2apic_read(uint32_t msr);
+static void local_x2apic_write(uint32_t msr, uint64_t value);
+static int get_local_x2apic_pri(void);
+static void local_x2apic_write_task_reg(uint64_t value);
+static void local_x2apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1);
+
+/*
+ * According to the X2APIC specification:
+ *
+ *   xAPIC global enable    X2APIC enable         Description
+ *   (IA32_APIC_BASE[11])   (IA32_APIC_BASE[10])
+ * -----------------------------------------------------------
+ *	0			0	APIC is disabled
+ *	0			1	Invalid
+ *	1			0	APIC is enabled in xAPIC mode
+ *	1			1	APIC is enabled in X2APIC mode
+ * -----------------------------------------------------------
+ */
+int	x2apic_enable = 1;
+
+/* X2APIC : Uses RDMSR/WRMSR instructions to access APIC registers */
+static apic_reg_ops_t x2apic_regs_ops = {
+	local_x2apic_read,
+	local_x2apic_write,
+	get_local_x2apic_pri,
+	local_x2apic_write_task_reg,
+	local_x2apic_write_int_cmd,
+	apic_send_EOI,
+};
+
+/*
+ * X2APIC Implementation.
+ */
+static uint64_t
+local_x2apic_read(uint32_t msr)
+{
+	uint64_t i;
+
+	i = (uint64_t)(rdmsr(REG_X2APIC_BASE_MSR + (msr >> 2)) & 0xffffffff);
+	return (i);
+}
+
+static void
+local_x2apic_write(uint32_t msr, uint64_t value)
+{
+	uint64_t tmp;
+
+	if (msr != APIC_EOI_REG) {
+		tmp = rdmsr(REG_X2APIC_BASE_MSR + (msr >> 2));
+		tmp = (tmp & 0xffffffff00000000) | value;
+	} else {
+		tmp = 0;
+	}
+
+	wrmsr((REG_X2APIC_BASE_MSR + (msr >> 2)), tmp);
+}
+
+static int
+get_local_x2apic_pri(void)
+{
+	return (rdmsr(REG_X2APIC_BASE_MSR + (APIC_TASK_REG >> 2)));
+}
+
+static void
+local_x2apic_write_task_reg(uint64_t value)
+{
+	X2APIC_WRITE(APIC_TASK_REG, value);
+}
+
+static void
+local_x2apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1)
+{
+	wrmsr((REG_X2APIC_BASE_MSR + (APIC_INT_CMD1 >> 2)),
+	    (((uint64_t)cpu_id << 32) | cmd1));
+}
+
+int
+apic_detect_x2apic(void)
+{
+	if (x2apic_enable == 0)
+		return (0);
+
+	return (is_x86_feature(x86_featureset, X86FSET_X2APIC));
+}
+
+void
+apic_enable_x2apic(void)
+{
+	uint64_t apic_base_msr;
+
+	if (apic_local_mode() == LOCAL_X2APIC) {
+		/* BIOS apparently has enabled X2APIC */
+		if (apic_mode != LOCAL_X2APIC)
+			x2apic_update_psm();
+		return;
+	}
+
+	/*
+	 * This is the first time we are enabling X2APIC on this CPU
+	 */
+	apic_base_msr = rdmsr(REG_APIC_BASE_MSR);
+	apic_base_msr = apic_base_msr | (0x1 << X2APIC_ENABLE_BIT);
+	wrmsr(REG_APIC_BASE_MSR, apic_base_msr);
+
+	if (apic_mode != LOCAL_X2APIC)
+		x2apic_update_psm();
+}
+
+/*
+ * Change apic_reg_ops depending upon the apic_mode.
+ */
+void
+apic_change_ops()
+{
+	if (apic_mode == LOCAL_APIC)
+		apic_reg_ops = &local_apic_regs_ops;
+	else if (apic_mode == LOCAL_X2APIC)
+		apic_reg_ops = &x2apic_regs_ops;
+}
+
+/*
+ * Generates an interprocessor interrupt to another CPU when X2APIC mode is
+ * enabled.
+ */
+void
+x2apic_send_ipi(int cpun, int ipl)
+{
+	int vector;
+	ulong_t flag;
+
+	ASSERT(apic_mode == LOCAL_X2APIC);
+
+	/*
+	 * With X2APIC, Intel relaxed the semantics of the
+	 * WRMSR instruction such that references to the X2APIC
+	 * MSR registers are no longer serializing instructions.
+	 * The code that initiates IPIs assumes that some sort
+	 * of memory serialization occurs. The old APIC code
+	 * did a write to uncachable memory mapped registers.
+	 * Any reference to uncached memory is a serializing
+	 * operation. To mimic those semantics here, we do an
+	 * atomic operation, which translates to a LOCK OR instruction,
+	 * which is serializing.
+	 */
+	atomic_or_ulong(&flag, 1);
+
+	vector = apic_resv_vector[ipl];
+
+	flag = intr_clear();
+
+	/*
+	 * According to X2APIC specification in section '2.3.5.1' of
+	 * Interrupt Command Register Semantics, the semantics of
+	 * programming Interrupt Command Register to dispatch an interrupt
+	 * is simplified. A single MSR write to the 64-bit ICR is required
+	 * for dispatching an interrupt. Specifically with the 64-bit MSR
+	 * interface to ICR, system software is not required to check the
+	 * status of the delivery status bit prior to writing to the ICR
+	 * to send an IPI. With the removal of the Delivery Status bit,
+	 * system software no longer has a reason to read the ICR. It remains
+	 * readable only to aid in debugging.
+	 */
+#ifdef	DEBUG
+	APIC_AV_PENDING_SET();
+#endif	/* DEBUG */
+
+	if ((cpun == psm_get_cpu_id())) {
+		X2APIC_WRITE(X2APIC_SELF_IPI, vector);
+	} else {
+		apic_reg_ops->apic_write_int_cmd(
+		    apic_cpus[cpun].aci_local_id, vector);
+	}
+
+	intr_restore(flag);
+}
+
+/*
+ * Generates IPI to another CPU depending on the local APIC mode.
+ * apic_send_ipi() and x2apic_send_ipi() depends on the configured
+ * mode of the local APIC, but that may not match the actual mode
+ * early in CPU startup.
+ *
+ * Any changes made to this routine must be accompanied by similar
+ * changes to apic_send_ipi().
+ */
+void
+apic_common_send_ipi(int cpun, int ipl)
+{
+	int vector;
+	ulong_t flag;
+	int mode = apic_local_mode();
+
+	if (mode == LOCAL_X2APIC) {
+		x2apic_send_ipi(cpun, ipl);
+		return;
+	}
+
+	ASSERT(mode == LOCAL_APIC);
+
+	vector = apic_resv_vector[ipl];
+	ASSERT((vector >= APIC_BASE_VECT) && (vector <= APIC_SPUR_INTR));
+	flag = intr_clear();
+	while (local_apic_regs_ops.apic_read(APIC_INT_CMD1) & AV_PENDING)
+		apic_ret();
+	local_apic_regs_ops.apic_write_int_cmd(apic_cpus[cpun].aci_local_id,
+	    vector);
+	intr_restore(flag);
+}

--- a/usr/src/uts/i86pc/io/mp_platform_common.c
+++ b/usr/src/uts/i86pc/io/mp_platform_common.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc.
  * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 /*
  * Copyright (c) 2010, Intel Corporation.
@@ -330,9 +331,9 @@ apic_probe_common(char *modname)
 {
 	uint32_t mpct_addr, ebda_start = 0, base_mem_end;
 	caddr_t	biosdatap;
-	caddr_t	mpct = 0;
+	caddr_t	mpct = NULL;
 	caddr_t	fptr;
-	int	i, mpct_size, mapsize, retval = PSM_FAILURE;
+	int	i, mpct_size = 0, mapsize, retval = PSM_FAILURE;
 	ushort_t	ebda_seg, base_mem_size;
 	struct	apic_mpfps_hdr	*fpsp;
 	struct	apic_mp_cnf_hdr	*hdrp;

--- a/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
@@ -128,8 +128,6 @@ extern void cmi_cmci_trap(void);
 kmutex_t cmci_cpu_setup_lock;	/* protects cmci_cpu_setup_registered */
 int cmci_cpu_setup_registered;
 
-/* number of CPUs in power-on transition state */
-static int apic_poweron_cnt = 0;
 lock_t apic_mode_switch_lock;
 
 /*
@@ -848,7 +846,7 @@ apic_cpu_add(psm_cpu_request_t *reqp)
 	int i, rv = 0;
 	ulong_t iflag;
 	boolean_t first = B_TRUE;
-	uchar_t localver;
+	uchar_t localver = 0;
 	uint32_t localid, procid;
 	processorid_t cpuid = (processorid_t)-1;
 	mach_cpu_add_arg_t *ap;
@@ -1454,45 +1452,6 @@ apic_find_cpu(int flag)
 
 	ASSERT((apic_cpus[acid].aci_status & flag) != 0);
 	return (acid);
-}
-
-/*
- * Switch between safe and x2APIC IPI sending method.
- * CPU may power on in xapic mode or x2apic mode. If CPU needs to send IPI to
- * other CPUs before entering x2APIC mode, it still needs to xAPIC method.
- * Before sending StartIPI to target CPU, psm_send_ipi will be changed to
- * apic_common_send_ipi, which detects current local APIC mode and use right
- * method to send IPI. If some CPUs fail to start up, apic_poweron_cnt
- * won't return to zero, so apic_common_send_ipi will always be used.
- * psm_send_ipi can't be simply changed back to x2apic_send_ipi if some CPUs
- * failed to start up because those failed CPUs may recover itself later at
- * unpredictable time.
- */
-void
-apic_switch_ipi_callback(boolean_t enter)
-{
-	ulong_t iflag;
-	struct psm_ops *pops = psmops;
-
-	iflag = intr_clear();
-	lock_set(&apic_mode_switch_lock);
-	if (enter) {
-		ASSERT(apic_poweron_cnt >= 0);
-		if (apic_poweron_cnt == 0) {
-			pops->psm_send_ipi = apic_common_send_ipi;
-			send_dirintf = pops->psm_send_ipi;
-		}
-		apic_poweron_cnt++;
-	} else {
-		ASSERT(apic_poweron_cnt > 0);
-		apic_poweron_cnt--;
-		if (apic_poweron_cnt == 0) {
-			pops->psm_send_ipi = x2apic_send_ipi;
-			send_dirintf = pops->psm_send_ipi;
-		}
-	}
-	lock_clear(&apic_mode_switch_lock);
-	intr_restore(iflag);
 }
 
 void

--- a/usr/src/uts/i86pc/io/pcplusmp/apic_regops.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic_regops.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2014 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
  * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/cpuvar.h>
@@ -40,17 +41,12 @@
 #include <sys/privregs.h>
 #include <sys/psm_common.h>
 
-/* Function prototypes of local apic and X2APIC */
+/* Function prototypes of local apic */
 static uint64_t local_apic_read(uint32_t reg);
 static void local_apic_write(uint32_t reg, uint64_t value);
 static int get_local_apic_pri(void);
 static void local_apic_write_task_reg(uint64_t value);
 static void local_apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1);
-static uint64_t local_x2apic_read(uint32_t msr);
-static void local_x2apic_write(uint32_t msr, uint64_t value);
-static int get_local_x2apic_pri(void);
-static void local_x2apic_write_task_reg(uint64_t value);
-static void local_x2apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1);
 
 /*
  * According to the X2APIC specification:
@@ -64,29 +60,18 @@ static void local_x2apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1);
  *	1			1	APIC is enabled in X2APIC mode
  * -----------------------------------------------------------
  */
-int	x2apic_enable = 1;
 apic_mode_t apic_mode = LOCAL_APIC;	/* Default mode is Local APIC */
 
 /* See apic_directed_EOI_supported().  Currently 3-state variable. */
 volatile int apic_directed_eoi_state = 2;
 
 /* Uses MMIO (Memory Mapped IO) */
-static apic_reg_ops_t local_apic_regs_ops = {
+apic_reg_ops_t local_apic_regs_ops = {
 	local_apic_read,
 	local_apic_write,
 	get_local_apic_pri,
 	local_apic_write_task_reg,
 	local_apic_write_int_cmd,
-	apic_send_EOI,
-};
-
-/* X2APIC : Uses RDMSR/WRMSR instructions to access APIC registers */
-static apic_reg_ops_t x2apic_regs_ops = {
-	local_x2apic_read,
-	local_x2apic_write,
-	get_local_x2apic_pri,
-	local_x2apic_write_task_reg,
-	local_x2apic_write_int_cmd,
 	apic_send_EOI,
 };
 
@@ -100,8 +85,6 @@ apic_reg_ops_t *apic_reg_ops = &local_apic_regs_ops;
  */
 void apic_send_EOI();
 void apic_send_directed_EOI(uint32_t irq);
-
-#define	X2APIC_ENABLE_BIT	10
 
 /*
  * Local APIC Implementation
@@ -150,51 +133,6 @@ local_apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1)
 	apicadr[APIC_INT_CMD1] = cmd1;
 }
 
-/*
- * X2APIC Implementation.
- */
-static uint64_t
-local_x2apic_read(uint32_t msr)
-{
-	uint64_t i;
-
-	i = (uint64_t)(rdmsr(REG_X2APIC_BASE_MSR + (msr >> 2)) & 0xffffffff);
-	return (i);
-}
-
-static void
-local_x2apic_write(uint32_t msr, uint64_t value)
-{
-	uint64_t tmp;
-
-	if (msr != APIC_EOI_REG) {
-		tmp = rdmsr(REG_X2APIC_BASE_MSR + (msr >> 2));
-		tmp = (tmp & 0xffffffff00000000) | value;
-	} else {
-		tmp = 0;
-	}
-
-	wrmsr((REG_X2APIC_BASE_MSR + (msr >> 2)), tmp);
-}
-
-static int
-get_local_x2apic_pri(void)
-{
-	return (rdmsr(REG_X2APIC_BASE_MSR + (APIC_TASK_REG >> 2)));
-}
-
-static void
-local_x2apic_write_task_reg(uint64_t value)
-{
-	X2APIC_WRITE(APIC_TASK_REG, value);
-}
-
-static void
-local_x2apic_write_int_cmd(uint32_t cpu_id, uint32_t cmd1)
-{
-	wrmsr((REG_X2APIC_BASE_MSR + (APIC_INT_CMD1 >> 2)),
-	    (((uint64_t)cpu_id << 32) | cmd1));
-}
 
 /*ARGSUSED*/
 void
@@ -234,38 +172,6 @@ apic_send_directed_EOI(uint32_t irq)
 		}
 		apic_irq = apic_irq->airq_next;
 	}
-}
-
-int
-apic_detect_x2apic(void)
-{
-	if (x2apic_enable == 0)
-		return (0);
-
-	return (is_x86_feature(x86_featureset, X86FSET_X2APIC));
-}
-
-void
-apic_enable_x2apic(void)
-{
-	uint64_t apic_base_msr;
-
-	if (apic_local_mode() == LOCAL_X2APIC) {
-		/* BIOS apparently has enabled X2APIC */
-		if (apic_mode != LOCAL_X2APIC)
-			x2apic_update_psm();
-		return;
-	}
-
-	/*
-	 * This is the first time we are enabling X2APIC on this CPU
-	 */
-	apic_base_msr = rdmsr(REG_APIC_BASE_MSR);
-	apic_base_msr = apic_base_msr | (0x1 << X2APIC_ENABLE_BIT);
-	wrmsr(REG_APIC_BASE_MSR, apic_base_msr);
-
-	if (apic_mode != LOCAL_X2APIC)
-		x2apic_update_psm();
 }
 
 /*
@@ -338,105 +244,4 @@ apic_directed_EOI_supported()
 		return (1);
 
 	return (0);
-}
-
-/*
- * Change apic_reg_ops depending upon the apic_mode.
- */
-void
-apic_change_ops()
-{
-	if (apic_mode == LOCAL_APIC)
-		apic_reg_ops = &local_apic_regs_ops;
-	else if (apic_mode == LOCAL_X2APIC)
-		apic_reg_ops = &x2apic_regs_ops;
-}
-
-/*
- * Generates an interprocessor interrupt to another CPU when X2APIC mode is
- * enabled.
- */
-void
-x2apic_send_ipi(int cpun, int ipl)
-{
-	int vector;
-	ulong_t flag;
-
-	ASSERT(apic_mode == LOCAL_X2APIC);
-
-	/*
-	 * With X2APIC, Intel relaxed the semantics of the
-	 * WRMSR instruction such that references to the X2APIC
-	 * MSR registers are no longer serializing instructions.
-	 * The code that initiates IPIs assumes that some sort
-	 * of memory serialization occurs. The old APIC code
-	 * did a write to uncachable memory mapped registers.
-	 * Any reference to uncached memory is a serializing
-	 * operation. To mimic those semantics here, we do an
-	 * atomic operation, which translates to a LOCK OR instruction,
-	 * which is serializing.
-	 */
-	atomic_or_ulong(&flag, 1);
-
-	vector = apic_resv_vector[ipl];
-
-	flag = intr_clear();
-
-	/*
-	 * According to X2APIC specification in section '2.3.5.1' of
-	 * Interrupt Command Register Semantics, the semantics of
-	 * programming Interrupt Command Register to dispatch an interrupt
-	 * is simplified. A single MSR write to the 64-bit ICR is required
-	 * for dispatching an interrupt. Specifically with the 64-bit MSR
-	 * interface to ICR, system software is not required to check the
-	 * status of the delivery status bit prior to writing to the ICR
-	 * to send an IPI. With the removal of the Delivery Status bit,
-	 * system software no longer has a reason to read the ICR. It remains
-	 * readable only to aid in debugging.
-	 */
-#ifdef	DEBUG
-	APIC_AV_PENDING_SET();
-#endif	/* DEBUG */
-
-	if ((cpun == psm_get_cpu_id())) {
-		X2APIC_WRITE(X2APIC_SELF_IPI, vector);
-	} else {
-		apic_reg_ops->apic_write_int_cmd(
-		    apic_cpus[cpun].aci_local_id, vector);
-	}
-
-	intr_restore(flag);
-}
-
-/*
- * Generates IPI to another CPU depending on the local APIC mode.
- * apic_send_ipi() and x2apic_send_ipi() depends on the configured
- * mode of the local APIC, but that may not match the actual mode
- * early in CPU startup.
- *
- * Any changes made to this routine must be accompanied by similar
- * changes to apic_send_ipi().
- */
-void
-apic_common_send_ipi(int cpun, int ipl)
-{
-	int vector;
-	ulong_t flag;
-	int mode = apic_local_mode();
-
-	if (mode == LOCAL_X2APIC) {
-		x2apic_send_ipi(cpun, ipl);
-		return;
-	}
-
-	ASSERT(mode == LOCAL_APIC);
-
-	vector = apic_resv_vector[ipl];
-	ASSERT((vector >= APIC_BASE_VECT) && (vector <= APIC_SPUR_INTR));
-	flag = intr_clear();
-	while (local_apic_regs_ops.apic_read(APIC_INT_CMD1) & AV_PENDING)
-		apic_ret();
-	local_apic_regs_ops.apic_write_int_cmd(apic_cpus[cpun].aci_local_id,
-	    vector);
-	intr_restore(flag);
 }

--- a/usr/src/uts/i86pc/io/rootnex.c
+++ b/usr/src/uts/i86pc/io/rootnex.c
@@ -25,6 +25,7 @@
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2011 Bayard G. Bell.  All rights reserved.
  * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -2171,7 +2172,7 @@ out:
 	 */
 	if ((sinfo->si_copybuf_req == 0) &&
 	    (sinfo->si_sgl_size <= (unsigned)attr->dma_attr_sgllen) &&
-	    (dmao->dmao_size < dma->dp_maxxfer)) {
+	    (dmao->dmao_size <= dma->dp_maxxfer)) {
 fast:
 		/*
 		 * If the driver supports FMA, insert the handle in the FMA DMA
@@ -2336,7 +2337,7 @@ rootnex_coredma_unbindhdl(dev_info_t *dip, dev_info_t *rdip,
 	rootnex_teardown_windows(dma);
 
 #if defined(__amd64) && !defined(__xpv)
-	if (IOMMU_USED(rdip))
+	if (IOMMU_USED(rdip) && dma->dp_dvma_used)
 		(void) iommulib_nexdma_unmapobject(dip, rdip, handle,
 		    &dma->dp_dvma);
 #endif

--- a/usr/src/uts/i86pc/pcplusmp/Makefile
+++ b/usr/src/uts/i86pc/pcplusmp/Makefile
@@ -24,7 +24,7 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Copyright 2016, Joyent, Inc.
+# Copyright 2017, Joyent, Inc.
 #
 
 #
@@ -66,20 +66,6 @@ $(NOT_RELEASE_BUILD)DEBUG_DEFS	+= $(DEBUG_FLGS)
 # Depends on ACPI CA interpreter
 #
 LDFLAGS		+= -dy -N misc/acpica
-
-CERRWARN	+= -_gcc=-Wno-unused-function
-
-#
-# For now, disable these lint checks; maintainers should endeavor
-# to investigate and remove these for maximum lint coverage.
-# Please do not carry these forward to new Makefiles.
-#
-LINTTAGS	+= -erroff=E_BAD_PTR_CAST_ALIGN
-LINTTAGS	+= -erroff=E_SUPPRESSION_DIRECTIVE_UNUSED
-LINTTAGS	+= -erroff=E_STATIC_UNUSED
-LINTTAGS	+= -erroff=E_ASSIGN_NARROW_CONV
-
-CERRWARN	+= -_gcc=-Wno-uninitialized
 
 #
 #	Default build targets.

--- a/usr/src/uts/i86pc/sys/apic.h
+++ b/usr/src/uts/i86pc/sys/apic.h
@@ -20,8 +20,8 @@
  */
 /*
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
-
 /*
  * Copyright (c) 2010, Intel Corporation.
  * All rights reserved.
@@ -116,6 +116,9 @@ typedef enum apic_mode {
 /* General x2APIC constants used at various places */
 #define	APIC_SVR_SUPPRESS_BROADCAST_EOI		0x1000
 #define	APIC_DIRECTED_EOI_BIT			0x1000000
+
+/* x2APIC enable bit in REG_APIC_BASE_MSR */
+#define	X2APIC_ENABLE_BIT	10
 
 /* IRR register	*/
 #define	APIC_IRR_REG		0x80
@@ -867,6 +870,7 @@ extern int apic_sci_vect;
 extern int apic_hpet_vect;
 extern uchar_t apic_ipls[];
 extern apic_reg_ops_t *apic_reg_ops;
+extern apic_reg_ops_t local_apic_regs_ops;
 extern apic_mode_t apic_mode;
 extern void x2apic_update_psm();
 extern void apic_change_ops();

--- a/usr/src/uts/i86pc/sys/apix.h
+++ b/usr/src/uts/i86pc/sys/apix.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #ifndef __SYS_APIX_APIX_H
@@ -287,11 +288,12 @@ extern struct apix_rebind_info apix_rebindinfo;
 
 #define	APIX_DO_FAKE_INTR(_cpu, _vector)\
 	if (APIX_IS_FAKE_INTR(_vector)) {\
-		struct autovec *tp;\
+		struct autovec *tp = NULL;\
 		if ((_cpu) == apix_rebindinfo.i_old_cpuid)\
 			tp = apix_rebindinfo.i_old_av;\
 		else if ((_cpu) == apix_rebindinfo.i_new_cpuid)\
 			tp = apix_rebindinfo.i_new_av;\
+		ASSERT(tp != NULL);\
 		if (tp->av_vector != NULL &&\
 		    (tp->av_flags & AV_PENTRY_PEND) == 0) {\
 			tp->av_flags |= AV_PENTRY_PEND;\


### PR DESCRIPTION
Weekly upstream merge from gate.

## backports

* 8651 loader: biosmem allocate heap just below 4GB

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2017092101-aae393d3e5 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu Sep 21 09:54:46 UTC 2017 ====
==== Nightly distributed build completed: Thu Sep 21 10:56:53 UTC 2017 ====

==== Total build time ====

real    1:02:07

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-5e982daae6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   709620

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2017092101-aae393d3e5

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:41.0
user  1:32:38.5
sys     11:56.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:07.1
user  1:23:27.9
sys      8:49.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    20:07.2
user  1:07:42.5
sys     20:30.7

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```