### PR TITLE
Upstream merge/2017113002

### DIFF
--- a/usr/src/boot/lib/libstand/bootp.c
+++ b/usr/src/boot/lib/libstand/bootp.c
@@ -90,7 +90,7 @@ size_t bootp_response_size;
 
 /* Fetch required bootp infomation */
 void
-bootp(int sock, int flag)
+bootp(int sock)
 {
 	void *pkt;
 	struct iodesc *d;
@@ -133,32 +133,29 @@ bootp(int sock, int flag)
 	bp->bp_vend[6] = DHCPDISCOVER;
 
 	/*
-	 * If we are booting from PXE, we want to send the string
+	 * We are booting from PXE, we want to send the string
 	 * 'PXEClient' to the DHCP server so you have the option of
 	 * only responding to PXE aware dhcp requests.
 	 */
-	if (flag & BOOTP_PXE) {
-		bp->bp_vend[7] = TAG_CLASSID;
-		bp->bp_vend[8] = 9;
-		bcopy("PXEClient", &bp->bp_vend[9], 9);
-		bp->bp_vend[18] = TAG_USER_CLASS;
-		/* len of each user class + number of user class */
-		bp->bp_vend[19] = 8;
-		/* len of the first user class */
-		bp->bp_vend[20] = 7;
-		bcopy("illumos", &bp->bp_vend[21], 7);
-		bp->bp_vend[28] = TAG_PARAM_REQ;
-		bp->bp_vend[29] = 7;
-		bp->bp_vend[30] = TAG_ROOTPATH;
-		bp->bp_vend[31] = TAG_HOSTNAME;
-		bp->bp_vend[32] = TAG_SWAPSERVER;
-		bp->bp_vend[33] = TAG_GATEWAY;
-		bp->bp_vend[34] = TAG_SUBNET_MASK;
-		bp->bp_vend[35] = TAG_INTF_MTU;
-		bp->bp_vend[36] = TAG_SERVERID;
-		bp->bp_vend[37] = TAG_END;
-	} else
-		bp->bp_vend[7] = TAG_END;
+	bp->bp_vend[7] = TAG_CLASSID;
+	bp->bp_vend[8] = 9;
+	bcopy("PXEClient", &bp->bp_vend[9], 9);
+	bp->bp_vend[18] = TAG_USER_CLASS;
+	/* len of each user class + number of user class */
+	bp->bp_vend[19] = 8;
+	/* len of the first user class */
+	bp->bp_vend[20] = 7;
+	bcopy("illumos", &bp->bp_vend[21], 7);
+	bp->bp_vend[28] = TAG_PARAM_REQ;
+	bp->bp_vend[29] = 7;
+	bp->bp_vend[30] = TAG_ROOTPATH;
+	bp->bp_vend[31] = TAG_HOSTNAME;
+	bp->bp_vend[32] = TAG_SWAPSERVER;
+	bp->bp_vend[33] = TAG_GATEWAY;
+	bp->bp_vend[34] = TAG_SUBNET_MASK;
+	bp->bp_vend[35] = TAG_INTF_MTU;
+	bp->bp_vend[36] = TAG_SERVERID;
+	bp->bp_vend[37] = TAG_END;
 #else
 	bp->bp_vend[4] = TAG_END;
 #endif
@@ -194,13 +191,10 @@ bootp(int sock, int flag)
 		bp->bp_vend[20] = 4;
 		leasetime = htonl(300);
 		bcopy(&leasetime, &bp->bp_vend[21], 4);
-		if (flag & BOOTP_PXE) {
-			bp->bp_vend[25] = TAG_CLASSID;
-			bp->bp_vend[26] = 9;
-			bcopy("PXEClient", &bp->bp_vend[27], 9);
-			bp->bp_vend[36] = TAG_END;
-		} else
-			bp->bp_vend[25] = TAG_END;
+		bp->bp_vend[25] = TAG_CLASSID;
+		bp->bp_vend[26] = 9;
+		bcopy("PXEClient", &bp->bp_vend[27], 9);
+		bp->bp_vend[36] = TAG_END;
 
 		expected_dhcpmsgtype = DHCPACK;
 

--- a/usr/src/boot/lib/libstand/bootp.h
+++ b/usr/src/boot/lib/libstand/bootp.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: bootp.h,v 1.4 1997/09/06 13:55:57 drochner Exp $	*/
-
 /*
  * Bootstrap Protocol (BOOTP).  RFC951 and RFC1048.
  *
@@ -122,12 +120,6 @@ struct bootp {
 #define DHCPNAK 6
 #define DHCPRELEASE 7
 #endif
-
-/*
- * bootp flags
- */
-#define	BOOTP_NONE		0x0000		/* No flags */
-#define	BOOTP_PXE		0x0001		/* Booting from PXE. */
 
 /*
  * "vendor" data permitted for CMU bootp clients.

--- a/usr/src/boot/lib/libstand/net.h
+++ b/usr/src/boot/lib/libstand/net.h
@@ -1,5 +1,3 @@
-/*	$NetBSD: net.h,v 1.10 1995/10/20 00:46:30 cgd Exp $	*/
-
 /*
  * Copyright (c) 1993 Adam Glass 
  * Copyright (c) 1992 Regents of the University of California.
@@ -17,7 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -32,8 +30,6 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * $FreeBSD$
  */
 
 #ifndef _STAND_NET_H
@@ -120,7 +116,7 @@ ssize_t	sendrecv(struct iodesc *,
 			void **, void **);
 
 /* bootp/DHCP */
-void	bootp(int, int);
+void	bootp(int);
 
 /* Utilities: */
 char	*ether_sprintf(u_char *);

--- a/usr/src/boot/sys/boot/common/dev_net.c
+++ b/usr/src/boot/sys/boot/common/dev_net.c
@@ -280,7 +280,7 @@ net_getparams(int sock)
 			d->myip = myip;
 		}
 		if (rc < 0)
