### PR TITLE
Eliminate error from clobber

### DIFF
--- a/usr/src/uts/intel/Makefile
+++ b/usr/src/uts/intel/Makefile
@@ -81,7 +81,7 @@ PRIVS_C = $(SRC)/uts/common/os/priv_const.c
 $(PRIVS_C): $(PRIVS_AWK) $(PRIVS_DEF)
 	$(AWK) -f $(PRIVS_AWK) < $(PRIVS_DEF) cfile=$@
 
-CLOBBERFILES += $(PRIVS_C)
+CLOBBERFILES = $(PRIVS_C)
 
 #
 # Prerequisites

--- a/usr/src/uts/sun4u/Makefile
+++ b/usr/src/uts/sun4u/Makefile
@@ -115,7 +115,7 @@ PRIVS_C = $(UTSBASE)/common/os/priv_const.c
 $(PRIVS_C): $(PRIVS_AWK) $(PRIVS_DEF)
 	$(AWK) -f $(PRIVS_AWK) < $(PRIVS_DEF) cfile=$@
 
-CLOBBERFILES += $(PRIVS_C)
+CLOBBERFILES = $(PRIVS_C)
 
 #
 # Prerequisites


### PR DESCRIPTION
`dmake clobber` outputs an error as it tries to remove a directory with `rm -f`. This problem was introduced in the fix for issue 4072. Note also the empty lint library name.

```
% dmake -m serial clobber > old 2>&1
... apply this patch ...
% git st
## master...origin/master
 M uts/intel/Makefile
 M uts/sun4u/Makefile

% dmake -m serial clobber > new 2>&1

% diff old new

< /usr/bin/rm -f debug32/   ../intel/lint-libs/debug32/llib-l.ln /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/common/os/priv_const.c Nothing_to_remove
< rm: debug32/ is a directory
< *** Error code 2 (ignored)
---
> /usr/bin/rm -f /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/common/os/priv_const.c Nothing_to_remove
```