### PR TITLE
Backports/2017100501

### DIFF
--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -1676,6 +1676,10 @@ lxpr_read_pid_maps(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 		vnode_t *vp;
 		uint_t protbits;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		pbuf = kmem_alloc(sizeof (*pbuf), KM_SLEEP);
 
 		pbuf->saddr = (uintptr_t)seg->s_base;

--- a/usr/src/uts/common/fs/smbclnt/netsmb/smb_dev.c
+++ b/usr/src/uts/common/fs/smbclnt/netsmb/smb_dev.c
@@ -318,7 +318,7 @@ nsmb_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
 /*ARGSUSED*/
 static int
 nsmb_ioctl(dev_t dev, int cmd, intptr_t arg, int flags,	/* model.h */
-	cred_t *cr, int *rvalp)
+    cred_t *cr, int *rvalp)
 {
 	smb_dev_t *sdp;
 	int err;

--- a/usr/src/uts/common/smbsrv/smb_ioctl.h
+++ b/usr/src/uts/common/smbsrv/smb_ioctl.h
@@ -119,7 +119,7 @@ typedef	struct smb_ioc_opennum {
 #define	SMB_SVCENUM_TYPE_FILE	0x46494C45	/* 'FILE' */
 #define	SMB_SVCENUM_TYPE_SHARE	0x53484152	/* 'SHAR' */
 
-/* The enumeration ioctl needs a LOT of space.  We cap it here. */
+/* Maximum size of payload data an smbsrv ioctl may use. */
 #define	SMB_IOC_DATA_SIZE		(256 * 1024)
 
 typedef struct smb_svcenum {

--- a/usr/src/uts/common/vm/seg.h
+++ b/usr/src/uts/common/vm/seg.h
@@ -21,7 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -113,6 +113,7 @@ typedef struct seg {
 } seg_t;
 
 #define	S_PURGE		(0x01)		/* seg should be purged in as_gap() */
+#define	S_HOLE		(0x02)		/* seg represents hole in AS */
 
 struct	seg_ops {
 	int	(*dup)(struct seg *, struct seg *);


### PR DESCRIPTION
Backporting to r151022 stable.
Updated CIFS fixes + preparation for stackclash fix from upstream (cover the LX bits).

```
==== Nightly distributed build started:   Thu Oct  5 21:08:54 UTC 2017 ====
==== Nightly distributed build completed: Thu Oct  5 22:12:05 UTC 2017 ====

==== Total build time ====

real    1:03:11

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-eb9d5cb557 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   68521

==== Nightly argument issues ====


==== Build version ====

omnios-backports-2017100501-c35ef764f2

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:53.4
user  1:29:21.8
sys     11:17.3

==== Build noise differences (non-DEBUG) ====

83,84c83,84
< maximum offset: 1d00
< maximum offset: 235c
---
> maximum offset: 1d0b
> maximum offset: 2367

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:17.8
user  1:22:17.8
sys      8:35.1

==== Build noise differences (DEBUG) ====

48,49c48,49
< maximum offset: 1d39
< maximum offset: 2395
---
> maximum offset: 1d44
> maximum offset: 23a0

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:51.4
user  1:06:34.0
sys     20:04.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```