### PR TITLE
Joyent merge/2017102601

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 8359acfb8fd4655b7437bff72bed36033caf5420
+Last illumos-joyent commit: daa3911f02365820bf2df2a1cdf96602eda66912
 

--- a/usr/src/lib/brand/lx/testing/ltp_skiplist
+++ b/usr/src/lib/brand/lx/testing/ltp_skiplist
@@ -177,6 +177,8 @@ keyctl02
 keyctl03
 keyctl04
 keyctl05
+keyctl06
+keyctl07
 kcmp01
 kcmp02
 kcmp03


### PR DESCRIPTION
## Backports

`OS-6338 panic from kvm_load_gs` to r151024

## mail_msg

```
==== Nightly distributed build started:   Thu Oct 26 18:35:44 UTC 2017 ====
==== Nightly distributed build completed: Thu Oct 26 19:37:48 UTC 2017 ====

==== Total build time ====

real    1:02:04

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-eb9d5cb557 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   489022

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017102601-516b932b70

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:43.9
user  1:32:29.9
sys     11:36.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:05.9
user  1:23:14.8
sys      8:23.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    20:03.1
user  1:06:59.5
sys     20:31.1

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```