### PR TITLE
Upstream merge/2018010401

### DIFF
--- a/usr/src/boot/lib/libstand/bootp.c
+++ b/usr/src/boot/lib/libstand/bootp.c
@@ -349,17 +349,6 @@ bad:
 	return (-1);
 }
 
-int
-dhcp_try_rfc1048(uint8_t *cp, size_t len)
-{
-
-	expected_dhcpmsgtype = DHCPACK;
-	if (bcmp(vm_rfc1048, cp, sizeof (vm_rfc1048)) == 0) {
-		return (vend_rfc1048(cp, len));
-	}
-	return (-1);
-}
-
 static int
 vend_rfc1048(u_char *cp, u_int len)
 {

--- a/usr/src/boot/lib/libstand/bootp.h
+++ b/usr/src/boot/lib/libstand/bootp.h
@@ -144,6 +144,4 @@ struct cmu_vend {
 extern struct bootp *bootp_response;
 extern size_t bootp_response_size;
 
-int	dhcp_try_rfc1048(uint8_t *cp, size_t len);
-
 #endif /* _BOOTP_H_ */

--- a/usr/src/boot/sys/boot/efi/boot1/boot1.c
+++ b/usr/src/boot/sys/boot/efi/boot1/boot1.c
@@ -52,8 +52,6 @@ static const boot_module_t *boot_modules[] =
 /* The initial number of handles used to query EFI for partitions. */
 #define NUM_HANDLES_INIT	24
 
-EFI_STATUS efi_main(EFI_HANDLE Ximage, EFI_SYSTEM_TABLE* Xsystab);
-
 EFI_SYSTEM_TABLE *systab;
 EFI_BOOT_SERVICES *bs;
 static EFI_HANDLE *image;
@@ -93,7 +91,7 @@ Free(void *buf, const char *file __unused, int line __unused)
 static BOOLEAN
 nodes_match(EFI_DEVICE_PATH *imgpath, EFI_DEVICE_PATH *devpath)
 {
-	int len;
+	size_t len;
 
 	if (imgpath == NULL || imgpath->Type != devpath->Type ||
 	    imgpath->SubType != devpath->SubType)

--- a/usr/src/boot/sys/boot/efi/include/efiapi.h
+++ b/usr/src/boot/sys/boot/efi/include/efiapi.h
@@ -356,7 +356,7 @@ EFI_STATUS
     IN EFI_STATUS                   ExitStatus,
     IN UINTN                        ExitDataSize,
     IN CHAR16                       *ExitData OPTIONAL
-    );
+    ) __dead2;
 
 typedef
 EFI_STATUS

--- a/usr/src/boot/sys/boot/efi/include/efidevp.h
+++ b/usr/src/boot/sys/boot/efi/include/efidevp.h
@@ -51,7 +51,7 @@ typedef struct _EFI_DEVICE_PATH {
 
 #define DevicePathType(a)           ( ((a)->Type) & EFI_DP_TYPE_MASK )
 #define DevicePathSubType(a)        ( (a)->SubType )
-#define DevicePathNodeLength(a)     ( ((a)->Length[0]) | ((a)->Length[1] << 8) )
+#define DevicePathNodeLength(a)     ((size_t)(((a)->Length[0]) | ((a)->Length[1] << 8)))
 #define NextDevicePathNode(a)       ( (EFI_DEVICE_PATH *) ( ((UINT8 *) (a)) + DevicePathNodeLength(a)))
 #define IsDevicePathType(a, t)      ( DevicePathType(a) == t )
 #define IsDevicePathEndType(a)      IsDevicePathType(a, END_DEVICE_PATH_TYPE)

--- a/usr/src/boot/sys/boot/efi/include/efilib.h
+++ b/usr/src/boot/sys/boot/efi/include/efilib.h
@@ -84,8 +84,10 @@ EFI_STATUS errno_to_efi_status(int errno);
 void efi_time_init(void);
 void efi_time_fini(void);
 
+EFI_STATUS efi_main(EFI_HANDLE Ximage, EFI_SYSTEM_TABLE* Xsystab);
+
 EFI_STATUS main(int argc, CHAR16 *argv[]);
-void exit(EFI_STATUS status);
+void efi_exit(EFI_STATUS status) __dead2;
 void delay(int usecs);
 
 /* EFI environment initialization. */

--- a/usr/src/boot/sys/boot/efi/libefi/libefi.c
+++ b/usr/src/boot/sys/boot/efi/libefi/libefi.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 2000 Doug Rabson
  * All rights reserved.
  *
@@ -27,35 +27,12 @@
 #include <sys/cdefs.h>
 
 #include <efi.h>
-#include <eficonsctl.h>
 #include <efilib.h>
-#include <stand.h>
 
 EFI_HANDLE		IH;
 EFI_SYSTEM_TABLE	*ST;
 EFI_BOOT_SERVICES	*BS;
 EFI_RUNTIME_SERVICES	*RS;
-
-static EFI_PHYSICAL_ADDRESS heap;
-static UINTN heapsize;
-
-static CHAR16 *
-arg_skipsep(CHAR16 *argp)
-{
-
-	while (*argp == ' ' || *argp == '\t' || *argp == '\n')
-		argp++;
-	return (argp);
-}
-
-static CHAR16 *
-arg_skipword(CHAR16 *argp)
-{
-
-	while (*argp && *argp != ' ' && *argp != '\t' && *argp != '\n')
-		argp++;
-	return (argp);
-}
 
 void *
 efi_get_table(EFI_GUID *tbl)
@@ -69,159 +46,4 @@ efi_get_table(EFI_GUID *tbl)
 			return (ST->ConfigurationTable[i].VendorTable);
 	}
 	return (NULL);
-}
-
-void exit(EFI_STATUS exit_code)
-{
-
-	BS->FreePages(heap, EFI_SIZE_TO_PAGES(heapsize));
-	BS->Exit(IH, exit_code, 0, NULL);
-}
-
-void
-efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *system_table)
-{
-	static EFI_GUID image_protocol = LOADED_IMAGE_PROTOCOL;
-	static EFI_GUID console_control_protocol =
-	    EFI_CONSOLE_CONTROL_PROTOCOL_GUID;
-	EFI_CONSOLE_CONTROL_PROTOCOL *console_control = NULL;
-	EFI_LOADED_IMAGE *img;
-	CHAR16 *argp, *args, **argv;
-	EFI_STATUS status;
-	SIMPLE_TEXT_OUTPUT_INTERFACE *conout;
-	UINTN i, max_dim, best_mode, cols, rows;
-	int argc, addprog;
-
-	IH = image_handle;
-	ST = system_table;
-	BS = ST->BootServices;
-	RS = ST->RuntimeServices;
-
-	status = BS->LocateProtocol(&console_control_protocol, NULL,
-	    (VOID **)&console_control);
-	if (status == EFI_SUCCESS)
-		(void)console_control->SetMode(console_control,
-		    EfiConsoleControlScreenText);
-
-	conout = ST->ConOut;
-	max_dim = best_mode = 0;
-	for (i = 0; i <= conout->Mode->MaxMode ; i++) {
-		status = conout->QueryMode(conout, i, &cols, &rows);
-		if (EFI_ERROR(status))
-			continue;
-		if (cols * rows > max_dim) {
-			max_dim = cols * rows;
-			best_mode = i;
-		}
-	}
-	if (max_dim > 0)
-		conout->SetMode(conout, best_mode);
-
-	heapsize = 64 * 1024 * 1024;
-	/* 4GB upper limit, try to leave some space from 1MB */
-	heap = 0x0000000100000000;
-	status = BS->AllocatePages(AllocateMaxAddress, EfiLoaderData,
-	    EFI_SIZE_TO_PAGES(heapsize), &heap);
-	if (status != EFI_SUCCESS)
-		BS->Exit(IH, status, 0, NULL);
-
-	setheap((void *)(uintptr_t)heap, (void *)(uintptr_t)(heap + heapsize));
-
-	status = conout->QueryMode(conout, best_mode, &cols, &rows);
-	if (EFI_ERROR(status)) {
-		setenv("LINES", "24", 1);
-		setenv("COLUMNS", "80", 1);
-	} else {
-		char buf[8];
-		snprintf(buf, sizeof (buf), "%u", (unsigned)rows);
-		setenv("LINES", buf, 1);
-		snprintf(buf, sizeof (buf), "%u", (unsigned)cols);
-		setenv("COLUMNS", buf, 1);
-	}
-
-	/* Use exit() from here on... */
-
-	status = BS->HandleProtocol(IH, &image_protocol, (VOID**)&img);
-	if (status != EFI_SUCCESS)
-		exit(status);
-
-	/*
-	 * Pre-process the (optional) load options. If the option string
-	 * is given as an ASCII string, we use a poor man's ASCII to
-	 * Unicode-16 translation. The size of the option string as given
-	 * to us includes the terminating null character. We assume the
-	 * string is an ASCII string if strlen() plus the terminating
-	 * '\0' is less than LoadOptionsSize. Even if all Unicode-16
-	 * characters have the upper 8 bits non-zero, the terminating
-	 * null character will cause a one-off.
-	 * If the string is already in Unicode-16, we make a copy so that
-	 * we know we can always modify the string.
-	 */
-	if (img->LoadOptionsSize > 0 && img->LoadOptions != NULL) {
-		if (img->LoadOptionsSize == strlen(img->LoadOptions) + 1) {
-			args = malloc(img->LoadOptionsSize << 1);
-			for (argc = 0; argc < img->LoadOptionsSize; argc++)
-				args[argc] = ((char*)img->LoadOptions)[argc];
-		} else {
-			args = malloc(img->LoadOptionsSize);
-			memcpy(args, img->LoadOptions, img->LoadOptionsSize);
-		}
-	} else
-		args = NULL;
-
-	/*
-	 * Use a quick and dirty algorithm to build the argv vector. We
-	 * first count the number of words. Then, after allocating the
-	 * vector, we split the string up. We don't deal with quotes or
-	 * other more advanced shell features.
-	 * The EFI shell will pass the name of the image as the first
-	 * word in the argument list. This does not happen if we're
-	 * loaded by the boot manager. This is not so easy to figure
-	 * out though. The ParentHandle is not always NULL, because
-	 * there can be a function (=image) that will perform the task
-	 * for the boot manager.
-	 */
-	/* Part 1: Figure out if we need to add our program name. */
-	addprog = (args == NULL || img->ParentHandle == NULL ||
-	    img->FilePath == NULL) ? 1 : 0;
-	if (!addprog) {
-		addprog =
-		    (DevicePathType(img->FilePath) != MEDIA_DEVICE_PATH ||
-		     DevicePathSubType(img->FilePath) != MEDIA_FILEPATH_DP ||
-		     DevicePathNodeLength(img->FilePath) <=
-			sizeof(FILEPATH_DEVICE_PATH)) ? 1 : 0;
-		if (!addprog) {
-			/* XXX todo. */
-		}
-	}
-	/* Part 2: count words. */
-	argc = (addprog) ? 1 : 0;
-	argp = args;
-	while (argp != NULL && *argp != 0) {
-		argp = arg_skipsep(argp);
-		if (*argp == 0)
-			break;
-		argc++;
-		argp = arg_skipword(argp);
-	}
-	/* Part 3: build vector. */
-	argv = malloc((argc + 1) * sizeof(CHAR16*));
-	argc = 0;
-	if (addprog)
-		argv[argc++] = (CHAR16 *)L"loader.efi";
-	argp = args;
-	while (argp != NULL && *argp != 0) {
-		argp = arg_skipsep(argp);
-		if (*argp == 0)
-			break;
-		argv[argc++] = argp;
-		argp = arg_skipword(argp);
-		/* Terminate the words. */
-		if (*argp != 0)
-			*argp++ = 0;
-	}
-	argv[argc] = NULL;
-
-	status = main(argc, argv);
-	exit(status);
 }

