### PR TITLE
Upstream merge joyent_merge/2018020101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -2,5 +2,5 @@ This README is new for OmniOS as of Stable release r151020 -- it is here
 because it keeps track of LX merges from OmniOS (a massive and continuing
 side-pull).
 
-Last illumos-joyent commit: 7f072df6d4905b9c58c1d1b3df55d14a71be3739
+Last illumos-joyent commit: 6afca163c6f9158c8d995916782cd765188cbdf1
 

--- a/usr/src/uts/common/brand/lx/syscall/lx_mem.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_mem.c
@@ -12,7 +12,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -43,6 +43,8 @@ extern uint_t pr_getprot(struct seg *, int, void **, caddr_t *, caddr_t *,
 extern struct seg_ops segspt_shmops;
 /* From uts/common/syscall/memcntl.c */
 extern int memcntl(caddr_t, size_t, int, caddr_t, int, int);
+/* From uts/common/os/grow.c */
+extern int smmap_common(caddr_t *, size_t, int, int, struct file *, offset_t);
 
 /*
  * After Linux 2.6.8, an unprivileged process can lock memory up to its
@@ -513,7 +515,8 @@ lx_get_mapping(uintptr_t find_addr, size_t find_size, lx_segmap_t *mp,
 	uint_t prot;
 	caddr_t saddr, eaddr, naddr;
 
-	AS_LOCK_ENTER(as, RW_READER);
+	/* pr_getprot asserts that the as is held as a writer */
+	AS_LOCK_ENTER(as, RW_WRITER);
 
 	seg = as_segat(as, (caddr_t)find_addr);
 	if (seg == NULL || (seg->s_flags & S_HOLE) != 0) {
@@ -865,13 +868,14 @@ long
 lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
     uintptr_t new_addr)
 {
-	int prot = 0, oflags, mflags = 0, i, fd, res;
+	int prot = 0, oflags, mflags = 0, i, res;
 	lx_segmap_t map, *mp;
-	long rval = 0;
+	int rval = 0;
 	lx_proc_data_t *lxpd;
 	offset_t off;
 	struct vnode *vp = NULL;
 	file_t *fp;
+	caddr_t naddr;
 
 	if (flags & LX_MREMAP_FIXED) {
 		/* MREMAP_FIXED requires MREMAP_MAYMOVE */
@@ -905,6 +909,8 @@ lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
 	mutex_enter(&lxpd->l_remap_anoncache_lock);
 
 	for (i = 0; i < LX_REMAP_ANONCACHE_NENTRIES; i++) {
+		long rv;
+
 		mp = &lxpd->l_remap_anoncache[i];
 
 		if (mp->lxsm_vaddr != old_addr)
@@ -919,9 +925,9 @@ lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
 		 * b) relocate & expand the mapping, returning a new address
 		 * c) there will be an error of some sort and errno will be set
 		 */
-		rval = lx_remap_anon(mp, new_size, flags, new_addr);
+		rv = lx_remap_anon(mp, new_size, flags, new_addr);
 		mutex_exit(&lxpd->l_remap_anoncache_lock);
-		return (rval);
+		return (rv);
 	}
 
 	mutex_exit(&lxpd->l_remap_anoncache_lock);
@@ -952,12 +958,14 @@ lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
 		 * This is an anonymous mapping -- which is the one case in
 		 * which we perform something that approaches a true remap.
 		 */
+		long rv;
+
 		if (vp != NULL)
 			VN_RELE(vp);
 		mutex_enter(&lxpd->l_remap_anoncache_lock);
-		rval = lx_remap_anon(mp, new_size, flags, new_addr);
+		rv = lx_remap_anon(mp, new_size, flags, new_addr);
 		mutex_exit(&lxpd->l_remap_anoncache_lock);
-		return (rval);
+		return (rv);
 	}
 
 	/* The rest of the code is for a 'named' mapping */
@@ -979,19 +987,19 @@ lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
 		goto out;
 	}
 
