### PR TITLE
Use debug zone ID.

### DIFF
--- a/usr/src/cmd/mdb/common/modules/genunix/genunix.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/genunix.c
@@ -4362,6 +4362,8 @@ static const mdb_dcmd_t dcmds[] = {
 	/* from zone.c */
 	{ "zid2zone", ":", "find the zone_t with the given zone id",
 		zid2zone },
+	{ "zdid2zone", ":", "find the zone_t with the given zone debug id",
+		zdid2zone },
 	{ "zone", "?[-r [-v]]", "display kernel zone(s)", zoneprt },
 	{ "zsd", ":[-v] [zsd_key]", "display zone-specific-data entries for "
 	    "selected zones", zsd },

--- a/usr/src/cmd/mdb/common/modules/genunix/zone.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/zone.c
@@ -80,6 +80,31 @@ zid2zone(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	return (DCMD_OK);
 }
 
+static int
+zdid_lookup_cb(uintptr_t addr, const zone_t *zone, void *arg)
+{
+	zoneid_t zdid = *(uintptr_t *)arg;
+	if (zone->zone_did == zdid)
+		mdb_printf("%p\n", addr);
+
+	return (WALK_NEXT);
+}
+
+/*ARGSUSED*/
+int
+zdid2zone(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+{
+	if (!(flags & DCMD_ADDRSPEC) || argc != 0)
+		return (DCMD_USAGE);
+
+	if (mdb_walk("zone", (mdb_walk_cb_t)zdid_lookup_cb, &addr) == -1) {
+		mdb_warn("failed to walk zone");
+		return (DCMD_ERR);
+	}
+
+	return (DCMD_OK);
+}
+
 int
 zoneprt(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {

--- a/usr/src/cmd/mdb/common/modules/genunix/zone.h
+++ b/usr/src/cmd/mdb/common/modules/genunix/zone.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 extern int zid2zone(uintptr_t, uint_t, int argc, const mdb_arg_t *);
+extern int zdid2zone(uintptr_t, uint_t, int argc, const mdb_arg_t *);
 extern int zoneprt(uintptr_t, uint_t, int argc, const mdb_arg_t *);
 
 extern int zone_walk_init(mdb_walk_state_t *);

--- a/usr/src/cmd/zoneadmd/vplat.c
+++ b/usr/src/cmd/zoneadmd/vplat.c
@@ -4833,8 +4833,15 @@ out:
 	return (res);
 }
 
+/*
+ * The requested zoneid (req_zoneid) is advisory to the kernel and will be
+ * -1 if this is a new instance of a zone without a pre-existing zoneid.
+ * If this zone already exists (i.e. we're rebooting it) then the kernel will
+ * try to reassign the same zoneid, however there is no guarantee that this
+ * will occur.  In practice it should always occur.
+ */
 zoneid_t
-vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd)
+vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd, zoneid_t req_zoneid)
 {
 	zoneid_t rval = -1;
 	priv_set_t *privs;
@@ -4975,7 +4982,7 @@ vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd)
 	xerr = 0;
 	if ((zoneid = zone_create(kzone, rootpath, privs, rctlbuf,
 	    rctlbufsz, zfsbuf, zfsbufsz, &xerr, match, doi, zlabel,
-	    flags)) == -1) {
+	    flags, req_zoneid)) == -1) {
 		if (xerr == ZE_AREMOUNTS) {
 			if (zonecfg_find_mounts(rootpath, NULL, NULL) < 1) {
 				zerror(zlogp, B_FALSE,

--- a/usr/src/cmd/zoneadmd/vplat.c
+++ b/usr/src/cmd/zoneadmd/vplat.c
@@ -4834,14 +4834,13 @@ out:
 }
 
 /*
- * The requested zoneid (req_zoneid) is advisory to the kernel and will be
- * -1 if this is a new instance of a zone without a pre-existing zoneid.
- * If this zone already exists (i.e. we're rebooting it) then the kernel will
- * try to reassign the same zoneid, however there is no guarantee that this
- * will occur.  In practice it should always occur.
+ * The zone_did is a persistent debug ID.  Each zone should have a unique ID
+ * in the kernel.  This is used for things like DTrace which want to monitor
+ * zones across reboots.  They can't use the zoneid since that changes on
+ * each boot.
  */
 zoneid_t
-vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd, zoneid_t req_zoneid)
+vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd, zoneid_t zone_did)
 {
 	zoneid_t rval = -1;
 	priv_set_t *privs;
@@ -4982,7 +4981,7 @@ vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd, zoneid_t req_zoneid)
 	xerr = 0;
 	if ((zoneid = zone_create(kzone, rootpath, privs, rctlbuf,
 	    rctlbufsz, zfsbuf, zfsbufsz, &xerr, match, doi, zlabel,
-	    flags, req_zoneid)) == -1) {
+	    flags, zone_did)) == -1) {
 		if (xerr == ZE_AREMOUNTS) {
 			if (zonecfg_find_mounts(rootpath, NULL, NULL) < 1) {
 				zerror(zlogp, B_FALSE,

--- a/usr/src/cmd/zoneadmd/zoneadmd.c
+++ b/usr/src/cmd/zoneadmd/zoneadmd.c
@@ -552,7 +552,7 @@ notify_zonestatd(zoneid_t zoneid)
  * subcommand.
  */
 static int
-zone_ready(zlog_t *zlogp, zone_mnt_t mount_cmd, int zstate)
+zone_ready(zlog_t *zlogp, zone_mnt_t mount_cmd, int zstate, zoneid_t req_zoneid)
 {
 	int err;
 	boolean_t do_prestate;
@@ -573,7 +573,7 @@ zone_ready(zlog_t *zlogp, zone_mnt_t mount_cmd, int zstate)
 		goto bad;
 	}
 
-	if ((zone_id = vplat_create(zlogp, mount_cmd)) == -1) {
+	if ((zone_id = vplat_create(zlogp, mount_cmd, req_zoneid)) == -1) {
 		if ((err = zonecfg_destroy_snapshot(zone_name)) != Z_OK)
 			zerror(zlogp, B_FALSE, "destroying snapshot: %s",
 			    zonecfg_strerror(err));
@@ -1535,12 +1535,14 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 		goto out;
 	}
 
+	zoneid = getzoneidbyname(zone_name);
+
 	if (kernelcall) {
 		/*
 		 * Kernel-initiated requests may lose their validity if the
 		 * zone_t the kernel was referring to has gone away.
 		 */
-		if ((zoneid = getzoneidbyname(zone_name)) == -1 ||
+		if (zoneid == -1 ||
 		    zone_getattr(zoneid, ZONE_ATTR_UNIQID, &uniqid,
 		    sizeof (uniqid)) == -1 || uniqid != zargp->uniqid) {
 			/*
@@ -1576,7 +1578,7 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 	case ZONE_STATE_INSTALLED:
 		switch (cmd) {
 		case Z_READY:
-			rval = zone_ready(zlogp, Z_MNT_BOOT, zstate);
+			rval = zone_ready(zlogp, Z_MNT_BOOT, zstate, zoneid);
 			if (rval == 0)
 				eventstream_write(Z_EVT_ZONE_READIED);
 			zcons_statechanged();
@@ -1584,8 +1586,8 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 		case Z_BOOT:
 		case Z_FORCEBOOT:
 			eventstream_write(Z_EVT_ZONE_BOOTING);
-			if ((rval = zone_ready(zlogp, Z_MNT_BOOT, zstate))
-			    == 0) {
+			if ((rval = zone_ready(zlogp, Z_MNT_BOOT, zstate,
+			    zoneid)) == 0) {
 				rval = zone_bootup(zlogp, zargp->bootbuf,
 				    zstate);
 			}
@@ -1646,7 +1648,7 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 
 			rval = zone_ready(zlogp,
 			    strcmp(zargp->bootbuf, "-U") == 0 ?
-			    Z_MNT_UPDATE : Z_MNT_SCRATCH, zstate);
+			    Z_MNT_UPDATE : Z_MNT_SCRATCH, zstate, zoneid);
 			if (rval != 0)
 				break;
 
@@ -1777,7 +1779,8 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 			    != 0)
 				break;
 			zcons_statechanged();
-			if ((rval = zone_ready(zlogp, Z_MNT_BOOT, zstate)) == 0)
+			if ((rval = zone_ready(zlogp, Z_MNT_BOOT, zstate,
+			    zoneid)) == 0)
 				eventstream_write(Z_EVT_ZONE_READIED);
 			else
 				eventstream_write(Z_EVT_ZONE_HALTED);
@@ -1815,8 +1818,8 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 				break;
 			}
 			zcons_statechanged();
-			if ((rval = zone_ready(zlogp, Z_MNT_BOOT, zstate)) !=
-			    0) {
+			if ((rval = zone_ready(zlogp, Z_MNT_BOOT, zstate,
+			    zoneid)) != 0) {
 				eventstream_write(Z_EVT_ZONE_BOOTFAILED);
 				boot_args[0] = '\0';
 				break;

--- a/usr/src/cmd/zoneadmd/zoneadmd.h
+++ b/usr/src/cmd/zoneadmd/zoneadmd.h
@@ -137,7 +137,7 @@ typedef enum {
 /*
  * Virtual platform interfaces.
  */
-extern zoneid_t vplat_create(zlog_t *, zone_mnt_t);
+extern zoneid_t vplat_create(zlog_t *, zone_mnt_t, zoneid_t);
 extern int vplat_bringup(zlog_t *, zone_mnt_t, zoneid_t);
 extern int vplat_teardown(zlog_t *, boolean_t, boolean_t);
 extern int vplat_get_iptype(zlog_t *, zone_iptype_t *);

--- a/usr/src/head/zone.h
+++ b/usr/src/head/zone.h
@@ -60,7 +60,7 @@ extern int zone_get_id(const char *, zoneid_t *);
 /* System call API */
 extern zoneid_t	zone_create(const char *, const char *,
     const struct priv_set *, const char *, size_t, const char *, size_t, int *,
-    int, int, const bslabel_t *, int);
+    int, int, const bslabel_t *, int, zoneid_t);
 extern int	zone_boot(zoneid_t);
 extern int	zone_destroy(zoneid_t);
 extern ssize_t	zone_getattr(zoneid_t, int, void *, size_t);

--- a/usr/src/lib/libc/port/sys/zone.c
+++ b/usr/src/lib/libc/port/sys/zone.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2011 Joyent Inc.  All rights reserved.
  */
 
 #include "lint.h"
@@ -40,7 +41,8 @@
 zoneid_t
 zone_create(const char *name, const char *root, const struct priv_set *privs,
     const char *rctls, size_t rctlsz, const char *zfs, size_t zfssz,
-    int *extended_error, int match, int doi, const bslabel_t *label, int flags)
+    int *extended_error, int match, int doi, const bslabel_t *label, int flags,
+    zoneid_t req_zoneid)
 {
 	zone_def  zd;
 	priv_data_t *d;
@@ -60,6 +62,7 @@ zone_create(const char *name, const char *root, const struct priv_set *privs,
 	zd.doi = doi;
 	zd.label = label;
 	zd.flags = flags;
+	zd.zoneid = req_zoneid;
 
 	return ((zoneid_t)syscall(SYS_zone, ZONE_CREATE, &zd));
 }

--- a/usr/src/man/man1m/zoneadm.1m
+++ b/usr/src/man/man1m/zoneadm.1m
@@ -342,18 +342,22 @@ zone, with colon- delimited fields. These fields are:
 .sp
 .in +2
 .nf
-zoneid:zonename:state:zonepath:uuid:brand:ip-type
+zoneid:zonename:state:zonepath:uuid:brand:ip-type:debugid
 .fi
 .in -2
 .sp
 
 If the \fBzonepath\fR contains embedded colons, they can be escaped by a
 backslash ("\:"), which is parsable by using the shell \fBread\fR(1) function
-with the environmental variable \fBIFS\fR. The \fIuuid\fR value is assigned by
-\fBlibuuid\fR(3LIB) when the zone is installed, and is useful for identifying
-the same zone when present (or renamed) on alternate boot environments. Any
-software that parses the output of the "\fBzoneadm list -p\fR" command must be
-able to handle any fields that may be added in the future.
+with the environmental variable \fBIFS\fR.
+The \fIuuid\fR value is assigned by \fBlibuuid\fR(3LIB) when the zone is
+installed, and is useful for identifying the same zone when present (or
+renamed) on alternate boot environments.
+The \fIdebugid\fR value is a constant numeric identifier which is attached
+to the zone and can be used by tools such as DTrace to track zones across
+reboots (since \fIzoneid\fR will change).
+Any software that parses the output of the "\fBzoneadm list -p\fR" command must
+be able to handle any fields that may be added in the future.
 .sp
 The \fB-v\fR and \fB-p\fR options are mutually exclusive. If neither \fB-v\fR
 nor \fB-p\fR is used, just the zone name is listed.

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -422,8 +422,9 @@ static boolean_t zsd_wait_for_inprogress(zone_t *, struct zsd_entry *,
  * Version 5 alters the zone_boot system call, and converts its old
  *     bootargs parameter to be set by the zone_setattr API instead.
  * Version 6 adds the flag argument to zone_create.
+ * Version 7 adds the requested zoneid to zone_create.
  */
-static const int ZONE_SYSCALL_API_VERSION = 6;
+static const int ZONE_SYSCALL_API_VERSION = 7;
 
 /*
  * Certain filesystems (such as NFS and autofs) need to know which zone
@@ -4812,7 +4813,7 @@ zone_create(const char *zone_name, const char *zone_root,
     caddr_t rctlbuf, size_t rctlbufsz,
     caddr_t zfsbuf, size_t zfsbufsz, int *extended_error,
     int match, uint32_t doi, const bslabel_t *label,
-    int flags)
+    int flags, zoneid_t req_zoneid)
 {
 	struct zsched_arg zarg;
 	nvlist_t *rctls = NULL;
@@ -4883,6 +4884,19 @@ zone_create(const char *zone_name, const char *zone_root,
 	}
 
 	zone = kmem_zalloc(sizeof (zone_t), KM_SLEEP);
+	/*
+	 * If zoneadmd is asking for a specific zoneid, see if we can grant
+	 * the request, but allocate a new id if that fails for any reason.
+	 */
+	if (req_zoneid != -1) {
+		zoneid = id_alloc_specific_nosleep(zoneid_space, req_zoneid);
+		if (zoneid == -1)
+			cmn_err(CE_WARN,
+			    "zone_create: re-use zoneid %d failed\n",
+		    	    req_zoneid);
+	}
+	if (zoneid == -1)
+		zoneid = id_alloc(zoneid_space);
 	zone->zone_id = zoneid;
 	zone->zone_status = ZONE_IS_UNINITIALIZED;
 	zone->zone_pool = pool_default;
@@ -6930,6 +6944,7 @@ zone(int cmd, void *arg1, void *arg2, void *arg3, void *arg4)
 			zs.doi = zs32.doi;
 			zs.label = (const bslabel_t *)(uintptr_t)zs32.label;
 			zs.flags = zs32.flags;
+			zs.zoneid = zs32.zoneid;
 #else
 			panic("get_udatamodel() returned bogus result\n");
 #endif
@@ -6940,7 +6955,7 @@ zone(int cmd, void *arg1, void *arg2, void *arg3, void *arg4)
 		    (caddr_t)zs.rctlbuf, zs.rctlbufsz,
 		    (caddr_t)zs.zfsbuf, zs.zfsbufsz,
 		    zs.extended_error, zs.match, zs.doi,
-		    zs.label, zs.flags));
+		    zs.label, zs.flags, zs.zoneid));
 	case ZONE_BOOT:
 		return (zone_boot((zoneid_t)(uintptr_t)arg1));
 	case ZONE_DESTROY:

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -4884,7 +4884,7 @@ zone_create(const char *zone_name, const char *zone_root,
 	}
 
 	zone = kmem_zalloc(sizeof (zone_t), KM_SLEEP);
-	zoneid = zone->zone_id = id_alloc(zoneid_space);
+	zone->zone_id = zoneid;
 	zone->zone_did = zone_did;
 	zone->zone_status = ZONE_IS_UNINITIALIZED;
 	zone->zone_pool = pool_default;

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -4813,7 +4813,7 @@ zone_create(const char *zone_name, const char *zone_root,
     caddr_t rctlbuf, size_t rctlbufsz,
     caddr_t zfsbuf, size_t zfsbufsz, int *extended_error,
     int match, uint32_t doi, const bslabel_t *label,
-    int flags, zoneid_t req_zoneid)
+    int flags, zoneid_t zone_did)
 {
 	struct zsched_arg zarg;
 	nvlist_t *rctls = NULL;
@@ -4884,20 +4884,8 @@ zone_create(const char *zone_name, const char *zone_root,
 	}
 
 	zone = kmem_zalloc(sizeof (zone_t), KM_SLEEP);
-	/*
-	 * If zoneadmd is asking for a specific zoneid, see if we can grant
-	 * the request, but allocate a new id if that fails for any reason.
-	 */
-	if (req_zoneid != -1) {
-		zoneid = id_alloc_specific_nosleep(zoneid_space, req_zoneid);
-		if (zoneid == -1)
-			cmn_err(CE_WARN,
-			    "zone_create: re-use zoneid %d failed\n",
-		    	    req_zoneid);
-	}
-	if (zoneid == -1)
-		zoneid = id_alloc(zoneid_space);
-	zone->zone_id = zoneid;
+	zoneid = zone->zone_id = id_alloc(zoneid_space);
+	zone->zone_did = zone_did;
 	zone->zone_status = ZONE_IS_UNINITIALIZED;
 	zone->zone_pool = pool_default;
 	zone->zone_pool_mod = gethrtime();

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -506,6 +506,7 @@ typedef struct zone {
 	 */
 	list_node_t	zone_linkage;
 	zoneid_t	zone_id;	/* ID of zone */
+	zoneid_t	zone_did;	/* persistent debug ID of zone */
 	uint_t		zone_ref;	/* count of zone_hold()s on zone */
 	uint_t		zone_cred_ref;	/* count of zone_hold_cred()s on zone */
 	/*

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -193,6 +193,7 @@ typedef struct {
 	uint32_t doi;			/* DOI for label */
 	caddr32_t label;		/* label associated with zone */
 	int flags;
+	zoneid_t zoneid;		/* requested zoneid */
 } zone_def32;
 #endif
 typedef struct {
@@ -209,6 +210,7 @@ typedef struct {
 	uint32_t doi;			/* DOI for label */
 	const bslabel_t *label;		/* label associated with zone */
 	int flags;
+	zoneid_t zoneid;		/* requested zoneid */
 } zone_def;
 
 /* extended error information */


### PR DESCRIPTION
This completes a feature that is partially merged from Joyent into OmniOS, a non-changing ID for zones (a debug ID). It also fixes the `zoneadm` man page to reflect the extra field that is (already) shown in parseable output on OmniOS versus vanilla illumos.

It looks like Joyent had a couple of ideas here. Zone IDs are arbitrary and change between reboots and other operations, so they first tried to make the zone ID persistent across reboots (OS-180) but reverted this fairly quickly (OS-192) and created a persistent non-changing ID attached to each zone, the _debug zone id_. With OS-192 this was derived from the zone's location within the `/etc/zones/index` file but as of OS-200 this is stored in the zone's XML configuration file with the _debugid_ tag and the last assigned ID is stored in `/etc/zones/did.txt`.

OmniOS has most of OS-200 but not the other commits which leaves it in a halfway state regarding debug IDs.

* OS-180 need zoneid to be persistent across zone reboot
* OS-192 zone_create() warning on headnode
* OS-200 need a better mechanism for storing persistent zone_did

There's also:

* OS-1690 want zid2zone and zdid2zone

Most of this was upstreamed to illumos, we're just missing the `zdid2zone` mdb command.

## So, here's our existing bloody:

```
bloody# grep debugid /etc/zones/*
/etc/zones/alpine.xml:<zone name="alpine" zonepath="/data/zone/alpine" autoboot="false" brand="lx" ip-type="exclusive" debugid="2" limitpriv="default">
/etc/zones/test1.xml:<zone name="test1" zonepath="/data/zone/test1" autoboot="false" brand="lipkg" debugid="4"/>
/etc/zones/test2.xml:<zone name="test2" zonepath="/data/zone/test2" autoboot="false" brand="lipkg" debugid="5"/>

bloody# more /etc/zones/did.txt
5
```

 The persistent debug zone ID is shown in the last field of `zoneadm list -p`
 
 ```
bloody# zoneadm list -pc
0:global:running:/::ipkg:shared:0
-:alpine:installed:/data/zone/alpine:8fb8d5c2-2c24-c7ae-a71d-bef2b0b01b99:lx:excl:2
-:test1:installed:/data/zone/test1:450f6fdc-eef0-e8c3-a401-efbb4b05f03c:lipkg:shared:4
-:test2:installed:/data/zone/test2:19f531dc-e809-6b73-a537-be309374dba1:lipkg:shared:5
```

Once the zone is running, it gets an arbitrary zone ID

```
bloody# zoneadm -z test1 list -v
  ID NAME             STATUS     PATH                           BRAND    IP
   1 test1            running    /data/zone/test1               lipkg    shared

bloody# mdb -k
> 1::zid2zone | ::zone
            ADDR     ID STATUS        NAME                 PATH
ffffff026c908340      1 running       test1
/data/zone/test1/root/
```

As you can see, the debug zone ID is not used at all.

```
bloody# mdb -k
> 1::zid2zone | ::print -t zone_t ! grep 4$
    rctl_qty_t zone_nlwps = 0x64
> 1::zid2zone | ::print -t zone_t ! egrep '_id|id ='
    uint32_t zone_hostid = 0xffffffff
    zoneid_t zone_id = 0x1
    pid_t zone_proc_initpid = 0x895
    uint64_t zone_uniqid = 0x1
    psetid_t zone_psetid = 0xfffffffd
    id_t zone_defaultcid = 0
```

## Now with this change:

The debug ID is assigned to the zone and the mdb `zdid2zone` command can be used to map between debug IDs and zones.

```
bloody# zoneadm -z test1 list -v
  ID NAME             STATUS     PATH                           BRAND    IP
   2 test1            running    /data/zone/test1               lipkg    shared
bloody# mdb -k
Loading modules: [ unix genunix specfs dtrace mac cpu.generic uppc pcplusmp scsi_vhci zfs ip hook neti sockfs arp usba xhci uhci s1394 stmf stmf_sbd mm lofs random ptm idm cpc crypto kvm ufs logindmux nsmb smbsrv nfs ]
> 2::zid2zone | ::zone
            ADDR     ID STATUS        NAME                 PATH
ffffff0251004cc0      2 running       test1
/data/zone/test1/root/
> 4::zdid2zone | ::zone
            ADDR     ID STATUS        NAME                 PATH
ffffff0251004cc0      2 running       test1
/data/zone/test1/root/
> 2::zid2zone | ::print -t zone_t ! grep 'zone_did'
    zoneid_t zone_did = 0x4
   
```