--- a/usr/src/boot/sys/boot/efi/loader/Makefile
+++ b/usr/src/boot/sys/boot/efi/loader/Makefile
@@ -26,10 +26,10 @@ PROG=		loader.sym
 MACHINE=	$(MACH64)
 
 # architecture-specific loader code
-SRCS=	autoload.c bootinfo.c conf.c copy.c devicename.c main.c self_reloc.c \
-	smbios.c acpi.c vers.c memmap.c multiboot2.c
-OBJS= autoload.o bootinfo.o conf.o copy.o devicename.o main.o self_reloc.o \
-	smbios.o acpi.o vers.o memmap.o multiboot2.o
+SRCS=	autoload.c bootinfo.c conf.c copy.c devicename.c efi_main.c main.c \
+	self_reloc.c smbios.c acpi.c vers.c memmap.c multiboot2.c
+OBJS= autoload.o bootinfo.o conf.o copy.o devicename.o efi_main.o main.o \
+	self_reloc.o smbios.o acpi.o vers.o memmap.o multiboot2.o
 
 ASFLAGS=-m64 -fPIC
 CFLAGS=	-O2

--- a/usr/src/boot/sys/boot/efi/loader/efi_main.c
+++ b/usr/src/boot/sys/boot/efi/loader/efi_main.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2000 Doug Rabson
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <efi.h>
+#include <eficonsctl.h>
+#include <efilib.h>
+#include <stand.h>
+
+static EFI_PHYSICAL_ADDRESS heap;
+static UINTN heapsize;
+
+void
+efi_exit(EFI_STATUS exit_code)
+{
+
+	BS->FreePages(heap, EFI_SIZE_TO_PAGES(heapsize));
+	BS->Exit(IH, exit_code, 0, NULL);
+}
+
+void
+exit(int status)
+{
+
+	efi_exit(EFI_LOAD_ERROR);
+}
+
+static CHAR16 *
+arg_skipsep(CHAR16 *argp)
+{
+
+	while (*argp == ' ' || *argp == '\t' || *argp == '\n')
+		argp++;
+	return (argp);
+}
+
+static CHAR16 *
+arg_skipword(CHAR16 *argp)
+{
+
+	while (*argp && *argp != ' ' && *argp != '\t' && *argp != '\n')
+		argp++;
+	return (argp);
+}
+
+EFI_STATUS
+efi_main(EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *system_table)
+{
+	static EFI_GUID image_protocol = LOADED_IMAGE_PROTOCOL;
+	static EFI_GUID console_control_protocol =
+	    EFI_CONSOLE_CONTROL_PROTOCOL_GUID;
+	EFI_CONSOLE_CONTROL_PROTOCOL *console_control = NULL;
+	EFI_LOADED_IMAGE *img;
+	CHAR16 *argp, *args, **argv;
+	EFI_STATUS status;
+	SIMPLE_TEXT_OUTPUT_INTERFACE *conout;
+	UINTN i, max_dim, best_mode, cols, rows;
+	int argc, addprog;
+
+	IH = image_handle;
+	ST = system_table;
+	BS = ST->BootServices;
+	RS = ST->RuntimeServices;
+
+	status = BS->LocateProtocol(&console_control_protocol, NULL,
+	    (VOID **)&console_control);
+	if (status == EFI_SUCCESS)
+		(void)console_control->SetMode(console_control,
+		    EfiConsoleControlScreenText);
+
+	conout = ST->ConOut;
+	max_dim = best_mode = 0;
+	for (i = 0; i <= conout->Mode->MaxMode ; i++) {
+		status = conout->QueryMode(conout, i, &cols, &rows);
+		if (EFI_ERROR(status))
+			continue;
+		if (cols * rows > max_dim) {
+			max_dim = cols * rows;
+			best_mode = i;
+		}
+	}
+	if (max_dim > 0)
+		conout->SetMode(conout, best_mode);
+
+	heapsize = 64 * 1024 * 1024;
+	/* 4GB upper limit, try to leave some space from 1MB */
+	heap = 0x0000000100000000;
+	status = BS->AllocatePages(AllocateMaxAddress, EfiLoaderData,
+	    EFI_SIZE_TO_PAGES(heapsize), &heap);
+	if (status != EFI_SUCCESS)
+		BS->Exit(IH, status, 0, NULL);
+
+	setheap((void *)(uintptr_t)heap, (void *)(uintptr_t)(heap + heapsize));
+
+	status = conout->QueryMode(conout, best_mode, &cols, &rows);
+	if (EFI_ERROR(status)) {
+		setenv("LINES", "24", 1);
+		setenv("COLUMNS", "80", 1);
+	} else {
+		char buf[8];
+		snprintf(buf, sizeof (buf), "%u", (unsigned)rows);
+		setenv("LINES", buf, 1);
+		snprintf(buf, sizeof (buf), "%u", (unsigned)cols);
+		setenv("COLUMNS", buf, 1);
+	}
+
+	/* Use efi_exit() from here on... */
+
+	status = BS->HandleProtocol(IH, &image_protocol, (VOID**)&img);
+	if (status != EFI_SUCCESS)
+		efi_exit(status);
+
+	/*
+	 * Pre-process the (optional) load options. If the option string
+	 * is given as an ASCII string, we use a poor man's ASCII to
+	 * Unicode-16 translation. The size of the option string as given
+	 * to us includes the terminating null character. We assume the
+	 * string is an ASCII string if strlen() plus the terminating
+	 * '\0' is less than LoadOptionsSize. Even if all Unicode-16
+	 * characters have the upper 8 bits non-zero, the terminating
+	 * null character will cause a one-off.
+	 * If the string is already in Unicode-16, we make a copy so that
+	 * we know we can always modify the string.
+	 */
+	if (img->LoadOptionsSize > 0 && img->LoadOptions != NULL) {
+		if (img->LoadOptionsSize == strlen(img->LoadOptions) + 1) {
+			args = malloc(img->LoadOptionsSize << 1);
+			for (argc = 0; argc < (int)img->LoadOptionsSize; argc++)
+				args[argc] = ((char*)img->LoadOptions)[argc];
+		} else {
+			args = malloc(img->LoadOptionsSize);
+			memcpy(args, img->LoadOptions, img->LoadOptionsSize);
+		}
+	} else
+		args = NULL;
+
+	/*
+	 * Use a quick and dirty algorithm to build the argv vector. We
+	 * first count the number of words. Then, after allocating the
+	 * vector, we split the string up. We don't deal with quotes or
+	 * other more advanced shell features.
+	 * The EFI shell will pass the name of the image as the first
+	 * word in the argument list. This does not happen if we're
+	 * loaded by the boot manager. This is not so easy to figure
+	 * out though. The ParentHandle is not always NULL, because
+	 * there can be a function (=image) that will perform the task
+	 * for the boot manager.
+	 */
+	/* Part 1: Figure out if we need to add our program name. */
+	addprog = (args == NULL || img->ParentHandle == NULL ||
+	    img->FilePath == NULL) ? 1 : 0;
+	if (!addprog) {
+		addprog =
+		    (DevicePathType(img->FilePath) != MEDIA_DEVICE_PATH ||
+		     DevicePathSubType(img->FilePath) != MEDIA_FILEPATH_DP ||
+		     DevicePathNodeLength(img->FilePath) <=
+			sizeof(FILEPATH_DEVICE_PATH)) ? 1 : 0;
+		if (!addprog) {
+			/* XXX todo. */
+		}
+	}
+	/* Part 2: count words. */
+	argc = (addprog) ? 1 : 0;
+	argp = args;
+	while (argp != NULL && *argp != 0) {
+		argp = arg_skipsep(argp);
+		if (*argp == 0)
+			break;
+		argc++;
+		argp = arg_skipword(argp);
+	}
+	/* Part 3: build vector. */
+	argv = malloc((argc + 1) * sizeof(CHAR16*));
+	argc = 0;
+	if (addprog)
+		argv[argc++] = (CHAR16 *)L"loader.efi";
+	argp = args;
+	while (argp != NULL && *argp != 0) {
+		argp = arg_skipsep(argp);
+		if (*argp == 0)
+			break;
+		argv[argc++] = argp;
+		argp = arg_skipword(argp);
+		/* Terminate the words. */
+		if (*argp != 0)
+			*argp++ = 0;
+	}
+	argv[argc] = NULL;
+
+	status = main(argc, argv);
+	efi_exit(status);
+	return (status);
+}

