### PR TITLE
Upstream merge/2017110201

### DIFF
--- a/usr/src/boot/lib/libstand/Makefile.inc
+++ b/usr/src/boot/lib/libstand/Makefile.inc
@@ -168,11 +168,11 @@ OBJS +=	closeall.o dev.o ioctl.o nullfs.o stat.o fstat.o close.o lseek.o \
 	open.o read.o write.o readdir.o
 
 # network routines
-SRCS +=	$(LIBSTAND_SRC)/arp.c $(LIBSTAND_SRC)/ether.c \
+SRCS +=	$(LIBSTAND_SRC)/arp.c $(LIBSTAND_SRC)/ether.c $(LIBSTAND_SRC)/ip.c \
 	$(LIBSTAND_SRC)/inet_ntoa.c $(LIBSTAND_SRC)/in_cksum.c \
 	$(LIBSTAND_SRC)/net.c $(LIBSTAND_SRC)/udp.c $(LIBSTAND_SRC)/netif.c \
 	$(LIBSTAND_SRC)/rpc.c
-OBJS +=	arp.o ether.o inet_ntoa.o in_cksum.o net.o udp.o netif.o rpc.o
+OBJS +=	arp.o ether.o ip.o inet_ntoa.o in_cksum.o net.o udp.o netif.o rpc.o
 
 # network info services:
 SRCS +=	$(LIBSTAND_SRC)/bootp.c $(LIBSTAND_SRC)/rarp.c \

