### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+
+* @citrus-it @hadfl @oetiker
+


### PR DESCRIPTION
Experimenting with this new GitHub feature which should automatically add reviewers.
If we wish, in future, we can set it to automatically require reviewers based on repository path or code type.