--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -28,7 +28,7 @@
  * Copyright (c) 2013 Martin Matuska. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright 2017 RackTop Systems.
  */
@@ -3476,6 +3476,10 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 			    "pool must be upgraded to set this "
 			    "property or value"));
 			return (zfs_error(hdl, EZFS_BADVERSION, errbuf));
+		case ERANGE:
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "invalid property value(s) specified"));
+			return (zfs_error(hdl, EZFS_BADPROP, errbuf));
 #ifdef _ILP32
 		case EOVERFLOW:
 			/*

--- a/usr/src/lib/libzfs/common/libzfs_pool.c
+++ b/usr/src/lib/libzfs/common/libzfs_pool.c
@@ -2425,6 +2425,7 @@ zpool_vdev_online(zpool_handle_t *zhp, const char *path, int flags,
 {
 	zfs_cmd_t zc = { 0 };
 	char msg[1024];
+	char *pathname;
 	nvlist_t *tgt;
 	boolean_t avail_spare, l2cache, islog;
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
@@ -2447,15 +2448,13 @@ zpool_vdev_online(zpool_handle_t *zhp, const char *path, int flags,
 	if (avail_spare)
 		return (zfs_error(hdl, EZFS_ISSPARE, msg));
 
-	if (flags & ZFS_ONLINE_EXPAND ||
-	    zpool_get_prop_int(zhp, ZPOOL_PROP_AUTOEXPAND, NULL)) {
-		char *pathname = NULL;
+	if ((flags & ZFS_ONLINE_EXPAND ||
+	    zpool_get_prop_int(zhp, ZPOOL_PROP_AUTOEXPAND, NULL)) &&
+	    nvlist_lookup_string(tgt, ZPOOL_CONFIG_PATH, &pathname) == 0) {
 		uint64_t wholedisk = 0;
 
 		(void) nvlist_lookup_uint64(tgt, ZPOOL_CONFIG_WHOLE_DISK,
 		    &wholedisk);
-		verify(nvlist_lookup_string(tgt, ZPOOL_CONFIG_PATH,
-		    &pathname) == 0);
 
 		/*
 		 * XXX - L2ARC 1.0 devices can't support expansion.

--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -28,7 +28,7 @@
 .\" Copyright (c) 2014 Integros [integros.com]
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\"
-.Dd September 16, 2016
+.Dd December 6, 2017
 .Dt ZFS 1M
 .Os
 .Sh NAME
@@ -997,6 +997,10 @@ Please see
 for more information on these algorithms.
 .Pp
 Changing this property affects only newly-written data.
+.Pp
+Salted checksum algorithms
+.Pq Cm edonr , skein
+are currently not supported for any filesystem on the boot pools.
 .It Xo
 .Sy compression Ns = Ns Sy on Ns | Ns Sy off Ns | Ns Sy gzip Ns | Ns
 .Sy gzip- Ns Em N Ns | Ns Sy lz4 Ns | Ns Sy lzjb Ns | Ns Sy zle

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -25,7 +25,7 @@
 .\" Copyright (c) 2017 Datto Inc.
 .\" Copyright (c) 2017 George Melikov. All Rights Reserved.
 .\"
-.Dd August 23, 2017
+.Dd December 6, 2017
 .Dt ZPOOL 1M
 .Os
 .Sh NAME
@@ -454,10 +454,8 @@ change the behavior of the pool.
 .Pp
 The following are read-only properties:
 .Bl -tag -width Ds
-.It Sy available
-Amount of storage available within the pool.
-This property can also be referred to by its shortened column name,
-.Sy avail .
+.It Cm allocated
+Amount of storage space used within the pool.
 .It Sy bootsize
 The size of the system boot partition.
 This property can only be set at pool creation time and is read-only once pool
@@ -505,8 +503,6 @@ Information about unsupported features that are enabled on the pool.
 See
 .Xr zpool-features 5
 for details.
-.It Sy used
-Amount of storage space used within the pool.
 .El
 .Pp
 The space usage properties report actual physical space available to the
@@ -1325,8 +1321,8 @@ See the
 .Sx Properties
 section for a list of valid properties.
 The default list is
-.Sy name , size , used , available , fragmentation , expandsize , capacity ,
-.Sy dedupratio , health , altroot .
+.Cm name , size , allocated , free , expandsize , fragmentation , capacity ,
+.Cm dedupratio , health , altroot .
 .It Fl p
 Display numbers in parsable
 .Pq exact

--- a/usr/src/man/man5/pxeboot.5
+++ b/usr/src/man/man5/pxeboot.5
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd May 25, 2017
+.Dd May 28, 2017
 .Dt PXEBOOT 5
 .Os
 .Sh NAME
@@ -37,6 +37,11 @@ configured to run under Intel's Preboot Execution Environment (PXE) system.
 PXE is a form of smart boot ROM, built into Ethernet cards, and
 Ethernet-equipped motherboards.
 PXE supports DHCP configuration and provides low-level NIC access services.
+.Pp
+The DHCP client will set a DHCP user class named
+.Va illumos
+to allow flexible configuration of the DHCP server.
+.Pp
 The
 .Nm
 bootloader retrieves the kernel, modules,
@@ -63,6 +68,9 @@ max-lease-time 120;
 subnet 10.0.0.0 netmask 255.255.255.0 {
        filename "pxeboot";
        range 10.0.0.10 10.0.0.254;
+       if exists user-class and option user-class = "illumos" {
+            option root-path "tftp://10.0.0.1/illumos";
+       }
 }
 
 .Ed
@@ -80,6 +88,33 @@ expects to fetch
 .Pa /boot/loader.rc
 from the specified server before loading any other files.
 .Pp
+Valid
+.Cm option Va root-path
+syntax is
+.Bd -literal -offset indent
+[<scheme>://][<ip-address>/]<path>
+.Ed
+.Pp
+\&...where
+.Qq scheme
+is either
+.Qq nfs
+or
+.Qq tftp ,
+.Qq ip-address
+is the address of the server, and
+.Qq path
+is the path to the root filesystem on the server.
+If
+.Qq scheme
+is not specified,
+.Nm
+defaults to using NFS if the
+.Va root-path
+variable is in the
+.Qq Pa ip-address Ns :/ Ns Pa path
+form, otherwise TFTP is used.
+.Pp
 .Nm
 defaults to a conservative 1024 byte NFS data packet size.
 This may be changed by setting the
@@ -87,17 +122,6 @@ This may be changed by setting the
 variable in
 .Pa /boot/loader.conf .
 Valid values range from 1024 to 16384 bytes.
-.Pp
-.Nm
-chooses NFS or TFTP based on the value of
-.Va root-path
-variable provided by the DHCP server.
-.Nm
-defaults to use NFS if the
-.Va root-path
-variable is in the
-.Qq Pa ip-address Ns :/ Ns Pa path
-form, otherwise TFTP is used.
 .Pp
 TFTP block size can be controlled by setting the
 .Va tftp.blksize

--- a/usr/src/pkg/manifests/driver-network-cxgbe.mf
+++ b/usr/src/pkg/manifests/driver-network-cxgbe.mf
@@ -87,7 +87,6 @@ driver name=t4nex clone_perms="t4nex 0666 root sys" \
     alias=pciex1425,549a \
     alias=pciex1425,549b \
     alias=pciex1425,549c \
-    alias=pciex1425,549c \
     alias=pciex1425,549d \
     alias=pciex1425,549e \
     alias=pciex1425,549f \

--- a/usr/src/tools/btxld/btxld.c
+++ b/usr/src/tools/btxld/btxld.c
@@ -190,7 +190,7 @@ static void
 cleanup(void)
 {
     if (tname)
-	remove(tname);
+	(void) remove(tname);
 }
 
 /*
@@ -288,6 +288,7 @@ btxld(const char *iname)
 	err(2, "%s", tname);
     if (rename(tname, oname))
 	err(2, "%s: Can't rename to %s", tname, oname);
+    free((void *)(intptr_t)tname);
     tname = NULL;
     if (verbose) {
 	printf(binfo, btx.btx_majver, btx.btx_minver, btx.btx_textsz,

--- a/usr/src/uts/common/fs/smbsrv/smb_kshare.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_kshare.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 #include <smbsrv/smb_door.h>
@@ -386,6 +387,15 @@ smb_kshare_export_list(smb_ioc_share_t *ioc)
 		goto out;
 	}
 
+	/*
+	 * Reality check that the nvlist's reported length doesn't exceed the
+	 * ioctl's total length.  We then assume the nvlist_unpack() will
+	 * sanity check the nvlist itself.
+	 */
+	if ((ioc->shrlen + offsetof(smb_ioc_share_t, shr)) > ioc->hdr.len) {
+		rc = EINVAL;
+		goto out;
+	}
 	rc = nvlist_unpack(ioc->shr, ioc->shrlen, &shrlist, KM_SLEEP);
 	if (rc != 0)
 		goto out;
