### PR TITLE
HVM exclusion lock (r151024)

### DIFF
--- a/usr/src/uts/common/io/vioblk/vioblk.c
+++ b/usr/src/uts/common/io/vioblk/vioblk.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2015, Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2012, Alexey Zaytsev <alexey.zaytsev@gmail.com>
+ * Copyright 2017, Joyent Inc.
  */
 
 
@@ -829,13 +830,11 @@ vioblk_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 	case DDI_RESUME:
 	case DDI_PM_RESUME:
 		dev_err(devinfo, CE_WARN, "resume not supported yet");
-		ret = DDI_FAILURE;
-		goto exit;
+		return (DDI_FAILURE);
 
 	default:
 		dev_err(devinfo, CE_WARN, "cmd 0x%x not recognized", cmd);
-		ret = DDI_FAILURE;
-		goto exit;
+		return (DDI_FAILURE);
 	}
 
 	sc = kmem_zalloc(sizeof (struct vioblk_softc), KM_SLEEP);
@@ -1029,8 +1028,7 @@ exit_intrstat:
 	mutex_destroy(&sc->lock_devid);
 	cv_destroy(&sc->cv_devid);
 	kmem_free(sc, sizeof (struct vioblk_softc));
-exit:
-	return (ret);
+	return (DDI_FAILURE);
 }
 
 static int

--- a/usr/src/uts/common/io/virtio/virtio.c
+++ b/usr/src/uts/common/io/virtio/virtio.c
@@ -23,6 +23,7 @@
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2012 Alexey Zaytsev <alexey.zaytsev@gmail.com>
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /* Based on the NetBSD virtio driver by Minoura Makoto. */
@@ -987,6 +988,7 @@ virtio_register_intx(struct virtio_softc *sc,
 	int config_handler_count = 0;
 	int actual;
 	struct virtio_handler_container *vhc;
+	size_t vhc_sz;
 	int ret = DDI_FAILURE;
 
 	/* Walk the handler table to get the number of handlers. */
@@ -998,8 +1000,9 @@ virtio_register_intx(struct virtio_softc *sc,
 	if (config_handler != NULL)
 		config_handler_count = 1;
 
-	vhc = kmem_zalloc(sizeof (struct virtio_handler_container) +
-	    sizeof (struct virtio_int_handler) * vq_handler_count, KM_SLEEP);
+	vhc_sz = sizeof (struct virtio_handler_container) +
+	    sizeof (struct virtio_int_handler) * vq_handler_count;
+	vhc = kmem_zalloc(vhc_sz, KM_SLEEP);
 
 	vhc->nhandlers = vq_handler_count;
 	(void) memcpy(vhc->vq_handlers, vq_handlers,
@@ -1046,8 +1049,7 @@ out_prio:
 	(void) ddi_intr_free(sc->sc_intr_htable[0]);
 out_int_alloc:
 	kmem_free(sc->sc_intr_htable, sizeof (ddi_intr_handle_t));
-	kmem_free(vhc, sizeof (struct virtio_int_handler) *
-	    (vq_handler_count + config_handler_count));
+	kmem_free(vhc, vhc_sz);
 	return (ret);
 }
 

--- a/usr/src/uts/common/io/virtio/virtio.c
+++ b/usr/src/uts/common/io/virtio/virtio.c
@@ -985,7 +985,6 @@ virtio_register_intx(struct virtio_softc *sc,
     struct virtio_int_handler vq_handlers[])
 {
 	int vq_handler_count;
-	int config_handler_count = 0;
 	int actual;
 	struct virtio_handler_container *vhc;
 	size_t vhc_sz;
@@ -996,9 +995,6 @@ virtio_register_intx(struct virtio_softc *sc,
 	    vq_handlers && vq_handlers[vq_handler_count].vh_func;
 	    vq_handler_count++)
 		;
-
-	if (config_handler != NULL)
-		config_handler_count = 1;
 
 	vhc_sz = sizeof (struct virtio_handler_container) +
 	    sizeof (struct virtio_int_handler) * vq_handler_count;

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -99,6 +99,7 @@ CORE_OBJS +=			\
 	memscrub.o		\
 	mpcore.o		\
 	notes.o			\
+	pc_hvm.o		\
 	pci_bios.o		\
 	pci_cfgacc.o		\
 	pci_cfgacc_x86.o	\

--- a/usr/src/uts/i86pc/os/pc_hvm.c
+++ b/usr/src/uts/i86pc/os/pc_hvm.c
@@ -1,0 +1,57 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Joyent, Inc.
+ */
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/mutex.h>
+#include <sys/debug.h>
+
+static kmutex_t hvm_excl_lock;
+static const char *hvm_excl_holder = NULL;
+
+/*
+ * HVM Exclusion Interface
+ *
+ * To avoid VMX/SVM conflicts from arising when multiple hypervisor providers
+ * (eg. KVM, bhyve) are shipped with the system, this simple advisory locking
+ * system is presented for their use.  Until a proper hypervisor API, like the
+ * one in OSX, is shipped in illumos, this will serve as opt-in regulation to
+ * dictate that only a single hypervisor be allowed to configure the system and
+ * run at any given time.
+ */
+
+boolean_t
+hvm_excl_hold(const char *consumer)
+{
+	boolean_t res = B_FALSE;
+
+	mutex_enter(&hvm_excl_lock);
+	if (hvm_excl_holder == NULL) {
+		hvm_excl_holder = consumer;
+		res = B_TRUE;
+	}
+	mutex_exit(&hvm_excl_lock);
+
+	return (res);
+}
+
+void
+hvm_excl_rele(const char *consumer)
+{
+	mutex_enter(&hvm_excl_lock);
+	VERIFY(consumer == hvm_excl_holder);
+	hvm_excl_holder = NULL;
+	mutex_exit(&hvm_excl_lock);
+}

--- a/usr/src/uts/i86pc/sys/pc_hvm.h
+++ b/usr/src/uts/i86pc/sys/pc_hvm.h
@@ -1,0 +1,35 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Joyent, Inc.
+ */
+
+
+#ifndef _PC_HVM_H
+#define	_PC_HVM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_KERNEL)
+
+extern boolean_t hvm_excl_hold(const char *);
+extern void hvm_excl_rele(const char *);
+
+#endif /* defined(_KERNEL) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PC_HVM_H */


### PR DESCRIPTION
backport for https://github.com/omniosorg/illumos-omnios/pull/89

### onu
```
hadfl@r151024:~$ uname -a
SunOS r151024 5.11 omnios-hvm_r24-9e8b38e55d i86pc i386 i86pc
```

### mail_msg
```
==== Nightly distributed build started:   Fri Oct 20 17:55:44 CEST 2017 ====
==== Nightly distributed build completed: Fri Oct 20 18:56:15 CEST 2017 ====

==== Total build time ====

real    1:00:30

==== Build environment ====

/usr/bin/uname
SunOS r151024 5.11 omnios-r151024-a65cbf9c46 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   73

==== Nightly argument issues ====


==== Build version ====

omnios-hvm_r24-9e8b38e55d

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:46.1
user  1:09:38.3
sys      5:42.7

==== Build noise differences (non-DEBUG) ====

82,83c82,83
< maximum offset: 1d0c
< maximum offset: 2368
---
> maximum offset: 1cfe
> maximum offset: 235a

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:34.4
user  1:00:54.8
sys      3:54.5

==== Build noise differences (DEBUG) ====

46,47c46,47
< maximum offset: 1d4f
< maximum offset: 23ab
---
> maximum offset: 1d41
> maximum offset: 239d

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:57.2
user    47:02.4
sys      5:15.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```