### PR TITLE
Joyent merge/2017122101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: a52dd1de494223aa5cbd41a0f9caa61a31da59cf
+Last illumos-joyent commit: 544f34505a03cd85e0b4d03c9b3d3add73c025ed
 

--- a/usr/src/lib/brand/lx/lx_brand/common/signal.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/signal.c
@@ -2379,3 +2379,15 @@ lx_signalfd4(int fd, uintptr_t mask, size_t msize, int flags)
 
 	return (r == -1 ? -errno : r);
 }
+
+void
+lx_block_all_signals()
+{
+	(void) syscall(SYS_brand, B_BLOCK_ALL_SIGS);
+}
+
+void
+lx_unblock_all_signals()
+{
+	(void) syscall(SYS_brand, B_UNBLOCK_ALL_SIGS);
+}

--- a/usr/src/lib/brand/lx/lx_brand/sys/lx_misc.h
+++ b/usr/src/lib/brand/lx/lx_brand/sys/lx_misc.h
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.  All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #ifndef _SYS_LX_H
@@ -146,6 +146,9 @@ extern void lx_free_stack(void);
 extern void lx_free_other_stacks(void);
 extern void lx_stack_prefork(void);
 extern void lx_stack_postfork(void);
+
+extern void lx_block_all_signals();
+extern void lx_unblock_all_signals();
 
 /*
  * NO_UUCOPY disables calls to the uucopy* system calls to help with

--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -1870,6 +1870,27 @@ lx_brandsys(int cmd, int64_t *rval, uintptr_t arg1, uintptr_t arg2,
 		(void) lx_start_nfs_lockd();
 		return (0);
 
+	case B_BLOCK_ALL_SIGS:
+		mutex_enter(&p->p_lock);
+		pd = ptolxproc(p);
+		pd->l_block_all_signals++;
+		mutex_exit(&p->p_lock);
+		return (0);
+
+	case B_UNBLOCK_ALL_SIGS: {
+		uint_t result;
+
+		mutex_enter(&p->p_lock);
+		pd = ptolxproc(p);
+		if (pd->l_block_all_signals == 0) {
+			result = set_errno(EINVAL);
+		} else {
+			pd->l_block_all_signals--;
+			result = 0;
+		}
+		mutex_exit(&p->p_lock);
+		return (result);
+	}
 	}
 
 	return (EINVAL);

--- a/usr/src/uts/common/brand/lx/os/lx_ptrace.c
+++ b/usr/src/uts/common/brand/lx/os/lx_ptrace.c
@@ -1644,6 +1644,14 @@ lx_ptrace_stop(ushort_t what)
 	return (lx_ptrace_stop_common(p, lwpd, what));
 }
 
+/*
+ * In addition to performing the ptrace sig_stop handling, this function is
+ * also used to block signal from being delivered.
+ *
+ * Return 0 if issig_forreal() should continue on, -1 if issig_forreal should
+ * recheck after we've made changes, or 1 if issig_forreal should stop checking
+ * signals.
+ */
 int
 lx_ptrace_issig_stop(proc_t *p, klwp_t *lwp)
 {
@@ -1651,6 +1659,9 @@ lx_ptrace_issig_stop(proc_t *p, klwp_t *lwp)
 	int lx_sig;
 
 	VERIFY(MUTEX_HELD(&p->p_lock));
+
+	if (ptolxproc(p)->l_block_all_signals != 0)
+		return (1);
 
 	/*
 	 * In very rare circumstances, a process which is almost completely

--- a/usr/src/uts/common/brand/lx/sys/lx_brand.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_brand.h
@@ -94,8 +94,8 @@ extern "C" {
 #define	B_GET_CURRENT_CONTEXT	129
 #define	B_EMULATION_DONE	130
 #define	B_START_NFS_LOCKD	131
-/* formerly B_SET_AFFINITY_MASK	132 */
-/* formerly B_GET_AFFINITY_MASK	133 */
+#define	B_BLOCK_ALL_SIGS	132
+#define	B_UNBLOCK_ALL_SIGS	133
 #define	B_PTRACE_CLONE_BEGIN	134
 #define	B_PTRACE_STOP_FOR_OPT	135
 #define	B_UNSUPPORTED		136
@@ -362,6 +362,9 @@ typedef struct lx_proc_data {
 	kmutex_t l_remap_anoncache_lock;
 	uint64_t l_remap_anoncache_generation;
 	lx_segmap_t l_remap_anoncache[LX_REMAP_ANONCACHE_NENTRIES];
+
+	/* Block all signals to all threads; used during vfork */
+	uint_t	 l_block_all_signals;
 } lx_proc_data_t;
 
 #endif	/* _KERNEL */

--- a/usr/src/uts/common/os/sig.c
+++ b/usr/src/uts/common/os/sig.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2015, Joyent, Inc.
+ * Copyright 2017, Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -640,17 +640,24 @@ issig_forreal(void)
 		}
 
 		/*
+		 * The brand hook name 'b_issig_stop' is a misnomer.
 		 * Allow the brand the chance to alter (or suppress) delivery
 		 * of this signal.
 		 */
 		if (PROC_IS_BRANDED(p) && BROP(p)->b_issig_stop != NULL) {
+			int r;
+
 			/*
 			 * The brand hook will return 0 if it would like
-			 * us to drive on, or -1 if we should restart
-			 * the loop to check other conditions.
+			 * us to drive on, -1 if we should restart
+			 * the loop to check other conditions, or 1 if we
+			 * should terminate the loop.
 			 */
-			if (BROP(p)->b_issig_stop(p, lwp) != 0) {
+			r = BROP(p)->b_issig_stop(p, lwp);
+			if (r < 0) {
 				continue;
+			} else if (r > 0) {
+				break;
 			}
 		}
 


### PR DESCRIPTION
Weekly merge from `illumos-joyent`

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2017122101-bbcfab8708 i86pc i386 i86pc
hadfl@mars:~$ sudo zlogin ubuntu-16
[Connected to zone 'ubuntu-16' pts/2]
Last login: Thu Dec 14 16:48:23 UTC 2017 from zone:global on pts/3
Welcome to Ubuntu 16.04.1 LTS (GNU/Linux 4.3.0 x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage
   __        .                   .
 _|  |_      | .-. .  . .-. :--. |-
|_    _|     ;|   ||  |(.-' |  | |
  |__|   `--'  `-' `;-| `-' '  ' `-'
                   /  ;  Instance (Ubuntu 16.04 20161213)
                   `-'   https://docs.joyent.com/images/container-native-linux
```

### mail_msg

```
==== Nightly distributed build started:   Thu Dec 21 18:55:20 CET 2017 ====
==== Nightly distributed build completed: Thu Dec 21 19:55:29 CET 2017 ====

==== Total build time ====

real    1:00:08

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-9e595b51c7 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   77

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2017122101-bbcfab8708

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:14.2
user  1:07:10.7
sys      5:17.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:44.8
user  1:01:08.5
sys      4:05.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:53.5
user    47:11.6
sys      5:13.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```