@@ -463,6 +473,15 @@ smb_kshare_unexport_list(smb_ioc_share_t *ioc)
 	if ((rc = smb_server_lookup(&sv)) != 0)
 		return (rc);
 
+	/*
+	 * Reality check that the nvlist's reported length doesn't exceed the
+	 * ioctl's total length.  We then assume the nvlist_unpack() will
+	 * sanity check the nvlist itself.
+	 */
+	if ((ioc->shrlen + offsetof(smb_ioc_share_t, shr)) > ioc->hdr.len) {
+		rc = EINVAL;
+		goto out;
+	}
 	if ((rc = nvlist_unpack(ioc->shr, ioc->shrlen, &shrlist, 0)) != 0)
 		goto out;
 

--- a/usr/src/uts/common/fs/smbsrv/smb_server.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_server.c
@@ -535,6 +535,12 @@ smb_server_configure(smb_ioc_cfg_t *ioc)
 	int		rc = 0;
 	smb_server_t	*sv;
 
+	/*
+	 * Reality check negotiation token length vs. #define'd maximum.
+	 */
+	if (ioc->negtok_len > SMB_PI_MAX_NEGTOK)
+		return (EINVAL);
+
 	rc = smb_server_lookup(&sv);
 	if (rc)
 		return (rc);
