### PR TITLE
Include OmniOSce in copyright output

### DIFF
--- a/usr/src/cmd/init/init.c
+++ b/usr/src/cmd/init/init.c
@@ -699,6 +699,9 @@ main(int argc, char *argv[])
 		console(B_FALSE,
 		    "Copyright (c) 1983, 2010, Oracle and/or its affiliates."
 		    " All rights reserved.\r\n");
+		console(B_FALSE,
+		    "Copyright (c) 2017-2018 OmniOS Community Edition "
+		    "(OmniOSce) Association.\r\n");
 	}
 
 	/*

--- a/usr/src/uts/common/os/logsubr.c
+++ b/usr/src/uts/common/os/logsubr.c
@@ -251,6 +251,8 @@ log_init(void)
 	    utsname.release, utsname.version, NBBY * (uint_t)sizeof (void *));
 	printf("Copyright (c) 1983, 2010, Oracle and/or its affiliates. "
 	    "All rights reserved.\n");
+	printf("Copyright (c) 2017-2018 OmniOS Community Edition "
+	    "(OmniOSce) Association.\n");
 #ifdef DEBUG
 	printf("DEBUG enabled\n");
 #endif


### PR DESCRIPTION
Adding the OmniOSce copyright to the boot messages for GZ & NGZ.
(FI :In illumos-joyent they've also removed the Oracle copyright messages entirely but let's keep them in here)
  