--- a/usr/src/boot/lib/libstand/ip.c
+++ b/usr/src/boot/lib/libstand/ip.c
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 1992 Regents of the University of California.
+ * All rights reserved.
+ *
+ * This software was developed by the Computer Systems Engineering group
+ * at Lawrence Berkeley Laboratory under DARPA contract BG 91-66 and
+ * contributed to Berkeley.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * The send and receive functions were originally implemented in udp.c and
+ * moved here. Also it is likely some more cleanup can be done, especially
+ * once we will implement the support for tcp.
+ */
+
+#include <sys/cdefs.h>
+
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/queue.h>
+
+#include <string.h>
+
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/if_ether.h>
+#include <netinet/in_systm.h>
+
+#include <netinet/in_pcb.h>
+#include <netinet/ip.h>
+#include <netinet/ip_var.h>
+#include <netinet/udp.h>
+#include <netinet/udp_var.h>
+
+#include "stand.h"
+#include "net.h"
+
+typedef STAILQ_HEAD(ipqueue, ip_queue) ip_queue_t;
+struct ip_queue {
+	void		*ipq_pkt;
+	struct ip	*ipq_hdr;
+	STAILQ_ENTRY(ip_queue) ipq_next;
+};
+
+/*
+ * Fragment re-assembly queue.
+ */
+struct ip_reasm {
+	struct in_addr	ip_src;
+	struct in_addr	ip_dst;
+	uint16_t	ip_id;
+	uint8_t		ip_proto;
+	uint8_t		ip_ttl;
+	size_t		ip_total_size;
+	ip_queue_t	ip_queue;
+	void		*ip_pkt;
+	struct ip	*ip_hdr;
+	STAILQ_ENTRY(ip_reasm) ip_next;
+};
+
+STAILQ_HEAD(ire_list, ip_reasm) ire_list = STAILQ_HEAD_INITIALIZER(ire_list);
+
+/* Caller must leave room for ethernet and ip headers in front!! */
+ssize_t
+sendip(struct iodesc *d, void *pkt, size_t len, uint8_t proto)
+{
+	ssize_t cc;
+	struct ip *ip;
+	u_char *ea;
+
+#ifdef NET_DEBUG
+	if (debug) {
+		printf("sendip: proto: %x d=%p called.\n", proto, (void *)d);
+		if (d) {
+			printf("saddr: %s:%d",
+			    inet_ntoa(d->myip), ntohs(d->myport));
+			printf(" daddr: %s:%d\n",
+			    inet_ntoa(d->destip), ntohs(d->destport));
+		}
+	}
+#endif
+
+	ip = (struct ip *)pkt - 1;
+	len += sizeof(*ip);
+
+	bzero(ip, sizeof(*ip));
+
+	ip->ip_v = IPVERSION;			/* half-char */
+	ip->ip_hl = sizeof(*ip) >> 2;		/* half-char */
+	ip->ip_len = htons(len);
+	ip->ip_p = proto;			/* char */
+	ip->ip_ttl = IPDEFTTL;			/* char */
+	ip->ip_src = d->myip;
+	ip->ip_dst = d->destip;
+	ip->ip_sum = in_cksum(ip, sizeof(*ip));	 /* short, but special */
+
+	if (ip->ip_dst.s_addr == INADDR_BROADCAST || ip->ip_src.s_addr == 0 ||
+	    netmask == 0 || SAMENET(ip->ip_src, ip->ip_dst, netmask))
+		ea = arpwhohas(d, ip->ip_dst);
+	else
+		ea = arpwhohas(d, gateip);
+
+	cc = sendether(d, ip, len, ea, ETHERTYPE_IP);
+	if (cc == -1)
+		return (-1);
+	if (cc != len)
+		panic("sendip: bad write (%zd != %zd)", cc, len);
+	return (cc - sizeof(*ip));
+}
+
+static void
+ip_reasm_free(struct ip_reasm *ipr)
+{
+	struct ip_queue *ipq;
+
+	while ((ipq = STAILQ_FIRST(&ipr->ip_queue)) != NULL) {
+		STAILQ_REMOVE_HEAD(&ipr->ip_queue, ipq_next);
+		free(ipq->ipq_pkt);
+		free(ipq);
+	}
+	free(ipr->ip_pkt);
+	free(ipr);
+}
+
+static int
+ip_reasm_add(struct ip_reasm *ipr, void *pkt, struct ip *ip)
+{
+	struct ip_queue *ipq, *prev, *p;
+
+	if ((ipq = calloc(1, sizeof (*ipq))) == NULL)
+		return (1);
+
+	ipq->ipq_pkt = pkt;
+	ipq->ipq_hdr = ip;
+
+	prev = NULL;
+	STAILQ_FOREACH(p, &ipr->ip_queue, ipq_next) {
+		if ((ntohs(p->ipq_hdr->ip_off) & IP_OFFMASK) <
+		    (ntohs(ip->ip_off) & IP_OFFMASK)) {
+			prev = p;
+			continue;
+		}
+		if (prev == NULL)
+			break;
+
+		STAILQ_INSERT_AFTER(&ipr->ip_queue, prev, ipq, ipq_next);
+		return (0);
+	}
+	STAILQ_INSERT_HEAD(&ipr->ip_queue, ipq, ipq_next);
+	return (0);
+}
+
+/*
+ * Receive a IP packet and validate it is for us.
+ */
+static ssize_t
+readipv4(struct iodesc *d, void **pkt, void **payload, time_t tleft,
+    uint8_t proto)
+{
+	ssize_t n;
+	size_t hlen;
+	struct ether_header *eh;
+	struct ip *ip;
+	struct udphdr *uh;
+	uint16_t etype;		/* host order */
+	char *ptr;
+	struct ip_reasm *ipr;
+	struct ip_queue *ipq, *last;
+
+#ifdef NET_DEBUG
+	if (debug)
+		printf("readip: called\n");
+#endif
+
+	ip = NULL;
+	ptr = NULL;
+	n = readether(d, (void **)&ptr, (void **)&ip, tleft, &etype);
+	if (n == -1 || n < sizeof(*ip) + sizeof(*uh)) {
+		free(ptr);
+		return (-1);
+	}
+
+	/* Ethernet address checks now in readether() */
+
+	/* Need to respond to ARP requests. */
+	if (etype == ETHERTYPE_ARP) {
+		struct arphdr *ah = (void *)ip;
+		if (ah->ar_op == htons(ARPOP_REQUEST)) {
+			/* Send ARP reply */
+			arp_reply(d, ah);
+		}
+		free(ptr);
+		errno = EAGAIN;	/* Call me again. */
+		return (-1);
+	}
+
+	if (etype != ETHERTYPE_IP) {
+#ifdef NET_DEBUG
+		if (debug)
+			printf("readip: not IP. ether_type=%x\n", etype);
+#endif
+		free(ptr);
+		return (-1);
+	}
+
+	/* Check ip header */
+	if (ip->ip_v != IPVERSION ||	/* half char */
+	    ip->ip_p != proto) {
+#ifdef NET_DEBUG
+		if (debug) {
+			printf("readip: IP version or proto. ip_v=%d ip_p=%d\n",
+			    ip->ip_v, ip->ip_p);
+		}
+#endif
+		free(ptr);
+		return (-1);
+	}
+
+	hlen = ip->ip_hl << 2;
+	if (hlen < sizeof(*ip) ||
+	    in_cksum(ip, hlen) != 0) {
+#ifdef NET_DEBUG
+		if (debug)
+			printf("readip: short hdr or bad cksum.\n");
+#endif
+		free(ptr);
+		return (-1);
+	}
+	if (n < ntohs(ip->ip_len)) {
+#ifdef NET_DEBUG
+		if (debug)
+			printf("readip: bad length %d < %d.\n",
+			       (int)n, ntohs(ip->ip_len));
+#endif
+		free(ptr);
+		return (-1);
+	}
+	if (d->myip.s_addr && ip->ip_dst.s_addr != d->myip.s_addr) {
+#ifdef NET_DEBUG
+		if (debug) {
+			printf("readip: bad saddr %s != ", inet_ntoa(d->myip));
+			printf("%s\n", inet_ntoa(ip->ip_dst));
+		}
+#endif
+		free(ptr);
+		return (-1);
+	}
+
+	/* Unfragmented packet. */
+	if ((ntohs(ip->ip_off) & IP_MF) == 0 &&
+	    (ntohs(ip->ip_off) & IP_OFFMASK) == 0) {
+		uh = (struct udphdr *)((uintptr_t)ip + sizeof (*ip));
+		/* If there were ip options, make them go away */
+		if (hlen != sizeof(*ip)) {
+			bcopy(((u_char *)ip) + hlen, uh, uh->uh_ulen - hlen);
+			ip->ip_len = htons(sizeof(*ip));
+			n -= hlen - sizeof(*ip);
+		}
+
+		n = (n > (ntohs(ip->ip_len) - sizeof(*ip))) ?
+		    ntohs(ip->ip_len) - sizeof(*ip) : n;
+		*pkt = ptr;
+		*payload = (void *)((uintptr_t)ip + sizeof(*ip));
+		return (n);
+	}
+
+	STAILQ_FOREACH(ipr, &ire_list, ip_next) {
+		if (ipr->ip_src.s_addr == ip->ip_src.s_addr &&
+		    ipr->ip_dst.s_addr == ip->ip_dst.s_addr &&
+		    ipr->ip_id == ip->ip_id &&
+		    ipr->ip_proto == ip->ip_p)
+			break;
+	}
+
+	/* Allocate new reassembly entry */
+	if (ipr == NULL) {
+		if ((ipr = calloc(1, sizeof (*ipr))) == NULL) {
+			free(ptr);
+			return (-1);
+		}
+
+		ipr->ip_src = ip->ip_src;
+		ipr->ip_dst = ip->ip_dst;
+		ipr->ip_id = ip->ip_id;
+		ipr->ip_proto = ip->ip_p;
+		ipr->ip_ttl = MAXTTL;
+		STAILQ_INIT(&ipr->ip_queue);
+		STAILQ_INSERT_TAIL(&ire_list, ipr, ip_next);
+	}
+
+	if (ip_reasm_add(ipr, ptr, ip) != 0) {
+		STAILQ_REMOVE(&ire_list, ipr, ip_reasm, ip_next);
+		free(ipr);
+		free(ptr);
+		return (-1);
+	}
+
+	if ((ntohs(ip->ip_off) & IP_MF) == 0) {
+		ipr->ip_total_size = (8 * (ntohs(ip->ip_off) & IP_OFFMASK));
+		ipr->ip_total_size += n + sizeof (*ip);
+		ipr->ip_total_size += sizeof (struct ether_header);
+
+		ipr->ip_pkt = malloc(ipr->ip_total_size + 2);
+		if (ipr->ip_pkt == NULL) {
+			STAILQ_REMOVE(&ire_list, ipr, ip_reasm, ip_next);
+			ip_reasm_free(ipr);
+			return (-1);
+		}
+	}
+
+	/*
+	 * If we do not have re-assembly buffer ipr->ip_pkt, we are still
+	 * missing fragments, so just restart the read.
+	 */
+	if (ipr->ip_pkt == NULL) {
+		errno = EAGAIN;
+		return (-1);
+	}
+
+	/*
+	 * Walk the packet list in reassembly queue, if we got all the
+	 * fragments, build the packet.
+	 */
+	n = 0;
+	last = NULL;
+	STAILQ_FOREACH(ipq, &ipr->ip_queue, ipq_next) {
+		if ((ntohs(ipq->ipq_hdr->ip_off) & IP_OFFMASK) != n / 8) {
+			STAILQ_REMOVE(&ire_list, ipr, ip_reasm, ip_next);
+			ip_reasm_free(ipr);
+			return (-1);
+		}
+
+		n += ntohs(ipq->ipq_hdr->ip_len) - (ipq->ipq_hdr->ip_hl << 2);
+		last = ipq;
+	}
+	if ((ntohs(last->ipq_hdr->ip_off) & IP_MF) != 0) {
+		errno = EAGAIN;
+		return (-1);
+	}
+
+	ipq = STAILQ_FIRST(&ipr->ip_queue);
+	/* Fabricate ethernet header */
+	eh = (struct ether_header *)((uintptr_t)ipr->ip_pkt + 2);
+	bcopy((void *)((uintptr_t)ipq->ipq_pkt + 2), eh, sizeof (*eh));
+
+	/* Fabricate IP header */
+	ipr->ip_hdr = (struct ip *)((uintptr_t)eh + sizeof (*eh));
+	bcopy(ipq->ipq_hdr, ipr->ip_hdr, sizeof (*ipr->ip_hdr));
+	ipr->ip_hdr->ip_hl = sizeof (*ipr->ip_hdr) >> 2;
+	ipr->ip_hdr->ip_len = htons(n);
+	ipr->ip_hdr->ip_sum = 0;
+	ipr->ip_hdr->ip_sum = in_cksum(ipr->ip_hdr, sizeof (*ipr->ip_hdr));
+
+	n = 0;
+	ptr = (char *)((uintptr_t)ipr->ip_hdr + sizeof (*ipr->ip_hdr));
+	STAILQ_FOREACH(ipq, &ipr->ip_queue, ipq_next) {
+		char *data;
+		size_t len;
+
+		hlen = ipq->ipq_hdr->ip_hl << 2;
+		len = ntohs(ipq->ipq_hdr->ip_len) - hlen;
+		data = (char *)((uintptr_t)ipq->ipq_hdr + hlen);
+
+		bcopy(data, ptr + n, len);
+		n += len;
+	}
+
+	*pkt = ipr->ip_pkt;
+	ipr->ip_pkt = NULL;	/* Avoid free from ip_reasm_free() */
+	*payload = ptr;
+
+	/* Clean up the reassembly list */
+	while ((ipr = STAILQ_FIRST(&ire_list)) != NULL) {
+		STAILQ_REMOVE_HEAD(&ire_list, ip_next);
+		ip_reasm_free(ipr);
+	}
+	return (n);
+}
+
+/*
+ * Receive a IP packet.
+ */
+ssize_t
+readip(struct iodesc *d, void **pkt, void **payload, time_t tleft,
+    uint8_t proto)
+{
+	time_t t;
+	ssize_t ret = -1;
+
+	t = getsecs();
+	while ((getsecs() - t) < tleft) {
+		errno = 0;
+		ret = readipv4(d, pkt, payload, tleft, proto);
+		if (errno != EAGAIN)
+			break;
+	}
+	return (ret);
+}