@@ -841,6 +847,13 @@ smb_server_enum(smb_ioc_svcenum_t *ioc)
 	smb_svcenum_t	*svcenum = &ioc->svcenum;
 	smb_server_t	*sv;
 	int		rc;
+
+	/*
+	 * Reality check that the buffer-length insize the enum doesn't
+	 * overrun the ioctl's total length.
+	 */
+	if (svcenum->se_buflen + sizeof (*ioc) > ioc->hdr.len)
+		return (EINVAL);
 
 	if ((rc = smb_server_lookup(&sv)) != 0)
 		return (rc);

--- a/usr/src/uts/common/smbsrv/smb_ioctl.h
+++ b/usr/src/uts/common/smbsrv/smb_ioctl.h
@@ -126,6 +126,7 @@ typedef struct smb_svcenum {
 	uint32_t	se_type;	/* object type to enumerate */
 	uint32_t	se_level;	/* level of detail being requested */
 	uint32_t	se_prefmaxlen;	/* client max size buffer preference */
+					/* (ignored by kernel) */
 	uint32_t	se_resume;	/* client resume handle */
 	uint32_t	se_bavail;	/* remaining buffer space in bytes */
 	uint32_t	se_bused;	/* consumed buffer space in bytes */

--- a/usr/src/uts/i86pc/io/mp_platform_common.c
+++ b/usr/src/uts/i86pc/io/mp_platform_common.c
@@ -761,23 +761,6 @@ acpi_probe(char *modname)
 		case ACPI_MADT_TYPE_LOCAL_X2APIC:
 			mpx2a = (ACPI_MADT_LOCAL_X2APIC *) ap;
 
-			/*
-			 * All logical processors with APIC ID values
-			 * of 255 and greater will have their APIC
-			 * reported through Processor X2APIC structure.
-			 * All logical processors with APIC ID less than
-			 * 255 will have their APIC reported through
-			 * Processor Local APIC.
-			 *
-			 * Some systems apparently don't care and report all
-			 * processors through Processor X2APIC structures. We
-			 * warn about that but don't ignore those CPUs.
-			 */
-			if (mpx2a->LocalApicId < 255) {
-				cmn_err(CE_WARN, "!%s: ignoring invalid entry "
-				    "in MADT: CPU %d has X2APIC Id %d (< 255)",
-				    psm_name, mpx2a->Uid, mpx2a->LocalApicId);
-			}
 			if (mpx2a->LapicFlags & ACPI_MADT_ENABLED) {
 				if (mpx2a->LocalApicId == local_ids[0]) {
 					ASSERT(index == 1);


### PR DESCRIPTION
Weekly merge from `illumos-gate`

### Backports r22

* none

### Backports r24

* 8935 SMB ioctl fixes incomplete

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2018010401-5ccbc88aa8 i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Jan  4 10:59:29 CET 2018 ====
==== Nightly distributed build completed: Thu Jan  4 12:00:49 CET 2018 ====

==== Total build time ====

real    1:01:19

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-9e595b51c7 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_161-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   76

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018010401-5ccbc88aa8

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:34.5
user  1:08:19.3
sys      5:32.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:35.9
user  1:00:34.7
sys      3:57.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:37.1
user    48:43.6
sys      5:26.3

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```