### PR TITLE
fix lint warning

### DIFF
--- a/usr/src/lib/brand/lx/lx_init/lxinit.c
+++ b/usr/src/lib/brand/lx/lx_init/lxinit.c
@@ -810,8 +810,9 @@ lxi_hook_postnet()
 		lxi_err("fork() failed: %s", strerror(errno));
 	}
 	if (pid == 0) {
-		char *argv[] = { cmd, NULL };
+		char *argv[] = { NULL, NULL };
 		char *const envp[] = { NULL };
+		argv[0] = cmd;
 
 		/* wire up stderr first, in case the hook wishes to use it */
 		if (dup2(1, 2) < 0) {
@@ -819,7 +820,7 @@ lxi_hook_postnet()
 		}
 
 		/* child executes the hook */
-		(void) execve(cmd, (char *const *)argv, envp);
+		(void) execve(cmd, argv, envp);
 
 		/*
 		 * Since this is running as root, access(2) is less strict than


### PR DESCRIPTION
this fixes the following lint warning:
`"lxinit.c", line 813: warning: non-constant initializer: op "U&" (E_NON_CONST_INIT)`

similar to how it has been done here:
https://github.com/omniosorg/illumos-omnios/blob/dbbdc0c68668ec9f0d8710905eb02ef10aa8d818/usr/src/lib/brand/lx/lx_init/lxinit.c#L211-L220