### PR TITLE
Stack-clash mitigation

### DIFF
--- a/usr/src/uts/common/Makefile.files
+++ b/usr/src/uts/common/Makefile.files
@@ -304,6 +304,7 @@ GENUNIX_OBJS +=	\
 		sctp_crc32.o	\
 		secflags.o	\
 		seg_dev.o	\
+		seg_hole.o	\
 		seg_kp.o	\
 		seg_kpm.o	\
 		seg_map.o	\

--- a/usr/src/uts/common/exec/elf/elf.c
+++ b/usr/src/uts/common/exec/elf/elf.c
@@ -26,7 +26,7 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -2354,6 +2354,10 @@ top:
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 		extern struct seg_ops segspt_shmops;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			uint_t prot;

--- a/usr/src/uts/common/fs/proc/prioctl.c
+++ b/usr/src/uts/common/fs/proc/prioctl.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -3542,6 +3543,10 @@ oprgetmap(proc_t *p, list_t *iolhead)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			prot = pr_getprot(seg, 0, &tmp, &saddr, &naddr, eaddr);
 			if (saddr == naddr)
@@ -3602,6 +3607,10 @@ oprgetmap32(proc_t *p, list_t *iolhead)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			prot = pr_getprot(seg, 0, &tmp, &saddr, &naddr, eaddr);
 			if (saddr == naddr)
@@ -3655,6 +3664,10 @@ oprpdsize(struct as *as)
 		void *tmp = NULL;
 		size_t npage;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			(void) pr_getprot(seg, 0, &tmp, &saddr, &naddr, eaddr);
 			if ((npage = (naddr - saddr) / PAGESIZE) != 0)
@@ -3684,6 +3697,10 @@ oprpdsize32(struct as *as)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 		size_t npage;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			(void) pr_getprot(seg, 0, &tmp, &saddr, &naddr, eaddr);
@@ -3734,6 +3751,10 @@ again:
 		caddr_t eaddr = seg->s_base + pr_getsegsize(seg, 0);
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			size_t len;
@@ -3841,6 +3862,10 @@ again:
 		caddr_t eaddr = seg->s_base + pr_getsegsize(seg, 0);
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			size_t len;

--- a/usr/src/uts/common/fs/proc/prsubr.c
+++ b/usr/src/uts/common/fs/proc/prsubr.c
@@ -1395,6 +1395,10 @@ prnsegs(struct as *as, int reserved)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			(void) pr_getprot(seg, reserved, &tmp,
 			    &saddr, &naddr, eaddr);
@@ -1650,6 +1654,10 @@ prgetmap(proc_t *p, int reserved, list_t *iolhead)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			prot = pr_getprot(seg, reserved, &tmp,
 			    &saddr, &naddr, eaddr);
@@ -1761,6 +1769,10 @@ prgetmap32(proc_t *p, int reserved, list_t *iolhead)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			prot = pr_getprot(seg, reserved, &tmp,
 			    &saddr, &naddr, eaddr);
@@ -1864,6 +1876,10 @@ prpdsize(struct as *as)
 		void *tmp = NULL;
 		size_t npage;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
+
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			(void) pr_getprot(seg, 0, &tmp, &saddr, &naddr, eaddr);
 			if ((npage = (naddr - saddr) / PAGESIZE) != 0)
@@ -1893,6 +1909,10 @@ prpdsize32(struct as *as)
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
 		size_t npage;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			(void) pr_getprot(seg, 0, &tmp, &saddr, &naddr, eaddr);
@@ -1944,6 +1964,10 @@ again:
 		caddr_t eaddr = seg->s_base + pr_getsegsize(seg, 0);
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			struct vnode *vp;
@@ -2091,6 +2115,10 @@ again:
 		caddr_t eaddr = seg->s_base + pr_getsegsize(seg, 0);
 		caddr_t saddr, naddr;
 		void *tmp = NULL;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			struct vnode *vp;
