### PR TITLE
Upstream merge joyent_merge/2017110201

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: daa3911f02365820bf2df2a1cdf96602eda66912
+Last illumos-joyent commit: 5f694814304876e7d02ac81701220b11cf7fc897
 


### PR DESCRIPTION
Weekly upstream for joyent_merge/2017110201

## Backports

* none

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2017110201-8f066370cd i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Nov  2 11:30:35 CET 2017 ====
==== Nightly distributed build completed: Thu Nov  2 12:32:06 CET 2017 ====

==== Total build time ====

real    1:01:30

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-f81a14270f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   86

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017110201-8f066370cd

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:05.5
user  1:10:01.5
sys      5:57.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:54.5
user  1:01:42.7
sys      4:14.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:04.5
user    47:26.7
sys      5:21.1

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
