### PR TITLE
Upstream merge/2017113001

### DIFF
--- a/usr/src/boot/sys/boot/efi/libefi/efipart.c
+++ b/usr/src/boot/sys/boot/efi/libefi/efipart.c
@@ -178,6 +178,72 @@ efipart_floppy(EFI_DEVICE_PATH *node)
 }
 
 /*
+ * Determine if the provided device path is hdd.
+ *
+ * There really is no simple fool proof way to classify the devices.
+ * Since we do build three lists of devices - floppy, cd and hdd, we
+ * will try to see  if the device is floppy or cd, and list anything else
+ * as hdd.
+ */
+static bool
+efipart_hdd(EFI_DEVICE_PATH *dp)
+{
+	unsigned i, nin;
+	EFI_DEVICE_PATH *devpath, *node;
+	EFI_BLOCK_IO *blkio;
+	EFI_STATUS status;
+
+	if (dp == NULL)
+		return (false);
+
+	if ((node = efi_devpath_last_node(dp)) == NULL)
+		return (false);
+
+	if (efipart_floppy(node) != NULL)
+		return (false);
+
+	/*
+	 * Test every EFI BLOCK IO handle to make sure dp is not device path
+	 * for CD/DVD.
+	 */
+	nin = efipart_nhandles / sizeof (*efipart_handles);
+	for (i = 0; i < nin; i++) {
+		devpath = efi_lookup_devpath(efipart_handles[i]);
+		if (devpath == NULL)
+			return (false);
+
+		/* Only continue testing when dp is prefix in devpath. */
+		if (!efi_devpath_is_prefix(dp, devpath))
+			continue;
+
+		/*
+		 * The device path has to have last node describing the
+		 *  device, or we can not test the type.
+		 */
+		if ((node = efi_devpath_last_node(devpath)) == NULL)
+			return (false);
+
+		if (DevicePathType(node) == MEDIA_DEVICE_PATH &&
+		    DevicePathSubType(node) == MEDIA_CDROM_DP) {
+			return (false);
+		}
+
+		/* Make sure we do have the media. */
+		status = BS->HandleProtocol(efipart_handles[i],
+		    &blkio_guid, (void **)&blkio);
+		if (EFI_ERROR(status))
+			return (false);
+
+		/* USB or SATA cd without the media. */
+		if (blkio->Media->RemovableMedia &&
+		    !blkio->Media->MediaPresent) {
+			return (false);
+		}
+	}
+	return (true);
+}
+
+/*
  * Add or update entries with new handle data.
  */
 static int
@@ -290,7 +356,11 @@ efipart_updatecd(void)
 
 		if ((node = efi_devpath_last_node(devpath)) == NULL)
 			continue;
+
 		if (efipart_floppy(node) != NULL)
