### PR TITLE
Backports/20171019 (r151024)

### DIFF
--- a/usr/src/lib/libscf/common/error.c
+++ b/usr/src/lib/libscf/common/error.c
@@ -200,7 +200,7 @@ scf_get_msg(scf_msg_t msg)
 
 	case SCF_MSG_PATTERN_MULTIPARTIAL:
 		return (dgettext(TEXT_DOMAIN,
-		    "Partial FMRI '%s' matches multiple instances\n"));
+		    "Partial FMRI '%s' matches multiple instances:\n"));
 
 	default:
 		abort();

--- a/usr/src/lib/libscf/common/lowlevel.c
+++ b/usr/src/lib/libscf/common/lowlevel.c
@@ -6289,6 +6289,7 @@ scf_multiple_match_error(scf_pattern_t *pattern, const char *format)
 	 * Note that strlen(format) includes the length of '%s', which
 	 * accounts for the terminating null byte.
 	 */
+	assert(strstr(format, "%s") != NULL);
 	len = strlen(format) + strlen(pattern->sp_arg);
 	for (match = pattern->sp_matches; match != NULL;
 	    match = match->sm_next)
@@ -6297,11 +6298,14 @@ scf_multiple_match_error(scf_pattern_t *pattern, const char *format)
 	if ((msg = malloc(len)) == NULL)
 		return (NULL);
 
-	off = snprintf(msg, len, format, pattern->sp_arg);
+	(void) snprintf(msg, len, format, pattern->sp_arg);
+	off = strlen(msg);
 	for (match = pattern->sp_matches; match != NULL;
-	    match = match->sm_next)
+	    match = match->sm_next) {
+		assert(off < len);
 		off += snprintf(msg + off, len - off, "\t%s\n",
 		    match->sm_key->sk_fmri);
+	}
 
 	return (msg);
 }

--- a/usr/src/man/man1m/svcadm.1m
+++ b/usr/src/man/man1m/svcadm.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SVCADM 1M "May 9, 2008"
+.TH SVCADM 1M "Oct 17, 2017"
 .SH NAME
 svcadm \- manipulate service instances
 .SH SYNOPSIS
@@ -49,14 +49,12 @@ svcadm \- manipulate service instances
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 \fBsvcadm\fR issues requests for actions on services executing within the
 service management facility (see \fBsmf\fR(5)). Actions for a service are
 carried out by its assigned service restarter agent. The default service
 restarter is \fBsvc.startd\fR (see \fBsvc.startd\fR(1M)).
 .SH OPTIONS
-.sp
 .LP
 The following options are supported:
 .sp
@@ -101,7 +99,6 @@ from the global zone, see \fBzones\fR(5).
 
 .SH SUBCOMMANDS
 .SS "Common Operations"
-.sp
 .LP
 The subcommands listed below are used during the typical administration of a
 service instance.
@@ -226,7 +223,6 @@ service instance (see \fBsmf_security\fR(5)).
 .RE
 
 .SS "Exceptional Operations"
-.sp
 .LP
 The following subcommands are used for service development and temporary
 administrative manipulation.