--- a/usr/src/boot/lib/libstand/net.h
+++ b/usr/src/boot/lib/libstand/net.h
@@ -109,6 +109,8 @@ ssize_t sendether(struct iodesc *d, void *pkt, size_t len,
 			u_char *dea, int etype);
 ssize_t readether(struct iodesc *, void **, void **, time_t, u_int16_t *);
 
+ssize_t	sendip(struct iodesc *, void *, size_t, uint8_t);
+ssize_t	readip(struct iodesc *, void **, void **, time_t, uint8_t);
 ssize_t	sendudp(struct iodesc *, void *, size_t);
 ssize_t	readudp(struct iodesc *, void **, void **, time_t);
 ssize_t	sendrecv(struct iodesc *,

--- a/usr/src/boot/lib/libstand/udp.c
+++ b/usr/src/boot/lib/libstand/udp.c
@@ -61,9 +61,8 @@ ssize_t
 sendudp(struct iodesc *d, void *pkt, size_t len)
 {
 	ssize_t cc;
-	struct ip *ip;
+	struct udpiphdr *ui;
 	struct udphdr *uh;
-	u_char *ea;
 
 #ifdef NET_DEBUG
  	if (debug) {
@@ -77,52 +76,31 @@ sendudp(struct iodesc *d, void *pkt, size_t len)
 	}
 #endif
 
+	ui = (struct udpiphdr *)pkt - 1;
+	bzero(ui, sizeof(*ui));
+
 	uh = (struct udphdr *)pkt - 1;
-	ip = (struct ip *)uh - 1;
-	len += sizeof(*ip) + sizeof(*uh);
-
-	bzero(ip, sizeof(*ip) + sizeof(*uh));
-
-	ip->ip_v = IPVERSION;			/* half-char */
-	ip->ip_hl = sizeof(*ip) >> 2;		/* half-char */
-	ip->ip_len = htons(len);
-	ip->ip_p = IPPROTO_UDP;			/* char */
-	ip->ip_ttl = IPDEFTTL;			/* char */
-	ip->ip_src = d->myip;
-	ip->ip_dst = d->destip;
-	ip->ip_sum = in_cksum(ip, sizeof(*ip));	 /* short, but special */
+	len += sizeof(*uh);
 
 	uh->uh_sport = d->myport;
 	uh->uh_dport = d->destport;
-	uh->uh_ulen = htons(len - sizeof(*ip));
+	uh->uh_ulen = htons(len);
+
+	ui->ui_pr = IPPROTO_UDP;
+	ui->ui_len = uh->uh_ulen;
+	ui->ui_src = d->myip;
+	ui->ui_dst = d->destip;
 
 #ifndef UDP_NO_CKSUM
-	{
-		struct udpiphdr *ui;
-		struct ip tip;
-
-		/* Calculate checksum (must save and restore ip header) */
-		tip = *ip;
-		ui = (struct udpiphdr *)ip;
-		bzero(&ui->ui_x1, sizeof(ui->ui_x1));
-		ui->ui_len = uh->uh_ulen;
-		uh->uh_sum = in_cksum(ui, len);
-		*ip = tip;
-	}
+	uh->uh_sum = in_cksum(ui, len + sizeof (struct ip));
 #endif
 
-	if (ip->ip_dst.s_addr == INADDR_BROADCAST || ip->ip_src.s_addr == 0 ||
-	    netmask == 0 || SAMENET(ip->ip_src, ip->ip_dst, netmask))
-		ea = arpwhohas(d, ip->ip_dst);
-	else
-		ea = arpwhohas(d, gateip);
-
-	cc = sendether(d, ip, len, ea, ETHERTYPE_IP);
+	cc = sendip(d, uh, len, IPPROTO_UDP);
 	if (cc == -1)
 		return (-1);
 	if (cc != len)
 		panic("sendudp: bad write (%zd != %zd)", cc, len);
-	return (cc - (sizeof(*ip) + sizeof(*uh)));
+	return (cc - sizeof(*uh));
 }
 
 /*
@@ -132,10 +110,7 @@ ssize_t
 readudp(struct iodesc *d, void **pkt, void **payload, time_t tleft)
 {
 	ssize_t n;
-	size_t hlen;
-	struct ip *ip;
 	struct udphdr *uh;
-	uint16_t etype;		/* host order */
 	void *ptr;
 
 #ifdef NET_DEBUG
@@ -143,84 +118,14 @@ readudp(struct iodesc *d, void **pkt, void **payload, time_t tleft)
 		printf("readudp: called\n");
 #endif
 
-	ip = NULL;
+	uh = NULL;
 	ptr = NULL;
-	n = readether(d, &ptr, (void **)&ip, tleft, &etype);
-	if (n == -1 || n < sizeof(*ip) + sizeof(*uh)) {
+	n = readip(d, &ptr, (void **)&uh, tleft, IPPROTO_UDP);
+	if (n == -1 || n < sizeof(*uh) || n != ntohs(uh->uh_ulen)) {
 		free(ptr);
 		return (-1);
 	}
 
-	/* Ethernet address checks now in readether() */
-
-	/* Need to respond to ARP requests. */
-	if (etype == ETHERTYPE_ARP) {
-		struct arphdr *ah = (void *)ip;
-		if (ah->ar_op == htons(ARPOP_REQUEST)) {
-			/* Send ARP reply */
-			arp_reply(d, ah);
-		}
-		free(ptr);
-		return (-1);
-	}
-
-	if (etype != ETHERTYPE_IP) {
-#ifdef NET_DEBUG
-		if (debug)
-			printf("readudp: not IP. ether_type=%x\n", etype);
-#endif
-		free(ptr);
-		return (-1);
-	}
-
-	/* Check ip header */
-	if (ip->ip_v != IPVERSION ||
-	    ip->ip_p != IPPROTO_UDP) {	/* half char */
-#ifdef NET_DEBUG
-		if (debug)
-			printf("readudp: IP version or not UDP. ip_v=%d ip_p=%d\n", ip->ip_v, ip->ip_p);
-#endif
-		free(ptr);
-		return (-1);
-	}
-
-	hlen = ip->ip_hl << 2;
-	if (hlen < sizeof(*ip) ||
-	    in_cksum(ip, hlen) != 0) {
-#ifdef NET_DEBUG
-		if (debug)
-			printf("readudp: short hdr or bad cksum.\n");
-#endif
-		free(ptr);
-		return (-1);
-	}
-	if (n < ntohs(ip->ip_len)) {
-#ifdef NET_DEBUG
-		if (debug)
-			printf("readudp: bad length %d < %d.\n",
-			       (int)n, ntohs(ip->ip_len));
-#endif
-		free(ptr);
-		return (-1);
-	}
-	if (d->myip.s_addr && ip->ip_dst.s_addr != d->myip.s_addr) {
-#ifdef NET_DEBUG
-		if (debug) {
-			printf("readudp: bad saddr %s != ", inet_ntoa(d->myip));
-			printf("%s\n", inet_ntoa(ip->ip_dst));
-		}
-#endif
-		free(ptr);
-		return (-1);
-	}
-
-	uh = (struct udphdr *)((uintptr_t)ip + sizeof (*ip));
-	/* If there were ip options, make them go away */
-	if (hlen != sizeof(*ip)) {
-		bcopy(((u_char *)ip) + hlen, uh, uh->uh_ulen - hlen);
-		ip->ip_len = htons(sizeof(*ip));
-		n -= hlen - sizeof(*ip);
-	}
 	if (uh->uh_dport != d->myport) {
 #ifdef NET_DEBUG
 		if (debug)
@@ -234,16 +139,13 @@ readudp(struct iodesc *d, void **pkt, void **payload, time_t tleft)
 #ifndef UDP_NO_CKSUM
 	if (uh->uh_sum) {
 		struct udpiphdr *ui;
+		struct ip *ip;
 		struct ip tip;
 
 		n = ntohs(uh->uh_ulen) + sizeof(*ip);
-		if (n > RECV_SIZE - ETHER_SIZE) {
-			printf("readudp: huge packet, udp len %d\n", (int)n);
-			free(ptr);
-			return (-1);
-		}
 
 		/* Check checksum (must save and restore ip header) */
+		ip = (struct ip *)uh - 1;
 		tip = *ip;
 		ui = (struct udpiphdr *)ip;
 		bzero(&ui->ui_x1, sizeof(ui->ui_x1));

--- a/usr/src/cmd/fm/dicts/DISK.dict
+++ b/usr/src/cmd/fm/dicts/DISK.dict
@@ -1,6 +1,7 @@
 #
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
 #
 # CDDL HEADER START
 #
@@ -32,3 +33,4 @@ fault.io.disk.over-temperature=1
 fault.io.disk.self-test-failure=2
 fault.io.scsi.cmd.disk.dev.rqs.derr=3
 fault.io.scsi.cmd.disk.dev.rqs.merr=4
+fault.io.disk.ssm-wearout=8

--- a/usr/src/cmd/fm/dicts/DISK.po
+++ b/usr/src/cmd/fm/dicts/DISK.po
@@ -1,6 +1,7 @@
 #
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
 #
 # CDDL HEADER START
 #
@@ -104,3 +105,19 @@ msgid "DISK-8000-4Q.impact"
 msgstr "It is likely that continued operation will result in data corruption, which may eventually cause the loss of service or the service degradation.\n"
 msgid "DISK-8000-4Q.action"
 msgstr "Schedule a repair procedure to replace the affected device. Use 'fmadm faulty' to find the affected disk.\n"
+#
+# code: DISK-8000-8D
+# keys: fault.io.disk.ssm-wearout
+#
+msgid "DISK-8000-8D.type"
+msgstr "Fault"
+msgid "DISK-8000-8D.severity"
+msgstr "Major"
+msgid "DISK-8000-8D.description"
+msgstr "A solid state media device is nearing end of life as projected by the manufacturer."
+msgid "DISK-8000-8D.response"
+msgstr "None."
+msgid "DISK-8000-8D.impact"
+msgstr "Performance degradation is likely and continued operation of this device will cause drive failure and potential data loss."
+msgid "DISK-8000-8D.action"
+msgstr "Schedule a repair procedure to replace the affected drive.\nUse fmdump -V -u <EVENT_ID> to identify the drive."

--- a/usr/src/cmd/fm/eversholt/files/common/disk.esc
+++ b/usr/src/cmd/fm/eversholt/files/common/disk.esc
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #pragma dictionary "DISK"
@@ -44,7 +45,8 @@ asru P;
  * to trigger a fault when recovery/relocation is not possible.
  *
  * We let the engine propagate one error only once every 1 minute and then if we
- * still get 2 or more * errors within 24 hours for the same LBA, there is a fault.
+ * still get 2 or more errors within 24 hours for the same LBA,
+ * there is a fault.
  */
 engine serd.io.scsi.cmd.disk.dev.rqs.merr@P, N=1, T=24h;
 
@@ -185,6 +187,7 @@ event fault.io.disk.predictive-failure@P, FITrate=10,
     FITrate=10, FRU=P, ASRU=P;
 event fault.io.disk.self-test-failure@P, FITrate=10,
     FITrate=10, FRU=P, ASRU=P;
+event fault.io.disk.ssm-wearout@P;
 
 /*
  * ereports.
@@ -192,6 +195,7 @@ event fault.io.disk.self-test-failure@P, FITrate=10,
 event ereport.io.scsi.disk.over-temperature@P;
 event ereport.io.scsi.disk.predictive-failure@P;
 event ereport.io.scsi.disk.self-test-failure@P;
+event ereport.io.scsi.disk.ssm-wearout@P;
 
 /*
  * Propagations.
@@ -206,3 +210,10 @@ prop fault.io.disk.predictive-failure@P ->
     ereport.io.scsi.disk.predictive-failure@P {
     setpayloadprop("asc", payloadprop("additional-sense-code")) &&
     setpayloadprop("ascq", payloadprop("additional-sense-code-qualifier")) };
+
+prop fault.io.disk.ssm-wearout@P ->
+    ereport.io.scsi.disk.ssm-wearout@P {
+    setpayloadprop("current-wearout-percentage",
+    payloadprop("current-ssm-wearout"))
+    && setpayloadprop("threshold-wearout-percentage",
+    payloadprop("threshold-ssm-wearout")) };

--- a/usr/src/cmd/fm/modules/common/disk-monitor/disk_monitor.c
+++ b/usr/src/cmd/fm/modules/common/disk-monitor/disk_monitor.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -157,6 +158,10 @@ dm_fault_execute_actions(fmd_hdl_t *hdl, diskmon_t *diskp, nvlist_t *nvl)
 	if (fmd_nvl_class_match(hdl, nvl,
 	    DISK_ERROR_CLASS "." FM_FAULT_DISK_TESTFAIL))
 		action_prop = DISK_PROP_STFAILACTION;
+
+	if (fmd_nvl_class_match(hdl, nvl,
+	    DISK_ERROR_CLASS "." FM_FAULT_SSM_WEAROUT))
+		action_prop = DISK_PROP_SSMWEAROUTACTION;
 
 	dm_fault_indicator_set(diskp, INDICATOR_ON);
 

--- a/usr/src/cmd/fm/modules/common/disk-monitor/diskmon_conf.h
+++ b/usr/src/cmd/fm/modules/common/disk-monitor/diskmon_conf.h
@@ -22,12 +22,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef _DISKMOND_CONF_H
 #define	_DISKMOND_CONF_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
  * Configuration File data
@@ -62,6 +61,7 @@ extern "C" {
 #define	DISK_PROP_FRUACTION		"fru-update-action"
 #define	DISK_PROP_OTEMPACTION		"overtemp-action"
 #define	DISK_PROP_STFAILACTION		"selftest-fail-action"
+#define	DISK_PROP_SSMWEAROUTACTION	"ssm-wearout-action"
 
 /* Properties for the "ap" subentity */
 #define	DISK_AP_PROP_APID "path"

--- a/usr/src/cmd/fm/modules/common/disk-transport/disk-transport.conf
+++ b/usr/src/cmd/fm/modules/common/disk-transport/disk-transport.conf
@@ -21,5 +21,8 @@
 #
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
 #
-#ident	"%Z%%M%	%I%	%E% SMI"
+#
+# To disable transport of "high solid state media used %" faults uncomment:
+# setprop ignore-ssm-wearout true

--- a/usr/src/cmd/fm/modules/common/disk-transport/disk_transport.c
+++ b/usr/src/cmd/fm/modules/common/disk-transport/disk_transport.c
@@ -21,9 +21,8 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
  * Disk error transport module
@@ -32,17 +31,18 @@
  * and FMA ereports.  It is a read-only transport module, and checks for the
  * following failures:
  *
- * 	- overtemp
- * 	- predictive failure
- * 	- self-test failure
+ *	- overtemp
+ *	- predictive failure
+ *	- self-test failure
+ *	- solid state media wearout
  *
  * These failures are detected via the TOPO_METH_DISK_STATUS method, which
  * leverages libdiskstatus to do the actual analysis.  This transport module is
  * in charge of the following tasks:
  *
- * 	- discovering available devices
- * 	- periodically checking devices
- * 	- managing device addition/removal
+ *	- discovering available devices
+ *	- periodically checking devices
+ *	- managing device addition/removal
  */
 
 #include <ctype.h>
@@ -113,7 +113,6 @@ dt_analyze_disk(topo_hdl_t *thp, tnode_t *node, void *arg)
 	char *protocol;
 	int err;
 	disk_monitor_t *dmp = arg;
-	uint64_t ena;
 	nvpair_t *elem;
 	boolean_t fault;
 	nvlist_t *details;
@@ -152,10 +151,8 @@ dt_analyze_disk(topo_hdl_t *thp, tnode_t *node, void *arg)
 
 	nvlist_free(in);
 
-	ena = fmd_event_ena_create(dmp->dm_hdl);
-
 	/*
-	 * Add any faults.
+	 * Check for faults and post ereport(s) if needed
 	 */
 	if (nvlist_lookup_nvlist(result, "faults", &faults) == 0 &&
 	    nvlist_lookup_string(result, "protocol", &protocol) == 0) {
@@ -170,8 +167,15 @@ dt_analyze_disk(topo_hdl_t *thp, tnode_t *node, void *arg)
 			    &details) != 0)
 				continue;
 
+			if (strcmp(nvpair_name(elem),
+			    FM_EREPORT_SCSI_SSMWEAROUT) == 0 &&
+			    fmd_prop_get_int32(dmp->dm_hdl,
+			    "ignore-ssm-wearout") == FMD_B_TRUE)
+				continue;
+
 			dt_post_ereport(dmp->dm_hdl, dmp->dm_xprt, protocol,
-			    nvpair_name(elem), ena, fmri, details);
+			    nvpair_name(elem),
+			    fmd_event_ena_create(dmp->dm_hdl), fmri, details);
 		}
 	}
 
