### PR TITLE
Update perl version in template nightly gate.env

### DIFF
--- a/usr/src/tools/env/omnios-illumos-gate.sh
+++ b/usr/src/tools/env/omnios-illumos-gate.sh
@@ -240,7 +240,7 @@ ONLY_LINT_DEFS=-I${SPRO_ROOT}/sunstudio12.1/prod/include/lint; export ONLY_LINT_
 # If your distro uses certain versions of Perl, make sure either
 # Makefile.master contains your new defaults OR your .env file sets them.
 # Stock illumos-gate does not have these set already.
-export PERL_VERSION=5.24.1
+export PERL_VERSION=5.24
 export PERL_ARCH=i86pc-solaris-thread-multi-64int
 export PERL_PKGVERS=
 


### PR DESCRIPTION
Change required to the template file for anyone that wants to build stock illumos-gate on bloody (and on r151024 once it's released).