### PR TITLE
Joyent merge/2017100501

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 02ba530437bfbfdddf56de010d62a5ff453813ae
+Last illumos-joyent commit: 6dda4c2c4460e45b80f917d3676f5ce39e479cac
 

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 6dda4c2c4460e45b80f917d3676f5ce39e479cac
+Last illumos-joyent commit: 3df01e00bc5ef3f882d18e8188e4165831f8b694
 

--- a/usr/src/cmd/mdb/common/modules/genunix/genunix.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/genunix.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2017, Joyent, Inc.
  * Copyright (c) 2013 by Delphix. All rights reserved.
  */
 
@@ -160,8 +160,15 @@ ps_threadprint(uintptr_t addr, const void *data, void *private)
 	if (prt_flags & PS_PRTTHREADS)
 		mdb_printf("\tT  %?a <%b>\n", addr, t->t_state, t_state_bits);
 
-	if (prt_flags & PS_PRTLWPS)
-		mdb_printf("\tL  %?a ID: %u\n", t->t_lwp, t->t_tid);
+	if (prt_flags & PS_PRTLWPS) {
+		char name[THREAD_NAME_MAX];
+
+		mdb_printf("\tL  %?a ID: %u", t->t_lwp, t->t_tid);
+		if (thread_getname(addr, name, sizeof (name))) {
+			mdb_printf(" NAME: %s", name);
+		}
+		mdb_printf("\n");
+	}
 
 	return (WALK_NEXT);
 }

--- a/usr/src/cmd/mdb/common/modules/genunix/thread.h
+++ b/usr/src/cmd/mdb/common/modules/genunix/thread.h
@@ -21,6 +21,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright (c) 2017, Joyent, Inc.
  */
 
 #ifndef	_THREAD_H
@@ -57,6 +59,8 @@ void stackinfo_help(void);
 void thread_state_to_text(uint_t, char *, size_t);
 int thread_text_to_state(const char *, uint_t *);
 void thread_walk_states(void (*)(uint_t, const char *, void *), void *);
+
+boolean_t thread_getname(uintptr_t, char *, size_t);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/lib/brand/lx/testing/ltp_skiplist
+++ b/usr/src/lib/brand/lx/testing/ltp_skiplist
@@ -240,11 +240,7 @@ setxattr02
 setxattr03
 sgetmask01
 shmget05		# OS-3326
-splice01
-splice02
-splice03
-splice04
-splice05
+splice02		# bad test, fails on Linux too
 ssetmask01
 sync_file_range01
 sysconf01		# OS-3305