@@ -248,6 +252,7 @@ static const fmd_prop_t fmd_props[] = {
 	{ "interval", FMD_TYPE_TIME, "1h" },
 	{ "min-interval", FMD_TYPE_TIME, "1min" },
 	{ "simulate", FMD_TYPE_STRING, "" },
+	{ "ignore-ssm-wearout", FMD_TYPE_BOOL, "false"},
 	{ NULL, 0, NULL }
 };
 
@@ -262,7 +267,7 @@ static const fmd_hdl_ops_t fmd_ops = {
 };
 
 static const fmd_hdl_info_t fmd_info = {
-	"Disk Transport Agent", "1.0", &fmd_ops, fmd_props
+	"Disk Transport Agent", "1.1", &fmd_ops, fmd_props
 };
 
 void
@@ -289,7 +294,7 @@ _fmd_init(fmd_hdl_t *hdl)
 	 * the developer to substitute a faulty device based off all or part of
 	 * an FMRI string.  For example, one could do:
 	 *
-	 * 	setprop simulate "bay=4/disk=4	/path/to/sim.so"
+	 *	setprop simulate "bay=4/disk=4	/path/to/sim.so"
 	 *
 	 * When the transport module encounters an FMRI containing the given
 	 * string, then it will open the simulator file instead of the

