### PR TITLE
Upstream merge joyent_merge/2017121401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 86aa638917f0ec83401d6523f879fbdf56cde0b9
+Last illumos-joyent commit: a52dd1de494223aa5cbd41a0f9caa61a31da59cf
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_prsubr.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prsubr.c
@@ -284,15 +284,7 @@ retry:
 netstack_t *
 lxpr_netstack(lxpr_node_t *lxpnp)
 {
-	netstack_t *ns;
-
-	ns = LXPTOZ(lxpnp)->zone_netstack;
-	ASSERT(ns != NULL);
-	if (ns->netstack_flags & (NSF_UNINIT | NSF_CLOSING))
-		return (NULL);
-
-	netstack_hold(ns);
-	return (ns);
+	return (netstack_hold_if_active(LXPTOZ(lxpnp)->zone_netstack));
 }
 
 /*

--- a/usr/src/uts/common/brand/lx/syscall/lx_mount.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_mount.c
@@ -132,6 +132,17 @@ static mount_opt_t lx_autofs_options[] = {
 	{ NULL,			MOUNT_OPT_INVALID }
 };
 
+static const char *lx_common_mnt_opts[] = {
+	"exec",
+	"noexec",
+	"devices",
+	"nodevices",
+	"dev",
+	"nodev",
+	"suid",
+	"nosuid",
+	NULL
+};
 
 /*
  * Check the mount options.
@@ -182,6 +193,12 @@ lx_mnt_opt_verify(char *opts, mount_opt_t *mop)
 	}
 	for (;;) {
 		opt_len = strlen(opt);
+
+		/* Check common options we support on all filesystems */
+		for (i = 0; lx_common_mnt_opts[i] != NULL; i++) {
+			if (strcmp(opt, lx_common_mnt_opts[i]) == 0)
+				goto next_opt;
+		}
 
 		/* Check for matching option/value pair. */
 		for (i = 0; mop[i].mo_name != NULL; i++) {
@@ -252,6 +269,7 @@ lx_mnt_opt_verify(char *opts, mount_opt_t *mop)
 			goto bad;
 		}
 
+next_opt:
 		/*
 		 * This option is ok, either we're done or move on to the next
 		 * option.

--- a/usr/src/uts/common/brand/lx/sysfs/lx_syssubr.c
+++ b/usr/src/uts/common/brand/lx/sysfs/lx_syssubr.c
@@ -281,17 +281,8 @@ netstack_t *
 lxsys_netstack(lxsys_node_t *lnp)
 {
 	zone_t *zone = VTOLXSM(LXSTOV(lnp))->lxsysm_zone;
-	netstack_t *ns = zone->zone_netstack;
 
-	VERIFY(ns != NULL);
-
-	if (ns->netstack_flags & (NSF_UNINIT|NSF_CLOSING)) {
-		ns = NULL;
-	} else {
-		netstack_hold(ns);
-	}
-
-	return (ns);
+	return (netstack_hold_if_active(zone->zone_netstack));
 }
 
 ill_t *


### PR DESCRIPTION
Weekly upstream for joyent_merge/2017121401

## Backports

None.

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2017121401-8d2a72fdf4 i86pc i386 i86pc
```

Before:

```
[Connected to zone 'alpine' pts/2]
   __        .                   .
 _|  |_      | .-. .  . .-. :--. |-
|_    _|     ;|   ||  |(.-' |  | |
  |__|   `--'  `-' `;-| `-' '  ' `-'
                   /  ;  Instance (Alpine Linux 3.5 20170303)
                   `-'   https://docs.joyent.com/images/container-native-linux

localhost:~# cat /proc/mounts
/dev/zfsds0 / zfs rw 0 0
devtmpfs /dev devtmpfs rw 0 0
proc /proc proc rw 0 0
tmpfs /run tmpfs rw 0 0
tmpfs /dev/shm tmpfs rw 0 0
/native/usr /native/usr zfs ro 0 0
```

After:

```
localhost:~# cat /proc/mounts
/dev/zfsds0 / zfs rw,nodevices,setuid,nonbmand,exec,atime 0 0
devtmpfs /dev devtmpfs rw 0 0
proc /proc proc rw,nodevices 0 0
tmpfs /run tmpfs rw,nodevices,size=10%,mode=0755 0 0
tmpfs /dev/shm tmpfs rw,nodevices,mode=1777 0 0
/native/usr /native/usr zfs ro 0 0
```

## mail_msg

```

==== Nightly distributed build started:   Thu Dec 14 14:59:51 GMT 2017 ====
==== Nightly distributed build completed: Thu Dec 14 16:24:11 GMT 2017 ====

==== Total build time ====

real    1:24:20

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-d10da2a236 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   113

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017121401-8d2a72fdf4

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    21:54.4
user  1:29:50.9
sys     13:30.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:26.2
user  1:20:02.4
sys      9:53.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    32:29.9
user  1:16:29.8
sys     16:42.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
