### PR TITLE
8309 libbsm should support AUE_sudo audit event

### DIFF
--- a/usr/src/cmd/auditrecord/audit_record_attr.txt
+++ b/usr/src/cmd/auditrecord/audit_record_attr.txt
@@ -722,6 +722,11 @@ label=AUE_PFEXEC
     comment=process if ruid, euid, rgid or egid is changed:
     comment=output if arge policy is set
 
+label=AUE_sudo
+  format=exec_args1:[text]2
+    comment=command args:
+    comment=error message (failure only)
+
 label=AUE_EXIT
   format=arg1:[text]2
     comment=1, exit status, "exit status":

--- a/usr/src/lib/libbsm/audit_event.txt
+++ b/usr/src/lib/libbsm/audit_event.txt
@@ -565,6 +565,11 @@
 6501:AUE_hotplug_set:set hotplug bus private options:ss
 
 #
+# sudo event
+#
+6650:AUE_sudo:sudo(1m):lo,ua,as
+
+#
 # Trusted Extensions events:
 #
 9035:AUE_sl_change:Workspace label change:ap


### PR DESCRIPTION
backporting so the updated `sudo` (see https://github.com/omniosorg/omnios-build/pull/271) works