--- a/usr/src/cmd/fm/modules/common/zfs-retire/zfs-retire.conf
+++ b/usr/src/cmd/fm/modules/common/zfs-retire/zfs-retire.conf
@@ -25,6 +25,9 @@
 #
 # fmd configuration file for the zfs retire agent.
 #
+# To enable automated retire for SSM wearout faults uncomment the line below:
+# setprop ssm_wearout_skip_retire false
+#
 subscribe fault.fs.zfs.*
 subscribe fault.io.*
 subscribe resource.fs.zfs.removed

--- a/usr/src/cmd/fm/modules/common/zfs-retire/zfs_retire.c
+++ b/usr/src/cmd/fm/modules/common/zfs-retire/zfs_retire.c
@@ -427,6 +427,14 @@ zfs_retire_recv(fmd_hdl_t *hdl, fmd_event_t *ep, nvlist_t *nvl,
 		    &retire) == 0 && retire == 0)
 			continue;
 
+		if (fmd_nvl_class_match(hdl, fault,
+		    "fault.io.disk.ssm-wearout") &&
+		    fmd_prop_get_int32(hdl, "ssm_wearout_skip_retire") ==
+		    FMD_B_TRUE) {
+			fmd_hdl_debug(hdl, "zfs-retire: ignoring SSM fault");
+			continue;
+		}
+
 		/*
 		 * While we subscribe to fault.fs.zfs.*, we only take action
 		 * for faults targeting a specific vdev (open failure or SERD
@@ -561,6 +569,7 @@ static const fmd_hdl_ops_t fmd_ops = {
 
 static const fmd_prop_t fmd_props[] = {
 	{ "spare_on_remove", FMD_TYPE_BOOL, "true" },
+	{ "ssm_wearout_skip_retire", FMD_TYPE_BOOL, "true"},
 	{ NULL, 0, NULL }
 };
 

--- a/usr/src/lib/fm/libdiskstatus/common/ds_impl.h
+++ b/usr/src/lib/fm/libdiskstatus/common/ds_impl.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_DS_IMPL_H
 #define	_DS_IMPL_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <dlfcn.h>
 #include <libnvpair.h>
@@ -53,6 +52,7 @@ struct disk_status {
 	nvlist_t		*ds_overtemp;	/* overtemp */
 	nvlist_t		*ds_predfail;	/* predict fail */
 	nvlist_t		*ds_testfail;	/* self test fail */
