### PR TITLE
8969 Cannot boot from RAIDZ with parity > 1

### DIFF
--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -29,6 +29,7 @@
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2017 Datto Inc.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -3981,6 +3982,9 @@ spa_import_rootpool(char *devpath, char *devid)
 	spa = spa_add(pname, config, NULL);
 	spa->spa_is_root = B_TRUE;
 	spa->spa_import_flags = ZFS_IMPORT_VERBATIM;
+	if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_VERSION,
+	    &spa->spa_ubsync.ub_version) != 0)
+		spa->spa_ubsync.ub_version = SPA_VERSION_INITIAL;
 
 	/*
 	 * Build up a vdev tree based on the boot device's label config.


### PR DESCRIPTION
vdev_alloc() checks the pool version to make sure that the requested parity level is supported. It does this via spa_version() which looks at spa->spa_ubsync.ub_version.

The spa created in spa_import_rootpool() does not currently have the version set which results in vdev_alloc() returning ENOTSUP for parity > 1.

With this fix I've verified booting OmniOS with a raidz, raidz2 & raidz3 root pool.

Pull request opened against OpenZFS - https://github.com/openzfs/openzfs/pull/526