### PR TITLE
Publish obsoleted packages with correct ONNV build number

### DIFF
--- a/usr/src/pkg/manifests/consolidation-man-man-incorporation.mf
+++ b/usr/src/pkg/manifests/consolidation-man-man-incorporation.mf
@@ -12,7 +12,7 @@
 # Copyright 2011, Richard Lowe.
 
 set name=pkg.fmri \
-    value=pkg:/consolidation/man/man-incorporation@0.5.11,5.11-0.148
+    value=pkg:/consolidation/man/man-incorporation@$(PKGVERS)
 set name=pkg.obsolete value=true
 # Don't incorporate, as we were one and that would get deeply confusing
 set name=org.opensolaris.noincorp value=true

--- a/usr/src/pkg/manifests/driver-network-llc2.mf
+++ b/usr/src/pkg/manifests/driver-network-llc2.mf
@@ -23,6 +23,6 @@
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/driver/network/llc2@0.5.11,5.11-0.148
+set name=pkg.fmri value=pkg:/driver/network/llc2@$(PKGVERS)
 set name=pkg.obsolete value=true
 set name=variant.arch value=$(ARCH)

--- a/usr/src/pkg/manifests/service-network-snmp-mibiisa.mf
+++ b/usr/src/pkg/manifests/service-network-snmp-mibiisa.mf
@@ -23,6 +23,6 @@
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/service/network/snmp/mibiisa@0.5.11,5.11-0.148
+set name=pkg.fmri value=pkg:/service/network/snmp/mibiisa@$(PKGVERS)
 set name=pkg.obsolete value=true
 set name=variant.arch value=$(ARCH)

--- a/usr/src/pkg/manifests/source-network-pppdump.mf
+++ b/usr/src/pkg/manifests/source-network-pppdump.mf
@@ -24,6 +24,6 @@
 # Copyright 2011 Nexenta Systems, Inc. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/source/network/pppdump@0.5.11,5.11-0.148
+set name=pkg.fmri value=pkg:/source/network/pppdump@$(PKGVERS)
 set name=pkg.obsolete value=true
 set name=variant.arch value=$(ARCH)

--- a/usr/src/pkg/manifests/source-security-tcp-wrapper.mf
+++ b/usr/src/pkg/manifests/source-security-tcp-wrapper.mf
@@ -24,6 +24,6 @@
 # Copyright 2011 Nexenta Systems, Inc. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/source/security/tcp-wrapper@7.6,5.11-0.148
+set name=pkg.fmri value=pkg:/source/security/tcp-wrapper@$(PKGVERS)
 set name=pkg.obsolete value=true
 set name=variant.arch value=$(ARCH)

--- a/usr/src/pkg/manifests/system-library-storage-scsi-plugin.mf
+++ b/usr/src/pkg/manifests/system-library-storage-scsi-plugin.mf
@@ -24,7 +24,7 @@
 #
 
 set name=pkg.fmri \
-    value=pkg:/system/library/storage/scsi-plugin@0.5.11,5.11-0.134
+    value=pkg:/system/library/storage/scsi-plugin@$(PKGVERS)
 set name=pkg.renamed value=true
 set name=variant.arch value=$(ARCH)
 depend fmri=pkg:/system/library/storage/scsi-plugins@0.5.11,5.11-0.134 \

--- a/usr/src/pkg/manifests/system-management-snmp-sea.mf
+++ b/usr/src/pkg/manifests/system-management-snmp-sea.mf
@@ -23,6 +23,6 @@
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/system/management/snmp/sea@0.5.11,5.11-0.148
+set name=pkg.fmri value=pkg:/system/management/snmp/sea@$(PKGVERS)
 set name=pkg.obsolete value=true
 set name=variant.arch value=$(ARCH)

--- a/usr/src/pkg/manifests/system-manual.mf
+++ b/usr/src/pkg/manifests/system-manual.mf
@@ -11,7 +11,7 @@
 
 # Copyright 2011, Richard Lowe.
 
-set name=pkg.fmri value=pkg:/system/manual@0.5.11,5.11-0.148
+set name=pkg.fmri value=pkg:/system/manual@$(PKGVERS)
 set name=pkg.obsolete value=true
 set name=org.opensolaris.noincorp value=true
 set name=variant.arch value=$(ARCH)


### PR DESCRIPTION
There are a 25 obsoleted packages in `illumos-omnios` but 8 of those use an old ONNV build number in their package version which causes them to be thrown away due to the integrity checking performed by `pkgmgr`.

Fixing this for bloody & r151024. We may stop publishing these altogether in a future release
(I've put it on the project board for r151026 so we think about it then).