-	oflags = (mp->lxsm_flags & LX_SM_WRITE) ? FWRITE | FREAD : FREAD;
-	if (vp == NULL || falloc(vp, oflags, &fp, &fd) != 0) {
+	oflags = (mp->lxsm_flags & LX_SM_WRITE) ? (FWRITE | FREAD) : FREAD;
+	if (vp == NULL) {
 		/*
-		 * If we failed the path might not exist, or we had an issue
-		 * in falloc. Either way we're going to kick it back with
-		 * EINVAL.
+		 * If vp is NULL, the path might not exist. We're going to kick
+		 * it back with EINVAL.
 		 */
 		rval = set_errno(EINVAL);
 		goto out;
 	}
+
+	/* falloc cannot fail with a NULL fdp. */
+	VERIFY0(falloc(vp, oflags, &fp, NULL));
 	mutex_exit(&fp->f_tlock);
-	setf(fd, fp);
-	vp = NULL;	/* VN_RELE handled in close() */
 
 	if (mp->lxsm_flags & LX_SM_WRITE)
 		prot |= PROT_WRITE;
@@ -1004,13 +1012,22 @@ lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
 
 	mflags |= MAP_SHARED;
 
-	rval = (long)smmap64((void *)new_addr, new_size, prot, mflags, fd, off);
-	if (ttolwp(curthread)->lwp_errno != 0) {
-		(void) close(fd);
+	/*
+	 * We're using smmap_common to pass the fp directly, instead of
+	 * initializing a temporary file descriptor for smmap64(), so as to
+	 * prevent any inadvertent use of that temporary fd within the
+	 * application.
+	 */
+	naddr = (caddr_t)new_addr;
+	rval = smmap_common(&naddr, new_size, prot, mflags, fp, off);
+
+	mutex_enter(&fp->f_tlock);
+	unfalloc(fp);
+
+	if (rval != 0) {
 		rval = set_errno(ENOMEM);
 		goto out;
 	}
-	(void) close(fd);
 
 	/*
 	 * Our mapping succeeded; we're now going to rip down the old mapping.
@@ -1020,7 +1037,10 @@ lx_mremap(uintptr_t old_addr, size_t old_size, size_t new_size, int flags,
 out:
 	if (vp != NULL)
 		VN_RELE(vp);
-	return (rval);
+
+	if (rval == 0)
+		return ((long)naddr);
+	return ((long)rval);
 }
 
 #ifndef lint
@@ -1085,7 +1105,7 @@ lx_u2u_copy(void *src, void *dst, size_t len)
 			as_pageunlock(p_as, ppa_src, sp, mlen, S_READ);
 			return (EFAULT);
 		}
-		bcopy(sp, dp, mlen);
+		ucopy(sp, dp, mlen);
 		no_fault();		/* calls smap_enable */
 
 		as_pageunlock(p_as, ppa_dst, dp, mlen, S_WRITE);

--- a/usr/src/uts/common/os/grow.c
+++ b/usr/src/uts/common/os/grow.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2013 OmniTI Computer Consulting, Inc. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -670,7 +670,7 @@ zmap(struct as *as, caddr_t *addrp, size_t len, uint_t uprot, int flags,
 #define	RANDOMIZABLE_MAPPING(addr, flags) (((flags & MAP_FIXED) == 0) && \
 	!(((flags & MAP_ALIGN) == 0) && (addr != 0) && aslr_respect_mmap_hint))
 
-static int
+int
 smmap_common(caddr_t *addrp, size_t len,
     int prot, int flags, struct file *fp, offset_t pos)
 {


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018020101

## Backports

None - the commit is a fix for `OS-6407 lx: move mmap and mremap support in-kernel` which is only in bloody.

## onu

Worked and lx zone booted.

## mail_msg

```

==== Nightly distributed build started:   Thu Feb  1 23:18:23 GMT 2018 ====
==== Nightly distributed build completed: Fri Feb  2 00:34:59 GMT 2018 ====

==== Total build time ====

real    1:16:35

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-upstream_merge-2018020101-2d34a01d24 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_161-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   261

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018020101-5d849e9254

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    20:25.2
user  1:09:57.5
sys     12:10.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    18:04.8
user    58:53.7
sys      7:56.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====

3171a3172,3182
> lib/amd64/libfakekernel.so.1: NEEDED=libc.so.1
> lib/amd64/libfakekernel.so.1: NEEDED=libcryptoutil.so.1
> lib/amd64/libfakekernel.so.1: NEEDED=libsocket.so.1
> lib/amd64/libfakekernel.so.1: NEEDED=libumem.so.1
> lib/amd64/libfakekernel.so.1: VERDEF=libfakekernel.so.1 [BASE]
> lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_DYNAMIC
> lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_GLOBAL_OFFSET_TABLE_
> lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_PROCEDURE_LINKAGE_TABLE_
> lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_edata
> lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_end
> lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_etext
10271a10283,10293
> lib/libfakekernel.so.1: NEEDED=libc.so.1
> lib/libfakekernel.so.1: NEEDED=libcryptoutil.so.1
> lib/libfakekernel.so.1: NEEDED=libsocket.so.1
> lib/libfakekernel.so.1: NEEDED=libumem.so.1
> lib/libfakekernel.so.1: VERDEF=libfakekernel.so.1 [BASE]
> lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_DYNAMIC
> lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_GLOBAL_OFFSET_TABLE_
> lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_PROCEDURE_LINKAGE_TABLE_
> lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_edata
> lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_end
> lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_etext
14783a14806
> usr/bin/amd64/crle: VERSION=crle, SYMBOL=_start_crt
14816a14840
> usr/bin/amd64/elfdump: VERSION=elfdump, SYMBOL=_start_crt
14955a14980
> usr/bin/amd64/elfwrap: VERSION=elfwrap, SYMBOL=_start_crt
14996a15022
> usr/bin/amd64/ld: VERSION=ld, SYMBOL=_start_crt
15020a15047
> usr/bin/amd64/ldd: VERSION=ldd, SYMBOL=_start_crt
15062a15090
> usr/bin/amd64/moe: VERSION=moe, SYMBOL=_start_crt
15153a15182
> usr/bin/amd64/pvs: VERSION=pvs, SYMBOL=_start_crt
15194a15224
> usr/bin/amd64/ztest: NEEDED=libfakekernel.so.1
15273a15304
> usr/bin/chat: VERSION=chat, SYMBOL=_start_crt
15363a15395
> usr/bin/crle: VERSION=crle, SYMBOL=_start_crt
15389a15422
> usr/bin/csh: VERSION=csh, SYMBOL=_start_crt
15435a15469
> usr/bin/dc: VERSION=dc, SYMBOL=_start_crt
15518a15553
> usr/bin/edit: VERSION=ex, SYMBOL=_start_crt
15553a15589
> usr/bin/elfdump: VERSION=elfdump, SYMBOL=_start_crt
15697a15734
> usr/bin/elfwrap: VERSION=elfwrap, SYMBOL=_start_crt
15722a15760
> usr/bin/eqn: VERSION=eqn, SYMBOL=_start_crt
15743a15782
> usr/bin/expr: VERSION=expr, SYMBOL=_start_crt
15810a15850
> usr/bin/ftp: VERSION=ftp, SYMBOL=_start_crt
15836a15877
> usr/bin/genmsg: VERSION=genmsg, SYMBOL=_start_crt
16037a16079
> usr/bin/i86/ztest: NEEDED=libfakekernel.so.1
16078a16121
> usr/bin/infocmp: VERSION=infocmp, SYMBOL=_start_crt
16175a16219
> usr/bin/ld: VERSION=ld, SYMBOL=_start_crt
16212a16257
> usr/bin/ldd: VERSION=ldd, SYMBOL=_start_crt
16275a16321
> usr/bin/mail: VERSION=mail, SYMBOL=_start_crt
16297a16344
> usr/bin/mailcompat: VERSION=mailcompat, SYMBOL=_start_crt
16316a16364
> usr/bin/mailstats: VERSION=mailstats, SYMBOL=_start_crt
16338a16387
> usr/bin/mailx: VERSION=mailx, SYMBOL=_start_crt
16369a16419
> usr/bin/mconnect: VERSION=mconnect, SYMBOL=_start_crt
16399a16450
> usr/bin/moe: VERSION=moe, SYMBOL=_start_crt
16441a16493
> usr/bin/neqn: VERSION=neqn, SYMBOL=_start_crt
16591a16644
> usr/bin/praliases: VERSION=praliases, SYMBOL=_start_crt
16643a16697
> usr/bin/pvs: VERSION=pvs, SYMBOL=_start_crt
16669a16724
> usr/bin/rcapstat: VERSION=rcapstat, SYMBOL=_start_crt
16702a16758
> usr/bin/rdist: VERSION=rdist, SYMBOL=_start_crt
16839a16896
> usr/bin/stty: VERSION=stty, SYMBOL=_start_crt
16919a16977
> usr/bin/tic: VERSION=tic, SYMBOL=_start_crt
17008a17067
> usr/bin/vacation: VERSION=vacation, SYMBOL=_start_crt
17031a17091
> usr/bin/vedit: VERSION=ex, SYMBOL=_start_crt
17126a17187
> usr/has/bin/edit: VERSION=ex, SYMBOL=_start_crt
17159a17221
> usr/has/bin/ex: VERSION=ex, SYMBOL=_start_crt
17188a17251
> usr/has/bin/sh: VERSION=sh, SYMBOL=_start_crt
17217a17281
> usr/has/bin/vedit: VERSION=ex, SYMBOL=_start_crt
17250a17315
> usr/has/bin/vi: VERSION=ex, SYMBOL=_start_crt
17283a17349
> usr/has/bin/view: VERSION=ex, SYMBOL=_start_crt
18006,18016d18071
< usr/lib/amd64/libfakekernel.so.1: NEEDED=libc.so.1
< usr/lib/amd64/libfakekernel.so.1: NEEDED=libcryptoutil.so.1
< usr/lib/amd64/libfakekernel.so.1: NEEDED=libsocket.so.1
< usr/lib/amd64/libfakekernel.so.1: NEEDED=libumem.so.1
< usr/lib/amd64/libfakekernel.so.1: VERDEF=libfakekernel.so.1 [BASE]
< usr/lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_DYNAMIC
< usr/lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_GLOBAL_OFFSET_TABLE_
< usr/lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_PROCEDURE_LINKAGE_TABLE_
< usr/lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_edata
< usr/lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_end
< usr/lib/amd64/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_etext
20312a20368
> usr/lib/amd64/libzpool.so.1: NEEDED=libfakekernel.so.1
20947a21004
> usr/lib/expreserve: VERSION=expreserve, SYMBOL=_start_crt
20967a21025
> usr/lib/exrecover: VERSION=exrecover, SYMBOL=_start_crt
21650a21709
> usr/lib/fs/udfs/fsdb: VERSION=fsdb, SYMBOL=_start_crt
21874a21934
> usr/lib/gss/gssd: VERSION=gssd, SYMBOL=_start_crt
22079a22140
> usr/lib/idmapd: VERSION=idmapd, SYMBOL=_start_crt
22301a22363
> usr/lib/ipf/amd64/ipftest: VERSION=ipftest, SYMBOL=_start_crt
22325a22388
> usr/lib/ipf/i86/ipftest: VERSION=ipftest, SYMBOL=_start_crt
22434a22498
> usr/lib/krb5/ktkt_warnd: VERSION=ktkt_warnd, SYMBOL=_start_crt
23196,23206d23259
< usr/lib/libfakekernel.so.1: NEEDED=libc.so.1
< usr/lib/libfakekernel.so.1: NEEDED=libcryptoutil.so.1
< usr/lib/libfakekernel.so.1: NEEDED=libsocket.so.1
< usr/lib/libfakekernel.so.1: NEEDED=libumem.so.1
< usr/lib/libfakekernel.so.1: VERDEF=libfakekernel.so.1 [BASE]
< usr/lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_DYNAMIC
< usr/lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_GLOBAL_OFFSET_TABLE_
< usr/lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_PROCEDURE_LINKAGE_TABLE_
< usr/lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_edata
< usr/lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_end
< usr/lib/libfakekernel.so.1: VERSION=libfakekernel.so.1, SYMBOL=_etext
26222a26276
> usr/lib/libzpool.so.1: NEEDED=libfakekernel.so.1
26339a26394
> usr/lib/lp/local/lpadmin: VERSION=lpadmin, SYMBOL=_start_crt
26368a26424
> usr/lib/lp/local/lpshut: VERSION=lpshut, SYMBOL=_start_crt
26405a26462
> usr/lib/mail.local: VERSION=mail.local, SYMBOL=_start_crt
26572a26630
> usr/lib/netsvc/yp/rpc.yppasswdd: VERSION=rpc.yppasswdd, SYMBOL=_start_crt
27144a27203
> usr/lib/rcap/amd64/rcapd: VERSION=rcapd, SYMBOL=_start_crt
27167a27227
> usr/lib/rcap/i86/rcapd: VERSION=rcapd, SYMBOL=_start_crt
27252a27313
> usr/lib/saf/listen: VERSION=listen, SYMBOL=_start_crt
27276a27338
> usr/lib/saf/nlps_server: VERSION=nlps_server, SYMBOL=_start_crt
27296a27359
> usr/lib/saf/sac: VERSION=sac, SYMBOL=_start_crt
27320a27384
> usr/lib/saf/ttymon: VERSION=ttymon, SYMBOL=_start_crt
29069a29134
> usr/lib/smrsh: VERSION=smrsh, SYMBOL=_start_crt
29088a29154
> usr/lib/smtp/sendmail/mailq: VERSION=mailq, SYMBOL=_start_crt
29117a29184
> usr/lib/smtp/sendmail/sendmail: VERSION=sendmail, SYMBOL=_start_crt
29468a29536
> usr/sbin/amd64/ipf: VERSION=ipf, SYMBOL=_start_crt
29488a29557
> usr/sbin/amd64/ipfs: VERSION=ipfs, SYMBOL=_start_crt
29513a29583
> usr/sbin/amd64/ipfstat: VERSION=ipfstat, SYMBOL=_start_crt
29537a29608
> usr/sbin/amd64/ipmon: VERSION=ipmon, SYMBOL=_start_crt
29561a29633
> usr/sbin/amd64/ipnat: VERSION=ipnat, SYMBOL=_start_crt
29585a29658
> usr/sbin/amd64/ippool: VERSION=ippool, SYMBOL=_start_crt
29599a29673
> usr/sbin/amd64/zdb: NEEDED=libfakekernel.so.1
29750a29825
> usr/sbin/editmap: VERSION=editmap, SYMBOL=_start_crt
29861a29937
> usr/sbin/i86/ipf: VERSION=ipf, SYMBOL=_start_crt
29882a29959
> usr/sbin/i86/ipfs: VERSION=ipfs, SYMBOL=_start_crt
29908a29986
> usr/sbin/i86/ipfstat: VERSION=ipfstat, SYMBOL=_start_crt
29933a30012
> usr/sbin/i86/ipmon: VERSION=ipmon, SYMBOL=_start_crt
29958a30038
> usr/sbin/i86/ipnat: VERSION=ipnat, SYMBOL=_start_crt
29983a30064
> usr/sbin/i86/ippool: VERSION=ippool, SYMBOL=_start_crt
29997a30079
> usr/sbin/i86/zdb: NEEDED=libfakekernel.so.1
30048a30131
> usr/sbin/in.comsat: VERSION=in.comsat, SYMBOL=_start_crt
30249a30333
> usr/sbin/lpfilter: VERSION=lpfilter, SYMBOL=_start_crt
30274a30359
> usr/sbin/lpforms: VERSION=lpforms, SYMBOL=_start_crt
30296a30382
> usr/sbin/lpusers: VERSION=lpusers, SYMBOL=_start_crt
30328a30415
> usr/sbin/makedbm: VERSION=makedbm, SYMBOL=_start_crt
30347a30435
> usr/sbin/makemap: VERSION=makemap, SYMBOL=_start_crt
30459a30548
> usr/sbin/pmadm: VERSION=pmadm, SYMBOL=_start_crt
30492a30582
> usr/sbin/poolcfg: VERSION=poolcfg, SYMBOL=_start_crt
30571a30662
> usr/sbin/rcapadm: VERSION=rcapadm, SYMBOL=_start_crt
30652a30744
> usr/sbin/sacadm: VERSION=sacadm, SYMBOL=_start_crt
30725a30818
> usr/sbin/snoop: VERSION=snoop, SYMBOL=_start_crt
30761a30855
> usr/sbin/sttydefs: VERSION=sttydefs, SYMBOL=_start_crt
30799a30894
> usr/sbin/svccfg: VERSION=svccfg, SYMBOL=_start_crt
30867a30963
> usr/sbin/tcpdchk: VERSION=tcpdchk, SYMBOL=_start_crt
30907a31004
> usr/sbin/tcpdmatch: VERSION=tcpdmatch, SYMBOL=_start_crt
30966a31064
> usr/sbin/try-from: VERSION=try-from, SYMBOL=_start_crt
30990a31089
> usr/sbin/ttyadm: VERSION=ttyadm, SYMBOL=_start_crt
31090a31190
> usr/sbin/zonecfg: VERSION=zonecfg, SYMBOL=_start_crt
31132a31233
> usr/ucb/chown: VERSION=chown, SYMBOL=_start_crt
31149a31251
> usr/ucb/expr: VERSION=expr, SYMBOL=_start_crt
31841a31944
> usr/xpg4/bin/edit: VERSION=ex.xpg4, SYMBOL=_start_crt
31876a31980
> usr/xpg4/bin/ex: VERSION=ex.xpg4, SYMBOL=_start_crt
31906a32011
> usr/xpg4/bin/expr: VERSION=expr.xpg4, SYMBOL=_start_crt
31970a32076
> usr/xpg4/bin/stty: VERSION=stty.xpg4, SYMBOL=_start_crt
31993a32100
> usr/xpg4/bin/vedit: VERSION=ex.xpg4, SYMBOL=_start_crt
32027a32135
> usr/xpg4/bin/vi: VERSION=ex.xpg4, SYMBOL=_start_crt
32061a32170
> usr/xpg4/bin/view: VERSION=ex.xpg4, SYMBOL=_start_crt
33659a33769
> usr/xpg6/bin/dc: VERSION=dc.xpg6, SYMBOL=_start_crt
33686a33797
> usr/xpg6/bin/edit: VERSION=ex.xpg6, SYMBOL=_start_crt
33720a33832
> usr/xpg6/bin/ex: VERSION=ex.xpg6, SYMBOL=_start_crt
33750a33863
> usr/xpg6/bin/expr: VERSION=expr.xpg6, SYMBOL=_start_crt
33790a33904
> usr/xpg6/bin/vedit: VERSION=ex.xpg6, SYMBOL=_start_crt
33824a33939
> usr/xpg6/bin/vi: VERSION=ex.xpg6, SYMBOL=_start_crt
33858a33974
> usr/xpg6/bin/view: VERSION=ex.xpg6, SYMBOL=_start_crt

==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    24:51.4
user    39:43.7
sys      8:10.8

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
