### PR TITLE
libdtrace fix

### DIFF
--- a/usr/src/lib/libdtrace/common/dt_link.c
+++ b/usr/src/lib/libdtrace/common/dt_link.c
@@ -22,9 +22,8 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2016 Mark Johnston.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #define	ELF_TARGET_ALL
 #include <elf.h>
@@ -1013,6 +1012,7 @@ process_obj(dtrace_hdl_t *dtp, const char *obj, int *eprobesp)
 	static const char dt_enabled[] = "enabled";
 	static const char dt_symprefix[] = "$dtrace";
 	static const char dt_symfmt[] = "%s%d.%s";
+	char probename[DTRACE_NAMELEN];
 	int fd, i, ndx, eprobe, mod = 0;
 	Elf *elf = NULL;
 	GElf_Ehdr ehdr;
@@ -1355,8 +1355,6 @@ process_obj(dtrace_hdl_t *dtp, const char *obj, int *eprobesp)
 			bcopy(s, pname, p - s);
 			pname[p - s] = '\0';
 
-			p = strhyphenate(p + 3); /* strlen("___") */
-
 			if (dt_symtab_lookup(data_sym, isym, rela.r_offset,
 			    shdr_rel.sh_info, &fsym) != 0)
 				goto err;
@@ -1406,9 +1404,17 @@ process_obj(dtrace_hdl_t *dtp, const char *obj, int *eprobesp)
 				    "no such provider %s", pname));
 			}
 
-			if ((prp = dt_probe_lookup(pvp, p)) == NULL) {
+			/* strlen("___") */
+			if (strlcpy(probename, p + 3, sizeof (probename)) >=
+			    sizeof (probename))
 				return (dt_link_error(dtp, elf, fd, bufs,
-				    "no such probe %s", p));
+				    "invalid probe name %s", probename));
+
+			(void) strhyphenate(probename);
+
+			if ((prp = dt_probe_lookup(pvp, probename)) == NULL) {
+				return (dt_link_error(dtp, elf, fd, bufs,
+				    "no such probe %s", probename));
 			}
 
 			assert(fsym.st_value <= rela.r_offset);


### PR DESCRIPTION
cherry-picking this dtrace fix from joyent. see:
- https://www.illumos.org/issues/6653
- https://smartos.org/bugview/OS-5946

in order to allow us to update `binutils` post 2.25.x

The fix seems to have originated in FreeBSD - here's their commit message:

> dtrace converts pairs of consecutive underscores in a probe name to dashes.
When dtrace -G processes relocations corresponding to USDT probe sites, it
performs this conversion on the corresponding symbol names prior to looking
up the resulting probe names in the USDT provider definition. However, in
so doing it would actually modify the input object's string table, which
breaks the string suffix merging done by recent binutils. Because we don't
care about the symbol name once the probe site is recorded, just perform the
probe lookup using a temporary copy.

From https://github.com/freebsd/freebsd/commit/bdbe7eaee6d095d91694b16f10fd0c3b90c0de20

The binutils change that exposed the problem in dtrace was when the string section moved to ELF and string suffix merging was introduced: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=ef10c3ace00674e8c3599c3bf95f06c87d68898b