### PR TITLE
Update initial-boot service:

### DIFF
--- a/usr/src/cmd/svc/milestone/initial-boot
+++ b/usr/src/cmd/svc/milestone/initial-boot
@@ -21,16 +21,11 @@
 #
 #
 # Copyright 2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
 . /lib/svc/share/smf_include.sh
 . /lib/svc/share/initial_include.sh
-
-if [ /etc/svc/profile/site/sc_profile.xml -nt /etc/default/init ] ; then
-	# special case the profile that might have been dropped by the
-	# caiman installer
-	sc_profile_timezone /etc/svc/profile/site/sc_profile.xml
-fi
 
 if [ -e "/.initialboot" ]; then
 	SCRIPT=`/bin/mktemp`
@@ -39,14 +34,16 @@ if [ -e "/.initialboot" ]; then
 	echo ". /lib/svc/share/initial_include.sh" >> $SCRIPT
 	cat /.initialboot >> $SCRIPT
 	chmod 550 $SCRIPT
+	echo "Applying initial boot settings..." | tee /dev/msglog
 	$SCRIPT
 	rv=$?
 	if [ "$rv" != "$SMF_EXIT_OK" ]; then
 		exit $rv
 	fi
 	rm -f /.initialboot
+else
+	/usr/sbin/svcadm disable $SMF_FMRI
 fi
 
-/usr/sbin/svcadm disable $SMF_FMRI
 exit $SMF_EXIT_OK
 

--- a/usr/src/cmd/svc/milestone/initial-boot.xml
+++ b/usr/src/cmd/svc/milestone/initial-boot.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
  Copyright 2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+ Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  Use is subject to license terms.
 
  CDDL HEADER START
@@ -57,11 +58,11 @@
 	</dependency>
 
 	<dependent
-	  name='ibootsvc_single'
+	  name='ibootsvc_sysconfig'
 	  grouping='optional_all'
 	  restart_on='none'>
 		<service_fmri
-			value='svc:/milestone/single-user'/>
+			value='svc:/milestone/sysconfig'/>
 	</dependent>
 
 	<exec_method


### PR DESCRIPTION
 * Become a dependency of milestone/sysconfig rather than single-user
   since sysconfig is designed to collect anything which modifies system
   configuration, including IP addresses.
 * Do not disable the service immediately following execution, but rather
   wait for the next boot.

These changes fix a problem where console-login occasionally fails
to start on the first boot following a fresh installation.

Also removing legacy caiman timezone-setting support since caiman is gone.