### PR TITLE
remove pending zfs patches to README.OmniOS

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -13,16 +13,7 @@ are included at the end of this file.
 
 =======================================================================
 
-## 8648 Fix range locking in ZIL commit codepath
-
-Commits:
- > 8648 Fix range locking in ZIL commit codepath
-
-Packages:
- > system/file-system/zfs
-
-Archive:
- > https://downloads.omniosce.org/pkg/8648-backport.p5p
+No current pending patches.
 
 =======================================================================
 


### PR DESCRIPTION
'8648 Fix range locking in ZIL commit codepath' will be part of `r151022y`