### PR TITLE
Upstream merge upstream_merge/2017110801

### DIFF
--- a/usr/src/boot/lib/libstand/nfs.c
+++ b/usr/src/boot/lib/libstand/nfs.c
@@ -51,7 +51,7 @@
 #define NFS_DEBUGxx
 
 #define NFSREAD_MIN_SIZE 1024
-#define NFSREAD_MAX_SIZE 4096
+#define NFSREAD_MAX_SIZE 16384
 
 /* NFSv3 definitions */
 #define	NFS_V3MAXFHSIZE		64

--- a/usr/src/boot/sys/boot/common/bootstrap.h
+++ b/usr/src/boot/sys/boot/common/bootstrap.h
@@ -304,7 +304,7 @@ struct arch_switch
      * Interface to adjust the load address according to the "object"
      * being loaded.
      */
-    uint64_t	(*arch_loadaddr)(u_int type, void *data, uint64_t addr);
+    vm_offset_t	(*arch_loadaddr)(u_int type, void *data, vm_offset_t addr);
 #define	LOAD_ELF	1	/* data points to the ELF header. */
 #define	LOAD_RAW	2	/* data points to the module file name. */
 #define	LOAD_KERN	3	/* data points to the kernel file name. */

--- a/usr/src/boot/sys/boot/common/disk.c
+++ b/usr/src/boot/sys/boot/common/disk.c
@@ -87,6 +87,12 @@ ptblread(void *d, void *buf, size_t blocks, uint64_t offset)
 	od = (struct open_disk *)dev->d_opendata;
 
 	/*
+	 * The strategy function assumes the offset is in units of 512 byte
+	 * sectors. For larger sector sizes, we need to adjust the offset to
+	 * match the actual sector size.
+	 */
+	offset *= (od->sectorsize / 512);
+	/*
 	 * As the GPT backup partition is located at the end of the disk,
 	 * to avoid reading past disk end, flag bcache not to use RA.
 	 */

--- a/usr/src/boot/sys/boot/efi/include/efi.h
+++ b/usr/src/boot/sys/boot/efi/include/efi.h
@@ -61,10 +61,4 @@ Revision History
 #include "efipoint.h"
 #include "efiuga.h"
 
-#define EFI_STRINGIZE(a)                #a 
-#define EFI_PROTOCOL_DEFINITION(a)      EFI_STRINGIZE(Protocol/a/a.h) 
-
-#define EFI_GUID_DEFINITION(a) EFI_STRINGIZE(Guid/a/a##.h) 
-#define EFI_GUID_STRING(guidpointer, shortstring, longstring)
-
 #endif