+			continue;
+
+		if (efipart_hdd(devpath))
 			continue;
 
 		status = BS->HandleProtocol(efipart_handles[i],
@@ -362,13 +432,21 @@ efipart_hdinfo_add(EFI_HANDLE disk_handle, EFI_HANDLE part_handle)
 	pdinfo_t *hd, *pd, *last;
 
 	disk_devpath = efi_lookup_devpath(disk_handle);
-	part_devpath = efi_lookup_devpath(part_handle);
-	if (disk_devpath == NULL || part_devpath == NULL) {
+	if (disk_devpath == NULL)
 		return (ENOENT);
+
+	if (part_handle != NULL) {
+		part_devpath = efi_lookup_devpath(part_handle);
+		if (part_devpath == NULL)
+			return (ENOENT);
+		node = (HARDDRIVE_DEVICE_PATH *)
+		    efi_devpath_last_node(part_devpath);
+		if (node == NULL)
+			return (ENOENT);	/* This should not happen. */
+	} else {
+		part_devpath = NULL;
+		node = NULL;
 	}
-	node = (HARDDRIVE_DEVICE_PATH *)efi_devpath_last_node(part_devpath);
-	if (node == NULL)
-		return (ENOENT);	/* This should not happen. */
 
 	pd = calloc(1, sizeof(pdinfo_t));
 	if (pd == NULL) {
@@ -379,6 +457,9 @@ efipart_hdinfo_add(EFI_HANDLE disk_handle, EFI_HANDLE part_handle)
 
 	STAILQ_FOREACH(hd, &hdinfo, pd_link) {
 		if (efi_devpath_match(hd->pd_devpath, disk_devpath) == true) {
+			if (part_devpath == NULL)
+				return (0);
+
 			/* Add the partition. */
 			pd->pd_handle = part_handle;
 			pd->pd_unit = node->PartitionNumber;
@@ -400,6 +481,9 @@ efipart_hdinfo_add(EFI_HANDLE disk_handle, EFI_HANDLE part_handle)
 	hd->pd_unit = unit;
 	hd->pd_devpath = disk_devpath;
 	STAILQ_INSERT_TAIL(&hdinfo, hd, pd_link);
+
+	if (part_devpath == NULL)
+		return (0);
 
 	pd = calloc(1, sizeof(pdinfo_t));
 	if (pd == NULL) {
@@ -523,13 +607,20 @@ efipart_updatehd(void)
 
 		if ((node = efi_devpath_last_node(devpath)) == NULL)
 			continue;
-		if (efipart_floppy(node) != NULL)
+
+		if (!efipart_hdd(devpath))
 			continue;
 
 		status = BS->HandleProtocol(efipart_handles[i],
 		    &blkio_guid, (void **)&blkio);
 		if (EFI_ERROR(status))
 			continue;
+
+		if (DevicePathType(node) == MEDIA_DEVICE_PATH &&
+		    DevicePathSubType(node) == MEDIA_FILEPATH_DP) {
+			efipart_hdinfo_add_filepath(efipart_handles[i]);
+			continue;
+		}
 
 		if (DevicePathType(node) == MEDIA_DEVICE_PATH &&
 		    DevicePathSubType(node) == MEDIA_HARDDRIVE_DP) {
@@ -550,18 +641,16 @@ efipart_updatehd(void)
 				continue;
 			if ((node = efi_devpath_last_node(devpathcpy)) == NULL)
 				continue;
+
 			if (DevicePathType(node) == MEDIA_DEVICE_PATH &&
 			    DevicePathSubType(node) == MEDIA_HARDDRIVE_DP)
 				continue;
+
 			efipart_hdinfo_add(handle, efipart_handles[i]);
 			continue;
 		}
 
-		if (DevicePathType(node) == MEDIA_DEVICE_PATH &&
-		    DevicePathSubType(node) == MEDIA_FILEPATH_DP) {
-			efipart_hdinfo_add_filepath(efipart_handles[i]);
-			continue;
-		}
+		efipart_hdinfo_add(efipart_handles[i], NULL);
 	}
 }
 

--- a/usr/src/cmd/sgs/prof/common/prof.c
+++ b/usr/src/cmd/sgs/prof/common/prof.c
@@ -25,10 +25,7 @@
  */
 
 /*	Copyright (c) 1988 AT&T	*/
-/*	  All Rights Reserved  	*/
-
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
+/*	  All Rights Reserved	*/
 
 /*
  *	Program profiling report generator.
@@ -351,10 +348,6 @@ main(int argc, char **argv)
 	long sf;	/* Scale for index into pcounts: */
 			/*	i(pc) = ((pc - pc_l) * sf)/bias. */
 
-	/* LINTED: set but not used */
-	long s_inv;	/* Inverse: i_inv(i) = */
-			/*		{pc00, pc00+1, ... pc00+s_inv-1}. */
-
 	unsigned pc_m;	/* Range of PCs profiled: pc_m = pc_h - pc_l */
 
 	float	t, t0;
@@ -605,15 +598,13 @@ pc_l, pc_h, pc_m, pc_m, head.nfns, n_cc, n_pc));
 		sf >>= 1;
 		bias >>= 1;
 	}
-	s_inv = pc_m/n_pc;	/* Range of PCs mapped into one index. */
 
 	/* BEGIN CSTYLED */
 OLD_DEBUG(
 	if (debug_value) {
-		Fprint(
-			stderr,
-			"sf = %d, s_inv = %d bias = %d\n",
-			(long)sf, s_inv, bias);
+
+		Fprint(stderr, "sf = %d, s_inv = %d bias = %d\n",
+		    (long)sf, pc_m / n_pc, bias);
 	}
 );
 	/* END CSTYLED */
@@ -1020,8 +1011,8 @@ if (debug_value)  {
 	 * option causes certain additional information to be printed.
 	 */
 
-OLD_DEBUG(if (debug_value) Fprint(stderr,
-"Time unaccounted for: %.7G\n", t_tot - t0));
+	OLD_DEBUG(if (debug_value) Fprint(stderr,
+	    "Time unaccounted for: %.7G\n", t_tot - t0));
 
 	if (sort)	/* If comparison routine given then use it. */
 		qsort((char *)slist, (unsigned)n_syms,
@@ -1219,11 +1210,14 @@ eofon(FILE *iop, char *fn)
 	exit(1);
 }
 
-/* Version of perror() that prints cmdname first. */
+/*
+ * Version of perror() that prints cmdname first.
+ * Print system error message & exit.
+ */
 
 static void
 Perror(char *s)
-{				/* Print system error message & exit. */
+{
 	int err = errno;	/* Save current errno in case */
 
 	Fprint(stderr, "%s: ", cmdname);

--- a/usr/src/cmd/syslogd/list.c
+++ b/usr/src/cmd/syslogd/list.c
@@ -23,8 +23,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <pthread.h>
 #include <malloc.h>
 #include <memory.h>
@@ -32,12 +30,14 @@
 #include <poll.h>
 #include <stdio.h>
 #include "llt.h"
+
 void
 ll_init(llh_t *head)
 {
 	head->back = &head->front;
 	head->front = NULL;
 }
+
 void
 ll_enqueue(llh_t *head, ll_t *data)
 {
@@ -45,6 +45,7 @@ ll_enqueue(llh_t *head, ll_t *data)
 	*head->back = data;
 	head->back = &data->n;
 }
+
 /*
  * apply the function func to every element of the ll in sequence.  Can
  * be used to free up the element, so "n" is computed before func is
@@ -62,11 +63,13 @@ ll_mapf(llh_t *head, void (*func)(void *))
 		t = n;
 	}
 }
+
 ll_t *
 ll_peek(llh_t *head)
 {
 	return (head->front);
 }
+
 ll_t *
 ll_dequeue(llh_t *head)
 {
@@ -76,6 +79,7 @@ ll_dequeue(llh_t *head)
 		head->back = &head->front;
 	return (ptr);
 }
+
 ll_t *
 ll_traverse(llh_t *ptr, int (*func)(void *, void *), void *user)
 {
@@ -99,17 +103,22 @@ ll_traverse(llh_t *ptr, int (*func)(void *, void *), void *user)
 	}
 	return (NULL);
 }
+
 /* Make sure the list isn't corrupt and returns number of list items */
 int
 ll_check(llh_t *head)
 {
 	int i = 0;
 	ll_t *ptr = head->front;
+#ifndef NDEBUG
 	ll_t **prev = &head->front;
+#endif
 
 	while (ptr) {
 		i++;
+#ifndef NDEBUG
 		prev = &ptr->n;
+#endif
 		ptr = ptr->n;
 	}
 	assert(head->back == prev);

--- a/usr/src/lib/libadm/common/ckdate.c
+++ b/usr/src/lib/libadm/common/ckdate.c
@@ -115,22 +115,19 @@ static char *
 p_eday(char *string, int llim, int ulim)
 {
 	char *ptr, *copy;
-	char daynum[3];
 	int begin = -1;
 	int iday = 0;
 	int idaymax = 2;
 
-	daynum[0] = '\0';
 	if (*string == BLANK) {
 		string++;
 		idaymax--;
 	}
 	copy = string;
 	while (isdigit((unsigned char)*copy) && (iday < idaymax)) {
-		daynum[iday] = *copy++;
+		copy++;
 		iday++;
 	}
-	daynum[iday] = '\0';
 	if (iday == 1) {
 		llim = 1;
 		ulim = 9;

--- a/usr/src/lib/libadutils/common/srv_query.c
+++ b/usr/src/lib/libadutils/common/srv_query.c
@@ -261,7 +261,7 @@ srv_parse(uchar_t *msg, int len, int *scnt, int *maxcnt)
 	uchar_t *end;
 	uint16_t type;
 	/* LINTED  E_FUNC_SET_NOT_USED */
-	uint16_t class;
+	uint16_t class __unused;
 	uint32_t rttl;
 	uint16_t size;
 	char namebuf[NS_MAXDNAME];

--- a/usr/src/lib/libast/Makefile.com
+++ b/usr/src/lib/libast/Makefile.com
@@ -728,6 +728,8 @@ CERRWARN += -_gcc=-Wno-uninitialized
 CERRWARN += -_gcc=-Wno-char-subscripts
 CERRWARN += -_gcc=-Wno-clobbered
 CERRWARN += -_gcc=-Wno-unused-variable
+CERRWARN += -_gcc=-Wno-unused-but-set-variable
+CERRWARN += -_gcc=-Wno-unused-but-set-parameter
 CERRWARN += -_gcc=-Wno-unused-value
 CERRWARN += -_gcc=-Wno-unused-function
 CERRWARN += -_gcc=-Wno-unused-label

--- a/usr/src/lib/libdll/common/dlfcn.c
+++ b/usr/src/lib/libdll/common/dlfcn.c
@@ -26,8 +26,6 @@
  * AT&T Research
  */
 
-static const char id[] = "\n@(#)$Id: dll library (AT&T Research) 2009-04-15 $\0\n";
-
 #include <ast.h>
 #include <dlldefs.h>
 #include <error.h>

--- a/usr/src/lib/libima/Makefile
+++ b/usr/src/lib/libima/Makefile
@@ -39,8 +39,6 @@ lint :=		TARGET = lint
 
 .KEEP_STATE:
 
-install_h: $(ROOTHDRS)
-
 all clean clobber install lint: $(SUBDIRS)
 
 install_h:      $(ROOTHDRS)

--- a/usr/src/lib/libima/common/ima-lib.c
+++ b/usr/src/lib/libima/common/ima-lib.c
@@ -278,11 +278,13 @@ static IMA_STATUS setSolarisSharedNodeAlias(const IMA_NODE_ALIAS alias) {
  * "__attribute__ ((constructor))" and "__attribute__ ((destructor))"
  * are used with gcc
  */
-__attribute__((constructor)) void init() {
+__attribute__((constructor)) void init()
+{
 	InitLibrary();
 }
 
-__attribute__((destructor)) void fini() {
+__attribute__((destructor)) void fini()
+{
 	ExitLibrary();
 }
 
@@ -352,35 +354,35 @@ static int os_createmutex(int *semid) {
 	return (1);
 }
 
-static void os_obtainmutex(int semid) {
-	int retVal;
+static void
+os_obtainmutex(int semid)
+{
 	struct sembuf sem_b;
 
 	sem_b.sem_num = 0;
 	sem_b.sem_op = -1;
 	sem_b.sem_flg = SEM_UNDO;
-	retVal = semop(semid, &sem_b, 1);
-
+	(void) semop(semid, &sem_b, 1);
 }
 
-static void os_releasemutex(int semid) {
-	int retVal;
+static void
+os_releasemutex(int semid)
+{
 	struct sembuf sem_b;
 
 	sem_b.sem_num = 0;
 	sem_b.sem_op = 1;
 	sem_b.sem_flg = SEM_UNDO;
-	retVal = semop(semid, &sem_b, 1);
-
+	(void) semop(semid, &sem_b, 1);
 }
 
 /* Destroy the SNMP semaphore. */
-static void os_destroymutex(int semid) {
-	int retVal;
+static void
+os_destroymutex(int semid)
+{
 	union semun sem_union;
 
-	retVal = semctl(semid, 0, IPC_RMID, sem_union);
-
+	(void) semctl(semid, 0, IPC_RMID, sem_union);
 }
 #endif
 
@@ -394,8 +396,6 @@ void InitLibrary() {
 	char imaConfFilePath[256];
 	char systemPath[256];
 	char *charPtr;
-	IMA_UINT dwStrLength;
-
 	IMA_UINT i = 0;
 
 	if (number_of_plugins != -1)
@@ -409,9 +409,6 @@ void InitLibrary() {
 	os_obtainmutex(libMutex);
 
 	sharedNodeAlias[0] = 0;
-	dwStrLength = 255;
-
-
 
 	/* Open configuration file from known location */
 #ifdef WIN32
@@ -475,7 +472,6 @@ void InitLibrary() {
 			if (plugintable[i].hPlugin != NULL) {
 				typedef int (*InitializeFn)();
 				InitializeFn PassFunc;
-				IMA_STATUS status;
 
 				memcpy((char *)&plugintable[i].PluginName,
 				    (char *)&pluginname, 64);
@@ -494,8 +490,7 @@ void InitLibrary() {
 				    plugintable[i].hPlugin, "Initialize");
 #endif
 				if (PassFunc != NULL) {
-					status =
-					    PassFunc(plugintable[i].ownerId);
+					(void) PassFunc(plugintable[i].ownerId);
 				}
 
 				plugintable[i].number_of_vbcallbacks = 0;

--- a/usr/src/lib/libima/common/sunima-lib.c
+++ b/usr/src/lib/libima/common/sunima-lib.c
@@ -125,24 +125,24 @@ IMA_API IMA_STATUS SUN_IMA_GetTunableProperties(
 	return (status);
 }
 
-static void os_obtainmutex(int semid) {
-	int retVal;
+static void
+os_obtainmutex(int semid)
+{
 	struct sembuf sem_b;
 
 	sem_b.sem_num = 0;
 	sem_b.sem_op = -1;
 	sem_b.sem_flg = SEM_UNDO;
-	retVal = semop(semid, &sem_b, 1);
-
+	(void) semop(semid, &sem_b, 1);
 }
 
-static void os_releasemutex(int semid) {
-	int retVal;
+static void
+os_releasemutex(int semid)
+{
 	struct sembuf sem_b;
 
 	sem_b.sem_num = 0;
 	sem_b.sem_op = 1;
 	sem_b.sem_flg = SEM_UNDO;
-	retVal = semop(semid, &sem_b, 1);
-
+	(void) semop(semid, &sem_b, 1);
 }

--- a/usr/src/lib/libmail/common/s_string.c
+++ b/usr/src/lib/libmail/common/s_string.c
@@ -27,8 +27,6 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <sys/types.h>
 #include <stdio.h>
 #include <ctype.h>

--- a/usr/src/lib/libmail/inc/s_string.h
+++ b/usr/src/lib/libmail/inc/s_string.h
@@ -30,11 +30,10 @@
 
 /* This is a private header file.				*/
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI" 	/* SVr4.0 1.4	*/
 /* extensible strings */
 
 #ifndef _S_STRING_H
-#define _S_STRING_H
+#define	_S_STRING_H
 
 #include <string.h>
 
@@ -50,25 +49,27 @@ typedef struct string {
  * to lint, but causes the last expression to be evaluated as an int (didn't
  * change this).
  */
-#define s_clone(s)	s_copy((s)->ptr)
-#define s_curlen(s)	((s)->ptr - (s)->base)
-#define s_dup(s)	s_copy((s)->base)
-#define s_getc(s)	(*((s)->ptr++))
-#define s_peek(s)	(*((s)->ptr))
-#define s_putc(s,c)     (((s)->ptr < (s)->end) ? (*((s)->ptr)++ = (char)(c)) : s_grow((s),(c)))
-#define s_reset(s)	((s) ? (*((s)->ptr = (s)->base) = '\0' , (s)) : s_new())
-#define s_restart(s)	((s)->ptr = (s)->base , (s))
-#define s_skipc(s)	((s)->ptr++)
-#define s_space(s)	((s)->end - (s)->base)
-#define s_terminate(s)  (((s)->ptr < (s)->end) ? (*(s)->ptr = 0) : (s_grow((s),0), (s)->ptr--, 0))
-#define s_to_c(s)	((s)->base)
-#define s_ptr_to_c(s)	((s)->ptr)
+#define	s_clone(s)	s_copy((s)->ptr)
+#define	s_curlen(s)	((s)->ptr - (s)->base)
+#define	s_dup(s)	s_copy((s)->base)
+#define	s_getc(s)	(*((s)->ptr++))
+#define	s_peek(s)	(*((s)->ptr))
+#define	s_putc(s, c)	(((s)->ptr < (s)->end) ? \
+	(*((s)->ptr)++ = (char)(c)) : s_grow((s), (c)))
+#define	s_reset(s)	((s) ? (*((s)->ptr = (s)->base) = '\0', (s)) : s_new())
+#define	s_restart(s)	((s)->ptr = (s)->base)
+#define	s_skipc(s)	((s)->ptr++)
+#define	s_space(s)	((s)->end - (s)->base)
+#define	s_terminate(s)  (((s)->ptr < (s)->end) ? \
+	(*(s)->ptr = 0) : (s_grow((s), 0), (s)->ptr--, 0))
+#define	s_to_c(s)	((s)->base)
+#define	s_ptr_to_c(s)	((s)->ptr)
 
 #ifdef __STDC__
 extern string *s_append(string *to, char *from);
 extern string *s_array(char *, size_t len);
 extern string *s_copy(char *);
-extern void s_free(string*);
+extern void s_free(string *);
 extern int s_grow(string *sp, int c);
 extern string *s_new(void);
 extern string *s_parse(string *from, string *to);
@@ -76,8 +77,8 @@ extern char *s_read_line(FILE *fp, string *to);
 extern size_t s_read_to_eof(FILE *fp, string *to);
 extern string *s_seq_read(FILE *fp, string *to, int lineortoken);
 extern void s_skipwhite(string *from);
-extern string *s_tok(string*, char*);
-extern void s_tolower(string*);
+extern string *s_tok(string *, char *);
+extern void s_tolower(string *);
 #else
 extern string *s_append();
 extern string *s_array();
@@ -95,9 +96,9 @@ extern void s_tolower();
 #endif
 
 /* controlling the action of s_seq_read */
-#define TOKEN 0		/* read the next whitespace delimited token */
-#define LINE 1		/* read the next logical input line */
-#define s_getline(a,b) s_seq_read(a,b,LINE)
-#define s_gettoken(a,b) s_seq_read(a,b,TOKEN)
+#define	TOKEN 0		/* read the next whitespace delimited token */
+#define	LINE 1		/* read the next logical input line */
+#define	s_getline(a, b) s_seq_read(a, b, LINE)
+#define	s_gettoken(a, b) s_seq_read(a, b, TOKEN)
 
 #endif /* _S_STRING_H */

--- a/usr/src/lib/libnisdb/ldap_map.c
+++ b/usr/src/lib/libnisdb/ldap_map.c
@@ -53,13 +53,11 @@ int
 setColumnNames(__nis_table_mapping_t *t) {
 	int	i, j, nic, noc;
 	char	**col;
-	zotypes	type;
 	char	*myself = "setColumnNames";
 
 	if (t == 0)
 		return (0);
 
-	type = t->objType;
 	col = t->column;
 	nic = (col != 0) ? t->numColumns : -1;
 
@@ -1130,7 +1128,6 @@ verifyIndexMatch(__nis_table_mapping_t *x, db_query *q,
 
 	/* Check each index */
 	for (i = 0; i < x->index.numIndexes; i++) {
-		int	len = 0;
 		char	*value = 0;
 
 		/* Skip NULL index names */
@@ -1178,11 +1175,6 @@ verifyIndexMatch(__nis_table_mapping_t *x, db_query *q,
 							index_value->
 							itemvalue.
 							itemvalue_val;
-						len = q->components.
-							components_val[k].
-							index_value->
-							itemvalue.
-							itemvalue_len;
 						break;
 					}
 				}
@@ -1240,7 +1232,7 @@ __nis_table_mapping_t **
 selectTableMapping(__nis_table_mapping_t *t, db_query *q,
 			int wantWrite, int wantObj, char *dbId,
 			int *numMatches) {
-	__nis_table_mapping_t	*r, *x, **tp;
+	__nis_table_mapping_t	*x, **tp;
 	int			i, nm, numap;
 	char			*myself = "selectTableMapping";
 
@@ -1306,7 +1298,7 @@ selectTableMapping(__nis_table_mapping_t *t, db_query *q,
 	}
 
 	/* Scan all mappings, and collect candidates */
-	for (nm = 0, r = 0, x = t; x != 0; x = x->next) {
+	for (nm = 0, x = t; x != 0; x = x->next) {
 		if (x->objectDN == 0)
 			continue;
 		if (wantWrite) {

--- a/usr/src/lib/libnsl/key/publickey.c
+++ b/usr/src/lib/libnsl/key/publickey.c
@@ -116,8 +116,8 @@ static DEFINE_NSS_DB_ROOT(db_root);
  */
 /* ARGSUSED */
 static int
-str2key(const char *instr, int lenstr,
-			void *ent, char *buffer, int buflen) {
+str2key(const char *instr, int lenstr, void *ent, char *buffer, int buflen)
+{
 	if (lenstr + 1 > buflen)
 		return (NSS_STR_PARSE_ERANGE);
 	/*
@@ -342,20 +342,19 @@ getsecretkey(const char *netname, char *skey, const char *passwd)
  */
 static int
 extract_secret_g(
-	char		*raw,		/* in  */
-	char		*private,	/* out */
-	int		prilen,		/* in  */
-	char		*passwd,	/* in  */
-	char		*netname,	/* in  */
-	keylen_t	keylen,		/* in  */
-	algtype_t	algtype)	/* in  */
-
+    char	*raw,		/* in  */
+    char	*private,	/* out */
+    int		prilen,		/* in  */
+    char	*passwd,	/* in  */
+    char	*netname,	/* in  */
+    keylen_t	keylen,		/* in  */
+    algtype_t	algtype)	/* in  */
 {
 	char	*buf = malloc(strlen(raw) + 1); /* private tmp buf */
 	char	*p;
 
 	if (!buf || !passwd || !raw || !private || !prilen ||
-			!VALID_KEYALG(keylen, algtype)) {
+	    !VALID_KEYALG(keylen, algtype)) {
 		if (private)
 			*private = NUL;
 		if (buf)
@@ -535,8 +534,10 @@ netname2hashname(
 void
 __getpublickey_flush_g(const char *netname, keylen_t keylen, algtype_t algtype)
 {
-	char	*p, hashname[MAXNETNAMELEN+1];
-	p = netname2hashname(netname, hashname, MAXNETNAMELEN, keylen, algtype);
+	char	hashname[MAXNETNAMELEN+1];
+
+	(void) netname2hashname(netname, hashname, MAXNETNAMELEN, keylen,
+	    algtype);
 }
 
 /*
@@ -544,11 +545,11 @@ __getpublickey_flush_g(const char *netname, keylen_t keylen, algtype_t algtype)
  */
 int
 __getpublickey_cached_g(const char netname[],	/* in  */
-			keylen_t keylen,	/* in  */
-			algtype_t algtype,	/* in  */
-			char *pkey,		/* out */
-			size_t pkeylen,		/* in  */
-			int *from_cache)	/* in/out  */
+    keylen_t keylen,	/* in  */
+    algtype_t algtype,	/* in  */
+    char *pkey,		/* out */
+    size_t pkeylen,	/* in  */
+    int *from_cache)	/* in/out  */
 {
 	int	needfree = 1, res, err;
 	struct __nsw_switchconfig *conf;

--- a/usr/src/lib/libpp/common/ppproto.c
+++ b/usr/src/lib/libpp/common/ppproto.c
@@ -29,8 +29,6 @@
  * PROTOMAIN is coded for minimal library support
  */
 
-static const char id[] = "\n@(#)$Id: proto (AT&T Research) 2008-05-11 $\0\n";
-
 #if PROTOMAIN
 
 #include "ppfsm.c"

--- a/usr/src/lib/librdc/common/rdcconfig.c
+++ b/usr/src/lib/librdc/common/rdcconfig.c
@@ -244,7 +244,7 @@ populate_addrs(rdc_set_t *urdc, int isenable)
 	if ((fromname[0] == '\0') || (fromname[0] == '\0')) {
 		rdc_set_error(NULL, RDC_INTERNAL, RDC_FATAL,
 		    "NULL hostname recieved");
-		    return (-1);
+		return (-1);
 	}
 
 	hp = gethost_byname(fromname);
@@ -313,7 +313,8 @@ rdc_free_config(rdcconfig_t *rdc, int all)
 }
 
 void
-rdc_free_rclist(rdc_rc_t *rc) {
+rdc_free_rclist(rdc_rc_t *rc)
+{
 	rdc_rc_t *rcp, *rcq;
 
 	rcp = rc;
@@ -635,7 +636,6 @@ rdc_usync(rdcconfig_t *rdc)
 	rdc_rc_t	*rc = NULL;
 	rdc_rc_t	*rcp = NULL;
 	rdc_rc_t	*tmprc;
-	int trc;
 
 	rdcp = rdc;
 
@@ -646,7 +646,7 @@ rdc_usync(rdcconfig_t *rdc)
 		rdccfg->command = RDC_CMD_COPY;
 		rdccfg->options = RDC_OPT_UPDATE|RDC_OPT_FORWARD;
 		populate_addrs(&rdccfg->rdc_set[0], 0);
-		trc = thr_create(NULL, 0, rdc_mtconfig,
+		(void) thr_create(NULL, 0, rdc_mtconfig,
 		    (void **) rdccfg, THR_BOUND, NULL);
 		rdcp = rdcp->next;
 		if (!rdcp)
@@ -679,7 +679,6 @@ rdc_fsync(rdcconfig_t *rdc)
 	rdc_rc_t	*rc = NULL;
 	rdc_rc_t	*rcp = NULL;
 	rdc_rc_t	*tmprc = NULL;
-	int trc;
 
 	rdcp = rdc;
 	rc = new_rc();
@@ -695,7 +694,7 @@ rdc_fsync(rdcconfig_t *rdc)
 		rdccfg->command = RDC_CMD_COPY;
 		rdccfg->options = RDC_OPT_FULL|RDC_OPT_FORWARD;
 		populate_addrs(&rdccfg->rdc_set[0], 0);
-		trc = thr_create(NULL, 0, rdc_mtconfig,
+		(void) thr_create(NULL, 0, rdc_mtconfig,
 		    (void **) rdccfg, THR_BOUND, NULL);
 		rdcp = rdcp->next;
 		if (!rdcp)
@@ -728,7 +727,6 @@ rdc_rsync(rdcconfig_t *rdc)
 	rdc_rc_t	*rc = NULL;
 	rdc_rc_t	*rcp = NULL;
 	rdc_rc_t	*tmprc = NULL;
-	int trc;
 
 	rdcp = rdc;
 	rc = new_rc();
@@ -755,7 +753,7 @@ rdc_rsync(rdcconfig_t *rdc)
 		rdccfg->command = RDC_CMD_COPY;
 		rdccfg->options = RDC_OPT_REVERSE|RDC_OPT_FULL;
 		populate_addrs(&rdccfg->rdc_set[0], 0);
-		trc = thr_create(NULL, 0, rdc_mtconfig,
+		(void) thr_create(NULL, 0, rdc_mtconfig,
 		    (void **) rdccfg, THR_BOUND, NULL);
 next:
 		rdcp = rdcp->next;
@@ -788,7 +786,6 @@ rdc_ursync(rdcconfig_t *rdc)
 	rdc_rc_t	*rc = NULL;
 	rdc_rc_t	*rcp = NULL;
 	rdc_rc_t	*tmprc = NULL;
-	int trc;
 
 	rdcp = rdc;
 
@@ -810,7 +807,7 @@ rdc_ursync(rdcconfig_t *rdc)
 		rdccfg->command = RDC_CMD_COPY;
 		rdccfg->options = RDC_OPT_REVERSE | RDC_OPT_UPDATE;
 		populate_addrs(&rdccfg->rdc_set[0], 0);
-		trc = thr_create(NULL, 0, rdc_mtconfig,
+		(void) thr_create(NULL, 0, rdc_mtconfig,
 		    (void **) rdccfg, THR_BOUND, NULL);
 next:
 		rdcp = rdcp->next;

--- a/usr/src/lib/libsldap/common/ns_mapping.c
+++ b/usr/src/lib/libsldap/common/ns_mapping.c
@@ -58,7 +58,7 @@ ns_hash(const char *str)
 
 static ns_hash_t *
 ns_scan_hash(ns_hashtype_t type, const char *service,
-		const char *str, ns_hash_t *idx)
+    const char *str, ns_hash_t *idx)
 {
 	while (idx) {
 		if (idx->h_type == type &&
@@ -77,7 +77,7 @@ ns_scan_hash(ns_hashtype_t type, const char *service,
 
 static ns_hash_t *
 ns_get_hash(const ns_config_t *config,
-	    ns_hashtype_t type, const char *service, const char *str)
+    ns_hashtype_t type, const char *service, const char *str)
 {
 	ns_hash_t	*idx, *hashp;
 	unsigned long	hash;
@@ -168,7 +168,7 @@ __s_api_destroy_hash(ns_config_t *config)
 
 int
 __s_api_add_map2hash(ns_config_t *config, ns_hashtype_t type,
-			ns_mapping_t *map)
+    ns_mapping_t *map)
 {
 	ns_hash_t	*idx, *newp;
 	unsigned long	hash;
@@ -324,11 +324,10 @@ typedef enum _ns_parse_state {
 static
 int
 __s_api_parseASearchDesc(const char *service,
-	char **cur, ns_ldap_search_desc_t **ret)
+    char **cur, ns_ldap_search_desc_t **ret)
 {
 	ns_ldap_search_desc_t	*ptr;
 	char			*sptr, *dptr;
-	char			buf[BUFSIZ];
 	int			i, rc;
 	ns_ldap_error_t		**errorp = NULL;
 	ns_ldap_error_t		*error = NULL;
@@ -456,7 +455,6 @@ __s_api_parseASearchDesc(const char *service,
 			state = P_FILTER;
 			break;
 		case P_SCOPE:
-			buf[0] = '\0';
 			if (*sptr == SEMITOK) {
 				/* no more SSD */
 				state = P_EXIT;
@@ -617,7 +615,7 @@ __s_api_parseASearchDesc(const char *service,
 
 static int
 __ns_ldap_saveSearchDesc(ns_ldap_search_desc_t ***sdlist,
-	int *cnt, int *max, ns_ldap_search_desc_t *ret)
+    int *cnt, int *max, ns_ldap_search_desc_t *ret)
 {
 	ns_ldap_search_desc_t	**tmplist;
 

--- a/usr/src/lib/libsmedia/plugins/scsi/common/s_generic.c
+++ b/usr/src/lib/libsmedia/plugins/scsi/common/s_generic.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * s_generic.c :
  *      This file contains generic SCSI related functions for scsi plug-in
@@ -74,9 +72,8 @@ _m_get_media_info(rmedia_handle_t *handle, void *ip)
 	}
 	if (handle->sm_signature != (int32_t)LIBSMEDIA_SIGNATURE) {
 		DPRINTF("Invalid signature in handle.\n");
-		DPRINTF2(
-		"Signature expected=0x%x, found=0x%x\n",
-			LIBSMEDIA_SIGNATURE, handle->sm_signature);
+		DPRINTF2("Signature expected=0x%x, found=0x%x\n",
+		    LIBSMEDIA_SIGNATURE, handle->sm_signature);
 		DPRINTF1("fd=%d\n", handle->sm_fd);
 		errno = EINVAL;
 		return (-1);
@@ -97,7 +94,7 @@ _m_get_media_info(rmedia_handle_t *handle, void *ip)
 		return (-1);
 	}
 	retget_medium_property =
-		(smedia_retget_medium_property_t *)((void *)door_args.data_ptr);
+	    (smedia_retget_medium_property_t *)((void *)door_args.data_ptr);
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
 		DPRINTF1(
@@ -174,11 +171,11 @@ _m_get_device_info(rmedia_handle_t *handle, void *ip)
 		return (-1);
 	}
 	retget_device_info = (smedia_retget_device_info_t *)
-		((void *)door_args.data_ptr);
+	    ((void *)door_args.data_ptr);
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
-		DPRINTF1(
-	"Error in get_device_info. errnum = 0x%x \n", reterror->errnum);
+		DPRINTF1("Error in get_device_info. errnum = 0x%x \n",
+		    reterror->errnum);
 		errno = reterror->errnum;
 		free(vendor_name);
 		free(product_name);
@@ -192,13 +189,13 @@ _m_get_device_info(rmedia_handle_t *handle, void *ip)
 
 
 	(void) strlcpy(dev_info->sm_vendor_name,
-		retget_device_info->sm_vendor_name, 8);
+	    retget_device_info->sm_vendor_name, 8);
 	dev_info->sm_vendor_name[8] = 0;
 	(void) strlcpy(dev_info->sm_product_name,
-		retget_device_info->sm_product_name, 16);
+	    retget_device_info->sm_product_name, 16);
 	dev_info->sm_product_name[16] = 0;
 	(void) strlcpy(dev_info->sm_firmware_version,
-		retget_device_info->sm_firmware_version, 17);
+	    retget_device_info->sm_firmware_version, 17);
 	dev_info->sm_firmware_version[17] = 0;
 
 	dev_info->sm_interface_type = retget_device_info->sm_interface_type;
@@ -279,9 +276,9 @@ _m_raw_write(rmedia_handle_t *handle, void *i_p)
 	retraw_write = (smedia_retraw_write_t *)((void *)door_args.data_ptr);
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
-		DPRINTF3(
-	"Error in raw write. errnum = 0x%x blk_num = 0x%x(%d)\n",
-		reterror->errnum, r_p->offset, r_p->offset);
+		DPRINTF3("Error in raw write. errnum = 0x%x "
+		    "blk_num = 0x%x(%d)\n", reterror->errnum, r_p->offset,
+		    r_p->offset);
 		errno = reterror->errnum;
 		goto error;
 	}
@@ -343,9 +340,9 @@ _m_raw_read(rmedia_handle_t *handle, void *i_p)
 		/*
 		 * free(rbuf);
 		 */
-		DPRINTF3(
-	"Error in raw read. errnum = 0x%x blk_num = 0x%x(%d)\n",
-		reterror->errnum, r_p->offset, r_p->offset);
+		DPRINTF3("Error in raw read. errnum = 0x%x "
+		    "blk_num = 0x%x(%d)\n", reterror->errnum, r_p->offset,
+		    r_p->offset);
 		errno = reterror->errnum;
 		goto error;
 	}
@@ -366,7 +363,6 @@ _m_media_format(rmedia_handle_t *handle, void *ip)
 	int32_t ret_val;
 	struct format_flags *ffl = (struct format_flags *)ip;
 	smedia_reqformat_t	reqformat;
-	smedia_retformat_t	*retformat;
 	smedia_reterror_t	*reterror;
 	door_arg_t	door_args;
 	char	rbuf[sizeof (smedia_services_t) + sizeof (door_desc_t)];
@@ -397,10 +393,6 @@ _m_media_format(rmedia_handle_t *handle, void *ip)
 		perror("door_call");
 		return (size_t)(-1);
 	}
-	retformat = (smedia_retformat_t *)((void *)door_args.data_ptr);
-#ifdef lint
-	retformat = retformat;
-#endif
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
 		DPRINTF1("Error in format. errnum = 0x%x \n", reterror->errnum);
@@ -445,23 +437,23 @@ _m_get_media_status(rmedia_handle_t *handle, void *ip)
 		perror("door_call");
 		return (-1);
 	}
-	retget_protection_status =
-		(smedia_retget_protection_status_t *)
-		((void *)door_args.data_ptr);
+	retget_protection_status = (smedia_retget_protection_status_t *)
+	    ((void *)door_args.data_ptr);
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
-		DPRINTF1(
-	"Error in get_protection-status. errnum = 0x%x \n", reterror->errnum);
+		DPRINTF1("Error in get_protection-status. errnum = 0x%x \n",
+		    reterror->errnum);
 		errno = reterror->errnum;
 		return (-1);
 	}
 	(void) memcpy((char *)wp, (char *)&retget_protection_status->prot_state,
-		sizeof (smwp_state_t));
+	    sizeof (smwp_state_t));
 	return (0);
 }
 
 int32_t
-_m_set_media_status(rmedia_handle_t *handle, void *ip) {
+_m_set_media_status(rmedia_handle_t *handle, void *ip)
+{
 
 	smwp_state_t	*wp = ip;
 	int32_t ret_val;
@@ -545,9 +537,8 @@ _m_reassign_block(rmedia_handle_t *handle, void *ip)
 	}
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
-		DPRINTF2(
-		"Error in reassign_block. block = 0x%x errnum = 0x%x \n",
-			block, reterror->errnum);
+		DPRINTF2("Error in reassign_block. block = 0x%x "
+		    "errnum = 0x%x \n", block, reterror->errnum);
 		errno = reterror->errnum;
 		return (-1);
 	}
@@ -579,8 +570,8 @@ int32_t
 _m_device_type(ushort_t ctype, ushort_t mtype)
 {
 	if ((ctype == DKC_SCSI_CCS) ||
-		(ctype == DKC_MD21) ||
-		(ctype == DKC_CDROM)) {
+	    (ctype == DKC_MD21) ||
+	    (ctype == DKC_CDROM)) {
 		if (mtype == 0)
 			return (0);
 	}
@@ -631,11 +622,11 @@ _m_check_format_status(rmedia_handle_t *handle, void *ip)
 		return (-1);
 	}
 	retcheck_format_status =
-		(smedia_retcheck_format_status_t *)((void *)door_args.data_ptr);
+	    (smedia_retcheck_format_status_t *)((void *)door_args.data_ptr);
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
-		DPRINTF1(
-	"Error in check_format_status. errnum = 0x%x \n", reterror->errnum);
+		DPRINTF1("Error in check_format_status. errnum = 0x%x \n",
+		    reterror->errnum);
 		errno = reterror->errnum;
 		return (-1);
 	}
@@ -700,7 +691,7 @@ _m_uscsi_cmd(rmedia_handle_t *handle, struct uscsi_cmd *ucmd)
 	 */
 	(void) mutex_lock(&handle->sm_bufmutex);
 	ret_val = remap_shared_buf(handle, ucmd->uscsi_buflen,
-			ucmd->uscsi_bufaddr);
+	    ucmd->uscsi_bufaddr);
 	if (ret_val != 0) {
 		DPRINTF("remap of shared buf failed.\n");
 		goto error;
@@ -749,9 +740,9 @@ _m_uscsi_cmd(rmedia_handle_t *handle, struct uscsi_cmd *ucmd)
 	ucmd->uscsi_rqstatus = retuscsi_cmd->uscsi_rqstatus;
 	ucmd->uscsi_rqresid = retuscsi_cmd->uscsi_rqresid;
 	if ((ucmd->uscsi_flags & USCSI_RQENABLE) &&
-		(ucmd->uscsi_rqbuf != NULL)) {
-		bcopy(retuscsi_cmd->uscsi_rqbuf,
-			ucmd->uscsi_rqbuf, ucmd->uscsi_rqlen);
+	    (ucmd->uscsi_rqbuf != NULL)) {
+		bcopy(retuscsi_cmd->uscsi_rqbuf, ucmd->uscsi_rqbuf,
+		    ucmd->uscsi_rqlen);
 	}
 	errno = retuscsi_cmd->uscsi_errno;
 	if (errno) {
@@ -767,14 +758,13 @@ _m_uscsi_cmd(rmedia_handle_t *handle, struct uscsi_cmd *ucmd)
 	}
 	if (ucmd->uscsi_flags & USCSI_READ) {
 		(void) memcpy(ucmd->uscsi_bufaddr,
-				handle->sm_buf,
-				ucmd->uscsi_buflen - ucmd->uscsi_resid);
+		    handle->sm_buf, ucmd->uscsi_buflen - ucmd->uscsi_resid);
 	}
 	(void) mutex_unlock(&handle->sm_bufmutex);
 #ifdef DEBUG
 	if (retuscsi_cmd->uscsi_retval || ucmd->uscsi_status)
 		DPRINTF2("Error in uscsi_cmd: retval=0x%x uscsi_status=0x%x\n",
-			retuscsi_cmd->uscsi_retval, ucmd->uscsi_status);
+		    retuscsi_cmd->uscsi_retval, ucmd->uscsi_status);
 #endif
 	return (retuscsi_cmd->uscsi_retval);
 error:
@@ -799,7 +789,7 @@ remap_shared_buf(rmedia_handle_t *handle, size_t buf_size, char *buffer)
 	if (handle->sm_bufsize >= buf_size)
 		return (0);
 	shared_bufsize = ((buf_size + BUF_SIZE_MULTIPLE - 1)/BUF_SIZE_MULTIPLE)
-		* BUF_SIZE_MULTIPLE;
+	    * BUF_SIZE_MULTIPLE;
 	if (handle->sm_buffd != -1) {
 		/* extend the file and re-map */
 		fd = handle->sm_buffd;
@@ -851,8 +841,8 @@ remap_shared_buf(rmedia_handle_t *handle, size_t buf_size, char *buffer)
 		}
 		file_size += buf_size;
 	}
-	fbuf = (char *)mmap(0, shared_bufsize, PROT_READ | PROT_WRITE,
-		MAP_SHARED, fd, 0);
+	fbuf = mmap(NULL, shared_bufsize, PROT_READ | PROT_WRITE,
+	    MAP_SHARED, fd, 0);
 	if (fbuf == (char *)-1) {
 		perror("mmap failed");
 		(void) close(fd);
@@ -879,7 +869,7 @@ remap_shared_buf(rmedia_handle_t *handle, size_t buf_size, char *buffer)
 	reterror = (smedia_reterror_t *)((void *)door_args.data_ptr);
 	if (reterror->cnum == SMEDIA_CNUM_ERROR) {
 		DPRINTF1("Error in set shfd. errnum = 0x%x\n",
-			reterror->errnum);
+		    reterror->errnum);
 		errno = reterror->errnum;
 		(void) close(fd);
 		return (errno);

--- a/usr/src/lib/libsum/common/sumlib.c
+++ b/usr/src/lib/libsum/common/sumlib.c
@@ -25,8 +25,6 @@
  * man this is sum library
  */
 
-static const char id[] = "\n@(#)$Id: sumlib (AT&T Research) 2009-09-28 $\0\n";
-
 #define _SUM_PRIVATE_	\
 			struct Method_s*	method;	\
 			uintmax_t		total_count;	\

--- a/usr/src/lib/libtnfctl/comb.c
+++ b/usr/src/lib/libtnfctl/comb.c
@@ -23,8 +23,6 @@
  * Copyright (c) 1994, by Sun Microsytems, Inc.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * Functions that know how to create and decode combinations that are
  * used for connecting probe functions.
@@ -90,10 +88,10 @@ extern void	 prb_chain_end(void);
 
 static comb_calltmpl_t calltmpl[PRB_COMB_COUNT] = {
 {
-		(uintptr_t) prb_chain_entry,
-		(uintptr_t) prb_chain_down,
-		(uintptr_t) prb_chain_next,
-		(uintptr_t) prb_chain_end}
+		(uintptr_t)prb_chain_entry,
+		(uintptr_t)prb_chain_down,
+		(uintptr_t)prb_chain_next,
+		(uintptr_t)prb_chain_end}
 };
 
 /*
@@ -103,9 +101,9 @@ static comb_calltmpl_t calltmpl[PRB_COMB_COUNT] = {
 static tnfctl_errcode_t decode(tnfctl_handle_t *hndl, uintptr_t addr,
 	char ***func_names, uintptr_t **func_addrs);
 static boolean_t find(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down,
-	uintptr_t next, uintptr_t * comb_p);
+	uintptr_t next, uintptr_t *comb_p);
 static tnfctl_errcode_t build(tnfctl_handle_t *hndl, comb_op_t op,
-	uintptr_t down, uintptr_t next, uintptr_t * comb_p);
+	uintptr_t down, uintptr_t next, uintptr_t *comb_p);
 static tnfctl_errcode_t add(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down,
 	uintptr_t next, uintptr_t comb);
 static int comb_compare(const void *a, const void *b);
@@ -126,28 +124,28 @@ static tnfctl_errcode_t findname(tnfctl_handle_t *hndl, uintptr_t addr,
  */
 tnfctl_errcode_t
 _tnfctl_comb_build(tnfctl_handle_t *hndl, comb_op_t op,
-	uintptr_t down, uintptr_t next, uintptr_t *comb_p)
+    uintptr_t down, uintptr_t next, uintptr_t *comb_p)
 {
 	tnfctl_errcode_t	prexstat;
 
 	*comb_p = NULL;
 
 	DBG_TNF_PROBE_0(_tnfctl_comb_build_start, "libtnfctl",
-			"start _tnfctl_comb_build; sunw%verbosity 1");
+	    "start _tnfctl_comb_build; sunw%verbosity 1");
 
 	if (find(hndl, op, down, next, comb_p)) {
 
 		DBG_TNF_PROBE_1(_tnfctl_comb_build_end, "libtnfctl",
-			"end _tnfctl_comb_build; sunw%verbosity 1",
-			tnf_opaque, found_comb_at, *comb_p);
+		    "end _tnfctl_comb_build; sunw%verbosity 1",
+		    tnf_opaque, found_comb_at, *comb_p);
 
 		return (TNFCTL_ERR_NONE);
 	}
 	prexstat = build(hndl, op, down, next, comb_p);
 
 	DBG_TNF_PROBE_1(_tnfctl_comb_build_end, "libtnfctl",
-			"end _tnfctl_comb_build; sunw%verbosity 1",
-			tnf_opaque, built_comb_at, *comb_p);
+	    "end _tnfctl_comb_build; sunw%verbosity 1",
+	    tnf_opaque, built_comb_at, *comb_p);
 
 	return (prexstat);
 }
@@ -160,17 +158,17 @@ _tnfctl_comb_build(tnfctl_handle_t *hndl, comb_op_t op,
  */
 tnfctl_errcode_t
 _tnfctl_comb_decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
-	uintptr_t **func_addrs)
+    uintptr_t **func_addrs)
 {
 	tnfctl_errcode_t prexstat;
 
 	DBG_TNF_PROBE_0(_tnfctl_comb_decode_start, "libtnfctl",
-			"start _tnfctl_comb_decode; sunw%verbosity 2");
+	    "start _tnfctl_comb_decode; sunw%verbosity 2");
 
 	prexstat = decode(hndl, addr, func_names, func_addrs);
 
 	DBG_TNF_PROBE_0(_tnfctl_comb_decode_end, "libtnfctl",
-			"end _tnfctl_comb_decode; sunw%verbosity 2");
+	    "end _tnfctl_comb_decode; sunw%verbosity 2");
 
 	return (prexstat);
 }
@@ -186,7 +184,7 @@ _tnfctl_comb_decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
  */
 static tnfctl_errcode_t
 decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
-	uintptr_t **func_addrs)
+    uintptr_t **func_addrs)
 {
 	tnfctl_errcode_t	prexstat = TNFCTL_ERR_NONE;
 	decode_key_t	key;
@@ -199,17 +197,17 @@ decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
 
 	/* see if we can find the previously decoded answer */
 	key.addr = addr;
-	find_pp = (decode_key_t **) tfind(&key, &hndl->decoderoot,
-			decode_compare);
+	find_pp = (decode_key_t **)tfind(&key, &hndl->decoderoot,
+	    decode_compare);
 	if (find_pp) {
 		DBG_TNF_PROBE_0(decode_1, "libtnfctl",
-			"sunw%verbosity 2; sunw%debug 'found existing'");
+		    "sunw%verbosity 2; sunw%debug 'found existing'");
 		*func_names = (*find_pp)->name_ptrs;
 		*func_addrs = (*find_pp)->func_addrs;
 		return (TNFCTL_ERR_NONE);
 	}
 
-	new_p = (decode_key_t *) calloc(1, sizeof (decode_key_t));
+	new_p = calloc(1, sizeof (decode_key_t));
 	if (!new_p)
 		return (TNFCTL_ERR_ALLOCFAIL);
 	new_p->addr = addr;
@@ -226,8 +224,7 @@ decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
 		int count, j;
 
 		DBG_TNF_PROBE_2(decode_2, "libtnfctl", "sunw%verbosity 2;",
-			tnf_opaque, down, down,
-			tnf_opaque, next, next);
+		    tnf_opaque, down, down, tnf_opaque, next, next);
 
 		prexstat = findname(hndl, down, &thisname);
 		if (prexstat == TNFCTL_ERR_USR1) {
@@ -245,18 +242,19 @@ decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
 			goto Error;
 
 		/* count number of elements - caution: empty 'for' loop */
-		for (count = 0; nextnames[count]; count++);
+		for (count = 0; nextnames[count]; count++)
+			;
 		count++;	/* since it was 0 based */
 
 		/* allocate one more for new function name */
 		new_p->name_ptrs = malloc((count + 1) *
-					sizeof (new_p->name_ptrs[0]));
+		    sizeof (new_p->name_ptrs[0]));
 		if (new_p->name_ptrs == NULL) {
 			prexstat = TNFCTL_ERR_ALLOCFAIL;
 			goto Error;
 		}
 		new_p->func_addrs = malloc((count + 1) *
-					sizeof (new_p->func_addrs[0]));
+		    sizeof (new_p->func_addrs[0]));
 		if (new_p->func_addrs == NULL) {
 			prexstat = TNFCTL_ERR_ALLOCFAIL;
 			goto Error;
@@ -295,12 +293,11 @@ decode(tnfctl_handle_t *hndl, uintptr_t addr, char ***func_names,
 	}
 
 	DBG_TNF_PROBE_1(decode_3, "libtnfctl",
-			"sunw%verbosity 2; sunw%debug 'decode built'",
-			tnf_string, func_name,
-				(thisname) ? (thisname) : "end_func");
+	    "sunw%verbosity 2; sunw%debug 'decode built'",
+	    tnf_string, func_name, (thisname) ? (thisname) : "end_func");
 
-	find_pp = (decode_key_t **) tsearch(new_p,
-		&hndl->decoderoot, decode_compare);
+	find_pp = (decode_key_t **)tsearch(new_p, &hndl->decoderoot,
+	    decode_compare);
 	assert(*find_pp == new_p);
 	*func_names = new_p->name_ptrs;
 	*func_addrs = new_p->func_addrs;
@@ -323,9 +320,8 @@ Error:
  * it is, return the down and next pointers
  */
 static tnfctl_errcode_t
-iscomb(tnfctl_handle_t *hndl,
-	uintptr_t addr, uintptr_t *down_p, uintptr_t *next_p,
-	boolean_t *ret_val)
+iscomb(tnfctl_handle_t *hndl, uintptr_t addr, uintptr_t *down_p,
+    uintptr_t *next_p, boolean_t *ret_val)
 {
 	int		type;
 	boolean_t	matched = B_FALSE;
@@ -342,8 +338,8 @@ iscomb(tnfctl_handle_t *hndl,
 		int		tmp_bits = prb_callinfo.mask;
 
 		/* allocate room to copy the target code */
-		size = (size_t) (calltmpl[type].end - calltmpl[type].entry);
-		targ_p = (char *) malloc(size);
+		size = (size_t)(calltmpl[type].end - calltmpl[type].entry);
+		targ_p = malloc(size);
 		if (!targ_p)
 			return (TNFCTL_ERR_ALLOCFAIL);
 
@@ -361,20 +357,20 @@ iscomb(tnfctl_handle_t *hndl,
 		}
 
 		/* loop over all the words */
-		tptr = (char *) calltmpl[type].entry;
+		tptr = (char *)calltmpl[type].entry;
 		for (ptr = targ_p; ptr < (targ_p + size); ptr++, tptr++) {
 			int			 downbits;
 			int			 nextbits;
 		/* LINTED pointer cast may result in improper alignment */
-			int			*uptr = (int *) ptr;
+			int			*uptr = (int *)ptr;
 
 			/*
 			 * If we are pointing at one of the words that we
 			 * patch, * (down or next displ) then read that value
 			 * in. * Otherwise make sure the words match.
 			 */
-			if ((uintptr_t) tptr == calltmpl[type].down +
-				prb_callinfo.offset) {
+			if ((uintptr_t)tptr == calltmpl[type].down +
+			    prb_callinfo.offset) {
 				downbits = *uptr;
 				downbits &= prb_callinfo.mask;
 				/* sign extend */
@@ -388,8 +384,8 @@ iscomb(tnfctl_handle_t *hndl,
 
 				ptr += 3;
 				tptr += 3;
-			} else if ((uintptr_t) tptr == calltmpl[type].next +
-				prb_callinfo.offset) {
+			} else if ((uintptr_t)tptr == calltmpl[type].next +
+			    prb_callinfo.offset) {
 				nextbits = *uptr;
 				nextbits &= prb_callinfo.mask;
 				/* sign extend */
@@ -478,7 +474,7 @@ findname(tnfctl_handle_t *hndl, uintptr_t addr, char **ret_name)
  */
 static boolean_t
 find(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
-	uintptr_t * comb_p)
+    uintptr_t *comb_p)
 {
 	comb_key_t	key;
 	comb_key_t	**find_pp;
@@ -488,7 +484,7 @@ find(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	key.next = next;
 	key.comb = NULL;
 
-	find_pp = (comb_key_t **) tfind(&key, &hndl->buildroot, comb_compare);
+	find_pp = (comb_key_t **)tfind(&key, &hndl->buildroot, comb_compare);
 	if (find_pp) {
 		*comb_p = (*find_pp)->comb;
 		return (B_TRUE);
@@ -502,13 +498,13 @@ find(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
  */
 static tnfctl_errcode_t
 add(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
-	uintptr_t comb)
+    uintptr_t comb)
 {
 	comb_key_t	 *new_p;
 	/* LINTED set but not used in function */
-	comb_key_t	**ret_pp;
+	comb_key_t	**ret_pp __unused;
 
-	new_p = (comb_key_t *) malloc(sizeof (comb_key_t));
+	new_p = malloc(sizeof (comb_key_t));
 	if (!new_p)
 		return (TNFCTL_ERR_ALLOCFAIL);
 
@@ -517,8 +513,8 @@ add(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	new_p->next = next;
 	new_p->comb = comb;
 
-	ret_pp = (comb_key_t **) tsearch(new_p, &hndl->buildroot,
-			comb_compare);
+	ret_pp = (comb_key_t **)tsearch(new_p, &hndl->buildroot,
+	    comb_compare);
 	assert(*ret_pp == new_p);
 	return (TNFCTL_ERR_NONE);
 }
@@ -531,10 +527,10 @@ add(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 static int
 decode_compare(const void *v0p, const void *v1p)
 {
-	decode_key_t   *k0p = (decode_key_t *) v0p;
-	decode_key_t   *k1p = (decode_key_t *) v1p;
+	const decode_key_t   *k0p = v0p;
+	const decode_key_t   *k1p = v1p;
 
-	return (int) ((uintptr_t) k1p->addr - (uintptr_t) k0p->addr);
+	return (int)((uintptr_t)k1p->addr - (uintptr_t)k0p->addr);
 }				/* end decode_compare */
 
 
@@ -544,8 +540,8 @@ decode_compare(const void *v0p, const void *v1p)
 static int
 comb_compare(const void *v0p, const void *v1p)
 {
-	comb_key_t	 *k0p = (comb_key_t *) v0p;
-	comb_key_t	 *k1p = (comb_key_t *) v1p;
+	const comb_key_t *k0p = v0p;
+	const comb_key_t *k1p = v1p;
 
 	if (k0p->op != k1p->op)
 		return ((k0p->op < k1p->op) ? -1 : 1);
@@ -565,7 +561,7 @@ comb_compare(const void *v0p, const void *v1p)
  */
 static tnfctl_errcode_t
 build(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
-	uintptr_t *comb_p)
+    uintptr_t *comb_p)
 {
 	size_t		size;
 	uintptr_t	addr;
@@ -576,14 +572,6 @@ build(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	int		miscstat;
 	tnfctl_errcode_t	prexstat;
 
-#if 0
-	(void) fprintf(stderr, "off=0x%x shift=0x%x mask=0x%x size=%d\n",
-		prb_callinfo.offset,
-		prb_callinfo.shift,
-		prb_callinfo.mask,
-		calltmpl[op].end - calltmpl[op].entry);
-#endif
-
 	*comb_p = NULL;
 	size = calltmpl[op].end - calltmpl[op].entry;
 
@@ -591,7 +579,7 @@ build(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	prexstat = _tnfctl_targmem_alloc(hndl, size, &addr);
 	if (prexstat) {
 		DBG((void) fprintf(stderr,
-			"build: trouble allocating target memory:\n"));
+		    "build: trouble allocating target memory:\n"));
 		goto Error;
 	}
 
@@ -607,17 +595,15 @@ build(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	/* poke the down address */
 	offset = calltmpl[op].down - calltmpl[op].entry;
 	/*LINTED pointer cast may result in improper alignment*/
-	word_p = (unsigned *) (buffer_p + offset + prb_callinfo.offset);
+	word_p = (unsigned *)(buffer_p + offset + prb_callinfo.offset);
 	contents = down - (addr + offset);
 #if defined(i386)
 	contents -= 5;		/* intel offset is relative to *next* instr */
 #endif
 
 	DBG_TNF_PROBE_4(build_1, "libtnfctl", "sunw%verbosity 3",
-			tnf_opaque, down, down,
-			tnf_opaque, contents, contents,
-			tnf_opaque, word_p, word_p,
-			tnf_long, offset, offset);
+	    tnf_opaque, down, down, tnf_opaque, contents, contents,
+	    tnf_opaque, word_p, word_p, tnf_long, offset, offset);
 
 	*word_p &= ~prb_callinfo.mask;	/* clear the relevant field */
 	*word_p |= ((contents >> prb_callinfo.shift) & prb_callinfo.mask);
@@ -625,17 +611,15 @@ build(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	/* poke the next address */
 	offset = calltmpl[op].next - calltmpl[op].entry;
 	/*LINTED pointer cast may result in improper alignment*/
-	word_p = (unsigned *) (buffer_p + offset + prb_callinfo.offset);
+	word_p = (unsigned *)(buffer_p + offset + prb_callinfo.offset);
 	contents = next - (addr + offset);
 #if defined(i386)
 	contents -= 5;		/* intel offset is relative to *next* instr */
 #endif
 
 	DBG_TNF_PROBE_4(build_2, "libtnfctl", "sunw%verbosity 3",
-			tnf_opaque, next, next,
-			tnf_opaque, contents, contents,
-			tnf_opaque, word_p, word_p,
-			tnf_long, offset, offset);
+	    tnf_opaque, next, next, tnf_opaque, contents, contents,
+	    tnf_opaque, word_p, word_p, tnf_long, offset, offset);
 
 	*word_p &= ~prb_callinfo.mask;	/* clear the relevant field */
 	*word_p |= ((contents >> prb_callinfo.shift) & prb_callinfo.mask);
@@ -644,7 +628,7 @@ build(tnfctl_handle_t *hndl, comb_op_t op, uintptr_t down, uintptr_t next,
 	miscstat = hndl->p_write(hndl->proc_p, addr, buffer_p, size);
 	if (miscstat) {
 		DBG((void) fprintf(stderr,
-			"build: trouble writing combination: \n"));
+		    "build: trouble writing combination: \n"));
 		prexstat = TNFCTL_ERR_INTERNAL;
 		goto Error;
 	}

--- a/usr/src/lib/mpapi/libmpapi/common/mpapi.c
+++ b/usr/src/lib/mpapi/libmpapi/common/mpapi.c
@@ -261,7 +261,6 @@ void InitLibrary()
 
 		if (plugintable[i].hdlPlugin != NULL) {
 		    InitializeFn PassFunc;
-		    MP_STATUS status;
 
                     wcsncpy(plugintable[i].pluginName,
                         name, MAX_NAME_SIZE);
@@ -273,7 +272,7 @@ void InitLibrary()
 		    PassFunc = (InitializeFn)
 			 dlsym(plugintable[i].hdlPlugin, "Initialize");
 		    if (PassFunc != NULL) {
-			status = PassFunc(plugintable[i].ownerId);
+			(void) PassFunc(plugintable[i].ownerId);
 		    }
 
 		    i++;

--- a/usr/src/lib/pam_modules/sample/sample_acct_mgmt.c
+++ b/usr/src/lib/pam_modules/sample/sample_acct_mgmt.c
@@ -52,9 +52,9 @@ pam_sm_acct_mgmt(
 	char	*pg;
 	int	i;
 	/*LINTED - set but not used. Would be used in a real module. */
-	int	debug = 0;
+	int	debug __unused = 0;
 	/*LINTED - set but not used. Would be used in a real module. */
-	int	nowarn = 0;
+	int	nowarn __unused = 0;
 	int	error = 0;
 
 	if (argc == 0)

--- a/usr/src/lib/smbsrv/libsmbns/common/smbns_netbios_name.c
+++ b/usr/src/lib/smbsrv/libsmbns/common/smbns_netbios_name.c
@@ -484,16 +484,12 @@ smb_name_buf_from_packet(unsigned char *buf, int n_buf,
 	addr_entry_t		*raddr;
 	unsigned char 		*heap = buf;
 	unsigned char 		*end_heap = heap + n_buf;
-	unsigned char 		*dnptrs[32];
 	unsigned char		comp_name_buf[MAX_NAME_LENGTH];
 	unsigned int		tmp;
 	int			i, step;
 
 	if (n_buf < NAME_HEADER_SIZE)
 		return (-1);		/* no header, impossible */
-
-	dnptrs[0] = heap;
-	dnptrs[1] = 0;
 
 	BE_OUT16(heap, npb->name_trn_id);
 	heap += 2;

--- a/usr/src/man/man1/cancel.1
+++ b/usr/src/man/man1/cancel.1
@@ -4,7 +4,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH CANCEL 1 "Feb 25, 2017"
+.TH CANCEL 1 "Nov 26, 2017"
 .SH NAME
 cancel \- cancel print request
 .SH SYNOPSIS
@@ -184,9 +184,9 @@ are treated as print requests if \fIdestination\fR has the same format as an
 \fBLP-style\fR \fIrequest-ID\fR. See \fBstandards\fR(5).
 .sp
 .LP
-Some print servers send cancelation notification to job owners when their print
-jobs have been cancelled. This notification usually comes in the form of an
-email message. Cancelation notices cannot be disabled on a Solaris server.
+Some print servers send cancellation notifications to job owners when their
+print jobs have been cancelled. This notification usually comes in the form of
+an email message. Cancellation notices cannot be disabled on a Solaris server.
 .sp
 .LP
 When IPP is in use, the user is prompted for a passphrase if the remote print

--- a/usr/src/man/man1b/lprm.1b
+++ b/usr/src/man/man1b/lprm.1b
@@ -1,7 +1,7 @@
 '\" te
 .\" Copyright (c) 1983 Regents of the University of California.  All rights reserved.  The Berkeley software License Agreement  specifies the terms and conditions for redistribution.
 .\" Copyright (C) 2006, Sun Microsystems, Inc. All Rights Reserved
-.TH LPRM 1B "Feb 25, 2017"
+.TH LPRM 1B "Nov 26, 2017"
 .SH NAME
 lprm \- remove print requests from the print queue
 .SH SYNOPSIS
@@ -186,9 +186,9 @@ requests on the host from which the print request was submitted. Superusers can
 also remove print requests from the print server.
 .sp
 .LP
-Some print servers send cancelation notification to job owners when their print
-jobs have been cancelled. This notification usually comes in the form of an
-email message. Cancelation notices cannot be disabled on a Solaris server.
+Some print servers send cancellation notifications to job owners when their
+print jobs have been cancelled. This notification usually comes in the form of
+an email message. Cancellation notices cannot be disabled on a Solaris server.
 .SH NOTES
 .LP
 When IPP is in use, the user is prompted for a passphrase if the remote print

--- a/usr/src/man/man1m/fmd.1m
+++ b/usr/src/man/man1m/fmd.1m
@@ -4,7 +4,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FMD 1M "Nov 17, 2004"
+.TH FMD 1M "Nov 26, 2017"
 .SH NAME
 fmd \- fault manager daemon
 .SH SYNOPSIS
@@ -14,7 +14,6 @@ fmd \- fault manager daemon
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 \fBfmd\fR is a daemon that runs in the background on each system.
 \fBfmd\fR receives telemetry information relating to problems detected by the
@@ -27,7 +26,7 @@ explains more about the problem impact and appropriate responses.
 .sp
 .LP
 Each problem diagnosed by the fault manager is assigned a Universal Unique
-Identifier (\fBUUID\fR). The \fBUUID\fR uniquely identifes this particular
+Identifier (\fBUUID\fR). The \fBUUID\fR uniquely identifies this particular
 problem across any set of systems. The \fBfmdump\fR(1M) utility can be used to
 view the list of problems diagnosed by the fault manager, along with their
 \fBUUID\fRs and knowledge article message identifiers. The \fBfmadm\fR(1M)
@@ -36,7 +35,6 @@ The \fBfmstat\fR(1M) utility can be used to report statistics kept by the fault
 manager. The fault manager is started automatically when the operating system
 boots, so it is not necessary to use the \fBfmd\fR command directly.
 .SH OPTIONS
-.sp
 .LP
 The following options are supported
 .sp
@@ -80,7 +78,6 @@ Print the fault manager's version to stdout and exit.
 .RE
 
 .SH EXIT STATUS
-.sp
 .LP
 The following exit values are returned:
 .sp
@@ -112,7 +109,6 @@ Invalid command-line options were specified.
 .RE
 
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/etc/fm/fmd\fR \fR
@@ -140,7 +136,6 @@ Fault manager log directory
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -156,7 +151,6 @@ Interface Stability	Evolving
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBsvcs\fR(1), \fBfmadm\fR(1M), \fBfmdump\fR(1M), \fBfmstat\fR(1M),
 \fBsyslogd\fR(1M), \fBattributes\fR(5), \fBsmf\fR(5)
@@ -164,7 +158,6 @@ Interface Stability	Evolving
 .LP
 http://illumos.org/msg/
 .SH NOTES
-.sp
 .LP
 The Fault Manager is managed by the service management facility, \fBsmf\fR(5),
 under the service identifier:

--- a/usr/src/man/man1m/fsck_udfs.1m
+++ b/usr/src/man/man1m/fsck_udfs.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FSCK_UDFS 1M "Sep 5, 2000"
+.TH FSCK_UDFS 1M "Nov 26, 2017"
 .SH NAME
 fsck_udfs \- file system consistency check and interactive repair
 .SH SYNOPSIS
@@ -19,7 +19,6 @@ fsck_udfs \- file system consistency check and interactive repair
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 \fBfsck\fR audits and interactively repairs inconsistent conditions on file
 systems. A file system to be checked can be specified by giving the name of the
@@ -121,7 +120,6 @@ Bad free block list format
 Total free block count incorrect
 .RE
 .SH OPTIONS
-.sp
 .LP
 The following options are supported:
 .sp
@@ -222,23 +220,20 @@ Check writable file systems only.
 .RE
 
 .SH FILES
-.sp
 .ne 2
 .na
-\fB\fB/etc/vtstab\fR\fR
+\fB\fB/etc/vfstab\fR\fR
 .ad
 .RS 15n
 List of default parameters for each file system.
 .RE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBfsck\fR(1M), \fBfsdb_udfs\fR(1M), \fBfstyp\fR(1M), \fBmkfs\fR(1M),
 \fBmkfs_udfs\fR(1M), \fBmountall\fR(1M), \fBreboot\fR(1M), \fBvfstab\fR(4),
 \fBattributes\fR(5)
 .SH WARNINGS
-.sp
 .LP
 The operating system buffers file system data. Running \fBfsck\fR on a mounted
 file system can cause the operating system's buffers to become out of date with
@@ -253,7 +248,6 @@ If an unmount of the file system is not done before the system is shut down,
 the file system might become corrupted. In this case, a file system check needs
 to be completed before the next mount operation.
 .SH DIAGNOSTICS
-.sp
 .ne 2
 .na
 \fBnot writable\fR

--- a/usr/src/man/man1m/fsdb_udfs.1m
+++ b/usr/src/man/man1m/fsdb_udfs.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FSDB_UDFS 1M "Jun 11, 1999"
+.TH FSDB_UDFS 1M "Nov 26, 2017"
 .SH NAME
 fsdb_udfs \- udfs file system debugger
 .SH SYNOPSIS
@@ -13,7 +13,6 @@ fsdb_udfs \- udfs file system debugger
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBfsdb_udfs\fR command is an interactive tool that can be used to patch up
 a damaged \fBudfs\fR file system. \fBfsdb_udfs\fR has conversions to translate
@@ -39,7 +38,6 @@ with the \fB-w\fR option.
 Wherever possible, \fBadb\fR-like syntax has been adopted to promote the use of
 \fBfsdb\fR through familiarity.
 .SH OPTIONS
-.sp
 .LP
 The following options are supported:
 .sp
@@ -89,7 +87,6 @@ Display usage.
 .RE
 
 .SH USAGE
-.sp
 .LP
 Numbers are considered hexadecimal by default. The user has control over how
 data is to be displayed or accepted. The \fBbase\fR command displays or sets
@@ -223,7 +220,6 @@ or
 .LP
 is again synonymous.
 .SS "Expressions"
-.sp
 .LP
 The following symbols are recognized by \fBfsdb\fR:
 .sp
@@ -243,7 +239,7 @@ using the current value of \fIcount\fR.
 .ad
 .RS 13n
 Update the value of dot by specifying a numeric expression. Specify numeric
-expressions using addition, subtraction, mulitiplication, and division
+expressions using addition, subtraction, multiplication, and division
 operators ( \fB+\fR, \fB-\fR, \fB*\fR, and \fB%\fR). Numeric expressions are
 evaluated from left to right and can use parentheses. After evaluation, the
 value of dot is updated.
@@ -394,7 +390,6 @@ of the address pointed to by dot by expression \fIe\fR.
 .RE
 
 .SS "Commands"
-.sp
 .LP
 A command must be prefixed by a colon (\fB:\fR). Only enough letters of the
 command to uniquely distinguish it are needed. Multiple commands can be entered
@@ -582,7 +577,6 @@ Escape to the shell.
 .RE
 
 .SS "Inode Commands"
-.sp
 .LP
 In addition to the above commands, several other commands deal with inode
 fields and operate directly on the current inode (they still require the colon
@@ -737,7 +731,6 @@ Unique \fBID\fR
 .RE
 
 .SS "Formatted Output"
-.sp
 .LP
 Formatted output comes in two styles and many format types. The two styles of
 formatted output are: structured and unstructured. Structured output is used to
@@ -1019,6 +1012,5 @@ address \fB1c92434\fR.
 .sp
 
 .SH SEE ALSO
-.sp
 .LP
 \fBclri\fR(1M), \fBfsck_udfs\fR(1M), \fBdir\fR(4),  \fBattributes\fR(5)

--- a/usr/src/man/man1m/hal-get-property.1m
+++ b/usr/src/man/man1m/hal-get-property.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH HAL-GET-PROPERTY 1M "Aug 18, 2006"
+.TH HAL-GET-PROPERTY 1M "Nov 26, 2017"
 .SH NAME
 hal-get-property, hal-set-property \- get and set HAL device properties
 .SH SYNOPSIS
@@ -22,13 +22,12 @@ hal-get-property, hal-set-property \- get and set HAL device properties
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The Hardware Abstraction Layer (HAL) provides a view of the various hardware
 attached to a system. This view is updated dynamically as hardware
 configuration changes by means of hotplug or other mechanisms. HAL represents a
 piece of hardware as a device object. A device object is identified by a unique
-identifer and carries a set of key/value pairs, referred to as device
+identifier and carries a set of key/value pairs, referred to as device
 properties. Some properties are derived from the actual hardware, some are
 merged from device information files (\fB\&.fdi\fR files), and some are related
 to the actual device configuration.
@@ -37,7 +36,6 @@ to the actual device configuration.
 The \fBhal-get-property\fR and \fBhal-set-property\fR commands allow you to get
 and set properties of hardware that conforms to HAL specifications.
 .SH OPTIONS
-.sp
 .LP
 The following options are supported:
 .sp
@@ -173,7 +171,6 @@ Display list of options and exit
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -189,6 +186,5 @@ Interface Stability	Volatile
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBhald\fR(1M), \fBattributes\fR(5), \fBhal\fR(5)

--- a/usr/src/man/man1m/iiadm.1m
+++ b/usr/src/man/man1m/iiadm.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH IIADM 1M "Mar 6, 2014"
+.TH IIADM 1M "Nov 26, 2017"
 .SH NAME
 iiadm \- command-line interface to control Sun StorageTek Availability Suite
 Point-in-Time Copy operations
@@ -79,7 +79,6 @@ Point-in-Time Copy operations
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 Point-in-Time Copy software is a point-in-time snapshot feature of the Solaris
 operating system.
@@ -184,7 +183,6 @@ redirected to the associated overflow volume. To facilitate efficient usage of
 this overflow volume, it can be associated with multiple Point-in-Time Copy
 volume sets on an as-needed basis.
 .SS "Considerations"
-.sp
 .LP
 Prior to invoking an Point-in-Time Copy \fBenable\fR, \fBcopy\fR or
 \fBupdate\fR operation, Point-in-Time Copy assures that the shadow volume is
@@ -205,7 +203,6 @@ occurs only when a system crashes, so the file system attempts to validate the
 integrity of the volume assuming a system failure occurred, not an
 Point-in-Time Copy.
 .SS "ENVIRONMENT OPTIONS"
-.sp
 .LP
 The \fBii_bitmap\fR variable in the \fB/usr/kernel/drv/ii.conf\fR configuration
 file determines the bitmap volume operational semantics as follows:
@@ -230,7 +227,7 @@ default value.
 
 .sp
 .LP
-If a system failure occurrs while using \fBii_bitmap=0\fR, the shadow volume
+If a system failure occurs while using \fBii_bitmap=0\fR, the shadow volume
 might be inconsistent and fast resynchronization would not be possible.
 .sp
 .LP
@@ -269,7 +266,6 @@ Indicates that developmental logging is sent to the system console.
 .RE
 
 .SH OPTIONS
-.sp
 .LP
 The \fBiiadm\fR utility supports the following options.
 .sp
@@ -982,7 +978,6 @@ point-in-time volume updates.
 .RE
 
 .SH EXIT STATUS
-.sp
 .ne 2
 .na
 \fB\fB0\fR\fR
@@ -1001,7 +996,6 @@ An error occurred.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -1017,7 +1011,6 @@ Interface Stability	Evolving
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBdscfg\fR(1M), \fBsvadm\fR(1M), \fBds.log\fR(4), \fBrdc.cf\fR(4),
 \fBattributes\fR(5), \fBii\fR(7D), \fBsv\fR(7D)

--- a/usr/src/man/man1m/syncinit.1m
+++ b/usr/src/man/man1m/syncinit.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SYNCINIT 1M "Mar 9, 1993"
+.TH SYNCINIT 1M "Nov 26, 2017"
 .SH NAME
 syncinit \- set serial line interface operating parameters
 .SH SYNOPSIS
@@ -88,7 +88,7 @@ T}
 
 .sp
 .LP
-There are also several single-word options that set one or more paramaters at a
+There are also several single-word options that set one or more parameters at a
 time:
 .sp
 

--- a/usr/src/man/man2/fork.2
+++ b/usr/src/man/man2/fork.2
@@ -9,7 +9,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FORK 2 "Oct 28, 2008"
+.TH FORK 2 "Nov 26, 2017"
 .SH NAME
 fork, fork1, forkall, forkx, forkallx \- create a new process
 .SH SYNOPSIS
@@ -44,7 +44,6 @@ fork, fork1, forkall, forkx, forkallx \- create a new process
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBfork()\fR, \fBfork1()\fR, \fBforkall()\fR, \fBforkx()\fR, and
 \fBforkallx()\fR functions create a new process. The address space of the new
@@ -298,7 +297,7 @@ child.
 .TP
 .ie t \(bu
 .el o
-Any preferred hardware address tranlsation sizes (see \fBmemcntl\fR(2)) are
+Any preferred hardware address translation sizes (see \fBmemcntl\fR(2)) are
 inherited by the child.
 .RE
 .RS +4
@@ -319,7 +318,6 @@ descriptor is open in the child. If a descriptor is closed in the parent,
 attempts to operate on the door descriptor will fail even if it is still open
 in the child.
 .SS "Threads"
-.sp
 .LP
 A call to \fBforkall()\fR or \fBforkallx()\fR replicates in the child process
 all of the threads (see \fBthr_create\fR(3C) and \fBpthread_create\fR(3C)) in
@@ -346,7 +344,6 @@ provides all threading support for both sets of application programming
 interfaces.  Applications that require replicate-all fork semantics must call
 \fBforkall()\fR or \fBforkallx()\fR.
 .SS "Fork Extensions"
-.sp
 .LP
 The \fBforkx()\fR and \fBforkallx()\fR functions accept a \fIflags\fR argument
 consisting of a bitwise inclusive-OR of zero or more of the following flags,
@@ -385,7 +382,6 @@ exits.
 If the \fIflags\fR argument is 0 \fBforkx()\fR is identical to \fBfork()\fR and
 \fBforkallx()\fR is identical to \fBforkall()\fR.
 .SS "\fBfork()\fR Safety"
-.sp
 .LP
 If a multithreaded application calls \fBfork()\fR, \fBfork1()\fR, or
 \fBforkx()\fR, and the child does more than simply call one of the
@@ -416,7 +412,6 @@ specification: "To avoid errors, the child process may only execute
 Async-Signal-Safe operations until such time as one of the \fBexec\fR(2)
 functions is called."
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, \fBfork()\fR, \fBfork1()\fR, \fBforkall()\fR,
 \fBforkx()\fR, and \fBforkallx()\fR return \fB0\fR to the child process and
@@ -424,7 +419,6 @@ return the process \fBID\fR of the child process to the parent process.
 Otherwise, \fB(pid_t)\(mi1\fR is returned to the parent process, no child
 process is created, and \fBerrno\fR is set to indicate the error.
 .SH ERRORS
-.sp
 .LP
 The \fBfork()\fR, \fBfork1()\fR, \fBforkall()\fR, \fBforkx()\fR, and
 \fBforkallx()\fR functions will fail if:
@@ -472,7 +466,6 @@ The \fIflags\fR argument is invalid.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -495,7 +488,6 @@ Standard	See below.
 .LP
 For \fBfork()\fR, see \fBstandards\fR(5).
 .SH SEE ALSO
-.sp
 .LP
 \fBalarm\fR(2), \fBexec\fR(2), \fBexit\fR(2), \fBfcntl\fR(2),
 \fBgetitimer\fR(2), \fBgetrlimit\fR(2), \fBmemcntl\fR(2), \fBmmap\fR(2),
@@ -506,7 +498,6 @@ For \fBfork()\fR, see \fBstandards\fR(5).
 \fBthr_create\fR(3C) \fBtimer_create\fR(3C), \fBwait\fR(3C), \fBcontract\fR(4),
 \fBprocess\fR(4), \fBattributes\fR(5), \fBprivileges\fR(5), \fBstandards\fR(5)
 .SH NOTES
-.sp
 .LP
 An application should call \fB_exit()\fR rather than \fBexit\fR(3C) if it
 cannot \fBexecve()\fR, since \fBexit()\fR will flush and close standard I/O

--- a/usr/src/man/man3/Intro.3
+++ b/usr/src/man/man3/Intro.3
@@ -5,7 +5,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\"  See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with
 .\" the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH INTRO 3 "Aug 3, 2017"
+.TH INTRO 3 "Nov 26, 2017"
 .SH NAME
 Intro, intro \- introduction to functions and libraries
 .SH DESCRIPTION
@@ -679,7 +679,7 @@ automatically linked by the C compilation system. Specify \fB-lmp\fR on the
 .ad
 .sp .6
 .RS 4n
-These functions constitute the Common Mulitipath Management library,
+These functions constitute the Common Multipath Management library,
 \fBlibMPAPI\fR. This library is implemented as a shared object,
 \fBlibMPAPI.so\fR, but is not automatically linked by the C compilation system.
 Specify \fB-lMPAPI\fR on the \fBcc\fR command line to link with this library.

--- a/usr/src/man/man3c/clock_settime.3c
+++ b/usr/src/man/man3c/clock_settime.3c
@@ -9,7 +9,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH CLOCK_SETTIME 3C "Feb 5, 2008"
+.TH CLOCK_SETTIME 3C "Nov 26, 2017"
 .SH NAME
 clock_settime, clock_gettime, clock_getres \- high-resolution clock operations
 .SH SYNOPSIS
@@ -31,7 +31,6 @@ clock_settime, clock_gettime, clock_getres \- high-resolution clock operations
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBclock_settime()\fR function sets the specified clock, \fIclock_id\fR, to
 the value specified by \fItp\fR. Time values that are between two consecutive
@@ -52,7 +51,7 @@ is not a multiple of \fIres\fR, then the value is truncated to a multiple of
 \fIres\fR.
 .sp
 .LP
-A clock may be systemwide (that is, visible to all processes) or per-process
+A clock may be system wide (that is, visible to all processes) or per-process
 (measuring time that is meaningful only within a process).
 .sp
 .LP
@@ -77,12 +76,10 @@ of \fBadjtime\fR(2), \fBntp_adjtime\fR(2), \fBsettimeofday\fR(3C), or
 Additional clocks may also be supported. The interpretation of time values for
 these clocks is unspecified.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, \fB0\fR  is returned. Otherwise, \fB\(mi1\fR is
 returned and \fBerrno\fR is set to indicate the error.
 .SH ERRORS
-.sp
 .LP
 The \fBclock_settime()\fR, \fBclock_gettime()\fR and \fBclock_getres()\fR
 functions will fail if:
@@ -133,7 +130,6 @@ specified clock.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -153,7 +149,6 @@ Standard	See \fBstandards\fR(5).
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBtime\fR(2), \fBctime\fR(3C), \fBgethrtime\fR(3C), \fBtime.h\fR(3HEAD),
 \fBtimer_gettime\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man3c/getprogname.3c
+++ b/usr/src/man/man3c/getprogname.3c
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright (c) 2014, Joyent, Inc.
 .\"
-.Dd "Dec 22, 2014"
+.Dd "Nov 26, 2017"
 .Dt GETPROGNAME 3C
 .Os
 .Sh NAME
@@ -45,7 +45,7 @@ The
 function is used to change the program name to another value.
 The argument
 .Fa progname
-must contain a null terminatd character string, whose last component
+must contain a null terminated character string, whose last component
 which will become the new program name.
 .Sh RETURN VALUES
 The

--- a/usr/src/man/man3c/getvfsent.3c
+++ b/usr/src/man/man3c/getvfsent.3c
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH GETVFSENT 3C "Mar 12, 1997"
+.TH GETVFSENT 3C "Nov 26, 2017"
 .SH NAME
 getvfsent, getvfsfile, getvfsspec, getvfsany \- get vfstab file entry
 .SH SYNOPSIS
@@ -31,7 +31,6 @@ getvfsent, getvfsfile, getvfsspec, getvfsany \- get vfstab file entry
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBgetvfsent()\fR, \fBgetvfsfile()\fR, \fBgetvfsspec()\fR, and
 \fBgetvfsany()\fR functions each fill in the structure pointed to by \fIvp\fR
@@ -72,13 +71,12 @@ it cannot match in this manner, then it compares the strings.
 .sp
 .LP
 The \fBgetvfsany()\fR function searches the file referenced by \fIfp\fR until a
-match is found between a line in the file and \fIvref\fR. A match occurrs if
+match is found between a line in the file and \fIvref\fR. A match occurs if
 all non-null entries in \fIvref\fR match the corresponding fields in the file.
 .sp
 .LP
 Note that these functions do not open, close, or rewind the file.
 .SH RETURN VALUES
-.sp
 .LP
 If the next entry is successfully read by \fBgetvfsent()\fR or a match is found
 with \fBgetvfsfile()\fR, \fBgetvfsspec()\fR, or \fBgetvfsany()\fR, \fB0\fR is
@@ -113,11 +111,9 @@ A line in the file contains too few fields.
 .RE
 
 .SH FILES
-.sp
 .LP
 \fB/etc/vfstab\fR
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -133,11 +129,9 @@ MT-Level	Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBvfstab\fR(4), \fBattributes\fR(5)
 .SH NOTES
-.sp
 .LP
 The members of the \fBvfstab\fR structure point to information contained in a
 static area, so it must be copied if it is to be saved.

--- a/usr/src/man/man3c/newlocale.3c
+++ b/usr/src/man/man3c/newlocale.3c
@@ -13,7 +13,7 @@
 .\" Copyright (c) 2014 Joyent, Inc.  All rights reserved.
 .\" Copyright 2014 Garrett D'Amore <garrett@damore.org>
 .\"
-.TH NEWLOCALE 3C "Jun 23, 2014"
+.TH NEWLOCALE 3C "Nov 26, 2017"
 .SH NAME
 duplocale, freelocale, newlocale \- create, duplicate, and destroy locale objects
 .SH SYNOPSIS
@@ -70,7 +70,7 @@ following three locales may always be passed in as the string
 Specifies the traditional UNIX system behavior.
 .TP
 "POSIX"
-An alternate name fo the locale "C".
+An alternate name for the locale "C".
 .TP
 ""
 Indicates that the locale should be processed based in the values in the

--- a/usr/src/man/man3c/priv_str_to_set.3c
+++ b/usr/src/man/man3c/priv_str_to_set.3c
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH PRIV_STR_TO_SET 3C "Jan 6, 2004"
+.TH PRIV_STR_TO_SET 3C "Nov 26, 2017"
 .SH NAME
 priv_str_to_set, priv_set_to_str, priv_getbyname, priv_getbynum,
 priv_getsetbyname, priv_getsetbynum, priv_gettext \- privilege name functions
@@ -47,7 +47,6 @@ priv_getsetbyname, priv_getsetbynum, priv_gettext \- privilege name functions
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBpriv_str_to_set()\fR function maps the privilege specification in
 \fIbuf\fR to a privilege set. It returns a privilege set on success or
@@ -108,7 +107,7 @@ be modified and is valid for the lifetime of the process. Both functions return
 .LP
 The \fBpriv_gettext()\fR function returns a pointer to a string consisting of
 one or more newline-separated lines of text describing the privilege. The text
-is localized using {\fBLC_MESSAGES\fR}. The application is responsibe for
+is localized using {\fBLC_MESSAGES\fR}. The application is responsible for
 freeing the memory returned.
 .sp
 .LP
@@ -116,7 +115,6 @@ These functions pick up privileges allocated during the lifetime of the process
 using \fBpriv_getbyname\fR(9F) by refreshing the internal data structures when
 necessary.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, \fBpriv_str_to_set()\fR and \fBpriv_set_to_str()\fR
 return a non-null pointer to allocated memory that should be freed by the
@@ -138,7 +136,6 @@ Upon successful completion, \fBpriv_gettext()\fR returns a non-null value. It
 returns \fINULL\fR if an error occurs or no descriptive text for the specified
 privilege can be found.
 .SH ERRORS
-.sp
 .LP
 The \fBpriv_str_to_set()\fR and \fBpriv_set_to_str()\fR functions will fail if:
 .sp
@@ -202,7 +199,6 @@ for (i = 0; (name = priv_getbynum(i++)) != NULL; )
 .in -2
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -220,7 +216,6 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBfree\fR(3C), \fBpriv_set\fR(3C), \fBattributes\fR(5), \fBprivileges\fR(5),
 \fBpriv_getbyname\fR(9F)

--- a/usr/src/man/man3c/sched_setscheduler.3c
+++ b/usr/src/man/man3c/sched_setscheduler.3c
@@ -9,7 +9,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SCHED_SETSCHEDULER 3C "Apr 1, 2008"
+.TH SCHED_SETSCHEDULER 3C "Nov 26, 2017"
 .SH NAME
 sched_setscheduler \- set scheduling policy and scheduling parameters
 .SH SYNOPSIS
@@ -22,7 +22,6 @@ sched_setscheduler \- set scheduling policy and scheduling parameters
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBsched_setscheduler()\fR function sets the scheduling policy and
 scheduling parameters of the process specified by \fIpid\fR to \fIpolicy\fR and
@@ -62,14 +61,12 @@ in setting the scheduling policy and scheduling parameters of the process
 specified by \fIpid\fR to the values specified by \fIpolicy\fR and the
 structure pointed to by \fIparam\fR, respectively.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, the function returns the former scheduling policy
 of the specified process. If the \fBsched_setscheduler()\fR function fails to
-complete successfully, the policy and scheduling paramenters remain unchanged,
+complete successfully, the policy and scheduling parameters remain unchanged,
 and the function returns \(mi1 and sets \fBerrno\fR to indicate the error.
 .SH ERRORS
-.sp
 .LP
 The \fBsched_setscheduler()\fR function will fail if:
 .sp
@@ -103,7 +100,6 @@ No process can be found corresponding to that specified by \fIpid.\fR
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -123,7 +119,6 @@ Standard	See \fBstandards\fR(5).
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBpriocntl\fR(1), \fBIntro\fR(2), \fBexec\fR(2), \fBpriocntl\fR(2),
 \fBlibrt\fR(3LIB), \fBsched.h\fR(3HEAD), \fBsched_get_priority_max\fR(3C),

--- a/usr/src/man/man3c/thr_min_stack.3c
+++ b/usr/src/man/man3c/thr_min_stack.3c
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH THR_MIN_STACK 3C "May 12, 1998"
+.TH THR_MIN_STACK 3C "Nov 26, 2017"
 .SH NAME
 thr_min_stack \- return the minimum-allowable size for a thread's stack
 .SH SYNOPSIS
@@ -16,11 +16,10 @@ cc -mt [ \fIflag\fR... ] \fIfile\fR...[ \fIlibrary\fR... ]
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 When a thread is created with a user-supplied stack, the user must reserve
 enough space to run this thread. In a dynamically linked execution environment,
-it is very hard to know what the minimum stack requirments are for a thread.
+it is very hard to know what the minimum stack requirements are for a thread.
 The function \fBthr_min_stack()\fR returns the amount of space needed to
 execute a null thread. This is a thread that was created to execute a null
 procedure. A thread that does something useful should have a stack size that is
@@ -67,7 +66,6 @@ main(\|)  {
 .in -2
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -83,6 +81,5 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBattributes\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man3ext/sendfilev.3ext
+++ b/usr/src/man/man3ext/sendfilev.3ext
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SENDFILEV 3EXT "Nov 3, 2017"
+.TH SENDFILEV 3EXT "Nov 26, 2017"
 .SH NAME
 sendfilev \- send a file
 .SH SYNOPSIS
@@ -112,7 +112,7 @@ to \fBSFV_FD_SELF\fR. \fBsfv_off\fR should point to the data, with
 Upon successful completion, the \fBsendfilev()\fR function returns total number
 of bytes written to \fBout_fd\fR. Otherwise, it returns \fB-1\fR, and
 \fBerrno\fR is set to indicate the error. The \fIxferred\fR argument contains
-the amount of data successfuly transferred, which can be used to discover the
+the amount of data successfully transferred, which can be used to discover the
 error vector.
 .SH ERRORS
 .ne 2

--- a/usr/src/man/man3fstyp/fstyp_get_attr.3fstyp
+++ b/usr/src/man/man3fstyp/fstyp_get_attr.3fstyp
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FSTYP_GET_ATTR 3FSTYP "Jun 20, 2006"
+.TH FSTYP_GET_ATTR 3FSTYP "Nov 26, 2017"
 .SH NAME
 fstyp_get_attr \- get file system attributes
 .SH SYNOPSIS
@@ -17,7 +17,6 @@ cc [ \fIflag\fR\&.\|.\|. ] \fIfile\fR\&.\|.\|. \fB-lfstyp\fR \fB -lnvpair \fR [ 
 .fi
 
 .SH PARAMETERS
-.sp
 .ne 2
 .na
 \fB\fIhandle\fR\fR
@@ -36,7 +35,6 @@ Address to which the name-pair list is returned.
 .RE
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBfstyp_get_attr()\fR function returns a name-value pair list of various
 attributes for an identified file system. This function can be called only
@@ -76,7 +74,7 @@ system.
 .ad
 .sp .6
 .RS 4n
-String that specifes the file system version.
+String that specifies the file system version.
 .RE
 
 .sp
@@ -94,12 +92,10 @@ Attribute names associated with specific file systems should not start with
 .RE
 
 .SH RETURN VALUES
-.sp
 .LP
 The \fBfstyp_get_attr()\fR function returns \fB0\fR on success and an error
 value on failure. See \fBfstyp_strerror\fR(3FSTYP).
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -117,7 +113,6 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBfstyp_ident\fR(3FSTYP), \fBfstyp_mod_init\fR(3FSTYP),
 \fBfstyp_strerror\fR(3FSTYP), \fBlibfstyp\fR(3LIB), \fBattributes\fR(5)

--- a/usr/src/man/man3lib/libMPAPI.3lib
+++ b/usr/src/man/man3lib/libMPAPI.3lib
@@ -4,9 +4,9 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH LIBMPAPI 3LIB "Dec 12, 2006"
+.TH LIBMPAPI 3LIB "Nov 26, 2017"
 .SH NAME
-libMPAPI, libmpapi \- Common Mulitipath Management library
+libMPAPI, libmpapi \- Common Multipath Management library
 .SH SYNOPSIS
 .LP
 .nf
@@ -16,13 +16,11 @@ cc [ \fIflag\fR... ] \fIfile\fR... \fB-lMPAPI\fR  [ \fIlibrary\fR... ]
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The functions in this library allow a management application to administer the
 multipath devices and associated resources through standard interfaces,
 independent of a vendor-unique multipathing solution.
 .SH INTERFACES
-.sp
 .LP
 The shared object \fBlibMPAPI.so.1\fR provides the public interfaces defined
 below. See \fBIntro\fR(3) for additional information on shared object
@@ -208,7 +206,6 @@ interfaces.
 \fBSun_MP_SendScsiCmd\fR
 .in -2
 .SH USAGE
-.sp
 .LP
 Client applications link with the Common Library (using \fB-lMPAPI\fR) to
 access  the  interfaces.  The Common Library dynamically loads an individual
@@ -470,7 +467,6 @@ resources by calling:
 .RE
 .RE
 .SH ERRORS
-.sp
 .LP
 Errors are generally returned from the underlying VSL and can include any of
 the following values:
@@ -623,7 +619,6 @@ permitted in other configurations.
 .RE
 
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/usr/lib/libMPAPI.so\fR\fR
@@ -642,7 +637,6 @@ shared object
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -663,7 +657,6 @@ T}
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBIntro\fR(3), \fBMP_RegisterPlugin\fR(3MPAPI), \fBattributes\fR(5)
 .sp

--- a/usr/src/man/man3nsl/getipsecalgbyname.3nsl
+++ b/usr/src/man/man3nsl/getipsecalgbyname.3nsl
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH GETIPSECALGBYNAME 3NSL "Aug 20, 2003"
+.TH GETIPSECALGBYNAME 3NSL "Nov 26, 2017"
 .SH NAME
 getipsecalgbyname, getipsecalgbynum, freeipsecalgent \- query algorithm mapping
 entries
@@ -31,7 +31,6 @@ entries
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 Use the \fBgetipsecalgbyname()\fR, \fBgetipsecalgbynum()\fR,
 \fBfreeipsecalgent()\fR functions to obtain the IPsec algorithm mappings  that
@@ -80,7 +79,6 @@ provide authentication.
 \fBgetipsecalgbyname()\fR looks up the algorithm by its name, while
 \fBgetipsecalgbynum()\fR looks up the algorithm by its assigned number.
 .SH PARAMETERS
-.sp
 .ne 2
 .na
 \fB\fIerrnop\fR\fR
@@ -91,7 +89,6 @@ conditions. See \fBERRORS\fR.
 .RE
 
 .SH RETURN VALUES
-.sp
 .LP
 The \fBgetipsecalgbyname()\fR and \fBgetipsecalgbynum()\fR functions return a
 pointer to the structure \fBipsecalgent_t\fR, defined in <\fBnetdb.h\fR>.   If
@@ -133,7 +130,7 @@ containing a \fINULL\fR pointer. \fBa_name[0]\fR is the  primary name for the
 algorithm.
 .sp
 .LP
-\fBa_proto_num\fR is the protocol identifer of this algorithm. \fBa_alg_num\fR
+\fBa_proto_num\fR is the protocol identifier of this algorithm. \fBa_alg_num\fR
 is the algorithm number. \fBa_mech_name\fR contains the mechanism name
 associated with the algorithm.
 .sp
@@ -142,7 +139,6 @@ associated with the algorithm.
 lengths, in bytes, supported by the algorithm.  The last valid value in the
 array is followed by an element containing the value \fB0\fR.
 .SH ERRORS
-.sp
 .LP
 When the specified algorithm cannot be returned to the caller,
 \fBgetipsecalgbynam()\fR and \fBgetipsecalgbynum()\fR return a value of
@@ -176,7 +172,6 @@ Specified protocol number not found
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5)  for descriptions of the following attributes:
 .sp
@@ -193,7 +188,6 @@ Interface Stability	Evolving
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBcryptoadm\fR(1M), \fBipsecalgs\fR(1M), \fBgetipsecprotobyname\fR(3NSL),
 \fBgetipsecprotobyname\fR(3NSL), \fBattributes\fR(5)

--- a/usr/src/man/man3picltree/ptree_get_propval.3picltree
+++ b/usr/src/man/man3picltree/ptree_get_propval.3picltree
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH PTREE_GET_PROPVAL 3PICLTREE "Mar 28, 2000"
+.TH PTREE_GET_PROPVAL 3PICLTREE "Nov 26, 2017"
 .SH NAME
 ptree_get_propval, ptree_get_propval_by_name \- get the value of a property
 .SH SYNOPSIS
@@ -23,11 +23,10 @@ ptree_get_propval, ptree_get_propval_by_name \- get the value of a property
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBptree_get_propval()\fR function gets the value of the property specified
 by the handle \fIproph\fR and copies it into the buffer specified by
-\fIvalbuf\fR.  The size of the buffer \fIvalbuf\fR is specifed in \fInbytes\fR.
+\fIvalbuf\fR.  The size of the buffer \fIvalbuf\fR is specified in \fInbytes\fR.
 .sp
 .LP
 The \fBptree_get_propval_by_name()\fR function gets the value of the property,
@@ -39,7 +38,6 @@ The size of the buffer is specified by \fInbytes\fR.
 For volatile properties, the read access function provided by the plug-in
 publishing the property is invoked.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, \fB0\fR is returned. On failure, a non-negative
 integer is returned to indicate an error.
@@ -51,7 +49,6 @@ occurs if the PICL tree was refreshed or reinitialized.
 .LP
 \fBPICL_INVALIDHANDLE\fR is returned if the specified handle never existed.
 .SH ERRORS
-.sp
 .ne 2
 .na
 \fB\fBPICL_VALUETOOBIG\fR\fR
@@ -115,7 +112,6 @@ General system failure
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -131,6 +127,5 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBptree_update_propval\fR(3PICLTREE), \fBattributes\fR(5)

--- a/usr/src/man/man3proc/Lprochandle.3proc
+++ b/usr/src/man/man3proc/Lprochandle.3proc
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2015 Joyent, Inc.
 .\"
-.Dd May 11, 2016
+.Dd Nov 26, 2017
 .Dt LPROCHANDLE 3PROC
 .Os
 .Sh NAME
@@ -30,7 +30,7 @@ The
 function returns the process handle to which the thread handle
 .Fa L
 belongs.
-This proccess handle may be used with other
+This process handle may be used with other
 .Xr libproc 3LIB
 functions just as if
 .Xr Pgrab 3PROC was called.

--- a/usr/src/man/man3rsm/rsm_intr_signal_post.3rsm
+++ b/usr/src/man/man3rsm/rsm_intr_signal_post.3rsm
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH RSM_INTR_SIGNAL_POST 3RSM "April 9, 2016"
+.TH RSM_INTR_SIGNAL_POST 3RSM "Nov 26, 2017"
 .SH NAME
 rsm_intr_signal_post, rsm_intr_signal_wait \- signal or wait for an event
 .SH SYNOPSIS
@@ -79,7 +79,7 @@ Connection aborted.
 .sp
 .ne 2
 .na
-\fB\fBRSMERR_REMOTE_NODE_UNREACHABL\fR \fR
+\fB\fBRSMERR_REMOTE_NODE_UNREACHABLE\fR \fR
 .ad
 .sp .6
 .RS 4n

--- a/usr/src/man/man3rsm/rsm_memseg_import_connect.3rsm
+++ b/usr/src/man/man3rsm/rsm_memseg_import_connect.3rsm
@@ -3,10 +3,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH RSM_MEMSEG_IMPORT_CONNECT 3RSM "Jun 8, 2001"
+.TH RSM_MEMSEG_IMPORT_CONNECT 3RSM "Nov 26, 2017"
 .SH NAME
 rsm_memseg_import_connect, rsm_memseg_import_disconnect \- create or break
-logical commection between import and export segments
+logical connection between import and export segments
 .SH SYNOPSIS
 .LP
 .nf
@@ -26,7 +26,6 @@ cc [ \fIflag\fR... ] \fIfile\fR... -lrsm [ \fIlibrary\fR... ]
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBrsm_memseg_import_connect()\fR function provides a means of creating an
 import segment called \fImemseg\fR and establishing a logical connection with
@@ -74,12 +73,10 @@ The \fBrsm_memseg_import_disconnect()\fR function breaks the logical connection
 between the import segment and the exported segment and deallocates the
 resources associated with the import segment handle \fImemseg\fR.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, these functions return 0. Otherwise, an error value
 is returned to indicate the error.
 .SH ERRORS
-.sp
 .LP
 The \fBrsm_memseg_import_connect()\fR and \fBrsm_memseg_import_disconnect()\fR
 functions can return the following errors:
@@ -219,7 +216,6 @@ Poll file descriptor in use.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -237,6 +233,5 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBrsm_memseg_import_map\fR(3RSM), \fBattributes\fR(5)

--- a/usr/src/man/man3rsm/rsm_memseg_import_map.3rsm
+++ b/usr/src/man/man3rsm/rsm_memseg_import_map.3rsm
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH RSM_MEMSEG_IMPORT_MAP 3RSM "Nov 13, 2002"
+.TH RSM_MEMSEG_IMPORT_MAP 3RSM "Nov 26, 2017"
 .SH NAME
 rsm_memseg_import_map, rsm_memseg_import_unmap \- map or unmap imported segment
 .SH SYNOPSIS
@@ -23,7 +23,6 @@ cc [ \fIflag\fR... ] \fIfile\fR... -lrsm [ \fIlibrary\fR... ]
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBrsm_memseg_import_map()\fR and \fBrsm_memseg_import_unmap()\fR functions
 provide for mapping and unmapping operations on imported segments. The mapping
@@ -38,8 +37,8 @@ The \fBrsm_memseg_import_map()\fR function maps an import segment into caller's
 address space for the segment to be accessed by CPU memory operations.  The
 \fIim_memseg\fR argument represents the import segment that is being mapped.
 The location where the process's address space is mapped to the segment is
-pointed to by the  \fIaddress\fR argument. The \fIattr\fR argiment can be one
-fo the following:
+pointed to by the  \fIaddress\fR argument. The \fIattr\fR argument can be one
+of the following:
 .sp
 .ne 2
 .na
@@ -75,12 +74,10 @@ number of bytes from offset to be mapped.
 The \fBrsm_memseg_import_unmap()\fR function unmaps a previously mapped import
 segment.
 .SH RETURN VALUES
-.sp
 .LP
 Upon successful completion, these functions return 0. Otherwise, an error value
 is returned to indicate the error.
 .SH ERRORS
-.sp
 .LP
 The \fBrsm_memseg_import_map()\fR and \fBrsm_memseg_import_unmap()\fR functions
 can return the following errors:
@@ -178,7 +175,6 @@ Segment not connected.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -196,7 +192,6 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBrsm_memseg_import_connect\fR(3RSM), \fBrsm_memseg_import_get\fR(3RSM),
 \fBrsm_memseg_import_put\fR(3RSM), \fBrsm_memseg_get_pollfd\fR(3RSM),

--- a/usr/src/man/man3sasl/sasl_client_step.3sasl
+++ b/usr/src/man/man3sasl/sasl_client_step.3sasl
@@ -5,7 +5,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SASL_CLIENT_STEP 3SASL "Aug 28, 2003"
+.TH SASL_CLIENT_STEP 3SASL "Nov 26, 2017"
 .SH NAME
 sasl_client_step \- acquire an auxiliary property context
 .SH SYNOPSIS
@@ -20,12 +20,11 @@ sasl_client_step \- acquire an auxiliary property context
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 Use the \fBsasl_client_step()\fR interface performs a step in the
 authentication negotiation. \fBsasl_client_step()\fR returns \fBSASL_OK\fR if
 the complete negotiation is successful. If the negotiation on step is completed
-successfuly, but at least one more step is required, \fBsasl_client_step()\fR
+successfully, but at least one more step is required, \fBsasl_client_step()\fR
 returns \fBSASL_CONTINUE\fR. A client should not assume an authentication
 negotiaion is successful because the server signaled success through the
 protocol. For example, if the server signaled \fBOK Authentication succeeded\fR
@@ -40,7 +39,6 @@ should fulfull these requests and call \fBsasl_client_step()\fR again with
 identical parameters. The \fIprompt_need\fR parameter will be the same pointer
 as before, but it will have been filled in by the application.
 .SH PARAMETERS
-.sp
 .ne 2
 .na
 \fB\fIconn\fR\fR
@@ -94,12 +92,10 @@ A list of prompts that are needed to continue, if necessary.
 .RE
 
 .SH RETURN VALUES
-.sp
 .LP
 \fBsasl_client_step()\fR returns an integer that corresponds to a SASL error
 code.
 .SH ERRORS
-.sp
 .ne 2
 .na
 \fB\fBSASL_OK\fR\fR
@@ -134,7 +130,6 @@ All other error codes indicate an error situation that must be handled, or the
 authentication session should be quit. See \fBsasl_errors\fR(3SASL) for
 information on SASL error codes.
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -152,6 +147,5 @@ MT-Level	Safe
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBsasl_errors\fR(3SASL), \fBattributes\fR(5)

--- a/usr/src/man/man3socket/sctp_opt_info.3socket
+++ b/usr/src/man/man3socket/sctp_opt_info.3socket
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SCTP_OPT_INFO 3SOCKET "Feb 25, 2005"
+.TH SCTP_OPT_INFO 3SOCKET "Nov 26, 2017"
 .SH NAME
 sctp_opt_info \- examine SCTP level options for an SCTP endpoint
 .SH SYNOPSIS
@@ -210,7 +210,7 @@ struct sctp_status {
 };
 where:
 
-       sstat_assoc_id          Association ID specifed by the caller
+       sstat_assoc_id          Association ID specified by the caller
        sstat_state             Current state of the association
                                which might be one of the following:
 

--- a/usr/src/man/man4/contract.4
+++ b/usr/src/man/man4/contract.4
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH CONTRACT 4 "Jul 11, 2005"
+.TH CONTRACT 4 "Nov 26, 2017"
 .SH NAME
 contract \- the contract file system
 .SH SYNOPSIS
@@ -13,7 +13,6 @@ contract \- the contract file system
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fB/system/contract\fR file system acts as the primary interface to the
 contract subsystem. There is a subdirectory of \fB/system/contract\fR for each
@@ -36,13 +35,11 @@ A combination of standard system calls (for example, \fBopen\fR(2),
 Consumers of the contract file system must be large file aware. See
 \fBlargefile\fR(5) and \fBlfcompile64\fR(5).
 .SS "DIRECTORY STRUCTURE"
-.sp
 .LP
 At the top level, the \fB/system/contract\fR directory contains subdirectories
 named with each available contract type, and one special directory, \fBall\fR.
 Each of these directories is world-readable and world-searchable.
 .SS "STRUCTURE OF \fB/system/contract/\fItype\fR\fR"
-.sp
 .LP
 Each \fB/system/contract/\fItype\fR\fR directory contains a fixed number of
 files. It also contains a variable number of subdirectories corresponding to
@@ -115,14 +112,12 @@ receives events from all \fItype\fR contracts held by the opening process. See
 .RE
 
 .SS "STRUCTURE OF /system/contract/all"
-.sp
 .LP
 The \fB/system/contract/all\fR directory contains a numerically named file for
 each contract in the system. Each file is a symbolic link to the type-specific
 directory for that contract, that is \fB/system/contract/all/\fIid\fR\fR points
 to \fB/system/contract/\fItype\fR/\fIid\fR\fR.
 .SS "STRUCTURE OF /system/contract/\fItype\fR/\fIid\fR"
-.sp
 .LP
 Each \fB/system/contract/\fItype\fR/\fIid\fR\fR directory contains the
 following files:
@@ -195,7 +190,6 @@ for a contract.
 .RE
 
 .SS "TERMS"
-.sp
 .LP
 The following terms are defined for all contracts:
 .sp
@@ -229,7 +223,6 @@ Selects which events are delivered as critical events. Use
 .RE
 
 .SS "STATUS"
-.sp
 .LP
 A status object returned by \fBct_status_read\fR(3CONTRACT) contains the
 following pieces of information:
@@ -251,7 +244,7 @@ this information.
 .ad
 .sp .6
 .RS 4n
-The type of the contract, specifed as a string. Obtained using
+The type of the contract, specified as a string. Obtained using
 \fBct_status_get_type\fR(3CONTRACT). The contract type is the same as its
 subdirectory name under \fB/system/contract\fR.
 .RE
@@ -371,7 +364,6 @@ to obtain this information.
 .RE
 
 .SS "EVENTS"
-.sp
 .LP
 All three event endpoints, \fB/system/contract/\fItype\fR/bundle\fR,
 \fB/system/contract/\fItype\fR/pbundle\fR, and
@@ -441,7 +433,6 @@ type's manual page or \fBCT_EV_NEGEND\fR. Use
 .RE
 
 .SS "EVENT TYPES"
-.sp
 .LP
 The following event types are defined:
 .sp
@@ -487,7 +478,6 @@ Use \fBct_event_get_newct\fR(3CONTRACT) to obtain this information.
 .RE
 
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/system/contract\fR\fR
@@ -608,7 +598,6 @@ Status info for contract ID
 .RE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBctrun\fR(1), \fBctstat\fR(1), \fBctwatch\fR(1), \fBchroot\fR(1M),
 \fBclose\fR(2), \fBioctl\fR(2), \fBopen\fR(2), \fBpoll\fR(2),

--- a/usr/src/man/man4/hosts.equiv.4
+++ b/usr/src/man/man4/hosts.equiv.4
@@ -4,11 +4,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH HOSTS.EQUIV 4 "Jun 23, 1997"
+.TH HOSTS.EQUIV 4 "Nov 26, 2017"
 .SH NAME
 hosts.equiv, rhosts \- trusted remote hosts and users
 .SH DESCRIPTION
-.sp
 .LP
 The \fB/etc/hosts.equiv\fR and \fB\&.rhosts\fR files provide the "remote
 authentication" database for \fBrlogin\fR(1), \fBrsh\fR(1), \fBrcp\fR(1), and
@@ -59,7 +58,6 @@ Hostnames must be the official name of the host, not one of its nicknames.
 Negative entries are differentiated from positive entries by a `\(mi' character
 preceding either the  \fIhostname\fR or \fIusername\fR field.
 .SS "Positive Entries"
-.sp
 .LP
 If the form:
 .sp
@@ -173,7 +171,6 @@ will allow the named user from any remote host to access the system. The entry
 .LP
 will allow any user from the named host to access the system as the local user.
 .SS "Negative Entries"
-.sp
 .LP
 Negative entries are preceded by a `\(mi' sign. The form:
 .sp
@@ -222,7 +219,6 @@ disallows access by the named user only from the named host, while the form:
 .LP
 will disallow access by all of the users in the named netgroup from all hosts.
 .SS "Search Sequence"
-.sp
 .LP
 To help maintain system security, the \fB/etc/hosts.equiv\fR file is not
 checked when access is being attempted for super-user. If the user attempting
@@ -256,7 +252,7 @@ following order:
 .RE
 .sp
 .LP
-The user is granted access if a positive match occurrs.  Negative entries apply
+The user is granted access if a positive match occurs.  Negative entries apply
 only to \fB/etc/hosts.equiv\fR and may be overridden by subsequent
 \fB\&.rhosts\fR entries.
 .sp
@@ -292,7 +288,6 @@ are made for lines in \fB\&.rhosts\fR in the following order:
 \fIhostname\fR
 .RE
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/etc/hosts.equiv\fR\fR
@@ -311,12 +306,10 @@ user's trusted hosts and users
 .RE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBrcp\fR(1), \fBrlogin\fR(1), \fBrsh\fR(1), \fBrcmd\fR(3SOCKET),
 \fBhosts\fR(4), \fBnetgroup\fR(4), \fBpasswd\fR(4)
 .SH WARNINGS
-.sp
 .LP
 Positive entries in \fB/etc/hosts.equiv\fR that include a \fIusername\fR field
 (either an individual named user, a netgroup, or `\fB+\fR' sign)  should be

--- a/usr/src/man/man4/krb5.conf.4
+++ b/usr/src/man/man4/krb5.conf.4
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH KRB5.CONF 4 "April 9, 2016"
+.TH KRB5.CONF 4 "Nov 26, 2017"
 .SH NAME
 krb5.conf \- Kerberos configuration file
 .SH SYNOPSIS
@@ -1588,7 +1588,7 @@ contain the private key. If no such file is found, then the certificate in the
 .sp
 .ne 2
 .na
-\fB\fBpkintit_anchors\fR\fR
+\fB\fBpkinit_anchors\fR\fR
 .ad
 .br
 .na
@@ -1597,7 +1597,7 @@ contain the private key. If no such file is found, then the certificate in the
 .RS 21n
 \fIdirectory-name\fR is assumed to be an OpenSSL-style hashed CA directory
 where each CA cert is stored in a file named \fBhash-of-ca-cert\fR.\fI#\fR.
-This infrastructure is encouraged, but all files in the directory is examined
+This infrastructure is encouraged, but all files in the directory are examined
 and if they contain certificates (in PEM format), they are used.
 .RE
 

--- a/usr/src/man/man4/ldapsearchprefs.conf.4
+++ b/usr/src/man/man4/ldapsearchprefs.conf.4
@@ -4,7 +4,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH LDAPSEARCHPREFS.CONF 4 "Jul 9, 2003"
+.TH LDAPSEARCHPREFS.CONF 4 "Nov 26, 2017"
 .SH NAME
 ldapsearchprefs.conf \- configuration file for LDAP search preference routines
 .SH SYNOPSIS
@@ -14,7 +14,6 @@ ldapsearchprefs.conf \- configuration file for LDAP search preference routines
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBldapsearchprefs.conf\fR file contains information used by LDAP when
 searching the directory. Blank lines and lines that start with a hash ('#')
@@ -73,7 +72,7 @@ using the \fBLDAP_IS_SEARCHOBJ_OPTION_SET()\fR macro. Use "" if no special
 options are required.
 .sp
 .LP
-The next line specifes a label to use for "Fewer Choices" searches. "Fewer
+The next line specifies a label to use for "Fewer Choices" searches. "Fewer
 Choices" searches are those where the user's input is fed to the ldap_filter
 routines to determine an appropriate filter to use. This contrasts with
 explicitly-constructed LDAP filters, or "More Choices" searches, where the user
@@ -262,7 +261,6 @@ END
 In this example, the user may search for People. For "fewer choices" searching,
 the tag for the \fBldapfilter.conf\fR(4) file is "x500-People".
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for a description of the following attributes:
 .sp
@@ -277,6 +275,5 @@ Stability Level	Evolving
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
-\fBldap_searchprefs\fR(3LDAP) , \fBattributes\fR(5)
+\fBldap_searchprefs\fR(3LDAP), \fBattributes\fR(5)

--- a/usr/src/man/man4/loader.conf.4
+++ b/usr/src/man/man4/loader.conf.4
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd Apr 20, 2016
+.Dd Nov 26, 2017
 .Dt LOADER.CONF 4
 .Os
 .Sh NAME
@@ -81,7 +81,7 @@ May be provided by the operating system.
 User editable loader configuration.
 .It Ar /boot/conf.d/*
 User editable loader configuration snippets.
-The files are proccessed in lexicographical order.
+The files are processed in lexicographical order.
 The configuration snippets mechanism is not available in case of TFTP boot as
 TFTP does not provide the directory list.
 .It Ar /boot/transient.conf

--- a/usr/src/man/man4/pkginfo.4
+++ b/usr/src/man/man4/pkginfo.4
@@ -5,7 +5,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH PKGINFO 4 "May 13, 2017"
+.TH PKGINFO 4 "Nov 26, 2017"
 .SH NAME
 pkginfo \- package characteristics file
 .SH DESCRIPTION
@@ -36,7 +36,7 @@ support of the zones (multiple Solaris environments) feature. See
 \fBzones\fR(5).
 .sp
 .LP
-The following paramaters are mandatory:
+The following parameters are mandatory:
 .sp
 .ne 2
 .na

--- a/usr/src/man/man5/filesystem.5
+++ b/usr/src/man/man5/filesystem.5
@@ -20,7 +20,7 @@
 .\" Copyright 2016 Nexenta Systems, Inc.
 .\" Copyright 2017 Peter Tribble
 .\"
-.TH FILESYSTEM 5 "May 13, 2017"
+.TH FILESYSTEM 5 "Nov 26, 2017"
 .SH NAME
 filesystem \- File system organization
 .SH SYNOPSIS
@@ -2377,7 +2377,7 @@ Auxiliary programs and daemons for \fBuucp\fR(1C).
 .ad
 .sp .6
 .RS 4n
-Zone administration daemon (\fBzoneamd\fR).
+Zone administration daemon (\fBzoneadmd\fR).
 .RE
 
 .sp

--- a/usr/src/man/man5/hal.5
+++ b/usr/src/man/man5/hal.5
@@ -3,17 +3,16 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH HAL 5 "Sep 11, 2006"
+.TH HAL 5 "Nov 26, 2017"
 .SH NAME
 hal \- overview of hardware abstraction layer
 .SH DESCRIPTION
-.sp
 .LP
 The Hardware Abstraction Layer (HAL) provides a view of the various hardware
 attached to a system. This view is updated dynamically as hardware
 configuration changes by means of hotplug or other mechanisms. HAL represents a
 piece of hardware as a device object. A device object is identified by a unique
-identifer and carries a set of key/value pairs, referred to as device
+identifier and carries a set of key/value pairs, referred to as device
 properties. Some properties are derived from the actual hardware, some are
 merged from device information files (\fB\&.fdi\fR files), and some are related
 to the actual device configuration.
@@ -31,7 +30,6 @@ In the Solaris operating system, HAL is supported by a daemon, \fBhald\fR(1M),
 and a set of utilities that enable the adding and removing of devices and the
 modification of their properties.
 .SH SEE ALSO
-.sp
 .LP
 \fBhald\fR(1M), \fBfdi\fR(4)
 .sp

--- a/usr/src/man/man5/pam_timestamp.5
+++ b/usr/src/man/man5/pam_timestamp.5
@@ -10,7 +10,7 @@
 .\"
 .\" Copyright 2014 Nexenta Systems, Inc.
 .\"
-.Dd Aug 20, 2014
+.Dd Nov 26, 2017
 .Dt PAM_TIMESTAMP 5
 .Os
 .Sh NAME
@@ -59,7 +59,7 @@ debugging information at the
 .Sy LOG_AUTH | LOG_DEBUG
 level.
 .It Dv timeout
-Specifies the period (in miniutes) for which the timestamp file is valid.
+Specifies the period (in minutes) for which the timestamp file is valid.
 The default value is 5 minutes.
 .El
 .Sh FILES
@@ -82,7 +82,7 @@ or timestamp file is expired or corrupt.
 .
 The following example is a
 .Xr pam.conf 4
-fragment that illustartes a default settings for allowing
+fragment that illustrates default settings for allowing
 .Xr su 1M
 authentication:
 .Bd -literal -offset indent

--- a/usr/src/man/man5/standards.5
+++ b/usr/src/man/man5/standards.5
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH STANDARDS 5 "Jan 11, 2015"
+.TH STANDARDS 5 "Nov 26, 2017"
 .SH NAME
 standards, ANSI, C, C++, ISO, POSIX, POSIX.1, POSIX.2, SUS, SUSv2, SUSv3, SVID,
 SVID3, XNS, XNS4, XNS5, XPG, XPG3, XPG4, XPG4v2 \- standards and specifications
@@ -386,7 +386,7 @@ link/load command line in addition to defining the feature test macros
 specified for SUS or SUSv2, respectively.
 .sp
 .LP
-If the compiler suppports the \fBredefine_extname\fR pragma feature (the \fBSun
+If the compiler supports the \fBredefine_extname\fR pragma feature (the \fBSun
 Studio C Compiler 5.6\fR compilers define the macro
 \fB__PRAGMA_REDEFINE_EXTNAME\fR to indicate that it supports this feature),
 then the standard headers use \fB#pragma\fR \fBredefine_extname\fR directives

--- a/usr/src/man/man9e/mac_capab_transceiver.9e
+++ b/usr/src/man/man9e/mac_capab_transceiver.9e
@@ -11,11 +11,11 @@
 .\"
 .\" Copyright (c) 2017, Joyent, Inc.
 .\"
-.Dd Mar 24, 2017
+.Dd Nov 26, 2017
 .Dt MAC_CAPAB_TRANSCEIVER 9E
 .Os
 .Sh NAME
-.Nm mac_capab_transciever ,
+.Nm mac_capab_transceiver ,
 .Nm mct_info ,
 .Nm mct_read
 .Nd MAC capability for networking transceivers

--- a/usr/src/man/man9e/mc_tx.9e
+++ b/usr/src/man/man9e/mc_tx.9e
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd June 02, 2016
+.Dd Nov 26, 2017
 .Dt MC_TX 9E
 .Os
 .Sh NAME
@@ -49,7 +49,7 @@ The
 .Fn mc_tx
 entry point is called when the system requires a device driver to
 transmit data.
-The device driver will receive a chain of messge blocks.
+The device driver will receive a chain of message blocks.
 The
 .Fa mp_chain
 argument represents the first frame.

--- a/usr/src/man/man9e/usba_hcdi_pipe_open.9e
+++ b/usr/src/man/man9e/usba_hcdi_pipe_open.9e
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd Dec 20, 2016
+.Dd Nov 26, 2017
 .Dt USBA_HCDI_PIPE_OPEN 9E
 .Os
 .Sh NAME
@@ -97,12 +97,12 @@ See
 for more information on how to determine which descriptors are present
 and get the information encoded in them.
 .Pp
-Host controller drviers should check the USB address of the
+Host controller drivers should check the USB address of the
 USB device that
 .Fa ph
 belongs to.
 The driver may be asked to open a pipe to the root hub.
-As the root hub is often sythetic, the driver man need to take a different
+As the root hub is often synthetic, the driver may need to take a different
 path than normal.
 .Ss Pipe open specifics
 A given endpoint on a device can only be opened once.

--- a/usr/src/man/man9f/ddi_add_event_handler.9f
+++ b/usr/src/man/man9f/ddi_add_event_handler.9f
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH DDI_ADD_EVENT_HANDLER 9F "Nov 2, 2003"
+.TH DDI_ADD_EVENT_HANDLER 9F "Nov 26, 2017"
 .SH NAME
 ddi_add_event_handler \- add an NDI event service callback handler
 .SH SYNOPSIS
@@ -18,11 +18,9 @@ ddi_add_event_handler \- add an NDI event service callback handler
 .fi
 
 .SH INTERFACE LEVEL
-.sp
 .LP
 Solaris DDI specific (Solaris DDI).
 .SH PARAMETERS
-.sp
 .ne 2
 .na
 \fB\fBdev_info_t *\fR\fIdip\fR\fR
@@ -77,10 +75,9 @@ Registration ID must be saved and used when calling
 .RE
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBddi_add_event_handler()\fR function adds a callback handler to be
-invoked in the face of the event specifed by \fIcookie\fR. The process of
+invoked in the face of the event specified by \fIcookie\fR. The process of
 adding a callback handler is also known as subscribing to an event. Upon
 successful subscription, the handler will be invoked by the system when the
 event occurs. The handler can be unregistered by using
@@ -131,7 +128,6 @@ callback function.
 .RE
 
 .SH RETURN VALUES
-.sp
 .ne 2
 .na
 \fB\fBDDI_SUCCESS\fR\fR
@@ -151,12 +147,10 @@ or a bad cookie.
 .RE
 
 .SH CONTEXT
-.sp
 .LP
 The \fBddi_add_event_handler()\fR and \fBhandler()\fR function can be called
 from user and kernel contexts only.
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for a description of the following attributes:
 .sp
@@ -172,7 +166,6 @@ Stability Level	Committed
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBattributes\fR(5), \fBddi_get_eventcookie\fR(9F),
 \fBddi_remove_event_handler\fR(9F)
@@ -180,7 +173,6 @@ Stability Level	Committed
 .LP
 \fIWriting Device Drivers\fR
 .SH NOTES
-.sp
 .LP
 Drivers must remove all registered callback handlers for a device instance by
 calling \fBddi_remove_event_handler\fR(9F) before detach completes.

--- a/usr/src/man/man9f/drv_getparm.9f
+++ b/usr/src/man/man9f/drv_getparm.9f
@@ -1,10 +1,10 @@
 '\" te
-.\"  opyright (c) 2006, Sun Microsystems, Inc.  All Rights Reserved.
+.\"  Copyright (c) 2006, Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright 1989 AT&T
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH DRV_GETPARM 9F "Jan 16, 2006"
+.TH DRV_GETPARM 9F "Nov 26, 2017"
 .SH NAME
 drv_getparm \- retrieve kernel state information
 .SH SYNOPSIS
@@ -18,11 +18,9 @@ drv_getparm \- retrieve kernel state information
 .fi
 
 .SH INTERFACE LEVEL
-.sp
 .LP
 Architecture independent level 1 (DDI/DKI).
 .SH PARAMETERS
-.sp
 .ne 2
 .na
 \fB\fIparm\fR\fR
@@ -115,7 +113,6 @@ copied.
 .RE
 
 .SH DESCRIPTION
-.sp
 .LP
 Since the release of the Solaris 2.6 operating environment, the
 \fBdrv_getparm()\fR function has been replaced by \fBddi_get_lbolt\fR(9F),
@@ -136,7 +133,6 @@ does not check for correct alignment in the data space pointed to by
 function only when it is appropriate to do so and to correctly declare the data
 space needed by the driver.
 .SH RETURN VALUES
-.sp
 .LP
 The \fBdrv_getparm()\fR function returns \fB0\fR to indicate success, \fB-1\fR
 to indicate failure. The value stored in the space pointed to by \fIvalue_p\fR
@@ -145,14 +141,12 @@ is returned. \fB-1\fR is returned if you specify a value other than
 \fBLBOLT\fR, \fBPPGRP\fR, \fBPPID\fR, \fBPSID\fR, \fBTIME\fR, \fBUCRED\fR, or
 \fBUPROCP\fR. Always check the return code when using this function.
 .SH CONTEXT
-.sp
 .LP
 The \fBdrv_getparm()\fR function can be called from user context only when
 using \fBPPGRP\fR, \fBPPID\fR, \fBPSID\fR, \fBUCRED\fR, or \fBUPROCP\fR. It can
 be called from user, interrupt, or kernel context when using the \fBLBOLT\fR or
 \fBTIME\fR argument.
 .SH SEE ALSO
-.sp
 .LP
 \fBddi_get_lbolt\fR(9F), \fBddi_get_pid\fR(9F), \fBddi_get_time\fR(9F),
 \fBbuf\fR(9S)

--- a/usr/src/man/man9f/mac_transceiver_info.9f
+++ b/usr/src/man/man9f/mac_transceiver_info.9f
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright (c) 2017, Joyent, Inc.
 .\"
-.Dd Feb 21, 2017
+.Dd Nov 26, 2017
 .Dt MAC_TRANSCEIVER_INFO 9F
 .Os
 .Sh NAME
@@ -68,7 +68,7 @@ If the transceiver is not plugged in, then the function
 should be called with
 .Fa present set to
 .Dv B_FALSE ,
-otehrwise it should use
+otherwise it should use
 .Dv B_TRUE .
 .Pp
 The

--- a/usr/src/man/man9f/scsi_sense_key.9f
+++ b/usr/src/man/man9f/scsi_sense_key.9f
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SCSI_SENSE_KEY 9F "Jun 28, 2006"
+.TH SCSI_SENSE_KEY 9F "Nov 26, 2017"
 .SH NAME
 scsi_sense_key, scsi_sense_asc, scsi_sense_ascq \- retrieve fields from SCSI
 sense data
@@ -28,11 +28,9 @@ sense data
 .fi
 
 .SH INTERFACE LEVEL
-.sp
 .LP
 Solaris DDI specific (Solaris DDI).
 .SH PARAMETERS
-.sp
 .ne 2
 .na
 \fB\fIsense_buffer\fR\fR
@@ -44,7 +42,6 @@ fixed or descriptor format.
 .RE
 
 .SH DESCRIPTION
-.sp
 .LP
 The \fBscsi_sense_key()\fR function returns the sense key value from the sense
 data contained in the sense_buffer.
@@ -59,26 +56,23 @@ qualifier (\fBASCQ\fR) value from the sense data contained in the sense_buffer.
 .sp
 .LP
 The \fBscsi_sense_key()\fR, \fBscsi_sense_asc()\fR, and \fBscsi_sense_ascq()\fR
-functions are used to retrieve values from \fBSCSI\fR sense data, regardles of
+functions are used to retrieve values from \fBSCSI\fR sense data, regardless of
 whether the sense data is in fixed format or descriptor format.
 .sp
 .LP
 Drivers should use \fBscsi_validate_sense\fR(9F) to ensure that valid sense
 key, \fBasc\fR, and \fBascq\fR values are present in the sense data.
 .SH RETURN VALUES
-.sp
 .LP
 The \fBscsi_sense_key()\fR function returns the sense key value from the sense
 buffer. The \fBscsi_sense_asc()\fR function returns the additional sense code
 (\fBASC\fR) from the sense buffer and the \fBscsi_sense_ascq()\fR function
 returns the additional sense code qualifier (\fBASCQ\fR) from the sense buffer.
 .SH CONTEXT
-.sp
 .LP
 The \fBscsi_sense_key()\fR, \fBscsi_sense_asc()\fR, and \fBscsi_sense_ascq()\fR
 functions can be called from user or interrupt context.
 .SH SEE ALSO
-.sp
 .LP
 \fBscsi_ext_sense_fields\fR(9F), \fBscsi_find_sense_descr\fR(9F),
 \fBscsi_sense_cmdspecific_uint64\fR(9F), \fBscsi_sense_info_uint64\fR(9F),

--- a/usr/src/man/man9f/usba_alloc_hcdi_ops.9f
+++ b/usr/src/man/man9f/usba_alloc_hcdi_ops.9f
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd May 7, 2016
+.Dd Nov 26, 2017
 .Dt USBA_ALLOC_HCDI_OPS 9F
 .Os
 .Sh NAME
@@ -34,7 +34,7 @@ illumos USB HCD private function
 .Pp
 This is a private function that is not part of the stable DDI.
 It may be removed or changed at any time.
-.Sh PARAMATERS
+.Sh PARAMETERS
 .Bl -tag -width Fa
 .It Fa ops
 Pointer to an allocated HCD interface operations structure.

--- a/usr/src/man/man9f/usba_hcdi_cb.9f
+++ b/usr/src/man/man9f/usba_hcdi_cb.9f
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd Sep 16, 2016
+.Dd Nov 26, 2017
 .Dt USBA_HCDI_CB 9F
 .Os
 .Sh NAME
@@ -86,7 +86,7 @@ argument is one of the four request structures,
 or
 .Xr usb_isoc_req 9S ,
 which have been cast to the type
-.Ft usb_oapque_t .
+.Ft usb_opaque_t .
 The caller should ensure that all appropriate members of the request
 structure have been filled in.
 For example, if expecting data from the device and the request has completed

--- a/usr/src/man/man9f/usba_hcdi_register.9f
+++ b/usr/src/man/man9f/usba_hcdi_register.9f
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd Sep 16, 2016
+.Dd Nov 26, 2017
 .Dt USBA_HCDI_REGISTER 9F
 .Os
 .Sh NAME
@@ -63,7 +63,7 @@ The
 function is called during a device driver's
 .Xr attach 9E
 entry point after it has finished initializing the device.
-After this function successfuly returns, device drivers should assume that the
+After this function successfully returns, device drivers should assume that the
 .Xr usba_hcdi_ops 9S
 functions may be called at any time.
 .Pp

--- a/usr/src/man/man9f/usba_hubdi_cb_ops.9f
+++ b/usr/src/man/man9f/usba_hubdi_cb_ops.9f
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd May 7, 2016
+.Dd Nov 26, 2017
 .Dt USBA_HCDI_CB_OPS 9F
 .Os
 .Sh NAME
@@ -54,7 +54,7 @@ illumos USB HCD private function
 .Pp
 This is a private function that is not part of the stable DDI.
 It may be removed or changed at any time.
-.Sh PARAMATERS
+.Sh PARAMETERS
 .Bl -tag -width Fa
 .It Fa dip
 Pointer to the device's

--- a/usr/src/man/man9s/usba_hcdi_register_args.9s
+++ b/usr/src/man/man9s/usba_hcdi_register_args.9s
@@ -11,13 +11,13 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd Sep 20, 2016
+.Dd Nov 26, 2017
 .Dt USBA_HCDI_REGISTER_ARGS 9S
 .Os
 .Sh NAME
 .Nm usba_hcdi_register_args ,
 .Nm usba_hcdi_register_args_t
-.Nd USB HCD driver registeration
+.Nd USB HCD driver registration
 .Sh SYNOPSIS
 .In sys/usb/usba/hcdi.h
 .Sh INTERFACE LEVEL
@@ -80,7 +80,7 @@ It should be allocated with a call to
 .Xr usba_alloc_hcdi_ops 9F
 and released with a call to
 .Xr usba_free_hcdi_ops 9F ,
-after the drive has called
+after the driver has called
 .Xr usba_hcdi_register 9F .
 .Pp
 Please see

--- a/usr/src/uts/common/fs/zfs/sys/zil_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/zil_impl.h
@@ -57,9 +57,9 @@ typedef enum {
  * Log write block (lwb)
  *
  * Prior to an lwb being issued to disk via zil_lwb_write_issue(), it
- * will be protected by the zilog's "zl_writer_lock". Basically, prior
+ * will be protected by the zilog's "zl_issuer_lock". Basically, prior
  * to it being issued, it will only be accessed by the thread that's
- * holding the "zl_writer_lock". After the lwb is issued, the zilog's
+ * holding the "zl_issuer_lock". After the lwb is issued, the zilog's
  * "zl_lock" is used to protect the lwb against concurrent access.
  */
 typedef struct lwb {
@@ -91,10 +91,10 @@ typedef struct lwb {
  *
  * The "zcw_lock" field is used to protect the commit waiter against
  * concurrent access. This lock is often acquired while already holding
- * the zilog's "zl_writer_lock" or "zl_lock"; see the functions
+ * the zilog's "zl_issuer_lock" or "zl_lock"; see the functions
  * zil_process_commit_list() and zil_lwb_flush_vdevs_done() as examples
  * of this. Thus, one must be careful not to acquire the
- * "zl_writer_lock" or "zl_lock" when already holding the "zcw_lock";
+ * "zl_issuer_lock" or "zl_lock" when already holding the "zcw_lock";
  * e.g. see the zil_commit_waiter_timeout() function.
  */
 typedef struct zil_commit_waiter {
@@ -161,7 +161,7 @@ struct zilog {
 	uint8_t		zl_keep_first;	/* keep first log block in destroy */
 	uint8_t		zl_replay;	/* replaying records while set */
 	uint8_t		zl_stop_sync;	/* for debugging */
-	kmutex_t	zl_writer_lock;	/* single writer, per ZIL, at a time */
+	kmutex_t	zl_issuer_lock;	/* single writer, per ZIL, at a time */
 	uint8_t		zl_logbias;	/* latency or throughput */
 	uint8_t		zl_sync;	/* synchronous or asynchronous */
 	int		zl_parse_error;	/* last zil_parse() error */

--- a/usr/src/uts/common/fs/zfs/zil.c
+++ b/usr/src/uts/common/fs/zfs/zil.c
@@ -1095,7 +1095,7 @@ zil_lwb_write_open(zilog_t *zilog, lwb_t *lwb)
 	zbookmark_phys_t zb;
 	zio_priority_t prio;
 
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 	ASSERT3P(lwb, !=, NULL);
 	EQUIV(lwb->lwb_root_zio == NULL, lwb->lwb_state == LWB_STATE_CLOSED);
 	EQUIV(lwb->lwb_root_zio != NULL, lwb->lwb_state == LWB_STATE_OPENED);
@@ -1192,7 +1192,7 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 	int i, error;
 	boolean_t slog;
 
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 	ASSERT3P(lwb->lwb_root_zio, !=, NULL);
 	ASSERT3P(lwb->lwb_write_zio, !=, NULL);
 	ASSERT3S(lwb->lwb_state, ==, LWB_STATE_OPENED);
@@ -1326,7 +1326,7 @@ zil_lwb_commit(zilog_t *zilog, itx_t *itx, lwb_t *lwb)
 	char *lr_buf;
 	uint64_t dlen, dnow, lwb_sp, reclen, txg;
 
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 	ASSERT3P(lwb, !=, NULL);
 	ASSERT3P(lwb->lwb_buf, !=, NULL);
 
@@ -1742,7 +1742,7 @@ zil_get_commit_list(zilog_t *zilog)
 	uint64_t otxg, txg;
 	list_t *commit_list = &zilog->zl_itx_commit_list;
 
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 
 	if (spa_freeze_txg(zilog->zl_spa) != UINT64_MAX) /* ziltest support */
 		otxg = ZILTEST_TXG;
@@ -1849,7 +1849,7 @@ zil_prune_commit_list(zilog_t *zilog)
 {
 	itx_t *itx;
 
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 
 	while (itx = list_head(&zilog->zl_itx_commit_list)) {
 		lr_t *lrc = &itx->itx_lr;
@@ -1899,12 +1899,12 @@ zil_commit_writer_stall(zilog_t *zilog)
 	 * crash (because the previous lwb on-disk would not point to
 	 * it).
 	 *
-	 * We must hold the zilog's zl_writer_lock while we do this, to
+	 * We must hold the zilog's zl_issuer_lock while we do this, to
 	 * ensure no new threads enter zil_process_commit_list() until
 	 * all lwb's in the zl_lwb_list have been synced and freed
 	 * (which is achieved via the txg_wait_synced() call).
 	 */
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 	txg_wait_synced(zilog->zl_dmu_pool, 0);
 	ASSERT3P(list_tail(&zilog->zl_lwb_list), ==, NULL);
 }
@@ -1923,7 +1923,7 @@ zil_process_commit_list(zilog_t *zilog)
 	lwb_t *lwb;
 	itx_t *itx;
 
-	ASSERT(MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(MUTEX_HELD(&zilog->zl_issuer_lock));
 
 	/*
 	 * Return if there's nothing to commit before we dirty the fs by
@@ -2093,17 +2093,17 @@ zil_commit_writer(zilog_t *zilog, zil_commit_waiter_t *zcw)
 	ASSERT(spa_writeable(zilog->zl_spa));
 	ASSERT0(zilog->zl_suspend);
 
-	mutex_enter(&zilog->zl_writer_lock);
+	mutex_enter(&zilog->zl_issuer_lock);
 
 	if (zcw->zcw_lwb != NULL || zcw->zcw_done) {
 		/*
 		 * It's possible that, while we were waiting to acquire
-		 * the "zl_writer_lock", another thread committed this
+		 * the "zl_issuer_lock", another thread committed this
 		 * waiter to an lwb. If that occurs, we bail out early,
 		 * without processing any of the zilog's queue of itxs.
 		 *
 		 * On certain workloads and system configurations, the
-		 * "zl_writer_lock" can become highly contended. In an
+		 * "zl_issuer_lock" can become highly contended. In an
 		 * attempt to reduce this contention, we immediately drop
 		 * the lock if the waiter has already been processed.
 		 *
@@ -2120,13 +2120,13 @@ zil_commit_writer(zilog_t *zilog, zil_commit_waiter_t *zcw)
 	zil_process_commit_list(zilog);
 
 out:
-	mutex_exit(&zilog->zl_writer_lock);
+	mutex_exit(&zilog->zl_issuer_lock);
 }
 
 static void
 zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
 {
-	ASSERT(!MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(!MUTEX_HELD(&zilog->zl_issuer_lock));
 	ASSERT(MUTEX_HELD(&zcw->zcw_lock));
 	ASSERT3B(zcw->zcw_done, ==, B_FALSE);
 
@@ -2138,7 +2138,7 @@ zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
 	 * If the lwb has already been issued by another thread, we can
 	 * immediately return since there's no work to be done (the
 	 * point of this function is to issue the lwb). Additionally, we
-	 * do this prior to acquiring the zl_writer_lock, to avoid
+	 * do this prior to acquiring the zl_issuer_lock, to avoid
 	 * acquiring it when it's not necessary to do so.
 	 */
 	if (lwb->lwb_state == LWB_STATE_ISSUED ||
@@ -2147,13 +2147,13 @@ zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
 
 	/*
 	 * In order to call zil_lwb_write_issue() we must hold the
-	 * zilog's "zl_writer_lock". We can't simply acquire that lock,
+	 * zilog's "zl_issuer_lock". We can't simply acquire that lock,
 	 * since we're already holding the commit waiter's "zcw_lock",
 	 * and those two locks are aquired in the opposite order
 	 * elsewhere.
 	 */
 	mutex_exit(&zcw->zcw_lock);
-	mutex_enter(&zilog->zl_writer_lock);
+	mutex_enter(&zilog->zl_issuer_lock);
 	mutex_enter(&zcw->zcw_lock);
 
 	/*
@@ -2171,7 +2171,7 @@ zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
 
 	/*
 	 * We've already checked this above, but since we hadn't
-	 * acquired the zilog's zl_writer_lock, we have to perform this
+	 * acquired the zilog's zl_issuer_lock, we have to perform this
 	 * check a second time while holding the lock. We can't call
 	 * zil_lwb_write_issue() if the lwb had already been issued.
 	 */
@@ -2234,7 +2234,7 @@ zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
 	}
 
 out:
-	mutex_exit(&zilog->zl_writer_lock);
+	mutex_exit(&zilog->zl_issuer_lock);
 	ASSERT(MUTEX_HELD(&zcw->zcw_lock));
 }
 
@@ -2261,7 +2261,7 @@ static void
 zil_commit_waiter(zilog_t *zilog, zil_commit_waiter_t *zcw)
 {
 	ASSERT(!MUTEX_HELD(&zilog->zl_lock));
-	ASSERT(!MUTEX_HELD(&zilog->zl_writer_lock));
+	ASSERT(!MUTEX_HELD(&zilog->zl_issuer_lock));
 	ASSERT(spa_writeable(zilog->zl_spa));
 	ASSERT0(zilog->zl_suspend);
 
@@ -2510,7 +2510,7 @@ zil_commit_itx_assign(zilog_t *zilog, zil_commit_waiter_t *zcw)
  *      on two fundamental concepts:
  *
  *          1. The creation and issuance of lwb zio's is protected by
- *             the zilog's "zl_writer_lock", which ensures only a single
+ *             the zilog's "zl_issuer_lock", which ensures only a single
  *             thread is creating and/or issuing lwb's at a time
  *          2. The "previous" lwb is a child of the "current" lwb
  *             (leveraging the zio parent-child depenency graph)
@@ -2759,7 +2759,7 @@ zil_alloc(objset_t *os, zil_header_t *zh_phys)
 	zilog->zl_last_lwb_latency = 0;
 
 	mutex_init(&zilog->zl_lock, NULL, MUTEX_DEFAULT, NULL);
-	mutex_init(&zilog->zl_writer_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&zilog->zl_issuer_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	for (int i = 0; i < TXG_SIZE; i++) {
 		mutex_init(&zilog->zl_itxg[i].itxg_lock, NULL,
@@ -2804,7 +2804,7 @@ zil_free(zilog_t *zilog)
 		mutex_destroy(&zilog->zl_itxg[i].itxg_lock);
 	}
 
-	mutex_destroy(&zilog->zl_writer_lock);
+	mutex_destroy(&zilog->zl_issuer_lock);
 	mutex_destroy(&zilog->zl_lock);
 
 	cv_destroy(&zilog->zl_cv_suspend);

--- a/usr/src/uts/common/io/bfe/bfe.c
+++ b/usr/src/uts/common/io/bfe/bfe.c
@@ -2551,15 +2551,6 @@ bfe_unmap_regs(bfe_t *bfe)
 static int
 bfe_get_chip_config(bfe_t *bfe)
 {
-	uint32_t	prom[BFE_EEPROM_SIZE];
-	int i;
-
-	/*
-	 * Read EEPROM in prom[]
-	 */
-	for (i = 0; i < BFE_EEPROM_SIZE; i++) {
-		prom[i] = INL(bfe, BFE_EEPROM_BASE + i * sizeof (uint32_t));
-	}
 
 	bfe->bfe_dev_addr[0] = bfe->bfe_ether_addr[0] =
 	    INB(bfe, BFE_EEPROM_BASE + 79);

--- a/usr/src/uts/common/io/mega_sas/megaraid_sas.c
+++ b/usr/src/uts/common/io/mega_sas/megaraid_sas.c
@@ -1127,7 +1127,7 @@ megasas_reset(dev_info_t *dip, ddi_reset_cmd_t cmd)
 /*ARGSUSED*/
 static int
 megasas_tran_tgt_init(dev_info_t *hba_dip, dev_info_t *tgt_dip,
-		scsi_hba_tran_t *tran, struct scsi_device *sd)
+    scsi_hba_tran_t *tran, struct scsi_device *sd)
 {
 	con_log(CL_ANN1, (CE_NOTE, "chkpnt:%s:%d", __func__, __LINE__));
 
@@ -1156,8 +1156,8 @@ megasas_tran_tgt_init(dev_info_t *hba_dip, dev_info_t *tgt_dip,
  */
 static struct scsi_pkt *
 megasas_tran_init_pkt(struct scsi_address *ap, register struct scsi_pkt *pkt,
-	struct buf *bp, int cmdlen, int statuslen, int tgtlen,
-	int flags, int (*callback)(), caddr_t arg)
+    struct buf *bp, int cmdlen, int statuslen, int tgtlen,
+    int flags, int (*callback)(), caddr_t arg)
 {
 	struct scsa_cmd	*acmd;
 	struct megasas_instance	*instance;
@@ -3307,7 +3307,6 @@ build_cmd(struct megasas_instance *instance, struct scsi_address *ap,
 {
 	uint16_t	flags = 0;
 	uint32_t	i;
-	uint32_t 	context;
 	uint32_t	sge_bytes;
 
 	struct megasas_cmd		*cmd;
@@ -3396,8 +3395,6 @@ build_cmd(struct megasas_instance *instance, struct scsi_address *ap,
 			ldio->sge_count = acmd->cmd_cookiecnt;
 			mfi_sgl = (struct megasas_sge64	*)&ldio->sgl;
 
-			context = ldio->context;
-
 			if (acmd->cmd_cdblen == CDB_GROUP0) {
 				ldio->lba_count	= host_to_le16(
 				    (uint16_t)(pkt->pkt_cdbp[4]));
@@ -3474,15 +3471,10 @@ build_cmd(struct megasas_instance *instance, struct scsi_address *ap,
 		pthru->sense_buf_phys_addr_hi = 0;
 		pthru->sense_buf_phys_addr_lo = cmd->sense_phys_addr;
 
-		context = pthru->context;
-
 		bcopy(pkt->pkt_cdbp, pthru->cdb, acmd->cmd_cdblen);
 
 		break;
 	}
-#ifdef lint
-	context = context;
-#endif
 	/* bzero(mfi_sgl, sizeof (struct megasas_sge64) * MAX_SGL); */
 
 	/* prepare the scatter-gather list for the firmware */
@@ -4749,8 +4741,6 @@ disable_intr_xscale(struct megasas_instance *instance)
 static void
 disable_intr_ppc(struct megasas_instance *instance)
 {
-	uint32_t	mask;
-
 	con_log(CL_ANN1, (CE_NOTE, "disable_intr_ppc: called\n"));
 
 	con_log(CL_ANN1, (CE_NOTE, "disable_intr_ppc: before : "
@@ -4763,10 +4753,7 @@ disable_intr_ppc(struct megasas_instance *instance)
 	    "outbound_intr_mask = 0x%x\n", RD_OB_INTR_MASK(instance)));
 
 	/* dummy read to force PCI flush */
-	mask = RD_OB_INTR_MASK(instance);
-#ifdef lint
-	mask = mask;
-#endif
+	(void) RD_OB_INTR_MASK(instance);
 }
 
 static int

--- a/usr/src/uts/common/io/mr_sas/mr_sas.c
+++ b/usr/src/uts/common/io/mr_sas/mr_sas.c
@@ -5051,7 +5051,6 @@ build_cmd(struct mrsas_instance *instance, struct scsi_address *ap,
 {
 	uint16_t	flags = 0;
 	uint32_t	i;
-	uint32_t	context;
 	uint32_t	sge_bytes;
 	uint32_t	tmp_data_xfer_len;
 	ddi_acc_handle_t acc_handle;
@@ -5166,7 +5165,7 @@ build_cmd(struct mrsas_instance *instance, struct scsi_address *ap,
 				mfi_sgl = (struct mrsas_sge64	*)&ldio->sgl;
 			}
 
-			context = ddi_get32(acc_handle, &ldio->context);
+			(void) ddi_get32(acc_handle, &ldio->context);
 
 			if (acmd->cmd_cdblen == CDB_GROUP0) {
 				/* 6-byte cdb */
@@ -5281,15 +5280,13 @@ build_cmd(struct mrsas_instance *instance, struct scsi_address *ap,
 		ddi_put32(acc_handle, &pthru->sense_buf_phys_addr_lo,
 		    cmd->sense_phys_addr);
 
-		context = ddi_get32(acc_handle, &pthru->context);
+		(void) ddi_get32(acc_handle, &pthru->context);
 		ddi_rep_put8(acc_handle, (uint8_t *)pkt->pkt_cdbp,
 		    (uint8_t *)pthru->cdb, acmd->cmd_cdblen, DDI_DEV_AUTOINCR);
 
 		break;
 	}
-#ifdef lint
-	context = context;
-#endif
+
 	/* prepare the scatter-gather list for the firmware */
 	if (instance->flag_ieee) {
 		for (i = 0; i < acmd->cmd_cookiecnt; i++, mfi_sgl_ieee++) {
@@ -6838,8 +6835,6 @@ enable_intr_ppc(struct mrsas_instance *instance)
 static void
 disable_intr_ppc(struct mrsas_instance *instance)
 {
-	uint32_t	mask;
-
 	con_log(CL_ANN1, (CE_NOTE, "disable_intr_ppc: called"));
 
 	con_log(CL_ANN1, (CE_NOTE, "disable_intr_ppc: before : "
@@ -6853,10 +6848,7 @@ disable_intr_ppc(struct mrsas_instance *instance)
 	    "outbound_intr_mask = 0x%x", RD_OB_INTR_MASK(instance)));
 
 	/* dummy read to force PCI flush */
-	mask = RD_OB_INTR_MASK(instance);
-#ifdef lint
-	mask = mask;
-#endif
+	(void) RD_OB_INTR_MASK(instance);
 }
 
 static int

--- a/usr/src/uts/common/io/ntxn/niu.c
+++ b/usr/src/uts/common/io/ntxn/niu.c
@@ -228,9 +228,8 @@ unm_niu_macaddr_set(struct unm_adapter_s *adapter, unm_ethernet_macaddr_t addr)
 }
 
 /* Enable a GbE interface */
-/* ARGSUSED */
-native_t unm_niu_enable_gbe_port(struct unm_adapter_s *adapter,
-		unm_niu_gbe_ifmode_t mode_dont_care)
+native_t
+unm_niu_enable_gbe_port(struct unm_adapter_s *adapter)
 {
 	unm_niu_gb_mac_config_0_t mac_cfg0;
 	unm_niu_gb_mac_config_1_t mac_cfg1;
@@ -239,8 +238,6 @@ native_t unm_niu_enable_gbe_port(struct unm_adapter_s *adapter,
 	int zero = 0;
 	int one = 1;
 	u32 port_mode = 0;
-
-	mode_dont_care = 0;
 
 	if ((port < 0) || (port > UNM_NIU_MAX_GBE_PORTS)) {
 		return (-1);
@@ -251,11 +248,11 @@ native_t unm_niu_enable_gbe_port(struct unm_adapter_s *adapter,
 	    adapter->link_speed != MBPS_1000) {
 
 		if (NX_IS_REVISION_P3(adapter->ahw.revision_id)) {
-/*
- * Do NOT fail this call because the cable is unplugged.
- * Updated when the link comes up...
- */
-		adapter->link_speed = MBPS_1000;
+			/*
+			 * Do NOT fail this call because the cable is unplugged.
+			 * Updated when the link comes up...
+			 */
+			adapter->link_speed = MBPS_1000;
 		} else {
 			return (-1);
 		}
@@ -479,7 +476,7 @@ unm_niu_set_promiscuous_mode(struct unm_adapter_s *adapter,
  */
 int
 unm_niu_xg_macaddr_set(struct unm_adapter_s *adapter,
-		unm_ethernet_macaddr_t addr)
+    unm_ethernet_macaddr_t addr)
 {
 	int		phy = adapter->physical_port;
 	unm_crbword_t	temp = 0;

--- a/usr/src/uts/common/io/ntxn/unm_nic.h
+++ b/usr/src/uts/common/io/ntxn/unm_nic.h
@@ -739,8 +739,7 @@ int unm_niu_xg_macaddr_set(struct unm_adapter_s *adapter,
 native_t unm_niu_disable_xg_port(struct unm_adapter_s *adapter);
 
 long unm_niu_gbe_init_port(long port);
-native_t unm_niu_enable_gbe_port(struct unm_adapter_s *adapter,
-    unm_niu_gbe_ifmode_t mode);
+native_t unm_niu_enable_gbe_port(struct unm_adapter_s *adapter);
 native_t unm_niu_disable_gbe_port(struct unm_adapter_s *adapter);
 
 int unm_niu_macaddr_get(struct unm_adapter_s *adapter, unsigned char *addr);

--- a/usr/src/uts/common/io/ntxn/unm_nic_hw.c
+++ b/usr/src/uts/common/io/ntxn/unm_nic_hw.c
@@ -324,7 +324,8 @@ crb_win_lock(struct unm_adapter_s *adapter)
 		/*
 		 *  Yield CPU
 		 */
-		for (i = 0; i < 20; i++);
+		for (i = 0; i < 20; i++)
+			;
 	}
 	adapter->unm_crb_writelit_adapter(adapter, UNM_CRB_WIN_LOCK_ID,
 	    adapter->portnum);
@@ -1904,8 +1905,7 @@ unm_nic_unset_promisc_mode(struct unm_adapter_s *adapter)
 }
 
 long
-unm_nic_phy_read(unm_adapter *adapter, long reg,
-		    __uint32_t *readval)
+unm_nic_phy_read(unm_adapter *adapter, long reg, __uint32_t *readval)
 {
 	long	ret = 0;
 
@@ -1934,21 +1934,20 @@ unm_nic_init_port(struct unm_adapter_s *adapter)
 	long	portnum = adapter->physical_port;
 	long	ret = 0;
 	long	reg = 0;
-	unm_niu_gbe_ifmode_t	mode_dont_care = 0;
 	u32			port_mode = 0;
 
 	unm_nic_set_link_parameters(adapter);
 
 	switch (adapter->ahw.board_type) {
 	case UNM_NIC_GBE:
-		ret = unm_niu_enable_gbe_port(adapter, mode_dont_care);
+		ret = unm_niu_enable_gbe_port(adapter);
 		break;
 
 	case UNM_NIC_XGBE:
 		adapter->unm_nic_hw_read_wx(adapter, UNM_PORT_MODE_ADDR,
 		    &port_mode, 4);
 		if (port_mode == UNM_PORT_MODE_802_3_AP) {
-			ret = unm_niu_enable_gbe_port(adapter, mode_dont_care);
+			ret = unm_niu_enable_gbe_port(adapter);
 		} else {
 			adapter->unm_crb_writelit_adapter(adapter,
 			    UNM_NIU_XGE_CONFIG_0 + (0x10000 * portnum), 0x5);

--- a/usr/src/uts/common/sys/smbios.h
+++ b/usr/src/uts/common/sys/smbios.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2015 OmniTI Computer Consulting, Inc. All rights reserved.
- * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2017, Joyent, Inc.
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -524,6 +524,7 @@ typedef struct smbios_processor {
 #define	SMB_PRU_BGA1515		0x35	/* BGA1515 */
 #define	SMB_PRU_LGA36471	0x36	/* LGA3647-1 */
 #define	SMB_PRU_SP3		0x37	/* socket SP3 */
+#define	SMB_PRU_SP3r2		0x38	/* socket SP3r2 */
 
 #define	SMB_PRC_RESERVED	0x0001	/* reserved */
 #define	SMB_PRC_UNKNOWN		0x0002	/* unknown */
@@ -631,7 +632,8 @@ typedef struct smbios_processor {
 #define	SMB_PRF_OPTERON_X1K	0x67	/* AMD Opteron X1000 */
 #define	SMB_PRF_OPTERON_X2K	0x68	/* AMD Opteron X2000 APU */
 #define	SMB_PRF_OPTERON_A	0x69	/* AMD Opteron A Series */
-#define	SMB_PRF_OPERTON_X3K	0x6A	/* AMD Opteron X3000 APU */
+#define	SMB_PRF_OPTERON_X3K	0x6A	/* AMD Opteron X3000 APU */
+#define	SMB_PRF_ZEN		0x6B	/* AMD Zen Processor Family */
 #define	SMB_PRF_HOBBIT		0x70	/* Hobbit */
 #define	SMB_PRF_TM5000		0x78	/* Crusoe TM5000 */
 #define	SMB_PRF_TM3000		0x79	/* Crusoe TM3000 */

--- a/usr/src/uts/i86xpv/cpu/generic_cpu/gcpu_mca_xpv.c
+++ b/usr/src/uts/i86xpv/cpu/generic_cpu/gcpu_mca_xpv.c
@@ -76,10 +76,9 @@ gcpu_xpv_proxy_logout(int what, struct mc_info *mi, struct mcinfo_common **micp,
 	struct mcinfo_bank *mib;
 	cmi_hdl_t hdl = NULL;
 	cmi_mca_regs_t *mcrp;
-	gcpu_data_t *gcpu;
 	int idx = *idxp;
 	int tried = 0;
-	int nbanks, j;
+	int j;
 
 	/* Skip over the MC_TYPE_GLOBAL record */
 	ASSERT(mgi->common.type == MC_TYPE_GLOBAL);
@@ -110,8 +109,6 @@ gcpu_xpv_proxy_logout(int what, struct mc_info *mi, struct mcinfo_common **micp,
 				gcpu_xpv_hdl_lookupfails++;
 				goto next_record;
 			} else {
-				gcpu = cmi_hdl_getcmidata(hdl);
-				nbanks = gcpu->gcpu_mca.gcpu_mca_nbanks;
 				bzero(bankregs, bankregs_sz);
 				mcrp = bankregs;
 			}


### PR DESCRIPTION
Weekly merge from `illumos-gate`

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2017113001-4b8cbf637d i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Nov 30 11:00:16 CET 2017 ====
==== Nightly distributed build completed: Thu Nov 30 12:01:24 CET 2017 ====

==== Total build time ====

real    1:01:08

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-0e8f6280a5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   78

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2017113001-4b8cbf637d

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:33.5
user  1:08:24.0
sys      5:22.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    16:00.5
user  1:01:00.3
sys      3:56.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====

6675a6676
> lib/amd64/libzfs_core.so.1: VERSION=ILLUMOS_0.1, SYMBOL=lzc_channel_program_nosync
14146a14148
> lib/libzfs_core.so.1: VERSION=ILLUMOS_0.1, SYMBOL=lzc_channel_program_nosync
14443a14446,14491
> opt/util-tests/tests/libsff/libsff_8472: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_8472: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_8472: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_8636_diag: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_8636_diag: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_8636_diag: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_8636_extspec: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_8636_extspec: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_8636_extspec: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_8636_tech: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_8636_tech: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_8636_tech: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_8636_temp: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_8636_temp: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_8636_temp: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_br: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_br: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_br: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_compliance: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_compliance: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_compliance: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_conn: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_conn: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_conn: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_efault: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_efault: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_einval: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_einval: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_enc: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_enc: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_enc: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_ident: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_ident: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_ident: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_lengths: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_lengths: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_lengths: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_opts: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_opts: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_opts: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_strings: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_strings: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_strings: NEEDED=libsff.so.1
> opt/util-tests/tests/libsff/libsff_wave: NEEDED=libc.so.1
> opt/util-tests/tests/libsff/libsff_wave: NEEDED=libnvpair.so.1
> opt/util-tests/tests/libsff/libsff_wave: NEEDED=libsff.so.1
19440a19489,19497
> usr/lib/amd64/libsff.so.1: NEEDED=libc.so.1
> usr/lib/amd64/libsff.so.1: NEEDED=libnvpair.so.1
> usr/lib/amd64/libsff.so.1: VERDEF=libsff.so.1 [BASE]
> usr/lib/amd64/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_DYNAMIC
> usr/lib/amd64/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_GLOBAL_OFFSET_TABLE_
> usr/lib/amd64/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_PROCEDURE_LINKAGE_TABLE_
> usr/lib/amd64/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_edata
> usr/lib/amd64/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_end
> usr/lib/amd64/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_etext
20717a20775,20778
> usr/lib/dl/dltraninfo: NEEDED=libc.so.1
> usr/lib/dl/dltraninfo: NEEDED=libdladm.so.1
> usr/lib/dl/dltraninfo: NEEDED=libnvpair.so.1
> usr/lib/dl/dltraninfo: NEEDED=libsff.so.1
21397a21459,21465
> usr/lib/fm/topo/plugins/nic.so: NEEDED=libc.so.1
> usr/lib/fm/topo/plugins/nic.so: NEEDED=libdevinfo.so.1
> usr/lib/fm/topo/plugins/nic.so: NEEDED=libdladm.so.1
> usr/lib/fm/topo/plugins/nic.so: NEEDED=libnvpair.so.1
> usr/lib/fm/topo/plugins/nic.so: NEEDED=libsff.so.1
> usr/lib/fm/topo/plugins/nic.so: NEEDED=libtopo.so.1
> usr/lib/fm/topo/plugins/nic.so: RPATH=/usr/lib/fm
25053a25122,25130
> usr/lib/libsff.so.1: NEEDED=libc.so.1
> usr/lib/libsff.so.1: NEEDED=libnvpair.so.1
> usr/lib/libsff.so.1: VERDEF=libsff.so.1 [BASE]
> usr/lib/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_DYNAMIC
> usr/lib/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_GLOBAL_OFFSET_TABLE_
> usr/lib/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_PROCEDURE_LINKAGE_TABLE_
> usr/lib/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_edata
> usr/lib/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_end
> usr/lib/libsff.so.1: VERSION=libsff.so.1, SYMBOL=_etext

==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:29.0
user    48:07.8
sys      5:17.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```