### PR TITLE
Upstream merge joyent_merge/2017112401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 802a31260b1873751a82dd69cc509e3082d868c0
+Last illumos-joyent commit: 99b859c7466d1745fdbf023efbb434b0e9f38e53
 

--- a/usr/src/uts/common/brand/lx/syscall/lx_prctl.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_prctl.c
@@ -191,6 +191,16 @@ lx_prctl(int opt, uintptr_t data)
 		}
 
 		/*
+		 * We are currently choosing to not allow an empty thread
+		 * name to clear p->p_user.u_comm and p->p_user.u_psargs.
+		 * This is a slight divergence from linux behavior (which
+		 * allows this) so that we can preserve the original command.
+		 */
+		if (strlen(name) == 0) {
+			return (0);
+		}
+
+		/*
 		 * We explicitly use t->t_name here instead of name in case
 		 * a thread has come in between the above thread_setname()
 		 * call and the setting of u_comm/u_psargs below.  On Linux,

--- a/usr/src/uts/common/brand/lx/syscall/lx_prctl.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_prctl.c
@@ -196,7 +196,7 @@ lx_prctl(int opt, uintptr_t data)
 		 * This is a slight divergence from linux behavior (which
 		 * allows this) so that we can preserve the original command.
 		 */
-		if (strlen(name) == 0) {
+		if (strlen(name) == 0 || t->t_name == NULL) {
 			return (0);
 		}
 
@@ -210,10 +210,8 @@ lx_prctl(int opt, uintptr_t data)
 		 * Linux.
 		 */
 		mutex_enter(&p->p_lock);
-		(void) strncpy(p->p_user.u_comm,
-		    t->t_name != NULL ? t->t_name : name, MAXCOMLEN + 1);
-		(void) strncpy(p->p_user.u_psargs,
-		    t->t_name != NULL ? t->t_name : name, PSARGSZ);
+		(void) strncpy(p->p_user.u_comm, t->t_name, MAXCOMLEN + 1);
+		(void) strncpy(p->p_user.u_psargs, t->t_name, PSARGSZ);
 		mutex_exit(&p->p_lock);
 		return (0);
 	}

--- a/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
@@ -1566,6 +1566,7 @@ apic_check_msi_support()
 	dev_info_t *cdip;
 	char dev_type[16];
 	int dev_len;
+	int hwenv = get_hwenv();
 
 	DDI_INTR_IMPLDBG((CE_CONT, "apic_check_msi_support:\n"));
 
@@ -1587,7 +1588,8 @@ apic_check_msi_support()
 			continue;
 		if (strcmp(dev_type, "pciex") == 0)
 			return (PSM_SUCCESS);
-		if (strcmp(dev_type, "pci") == 0 && get_hwenv() == HW_KVM)
+		if (strcmp(dev_type, "pci") == 0 &&
+		    (hwenv == HW_KVM || hwenv == HW_BHYVE))
 			return (PSM_SUCCESS);
 	}
 

--- a/usr/src/uts/i86pc/os/cpuid.c
+++ b/usr/src/uts/i86pc/os/cpuid.c
@@ -696,6 +696,10 @@ determine_platform(void)
 			platform_type = HW_KVM;
 			return;
 		}
+		if (strcmp(hvstr, HVSIG_BHYVE) == 0) {
+			platform_type = HW_BHYVE;
+			return;
+		}
 		if (strcmp(hvstr, HVSIG_MICROSOFT) == 0)
 			platform_type = HW_MICROSOFT;
 	} else {

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -898,6 +898,7 @@ extern void xsave_setup_msr(struct cpu *);
 #define	HVSIG_VMWARE	"VMwareVMware"
 #define	HVSIG_KVM	"KVMKVMKVM"
 #define	HVSIG_MICROSOFT	"Microsoft Hv"
+#define	HVSIG_BHYVE	"bhyve bhyve "
 
 /*
  * Defined hardware environments
@@ -909,8 +910,10 @@ extern void xsave_setup_msr(struct cpu *);
 #define	HW_VMWARE	(1 << 3)	/* Running on VMware hypervisor */
 #define	HW_KVM		(1 << 4)	/* Running on KVM hypervisor */
 #define	HW_MICROSOFT	(1 << 5)	/* Running on Microsoft hypervisor */
+#define	HW_BHYVE	(1 << 6)	/* Running on bhyve hypervisor */
 
-#define	HW_VIRTUAL	(HW_XEN_HVM | HW_VMWARE | HW_KVM | HW_MICROSOFT)
+#define	HW_VIRTUAL	(HW_XEN_HVM | HW_VMWARE | HW_KVM | HW_MICROSOFT | \
+	    HW_BHYVE)
 
 #endif	/* _KERNEL */
 


### PR DESCRIPTION
Weekly upstream for joyent_merge/2017112401

I've also back-ported support for enabling MSI-X when running as a guest under bhyve.

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2017112401-a3deab6af3 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Fri Nov 24 09:14:50 GMT 2017 ====
==== Nightly distributed build completed: Fri Nov 24 10:42:40 GMT 2017 ====

==== Total build time ====

real    1:27:50

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-0e8f6280a5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   929

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017112401-a3deab6af3

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    22:44.7
user  1:29:35.9
sys     13:43.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:25.3
user  1:19:31.6
sys     10:06.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    31:43.4
user  1:14:06.7
sys     16:15.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
