### PR TITLE
Exclude maximum offset changes from build noise

### DIFF
--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -285,6 +285,7 @@ function build {
 			| egrep -v '^\+' \
 			| egrep -v '^cc1: note: -fwritable-strings' \
 			| egrep -v 'svccfg-native -s svc:/' \
+			| egrep -v '^maximum offset:' \
 			| sort | uniq >$SRC/${NOISE}.out
 		if [ ! -f $SRC/${NOISE}.ref ]; then
 			cp $SRC/${NOISE}.out $SRC/${NOISE}.ref


### PR DESCRIPTION
This bit of build output changes on each build and is unnecessary noise in the mail_msg.
There are lots of existing output exclusions in `nightly` - add this one.