--- a/usr/src/boot/sys/boot/efi/libefi/efipart.c
+++ b/usr/src/boot/sys/boot/efi/libefi/efipart.c
@@ -888,7 +888,11 @@ efipart_strategy(void *devdata, int rw, daddr_t blk, size_t size,
 	bcd.dv_cache = pd->pd_bcache;
 
 	if (dev->d_dev->dv_type == DEVT_DISK) {
-		return (bcache_strategy(&bcd, rw, blk + dev->d_offset,
+		daddr_t offset;
+
+		offset = dev->d_offset * pd->pd_blkio->Media->BlockSize;
+		offset /= 512;
+		return (bcache_strategy(&bcd, rw, blk + offset,
 		    size, buf, rsize));
 	}
 	return (bcache_strategy(&bcd, rw, blk, size, buf, rsize));

--- a/usr/src/boot/sys/boot/efi/loader/copy.c
+++ b/usr/src/boot/sys/boot/efi/loader/copy.c
@@ -54,7 +54,7 @@ efi_loadaddr(u_int type, void *data, uint64_t addr)
 {
 	EFI_PHYSICAL_ADDRESS paddr;
 	struct stat st;
-	int size;
+	size_t size;
 	uint64_t pages;
 	EFI_STATUS status;
 
@@ -65,7 +65,7 @@ efi_loadaddr(u_int type, void *data, uint64_t addr)
 		return (0);	/* not supported */
 
 	if (type == LOAD_MEM)
-		size = *(int *)data;
+		size = *(size_t *)data;
 	else {
 		stat(data, &st);
 		size = st.st_size;
@@ -79,7 +79,7 @@ efi_loadaddr(u_int type, void *data, uint64_t addr)
 	    pages, &paddr);
 
 	if (EFI_ERROR(status)) {
-		printf("failed to allocate %d bytes for staging area: %lu\n",
+		printf("failed to allocate %zu bytes for staging area: %lu\n",
 		    size, EFI_ERROR_CODE(status));
 		return (0);
 	}

--- a/usr/src/boot/sys/boot/i386/libi386/Makefile
+++ b/usr/src/boot/sys/boot/i386/libi386/Makefile
@@ -96,6 +96,9 @@ CLEANFILES +=	machine x86
 
 include ../Makefile.inc
 
+# For multiboot2.h, must be last, to avoid conflicts
+CPPFLAGS +=	-I$(SRC)/uts/common
+
 machine:
 	$(RM) machine
 	$(SYMLINK) ../../../i386/include machine

--- a/usr/src/boot/sys/boot/i386/libi386/i386_copy.c
+++ b/usr/src/boot/sys/boot/i386/libi386/i386_copy.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 1998 Michael Smith <msmith@freebsd.org>
  * All rights reserved.
  *
@@ -27,47 +27,176 @@
 #include <sys/cdefs.h>
 
 /*
- * MD primitives supporting placement of module data 
+ * MD primitives supporting placement of module data
  *
  * XXX should check load address/size against memory top.
  */
 #include <stand.h>
-
+#include <sys/param.h>
+#include <sys/multiboot2.h>
+#include <machine/metadata.h>
+#include <machine/pc/bios.h>
 #include "libi386.h"
 #include "btxv86.h"
+#include "bootstrap.h"
+
+/*
+ * Verify the address is not in use by existing modules.
+ */
+static vm_offset_t
+addr_verify(struct preloaded_file *fp, vm_offset_t addr, size_t size)
+{
+	vm_offset_t f_addr;
+
+	while (fp != NULL) {
+		f_addr = fp->f_addr;
+
+		if ((f_addr <= addr) &&
+		     (f_addr + fp->f_size >= addr)) {
+			return (0);
+		}
+		if ((f_addr >= addr) && (f_addr <= addr + size)) {
+			return (0);
+		}
+		fp = fp->f_next;
+	}
+	return (addr);
+}
+
+/*
+ * Find smap entry above 1MB, able to contain size bytes from addr.
+ */
+static vm_offset_t
+smap_find(struct bios_smap *smap, int smaplen, vm_offset_t addr, size_t size)
+{
+	int i;
+
+	for (i = 0; i < smaplen; i++) {
+		if (smap[i].type != SMAP_TYPE_MEMORY)
+			continue;
+
+		/* We do not want address below 1MB. */
+		if (smap[i].base < 0x100000)
+			continue;
+
+		/* Do we fit into current entry? */
+		if ((smap[i].base <= addr) &&
+		    (smap[i].base + smap[i].length >= addr + size)) {
+			return (addr);
+		}
+
+		/* Do we fit into new entry? */
+		if ((smap[i].base > addr) && (smap[i].length >= size)) {
+			return (smap[i].base);
+		}
+	}
+	return (0);
+}
+
+/*
+ * Find usable address for loading. The address for the kernel is fixed, as
+ * it is determined by kernel linker map (dboot PT_LOAD address).
+ * For modules, we need to consult smap, the module address has to be
+ * aligned to page boundary and we have to fit into smap entry.
+ */
+vm_offset_t
+i386_loadaddr(u_int type, void *data, vm_offset_t addr)
+{
+	struct stat st;
+	size_t size, smaplen;
+	struct preloaded_file *fp, *mfp;
+	struct file_metadata *md;
+	struct bios_smap *smap;
+	vm_offset_t off;
+
+	/*
+	 * For now, assume we have memory for the kernel, the
+	 * required map is [1MB..) This assumption should be safe with x86 BIOS.
+	 */
+	if (type == LOAD_KERN)
+		return (addr);
+
+	if (addr == 0)
+		return (addr);	/* nothing to do */
+
+	if (type == LOAD_ELF)
+		return (0);	/* not supported */
+
+	if (type == LOAD_MEM) {
+		size = *(size_t *)data;
+	} else {
+		stat(data, &st);
+		size = st.st_size;
+	}
+
+	/*
+	 * Find our kernel, from it we will find the smap and the list of
+	 * loaded modules.
+	 */
+	fp = file_findfile(NULL, NULL);
+	if (fp == NULL)
+		return (0);
+	md = file_findmetadata(fp, MODINFOMD_SMAP);
+	if (md == NULL)
+		return (0);
+
+	smap = (struct bios_smap *)md->md_data;
+	smaplen = md->md_size / sizeof(struct bios_smap);
+
+	/* Start from the end of the kernel. */
+	mfp = fp;
+	do {
+		if (mfp == NULL) {
+			off = roundup2(addr + 1, MULTIBOOT_MOD_ALIGN);
+		} else {
+			off = roundup2(mfp->f_addr + mfp->f_size + 1,
+			    MULTIBOOT_MOD_ALIGN);
+		}
+		off = smap_find(smap, smaplen, off, size);
+		off = addr_verify(fp, off, size);
+		if (off != 0)
+			break;
+
+		if (mfp == NULL)
+			break;
+		mfp = mfp->f_next;
+	} while (off == 0);
+
+	return (off);
+}
 
 ssize_t
 i386_copyin(const void *src, vm_offset_t dest, const size_t len)
 {
-    if (dest + len >= memtop) {
-	errno = EFBIG;
-	return(-1);
-    }
+	if (dest + len >= memtop) {
+		errno = EFBIG;
+		return (-1);
+	}
 
-    bcopy(src, PTOV(dest), len);
-    return(len);
+	bcopy(src, PTOV(dest), len);
+	return (len);
 }
 
 ssize_t
 i386_copyout(const vm_offset_t src, void *dest, const size_t len)
 {
-    if (src + len >= memtop) {
-	errno = EFBIG;
-	return(-1);
-    }
-    
-    bcopy(PTOV(src), dest, len);
-    return(len);
+	if (src + len >= memtop) {
+		errno = EFBIG;
+		return (-1);
+	}
+
+	bcopy(PTOV(src), dest, len);
+	return (len);
 }
 
 
 ssize_t
 i386_readin(const int fd, vm_offset_t dest, const size_t len)
 {
-    if (dest + len >= memtop_copyin) {
-	errno = EFBIG;
-	return(-1);
-    }
+	if (dest + len >= memtop_copyin) {
+		errno = EFBIG;
+		return (-1);
+	}
 
-    return (read(fd, PTOV(dest), len));
+	return (read(fd, PTOV(dest), len));
 }

--- a/usr/src/boot/sys/boot/i386/libi386/libi386.h
+++ b/usr/src/boot/sys/boot/i386/libi386/libi386.h
@@ -145,6 +145,7 @@ int biospci_write_config(uint32_t locator, int offset, int width, uint32_t val);
 void	biosacpi_detect(void);
 
 int	i386_autoload(void);
+vm_offset_t i386_loadaddr(u_int type, void *data, vm_offset_t addr);
 
 int	bi_getboothowto(char *kargs);
 void	bi_setboothowto(int howto);

--- a/usr/src/boot/sys/boot/i386/loader/main.c
+++ b/usr/src/boot/sys/boot/i386/loader/main.c
@@ -40,7 +40,6 @@
 #include <sys/disk.h>
 #include <sys/param.h>
 #include <sys/reboot.h>
-#include <sys/multiboot2.h>
 
 #include "bootstrap.h"
 #include "common/bootargs.h"
@@ -82,18 +81,6 @@ extern char end[];
 
 static void *heap_top;
 static void *heap_bottom;
-
-static uint64_t
-i386_loadaddr(u_int type, void *data, uint64_t addr)
-{
-	/*
-	 * Our modules are page aligned.
-	 */
-	if (type == LOAD_RAW || type == LOAD_MEM)
-                return (roundup2(addr, MULTIBOOT_MOD_ALIGN));
-
-        return (addr);
-}
 
 int
 main(void)

--- a/usr/src/boot/sys/boot/zfs/zfs.c
+++ b/usr/src/boot/sys/boot/zfs/zfs.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 2007 Doug Rabson
  * All rights reserved.
  *
@@ -22,8 +22,6 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- *	$FreeBSD$
  */
 
 #include <sys/cdefs.h>
@@ -369,17 +367,61 @@ zfs_readdir(struct open_file *f, struct dirent *d)
 }
 
 static int
-vdev_read(vdev_t *vdev, void *priv, off_t offset, void *buf, size_t size)
+vdev_read(vdev_t *vdev, void *priv, off_t offset, void *buf, size_t bytes)
 {
-	int fd;
+	int fd, ret;
+	size_t res, size, remainder, rb_size, blksz;
+	unsigned secsz;
+	off_t off;
+	char *bouncebuf, *rb_buf;
 
 	fd = (uintptr_t) priv;
-	lseek(fd, offset, SEEK_SET);
-	if (read(fd, buf, size) == size) {
-		return 0;
-	} else {
-		return (EIO);
+	bouncebuf = NULL;
+
+	ret = ioctl(fd, DIOCGSECTORSIZE, &secsz);
+	if (ret != 0)
+		return (ret);
+
+	off = offset / secsz;
+	remainder = offset % secsz;
+	if (lseek(fd, off * secsz, SEEK_SET) == -1)
+		return (errno);
+
+	rb_buf = buf;
+	rb_size = bytes;
+	size = roundup2(bytes + remainder, secsz);
+	blksz = size;
+	if (remainder != 0 || size != bytes) {
+		bouncebuf = zfs_alloc(secsz);
+		if (bouncebuf == NULL) {
+			printf("vdev_read: out of memory\n");
+			return (ENOMEM);
+		}
+		rb_buf = bouncebuf;
+		blksz = rb_size - remainder;
 	}
+
+	while (bytes > 0) {
+		res = read(fd, rb_buf, rb_size);
+		if (res != rb_size) {
+			ret = EIO;
+			goto error;
+		}
+		if (bytes < blksz)
+			blksz = bytes;
+		if (bouncebuf != NULL)
+			memcpy(buf, rb_buf + remainder, blksz);
+		buf = (void *)((uintptr_t)buf + blksz);
+		bytes -= blksz;
+		remainder = 0;
+		blksz = rb_size;
+	}
+
+	ret = 0;
+error:
+	if (bouncebuf != NULL)
+		zfs_free(bouncebuf, secsz);
+	return (ret);
 }
 
 static int

--- a/usr/src/lib/fm/libdiskstatus/common/ds_scsi.c
+++ b/usr/src/lib/fm/libdiskstatus/common/ds_scsi.c
@@ -1210,10 +1210,10 @@ logpage_ssm_analyze(ds_scsi_info_t *sip, scsi_log_parameter_header_t *lphp,
 	nvlist_t *nvl;
 	int i, plen = 0;
 
-	assert(sip->si_dsp->ds_overtemp == NULL);
-	if (nvlist_alloc(&sip->si_dsp->ds_overtemp, NV_UNIQUE_NAME, 0) != 0)
+	assert(sip->si_dsp->ds_ssmwearout == NULL);
+	if (nvlist_alloc(&sip->si_dsp->ds_ssmwearout, NV_UNIQUE_NAME, 0) != 0)
 		return (scsi_set_errno(sip, EDS_NOMEM));
-	nvl = sip->si_dsp->ds_overtemp;
+	nvl = sip->si_dsp->ds_ssmwearout;
 
 	for (i = 0; i < log_length; i += plen) {
 		lphp = (scsi_log_parameter_header_t *)((uint8_t *)lphp + plen);

--- a/usr/src/man/man3ext/sendfile.3ext
+++ b/usr/src/man/man3ext/sendfile.3ext
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SENDFILE 3EXT "May 31, 2006"
+.TH SENDFILE 3EXT "Nov 3, 2017"
 .SH NAME
 sendfile \- send files over sockets or copy files to files
 .SH SYNOPSIS
@@ -16,7 +16,6 @@ sendfile \- send files over sockets or copy files to files
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBsendfile()\fR function copies data from \fIin_fd\fR to \fIout_fd\fR
 starting at offset \fIoff\fR and of length \fIlen\fR bytes. The \fIin_fd\fR
@@ -35,14 +34,12 @@ current file pointer of \fIin_fd\fR, but does modify the file pointer for
 The \fBsendfile()\fR function can also be used to send buffers by pointing
 \fIin_fd\fR to \fBSFV_FD_SELF\fR.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, \fBsendfile()\fR returns the total number of bytes
 written to \fIout_fd\fR and also updates the offset to point to the byte that
 follows the last byte read. Otherwise, it returns \fB-1\fR, and \fBerrno\fR is
 set to indicate the error.
 .SH ERRORS
-.sp
 .LP
 The \fBsendfile()\fR function will fail if:
 .sp
@@ -122,6 +119,9 @@ The socket type is not supported.
 .ad
 .RS 16n
 The \fIout_fd\fR argument is no longer connected to the peer endpoint.
+The \fBSIGPIPE\fR signal is generated to the calling thread.
+The process dies unless special provisions were taken to catch or ignore
+the signal.
 .RE
 
 .sp
@@ -134,7 +134,6 @@ A signal was caught during the write operation and no data was transferred.
 .RE
 
 .SH USAGE
-.sp
 .LP
 The \fBsendfile()\fR function has a transitional interface for 64-bit file
 offsets. See \fBlf64\fR(5).
@@ -244,7 +243,6 @@ while (len > 0) {
 .in -2
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5)  for descriptions of the following attributes:
 .sp
@@ -262,7 +260,6 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBopen\fR(2), \fBlibsendfile\fR(3LIB), \fBsendfilev\fR(3EXT),
 \fBsocket\fR(3SOCKET), \fBattributes\fR(5), \fBlf64\fR(5)

--- a/usr/src/man/man3ext/sendfilev.3ext
+++ b/usr/src/man/man3ext/sendfilev.3ext
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SENDFILEV 3EXT "Feb 25, 2009"
+.TH SENDFILEV 3EXT "Nov 3, 2017"
 .SH NAME
 sendfilev \- send a file
 .SH SYNOPSIS
@@ -17,7 +17,6 @@ sendfilev \- send a file
 .fi
 
 .SH PARAMETERS
-.sp
 .LP
 The \fBsendfilev()\fR function supports the following parameters:
 .sp
@@ -38,7 +37,7 @@ For \fBAF_NCA\fR, the protocol type should be zero.
 .ad
 .RS 11n
 An array of \fBSENDFILEVEC_T\fR, as defined in the \fBsendfilevec\fR structure
-above.
+below.
 .RE
 
 .sp
@@ -60,7 +59,6 @@ The total number of bytes written to \fBout_fd\fR.
 .RE
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBsendfilev()\fR function attempts to write data from the \fIsfvcnt\fR
 buffers specified by the members of \fIvec\fR array: \fBvec[0], vec[1], ... ,
@@ -110,7 +108,6 @@ To send data directly from the address space of the process, set \fBsfv_fd\fR
 to \fBSFV_FD_SELF\fR. \fBsfv_off\fR should point to the data, with
 \fBsfv_len\fR containing the length of the buffer.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, the \fBsendfilev()\fR function returns total number
 of bytes written to \fBout_fd\fR. Otherwise, it returns \fB-1\fR, and
@@ -118,7 +115,6 @@ of bytes written to \fBout_fd\fR. Otherwise, it returns \fB-1\fR, and
 the amount of data successfuly transferred, which can be used to discover the
 error vector.
 .SH ERRORS
-.sp
 .ne 2
 .na
 \fB\fBEACCES\fR\fR
@@ -209,6 +205,9 @@ An I/O error occurred while accessing the file system.
 .ad
 .RS 16n
 The \fIfildes\fR argument is a socket that has been shut down for writing.
+The \fBSIGPIPE\fR signal is generated to the calling thread.
+The process dies unless special provisions were taken to catch or ignore
+the signal.
 .RE
 
 .sp
@@ -221,12 +220,10 @@ The socket type is not supported.
 .RE
 
 .SH USAGE
-.sp
 .LP
 The \fBsendfilev()\fR function has a transitional interface for 64-bit file
 offsets. See \fBlf64\fR(5).
 .SH EXAMPLES
-.sp
 .LP
 The following example sends 2 vectors, one of HEADER data and a file of length
 100 over \fBsockfd\fR. \fBsockfd\fR is in a connected state, that is,
@@ -265,7 +262,6 @@ main (int argc, char *argv[]){
 .in -2
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -283,7 +279,6 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBopen\fR(2), \fBwritev\fR(2), \fBlibsendfile\fR(3LIB), \fBsendfile\fR(3EXT),
 \fBsocket\fR(3SOCKET), \fBattributes\fR(5)

--- a/usr/src/man/man5/pxeboot.5
+++ b/usr/src/man/man5/pxeboot.5
@@ -86,7 +86,7 @@ This may be changed by setting the
 .Va nfs.read_size
 variable in
 .Pa /boot/loader.conf .
-Valid values range from 1024 to 4096 bytes.
+Valid values range from 1024 to 16384 bytes.
 .Pp
 .Nm
 chooses NFS or TFTP based on the value of

--- a/usr/src/pkg/manifests/driver-network-iwh.mf
+++ b/usr/src/pkg/manifests/driver-network-iwh.mf
@@ -43,8 +43,6 @@ dir path=usr/share/man/man7d
 driver name=iwh clone_perms="iwh 0666 root sys" perms="* 0666 root sys" \
     alias=pciex8086,4232 \
     alias=pciex8086,4235 \
-    alias=pciex8086,4236 \
-    alias=pciex8086,4236.8086.1011 \
     alias=pciex8086,4237 \
     alias=pciex8086,423a \
     alias=pciex8086,423b \

--- a/usr/src/pkg/manifests/driver-network-iwn.mf
+++ b/usr/src/pkg/manifests/driver-network-iwn.mf
@@ -37,6 +37,7 @@ dir path=usr/share/man/man7d
 driver name=iwn clone_perms="iwn 0666 root sys" perms="* 0666 root sys" \
     alias=pciex8086,422b \
     alias=pciex8086,422c \
+    alias=pciex8086,4236 \
     alias=pciex8086,4238 \
     alias=pciex8086,4239 \
     alias=pciex8086,82 \

--- a/usr/src/uts/common/fs/zfs/dsl_pool.c
+++ b/usr/src/uts/common/fs/zfs/dsl_pool.c
@@ -387,7 +387,6 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops, uint64_t txg)
 	int err;
 	dsl_pool_t *dp = dsl_pool_open_impl(spa, txg);
 	dmu_tx_t *tx = dmu_tx_create_assigned(dp, txg);
-	objset_t *os;
 	dsl_dataset_t *ds;
 	uint64_t obj;
 
@@ -438,12 +437,15 @@ dsl_pool_create(spa_t *spa, nvlist_t *zplprops, uint64_t txg)
 
 	/* create the root objset */
 	VERIFY0(dsl_dataset_hold_obj(dp, obj, FTAG, &ds));
-	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
-	os = dmu_objset_create_impl(dp->dp_spa, ds,
-	    dsl_dataset_get_blkptr(ds), DMU_OST_ZFS, tx);
-	rrw_exit(&ds->ds_bp_rwlock, FTAG);
 #ifdef _KERNEL
-	zfs_create_fs(os, kcred, zplprops, tx);
+	{
+		objset_t *os;
+		rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
+		os = dmu_objset_create_impl(dp->dp_spa, ds,
+		    dsl_dataset_get_blkptr(ds), DMU_OST_ZFS, tx);
+		rrw_exit(&ds->ds_bp_rwlock, FTAG);
+		zfs_create_fs(os, kcred, zplprops, tx);
+	}
 #endif
 	dsl_dataset_rele(ds, FTAG);
 

--- a/usr/src/uts/common/fs/zfs/zfs_ioctl.c
+++ b/usr/src/uts/common/fs/zfs/zfs_ioctl.c
@@ -5554,10 +5554,6 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	dsl_dataset_t *tosnap;
 	int error;
 	char *fromname;
-	/* LINTED E_FUNC_SET_NOT_USED */
-	boolean_t largeblockok;
-	/* LINTED E_FUNC_SET_NOT_USED */
-	boolean_t embedok;
 	boolean_t compressok;
 	uint64_t space;
 
@@ -5571,8 +5567,6 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 		return (error);
 	}
 
-	largeblockok = nvlist_exists(innvl, "largeblockok");
-	embedok = nvlist_exists(innvl, "embedok");
 	compressok = nvlist_exists(innvl, "compressok");
 
 	error = nvlist_lookup_string(innvl, "from", &fromname);
@@ -5613,7 +5607,9 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 			goto out;
 		}
 	} else {
-		// If estimating the size of a full send, use dmu_send_estimate
+		/*
+		 * If estimating the size of a full send, use dmu_send_estimate.
+		 */
 		error = dmu_send_estimate(tosnap, NULL, compressok, &space);
 	}
 

--- a/usr/src/uts/common/io/myri10ge/drv/myri10ge.c
+++ b/usr/src/uts/common/io/myri10ge/drv/myri10ge.c
@@ -34,11 +34,6 @@
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
-#ifndef	lint
-static const char __idstring[] =
-	"@(#)$Id: myri10ge.c,v 1.186 2009-06-29 13:47:22 gallatin Exp $";
-#endif
-
 #define	MXGEFW_NDIS
 #include "myri10ge_var.h"
 #include "rss_eth_z8e.h"
@@ -1210,7 +1205,7 @@ abort:
 
 int
 myri10ge_send_cmd(struct myri10ge_priv *mgp, uint32_t cmd,
-		myri10ge_cmd_t *data)
+    myri10ge_cmd_t *data)
 {
 	mcp_cmd_t *buf;
 	char buf_bytes[sizeof (*buf) + 8];
@@ -5005,7 +5000,6 @@ myri10ge_watchdog(void *arg)
 /*ARGSUSED*/
 static int
 myri10ge_get_coalesce(queue_t *q, mblk_t *mp, caddr_t cp, cred_t *credp)
-
 {
 	struct myri10ge_priv *mgp = (struct myri10ge_priv *)(void *)cp;
 	(void) mi_mpprintf(mp, "%d", mgp->intr_coal_delay);
@@ -5016,7 +5010,6 @@ myri10ge_get_coalesce(queue_t *q, mblk_t *mp, caddr_t cp, cred_t *credp)
 static int
 myri10ge_set_coalesce(queue_t *q, mblk_t *mp, char *value,
     caddr_t cp, cred_t *credp)
-
 {
 	struct myri10ge_priv *mgp = (struct myri10ge_priv *)(void *)cp;
 	char *end;
@@ -5036,7 +5029,6 @@ myri10ge_set_coalesce(queue_t *q, mblk_t *mp, char *value,
 /*ARGSUSED*/
 static int
 myri10ge_get_pauseparam(queue_t *q, mblk_t *mp, caddr_t cp, cred_t *credp)
-
 {
 	struct myri10ge_priv *mgp = (struct myri10ge_priv *)(void *)cp;
 	(void) mi_mpprintf(mp, "%d", mgp->pause);
@@ -5046,8 +5038,7 @@ myri10ge_get_pauseparam(queue_t *q, mblk_t *mp, caddr_t cp, cred_t *credp)
 /*ARGSUSED*/
 static int
 myri10ge_set_pauseparam(queue_t *q, mblk_t *mp, char *value,
-			caddr_t cp, cred_t *credp)
-
+    caddr_t cp, cred_t *credp)
 {
 	struct myri10ge_priv *mgp = (struct myri10ge_priv *)(void *)cp;
 	char *end;
@@ -5070,7 +5061,6 @@ myri10ge_set_pauseparam(queue_t *q, mblk_t *mp, char *value,
 /*ARGSUSED*/
 static int
 myri10ge_get_int(queue_t *q, mblk_t *mp, caddr_t cp, cred_t *credp)
-
 {
 	(void) mi_mpprintf(mp, "%d", *(int *)(void *)cp);
 	return (0);
@@ -5080,7 +5070,6 @@ myri10ge_get_int(queue_t *q, mblk_t *mp, caddr_t cp, cred_t *credp)
 static int
 myri10ge_set_int(queue_t *q, mblk_t *mp, char *value,
     caddr_t cp, cred_t *credp)
-
 {
 	char *end;
 	size_t new_value;

--- a/usr/src/uts/common/io/myri10ge/drv/myri10ge_lro.c
+++ b/usr/src/uts/common/io/myri10ge/drv/myri10ge_lro.c
@@ -24,11 +24,6 @@
  * Use is subject to license terms.
  */
 
-#ifndef lint
-static const char __idstring[] =
-	"@(#)$Id: myri10ge_lro.c,v 1.7 2009-06-29 13:47:22 gallatin Exp $";
-#endif
-
 #include "myri10ge_var.h"
 
 #define	IP_OFFMASK 0x1fff
@@ -73,7 +68,7 @@ myri10ge_in_pseudo(unsigned int a, unsigned int b,
 
 void
 myri10ge_lro_flush(struct myri10ge_slice_state *ss, struct lro_entry *lro,
-	struct myri10ge_mblk_list *mbl)
+    struct myri10ge_mblk_list *mbl)
 {
 	struct ip *ip;
 	struct tcphdr *tcp;
@@ -134,7 +129,7 @@ myri10ge_lro_flush(struct myri10ge_slice_state *ss, struct lro_entry *lro,
 
 int
 myri10ge_lro_rx(struct myri10ge_slice_state *ss, mblk_t *m_head,
-		uint32_t csum, struct myri10ge_mblk_list *mbl)
+    uint32_t csum, struct myri10ge_mblk_list *mbl)
 {
 	struct ether_header *eh;
 	struct ip *ip;


### PR DESCRIPTION
Weekly upstream for upstream_merge/2017110801

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2017110801-8f6134fa70 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Wed Nov  8 14:19:30 GMT 2017 ====
==== Nightly distributed build completed: Wed Nov  8 15:59:53 GMT 2017 ====

==== Total build time ====

real    1:40:22

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-f81a14270f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   488

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2017110801-8f6134fa70

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:26.9
user  1:29:52.7
sys     13:29.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    30:07.1
user  1:19:17.7
sys      9:47.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    31:35.9
user  1:16:07.8
sys     16:04.5

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