@@ -4044,6 +4072,9 @@ prgetxmap(proc_t *p, list_t *iolhead)
 		uint64_t npages;
 		uint64_t pagenum;
 
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 		/*
 		 * Segment loop part one: iterate from the base of the segment
 		 * to its end, pausing at each address boundary (baddr) between
@@ -4239,6 +4270,10 @@ prgetxmap32(proc_t *p, list_t *iolhead)
 		char *parr;
 		uint64_t npages;
 		uint64_t pagenum;
+
+		if ((seg->s_flags & S_HOLE) != 0) {
+			continue;
+		}
 
 		/*
 		 * Segment loop part one: iterate from the base of the segment

--- a/usr/src/uts/common/os/exec.c
+++ b/usr/src/uts/common/os/exec.c
@@ -26,7 +26,7 @@
 /*	Copyright (c) 1988 AT&T	*/
 /*	  All Rights Reserved  	*/
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -78,6 +78,7 @@
 #include <vm/as.h>
 #include <vm/seg.h>
 #include <vm/seg_vn.h>
+#include <vm/seg_hole.h>
 
 #define	PRIV_RESET		0x01	/* needs to reset privs */
 #define	PRIV_SETID		0x02	/* needs to change uids */
@@ -114,6 +115,14 @@ uint_t auxv_hwcap32_2 = 0;	/* 32-bit version of auxv_hwcap2 */
 size_t aslr_max_brk_skew = 16 * 1024 * 1024; /* 16MB */
 #pragma weak exec_stackgap = aslr_max_stack_skew /* Old, compatible name */
 size_t aslr_max_stack_skew = 64 * 1024; /* 64KB */
+
+/*
+ * Size of guard segment for 64-bit processes and minimum size it can be shrunk
+ * to in the case of grow() operations.  These are kept as variables in case
+ * they need to be tuned in an emergency.
+ */
+size_t stack_guard_seg_sz = 256 * 1024 * 1024;
+size_t stack_guard_min_sz = 64 * 1024 * 1024;
 
 /*
  * exece() - system call wrapper around exec_common()
@@ -1946,6 +1955,15 @@ exec_get_spslew(void)
  * The initial user stack layout is as follows:
  *
  *	User Stack
+ *	+---------------+
+ *	|		|
+ *	| stack guard	|
+ *	| (64-bit only)	|
+ *	|		|
+ *	+...............+ <--- stack limit (base - curproc->p_stk_ctl)
+ *	.		.
+ *	.		.
+ *	.		.
  *	+---------------+ <--- curproc->p_usrstack
  *	|		|
  *	| slew		|
@@ -1987,6 +2005,11 @@ exec_get_spslew(void)
  *	+---------------+ <--- argv[]
  *	| argc		|
  *	+---------------+ <--- stack base
+ *
+ * In 64-bit processes, a stack guard segment is allocated at the address
+ * immediately below where the stack limit ends.  This protects new library
+ * mappings (such as the linker) from being placed in relatively dangerous
+ * proximity to the stack.
  */
 int
 exec_args(execa_t *uap, uarg_t *args, intpdata_t *intp, void **auxvpp)
@@ -2000,6 +2023,9 @@ exec_args(execa_t *uap, uarg_t *args, intpdata_t *intp, void **auxvpp)
 	struct as *as;
 	extern int use_stk_lpg;
 	size_t sp_slew;
+#if defined(_LP64)
+	const size_t sg_sz = (stack_guard_seg_sz & PAGEMASK);
+#endif /* defined(_LP64) */
 
 	args->from_model = p->p_model;
 	if (p->p_model == DATAMODEL_NATIVE) {
@@ -2151,6 +2177,8 @@ exec_args(execa_t *uap, uarg_t *args, intpdata_t *intp, void **auxvpp)
 	p->p_brkpageszc = 0;
 	p->p_stksize = 0;
 	p->p_stkpageszc = 0;
+	p->p_stkg_start = 0;
+	p->p_stkg_end = 0;
 	p->p_model = args->to_model;
 	p->p_usrstack = usrstack;
 	p->p_stkprot = args->stk_prot;
@@ -2188,10 +2216,36 @@ exec_args(execa_t *uap, uarg_t *args, intpdata_t *intp, void **auxvpp)
 	(void) hat_setup(as->a_hat, HAT_ALLOC);
 	hat_join_srd(as->a_hat, args->ex_vp);
 
-	/*
-	 * Finally, write out the contents of the new stack.
-	 */
+	/* Write out the contents of the new stack. */
 	error = stk_copyout(args, usrstack - sp_slew, auxvpp, up);
 	kmem_free(args->stk_base, args->stk_size);
+
+#if defined(_LP64)
+	/* Add stack guard segment (if needed) after successful copyout */
+	if (error == 0 && p->p_model == DATAMODEL_LP64 && sg_sz != 0) {
+		seghole_crargs_t sca;
+		caddr_t addr_end = (caddr_t)(((uintptr_t)usrstack -
+		    p->p_stk_ctl) & PAGEMASK);
+		caddr_t addr_start = addr_end - sg_sz;
+
+		DTRACE_PROBE4(stack__guard__chk, proc_t *, p,
+		    caddr_t, addr_start, caddr_t, addr_end, size_t, sg_sz);
+
+		if (addr_end >= usrstack || addr_start >= addr_end ||
+		    valid_usr_range(addr_start, sg_sz, PROT_NONE, as,
+		    as->a_userlimit) != RANGE_OKAY) {
+			return (E2BIG);
+		}
+
+		/* Create un-mappable area in AS with seg_hole */
+		sca.name = "stack_guard";
+		error = as_map(as, addr_start, sg_sz, seghole_create, &sca);
+		if (error == 0) {
+			p->p_stkg_start = (uintptr_t)addr_start;
+			p->p_stkg_end = (uintptr_t)addr_start + sg_sz;
+		}
+	}
+#endif /* defined(_LP64) */
+
 	return (error);
 }

