### PR TITLE
mailwrapper is optional; not required for OmniOS

### DIFF
--- a/usr/src/pkg/manifests/SUNWcs.mf
+++ b/usr/src/pkg/manifests/SUNWcs.mf
@@ -1872,4 +1872,6 @@ depend fmri=system/data/zoneinfo type=require
 #
 # The mailx binary calls /usr/lib/sendmail provided by mailwrapper
 #
-depend fmri=system/network/mailwrapper type=require
+# OmniOS ships The DragonFly Mail Agent (dma) as default MTA
+# which provides a mediated symlink to /usr/lib/sendmail
+#depend fmri=system/network/mailwrapper type=require


### PR DESCRIPTION
`mailwrapper` can be installed optionally on OmniOS but is not required.

see: https://github.com/omniosorg/omnios-build/pull/428