### PR TITLE
Re-synchronise lint overrides to match those in gate.

### DIFF
--- a/usr/src/cmd/cmd-inet/usr.lib/wanboot/p12split/p12split.c
+++ b/usr/src/cmd/cmd-inet/usr.lib/wanboot/p12split/p12split.c
@@ -24,6 +24,8 @@
  * Use is subject to license terms.
  */
 
+#pragma ident	"%Z%%M%	%I%	%E% SMI"
+
 #include <stdio.h>
 #include <libintl.h>
 #include <locale.h>
@@ -260,6 +262,7 @@ do_certs(void)
 			int i;
 
 			for (i = 0; i < sk_X509_num(ta_in); i++) {
+				/* LINTED */
 				x = sk_X509_value(ta_in, i);
 				(void) printf(
 				    gettext("\nTrust Anchor cert %d:\n"), i);
@@ -284,7 +287,7 @@ do_certs(void)
 				}
 
 				(void) sunw_print_times(stdout, PRNT_BOTH,
-				    NULL, x);
+					NULL, x);
 			}
 		}
 	}
@@ -373,11 +376,13 @@ check_certs(STACK_OF(X509) *ta_in, X509 **c_in)
 		return;
 
 	for (i = 0; i < sk_X509_num(ta_in); ) {
+		/* LINTED */
 		curr = sk_X509_value(ta_in, i);
 		ret = time_check_print(curr);
 		if ((ret != CHK_TIME_OK && ret != CHK_TIME_IS_BEFORE) &&
 		    del_expired) {
 			(void) fprintf(stderr, gettext("  Removing cert\n"));
+			/* LINTED */
 			curr = sk_X509_delete(ta_in, i);
 			X509_free(curr);
 			continue;
@@ -581,12 +586,14 @@ cleanup:
 	 */
 	if (clist != NULL) {
 		if (cert != NULL && sk_X509_num(clist) == 1) {
+			/* LINTED */
 			(void) sk_X509_delete(clist, 0);
 		}
 		sk_X509_pop_free(clist, X509_free);
 	}
 	if (klist != NULL) {
 		if (pkey != NULL && sk_EVP_PKEY_num(klist) == 1) {
+			/* LINTED */
 			(void) sk_EVP_PKEY_delete(klist, 0);
 		}
 		sk_EVP_PKEY_pop_free(klist, sunw_evp_pkey_free);

--- a/usr/src/common/net/wanboot/boot_http.c
+++ b/usr/src/common/net/wanboot/boot_http.c
@@ -2253,6 +2253,7 @@ print_ciphers(SSL *ssl)
 		return;
 
 	for (i = 0; i < sk_SSL_CIPHER_num(sk); i++) {
+		/* LINTED */
 		c = sk_SSL_CIPHER_value(sk, i);
 		libbootlog(BOOTLOG_VERBOSE, "%08lx %s", c->id, c->name);
 	}

--- a/usr/src/lib/libkmf/plugins/kmf_openssl/common/openssl_spi.c
+++ b/usr/src/lib/libkmf/plugins/kmf_openssl/common/openssl_spi.c
@@ -2497,6 +2497,7 @@ static X509 *ocsp_find_signer_sk(STACK_OF(X509) *certs, OCSP_RESPID *id)
 	keyhash = id->value.byKey->data;
 	/* Calculate hash of each key and compare */
 	for (i = 0; i < sk_X509_num(certs); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		X509 *x = sk_X509_value(certs, i);
 		/* Use pubkey_digest to get the key ID value */
 		(void) X509_pubkey_digest(x, EVP_sha1(), tmphash, NULL);
@@ -3636,6 +3637,7 @@ extract_pem(KMF_HANDLE *kmfh,
 	}
 
 	for (i = 0; i < sk_X509_INFO_num(x509_info_stack); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		cert_infos[ncerts] = sk_X509_INFO_value(x509_info_stack, i);
 		ncerts++;
 	}
@@ -3717,6 +3719,7 @@ extract_pem(KMF_HANDLE *kmfh,
 err:
 	/* Cleanup the stack of X509 info records */
 	for (i = 0; i < sk_X509_INFO_num(x509_info_stack); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		info = (X509_INFO *)sk_X509_INFO_value(x509_info_stack, i);
 		X509_INFO_free(info);
 	}
@@ -3737,6 +3740,7 @@ openssl_parse_bags(STACK_OF(PKCS12_SAFEBAG) *bags, char *pin,
 	int i;
 
 	for (i = 0; i < sk_PKCS12_SAFEBAG_num(bags); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		PKCS12_SAFEBAG *bag = sk_PKCS12_SAFEBAG_value(bags, i);
 		ret = openssl_parse_bag(bag, pin, (pin ? strlen(pin) : 0),
 		    keys, certs);
@@ -3767,9 +3771,11 @@ set_pkey_attrib(EVP_PKEY *pkey, ASN1_TYPE *attrib, int nid)
 		X509_ATTRIBUTE *a;
 		for (i = 0;
 		    i < sk_X509_ATTRIBUTE_num(pkey->attributes); i++) {
+			/* LINTED E_BAD_PTR_CASE_ALIGN */
 			a = sk_X509_ATTRIBUTE_value(pkey->attributes, i);
 			if (OBJ_obj2nid(a->object) == nid) {
 				X509_ATTRIBUTE_free(a);
+				/* LINTED E_BAD_PTR_CAST_ALIGN */
 				(void) sk_X509_ATTRIBUTE_set(pkey->attributes,
 				    i, attr);
 				return (KMF_OK);
@@ -3947,6 +3953,7 @@ openssl_pkcs12_parse(PKCS12 *p12, char *pin,
 
 	for (i = 0; ret == KMF_OK && i < sk_PKCS7_num(asafes); i++) {
 		bags = NULL;
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		p7 = sk_PKCS7_value(asafes, i);
 		bagnid = OBJ_obj2nid(p7->type);
 
@@ -4224,6 +4231,7 @@ find_attr(STACK_OF(X509_ATTRIBUTE) *attrs, int nid)
 		return (NULL);
 
 	for (i = 0; i < sk_X509_ATTRIBUTE_num(attrs); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		a = sk_X509_ATTRIBUTE_value(attrs, i);
 		if (OBJ_obj2nid(a->object) == nid)
 			return (a);
@@ -4264,6 +4272,7 @@ convertToRawKey(EVP_PKEY *pkey, KMF_RAW_KEY_DATA *key)
 		ASN1_TYPE *ty = NULL;
 		int numattr = sk_ASN1_TYPE_num(attr->value.set);
 		if (attr->single == 0 && numattr > 0) {
+			/* LINTED E_BAD_PTR_CAST_ALIGN */
 			ty = sk_ASN1_TYPE_value(attr->value.set, 0);
 		}
 		if (ty != NULL) {
@@ -4287,6 +4296,7 @@ convertToRawKey(EVP_PKEY *pkey, KMF_RAW_KEY_DATA *key)
 		ASN1_TYPE *ty = NULL;
 		int numattr = sk_ASN1_TYPE_num(attr->value.set);
 		if (attr->single == 0 && numattr > 0) {
+			/* LINTED E_BAD_PTR_CAST_ALIGN */
 			ty = sk_ASN1_TYPE_value(attr->value.set, 0);
 		}
 		key->id.Data = (uchar_t *)malloc(
@@ -4317,6 +4327,7 @@ convertPK12Objects(
 	int i;
 
 	for (i = 0; sslkeys != NULL && i < sk_EVP_PKEY_num(sslkeys); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		EVP_PKEY *pkey = sk_EVP_PKEY_value(sslkeys, i);
 		rv = convertToRawKey(pkey, &key);
 		if (rv == KMF_OK)
@@ -4328,6 +4339,7 @@ convertPK12Objects(
 
 	/* Now add the certificate to the certlist */
 	for (i = 0; sslcert != NULL && i < sk_X509_num(sslcert); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		X509 *cert = sk_X509_value(sslcert, i);
 		rv = add_cert_to_list(kmfh, cert, certlist, ncerts);
 		if (rv != KMF_OK)
@@ -4343,6 +4355,7 @@ convertPK12Objects(
 		 * Lint is complaining about the embedded casting, and
 		 * to fix it, you need to fix openssl header files.
 		 */
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		c = sk_X509_value(sslcacerts, i);
 
 		/* Now add the ca cert to the certlist */
@@ -5409,6 +5422,7 @@ OpenSSL_FindCertInCRL(KMF_HANDLE_T handle, int numattr, KMF_ATTRIBUTE *attrlist)
 	}
 
 	for (i = 0; i < sk_X509_REVOKED_num(revoke_stack); i++) {
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
 		revoke = sk_X509_REVOKED_value(revoke_stack, i);
 		if (ASN1_INTEGER_cmp(xcert->cert_info->serialNumber,
 		    revoke->serialNumber) == 0) {


### PR DESCRIPTION
This re-synchronises some files with illumos-gate where the only differences are in lint override statements. This will make the openssl 1.1 change branches easier to manage.

## mail_msg

still clean:

```
==== Nightly distributed build started:   Wed Jan 31 09:20:44 UTC 2018 ====
==== Nightly distributed build completed: Wed Jan 31 10:11:36 UTC 2018 ====

==== Total build time ====

real    0:50:52

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151024-32f54f0308 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_151-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   40445

==== Nightly argument issues ====


==== Build version ====

omnios-resync-c28f632c07

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    13:53.4
user  1:13:45.7
sys     10:11.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    10:09.0
user  1:01:25.5
sys      6:13.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    16:40.8
user    37:16.0
sys     11:52.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```