--- a/usr/src/uts/common/brand/lx/os/lx_syscall.c
+++ b/usr/src/uts/common/brand/lx/os/lx_syscall.c
@@ -836,7 +836,7 @@ lx_sysent_t lx_sysent32[] = {
 	{"unshare",	lx_unshare,		0,		1}, /* 310 */
 	{"set_robust_list", lx_set_robust_list,	0,		2}, /* 311 */
 	{"get_robust_list", lx_get_robust_list,	0,		3}, /* 312 */
-	{"splice",	NULL,			NOSYS_NULL,	0}, /* 313 */
+	{"splice",	lx_splice,		LX_SYS_EBPARG6,	6}, /* 313 */
 	{"sync_file_range", lx_sync_file_range,	0,		4}, /* 314 */
 	{"tee",		NULL,			NOSYS_NULL,	0}, /* 315 */
 	{"vmsplice",	NULL,			NOSYS_NULL,	0}, /* 316 */
@@ -1165,7 +1165,7 @@ lx_sysent_t lx_sysent64[] = {
 	{"unshare",	lx_unshare,		0,		1}, /* 272 */
 	{"set_robust_list", lx_set_robust_list,	0,		2}, /* 273 */
 	{"get_robust_list", lx_get_robust_list,	0,		3}, /* 274 */
-	{"splice",	NULL,			NOSYS_NULL,	0}, /* 275 */
+	{"splice",	lx_splice,		0,		6}, /* 275 */
 	{"tee",		NULL,			NOSYS_NULL,	0}, /* 276 */
 	{"sync_file_range", lx_sync_file_range,	0,		4}, /* 277 */
 	{"vmsplice",	NULL,			NOSYS_NULL,	0}, /* 278 */

--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -234,11 +234,14 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_NET_COREDIR,		/* /proc/sys/net/core		*/
 	LXPR_SYS_NET_CORE_SOMAXCON,	/* /proc/sys/net/core/somaxconn	*/
 	LXPR_SYS_NET_IPV4DIR,		/* /proc/sys/net/ipv4		*/
+	LXPR_SYS_NET_IPV4_ICMP_EIB,	/* .../icmp_echo_ignore_broadcasts */
+	LXPR_SYS_NET_IPV4_IP_FORWARD,	/* .../net/ipv4/ip_forward */
 	LXPR_SYS_NET_IPV4_IP_LPORT_RANGE, /* .../net/ipv4/ip_local_port_range */
 	LXPR_SYS_NET_IPV4_TCP_FIN_TO,	/* /proc/sys/net/ipv4/tcp_fin_timeout */
 	LXPR_SYS_NET_IPV4_TCP_KA_INT,	/* .../net/ipv4/tcp_keepalive_intvl */
 	LXPR_SYS_NET_IPV4_TCP_KA_TIM,	/* .../net/ipv4/tcp_keepalive_time */
 	LXPR_SYS_NET_IPV4_TCP_MAX_SYN_BL, /* .../net/ipv4/tcp_max_syn_backlog */
+	LXPR_SYS_NET_IPV4_TCP_RETRY2,	/* /proc/sys/net/ipv4/tcp_retries2 */
 	LXPR_SYS_NET_IPV4_TCP_RMEM,	/* /proc/sys/net/ipv4/tcp_rmem */
 	LXPR_SYS_NET_IPV4_TCP_SACK,	/* /proc/sys/net/ipv4/tcp_sack */
 	LXPR_SYS_NET_IPV4_TCP_WINSCALE,	/* .../net/ipv4/tcp_window_scaling */

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -249,6 +249,8 @@ static void lxpr_read_sys_kernel_shmmax(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_shmmni(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_threads_max(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_core_somaxc(lxpr_node_t *, lxpr_uiobuf_t *);
+static void lxpr_read_sys_net_ipv4_icmp_eib(lxpr_node_t *, lxpr_uiobuf_t *);
+static void lxpr_read_sys_net_ipv4_ip_forward(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_ip_lport_range(lxpr_node_t *,
     lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_fin_to(lxpr_node_t *, lxpr_uiobuf_t *);
@@ -256,6 +258,7 @@ static void lxpr_read_sys_net_ipv4_tcp_ka_int(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_ka_tim(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_max_syn_bl(lxpr_node_t *,
     lxpr_uiobuf_t *);
+static void lxpr_read_sys_net_ipv4_tcp_retry2(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_rwmem(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_sack(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_net_ipv4_tcp_winscale(lxpr_node_t *, lxpr_uiobuf_t *);
@@ -272,6 +275,8 @@ static int lxpr_write_sys_fs_pipe_max(lxpr_node_t *, uio_t *, cred_t *,
     caller_context_t *);
 static int lxpr_write_sys_net_core_somaxc(lxpr_node_t *, uio_t *, cred_t *,
     caller_context_t *);
+static int lxpr_write_sys_net_ipv4_icmp_eib(lxpr_node_t *, uio_t *,
+    cred_t *, caller_context_t *);
 static int lxpr_write_sys_net_ipv4_ip_lport_range(lxpr_node_t *, uio_t *,
     cred_t *, caller_context_t *);
 static int lxpr_write_sys_net_ipv4_tcp_fin_to(lxpr_node_t *, uio_t *, cred_t *,
@@ -281,6 +286,8 @@ static int lxpr_write_sys_net_ipv4_tcp_ka_int(lxpr_node_t *, uio_t *,
 static int lxpr_write_sys_net_ipv4_tcp_ka_tim(lxpr_node_t *, uio_t *,
     cred_t *, caller_context_t *);
 static int lxpr_write_sys_net_ipv4_tcp_max_syn_bl(lxpr_node_t *, uio_t *,
+    cred_t *, caller_context_t *);
+static int lxpr_write_sys_net_ipv4_tcp_retry2(lxpr_node_t *, uio_t *,
     cred_t *, caller_context_t *);
 static int lxpr_write_sys_net_ipv4_tcp_rwmem(lxpr_node_t *, uio_t *,
     cred_t *, caller_context_t *);
@@ -600,11 +607,14 @@ static lxpr_dirent_t sys_net_coredir[] = {
  * ip(7p) & tcp(7p) man pages for the native descriptions.
  */
 static lxpr_dirent_t sys_net_ipv4dir[] = {
+	{ LXPR_SYS_NET_IPV4_ICMP_EIB,	"icmp_echo_ignore_broadcasts" },
+	{ LXPR_SYS_NET_IPV4_IP_FORWARD, "ip_forward" },
 	{ LXPR_SYS_NET_IPV4_IP_LPORT_RANGE, "ip_local_port_range" },
 	{ LXPR_SYS_NET_IPV4_TCP_FIN_TO,	"tcp_fin_timeout" },
 	{ LXPR_SYS_NET_IPV4_TCP_KA_INT,	"tcp_keepalive_intvl" },
 	{ LXPR_SYS_NET_IPV4_TCP_KA_TIM,	"tcp_keepalive_time" },
 	{ LXPR_SYS_NET_IPV4_TCP_MAX_SYN_BL, "tcp_max_syn_backlog" },
+	{ LXPR_SYS_NET_IPV4_TCP_RETRY2,	"tcp_retries2" },
 	{ LXPR_SYS_NET_IPV4_TCP_RMEM,	"tcp_rmem" },
 	{ LXPR_SYS_NET_IPV4_TCP_SACK,	"tcp_sack" },
 	{ LXPR_SYS_NET_IPV4_TCP_WINSCALE, "tcp_window_scaling" },
@@ -659,6 +669,8 @@ static wftab_t wr_tab[] = {
 	{LXPR_SYS_KERNEL_SHMMAX, NULL},
 	{LXPR_SYS_FS_PIPE_MAX, lxpr_write_sys_fs_pipe_max},
 	{LXPR_SYS_NET_CORE_SOMAXCON, lxpr_write_sys_net_core_somaxc},
+	{LXPR_SYS_NET_IPV4_ICMP_EIB, lxpr_write_sys_net_ipv4_icmp_eib},
+	{LXPR_SYS_NET_IPV4_IP_FORWARD, NULL},
 	{LXPR_SYS_NET_IPV4_IP_LPORT_RANGE,
 	    lxpr_write_sys_net_ipv4_ip_lport_range},
 	{LXPR_SYS_NET_IPV4_TCP_FIN_TO, lxpr_write_sys_net_ipv4_tcp_fin_to},
@@ -666,6 +678,7 @@ static wftab_t wr_tab[] = {
 	{LXPR_SYS_NET_IPV4_TCP_KA_TIM, lxpr_write_sys_net_ipv4_tcp_ka_tim},
 	{LXPR_SYS_NET_IPV4_TCP_MAX_SYN_BL,
 	    lxpr_write_sys_net_ipv4_tcp_max_syn_bl},
+	{LXPR_SYS_NET_IPV4_TCP_RETRY2, lxpr_write_sys_net_ipv4_tcp_retry2},
 	{LXPR_SYS_NET_IPV4_TCP_RMEM, lxpr_write_sys_net_ipv4_tcp_rwmem},
 	{LXPR_SYS_NET_IPV4_TCP_SACK, lxpr_write_sys_net_ipv4_tcp_sack},
 	{LXPR_SYS_NET_IPV4_TCP_WINSCALE, lxpr_write_sys_net_ipv4_tcp_winscale},
@@ -907,11 +920,14 @@ static void (*lxpr_read_function[LXPR_NFILES])() = {
 	lxpr_read_invalid,		/* /proc/sys/net/core	*/
 	lxpr_read_sys_net_core_somaxc,	/* /proc/sys/net/core/somaxconn	*/
 	lxpr_read_invalid,		/* /proc/sys/net/ipv4	*/
+	lxpr_read_sys_net_ipv4_icmp_eib, /* .../icmp_echo_ignore_broadcasts */
+	lxpr_read_sys_net_ipv4_ip_forward, /* .../ipv4/ip_forward */
 	lxpr_read_sys_net_ipv4_ip_lport_range, /* ../ipv4/ip_local_port_range */
 	lxpr_read_sys_net_ipv4_tcp_fin_to, /* .../ipv4/tcp_fin_timeout */
 	lxpr_read_sys_net_ipv4_tcp_ka_int, /* .../ipv4/tcp_keepalive_intvl */
 	lxpr_read_sys_net_ipv4_tcp_ka_tim, /* .../ipv4/tcp_keepalive_time */
 	lxpr_read_sys_net_ipv4_tcp_max_syn_bl, /* ../ipv4/tcp_max_syn_backlog */
+	lxpr_read_sys_net_ipv4_tcp_retry2, /* .../ipv4/tcp_retries2 */
 	lxpr_read_sys_net_ipv4_tcp_rwmem, /* .../ipv4/tcp_rmem */
 	lxpr_read_sys_net_ipv4_tcp_sack, /* .../ipv4/tcp_sack */
 	lxpr_read_sys_net_ipv4_tcp_winscale, /* .../ipv4/tcp_window_scaling */
@@ -1065,11 +1081,14 @@ static vnode_t *(*lxpr_lookup_function[LXPR_NFILES])() = {
 	lxpr_lookup_sys_net_coredir,	/* /proc/sys/net/core */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/net/core/somaxconn */
 	lxpr_lookup_sys_net_ipv4dir,	/* /proc/sys/net/ipv4 */
+	lxpr_lookup_not_a_dir,		/* .../icmp_echo_ignore_broadcasts */
+	lxpr_lookup_not_a_dir,		/* .../net/ipv4/ip_forward */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/ip_local_port_range */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_fin_timeout */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_keepalive_intvl */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_keepalive_time */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_max_syn_backlog */
+	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_retries2 */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_rmem */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_sack */
 	lxpr_lookup_not_a_dir,		/* .../net/ipv4/tcp_window_scaling */
@@ -1223,11 +1242,14 @@ static int (*lxpr_readdir_function[LXPR_NFILES])() = {
 	lxpr_readdir_sys_net_coredir,	/* /proc/sys/net/core */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/net/core/somaxconn */
 	lxpr_readdir_sys_net_ipv4dir,	/* /proc/sys/net/ipv4 */
+	lxpr_readdir_not_a_dir,		/* .../icmp_echo_ignore_broadcasts */
+	lxpr_readdir_not_a_dir,		/* .../net/ipv4/ip_forward */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/ip_local_port_range */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_fin_timeout */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_keepalive_intvl */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_keepalive_time */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_max_syn_backlog */
+	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_retries2 */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_rmem */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_sack */
 	lxpr_readdir_not_a_dir,		/* .../net/ipv4/tcp_window_scaling */
@@ -4879,6 +4901,55 @@ lxpr_read_sys_net_core_somaxc(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 }
 
 /*
+ * icmp_echo_ignore_broadcasts
+ * integer; 0 or 1
+ *
+ * illumos: ndd /dev/ip ip_respond_to_echo_broadcast
+ * From the tunable guide: Control whether IPv4 responds to broadcast ICMPv4
+ * echo request. default: 1 (enabled)
+ * Not in ip(7p) man page.
+ *
+ * Note that the Linux setting is the inverse of the illumos value.
+ */
+/* ARGSUSED */
+static void
+lxpr_read_sys_net_ipv4_icmp_eib(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	netstack_t *ns;
+	ip_stack_t *ipst;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_ICMP_EIB);
+
+	ns = lxpr_netstack(lxpnp);
+	if (ns == NULL) {
+		lxpr_uiobuf_seterr(uiobuf, ENXIO);
+		return;
+	}
+
+	ipst = ns->netstack_ip;
+	lxpr_uiobuf_printf(uiobuf, "%d\n", !ipst->ips_ip_g_resp_to_echo_bcast);
+	netstack_rele(ns);
+}
+
+/*
+ * ip_forward
+ * integer; default: 0
+ *
+ * illumos: ndd /dev/ip ip_forwarding
+ * default: 0 (disabled)
+ * Forwarding is described in the ip(7p) man page. We do not support forwarding
+ * in lx at this time, thus we do not support Linux-ABI methods for
+ * enabling/disabling forwarding, and this is always 0.
+ */
+/* ARGSUSED */
+static void
+lxpr_read_sys_net_ipv4_ip_forward(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_IP_FORWARD);
+	lxpr_uiobuf_printf(uiobuf, "0\n");
+}
+
+/*
  * ip_local_port_range
  *
  * The low & high port number range.
@@ -5033,6 +5104,57 @@ lxpr_read_sys_net_ipv4_tcp_max_syn_bl(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	tcps = ns->netstack_tcp;
 	lxpr_uiobuf_printf(uiobuf, "%d\n", tcps->tcps_conn_req_max_q0);
 	netstack_rele(ns);
+}
+
+/*
+ * tcp_retries2
+ *
+ * Controls number of TCP retries for data packets. Often tuned down for HA
+ * configurations. RFC 1122 recommends at least 100 seconds for the timeout,
+ * which, for Linux, corresponds to a value of ~8. Oracle suggests a value of
+ * 3 for a RAC configuration, as do various HA tuning guides.
+ * integer; Ubuntu 16.04 default: 15
+ *
+ * illumos: There are 4 ndd parameters that are related to this:
+ *	tcp_rexmit_interval_initial:	 1000
+ *	tcp_rexmit_interval_min:	  400
+ *	tcp_rexmit_interval_max:	60000
+ * 	tcp_rexmit_interval_extra:	    0
+ * Not in tcp(7p) man page.
+ *
+ * From the tunables guide:
+ * tcp_rexmit_interval_initial is the initial retransmission timeout (RTO) for
+ * a TCP connection in milliseconds (ms).
+ * The interval_min value is the minimum RTO in ms.
+ * The interval_max value is the maximum RTO in ms.
+ * The extra value is an extra time (in ms) to add in to the RTO.
+ */
+/* ARGSUSED */
+static void
+lxpr_read_sys_net_ipv4_tcp_retry2(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	netstack_t *ns;
+	tcp_stack_t *tcps;
+	uint_t i, retry, rx_min, rx_max;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_TCP_RETRY2);
+
+	ns = lxpr_netstack(lxpnp);
+	if (ns == NULL) {
+		lxpr_uiobuf_seterr(uiobuf, ENXIO);
+		return;
+	}
+
+	tcps = ns->netstack_tcp;
+	rx_min = tcps->tcps_rexmit_interval_min;
+	rx_max = tcps->tcps_rexmit_interval_max;
+	netstack_rele(ns);
+
+	for (i = rx_min, retry = 0; i < rx_max; retry++) {
+		i *= 2;
+	}
+
+	lxpr_uiobuf_printf(uiobuf, "%u\n", retry);
 }
 
 /*
@@ -7165,6 +7287,45 @@ lxpr_xlate_ka_intvl(char *val, int size)
 	return (0);
 }
 
+/*
+ * Approximately translate the input count value into a reasonable
+ * _rexmit_interval_max timeout.
+ */
+static int
+lxpr_xlate_retry2(char *val, int size)
+{
+	long cnt;
+	char *ep;
+	uint_t i, rx_max;
+
+	if (lxpr_tokenize_num(val, &cnt, &ep) != 0)
+		return (EINVAL);
+	if (*ep != '\0')
+		return (EINVAL);
+
+	/*
+	 * The _rexmit_interval_max is limited to 2 hours, so a count of 15
+	 * or more will exceed that due to exponential backoff.
+	 */
+	if (cnt > 15)
+		cnt = 15;
+
+	rx_max = 400;	/* Start with default _rexmit_interval_min in ms */
+	for (i = 0; i < cnt; i++)
+		rx_max *= 2;
+
+	/*
+	 * The _rexmit_interval_max is limited to 2 hours, so if we went over
+	 * the limit, just use 2 hours (in ms).
+	 */
+	if (rx_max > (7200 * 1000))
+		rx_max = 7200 * 1000;
+
+	if (snprintf(val, size, "%u", rx_max) >= size)
+		return (EINVAL);
+	return (0);
+}
+
 static int
 lxpr_xlate_sack(char *val, int size)
 {
@@ -7180,6 +7341,63 @@ lxpr_xlate_sack(char *val, int size)
 	/* see comment on lxpr_read_sys_net_ipv4_tcp_sack */
 	if (snprintf(val, size, "%d", (flag == 0 ? 0 : 2)) >= size)
 		return (EINVAL);
+	return (0);
+}
+
+/*
+ * We're updating a property on the ip stack so we can't reuse
+ * lxpr_write_tcp_property.
+ */
+/* ARGSUSED */
+static int
+lxpr_write_sys_net_ipv4_icmp_eib(lxpr_node_t *lxpnp, struct uio *uio,
+    struct cred *cr, caller_context_t *ct)
+{
+	int error;
+	size_t olen;
+	char val[16];	/* big enough for a uint numeric string */
+	long flag;
+	char *ep;
+	netstack_t *ns;
+	ip_stack_t *ipst;
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_ICMP_EIB);
+
+	if (uio->uio_loffset != 0)
+		return (EINVAL);
+
+	if (uio->uio_resid == 0)
+		return (0);
+
+	olen = uio->uio_resid;
+	if (olen > sizeof (val) - 1)
+		return (EINVAL);
+
+	bzero(val, sizeof (val));
+	error = uiomove(val, olen, UIO_WRITE, uio);
+	if (error != 0)
+		return (error);
+
+	if (val[olen - 1] == '\n')
+		val[olen - 1] = '\0';
+
+	if (val[0] == '\0') /* no input */
+		return (EINVAL);
+
+	if (lxpr_tokenize_num(val, &flag, &ep) != 0)
+		return (EINVAL);
+
+	if (*ep != '\0' || (flag != 0 && flag != 1))
+		return (EINVAL);
+
+	ns = lxpr_netstack(lxpnp);
+	if (ns == NULL)
+		return (EINVAL);
+
+	ipst = ns->netstack_ip;
+	ipst->ips_ip_g_resp_to_echo_bcast = !flag;
+
+	netstack_rele(ns);
 	return (0);
 }
 
@@ -7400,6 +7618,15 @@ lxpr_write_sys_net_ipv4_tcp_max_syn_bl(lxpr_node_t *lxpnp, struct uio *uio,
 	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_TCP_MAX_SYN_BL);
 	return (lxpr_write_tcp_property(lxpnp, uio, cr, ct,
 	    "_conn_req_max_q0", NULL));
+}
+
+static int
+lxpr_write_sys_net_ipv4_tcp_retry2(lxpr_node_t *lxpnp, struct uio *uio,
+    struct cred *cr, caller_context_t *ct)
+{
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_NET_IPV4_TCP_RETRY2);
+	return (lxpr_write_tcp_property(lxpnp, uio, cr, ct,
+	    "_rexmit_interval_max", lxpr_xlate_retry2));
 }
 
 static int

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -1781,6 +1781,10 @@ lxpr_read_pid_maps(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 		vnode_t *vp;
 		uint_t protbits;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		pbuf = kmem_alloc(sizeof (*pbuf), KM_SLEEP);
 
 		pbuf->saddr = (uintptr_t)seg->s_base;

--- a/usr/src/uts/common/brand/lx/sys/lx_misc.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_misc.h
@@ -121,6 +121,9 @@ extern void lx_check_strict_failure(lx_lwp_data_t *);
 
 extern boolean_t lx_is_eventfd(file_t *);
 
+extern int lx_read_common(file_t *, uio_t *, size_t *, boolean_t);
+extern int lx_write_common(file_t *, uio_t *, size_t *, boolean_t);
+
 #endif
 
 #ifdef	__cplusplus

--- a/usr/src/uts/common/brand/lx/sys/lx_syscalls.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_syscalls.h
@@ -239,6 +239,7 @@ extern long lx_shutdown();
 extern long lx_socket();
 extern long lx_socketcall();
 extern long lx_socketpair();
+extern long lx_splice();
 extern long lx_stat32();
 extern long lx_stat64();
 extern long lx_stime();

--- a/usr/src/uts/common/brand/lx/syscall/lx_rw.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_rw.c
@@ -103,7 +103,7 @@ lx_iovec_copyin(void *uiovp, int iovcnt, iovec_t *kiovp, ssize_t *count)
 	return (0);
 }
 
-static int
+int
 lx_read_common(file_t *fp, uio_t *uiop, size_t *nread, boolean_t positioned)
 {
 	vnode_t *vp = fp->f_vnode;
@@ -205,7 +205,7 @@ out:
 	return (error);
 }
 
-static int
+int
 lx_write_common(file_t *fp, uio_t *uiop, size_t *nwrite, boolean_t positioned)
 {
 	vnode_t *vp = fp->f_vnode;

--- a/usr/src/uts/common/brand/lx/syscall/lx_splice.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_splice.c
@@ -1,0 +1,491 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017, Joyent, Inc.
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/thread.h>
+#include <sys/proc.h>
+#include <sys/zone.h>
+#include <sys/brand.h>
+#include <sys/sunddi.h>
+#include <sys/fs/fifonode.h>
+#include <sys/strsun.h>
+#include <sys/lx_brand.h>
+#include <sys/lx_types.h>
+#include <sys/lx_misc.h>
+#include <sys/lx_signal.h>
+
+/* Splice flags */
+#define	LX_SPLICE_F_MOVE	0x01
+#define	LX_SPLICE_F_NONBLOCK	0x02
+#define	LX_SPLICE_F_MORE	0x04
+#define	LX_SPLICE_F_GIFT	0x08
+
+/*
+ * Use a max buffer size of 32k. This is a good compromise between doing I/O in
+ * large chunks, the limit on how much data we can write into an lx pipe by
+ * default (LX_DEFAULT_PIPE_SIZE), and how much kernel memory we'll allocate.
+ */
+#define	LX_SPL_BUF_SIZE		(32 * 1024)
+
+/*
+ * We only want to read as much from the input fd as we can write into the
+ * output fd, up to our buffer size. Figure out what that quantity is.
+ * Note that len will continuously decrease to 0 which triggers the typical
+ * end of the splice loop.
+ */
+static size_t
+lx_spl_wr_sz(file_t *fp_out, u_offset_t fileoff, size_t bsz, size_t len,
+    boolean_t first)
+{
+	size_t sz;
+
+	sz = MIN(bsz, len);
+	if (fp_out->f_vnode->v_type == VFIFO) {
+		/*
+		 * If no readers on pipe, or if it would go over high water
+		 * mark then return 0. Note that the first write into a
+		 * pipe is expected to block if we're over the high water mark.
+		 */
+		fifonode_t *fn_dest = VTOF(fp_out->f_vnode)->fn_dest;
+		fifolock_t *fn_lock = fn_dest->fn_lock;
+
+		mutex_enter(&fn_lock->flk_lock);
+		if (fn_dest->fn_rcnt == 0) {
+			sz = 0;
+		} else if (!first &&
+		    (sz + fn_dest->fn_count) > fn_dest->fn_hiwat) {
+			sz = 0;
+		}
+		mutex_exit(&fn_lock->flk_lock);
+	} else if (fp_out->f_vnode->v_type == VREG) {
+		if (fileoff >= curproc->p_fsz_ctl ||
+		    fileoff >= OFFSET_MAX(fp_out)) {
+			sz = 0;
+		} else {
+			sz = MIN(sz, (size_t)curproc->p_fsz_ctl - fileoff);
+			sz = MIN(sz, (size_t)OFFSET_MAX(fp_out) - fileoff);
+		}
+	}
+
+	/*
+	 * if (fp_out->f_vnode->v_type == VSOCK)
+	 *
+	 * There is no good way to determine if a socket is "full". A write for
+	 * the different protocol implementations can return EWOULDBLOCK under
+	 * different conditions, none of which we can easily check for in
+	 * advance.
+	 */
+
+	return (sz);
+}
+
+/*
+ * The splice read function handles "reading" from a pipe and passes everything
+ * else along to our normal VOP_READ code path.
+ *
+ * When we have a pipe as our input, we don't want to consume the data out
+ * of the pipe until the write has succeeded. This aligns more closely with
+ * the Linux behavior when a write error occurs. Thus, when a pipe is the input
+ * and we got some data, we return with the fifo flagged as FIFORDBLOCK. This
+ * ensures that the data we're writing cannot be consumed by another thread
+ * until we consume it ourself.
+ *
+ * The pipe "read" code here is derived from the fifo I_PEEK code.
+ */
+static int
+lx_spl_read(file_t *fp, uio_t *uiop, size_t *nread, boolean_t pipe_in,
+    boolean_t rd_pos)
+{
+	fifonode_t *fnp;
+	fifolock_t *fn_lock;
+	int count;
+	mblk_t *bp;
+
+	if (!pipe_in)
+		return (lx_read_common(fp, uiop, nread, rd_pos));
+
+	ASSERT(fp->f_vnode->v_type == VFIFO);
+	fnp = VTOF(fp->f_vnode);
+	fn_lock = fnp->fn_lock;
+	*nread = 0;
+
+	mutex_enter(&fn_lock->flk_lock);
+
+	/*
+	 * If the pipe has been switched to socket mode then this implies an
+	 * internal programmatic error. Likewise, if it was switched to
+	 * socket mode because we dropped the lock to set the stayfast flag.
+	 */
+	if ((fnp->fn_flag & FIFOFAST) == 0 || !fifo_stayfast_enter(fnp)) {
+		mutex_exit(&fn_lock->flk_lock);
+		return (EBADF);
+	}
+
+	while (fnp->fn_count == 0 || (fnp->fn_flag & FIFORDBLOCK) != 0) {
+		fifonode_t *fn_dest = fnp->fn_dest;
+
+		/* No writer, EOF */
+		if (fn_dest->fn_wcnt == 0 || fn_dest->fn_rcnt == 0) {
+			fifo_stayfast_exit(fnp);
+			mutex_exit(&fn_lock->flk_lock);
+			return (0);
+		}
+
+		/* If non-blocking, return EAGAIN otherwise 0. */
+		if (uiop->uio_fmode & (FNDELAY|FNONBLOCK)) {
+			fifo_stayfast_exit(fnp);
+			mutex_exit(&fn_lock->flk_lock);
+			if (uiop->uio_fmode & FNONBLOCK)
+				return (EAGAIN);
+			return (0);
+		}
+
+		/* Wait for data */
+		fnp->fn_flag |= FIFOWANTR;
+		if (!cv_wait_sig_swap(&fnp->fn_wait_cv, &fn_lock->flk_lock)) {
+			fifo_stayfast_exit(fnp);
+			mutex_exit(&fn_lock->flk_lock);
+			return (EINTR);
+		}
+	}
+
+	VERIFY((fnp->fn_flag & FIFORDBLOCK) == 0);
+	VERIFY((fnp->fn_flag & FIFOSTAYFAST) != 0);
+
+	/* Get up to our read size or whatever is currently available. */
+	count = MIN(uiop->uio_resid, fnp->fn_count);
+	ASSERT(count > 0);
+	*nread = count;
+	bp = fnp->fn_mp;
+	while (count > 0) {
+		uint_t cnt = MIN(uiop->uio_resid, MBLKL(bp));
+
+		/*
+		 * We have the input pipe locked and we know there is data
+		 * available to consume. We're doing a UIO_SYSSPACE move into
+		 * an internal buffer that we allocated in lx_splice() so
+		 * this should never fail.
+		 */
+		VERIFY(uiomove((char *)bp->b_rptr, cnt, UIO_READ, uiop) == 0);
+		count -= cnt;
+		bp = bp->b_cont;
+	}
+
+	fnp->fn_flag |= FIFORDBLOCK;
+
+	mutex_exit(&fn_lock->flk_lock);
+	return (0);
+}
+
+/*
+ * We've already "read" the data out of the pipe without actually consuming it.
+ * Here we update the pipe to consume the data and discard it. This is derived
+ * from the fifo_read code, except that we already know the amount of data
+ * in the pipe to consume and we don't have to actually move any data.
+ */
+static void
+lx_spl_consume(file_t *fp, uint_t count)
+{
+	fifonode_t *fnp, *fn_dest;
+	fifolock_t *fn_lock;
+
+	ASSERT(fp->f_vnode->v_type == VFIFO);
+
+	fnp = VTOF(fp->f_vnode);
+	fn_lock = fnp->fn_lock;
+
+	mutex_enter(&fn_lock->flk_lock);
+	VERIFY(fnp->fn_count >= count);
+
+	while (count > 0) {
+		int bpsize = MBLKL(fnp->fn_mp);
+		int decr_size = MIN(bpsize, count);
+
+		fnp->fn_count -= decr_size;
+		if (bpsize <= decr_size) {
+			mblk_t *bp = fnp->fn_mp;
+			fnp->fn_mp = fnp->fn_mp->b_cont;
+			freeb(bp);
+		} else {
+			fnp->fn_mp->b_rptr += decr_size;
+		}
+
+		count -= decr_size;
+	}
+
+	fnp->fn_flag &= ~FIFORDBLOCK;
+	fifo_stayfast_exit(fnp);
+
+	fifo_wakereader(fnp, fn_lock);
+
+	/*
+	 * Wake up any blocked writers, processes sleeping on POLLWRNORM, or
+	 * processes waiting for SIGPOLL.
+	 */
+	fn_dest = fnp->fn_dest;
+	if (fn_dest->fn_flag & (FIFOWANTW | FIFOHIWATW) &&
+	    fnp->fn_count < fn_dest->fn_hiwat) {
+		fifo_wakewriter(fn_dest, fn_lock);
+	}
+
+	/* Update vnode update access time */
+	fnp->fn_atime = fnp->fn_dest->fn_atime = gethrestime_sec();
+
+	mutex_exit(&fn_lock->flk_lock);
+}
+
+/*
+ * Transfer data from the input file descriptor to the output file descriptor
+ * without leaving the kernel. For Linux this is limited by it's kernel
+ * implementation which forces at least one of the file descriptors to be a
+ * pipe. Our implementation is likely quite different from the Linux
+ * one, which appears to play some VM tricks with shared pages from the pipe
+ * code. Instead, our implementation uses our normal VOP_READ/VOP_WRITE
+ * operations to internally move the data while using a single uio buffer. We
+ * implement the additional Linux behavior around the various checks and
+ * limitations.
+ *
+ * One key point on the read side is how we handle an input pipe. We don't
+ * want to consume the data out of the pipe until the write has succeeded.
+ * This aligns more closely with the Linux behavior when a write error occurs.
+ * The lx_spl_read() and lx_spl_consume() functions are used to handle this
+ * case.
+ */
+long
+lx_splice(int fd_in, off_t *off_in, int fd_out, off_t *off_out, size_t len,
+    uint_t flags)
+{
+	int error = 0;
+	file_t *fp_in = NULL, *fp_out = NULL;
+	boolean_t found_pipe = B_FALSE, rd_pos = B_FALSE, wr_pos = B_FALSE;
+	boolean_t first = B_TRUE, pipe_in = B_FALSE;
+	iovec_t iov;
+	uio_t uio;
+	void *buf = NULL;
+	off_t r_off = 0, w_off = 0;
+	ushort_t r_flag, w_flag;
+	size_t bsize = 0, wr_sz, nread, nwrite, total = 0;
+
+	/*
+	 * Start by validating the inputs.
+	 *
+	 * Linux doesn't bother to check for valid flags, so neither do we.
+	 * Also, aside from SPLICE_F_NONBLOCK, we ignore the rest of the
+	 * flags since they're just hints to the Linux kernel implementation
+	 * and have no effect on the proper functioning of the syscall.
+	 */
+
+	if (len == 0)
+		return (0);
+
+	if ((fp_in = getf(fd_in)) == NULL) {
+		error = EBADF;
+		goto done;
+	}
+	switch (fp_in->f_vnode->v_type) {
+	case VFIFO:
+		/* A fifo that is not in fast mode does not count as a pipe */
+		if (((VTOF(fp_in->f_vnode))->fn_flag & FIFOFAST) != 0) {
+			found_pipe = B_TRUE;
+			pipe_in = B_TRUE;
+		}
+		/*FALLTHROUGH*/
+	case VSOCK:
+		if (off_in != NULL) {
+			error = ESPIPE;
+			goto done;
+		}
+		break;
+	case VREG:
+	case VBLK:
+	case VCHR:
+	case VPROC:
+		if (off_in != NULL) {
+			if (copyin(off_in, &r_off, sizeof (r_off)) != 0) {
+				error = EFAULT;
+				goto done;
+			}
+			rd_pos = B_TRUE;
+		}
+		break;
+	default:
+		error = EBADF;
+		goto done;
+	}
+	r_flag = fp_in->f_flag;
+	if ((r_flag & FREAD) == 0) {
+		error = EBADF;
+		goto done;
+	}
+
+	if ((fp_out = getf(fd_out)) == NULL) {
+		error = EBADF;
+		goto done;
+	}
+	switch (fp_out->f_vnode->v_type) {
+	case VFIFO:
+		found_pipe = B_TRUE;
+		/* Splicing to ourself returns EINVAL on Linux */
+		if (pipe_in) {
+			fifonode_t *fnp = VTOF(fp_in->f_vnode);
+			if (VTOF(fp_out->f_vnode) == fnp->fn_dest) {
+				error = EINVAL;
+				goto done;
+			}
+		}
+		/*FALLTHROUGH*/
+	case VSOCK:
+		if (off_out != NULL) {
+			error = ESPIPE;
+			goto done;
+		}
+		break;
+	case VREG:
+	case VBLK:
+	case VCHR:
+	case VPROC:
+		if (off_out != NULL) {
+			if (copyin(off_out, &w_off, sizeof (w_off)) != 0) {
+				error = EFAULT;
+				goto done;
+			}
+			wr_pos = B_TRUE;
+		}
+		break;
+	default:
+		error = EBADF;
+		goto done;
+	}
+	w_flag = fp_out->f_flag;
+	if ((w_flag & FWRITE) == 0) {
+		error = EBADF;
+		goto done;
+	}
+	/* Appending is invalid for output fd in splice */
+	if ((w_flag & FAPPEND) != 0) {
+		error = EINVAL;
+		goto done;
+	}
+
+	if (!found_pipe) {
+		error = EINVAL;
+		goto done;
+	}
+
+	/*
+	 * Check for non-blocking pipe operations. If no data in the input
+	 * pipe, return EAGAIN. If the output pipe is full, return EAGAIN.
+	 */
+	if (flags & LX_SPLICE_F_NONBLOCK) {
+		fifonode_t *fn_dest;
+
+		if (fp_in->f_vnode->v_type == VFIFO) {
+			fn_dest = VTOF(fp_in->f_vnode)->fn_dest;
+			if (fn_dest->fn_count == 0) {
+				error = EAGAIN;
+				goto done;
+			}
+		}
+		if (fp_out->f_vnode->v_type == VFIFO) {
+			fn_dest = VTOF(fp_out->f_vnode)->fn_dest;
+			fifolock_t *fn_lock = fn_dest->fn_lock;
+			mutex_enter(&fn_lock->flk_lock);
+			if (fn_dest->fn_count >= fn_dest->fn_hiwat) {
+				mutex_exit(&fn_lock->flk_lock);
+				error = EAGAIN;
+				goto done;
+			}
+			mutex_exit(&fn_lock->flk_lock);
+		}
+	}
+
+	bsize = MIN(LX_SPL_BUF_SIZE, len);
+
+	buf = kmem_alloc(bsize, KM_SLEEP);
+	bzero(&uio, sizeof (uio));
+	uio.uio_iovcnt = 1;
+	uio.uio_iov = &iov;
+	uio.uio_segflg = UIO_SYSSPACE;
+	uio.uio_llimit = curproc->p_fsz_ctl;
+
+	/*
+	 * Loop reading data from fd_in and writing to fd_out. This is
+	 * controlled by how much of the requested data we can actually write,
+	 * particularly when the destination is a pipe. This matches the Linux
+	 * behavior, which may terminate earlier than the full 'len' if the
+	 * pipe fills up. However, we need to block when writing into a full
+	 * pipe on the first iteration of the loop. We already checked above
+	 * for a full output pipe when non-blocking.
+	 */
+	while ((wr_sz = lx_spl_wr_sz(fp_out, w_off, bsize, len, first)) > 0) {
+		first = B_FALSE;
+
+		/* (re)setup for a read */
+		uio.uio_resid = iov.iov_len = wr_sz; /* only rd. max writable */
+		iov.iov_base = buf;
+		uio.uio_offset = r_off;
+		uio.uio_extflg = UIO_COPY_CACHED;
+		uio.uio_fmode = r_flag;
+		error = lx_spl_read(fp_in, &uio, &nread, pipe_in, rd_pos);
+		if (error != 0 || nread == 0)
+			break;
+		r_off = uio.uio_offset;
+
+		/* Setup and perform a write from the same buffer */
+		uio.uio_resid = iov.iov_len = nread;
+		iov.iov_base = buf;
+		uio.uio_offset = w_off;
+		uio.uio_extflg = UIO_COPY_DEFAULT;
+		uio.uio_fmode = w_flag;
+		error = lx_write_common(fp_out, &uio, &nwrite, wr_pos);
+		if (error != 0) {
+			if (pipe_in) {
+				/* Need to unblock reading from the fifo. */
+				fifonode_t *fnp = VTOF(fp_in->f_vnode);
+
+				mutex_enter(&fnp->fn_lock->flk_lock);
+				fnp->fn_flag &= ~FIFORDBLOCK;
+				fifo_stayfast_exit(fnp);
+				fifo_wakereader(fnp, fnp->fn_lock);
+				mutex_exit(&fnp->fn_lock->flk_lock);
+			}
+			break;
+		}
+		w_off  = uio.uio_offset;
+
+		/*
+		 * If input is a pipe, then we can consume the amount of data
+		 * out of the pipe that we successfully wrote.
+		 */
+		if (pipe_in)
+			lx_spl_consume(fp_in, nwrite);
+
+		total += nwrite;
+		len -= nwrite;
+	}
+
+done:
+	if (buf != NULL)
+		kmem_free(buf, bsize);
+	if (fp_in != NULL)
+		releasef(fd_in);
+	if (fp_out != NULL)
+		releasef(fd_out);
+	if (error != 0)
+		return (set_errno(error));
+
+	return (total);
+}

--- a/usr/src/uts/common/disp/thread.c
+++ b/usr/src/uts/common/disp/thread.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
  */
 
 #include <sys/types.h>
@@ -790,6 +790,11 @@ thread_free(kthread_t *t)
 	mutex_enter(&pidlock);
 	nthread--;
 	mutex_exit(&pidlock);
+
+	if (t->t_name != NULL) {
+		kmem_free(t->t_name, THREAD_NAME_MAX);
+		t->t_name = NULL;
+	}
 
 	/*
 	 * Free thread, lwp and stack.  This needs to be done carefully, since
@@ -2126,4 +2131,50 @@ stkinfo_percent(caddr_t t_stk, caddr_t t_stkbase, caddr_t sp)
 		percent = 100;
 	}
 	return (percent);
+}
+
+/*
+ * NOTE: This will silently truncate a name > THREAD_NAME_MAX - 1 characters
+ * long.  It is expected that callers (acting on behalf of userland clients)
+ * will perform any required checks to return the correct error semantics.
+ * It is also expected callers on behalf of userland clients have done
+ * any necessary permission checks.
+ */
+void
+thread_setname(kthread_t *t, const char *name)
+{
+	char *buf = NULL;
+
+	/*
+	 * We optimistically assume that a thread's name will only be set
+	 * once and so allocate memory in preparation of setting t_name.
+	 * If it turns out a name has already been set, we just discard (free)
+	 * the buffer we just allocated and reuse the current buffer
+	 * (as all should be THREAD_NAME_MAX large).
+	 *
+	 * Such an arrangement means over the lifetime of a kthread_t, t_name
+	 * is either NULL or has one value (the address of the buffer holding
+	 * the current thread name).   The assumption is that most kthread_t
+	 * instances will not have a name assigned, so dynamically allocating
+	 * the memory should minimize the footprint of this feature, but by
+	 * having the buffer persist for the life of the thread, it simplifies
+	 * usage in highly constrained situations (e.g. dtrace).
+	 */
+	if (name != NULL && name[0] != '\0') {
+		buf = kmem_zalloc(THREAD_NAME_MAX, KM_SLEEP);
+		(void) strlcpy(buf, name, THREAD_NAME_MAX);
+	}
+
+	mutex_enter(&ttoproc(t)->p_lock);
+	if (t->t_name == NULL) {
+		t->t_name = buf;
+	} else {
+		if (buf != NULL) {
+			(void) strlcpy(t->t_name, name, THREAD_NAME_MAX);
+			kmem_free(buf, THREAD_NAME_MAX);
+		} else {
+			bzero(t->t_name, THREAD_NAME_MAX);
+		}
+	}
+	mutex_exit(&ttoproc(t)->p_lock);
 }

--- a/usr/src/uts/common/sys/fs/fifonode.h
+++ b/usr/src/uts/common/sys/fs/fifonode.h
@@ -137,6 +137,8 @@ typedef struct fifodata {
 #define	FIFOPOLLRBAND	0x20000
 #define	FIFOSTAYFAST	0x40000	/* don't turn into stream mode */
 #define	FIFOWAITMODE	0x80000	/* waiting for the possibility to change mode */
+/* Data on loan, block reads. Use in conjunction with FIFOSTAYFAST. */
+#define	FIFORDBLOCK	0x100000
 
 #define	FIFOHIWAT	(16 * 1024)
 #define	FIFOLOWAT	(0)
@@ -173,6 +175,8 @@ extern void	fifo_fastoff(fifonode_t *);
 extern struct streamtab *fifo_getinfo();
 extern void	fifo_wakereader(fifonode_t *, fifolock_t *);
 extern void	fifo_wakewriter(fifonode_t *, fifolock_t *);
+extern boolean_t fifo_stayfast_enter(fifonode_t *);
+extern void	fifo_stayfast_exit(fifonode_t *);
 
 #endif /* _KERNEL */
 

--- a/usr/src/uts/common/sys/thread.h
+++ b/usr/src/uts/common/sys/thread.h
@@ -349,6 +349,8 @@ typedef struct _kthread {
 	kmutex_t	t_ctx_lock;	/* protects t_ctx in removectx() */
 	struct waitq	*t_waitq;	/* wait queue */
 	kmutex_t	t_wait_mutex;	/* used in CV wait functions */
+
+	char		*t_name;	/* thread name */
 } kthread_t;
 
 /*
@@ -599,9 +601,13 @@ extern disp_lock_t stop_lock;		/* lock protecting stopped threads */
 
 caddr_t	thread_stk_init(caddr_t);	/* init thread stack */
 
+void	thread_setname(kthread_t *, const char *);
+
 extern int default_binding_mode;
 
 #endif	/* _KERNEL */
+
+#define	THREAD_NAME_MAX	32	/* includes terminating NUL */
 
 /*
  * Macros to indicate that the thread holds resources that could be critical

--- a/usr/src/uts/common/vm/seg.h
+++ b/usr/src/uts/common/vm/seg.h
@@ -21,7 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -113,6 +113,7 @@ typedef struct seg {
 } seg_t;
 
 #define	S_PURGE		(0x01)		/* seg should be purged in as_gap() */
+#define	S_HOLE		(0x02)		/* seg represents hole in AS */
 
 struct	seg_ops {
 	int	(*dup)(struct seg *, struct seg *);

--- a/usr/src/uts/intel/Makefile.files
+++ b/usr/src/uts/intel/Makefile.files
@@ -353,6 +353,7 @@ LX_BRAND_OBJS  =		\
 	lx_signal.o		\
 	lx_signum.o		\
 	lx_socket.o		\
+	lx_splice.o		\
 	lx_stat.o		\
 	lx_sync.o		\
 	lx_syscall.o		\


### PR DESCRIPTION
Weekly Joyent merge.

Commit 7eadfb6 is noteworthy as it's a tiny bit of the stack clash mitigation that was committed to Joyent this week. We're not taking that commit but are taking just enough of it to ensure that our lx brand does not break once this lands in gate. This will also be backported to r151022 as we will want to backport the stack clash fix once it comes in.

## Backports

*  Add S_HOLE vm segment flag & hole skip in lx - 7eadfb6

## mail_msg

```
==== Nightly distributed build started:   Thu Oct  5 17:31:23 UTC 2017 ====
==== Nightly distributed build completed: Thu Oct  5 18:31:55 UTC 2017 ====

==== Total build time ====

real    1:00:31

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-eb9d5cb557 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   65521

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017100501-0687b42d22

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:31.3
user  1:32:11.7
sys     11:21.3

==== Build noise differences (non-DEBUG) ====

81,82c81,82
< maximum offset: 1d10
< maximum offset: 236c
---
> maximum offset: 1d0e
> maximum offset: 236a

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:21.0
user  1:22:41.0
sys      8:12.6

==== Build noise differences (DEBUG) ====

46,47c46,47
< maximum offset: 1d49
< maximum offset: 23a5
---
> maximum offset: 1d47
> maximum offset: 23a3

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:22.5
user  1:06:44.2
sys     20:24.4

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```

## onu

bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2017100501-0687b42d22 i86pc i386 i86pc

## lx zone test

```
[Connected to zone 'alpine' pts/2]
   __        .                   .
 _|  |_      | .-. .  . .-. :--. |-
|_    _|     ;|   ||  |(.-' |  | |
  |__|   `--'  `-' `;-| `-' '  ' `-'
                   /  ;  Instance (Alpine Linux 3.5 20170303)
                   `-'   https://docs.joyent.com/images/container-native-linux

localhost:~#
```