### PR TITLE
Upstream merge backport/2017103002

### DIFF
--- a/usr/src/uts/common/io/comstar/port/iscsit/iscsit.h
+++ b/usr/src/uts/common/io/comstar/port/iscsit/iscsit.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
  */
 
 #ifndef _ISCSIT_H_
@@ -61,9 +62,6 @@
 #define	ISCSIT_MAX_WINDOW	1024
 #define	ISCSIT_RXPDU_QUEUE_LEN	2048
 
-#define	ISCSIT_CMDSN_LT_EXPCMDSN	-1
-#define	ISCSIT_CMDSN_EQ_EXPCMDSN	1
-#define	ISCSIT_CMDSN_GT_EXPCMDSN	0
 /*
  * MC/S: A timeout is maintained to recover from lost CmdSN (holes in the
  * CmdSN ordering). When the timeout is reached, the ExpCmdSN is advanced


### PR DESCRIPTION
Weekly upstream for backport/2017103002

I've only tested basic iSCSI target functionality with this change but it has been reviewed and incorporated into gate so should be safe for r151022.

## mail_msg

```

==== Nightly distributed build started:   Mon Oct 30 23:00:02 UTC 2017 ====
==== Nightly distributed build completed: Tue Oct 31 00:06:19 UTC 2017 ====

==== Total build time ====

real    1:06:16

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151022-eb9d5cb557 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   573187

==== Nightly argument issues ====


==== Build version ====

omnios-backport-2017103002-dd5621285e

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    17:19.2
user  1:29:19.8
sys     11:26.3

==== Build noise differences (non-DEBUG) ====

83,84d82
< maximum offset: 1d0b
< maximum offset: 2367

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:54.3
user  1:21:44.6
sys      8:19.0

==== Build noise differences (DEBUG) ====

48,49d47
< maximum offset: 1d44
< maximum offset: 23a0

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:43.0
user  1:05:49.1
sys     20:24.3

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