--- a/usr/src/uts/common/os/grow.c
+++ b/usr/src/uts/common/os/grow.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2013 OmniTI Computer Consulting, Inc. All rights reserved.
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -333,9 +333,10 @@ grow(caddr_t sp)
 	} else {
 		err = grow_internal(sp, p->p_stkpageszc);
 	}
+	newsize = p->p_stksize;
 	as_rangeunlock(as);
 
-	if (err == 0 && (newsize = p->p_stksize) > oldsize) {
+	if (err == 0 && newsize > oldsize) {
 		ASSERT(IS_P2ALIGNED(oldsize, PAGESIZE));
 		ASSERT(IS_P2ALIGNED(newsize, PAGESIZE));
 		/*
@@ -428,6 +429,7 @@ grow_internal(caddr_t sp, uint_t growszc)
 	struct proc *p = curproc;
 	size_t newsize;
 	size_t oldsize;
+	uintptr_t new_start;
 	int    error;
 	size_t pgsz;
 	uint_t szc;
@@ -498,7 +500,32 @@ grow_internal(caddr_t sp, uint_t growszc)
 	}
 	crargs.lgrp_mem_policy_flags = LGRP_MP_FLAG_EXTEND_DOWN;
 
-	if ((error = as_map(p->p_as, p->p_usrstack - newsize, newsize - oldsize,
+	/*
+	 * The stack is about to grow into its guard.  This can be acceptable
+	 * if the size restriction on the stack has been expanded since its
+	 * initialization during exec().  In such cases, the guard segment will
+	 * be shrunk, provided the new size is reasonable.
+	 */
+	new_start = (uintptr_t)p->p_usrstack - newsize;
+	if (p->p_stkg_start != 0 && new_start > p->p_stkg_start &&
+	    new_start < p->p_stkg_end) {
+		const size_t unmap_sz = p->p_stkg_end - new_start;
+		const size_t remain_sz = new_start - p->p_stkg_start;
+		extern size_t stack_guard_min_sz;
+
+		/* Do not allow the guard to shrink below minimum size */
+		if (remain_sz < stack_guard_min_sz) {
+			return (ENOMEM);
+		}
+
+		error = as_unmap(p->p_as, (caddr_t)new_start, unmap_sz);
+		if (error != 0) {
+			return (error);
+		}
+		p->p_stkg_end -= unmap_sz;
+	}
+
+	if ((error = as_map(p->p_as, (caddr_t)new_start, newsize - oldsize,
 	    segvn_create, &crargs)) != 0) {
 		if (error == EAGAIN) {
 			cmn_err(CE_WARN, "Sorry, no swap space to grow stack "

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -2198,6 +2198,8 @@ zone_misc_kstat_update(kstat_t *ksp, int rw)
 	zmp->zm_ffnomem.value.ui32 = zone->zone_ffnomem;
 	zmp->zm_ffmisc.value.ui32 = zone->zone_ffmisc;
 
+	zmp->zm_mfseglim.value.ui32 = zone->zone_mfseglim;
+
 	zmp->zm_nested_intp.value.ui32 = zone->zone_nested_intp;
 
 	zmp->zm_init_pid.value.ui32 = zone->zone_proc_initpid;
@@ -2241,6 +2243,8 @@ zone_misc_kstat_create(zone_t *zone)
 	    KSTAT_DATA_UINT32);
 	kstat_named_init(&zmp->zm_ffnomem, "forkfail_nomem", KSTAT_DATA_UINT32);
 	kstat_named_init(&zmp->zm_ffmisc, "forkfail_misc", KSTAT_DATA_UINT32);
+	kstat_named_init(&zmp->zm_mfseglim, "mapfail_seglim",
+	    KSTAT_DATA_UINT32);
 	kstat_named_init(&zmp->zm_nested_intp, "nested_interp",
 	    KSTAT_DATA_UINT32);
 	kstat_named_init(&zmp->zm_init_pid, "init_pid", KSTAT_DATA_UINT32);

--- a/usr/src/uts/common/sys/proc.h
+++ b/usr/src/uts/common/sys/proc.h
@@ -251,8 +251,15 @@ typedef struct	proc {
 	kmutex_t p_maplock;		/* lock for pr_mappage() */
 	struct	proc  *p_rlink;		/* linked list for server */
 	kcondvar_t p_srwchan_cv;
-	size_t	p_stksize;		/* process stack size in bytes */
-	uint_t	p_stkpageszc;		/* preferred stack max page size code */
+
+	/*
+	 * Stack sizing and guard information.
+	 * Generally protected by as_rangelock()
+	 */
+	size_t		p_stksize;	/* process stack size in bytes */
+	uint_t		p_stkpageszc;	/* preferred stack max page size code */
+	uintptr_t	p_stkg_start;	/* start of stack guard */
+	uintptr_t	p_stkg_end;	/* end of stack guard */
 
 	/*
 	 * Microstate accounting, resource usage, and real-time profiling

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -462,6 +462,7 @@ typedef struct {
 	kstat_named_t	zm_ffnoproc;
 	kstat_named_t	zm_ffnomem;
 	kstat_named_t	zm_ffmisc;
+	kstat_named_t	zm_mfseglim;
 	kstat_named_t	zm_nested_intp;
 	kstat_named_t	zm_init_pid;
 	kstat_named_t	zm_boot_time;
@@ -716,6 +717,8 @@ typedef struct zone {
 	uint32_t	zone_ffnoproc;		/* get proc/lwp error */
 	uint32_t	zone_ffnomem;		/* as_dup/memory error */
 	uint32_t	zone_ffmisc;		/* misc. other error */
+
+	uint32_t	zone_mfseglim;		/* map failure (# segs limit) */
 
 	uint32_t	zone_nested_intp;	/* nested interp. kstat */
 

--- a/usr/src/uts/common/vm/seg_hole.c
+++ b/usr/src/uts/common/vm/seg_hole.c
@@ -1,0 +1,305 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Joyent, Inc.
+ */
+
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/errno.h>
+#include <sys/cred.h>
+#include <sys/kmem.h>
+#include <sys/lgrp.h>
+#include <sys/mman.h>
+
+#include <vm/hat.h>
+#include <vm/as.h>
+#include <vm/seg.h>
+#include <vm/seg_hole.h>
+
+
+static int seghole_dup(struct seg *, struct seg *);
+static int seghole_unmap(struct seg *, caddr_t, size_t);
+static void seghole_free(struct seg *);
+static faultcode_t seghole_fault(struct hat *, struct seg *, caddr_t, size_t,
+    enum fault_type, enum seg_rw);
+static faultcode_t seghole_faulta(struct seg *, caddr_t);
+static int seghole_setprot(struct seg *, caddr_t, size_t, uint_t);
+static int seghole_checkprot(struct seg *, caddr_t, size_t, uint_t);
+static int seghole_sync(struct seg *, caddr_t, size_t, int, uint_t);
+static size_t seghole_incore(struct seg *, caddr_t, size_t, char *);
+static int seghole_lockop(struct seg *, caddr_t, size_t, int, int, ulong_t *,
+    size_t);
+static int seghole_getprot(struct seg *, caddr_t, size_t, uint_t *);
+static u_offset_t seghole_getoffset(struct seg *, caddr_t);
+static int seghole_gettype(struct seg *, caddr_t);
+static int seghole_getvp(struct seg *, caddr_t, struct vnode **);
+static int seghole_advise(struct seg *, caddr_t, size_t, uint_t);
+static void seghole_dump(struct seg *);
+static int seghole_pagelock(struct seg *, caddr_t, size_t, struct page ***,
+    enum lock_type, enum seg_rw);
+static int seghole_setpagesize(struct seg *, caddr_t, size_t, uint_t);
+static int seghole_capable(struct seg *, segcapability_t);
+
+static struct seg_ops seghole_ops = {
+	seghole_dup,
+	seghole_unmap,
+	seghole_free,
+	seghole_fault,
+	seghole_faulta,
+	seghole_setprot,
+	seghole_checkprot,
+	NULL,			/* kluster: disabled */
+	NULL,			/* swapout: disabled */
+	seghole_sync,
+	seghole_incore,
+	seghole_lockop,
+	seghole_getprot,
+	seghole_getoffset,
+	seghole_gettype,
+	seghole_getvp,
+	seghole_advise,
+	seghole_dump,
+	seghole_pagelock,
+	seghole_setpagesize,
+	NULL,			/* getmemid: disabled */
+	NULL,			/* getpolicy: disabled */
+	seghole_capable,
+	seg_inherit_notsup
+};
+
+/*
+ * Create a hole in the AS.
+ */
+int
+seghole_create(struct seg *seg, void *argsp)
+{
+	seghole_crargs_t *crargs = argsp;
+	seghole_data_t *data;
+
+	data = kmem_alloc(sizeof (seghole_data_t), KM_SLEEP);
+	data->shd_name = crargs->name;
+
+	seg->s_ops = &seghole_ops;
+	seg->s_data = data;
+	seg->s_flags = S_HOLE;
+
+	return (0);
+}
+
+static int
+seghole_dup(struct seg *seg, struct seg *newseg)
+{
+	seghole_data_t *shd = (seghole_data_t *)seg->s_data;
+	seghole_data_t *newshd;
+
+	ASSERT(seg->s_as && AS_WRITE_HELD(seg->s_as));
+
+	newshd = kmem_zalloc(sizeof (seghole_data_t), KM_SLEEP);
+	newshd->shd_name = shd->shd_name;
+
+	newseg->s_ops = seg->s_ops;
+	newseg->s_data = newshd;
+	newseg->s_flags = S_HOLE;
+
+	return (0);
+}
+
+static int
+seghole_unmap(struct seg *seg, caddr_t addr, size_t len)
+{
+	seghole_data_t *sud = (seghole_data_t *)seg->s_data;
+
+	ASSERT(seg->s_as && AS_WRITE_HELD(seg->s_as));
+
+	/* Entire segment is being unmapped */
+	if (addr == seg->s_base && len == seg->s_size) {
+		seg_free(seg);
+		return (0);
+	}
+
+	/* Shrinking from low address side */
+	if (addr == seg->s_base) {
+		seg->s_base += len;
+		seg->s_size -= len;
+		return (0);
+	}
+
+	/* Shrinking from high address side */
+	if ((addr + len) == (seg->s_base + seg->s_size)) {
+		seg->s_size -= len;
+		return (0);
+	}
+
+	/* Do not tolerate splitting the segment */
+	return (EINVAL);
+}
+
+static void
+seghole_free(struct seg *seg)
+{
+	seghole_data_t *data = (seghole_data_t *)seg->s_data;
+
+	ASSERT(data != NULL);
+
+	kmem_free(data, sizeof (*data));
+	seg->s_data = NULL;
+}
+
+/* ARGSUSED */
+static faultcode_t
+seghole_fault(struct hat *hat, struct seg *seg, caddr_t addr, size_t len,
+    enum fault_type type, enum seg_rw tw)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	return (FC_NOMAP);
+}
+
+/* ARGSUSED */
+static faultcode_t
+seghole_faulta(struct seg *seg, caddr_t addr)
+{
+	return (FC_NOMAP);
+}
+
+/* ARGSUSED */
+static int
+seghole_setprot(struct seg *seg, caddr_t addr, size_t len, uint_t prot)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	return (ENOMEM);
+}
+
+/* ARGSUSED */
+static int
+seghole_checkprot(struct seg *seg, caddr_t addr, size_t len, uint_t prot)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	return (ENOMEM);
+}
+
+/* ARGSUSED */
+static int
+seghole_sync(struct seg *seg, caddr_t addr, size_t len, int attr, uint_t flags)
+{
+	/* Always succeed since there are no backing store to sync */
+	return (0);
+}
+
+/* ARGSUSED */
+static size_t
+seghole_incore(struct seg *seg, caddr_t addr, size_t len, char *vec)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+seghole_lockop(struct seg *seg, caddr_t addr, size_t len, int attr, int op,
+    ulong_t *lockmap, size_t pos)
+{
+	/*
+	 * Emit an error consistent with there being no segment in this hole in
+	 * the AS.  The MC_LOCKAS and MC_UNLOCKAS commands will explicitly skip
+	 * hole segments, allowing such operations to proceed as expected.
+	 */
+	return (ENOMEM);
+}
+
+static int
+seghole_getprot(struct seg *seg, caddr_t addr, size_t len, uint_t *protv)
+{
+	size_t pgno;
+
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	/*
+	 * Few SEGOP_GETPROT callers actually check for an error, so it's
+	 * necessary to report zeroed protection for the length of the request.
+	 */
+	pgno = seg_page(seg, addr + len) - seg_page(seg, addr) + 1;
+	while (pgno > 0) {
+		protv[--pgno] = 0;
+	}
+
+	return (ENOMEM);
+}
+
+/* ARGSUSED */
+static u_offset_t
+seghole_getoffset(struct seg *seg, caddr_t addr)
+{
+	/*
+	 * To avoid leaking information about the layout of the kernel address
+	 * space, always report '0' as the offset.
+	 */
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+seghole_gettype(struct seg *seg, caddr_t addr)
+{
+	return (MAP_PRIVATE);
+}
+
+/* ARGSUSED */
+static int
+seghole_getvp(struct seg *seg, caddr_t addr, struct vnode **vpp)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	return (ENOMEM);
+}
+
+/* ARGSUSED */
+static int
+seghole_advise(struct seg *seg, caddr_t addr, size_t len, uint_t behav)
+{
+	return (ENOMEM);
+}
+
+/* ARGSUSED */
+static void
+seghole_dump(struct seg *seg)
+{
+	/* There's nothing to dump from a hole in the AS */
+}
+
+/* ARGSUSED */
+static int
+seghole_pagelock(struct seg *seg, caddr_t addr, size_t len, struct page ***ppp,
+    enum lock_type type, enum seg_rw rw)
+{
+	return (EFAULT);
+}
+
+/* ARGSUSED */
+static int
+seghole_setpagesize(struct seg *seg, caddr_t addr, size_t len, uint_t szc)
+{
+	return (ENOMEM);
+}
+
+/* ARGSUSED */
+static int
+seghole_capable(struct seg *seg, segcapability_t capability)
+{
+	/* no special capablities */
+	return (0);
+}

--- a/usr/src/uts/common/vm/seg_hole.c
+++ b/usr/src/uts/common/vm/seg_hole.c
@@ -118,6 +118,7 @@ seghole_dup(struct seg *seg, struct seg *newseg)
 static int
 seghole_unmap(struct seg *seg, caddr_t addr, size_t len)
 {
+	/* LINTED E_FUNC_SET_NOT_USED */
 	seghole_data_t *sud = (seghole_data_t *)seg->s_data;
 
 	ASSERT(seg->s_as && AS_WRITE_HELD(seg->s_as));

--- a/usr/src/uts/common/vm/seg_hole.h
+++ b/usr/src/uts/common/vm/seg_hole.h
@@ -1,0 +1,40 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Joyent, Inc.
+ */
+
+#ifndef	_VM_SEG_HOLE_H
+#define	_VM_SEG_HOLE_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef struct seghole_crargs {
+	const char *name;
+} seghole_crargs_t;
+
+typedef struct seghole_data {
+	const char	*shd_name;
+} seghole_data_t;
+
+extern int seghole_create(struct seg *, void *);
+
+#define	AS_MAP_CHECK_SEGHOLE(crfp)		\
+	((crfp) == (int (*)())seghole_create)
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _VM_SEG_HOLE_H */

--- a/usr/src/uts/common/vm/vm_as.c
+++ b/usr/src/uts/common/vm/vm_as.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
@@ -68,6 +68,7 @@
 #include <vm/seg_kmem.h>
 #include <vm/seg_map.h>
 #include <vm/seg_spt.h>
+#include <vm/seg_hole.h>
 #include <vm/page.h>
 
 clock_t deadlk_wait = 1; /* number of ticks to wait before retrying */
@@ -819,7 +820,9 @@ as_dup(struct as *as, struct proc *forkedproc)
 			as_free(newas);
 			return (error);
 		}
-		newas->a_size += seg->s_size;
+		if ((newseg->s_flags & S_HOLE) == 0) {
+			newas->a_size += seg->s_size;
+		}
 	}
 	newas->a_resvsize = as->a_resvsize - purgesize;
 