-			bootp(sock, BOOTP_NONE);
+			bootp(sock);
 	}
 	if (myip.s_addr != 0)
 		goto exit;

--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -259,7 +259,6 @@ function build {
 			| egrep -v 'chars, width' \
 			| egrep -v "symbol (\`|')timezone' has differing types:" \
 			| egrep -v 'PSTAMP' \
-			| egrep -v '|%WHOANDWHERE%|' \
 			| egrep -v '^Manifying' \
 			| egrep -v 'Ignoring unknown host' \
 			| egrep -v 'Processing method:' \

--- a/usr/src/uts/common/dtrace/dtrace.c
+++ b/usr/src/uts/common/dtrace/dtrace.c
@@ -13127,6 +13127,7 @@ static int
 dtrace_dof_relocate(dof_hdr_t *dof, dof_sec_t *sec, uint64_t ubase)
 {
 	uintptr_t daddr = (uintptr_t)dof;
+	uintptr_t ts_end;
 	dof_relohdr_t *dofr =
 	    (dof_relohdr_t *)(uintptr_t)(daddr + sec->dofs_offset);
 	dof_sec_t *ss, *rs, *ts;
@@ -13142,6 +13143,7 @@ dtrace_dof_relocate(dof_hdr_t *dof, dof_sec_t *sec, uint64_t ubase)
 	ss = dtrace_dof_sect(dof, DOF_SECT_STRTAB, dofr->dofr_strtab);
 	rs = dtrace_dof_sect(dof, DOF_SECT_RELTAB, dofr->dofr_relsec);
 	ts = dtrace_dof_sect(dof, DOF_SECT_NONE, dofr->dofr_tgtsec);
+	ts_end = (uintptr_t)ts + sizeof (dof_sec_t);
 
 	if (ss == NULL || rs == NULL || ts == NULL)
 		return (-1); /* dtrace_dof_error() has been called already */
@@ -13164,6 +13166,11 @@ dtrace_dof_relocate(dof_hdr_t *dof, dof_sec_t *sec, uint64_t ubase)
 		case DOF_RELO_SETX:
 			if (r->dofr_offset >= ts->dofs_size || r->dofr_offset +
 			    sizeof (uint64_t) > ts->dofs_size) {
+				dtrace_dof_error(dof, "bad relocation offset");
+				return (-1);
+			}
+
+			if (taddr >= (uintptr_t)ts && taddr < ts_end) {
 				dtrace_dof_error(dof, "bad relocation offset");
 				return (-1);
 			}


### PR DESCRIPTION
forgot these bits when doing the weekly upstream from `illumos-gate`

### Backports

* TBD

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2017113002-64edc34206 i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Nov 30 22:29:48 CET 2017 ====
==== Nightly distributed build completed: Thu Nov 30 23:30:57 CET 2017 ====

==== Total build time ====

real    1:01:09

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-0e8f6280a5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   82

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2017113002-64edc34206

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:01.2
user  1:09:49.3
sys      5:57.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:52.2
user  1:01:29.3
sys      4:11.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:16.3
user    47:35.4
sys      5:18.2

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```