+	nvlist_t		*ds_ssmwearout;	/* SSM wearout fail */
 	int			ds_error;	/* last error */
 	nvlist_t		*ds_state;	/* protocol state */
 };
@@ -60,6 +60,7 @@ struct disk_status {
 #define	DS_FAULT_OVERTEMP	0x1
 #define	DS_FAULT_PREDFAIL	0x2
 #define	DS_FAULT_TESTFAIL	0x4
+#define	DS_FAULT_SSMWEAROUT	0x8
 
 extern void dprintf(const char *, ...);
 extern void ddump(const char *, const void *, size_t);

--- a/usr/src/lib/fm/libdiskstatus/common/ds_scsi.c
+++ b/usr/src/lib/fm/libdiskstatus/common/ds_scsi.c
@@ -21,9 +21,8 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <assert.h>
 #include <errno.h>
@@ -77,12 +76,16 @@ static int logpage_temp_verify(ds_scsi_info_t *,
     scsi_log_parameter_header_t *, int, nvlist_t *);
 static int logpage_selftest_verify(ds_scsi_info_t *,
     scsi_log_parameter_header_t *, int, nvlist_t *);
+static int logpage_ssm_verify(ds_scsi_info_t *,
+    scsi_log_parameter_header_t *, int, nvlist_t *);
 
 static int logpage_ie_analyze(ds_scsi_info_t *,
     scsi_log_parameter_header_t *, int);
 static int logpage_temp_analyze(ds_scsi_info_t *,
     scsi_log_parameter_header_t *, int);
 static int logpage_selftest_analyze(ds_scsi_info_t *,
+    scsi_log_parameter_header_t *, int);
+static int logpage_ssm_analyze(ds_scsi_info_t *,
     scsi_log_parameter_header_t *, int);
 
 static struct logpage_validation_entry log_validation[] = {
@@ -94,7 +97,10 @@ static struct logpage_validation_entry log_validation[] = {
 	    logpage_temp_verify, logpage_temp_analyze },
 	{ LOGPAGE_SELFTEST,	LOGPAGE_SUPP_SELFTEST,
 	    "self-test",
-	    logpage_selftest_verify, logpage_selftest_analyze }
+	    logpage_selftest_verify, logpage_selftest_analyze },
+	{ LOGPAGE_SSM,		LOGPAGE_SUPP_SSM,
+	    FM_EREPORT_SCSI_SSMWEAROUT,
+	    logpage_ssm_verify, logpage_ssm_analyze }
 };
 
 #define	NLOG_VALIDATION	(sizeof (log_validation) / sizeof (log_validation[0]))