@@ -1330,6 +1333,8 @@ top:
 	as_clearwatchprot(as, raddr, eaddr - raddr);
 
 	for (seg = as_findseg(as, raddr, 0); seg != NULL; seg = seg_next) {
+		const boolean_t is_hole = ((seg->s_flags & S_HOLE) != 0);
+
 		if (eaddr <= seg->s_base)
 			break;		/* eaddr was in a gap; all done */
 
@@ -1434,9 +1439,11 @@ retry:
 			return (-1);
 		}
 
-		as->a_size -= ssize;
-		if (rsize)
-			as->a_resvsize -= rsize;
+		if (!is_hole) {
+			as->a_size -= ssize;
+			if (rsize)
+				as->a_resvsize -= rsize;
+		}
 		raddr += ssize;
 	}
 	AS_LOCK_EXIT(as);
@@ -1686,6 +1693,7 @@ as_map_locked(struct as *as, caddr_t addr, size_t size, int (*crfp)(),
 	size_t rsize;			/* rounded up size */
 	int error;
 	int unmap = 0;
+	boolean_t is_hole = B_FALSE;
 	/*
 	 * The use of a_proc is preferred to handle the case where curproc is
 	 * a door_call server and is allocating memory in the client's (a_proc)
@@ -1712,7 +1720,14 @@ as_map_locked(struct as *as, caddr_t addr, size_t size, int (*crfp)(),
 	gethrestime(&as->a_updatetime);
 
 	if (as != &kas) {
-		if (as->a_size + rsize > (size_t)p->p_vmem_ctl) {
+		/*
+		 * Ensure that the virtual size of the process will not exceed
+		 * the configured limit.  Since seg_hole segments will later
+		 * set the S_HOLE flag indicating their status as a hole in the
+		 * AS, they are excluded from this check.
+		 */
+		if (as->a_size + rsize > (size_t)p->p_vmem_ctl &&
+		    !AS_MAP_CHECK_SEGHOLE(crfp)) {
 			AS_LOCK_EXIT(as);
 
 			(void) rctl_action(rctlproc_legacy[RLIMIT_VMEM],
@@ -1770,19 +1785,24 @@ as_map_locked(struct as *as, caddr_t addr, size_t size, int (*crfp)(),
 		}
 		/*
 		 * Add size now so as_unmap will work if as_ctl fails.
+		 * Not applicable to explicit hole segments.
 		 */
-		as->a_size += rsize;
-		as->a_resvsize += rsize;
+		if ((seg->s_flags & S_HOLE) == 0) {
+			as->a_size += rsize;
+			as->a_resvsize += rsize;
+		} else {
+			is_hole = B_TRUE;
+		}
 	}
 
 	as_setwatch(as);
 
 	/*
-	 * If the address space is locked,
-	 * establish memory locks for the new segment.
+	 * Establish memory locks for the segment if the address space is
+	 * locked, provided it's not an explicit hole in the AS.
 	 */
 	mutex_enter(&as->a_contents);
-	if (AS_ISPGLCK(as)) {
+	if (AS_ISPGLCK(as) && !is_hole) {
 		mutex_exit(&as->a_contents);
 		AS_LOCK_EXIT(as);
 		error = as_ctl(as, addr, size, MC_LOCK, 0, 0, NULL, 0);
@@ -2310,6 +2330,9 @@ retry:
 		}
 
 		for (seg = AS_SEGFIRST(as); seg; seg = AS_SEGNEXT(as, seg)) {
+			if ((seg->s_flags & S_HOLE) != 0) {
+				continue;
+			}
 			error = SEGOP_LOCKOP(seg, seg->s_base,
 			    seg->s_size, attr, MC_LOCK, mlock_map, pos);
 			if (error != 0)
@@ -2339,6 +2362,9 @@ retry:
 		mutex_exit(&as->a_contents);
 
 		for (seg = AS_SEGFIRST(as); seg; seg = AS_SEGNEXT(as, seg)) {
+			if ((seg->s_flags & S_HOLE) != 0) {
+				continue;
+			}
 			error = SEGOP_LOCKOP(seg, seg->s_base,
 			    seg->s_size, attr, MC_UNLOCK, NULL, 0);
 			if (error != 0)

--- a/usr/src/uts/i86pc/vm/vm_machdep.c
+++ b/usr/src/uts/i86pc/vm/vm_machdep.c
@@ -24,7 +24,7 @@
 /*
  * Copyright (c) 2010, Intel Corporation.
  * All rights reserved.
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /* Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T */
@@ -689,9 +689,6 @@ map_addr_proc(
 
 	base = p->p_brkbase;
 #if defined(__amd64)
-	/*
-	 * XX64 Yes, this needs more work.
-	 */
 	if (p->p_model == DATAMODEL_NATIVE) {
 		if (userlimit < as->a_userlimit) {
 			/*
@@ -711,16 +708,24 @@ map_addr_proc(
 			}
 		} else {
 			/*
-			 * XX64 This layout is probably wrong .. but in
-			 * the event we make the amd64 address space look
-			 * like sparcv9 i.e. with the stack -above- the
-			 * heap, this bit of code might even be correct.
+			 * With the stack positioned at a higher address than
+			 * the heap for 64-bit processes, it is necessary to be
+			 * mindful of its location and potential size.
+			 *
+			 * Unallocated space above the top of the stack (that
+			 * is, at a lower address) but still within the bounds
+			 * of the stack limit should be considered unavailable.
+			 *
+			 * As the 64-bit stack guard is mapped in immediately
+			 * adjacent to the stack limit boundary, this prevents
+			 * new mappings from having accidentally dangerous
+			 * proximity to the stack.
 			 */
 			slen = p->p_usrstack - base -
 			    ((p->p_stk_ctl + PAGEOFFSET) & PAGEMASK);
 		}
 	} else
-#endif
+#endif /* defined(__amd64) */
 		slen = userlimit - base;
 
 	/* Make len be a multiple of PAGESIZE */


### PR DESCRIPTION
This is a merge of the stack-clash mitigation from Joyent. I've also taken a small earlier change of theirs which adds an absolute limit on user-space segments in a process address space; in addition to being a good enhancement, it makes the following merge cleaner.

I expect them to upstream the stack-clash mitigation in due course but I want to get this into bloody early so we can get experience with it prior to considering any back porting. It is a potential security vulnerability after all.

Since we regularly perform full builds in bloody, it will get some good exercise there.

## mail_msg

```
==== Nightly distributed build started:   Wed Oct 18 13:05:57 UTC 2017 ====
==== Nightly distributed build completed: Wed Oct 18 14:08:02 UTC 2017 ====

==== Total build time ====

real    1:02:05

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-eb9d5cb557 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   323512

==== Nightly argument issues ====


==== Build version ====

omnios-stackclash-80b7e16762

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:57.5
user  1:33:20.6
sys     11:56.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:11.6
user  1:23:08.3
sys      8:30.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:59.7
user  1:06:26.8
sys     20:23.2

==== lint warnings src ====

==== lint noise differences src ====

0a1
< "../../common/vm/seg_hole.c", line 121: warning: set but not used in function: sud in seghole_unmap (E_FUNC_SET_NOT_USED)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====

```

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-stackclash-80b7e16762 i86pc i386 i86pc

bloody% pfexec mdb -k
> ::ps ! grep python
R    587    549    587    549    100 0x4a004000 ffffff0250f9c010 python2.7
> ffffff0250f9c010::pmap
             SEG             BASE     SIZE      RES PATH
... elided ...
ffffff0256783b08 fffffd7fef396000     336k     304k /lib/amd64/ld.so.1
ffffff0256783c88 fffffd7fef3fa000      12k      12k /lib/amd64/ld.so.1
ffffff02567dd270 fffffd7fef3fd000       8k       8k [ anon ]
ffffff0250e80c58 fffffd7fef400000  262144k        - [ hole:stack_guard ]
ffffff0250f8c650 fffffd7fffdfb000      20k      20k [ anon ]
```
