### PR TITLE
Backports 20180118

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -13,7 +13,27 @@ are included at the end of this file.
 
 =======================================================================
 
-No current pending patches.
+## ZFS fix
+
+Commits:
+
+	8969 Cannot boot from RAIDZ with parity > 1
+
+Packages:
+
+	system/file-system/zfs
+
+## UDP fix
+
+	8653 Use after free in UDP socket close.
+
+Packages:
+
+	system/kernel
+
+Archive:
+
+	https://downloads.omniosce.org/pkg/8953-udp-backport_r24.p5p
 
 =======================================================================
 

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -29,6 +29,7 @@
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright 2017 Joyent, Inc.
  * Copyright (c) 2017 Datto Inc.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -3981,6 +3982,9 @@ spa_import_rootpool(char *devpath, char *devid)
 	spa = spa_add(pname, config, NULL);
 	spa->spa_is_root = B_TRUE;
 	spa->spa_import_flags = ZFS_IMPORT_VERBATIM;
+	if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_VERSION,
+	    &spa->spa_ubsync.ub_version) != 0)
+		spa->spa_ubsync.ub_version = SPA_VERSION_INITIAL;
 
 	/*
 	 * Build up a vdev tree based on the boot device's label config.

--- a/usr/src/uts/common/inet/ip/ip.c
+++ b/usr/src/uts/common/inet/ip/ip.c
@@ -22,9 +22,9 @@
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1990 Mentat Inc.
- * Copyright (c) 2012 Joyent, Inc. All rights reserved.
  * Copyright (c) 2017 OmniTI Computer Consulting, Inc. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2018 Joyent, Inc. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -5415,6 +5415,7 @@ notfound:
 		}
 		return;
 	}
+	CONN_INC_REF(connp);
 	ASSERT(IPCL_IS_NONSTR(connp) || connp->conn_rq != NULL);
 
 	/*
@@ -5427,7 +5428,6 @@ notfound:
 		conn_t		*next_connp;
 		mblk_t		*mp1;
 
-		CONN_INC_REF(connp);
 		connp = connp->conn_next;
 		for (;;) {
 			while (connp != NULL) {


### PR DESCRIPTION
Clean build & ONU.

```
==== Nightly distributed build started:   Thu Jan 18 14:38:35 UTC 2018 ====
==== Nightly distributed build completed: Thu Jan 18 15:42:17 UTC 2018 ====

==== Total build time ====

real    1:03:42

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151024-c2a1589567 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   568271

==== Nightly argument issues ====


==== Build version ====

omnios-backports-20180118-cef479aed6

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:12.9
user  1:33:54.2
sys     12:01.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:25.6
user  1:24:27.5
sys      9:11.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    19:38.1
user  1:06:19.6
sys     19:54.6

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====

```