@@ -757,6 +763,51 @@ logpage_selftest_verify(ds_scsi_info_t *sip,
 }
 
 /*
+ * Verify the contents of the Solid State Media (SSM) log page.
+ * As of SBC3r36 SSM log page contains one log parameter:
+ * "Percentage Used Endurance Indicator" which is mandatory.
+ * For the verification phase, we sanity check this parameter
+ * by making sure it's present and it's length is set to 0x04.
+ */
+static int
+logpage_ssm_verify(ds_scsi_info_t *sip,
+    scsi_log_parameter_header_t *lphp, int log_length, nvlist_t *nvl)
+{
+	ushort_t param_code;
+	int i, plen = 0;
+
+	for (i = 0; i < log_length; i += plen) {
+		lphp = (scsi_log_parameter_header_t *)((char *)lphp + plen);
+		param_code = BE_16(lphp->lph_param);
+
+		switch (param_code) {
+		case LOGPARAM_PRCNT_USED:
+			if (nvlist_add_boolean_value(nvl,
+			    FM_EREPORT_SCSI_SSMWEAROUT, B_TRUE) != 0)
+				return (scsi_set_errno(sip, EDS_NOMEM));
+			if (lphp->lph_length != LOGPARAM_PRCNT_USED_PARAM_LEN) {
+				if (nvlist_add_uint8(nvl,
+				    "invalid-length", lphp->lph_length) != 0)
+					return (scsi_set_errno(sip, EDS_NOMEM));
+
+				dprintf("solid state media logpage bad len\n");
+				break;
+			}
+
+			/* verification succeded */
+			return (0);
+		}
+
+		plen = lphp->lph_length +
+		    sizeof (scsi_log_parameter_header_t);
+	}
+
+	/* verification failed */
+	sip->si_supp_log &= ~LOGPAGE_SUPP_SSM;
+	return (0);
+}
+
+/*
  * Load the current IE mode pages
  */
 static int
@@ -1142,6 +1193,65 @@ logpage_selftest_analyze(ds_scsi_info_t *sip, scsi_log_parameter_header_t *lphp,
 	}
 
 	return (0);
+}
+
+/*
+ * Analyze the contents of the Solid State Media (SSM) log page's
+ * "Percentage Used Endurance Indicator" log parameter.
+ * We generate a fault if the percentage used is equal to or over
+ * PRCNT_USED_FAULT_THRSH
+ */
+static int
+logpage_ssm_analyze(ds_scsi_info_t *sip, scsi_log_parameter_header_t *lphp,
+    int log_length)
+{
+	uint16_t param_code;
+	scsi_ssm_log_param_t *ssm;
+	nvlist_t *nvl;
+	int i, plen = 0;
+
+	assert(sip->si_dsp->ds_overtemp == NULL);
+	if (nvlist_alloc(&sip->si_dsp->ds_overtemp, NV_UNIQUE_NAME, 0) != 0)
+		return (scsi_set_errno(sip, EDS_NOMEM));
+	nvl = sip->si_dsp->ds_overtemp;
+
+	for (i = 0; i < log_length; i += plen) {
+		lphp = (scsi_log_parameter_header_t *)((uint8_t *)lphp + plen);
+		param_code = BE_16(lphp->lph_param);
+		ssm = (scsi_ssm_log_param_t *)lphp;
+
+		switch (param_code) {
+		case LOGPARAM_PRCNT_USED:
+			if (lphp->lph_length != LOGPARAM_PRCNT_USED_PARAM_LEN)
+				break;
+
+			if ((nvlist_add_uint8(nvl,
+			    FM_EREPORT_PAYLOAD_SCSI_CURSSMWEAROUT,
+			    ssm->ssm_prcnt_used) != 0) ||
+			    (nvlist_add_uint8(nvl,
+			    FM_EREPORT_PAYLOAD_SCSI_THRSHSSMWEAROUT,
+			    PRCNT_USED_FAULT_THRSH) != 0))
+				return (scsi_set_errno(sip, EDS_NOMEM));
+
+			if (ssm->ssm_prcnt_used >= PRCNT_USED_FAULT_THRSH)
+				sip->si_dsp->ds_faults |= DS_FAULT_SSMWEAROUT;
+
+			return (0);
+		}
+
+		plen = lphp->lph_length +
+		    sizeof (scsi_log_parameter_header_t);
+	}
+
+	/*
+	 * If we got this far we didn't see LOGPARAM_PRCNT_USED
+	 * which is strange since we verified that it's there
+	 */
+	dprintf("solid state media logpage analyze failed\n");
+#if DEBUG
+	abort();
+#endif
+	return (scsi_set_errno(sip, EDS_NOT_SUPPORTED));
 }
 
 /*

--- a/usr/src/lib/fm/libdiskstatus/common/ds_scsi.h
+++ b/usr/src/lib/fm/libdiskstatus/common/ds_scsi.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_DS_SCSI_H
 #define	_DS_SCSI_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <sys/types.h>
 #include <sys/byteorder.h>
@@ -50,12 +49,14 @@ extern "C" {
 typedef struct scsi_log_header {
 #if defined(_BIT_FIELDS_LTOH)
 	uint8_t		lh_code : 6,
-			__reserved : 2;
+			lh_spf : 1,
+			lh_ds : 1;
 #else
-	uint8_t		__reserved : 2,
+	uint8_t		lh_ds : 1,
+			lh_spf : 1,
 			lh_code : 6;
 #endif
-	uint8_t		__reserved2;
+	uint8_t		lh_subpage;
 	uint16_t	lh_length;
 } scsi_log_header_t;
 
@@ -156,6 +157,20 @@ typedef struct scsi_selftest_log_param {
 #define	LOGPARAM_TEMP_LEN	\
 	(sizeof (scsi_temp_log_param_t) - \
 	    sizeof (scsi_log_parameter_header_t))
+
+/*
+ * Described in SBC3
+ */
+typedef struct scsi_ssm_log_param {
+	scsi_log_parameter_header_t ssm_hdr;
+	uint16_t		__reserved2;
+	uint8_t			__reserved1;
+	uchar_t			ssm_prcnt_used;
+} scsi_ssm_log_param_t;
+
+#define	LOGPARAM_PRCNT_USED		0x0001
+#define	LOGPARAM_PRCNT_USED_PARAM_LEN	0x04
+#define	PRCNT_USED_FAULT_THRSH		90
 
 /*
  * Mode sense/select page header information
@@ -278,6 +293,8 @@ typedef struct scsi_ie_page {
 #define	LOGPAGE_TEMP		0x0d
 #define	LOGPAGE_SELFTEST	0x10
 #define	LOGPAGE_IE		0x2f
+/* Solid State Media log page code */
+#define	LOGPAGE_SSM		0x11
 
 /* ASC constants */
 #define	ASC_INVALID_OPCODE				0x20
