### PR TITLE
Joyent merge/2017092101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 9094e8556e7c00d1961a4dbff4777f615669fba8
+Last illumos-joyent commit: d78c4ca74e47a36eb7759ccc148b752017aef6bc
 

--- a/usr/src/lib/brand/lx/lx_init/lxinit.c
+++ b/usr/src/lib/brand/lx/lx_init/lxinit.c
@@ -810,7 +810,7 @@ lxi_hook_postnet()
 		lxi_err("fork() failed: %s", strerror(errno));
 	}
 	if (pid == 0) {
-		char *const argv[] = { cmd, NULL };
+		char *argv[] = { cmd, NULL };
 		char *const envp[] = { NULL };
 
 		/* wire up stderr first, in case the hook wishes to use it */
@@ -819,7 +819,7 @@ lxi_hook_postnet()
 		}
 
 		/* child executes the hook */
-		execve(cmd, argv, envp);
+		(void) execve(cmd, (char *const *)argv, envp);
 
 		/*
 		 * Since this is running as root, access(2) is less strict than
@@ -836,7 +836,7 @@ lxi_hook_postnet()
 
 	/* Parent waits for the hook to complete */
 	while (wait(&status) != pid) {
-		/* EMPTY */;
+		;
 	}
 	if (WIFEXITED(status)) {
 		if (WEXITSTATUS(status) != 0) {

--- a/usr/src/lib/brand/lx/lx_init/lxinit.c
+++ b/usr/src/lib/brand/lx/lx_init/lxinit.c
@@ -20,7 +20,7 @@
  */
 
 /*
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -72,8 +72,9 @@
 static void lxi_err(char *msg, ...) __NORETURN;
 static void lxi_err(char *msg, ...);
 
-#define	IPMGMTD_PATH	"/lib/inet/ipmgmtd"
-#define	IN_NDPD_PATH	"/usr/lib/inet/in.ndpd"
+#define	IPMGMTD_PATH		"/lib/inet/ipmgmtd"
+#define	IN_NDPD_PATH		"/usr/lib/inet/in.ndpd"
+#define	HOOK_POSTNET_PATH	"/usr/lib/brand/lx/lx_hook_postnet"
 
 #define	PREFIX_LOG_WARN	"lx_init warn: "
 #define	PREFIX_LOG_ERR	"lx_init err: "
@@ -792,6 +793,65 @@ lxi_config_close(zone_dochandle_t handle)
 }
 
 static void
+lxi_hook_postnet()
+{
+	char cmd[MAXPATHLEN];
+	const char *zroot = zone_get_nroot();
+	pid_t pid;
+	int status;
+
+	(void) snprintf(cmd, sizeof (cmd), "%s%s", zroot, HOOK_POSTNET_PATH);
+	if (access(cmd, X_OK) != 0) {
+		/* If no suitable script is present, soldier on. */
+		return;
+	}
+
+	if ((pid = fork()) < 0) {
+		lxi_err("fork() failed: %s", strerror(errno));
+	}
+	if (pid == 0) {
+		char *const argv[] = { cmd, NULL };
+		char *const envp[] = { NULL };
+
+		/* wire up stderr first, in case the hook wishes to use it */
+		if (dup2(1, 2) < 0) {
+			lxi_err("dup2() failed: %s", cmd, strerror(errno));
+		}
+
+		/* child executes the hook */
+		execve(cmd, argv, envp);
+
+		/*
+		 * Since this is running as root, access(2) is less strict than
+		 * necessary to ensure a successful exec.  If the permissions
+		 * on the hook are busted, ignore the failure and move on.
+		 */
+		if (errno == EACCES) {
+			exit(0);
+		}
+
+		lxi_err("execve(%s) failed: %s", cmd, strerror(errno));
+		/* NOTREACHED */
+	}
+
+	/* Parent waits for the hook to complete */
+	while (wait(&status) != pid) {
+		/* EMPTY */;
+	}
+	if (WIFEXITED(status)) {
+		if (WEXITSTATUS(status) != 0) {
+			lxi_err("%s[%d] exited: %d", cmd, (int)pid,
+			    WEXITSTATUS(status));
+		}
+	} else if (WIFSIGNALED(status)) {
+		lxi_err("%s[%d] died on signal: %d", cmd, (int)pid,
+		    WTERMSIG(status));
+	} else {
+		lxi_err("%s[%d] failed in unknown way", cmd, (int)pid);
+	}
+}
+
+static void
 lxi_init_exec(char **argv)
 {
 	const char *cmd = "/sbin/init";
@@ -836,6 +896,8 @@ main(int argc, char *argv[])
 	lxi_net_static_routes();
 
 	lxi_net_ipadm_close();
+
+	lxi_hook_postnet();
 
 	lxi_log_close();
 

--- a/usr/src/lib/smbsrv/libsmb/common/smb_kmod.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_kmod.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -42,7 +43,6 @@
 #include <smbsrv/libsmb.h>
 
 #define	SMBDRV_DEVICE_PATH		"/dev/smbsrv"
-#define	SMB_IOC_DATA_SIZE		(256 * 1024)
 
 int smb_kmod_ioctl(int, smb_ioc_header_t *, uint32_t);
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -244,6 +244,13 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_NET_IPV4_TCP_WINSCALE,	/* .../net/ipv4/tcp_window_scaling */
 	LXPR_SYS_NET_IPV4_TCP_WMEM,	/* /proc/sys/net/ipv4/tcp_wmem */
 	LXPR_SYS_VMDIR,			/* /proc/sys/vm			*/
+	LXPR_SYS_VM_DIRTY_BG_BYTES,	/* .../vm/dirty_background_bytes */
+	LXPR_SYS_VM_DIRTY_BG_RATIO,	/* .../vm/dirty_background_ratio */
+	LXPR_SYS_VM_DIRTY_BYTES,	/* /proc/sys/vm/dirty_bytes */
+	LXPR_SYS_VM_DIRTY_EXP_CS,	/* .../vm/dirty_expire_centisecs */
+	LXPR_SYS_VM_DIRTY_RATIO,	/* /proc/sys/vm/dirty_ratio */
+	LXPR_SYS_VM_DIRTYTIME_EXP_SEC,	/* .../vm/dirtytime_expire_seconds */
+	LXPR_SYS_VM_DIRTY_WB_CS,	/* .../vm/dirty_writeback_centisecs */
 	LXPR_SYS_VM_MAX_MAP_CNT,	/* /proc/sys/vm/max_map_count	*/
 	LXPR_SYS_VM_MINFR_KB,		/* /proc/sys/vm/min_free_kbytes	*/
 	LXPR_SYS_VM_NHUGEP,		/* /proc/sys/vm/nr_hugepages	*/

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -259,6 +259,7 @@ static void lxpr_read_sys_net_ipv4_tcp_max_syn_bl(lxpr_node_t *,
 static void lxpr_read_sys_net_ipv4_tcp_rwmem(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_sack(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_winscale(lxpr_node_t *, lxpr_uiobuf_t *);
+static void lxpr_read_sys_vm_dirty(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_vm_max_map_cnt(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_vm_minfr_kb(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_vm_nhpages(lxpr_node_t *, lxpr_uiobuf_t *);
@@ -617,6 +618,13 @@ static lxpr_dirent_t sys_net_ipv4dir[] = {
  * contents of /proc/sys/vm directory
  */
 static lxpr_dirent_t sys_vmdir[] = {
+	{ LXPR_SYS_VM_DIRTY_BG_BYTES,	"dirty_background_bytes" },
+	{ LXPR_SYS_VM_DIRTY_BG_RATIO,	"dirty_background_ratio" },
+	{ LXPR_SYS_VM_DIRTY_BYTES,	"dirty_bytes" },
+	{ LXPR_SYS_VM_DIRTY_EXP_CS,	"dirty_expire_centisecs" },
+	{ LXPR_SYS_VM_DIRTY_RATIO,	"dirty_ratio" },
+	{ LXPR_SYS_VM_DIRTYTIME_EXP_SEC, "dirtytime_expire_seconds" },
+	{ LXPR_SYS_VM_DIRTY_WB_CS,	"dirty_writeback_centisecs" },
 	{ LXPR_SYS_VM_MAX_MAP_CNT,	"max_map_count" },
 	{ LXPR_SYS_VM_MINFR_KB,		"min_free_kbytes" },
 	{ LXPR_SYS_VM_NHUGEP,		"nr_hugepages" },
@@ -662,6 +670,13 @@ static wftab_t wr_tab[] = {
 	{LXPR_SYS_NET_IPV4_TCP_SACK, lxpr_write_sys_net_ipv4_tcp_sack},
 	{LXPR_SYS_NET_IPV4_TCP_WINSCALE, lxpr_write_sys_net_ipv4_tcp_winscale},
 	{LXPR_SYS_NET_IPV4_TCP_WMEM, lxpr_write_sys_net_ipv4_tcp_rwmem},
+	{LXPR_SYS_VM_DIRTY_BG_BYTES, NULL},
+	{LXPR_SYS_VM_DIRTY_BG_RATIO, NULL},
+	{LXPR_SYS_VM_DIRTY_BYTES, NULL},
+	{LXPR_SYS_VM_DIRTY_EXP_CS, NULL},
+	{LXPR_SYS_VM_DIRTY_RATIO, NULL},
+	{LXPR_SYS_VM_DIRTYTIME_EXP_SEC, NULL},
+	{LXPR_SYS_VM_DIRTY_WB_CS, NULL},
 	{LXPR_SYS_VM_OVERCOMMIT_MEM, NULL},
 	{LXPR_SYS_VM_SWAPPINESS, NULL},
 	{LXPR_INVALID, NULL}
@@ -902,6 +917,13 @@ static void (*lxpr_read_function[LXPR_NFILES])() = {
 	lxpr_read_sys_net_ipv4_tcp_winscale, /* .../ipv4/tcp_window_scaling */
 	lxpr_read_sys_net_ipv4_tcp_rwmem, /* .../ipv4/tcp_wmem */
 	lxpr_read_invalid,		/* /proc/sys/vm	*/
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirty_background_bytes */
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirty_background_ratio */
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirty_bytes */
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirty_expire_centisecs */
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirty_ratio */
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirtytime_expire_seconds */
+	lxpr_read_sys_vm_dirty,		/* .../vm/dirty_writeback_centisecs */
 	lxpr_read_sys_vm_max_map_cnt,	/* /proc/sys/vm/max_map_count */
 	lxpr_read_sys_vm_minfr_kb,	/* /proc/sys/vm/min_free_kbytes */
 	lxpr_read_sys_vm_nhpages,	/* /proc/sys/vm/nr_hugepages */
@@ -1053,6 +1075,13 @@ static vnode_t *(*lxpr_lookup_function[LXPR_NFILES])() = {
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_window_scaling */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_wmem */
 	lxpr_lookup_sys_vmdir,		/* /proc/sys/vm */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirty_background_bytes */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirty_background_ratio */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirty_bytes */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirty_expire_centisecs */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirty_ratio */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirtytime_expire_seconds */
+	lxpr_lookup_not_a_dir,		/* .../vm/dirty_writeback_centisecs */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/vm/max_map_count */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/vm/min_free_kbytes */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/vm/nr_hugepages */
@@ -1204,6 +1233,13 @@ static int (*lxpr_readdir_function[LXPR_NFILES])() = {
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_window_scaling */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_wmem */
 	lxpr_readdir_sys_vmdir,		/* /proc/sys/vm */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirty_background_bytes */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirty_background_ratio */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirty_bytes */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirty_expire_centisecs */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirty_ratio */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirtytime_expire_seconds */
+	lxpr_readdir_not_a_dir,		/* .../vm/dirty_writeback_centisecs */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/vm/max_map_count */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/vm/min_free_kbytes */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/vm/nr_hugepages */
@@ -5102,6 +5138,50 @@ lxpr_read_sys_net_ipv4_tcp_winscale(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	tcps = ns->netstack_tcp;
 	lxpr_uiobuf_printf(uiobuf, "%d\n", tcps->tcps_wscale_always);
 	netstack_rele(ns);
+}
+
+/*
+ * The /proc/sys/vm/dirty* files are (poorly) documented in the Linux
+ * source file Documentation/sysctl/vm.txt. These are various VM tunables
+ * that we'll never support, but that a few misguided apps want to inspect and
+ * modify. We simply hardcode some default values and we'll lie about write
+ * success to these files.
+ */
+static void
+lxpr_read_sys_vm_dirty(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	uint_t val;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_VM_DIRTY_BG_BYTES ||
+	    lxpnp->lxpr_type == LXPR_SYS_VM_DIRTY_BG_RATIO ||
+	    lxpnp->lxpr_type == LXPR_SYS_VM_DIRTY_BYTES ||
+	    lxpnp->lxpr_type == LXPR_SYS_VM_DIRTY_EXP_CS ||
+	    lxpnp->lxpr_type == LXPR_SYS_VM_DIRTY_RATIO ||
+	    lxpnp->lxpr_type == LXPR_SYS_VM_DIRTYTIME_EXP_SEC ||
+	    lxpnp->lxpr_type == LXPR_SYS_VM_DIRTY_WB_CS);
+
+	switch (lxpnp->lxpr_type) {
+	case LXPR_SYS_VM_DIRTY_BG_RATIO:
+		val = 10;
+		break;
+	case LXPR_SYS_VM_DIRTY_EXP_CS:
+		val = 3000;
+		break;
+	case LXPR_SYS_VM_DIRTY_RATIO:
+		val = 20;
+		break;
+	case LXPR_SYS_VM_DIRTYTIME_EXP_SEC:
+		val = 43200;
+		break;
+	case LXPR_SYS_VM_DIRTY_WB_CS:
+		val = 500;
+		break;
+	default:
+		val = 0;
+		break;
+	}
+
+	lxpr_uiobuf_printf(uiobuf, "%u\n", val);
 }
 
 /* ARGSUSED */

--- a/usr/src/uts/common/fs/smbclnt/netsmb/smb_conn.h
+++ b/usr/src/uts/common/fs/smbclnt/netsmb/smb_conn.h
@@ -275,8 +275,7 @@ void smb_fscb_set(smb_fscb_t *);
  * Mostly used in: smb_dev.c, smb_usr.c
  */
 typedef struct smb_dev {
-	dev_info_t	*sd_dip;	/* ptr to dev_info node */
-	struct cred	*sd_cred;	/* per dev credentails */
+	kmutex_t	sd_lock;
 	struct smb_vc	*sd_vc;		/* Reference to VC */
 	struct smb_share *sd_share;	/* Reference to share if any */
 	int		sd_level;	/* SMBL_VC, ... */
@@ -285,6 +284,7 @@ typedef struct smb_dev {
 	int		sd_flags;	/* State of connection */
 #define	NSMBFL_OPEN		0x0001
 #define	NSMBFL_IOD		0x0002
+#define	NSMBFL_IOCTL		0x0004
 	int		sd_smbfid;	/* library read/write */
 	zoneid_t	zoneid;		/* Zone id */
 } smb_dev_t;

--- a/usr/src/uts/common/smbsrv/smb_ioctl.h
+++ b/usr/src/uts/common/smbsrv/smb_ioctl.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #ifndef _SMB_IOCTL_H_
@@ -117,6 +118,9 @@ typedef	struct smb_ioc_opennum {
 #define	SMB_SVCENUM_TYPE_TREE	0x54524545	/* 'TREE' */
 #define	SMB_SVCENUM_TYPE_FILE	0x46494C45	/* 'FILE' */
 #define	SMB_SVCENUM_TYPE_SHARE	0x53484152	/* 'SHAR' */
+
+/* The enumeration ioctl needs a LOT of space.  We cap it here. */
+#define	SMB_IOC_DATA_SIZE		(256 * 1024)
 
 typedef struct smb_svcenum {
 	uint32_t	se_type;	/* object type to enumerate */


### PR DESCRIPTION
Weekly joyent merge

## backports

* OS-6298 SMB client assumes serialized ioctls …
* OS-6297 SMB server ioctls should be appropriately sized … 
* OS-6319 Fix for OS-6297 forgot smb_ioc_svcenum_t …

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2017092101-1fe1b1faaf i86pc i386 i86pc
```

# lx zone

```
bloody% pfexec zlogin alpine
[Connected to zone 'alpine' pts/2]
   __        .                   .
 _|  |_      | .-. .  . .-. :--. |-
|_    _|     ;|   ||  |(.-' |  | |
  |__|   `--'  `-' `;-| `-' '  ' `-'
                   /  ;  Instance (Alpine Linux 3.5 20170303)
                   `-'   https://docs.joyent.com/images/container-native-linux

localhost:~#
```

## mail_msg

```
==== Nightly distributed build started:   Thu Sep 21 16:57:42 UTC 2017 ====
==== Nightly distributed build completed: Thu Sep 21 17:21:17 UTC 2017 ====

==== Total build time ====

real    0:23:34

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-5e982daae6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   715363

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017092101-1fe1b1faaf

==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real     4:20.4
user    10:40.8
sys      1:26.7

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    12:48.0
user    47:41.9
sys      6:58.6

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```