### PR TITLE
Joyent merge/2017120701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: b27a6a9c81b403a39941586ff9613958226267f2
+Last illumos-joyent commit: 86aa638917f0ec83401d6523f879fbdf56cde0b9
 

--- a/usr/src/lib/brand/lx/testing/ltp_skiplist
+++ b/usr/src/lib/brand/lx/testing/ltp_skiplist
@@ -59,6 +59,7 @@ move_pages11
 mremap04		# we don't yet support remapping shm
 open01
 open11
+open12			# needs a device
 ptrace04
 quotactl01
 quotactl02


### PR DESCRIPTION
Weekly merge from `illumos-joyent`

### Backports

* none

### ONU

```
builder@omniosce:~$ uname -a
SunOS omniosce 5.11 omnios-joyent_merge-2017120701-bd1642d264 i86pc i386 i86pc

... lx test pending
```

### mail_msg

```
==== Nightly distributed build started:   Thu Dec  7 18:30:36 CET 2017 ====
==== Nightly distributed build completed: Thu Dec  7 19:58:54 CET 2017 ====

==== Total build time ====

real    1:28:17

==== Build environment ====

/usr/bin/uname
SunOS omniosce 5.11 omnios-master-d10da2a236 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   81

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017120701-bd1642d264

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====

==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:43.0
user  1:48:08.4
sys     14:40.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:26.6
user  1:37:43.7
sys     14:13.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    32:36.0
user  1:23:30.4
sys      9:56.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```