@@ -307,6 +324,7 @@ typedef struct scsi_ie_page {
 #define	LOGPAGE_SUPP_IE			0x1
 #define	LOGPAGE_SUPP_TEMP		0x2
 #define	LOGPAGE_SUPP_SELFTEST		0x4
+#define	LOGPAGE_SUPP_SSM		0x8
 
 #define	MSG_BUFLEN	256
 

--- a/usr/src/lib/fm/libdiskstatus/common/libdiskstatus.c
+++ b/usr/src/lib/fm/libdiskstatus/common/libdiskstatus.c
@@ -21,9 +21,8 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
  * Disk status library
@@ -33,9 +32,10 @@
  * SCSI (and therefore SATA) disks are currently supported.  The library is
  * capable of detecting the following status conditions:
  *
- * 	- Predictive failure
- * 	- Overtemp
- * 	- Self-test failure
+ *	- Predictive failure
+ *	- Overtemp
+ *	- Self-test failure
+ *	- Solid State Media wearout
  */
 
 #include <assert.h>
@@ -131,6 +131,7 @@ disk_status_close(disk_status_t *dsp)
 	nvlist_free(dsp->ds_predfail);
 	nvlist_free(dsp->ds_overtemp);
 	nvlist_free(dsp->ds_testfail);
+	nvlist_free(dsp->ds_ssmwearout);
 	if (dsp->ds_data)
 		dsp->ds_transport->dt_close(dsp->ds_data);
 	(void) close(dsp->ds_fd);
@@ -172,6 +173,8 @@ disk_status_get(disk_status_t *dsp)
 	nvlist_free(dsp->ds_testfail);
 	nvlist_free(dsp->ds_predfail);
 	nvlist_free(dsp->ds_overtemp);
+	nvlist_free(dsp->ds_ssmwearout);
+	dsp->ds_ssmwearout = NULL;
 	dsp->ds_testfail = dsp->ds_overtemp = dsp->ds_predfail = NULL;
 	dsp->ds_faults = 0;
 
@@ -220,6 +223,15 @@ disk_status_get(disk_status_t *dsp)
 		    (dsp->ds_faults & DS_FAULT_OVERTEMP) != 0)) != 0 ||
 		    (err = nvlist_add_nvlist(nvl, FM_EREPORT_SCSI_OVERTEMP,
 		    dsp->ds_overtemp)) != 0)
+			goto nverror;
+	}
+
+	if (dsp->ds_ssmwearout != NULL) {
+		if ((err = nvlist_add_boolean_value(faults,
+		    FM_EREPORT_SCSI_SSMWEAROUT,
+		    (dsp->ds_faults & DS_FAULT_SSMWEAROUT) != 0)) != 0 ||
+		    (err = nvlist_add_nvlist(nvl, FM_EREPORT_SCSI_SSMWEAROUT,
+		    dsp->ds_ssmwearout)) != 0)
 			goto nverror;
 	}
 

--- a/usr/src/uts/common/sys/fm/io/disk.h
+++ b/usr/src/uts/common/sys/fm/io/disk.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_SYS_FM_IO_DISK_H
 #define	_SYS_FM_IO_DISK_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #ifdef	__cplusplus
 extern "C" {
@@ -37,6 +36,7 @@ extern "C" {
 #define	FM_FAULT_DISK_PREDFAIL		"predictive-failure"
 #define	FM_FAULT_DISK_OVERTEMP		"over-temperature"
 #define	FM_FAULT_DISK_TESTFAIL		"self-test-failure"
+#define	FM_FAULT_SSM_WEAROUT		"ssm-wearout"
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/sys/fm/io/scsi.h
+++ b/usr/src/uts/common/sys/fm/io/scsi.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_SYS_FM_IO_SCSI_H
 #define	_SYS_FM_IO_SCSI_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #ifdef	__cplusplus
 extern "C" {
@@ -47,6 +46,10 @@ extern "C" {
 #define	FM_EREPORT_SCSI_OVERTEMP		"over-temperature"
 #define	FM_EREPORT_PAYLOAD_SCSI_CURTEMP		"current-temperature"
 #define	FM_EREPORT_PAYLOAD_SCSI_THRESHTEMP	"threshold-temperature"
+
+#define	FM_EREPORT_SCSI_SSMWEAROUT		"ssm-wearout"
+#define	FM_EREPORT_PAYLOAD_SCSI_CURSSMWEAROUT	"current-ssm-wearout"
+#define	FM_EREPORT_PAYLOAD_SCSI_THRSHSSMWEAROUT	"threshold-ssm-wearout"
 
 #define	FM_EREPORT_SCSI_TESTFAIL		"self-test-failure"
 #define	FM_EREPORT_PAYLOAD_SCSI_RESULTCODE	"result-code"


### PR DESCRIPTION
Weekly merge from `illumos-gate`

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2017110201-eab15b66eb i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Nov  2 09:52:44 CET 2017 ====
==== Nightly distributed build completed: Thu Nov  2 10:54:09 CET 2017 ====

==== Total build time ====

real    1:01:25

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-f81a14270f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   78

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2017110201-eab15b66eb

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:55.1
user  1:09:33.5
sys      5:54.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:46.5
user  1:01:18.6
sys      4:08.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:02.8
user    47:41.5
sys      5:32.4

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```