### PR TITLE
Fix zone update during onu

### DIFF
--- a/usr/src/tools/scripts/onu.sh.in
+++ b/usr/src/tools/scripts/onu.sh.in
@@ -241,13 +241,14 @@ do_cmd beadm create $createargs $targetbe
 do_cmd beadm mount $targetbe $tmpdir
 update $tmpdir
 do_cmd beadm activate $targetbe
-do_cmd beadm unmount $targetbe
-rmdir $tmpdir
 
 if [ "$no_zones" != 1 ]; then
 	for zone in `do_cmd zoneadm -R $tmpdir list -cip`; do
 		update_zone $zone
 	done
 fi
+
+do_cmd beadm unmount $targetbe
+rmdir $tmpdir
 
 exit 0


### PR DESCRIPTION
ONU currently prints an error message and fails to update any zones in the new BE:

```
...
Activated successfully
Unmounted successfully
zoneadm: root path must be a directory.
```

because the BE is unmounted too early.