### PR TITLE
Joyent merge/2018012701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: a8da368ba60a3b5c5d9b4ca9a216514f9a652c8e
+Last illumos-joyent commit: 7f072df6d4905b9c58c1d1b3df55d14a71be3739
 

--- a/usr/src/uts/common/fs/ufs/ufs_vnops.c
+++ b/usr/src/uts/common/fs/ufs/ufs_vnops.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1984, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
@@ -183,7 +183,6 @@ static	int ufs_setsecattr(struct vnode *, vsecattr_t *, int, struct cred *,
 static	int ufs_priv_access(void *, int, struct cred *);
 static	int ufs_eventlookup(struct vnode *, char *, struct cred *,
     struct vnode **);
-extern int as_map_locked(struct as *, caddr_t, size_t, int ((*)()), void *);
 
 /*
  * For lockfs: ulockfs begin/end is now inlined in the ufs_xxx functions.

--- a/usr/src/uts/common/vm/as.h
+++ b/usr/src/uts/common/vm/as.h
@@ -24,7 +24,7 @@
  */
 
 /*
- * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T */
@@ -256,6 +256,8 @@ extern struct as kas;		/* kernel's address space */
 #define	AS_SEGNEXT(as, seg)	AVL_NEXT(&(as)->a_segtree, (seg))
 #define	AS_SEGPREV(as, seg)	AVL_PREV(&(as)->a_segtree, (seg))
 
+typedef int (*segcreate_func_t)(struct seg **, void *);
+
 void	as_init(void);
 void	as_avlinit(struct as *);
 struct	seg *as_segat(struct as *as, caddr_t addr);
@@ -273,8 +275,10 @@ faultcode_t as_faulta(struct as *as, caddr_t addr, size_t size);
 int	as_setprot(struct as *as, caddr_t addr, size_t size, uint_t prot);
 int	as_checkprot(struct as *as, caddr_t addr, size_t size, uint_t prot);
 int	as_unmap(struct as *as, caddr_t addr, size_t size);
-int	as_map(struct as *as, caddr_t addr, size_t size, int ((*crfp)()),
-		void *argsp);
+int	as_map(struct as *as, caddr_t addr, size_t size, segcreate_func_t crfp,
+    void *argsp);
+int as_map_locked(struct as *as, caddr_t addr, size_t size,
+    segcreate_func_t crfp, void *argsp);
 void	as_purge(struct as *as);
 int	as_gap(struct as *as, size_t minlen, caddr_t *basep, size_t *lenp,
 		uint_t flags, caddr_t addr);

--- a/usr/src/uts/common/vm/seg_dev.c
+++ b/usr/src/uts/common/vm/seg_dev.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -357,8 +358,9 @@ devmap_ctxto(void *data)
  * Create a device segment.
  */
 int
-segdev_create(struct seg *seg, void *argsp)
+segdev_create(struct seg **segpp, void *argsp)
 {
+	struct seg *seg = *segpp;
 	struct segdev_data *sdp;
 	struct segdev_crargs *a = (struct segdev_crargs *)argsp;
 	devmap_handle_t *dhp = (devmap_handle_t *)a->devmap_data;

--- a/usr/src/uts/common/vm/seg_dev.h
+++ b/usr/src/uts/common/vm/seg_dev.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -122,7 +123,7 @@ struct devmap_pmem_cookie {
 
 extern void segdev_init(void);
 
-extern int segdev_create(struct seg *, void *);
+extern int segdev_create(struct seg **, void *);
 
 extern int segdev_copyto(struct seg *, caddr_t, const void *, void *, size_t);
 extern int segdev_copyfrom(struct seg *, caddr_t, const void *, void *, size_t);

--- a/usr/src/uts/common/vm/seg_hole.c
+++ b/usr/src/uts/common/vm/seg_hole.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 
@@ -82,8 +82,9 @@ static struct seg_ops seghole_ops = {
  * Create a hole in the AS.
  */
 int
-seghole_create(struct seg *seg, void *argsp)
+seghole_create(struct seg **segpp, void *argsp)
 {
+	struct seg *seg = *segpp;
 	seghole_crargs_t *crargs = argsp;
 	seghole_data_t *data;
 

--- a/usr/src/uts/common/vm/seg_hole.h
+++ b/usr/src/uts/common/vm/seg_hole.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_VM_SEG_HOLE_H
@@ -28,10 +28,10 @@ typedef struct seghole_data {
 	const char	*shd_name;
 } seghole_data_t;
 
-extern int seghole_create(struct seg *, void *);
+extern int seghole_create(struct seg **, void *);
 
 #define	AS_MAP_CHECK_SEGHOLE(crfp)		\
-	((crfp) == (int (*)())seghole_create)
+	((crfp) == (segcreate_func_t)seghole_create)
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/vm/seg_spt.c
+++ b/usr/src/uts/common/vm/seg_spt.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, Joyent, Inc. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
@@ -72,7 +72,7 @@ size_t	spt_used;
  */
 pgcnt_t segspt_minfree = 0;
 
-static int segspt_create(struct seg *seg, caddr_t argsp);
+static int segspt_create(struct seg **segpp, void *argsp);
 static int segspt_unmap(struct seg *seg, caddr_t raddr, size_t ssize);
 static void segspt_free(struct seg *seg);
 static void segspt_free_pages(struct seg *seg, caddr_t addr, size_t len);
@@ -369,8 +369,9 @@ segspt_unmap(struct seg *seg, caddr_t raddr, size_t ssize)
 }
 
 int
-segspt_create(struct seg *seg, caddr_t argsp)
+segspt_create(struct seg **segpp, void *argsp)
 {
+	struct seg	*seg = *segpp;
 	int		err;
 	caddr_t		addr = seg->s_base;
 	struct spt_data *sptd;
@@ -1671,8 +1672,9 @@ softlock_decrement:
 }
 
 int
-segspt_shmattach(struct seg *seg, caddr_t *argsp)
+segspt_shmattach(struct seg **segpp, void *argsp)
 {
+	struct seg *seg = *segpp;
 	struct shm_data *shmd_arg = (struct shm_data *)argsp;
 	struct shm_data *shmd;
 	struct anon_map *shm_amp = shmd_arg->shm_amp;

--- a/usr/src/uts/common/vm/seg_spt.h
+++ b/usr/src/uts/common/vm/seg_spt.h
@@ -21,12 +21,11 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_VM_SEG_SPT_H
 #define	_VM_SEG_SPT_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #ifdef	__cplusplus
 extern "C" {
@@ -101,7 +100,7 @@ typedef struct shm_data {
 int	sptcreate(size_t size, struct seg **sptseg, struct anon_map *amp,
 	    uint_t prot, uint_t flags, uint_t szc);
 void	sptdestroy(struct as *, struct anon_map *);
-int	segspt_shmattach(struct seg *, caddr_t *);
+int	segspt_shmattach(struct seg **, void *);
 
 #define	isspt(sp)	((sp)->shm_sptinfo ? (sp)->shm_sptinfo->sptas : NULL)
 #define	spt_locked(a)	((a) & SHM_SHARE_MMU)

--- a/usr/src/uts/common/vm/seg_umap.c
+++ b/usr/src/uts/common/vm/seg_umap.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -99,8 +99,9 @@ static struct seg_ops segumap_ops = {
  * Create a kernel/user-mapped segment.
  */
 int
-segumap_create(struct seg *seg, void *argsp)
+segumap_create(struct seg **segpp, void *argsp)
 {
+	struct seg *seg = *segpp;
 	segumap_crargs_t *a = (struct segumap_crargs *)argsp;
 	segumap_data_t *data;
 

--- a/usr/src/uts/common/vm/seg_umap.h
+++ b/usr/src/uts/common/vm/seg_umap.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_VM_SEG_UMAP_H
@@ -33,7 +33,7 @@ typedef struct segumap_data {
 	size_t		sud_softlockcnt;
 } segumap_data_t;
 
-extern int segumap_create(struct seg *, void *);
+extern int segumap_create(struct seg **, void *);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/vm/seg_vn.c
+++ b/usr/src/uts/common/vm/seg_vn.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1986, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015, Joyent, Inc. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  */
 
@@ -538,8 +538,9 @@ segvn_setvnode_mpss(vnode_t *vp)
 }
 
 int
-segvn_create(struct seg *seg, void *argsp)
+segvn_create(struct seg **segpp, void *argsp)
 {
+	struct seg *seg = *segpp;
 	extern lgrp_mem_policy_t lgrp_mem_default_policy;
 	struct segvn_crargs *a = (struct segvn_crargs *)argsp;
 	struct segvn_data *svd;
@@ -758,6 +759,11 @@ segvn_create(struct seg *seg, void *argsp)
 				    (a->szc == pseg->s_szc &&
 				    IS_P2ALIGNED(pseg->s_base, pgsz) &&
 				    IS_P2ALIGNED(pseg->s_size, pgsz)));
+				/*
+				 * Communicate out the newly concatenated
+				 * segment as part of the result.
+				 */
+				*segpp = pseg;
 				return (0);
 			}
 		}
@@ -797,6 +803,11 @@ segvn_create(struct seg *seg, void *argsp)
 				    (a->szc == nseg->s_szc &&
 				    IS_P2ALIGNED(nseg->s_base, pgsz) &&
 				    IS_P2ALIGNED(nseg->s_size, pgsz)));
+				/*
+				 * Communicate out the newly concatenated
+				 * segment as part of the result.
+				 */
+				*segpp = nseg;
 				return (0);
 			}
 		}
@@ -1253,10 +1264,8 @@ segvn_concat(struct seg *seg1, struct seg *seg2, int amp_cat)
  * Return 0 on success.
  */
 static int
-segvn_extend_prev(seg1, seg2, a, swresv)
-	struct seg *seg1, *seg2;
-	struct segvn_crargs *a;
-	size_t swresv;
+segvn_extend_prev(struct seg *seg1, struct seg *seg2, struct segvn_crargs *a,
+    size_t swresv)
 {
 	struct segvn_data *svd1 = (struct segvn_data *)seg1->s_data;
 	size_t size;
@@ -1333,7 +1342,7 @@ segvn_extend_prev(seg1, seg2, a, swresv)
 		struct vpage *vp, *evp;
 		new_vpage =
 		    kmem_zalloc(vpgtob(seg_pages(seg1) + seg_pages(seg2)),
-			KM_NOSLEEP);
+		    KM_NOSLEEP);
 		if (new_vpage == NULL)
 			return (-1);
 		bcopy(svd1->vpage, new_vpage, vpgtob(seg_pages(seg1)));
@@ -1373,11 +1382,8 @@ segvn_extend_prev(seg1, seg2, a, swresv)
  * Return 0 on success.
  */
 static int
-segvn_extend_next(
-	struct seg *seg1,
-	struct seg *seg2,
-	struct segvn_crargs *a,
-	size_t swresv)
+segvn_extend_next(struct seg *seg1, struct seg *seg2, struct segvn_crargs *a,
+    size_t swresv)
 {
 	struct segvn_data *svd2 = (struct segvn_data *)seg2->s_data;
 	size_t size;
@@ -3357,7 +3363,6 @@ static int
 segvn_fill_vp_pages(struct segvn_data *svd, vnode_t *vp, u_offset_t off,
     uint_t szc, page_t **ppa, page_t **ppplist, uint_t *ret_pszc,
     int *downsize)
-
 {
 	page_t *pplist = *ppplist;
 	size_t pgsz = page_get_pagesize(szc);
@@ -3498,7 +3503,7 @@ segvn_fill_vp_pages(struct segvn_data *svd, vnode_t *vp, u_offset_t off,
 				goto out;
 			}
 			io_err = VOP_PAGEIO(vp, io_pplist, io_off, io_len,
-				B_READ, svd->cred, NULL);
+			    B_READ, svd->cred, NULL);
 			if (io_err) {
 				VM_STAT_ADD(segvnvmstats.fill_vp_pages[8]);
 				page_unlock(targpp);
@@ -9457,7 +9462,7 @@ segvn_purge(struct seg *seg)
 /*ARGSUSED*/
 static int
 segvn_reclaim(void *ptag, caddr_t addr, size_t len, struct page **pplist,
-	enum seg_rw rw, int async)
+    enum seg_rw rw, int async)
 {
 	struct seg *seg = (struct seg *)ptag;
 	struct segvn_data *svd = (struct segvn_data *)seg->s_data;
@@ -9534,7 +9539,7 @@ segvn_reclaim(void *ptag, caddr_t addr, size_t len, struct page **pplist,
 /*ARGSUSED*/
 static int
 shamp_reclaim(void *ptag, caddr_t addr, size_t len, struct page **pplist,
-	enum seg_rw rw, int async)
+    enum seg_rw rw, int async)
 {
 	amp_t *amp = (amp_t *)ptag;
 	pgcnt_t np, npages;
@@ -10207,10 +10212,8 @@ segvn_trupdate(void)
 }
 
 static void
-segvn_trupdate_seg(struct seg *seg,
-	segvn_data_t *svd,
-	svntr_t *svntrp,
-	ulong_t hash)
+segvn_trupdate_seg(struct seg *seg, segvn_data_t *svd, svntr_t *svntrp,
+    ulong_t hash)
 {
 	proc_t			*p;
 	lgrp_id_t		lgrp_id;

--- a/usr/src/uts/common/vm/seg_vn.h
+++ b/usr/src/uts/common/vm/seg_vn.h
@@ -21,7 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright (c) 2015, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -162,14 +162,14 @@ typedef struct	segvn_data {
 	{ NULL, NULL, 0, MAP_PRIVATE, prot, max, 0, NULL, 0, 0 }
 
 #define	AS_MAP_CHECK_VNODE_LPOOB(crfp, argsp)				\
-	((crfp) == (int (*)())segvn_create &&				\
+	((crfp) == (segcreate_func_t)segvn_create &&			\
 	(((struct segvn_crargs *)(argsp))->flags &			\
 	    (MAP_TEXT | MAP_INITDATA)) &&				\
 	((struct segvn_crargs *)(argsp))->szc == 0 &&			\
 	((struct segvn_crargs *)(argsp))->vp != NULL)
 
 #define	AS_MAP_CHECK_ANON_LPOOB(crfp, argsp)				\
-	((crfp) == (int (*)())segvn_create &&				\
+	((crfp) == (segcreate_func_t)segvn_create &&			\
 	(((struct segvn_crargs *)(argsp))->szc == 0 ||			\
 	((struct segvn_crargs *)(argsp))->szc == AS_MAP_HEAP ||		\
 	((struct segvn_crargs *)(argsp))->szc == AS_MAP_STACK) &&	\
@@ -228,7 +228,7 @@ typedef struct svntr_stats {
 } svntr_stats_t;
 
 extern void	segvn_init(void);
-extern int	segvn_create(struct seg *, void *);
+extern int	segvn_create(struct seg **, void *);
 
 extern	struct seg_ops segvn_ops;
 

--- a/usr/src/uts/i86xpv/vm/seg_mf.c
+++ b/usr/src/uts/i86xpv/vm/seg_mf.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -115,8 +116,9 @@ segmf_data_zalloc(struct seg *seg)
 }
 
 int
-segmf_create(struct seg *seg, void *args)
+segmf_create(struct seg **segpp, void *args)
 {
+	struct seg *seg = *segpp;
 	struct segmf_crargs *a = args;
 	struct segmf_data *data;
 	struct as *as = seg->s_as;

--- a/usr/src/uts/i86xpv/vm/seg_mf.h
+++ b/usr/src/uts/i86xpv/vm/seg_mf.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_VM_SEG_MF_H
@@ -42,7 +43,7 @@ struct segmf_crargs {
 	uchar_t		maxprot;
 };
 
-extern int segmf_create(struct seg *, void *);
+extern int segmf_create(struct seg **, void *);
 
 extern int segmf_add_mfns(struct seg *, caddr_t, mfn_t, pgcnt_t, domid_t);
 


### PR DESCRIPTION
side pull from Joyent to fix an issue with OS-6323.

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2018012701-f884b4a5d3 i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Sat Jan 27 00:02:20 CET 2018 ====
==== Nightly distributed build completed: Sat Jan 27 00:51:49 CET 2018 ====

==== Total build time ====

real    0:49:28

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-9330622831 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_161-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   76

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018012701-f884b4a5d3

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:17.8
user    52:28.9
sys      4:31.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    12:26.3
user    44:39.0
sys      3:01.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    15:08.9
user    25:40.2
sys      2:51.4

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```