### PR TITLE
Remove continuation lines that upset pkgfmt

### DIFF
--- a/usr/src/pkg/manifests/consolidation-man-man-incorporation.mf
+++ b/usr/src/pkg/manifests/consolidation-man-man-incorporation.mf
@@ -11,8 +11,7 @@
 
 # Copyright 2011, Richard Lowe.
 
-set name=pkg.fmri \
-    value=pkg:/consolidation/man/man-incorporation@$(PKGVERS)
+set name=pkg.fmri value=pkg:/consolidation/man/man-incorporation@$(PKGVERS)
 set name=pkg.obsolete value=true
 # Don't incorporate, as we were one and that would get deeply confusing
 set name=org.opensolaris.noincorp value=true

--- a/usr/src/pkg/manifests/system-library-storage-scsi-plugin.mf
+++ b/usr/src/pkg/manifests/system-library-storage-scsi-plugin.mf
@@ -23,8 +23,7 @@
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
-set name=pkg.fmri \
-    value=pkg:/system/library/storage/scsi-plugin@$(PKGVERS)
+set name=pkg.fmri value=pkg:/system/library/storage/scsi-plugin@$(PKGVERS)
 set name=pkg.renamed value=true
 set name=variant.arch value=$(ARCH)
 depend fmri=pkg:/system/library/storage/scsi-plugins@0.5.11,5.11-0.134 \


### PR DESCRIPTION
Changing the obsolete package build numbers shortened the version lines and now `pkgfmt` is unhappy!