@@ -303,7 +299,6 @@ group of the \fBsvc:/system/svc/restarter:default\fR service instance (see
 .RE
 
 .SS "Operands"
-.sp
 .LP
 The following operands are supported:
 .sp
@@ -365,8 +360,10 @@ does not begin with "svc:", then "svc:/" is prepended.
 
 .sp
 .LP
-If an abbreviated \fIFMRI\fR or pattern matches more than one service, a
-warning message is displayed and that operand is ignored.
+If an abbreviated \fIFMRI\fR matches more than one service, a warning message
+is displayed and that operand is ignored.
+If a pattern matches more than one service or instance, the subcommand is
+applied to all matches.
 .SH EXAMPLES
 .LP
 \fBExample 1 \fRRestarting a Service Instance
@@ -460,7 +457,6 @@ The following command restores the running services:
 .sp
 
 .SH EXIT STATUS
-.sp
 .LP
 The following exit values are returned:
 .sp
@@ -514,7 +510,6 @@ with the service's dependencies.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -534,13 +529,11 @@ Interface Stability	See below.
 The interactive output is Uncommitted. The invocation and non-interactive
 output are Committed.
 .SH SEE ALSO
-.sp
 .LP
 \fBsvcprop\fR(1), \fBsvcs\fR(1), \fBinetd\fR(1M), \fBinit\fR(1M),
 \fBsvccfg\fR(1M), \fBsvc.startd\fR(1M), \fBlibscf\fR(3LIB), \fBcontract\fR(4),
 \fBattributes\fR(5), \fBsmf\fR(5), \fBsmf_security\fR(5), \fBzones\fR(5)
 .SH NOTES
-.sp
 .LP
 The amount of time \fBsvcadm\fR will spend waiting for services and their
 dependencies to change state is implicitly limited by their method timeouts.
@@ -554,4 +547,4 @@ Attempts to synchronously enable a service which depends (directly or
 indirectly) on a file may fail with an exit status indicating that dependencies
 are unsatisfied if the caller does not have the privileges necessary to search
 the directory containing the file. This limitation may be removed in a future
-Solaris release.
+release.

--- a/usr/src/man/man7d/i40e.7d
+++ b/usr/src/man/man7d/i40e.7d
@@ -9,16 +9,16 @@
 .\" http://www.illumos.org/license/CDDL.
 .\"
 .\"
-.\" Copyright 2016 Joyent, Inc.
+.\" Copyright (c) 2017 Joyent, Inc.
 .\"
-.Dd December 16, 2016
+.Dd September 8, 2017
 .Dt I40E 7D
 .Os
 .Sh NAME
 .Nm i40e
-.Nd Intel 710 Ethernet Device Driver
+.Nd Intel 710/722 Ethernet Device Driver
 .Sh SYNOPSIS
-.Pa /dev/i40e*
+.Pa /dev/net/i40e*
 .Sh DESCRIPTION
 The
 .Nm
@@ -27,9 +27,9 @@ supports the Data Link Provider Interface,
 .Xr dlpi 7P .
 The
 .Nm
-driver supports the Intel XL710 Ethernet Controller family of networking
-interface cards which come in 1 GbE, 10 GbE, 25 GbE, and 40 GbE
-variants.
+driver supports the Intel 710 and 722 Ethernet Controller families of
+networking interface cards which come in 1 GbE, 10 GbE, 25 GbE, and 40
+GbE variants.
 .Pp
 In addition to basic device initialization and the sending and receiving
 of frames, it supports the following features:
@@ -71,7 +71,7 @@ For example, the first instance enumerated in the system, with id 0, would be
 named
 .Sy i40e0 .
 It exists in the file system at
-.Pa /dev/i40e0 .
+.Pa /dev/net/i40e0 .
 .Sh CONFIGURATION
 The
 .Nm i40e
@@ -282,7 +282,7 @@ driver is only supported on
 systems at this time.
 .Sh FILES
 .Bl -tag -width Pa
-.It Pa /dev/i40e*
+.It Pa /dev/net/i40e*
 Per-instance character device.
 .It Pa /kernel/drv/i40e
 32-bit device driver (x86).

--- a/usr/src/pkg/manifests/driver-network-i40e.mf
+++ b/usr/src/pkg/manifests/driver-network-i40e.mf
@@ -10,13 +10,13 @@
 #
 
 #
-# Copyright 2016 Joyent, Inc.
+# Copyright (c) 2017 Joyent, Inc.
 #
 
 <include global_zone_only_component>
 set name=pkg.fmri value=pkg:/driver/network/i40e@$(PKGVERS)
-set name=pkg.description value="Intel 710 Ethernet Driver"
-set name=pkg.summary value="Intel 710 Ethernet Driver"
+set name=pkg.description value="Intel 710/722 Ethernet Driver"
+set name=pkg.summary value="Intel 710/722 Ethernet Driver"
 set name=info.classification \
     value=org.opensolaris.category.2008:Drivers/Networking
 set name=variant.arch value=i386
@@ -35,7 +35,13 @@ driver name=i40e clone_perms="i40e 0666 root sys" perms="* 0666 root sys" \
     alias=pciex8086,1586 \
     alias=pciex8086,1589 \
     alias=pciex8086,158a \
-    alias=pciex8086,158b
+    alias=pciex8086,158b \
+    alias=pciex8086,37ce \
+    alias=pciex8086,37cf \
+    alias=pciex8086,37d0 \
+    alias=pciex8086,37d1 \
+    alias=pciex8086,37d2 \
+    alias=pciex8086,37d3
 file path=kernel/drv/$(ARCH64)/i40e group=sys
 file path=kernel/drv/i40e group=sys
 file path=kernel/drv/i40e.conf group=sys

--- a/usr/src/pkg/manifests/driver-storage-mpt_sas.mf
+++ b/usr/src/pkg/manifests/driver-storage-mpt_sas.mf
@@ -70,7 +70,9 @@ driver name=mpt_sas class=scsi-self-identifying \
     alias=pciex1000,94 \
     alias=pciex1000,95 \
     alias=pciex1000,96 \
-    alias=pciex1000,97
+    alias=pciex1000,97 \
+    alias=pciex1000,c4 \
+    alias=pciex1000,c9
 file path=kernel/drv/$(ARCH64)/mpt_sas group=sys
 $(i386_ONLY)file path=kernel/drv/mpt_sas group=sys
 file path=kernel/drv/mpt_sas.conf group=sys \

--- a/usr/src/uts/common/io/i40e/i40e_sw.h
+++ b/usr/src/uts/common/io/i40e/i40e_sw.h
@@ -151,7 +151,6 @@ typedef enum i40e_itr_index {
 	I40E_ITR_INDEX_NONE 	= 0x3
 } i40e_itr_index_t;
 
-
 /*
  * Table 1-5 of the PRM notes that LSO supports up to 256 KB.
  */
@@ -308,11 +307,22 @@ typedef enum i40e_itr_index {
 #define	I40E_PBANUM_STRLEN	13
 
 /*
- * Define the maximum size of a number of queues for a traffic class. While this
- * would ideally be a part of the common code parts, because it's not at this
- * time, we define it here.
+ * Define the maximum number of queues for a traffic class. These values come
+ * from the 'Number and offset of queue pairs per TCs' section of the 'Add VSI
+ * Command Buffer' table. For the 710 controller family this is table 7-62
+ * (r2.5) and for the 722 this is table 38-216 (r2.0).
  */
-#define	I40E_AQ_VSI_TC_QUE_SIZE_MAX	(1 << 0x6)
+#define	I40E_710_MAX_TC_QUEUES	64
+#define	I40E_722_MAX_TC_QUEUES	128
+
+/*
+ * Define the size of the HLUT table size. The HLUT table can either be 128 or
+ * 512 bytes. We always set the table size to be 512 bytes in i40e_chip_start().
+ * Note, this should not be confused with the common code's macro
+ * I40E_HASH_LUT_SIZE_512 which is the bit pattern needed to tell the card to
+ * use a 512 byte HLUT.
+ */
+#define	I40E_HLUT_TABLE_SIZE	512
 
 /*
  * Bit flags for attach_progress

--- a/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas_init.c
+++ b/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas_init.c
@@ -23,6 +23,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright (c) 2014, Tegile Systems Inc. All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc.
  */
 
 /*
@@ -165,7 +166,7 @@ mptsas_ioc_get_facts(mptsas_t *mpt)
 
 static int
 mptsas_ioc_do_get_facts(mptsas_t *mpt, caddr_t memp, int var,
-		ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))
@@ -190,7 +191,7 @@ mptsas_ioc_do_get_facts(mptsas_t *mpt, caddr_t memp, int var,
 
 static int
 mptsas_ioc_do_get_facts_reply(mptsas_t *mpt, caddr_t memp, int var,
-		ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))
@@ -306,7 +307,7 @@ mptsas_ioc_do_get_facts_reply(mptsas_t *mpt, caddr_t memp, int var,
 	 * Set flag to check for SAS3 support.
 	 */
 	msgversion = ddi_get16(accessp, &factsreply->MsgVersion);
-	if (msgversion == MPI2_VERSION_02_05) {
+	if (msgversion >= MPI2_VERSION_02_05) {
 		mptsas_log(mpt, CE_NOTE, "?mpt_sas%d SAS 3 Supported\n",
 		    mpt->m_instance);
 		mpt->m_MPI25 = TRUE;
@@ -388,7 +389,7 @@ mptsas_ioc_get_port_facts(mptsas_t *mpt, int port)
 
 static int
 mptsas_ioc_do_get_port_facts(mptsas_t *mpt, caddr_t memp, int var,
-			ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 	pMpi2PortFactsRequest_t	facts;
 	int			numbytes;
@@ -411,7 +412,7 @@ mptsas_ioc_do_get_port_facts(mptsas_t *mpt, caddr_t memp, int var,
 
 static int
 mptsas_ioc_do_get_port_facts_reply(mptsas_t *mpt, caddr_t memp, int var,
-				ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))
@@ -465,7 +466,7 @@ mptsas_ioc_enable_port(mptsas_t *mpt)
 
 static int
 mptsas_ioc_do_enable_port(mptsas_t *mpt, caddr_t memp, int var,
-	ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))
@@ -490,7 +491,7 @@ mptsas_ioc_do_enable_port(mptsas_t *mpt, caddr_t memp, int var,
 
 static int
 mptsas_ioc_do_enable_port_reply(mptsas_t *mpt, caddr_t memp, int var,
-	ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))
@@ -547,7 +548,7 @@ mptsas_ioc_enable_event_notification(mptsas_t *mpt)
 
 static int
 mptsas_ioc_do_enable_event_notification(mptsas_t *mpt, caddr_t memp, int var,
-	ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))
@@ -699,7 +700,7 @@ mptsas_do_ioc_init(mptsas_t *mpt, caddr_t memp, int var,
 
 static int
 mptsas_do_ioc_init_reply(mptsas_t *mpt, caddr_t memp, int var,
-		ddi_acc_handle_t accessp)
+    ddi_acc_handle_t accessp)
 {
 #ifndef __lock_lint
 	_NOTE(ARGUNUSED(var))

--- a/usr/src/uts/common/sys/scsi/adapters/mpt_sas/mptsas_var.h
+++ b/usr/src/uts/common/sys/scsi/adapters/mpt_sas/mptsas_var.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
- * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2017, Joyent, Inc.
  * Copyright (c) 2014, Tegile Systems Inc. All rights reserved.
  */
 
@@ -79,15 +79,13 @@ extern "C" {
 
 #define	MPTSAS_INITIAL_SOFT_SPACE	4
 
-#define	MAX_MPI_PORTS		16
-
 /*
  * Note below macro definition and data type definition
  * are used for phy mask handling, it should be changed
  * simultaneously.
  */
-#define	MPTSAS_MAX_PHYS		16
-typedef uint16_t		mptsas_phymask_t;
+#define	MPTSAS_MAX_PHYS		24
+typedef uint32_t		mptsas_phymask_t;
 
 #define	MPTSAS_INVALID_DEVHDL	0xffff
 #define	MPTSAS_SATA_GUID	"sata-guid"

--- a/usr/src/uts/i86pc/os/startup.c
+++ b/usr/src/uts/i86pc/os/startup.c
@@ -18,10 +18,11 @@
  *
  * CDDL HEADER END
  */
+
 /*
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
- * Copyright 2013 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2015 Joyent, Inc.
  * Copyright (c) 2015 by Delphix. All rights reserved.
  */
@@ -1776,14 +1777,13 @@ startup_modules(void)
 #else
 	/*
 	 * Initialize a handle for the boot cpu - others will initialize
-	 * as they startup.  Do not do this if we know we are in an HVM domU.
+	 * as they startup.
 	 */
-	if ((get_hwenv() & HW_XEN_HVM) == 0 &&
-	    (hdl = cmi_init(CMI_HDL_NATIVE, cmi_ntv_hwchipid(CPU),
-	    cmi_ntv_hwcoreid(CPU), cmi_ntv_hwstrandid(CPU))) != NULL &&
-	    is_x86_feature(x86_featureset, X86FSET_MCA)) {
+	if ((hdl = cmi_init(CMI_HDL_NATIVE, cmi_ntv_hwchipid(CPU),
+	    cmi_ntv_hwcoreid(CPU), cmi_ntv_hwstrandid(CPU))) != NULL) {
+		if (is_x86_feature(x86_featureset, X86FSET_MCA))
 			cmi_mca_init(hdl);
-			CPU->cpu_m.mcpu_cmi_hdl = hdl;
+		CPU->cpu_m.mcpu_cmi_hdl = hdl;
 	}
 #endif	/* __xpv */
 


### PR DESCRIPTION
Backports from weekly upstream merge.

## mail_msg
```
==== Nightly distributed build started:   Thu Oct 19 19:28:18 UTC 2017 ====
==== Nightly distributed build completed: Thu Oct 19 20:32:30 UTC 2017 ====

==== Total build time ====

real    1:04:12

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-eb9d5cb557 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   348893

==== Nightly argument issues ====


==== Build version ====

omnios-backports-20171019-a62a430752

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    17:13.4
user  1:33:03.6
sys     12:00.3

==== Build noise differences (non-DEBUG) ====

< maximum offset: 1d10
< maximum offset: 236c

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:51.6
user  1:23:04.5
sys      8:35.2

==== Build noise differences (DEBUG) ====

46,47d45
< maximum offset: 1d49
< maximum offset: 23a5

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:56.7
user  1:06:35.1
sys     20:02.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
## onu

```
r151024% uname -a
SunOS r151024 5.11 omnios-backports-20171019-a62a430752 i86pc i386 i86pc
```
