### PR TITLE
Upstream merge joyent_merge/2018022101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,6 +1,5 @@
-This README is new for OmniOS as of Stable release r151020 -- it is here
-because it keeps track of LX merges from OmniOS (a massive and continuing
-side-pull).
+This README is here to keep track of merges from Joyent (a massive and
+continuing side-pull).
 
-Last illumos-joyent commit: de818a9daccca7db99174202eb0e91352a54720e
+Last illumos-joyent commit: f49f984d73e73b99d7388dfffa647c0d2f406d31
 

--- a/usr/src/lib/brand/lx/lx_brand/common/clone.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/clone.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <assert.h>
@@ -631,7 +631,7 @@ lx_clone(uintptr_t p1, uintptr_t p2, uintptr_t p3, uintptr_t p4, uintptr_t p5)
 	 * thread:
 	 */
 	if ((cs = malloc(sizeof (*cs))) == NULL) {
-		lx_debug("could not allocate clone_state: %s", strerror(errno));
+		lx_debug("could not allocate clone_state: %d", errno);
 		return (-ENOMEM);
 	}
 	cs->c_flags = flags;
@@ -665,7 +665,7 @@ lx_clone(uintptr_t p1, uintptr_t p2, uintptr_t p3, uintptr_t p4, uintptr_t p5)
 	 */
 	VERIFY0(sigfillset(&sigmask));
 	if (sigprocmask(SIG_BLOCK, &sigmask, &osigmask) < 0) {
-		lx_debug("lx_clone sigprocmask() failed: %s", strerror(errno));
+		lx_debug("lx_clone sigprocmask() failed: %d", errno);
 		free(cs->c_lx_tsd);
 		free(cs);
 		return (-errno);

--- a/usr/src/lib/brand/lx/lx_brand/common/signal.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/signal.c
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc. All rights reserved.
+ * Copyright 2018 Joyent, Inc. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -1931,8 +1931,8 @@ lx_sigaction_common(int lx_sig, struct lx_sigaction *lxsp,
 
 			if (sigprocmask(SIG_BLOCK, &new_set, &oset) < 0) {
 				err = errno;
-				lx_debug("unable to block signal %d: %s", sig,
-				    strerror(err));
+				lx_debug("unable to block signal %d: %d",
+				    sig, err);
 				return (-err);
 			}
 
@@ -1945,8 +1945,8 @@ lx_sigaction_common(int lx_sig, struct lx_sigaction *lxsp,
 			if (sigaction(sig, NULL, &sa) < 0) {
 				err = errno;
 				lx_debug("sigaction() to get old "
-				    "disposition for signal %d failed: "
-				    "%s", sig, strerror(err));
+				    "disposition for signal %d failed: %d",
+				    sig, err);
 				(void) sigprocmask(SIG_SETMASK, &oset, NULL);
 				return (-err);
 			}
@@ -2003,7 +2003,7 @@ lx_sigaction_common(int lx_sig, struct lx_sigaction *lxsp,
 					err = errno;
 					lx_debug("sigaction() to set new "
 					    "disposition for signal %d failed: "
-					    "%s", sig, strerror(err));
+					    "%d", sig, err);
 					(void) sigprocmask(SIG_SETMASK, &oset,
 					    NULL);
 					return (-err);
@@ -2028,10 +2028,9 @@ lx_sigaction_common(int lx_sig, struct lx_sigaction *lxsp,
 
 				if (sigaction(sig, &sa, NULL) < 0) {
 					err = errno;
-					lx_debug("sigaction(%d, %s) failed: %s",
+					lx_debug("sigaction(%d, %s) failed: %d",
 					    sig, ((sa.sa_handler == SIG_DFL) ?
-					    "SIG_DFL" : "SIG_IGN"),
-					    strerror(err));
+					    "SIG_DFL" : "SIG_IGN"), err);
 					(void) sigprocmask(SIG_SETMASK, &oset,
 					    NULL);
 					return (-err);

--- a/usr/src/lib/brand/lx/lx_brand/common/stack.c
+++ b/usr/src/lib/brand/lx/lx_brand/common/stack.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -256,8 +256,7 @@ lx_alloc_stack(void **nstack, size_t *nstack_size)
 	if ((stack = mmap(NULL, stacksize, stackprot, MAP_PRIVATE |
 	    MAP_NORESERVE | MAP_ANON, -1, (off_t)0)) == MAP_FAILED) {
 		int en = errno;
-		lx_debug("lx_alloc_stack: failed to allocate stack: %s",
-		    strerror(errno));
+		lx_debug("lx_alloc_stack: failed to allocate stack: %d", errno);
 		errno = en;
 		return (-1);
 	}

--- a/usr/src/pkg/manifests/system-header.mf
+++ b/usr/src/pkg/manifests/system-header.mf
@@ -1024,6 +1024,7 @@ file path=usr/include/sys/fs/pc_label.h
 file path=usr/include/sys/fs/pc_node.h
 file path=usr/include/sys/fs/pxfs_ki.h
 file path=usr/include/sys/fs/sdev_impl.h
+file path=usr/include/sys/fs/sdev_plugin.h
 file path=usr/include/sys/fs/snode.h
 file path=usr/include/sys/fs/swapnode.h
 file path=usr/include/sys/fs/tmp.h

--- a/usr/src/uts/common/Makefile.files
+++ b/usr/src/uts/common/Makefile.files
@@ -1146,7 +1146,8 @@ DEV_OBJS  +=	sdev_subr.o	sdev_vfsops.o	sdev_vnops.o	\
 		sdev_ptsops.o	sdev_zvolops.o	sdev_comm.o	\
 		sdev_profile.o	sdev_ncache.o	sdev_netops.o	\
 		sdev_ipnetops.o	\
-		sdev_vtops.o
+		sdev_vtops.o \
+		sdev_plugin.o
 
 CTFS_OBJS +=	ctfs_all.o ctfs_cdir.o ctfs_ctl.o ctfs_event.o \
 		ctfs_latest.o ctfs_root.o ctfs_sym.o ctfs_tdir.o ctfs_tmpl.o

--- a/usr/src/uts/common/fs/dev/sdev_plugin.c
+++ b/usr/src/uts/common/fs/dev/sdev_plugin.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /*
@@ -145,6 +145,22 @@ sdev_ctx_name(sdev_ctx_t ctx)
 	return (sdp->sdev_name);
 }
 
+int
+sdev_ctx_minor(sdev_ctx_t ctx, minor_t *minorp)
+{
+	sdev_node_t *sdp = (sdev_node_t *)ctx;
+
+	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
+	ASSERT(minorp != NULL);
+	if (sdp->sdev_vnode->v_type == VCHR ||
+	    sdp->sdev_vnode->v_type == VBLK) {
+		*minorp = getminor(sdp->sdev_vnode->v_rdev);
+		return (0);
+	}
+
+	return (ENODEV);
+}
+
 /*
  * Currently we only support psasing through a single flag -- SDEV_IS_GLOBAL.
  */
@@ -155,30 +171,6 @@ sdev_ctx_flags(sdev_ctx_t ctx)
 
 	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
 	return (sdp->sdev_flags & SDEV_GLOBAL);
-}
-
-/*
- * Return some amount of private data specific to the vtype. In the case of a
- * character or block device this is the device number.
- */
-const void *
-sdev_ctx_vtype_data(sdev_ctx_t ctx)
-{
-	sdev_node_t *sdp = (sdev_node_t *)ctx;
-	void *ret;
-
-	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
-	switch (sdp->sdev_vnode->v_type) {
-	case VCHR:
-	case VBLK:
-		ret = (void *)(uintptr_t)(sdp->sdev_vnode->v_rdev);
-		break;
-	default:
-		ret = NULL;
-		break;
-	}
-
-	return (ret);
 }
 
 /*

--- a/usr/src/uts/common/fs/dev/sdev_plugin.c
+++ b/usr/src/uts/common/fs/dev/sdev_plugin.c
@@ -1,0 +1,913 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2014, Joyent, Inc. All rights reserved.
+ */
+
+/*
+ * Dynamic directory plugin interface for sdev.
+ *
+ * The sdev plugin interfaces provides a means for a dynamic directory based on
+ * in-kernel state to be simply created. Traditionally, dynamic directories were
+ * built into sdev itself. While these legacy plugins are useful, it makes more
+ * sense for these pieces of functionality to live with the individual drivers.
+ *
+ * The plugin interface requires folks to implement three interfaces and
+ * provides a series of callbacks that can be made in the context of those
+ * interfaces to interrogate the sdev_node_t without having to leak
+ * implementation details of the sdev_node_t. These interfaces are:
+ *
+ *   o spo_validate
+ *
+ *   Given a particular node, answer the question as to whether or not this
+ *   entry is still valid. Here, plugins should use the name and the dev_t
+ *   associated with the node to verify that it matches something that still
+ *   exists.
+ *
+ *   o spo_filldir
+ *
+ *   Fill all the entries inside of a directory. Note that some of these entries
+ *   may already exist.
+ *
+ *   o spo_inactive
+ *
+ *   The given node is no longer being used. This allows the consumer to
+ *   potentially tear down anything that was being held open related to this.
+ *   Note that this only fires when the given sdev_node_t becomes a zombie.
+ *
+ * During these callbacks a consumer is not allowed to register or unregister a
+ * plugin, especially their own. They may call the sdev_ctx style functions. All
+ * callbacks fire in a context where blocking is allowed (eg. the spl is below
+ * LOCK_LEVEL).
+ *
+ * When a plugin is added, we create its directory in the global zone. By doing
+ * that, we ensure that something isn't already there and that nothing else can
+ * come along and try and create something without our knowledge. We only have
+ * to create it in the GZ and not for all other instances of sdev because an
+ * instance of sdev that isn't at /dev does not have dynamic directories, and
+ * second, any instance of sdev present in a non-global zone cannot create
+ * anything, therefore we know that by it not being in the global zone's
+ * instance of sdev that we're good to go.
+ *
+ * Lock Ordering
+ * -------------
+ *
+ * The global sdev_plugin_lock must be held before any of the individual
+ * sdev_plugin_t`sp_lock. Further, once any plugin related lock has been held,
+ * it is not legal to take any holds on any sdev_node_t or to grab the
+ * sdev_node_t`contents_lock in any way.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/fs/sdev_impl.h>
+#include <sys/fs/sdev_plugin.h>
+#include <fs/fs_subr.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/ksynch.h>
+#include <sys/sysmacros.h>
+#include <sys/list.h>
+#include <sys/ctype.h>
+
+kmutex_t sdev_plugin_lock;
+list_t sdev_plugin_list;
+kmem_cache_t *sdev_plugin_cache;
+struct vnodeops *sdev_plugin_vnops;
+
+#define	SDEV_PLUGIN_NAMELEN	64
+
+typedef struct sdev_plugin {
+	list_node_t sp_link;
+	char sp_name[SDEV_PLUGIN_NAMELEN];	/* E */
+	int sp_nflags;				/* E */
+	struct vnodeops *sp_vnops;		/* E */
+	sdev_plugin_ops_t *sp_pops;		/* E */
+	boolean_t sp_islegacy;			/* E */
+	int (*sp_lvtor)(sdev_node_t *);		/* E */
+	kmutex_t sp_lock;			/* Protects everything below */
+	kcondvar_t sp_nodecv;
+	size_t sp_nnodes;
+} sdev_plugin_t;
+
+/* ARGSUSED */
+static int
+sdev_plugin_cache_constructor(void *buf, void *arg, int tags)
+{
+	sdev_plugin_t *spp = buf;
+	mutex_init(&spp->sp_lock, NULL, MUTEX_DRIVER, 0);
+	cv_init(&spp->sp_nodecv, NULL, CV_DRIVER, NULL);
+	return (0);
+}
+
+/* ARGSUSED */
+static void
+sdev_plugin_cache_destructor(void *buf, void *arg)
+{
+	sdev_plugin_t *spp = buf;
+	cv_destroy(&spp->sp_nodecv);
+	mutex_destroy(&spp->sp_lock);
+}
+
+enum vtype
+sdev_ctx_vtype(sdev_ctx_t ctx)
+{
+	sdev_node_t *sdp = (sdev_node_t *)ctx;
+
+	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
+	return (sdp->sdev_vnode->v_type);
+}
+
+const char *
+sdev_ctx_path(sdev_ctx_t ctx)
+{
+	sdev_node_t *sdp = (sdev_node_t *)ctx;
+
+	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
+	return (sdp->sdev_path);
+}
+
+const char *
+sdev_ctx_name(sdev_ctx_t ctx)
+{
+	sdev_node_t *sdp = (sdev_node_t *)ctx;
+
+	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
+	return (sdp->sdev_name);
+}
+
+/*
+ * Currently we only support psasing through a single flag -- SDEV_IS_GLOBAL.
+ */
+sdev_ctx_flags_t
+sdev_ctx_flags(sdev_ctx_t ctx)
+{
+	sdev_node_t *sdp = (sdev_node_t *)ctx;
+
+	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
+	return (sdp->sdev_flags & SDEV_GLOBAL);
+}
+
+/*
+ * Return some amount of private data specific to the vtype. In the case of a
+ * character or block device this is the device number.
+ */
+const void *
+sdev_ctx_vtype_data(sdev_ctx_t ctx)
+{
+	sdev_node_t *sdp = (sdev_node_t *)ctx;
+	void *ret;
+
+	ASSERT(RW_LOCK_HELD(&sdp->sdev_contents));
+	switch (sdp->sdev_vnode->v_type) {
+	case VCHR:
+	case VBLK:
+		ret = (void *)(uintptr_t)(sdp->sdev_vnode->v_rdev);
+		break;
+	default:
+		ret = NULL;
+		break;
+	}
+
+	return (ret);
+}
+
+/*
+ * Use the same rules as zones for a name. isalphanum + '-', '_', and '.'.
+ */
+static int
+sdev_plugin_name_isvalid(const char *c, int buflen)
+{
+	int i;
+
+	for (i = 0; i < buflen; i++, c++) {
+		if (*c == '\0')
+			return (1);
+
+		if (!ISALNUM(*c) && *c != '-' && *c != '_' && *c != '.')
+			return (0);
+	}
+	/* Never found a null terminator */
+	return (0);
+}
+
+static int
+sdev_plugin_mknode(sdev_plugin_t *spp, sdev_node_t *sdvp, char *name,
+    vattr_t *vap)
+{
+	int ret;
+	sdev_node_t *svp;
+
+	ASSERT(RW_WRITE_HELD(&sdvp->sdev_contents));
+	ASSERT(spp != NULL);
+	svp = sdev_cache_lookup(sdvp, name);
+	if (svp != NULL) {
+		SDEV_SIMPLE_RELE(svp);
+		return (EEXIST);
+	}
+
+	ret = sdev_mknode(sdvp, name, &svp, vap, NULL, NULL, kcred,
+	    SDEV_READY);
+	if (ret != 0)
+		return (ret);
+	SDEV_SIMPLE_RELE(svp);
+
+	return (0);
+}
+
+/*
+ * Plugin node creation callbacks
+ */
+int
+sdev_plugin_mkdir(sdev_ctx_t ctx, char *name)
+{
+	sdev_node_t *sdvp;
+	timestruc_t now;
+	struct vattr vap;
+
+	if (sdev_plugin_name_isvalid(name, SDEV_PLUGIN_NAMELEN) == 0)
+		return (EINVAL);
+
+	sdvp = (sdev_node_t *)ctx;
+	ASSERT(sdvp->sdev_private != NULL);
+	ASSERT(RW_WRITE_HELD(&sdvp->sdev_contents));
+
+	vap = *sdev_getdefault_attr(VDIR);
+	gethrestime(&now);
+	vap.va_atime = now;
+	vap.va_mtime = now;
+	vap.va_ctime = now;
+
+	return (sdev_plugin_mknode(sdvp->sdev_private, sdvp, name, &vap));
+}
+
+int
+sdev_plugin_mknod(sdev_ctx_t ctx, char *name, mode_t mode, dev_t dev)
+{
+	sdev_node_t *sdvp;
+	timestruc_t now;
+	struct vattr vap;
+
+	if (sdev_plugin_name_isvalid(name, SDEV_PLUGIN_NAMELEN) == 0)
+		return (EINVAL);
+
+	sdvp = (sdev_node_t *)ctx;
+	ASSERT(RW_WRITE_HELD(&sdvp->sdev_contents));
+	if (mode != S_IFCHR && mode != S_IFBLK)
+		return (EINVAL);
+
+	ASSERT(sdvp->sdev_private != NULL);
+
+	vap = *sdev_getdefault_attr(mode == S_IFCHR ? VCHR : VBLK);
+	gethrestime(&now);
+	vap.va_atime = now;
+	vap.va_mtime = now;
+	vap.va_ctime = now;
+	vap.va_rdev = dev;
+	vap.va_mode = mode | 0666;
+
+	/* Despite the similar name, this is in fact a different function */
+	return (sdev_plugin_mknode(sdvp->sdev_private, sdvp, name, &vap));
+
+}
+
+static int
+sdev_plugin_validate(sdev_node_t *sdp)
+{
+	int ret;
+	sdev_plugin_t *spp;
+
+	ASSERT(sdp->sdev_private != NULL);
+	spp = sdp->sdev_private;
+	ASSERT(spp->sp_islegacy == B_FALSE);
+	ASSERT(spp->sp_pops != NULL);
+	rw_enter(&sdp->sdev_contents, RW_READER);
+	ret = spp->sp_pops->spo_validate((uintptr_t)sdp);
+	rw_exit(&sdp->sdev_contents);
+	return (ret);
+}
+
+static void
+sdev_plugin_validate_dir(sdev_node_t *sdvp)
+{
+	int ret;
+	sdev_node_t *svp, *next;
+
+	ASSERT(RW_WRITE_HELD(&sdvp->sdev_contents));
+
+	for (svp = SDEV_FIRST_ENTRY(sdvp); svp != NULL; svp = next) {
+
+		next = SDEV_NEXT_ENTRY(sdvp, svp);
+		ASSERT(svp->sdev_state != SDEV_ZOMBIE);
+		/* skip nodes that aren't ready */
+		if (svp->sdev_state == SDEV_INIT)
+			continue;
+
+		switch (sdev_plugin_validate(svp)) {
+		case SDEV_VTOR_VALID:
+		case SDEV_VTOR_SKIP:
+			continue;
+		case SDEV_VTOR_INVALID:
+		case SDEV_VTOR_STALE:
+			break;
+		}
+
+		SDEV_HOLD(svp);
+
+		/*
+		 * Clean out everything underneath this node before we
+		 * remove it.
+		 */
+		if (svp->sdev_vnode->v_type == VDIR) {
+			ret = sdev_cleandir(svp, NULL, 0);
+			ASSERT(ret == 0);
+		}
+		/* remove the cache node */
+		(void) sdev_cache_update(sdvp, &svp, svp->sdev_name,
+		    SDEV_CACHE_DELETE);
+		SDEV_RELE(svp);
+	}
+}
+
+/* ARGSUSED */
+static int
+sdev_plugin_vop_readdir(struct vnode *dvp, struct uio *uiop, struct cred *cred,
+    int *eofp, caller_context_t *ct_unused, int flags_unused)
+{
+	int ret;
+	sdev_node_t *sdvp = VTOSDEV(dvp);
+	sdev_plugin_t *spp;
+
+	ASSERT(RW_READ_HELD(&sdvp->sdev_contents));
+
+	/* Sanity check we're not a zombie before we do anyting else */
+	if (sdvp->sdev_state == SDEV_ZOMBIE)
+		return (ENOENT);
+
+	spp = sdvp->sdev_private;
+	ASSERT(spp != NULL);
+	ASSERT(spp->sp_islegacy == B_FALSE);
+	ASSERT(spp->sp_pops != NULL);
+
+	if (crgetzoneid(cred) == GLOBAL_ZONEID && !SDEV_IS_GLOBAL(sdvp))
+		return (EPERM);
+
+	if (uiop->uio_offset == 0) {
+		/*
+		 * We upgrade to a write lock and grab the plugin's lock along
+		 * the way. We're almost certainly going to get creation
+		 * callbacks, so this is the only safe way to go.
+		 */
+		if (rw_tryupgrade(&sdvp->sdev_contents) == 0) {
+			rw_exit(&sdvp->sdev_contents);
+			rw_enter(&sdvp->sdev_contents, RW_WRITER);
+			if (sdvp->sdev_state == SDEV_ZOMBIE) {
+				rw_downgrade(&sdvp->sdev_contents);
+				return (ENOENT);
+			}
+		}
+
+		sdev_plugin_validate_dir(sdvp);
+		ret = spp->sp_pops->spo_filldir((uintptr_t)sdvp);
+		rw_downgrade(&sdvp->sdev_contents);
+		if (ret != 0)
+			return (ret);
+	}
+
+	return (devname_readdir_func(dvp, uiop, cred, eofp, 0));
+}
+
+/*
+ * If we don't have a callback function that returns a failure, then sdev will
+ * try to create a node for us which violates all of our basic assertions. To
+ * work around that we create our own callback for devname_lookup_func which
+ * always returns ENOENT as at this point either it was created with the filldir
+ * callback or it was not.
+ */
+/*ARGSUSED*/
+static int
+sdev_plugin_vop_lookup_cb(sdev_node_t *ddv, char *nm, void **arg, cred_t *cred,
+    void *unused, char *unused2)
+{
+	return (ENOENT);
+}
+
+/* ARGSUSED */
+static int
+sdev_plugin_vop_lookup(struct vnode *dvp, char *nm, struct vnode **vpp,
+    struct pathname *pnp, int flags, struct vnode *rdir, struct cred *cred,
+    caller_context_t *ct, int *direntflags, pathname_t *realpnp)
+{
+	int ret;
+	sdev_node_t *sdvp;
+	sdev_plugin_t *spp;
+
+	/* execute access is required to search the directory */
+	if ((ret = VOP_ACCESS(dvp, VEXEC, 0, cred, ct)) != 0)
+		return (ret);
+
+	sdvp = VTOSDEV(dvp);
+	spp = sdvp->sdev_private;
+	ASSERT(spp != NULL);
+	ASSERT(spp->sp_islegacy == B_FALSE);
+	ASSERT(spp->sp_pops != NULL);
+
+	if (crgetzoneid(cred) == GLOBAL_ZONEID && !SDEV_IS_GLOBAL(sdvp))
+		return (EPERM);
+
+	/*
+	 * Go straight for the write lock.
+	 */
+	rw_enter(&sdvp->sdev_contents, RW_WRITER);
+	if (sdvp->sdev_state == SDEV_ZOMBIE) {
+		rw_exit(&sdvp->sdev_contents);
+		return (ENOENT);
+	}
+	sdev_plugin_validate_dir(sdvp);
+	ret = spp->sp_pops->spo_filldir((uintptr_t)sdvp);
+	rw_exit(&sdvp->sdev_contents);
+	if (ret != 0)
+		return (ret);
+
+	return (devname_lookup_func(sdvp, nm, vpp, cred,
+	    sdev_plugin_vop_lookup_cb, SDEV_VATTR));
+}
+
+/*
+ * sdev is not a good citizen. We get inactive callbacks whenever a vnode goes
+ * to zero, but isn't necessairily a zombie yet. As such, to make things easier
+ * for users, we only fire the inactive callback when the node becomes a zombie
+ * and thus will be torn down here.
+ */
+static void
+sdev_plugin_vop_inactive_cb(struct vnode *dvp)
+{
+	sdev_node_t *sdp = VTOSDEV(dvp);
+	sdev_plugin_t *spp = sdp->sdev_private;
+
+	rw_enter(&sdp->sdev_contents, RW_READER);
+	if (sdp->sdev_state != SDEV_ZOMBIE) {
+		rw_exit(&sdp->sdev_contents);
+		return;
+	}
+	spp->sp_pops->spo_inactive((uintptr_t)sdp);
+	mutex_enter(&spp->sp_lock);
+	VERIFY(spp->sp_nnodes > 0);
+	spp->sp_nnodes--;
+	cv_signal(&spp->sp_nodecv);
+	mutex_exit(&spp->sp_lock);
+	rw_exit(&sdp->sdev_contents);
+}
+
+/*ARGSUSED*/
+static void
+sdev_plugin_vop_inactive(struct vnode *dvp, struct cred *cred,
+    caller_context_t *ct)
+{
+	sdev_node_t *sdp = VTOSDEV(dvp);
+	sdev_plugin_t *spp = sdp->sdev_private;
+	ASSERT(sdp->sdev_private != NULL);
+	ASSERT(spp->sp_islegacy == B_FALSE);
+	devname_inactive_func(dvp, cred, sdev_plugin_vop_inactive_cb);
+}
+
+const fs_operation_def_t sdev_plugin_vnodeops_tbl[] = {
+	VOPNAME_READDIR,	{ .vop_readdir = sdev_plugin_vop_readdir },
+	VOPNAME_LOOKUP,		{ .vop_lookup = sdev_plugin_vop_lookup },
+	VOPNAME_INACTIVE,	{ .vop_inactive = sdev_plugin_vop_inactive },
+	VOPNAME_CREATE,		{ .error = fs_nosys },
+	VOPNAME_REMOVE,		{ .error = fs_nosys },
+	VOPNAME_MKDIR,		{ .error = fs_nosys },
+	VOPNAME_RMDIR,		{ .error = fs_nosys },
+	VOPNAME_SYMLINK,	{ .error = fs_nosys },
+	VOPNAME_SETSECATTR,	{ .error = fs_nosys },
+	NULL,			NULL
+};
+
+/*
+ * construct a new template with overrides from vtab
+ */
+static fs_operation_def_t *
+sdev_merge_vtab(const fs_operation_def_t tab[])
+{
+	fs_operation_def_t *new;
+	const fs_operation_def_t *tab_entry;
+
+	/* make a copy of standard vnode ops table */
+	new = kmem_alloc(sdev_vnodeops_tbl_size, KM_SLEEP);
+	bcopy((void *)sdev_vnodeops_tbl, new, sdev_vnodeops_tbl_size);
+
+	/* replace the overrides from tab */
+	for (tab_entry = tab; tab_entry->name != NULL; tab_entry++) {
+		fs_operation_def_t *std_entry = new;
+		while (std_entry->name) {
+			if (strcmp(tab_entry->name, std_entry->name) == 0) {
+				std_entry->func = tab_entry->func;
+				break;
+			}
+			std_entry++;
+		}
+	}
+
+	return (new);
+}
+
+/* free memory allocated by sdev_merge_vtab */
+static void
+sdev_free_vtab(fs_operation_def_t *new)
+{
+	kmem_free(new, sdev_vnodeops_tbl_size);
+}
+
+/*
+ * Register a new plugin.
+ */
+sdev_plugin_hdl_t
+sdev_plugin_register(const char *name, sdev_plugin_ops_t *ops, int *errp)
+{
+	int ret, err;
+	sdev_plugin_t *spp, *iter;
+	vnode_t *vp, *nvp;
+	sdev_node_t *sdp, *slp;
+	timestruc_t now;
+	struct vattr vap;
+
+	/*
+	 * Some consumers don't care about why they failed. To keep the code
+	 * simple, we'll just pretend they gave us something.
+	 */
+	if (errp == NULL)
+		errp = &err;
+
+	if (sdev_plugin_name_isvalid(name, SDEV_PLUGIN_NAMELEN) == 0) {
+		*errp = EINVAL;
+		return (NULL);
+	}
+
+	if (ops->spo_version != 1) {
+		*errp = EINVAL;
+		return (NULL);
+	}
+
+	if (ops->spo_validate == NULL || ops->spo_filldir == NULL ||
+	    ops->spo_inactive == NULL) {
+		*errp = EINVAL;
+		return (NULL);
+	}
+
+	if ((ops->spo_flags & ~SDEV_PLUGIN_FLAGS_MASK) != 0) {
+		*errp = EINVAL;
+		return (NULL);
+	}
+
+	spp = kmem_cache_alloc(sdev_plugin_cache, KM_SLEEP);
+	(void) strlcpy(spp->sp_name, name, SDEV_PLUGIN_NAMELEN);
+
+	spp->sp_pops = ops;
+	spp->sp_nflags = SDEV_DYNAMIC | SDEV_VTOR;
+	if (ops->spo_flags & SDEV_PLUGIN_NO_NCACHE)
+		spp->sp_nflags |= SDEV_NO_NCACHE;
+	if (ops->spo_flags & SDEV_PLUGIN_SUBDIR)
+		spp->sp_nflags |= SDEV_SUBDIR;
+	spp->sp_vnops = sdev_plugin_vnops;
+	spp->sp_islegacy = B_FALSE;
+	spp->sp_lvtor = NULL;
+	spp->sp_nnodes = 0;
+
+	/*
+	 * Make sure it's unique, nothing exists with this name already, and add
+	 * it to the list. We also need to go through and grab the sdev
+	 * root node as we cannot grab any sdev node locks once we've grabbed
+	 * the sdev_plugin_lock. We effectively assert that if a directory is
+	 * not present in the GZ's /dev, then it doesn't exist in any of the
+	 * local zones.
+	 */
+	ret = vn_openat("/dev", UIO_SYSSPACE, FREAD, 0, &vp, 0, 0, rootdir, -1);
+	if (ret != 0) {
+		*errp = ret;
+		kmem_cache_free(sdev_plugin_cache, spp);
+		return (NULL);
+	}
+	/* Make sure we have the real vnode */
+	if (VOP_REALVP(vp, &nvp, NULL) == 0) {
+		VN_HOLD(nvp);
+		VN_RELE(vp);
+		vp = nvp;
+		nvp = NULL;
+	}
+	VERIFY(vp->v_op == sdev_vnodeops);
+	sdp = VTOSDEV(vp);
+	rw_enter(&sdp->sdev_contents, RW_WRITER);
+	slp = sdev_cache_lookup(sdp, spp->sp_name);
+	if (slp != NULL) {
+		SDEV_RELE(slp);
+		rw_exit(&sdp->sdev_contents);
+		VN_RELE(vp);
+		*errp = EEXIST;
+		kmem_cache_free(sdev_plugin_cache, spp);
+		return (NULL);
+	}
+
+	mutex_enter(&sdev_plugin_lock);
+	for (iter = list_head(&sdev_plugin_list); iter != NULL;
+	    iter = list_next(&sdev_plugin_list, iter)) {
+		if (strcmp(spp->sp_name, iter->sp_name) == 0) {
+			mutex_exit(&sdev_plugin_lock);
+			rw_exit(&sdp->sdev_contents);
+			VN_RELE(vp);
+			*errp = EEXIST;
+			kmem_cache_free(sdev_plugin_cache, spp);
+			return (NULL);
+		}
+	}
+
+	list_insert_tail(&sdev_plugin_list, spp);
+	mutex_exit(&sdev_plugin_lock);
+
+	/*
+	 * Now go ahead and create the top level directory for the global zone.
+	 */
+	vap = *sdev_getdefault_attr(VDIR);
+	gethrestime(&now);
+	vap.va_atime = now;
+	vap.va_mtime = now;
+	vap.va_ctime = now;
+
+	(void) sdev_plugin_mknode(spp, sdp, spp->sp_name, &vap);
+
+	rw_exit(&sdp->sdev_contents);
+	VN_RELE(vp);
+
+	return ((sdev_plugin_hdl_t)spp);
+}
+
+static void
+sdev_plugin_unregister_cb(sdev_node_t *rdp, void *arg)
+{
+	sdev_plugin_t *spp = arg;
+	sdev_node_t *sdp;
+
+	rw_enter(&rdp->sdev_contents, RW_WRITER);
+	sdp = sdev_cache_lookup(rdp, spp->sp_name);
+	/* If it doesn't exist, we're done here */
+	if (sdp == NULL) {
+		rw_exit(&rdp->sdev_contents);
+		return;
+	}
+
+	/*
+	 * We first delete the directory before recursively marking everything
+	 * else stale. This ordering should ensure that we don't accidentally
+	 * miss anything.
+	 */
+	sdev_cache_update(rdp, &sdp, spp->sp_name, SDEV_CACHE_DELETE);
+	sdev_stale(sdp);
+	SDEV_RELE(sdp);
+	rw_exit(&rdp->sdev_contents);
+}
+
+/*
+ * Remove a plugin. This will block until everything has become a zombie, thus
+ * guaranteeing the caller that nothing will call into them again once this call
+ * returns. While the call is ongoing, it could be called into. Note that while
+ * this is ongoing, it will block other mounts.
+ */
+int
+sdev_plugin_unregister(sdev_plugin_hdl_t hdl)
+{
+	sdev_plugin_t *spp = (sdev_plugin_t *)hdl;
+	if (spp->sp_islegacy)
+		return (EINVAL);
+
+	mutex_enter(&sdev_plugin_lock);
+	list_remove(&sdev_plugin_list, spp);
+	mutex_exit(&sdev_plugin_lock);
+
+	sdev_mnt_walk(sdev_plugin_unregister_cb, spp);
+	mutex_enter(&spp->sp_lock);
+	while (spp->sp_nnodes > 0)
+		cv_wait(&spp->sp_nodecv, &spp->sp_lock);
+	mutex_exit(&spp->sp_lock);
+	kmem_cache_free(sdev_plugin_cache, spp);
+	return (0);
+}
+
+/*
+ * Register an old sdev style plugin to deal with what used to be in the vtab.
+ */
+static int
+sdev_plugin_register_legacy(struct sdev_vop_table *vtp)
+{
+	sdev_plugin_t *spp;
+
+	spp = kmem_cache_alloc(sdev_plugin_cache, KM_SLEEP);
+	(void) strlcpy(spp->sp_name, vtp->vt_name, SDEV_PLUGIN_NAMELEN);
+	spp->sp_islegacy = B_TRUE;
+	spp->sp_pops = NULL;
+	spp->sp_nflags = vtp->vt_flags;
+	spp->sp_lvtor = vtp->vt_vtor;
+	spp->sp_nnodes = 0;
+
+	if (vtp->vt_service != NULL) {
+		fs_operation_def_t *templ;
+		templ = sdev_merge_vtab(vtp->vt_service);
+		if (vn_make_ops(vtp->vt_name,
+		    (const fs_operation_def_t *)templ,
+		    &spp->sp_vnops) != 0) {
+			cmn_err(CE_WARN, "%s: malformed vnode ops\n",
+			    vtp->vt_name);
+			sdev_free_vtab(templ);
+			kmem_cache_free(sdev_plugin_cache, spp);
+			return (1);
+		}
+
+		if (vtp->vt_global_vops) {
+			*(vtp->vt_global_vops) = spp->sp_vnops;
+		}
+
+		sdev_free_vtab(templ);
+	} else {
+		spp->sp_vnops = sdev_vnodeops;
+	}
+
+	/*
+	 * No need to check for EEXIST here. These are loaded as a part of the
+	 * sdev's initialization function. Further, we don't have to create them
+	 * as that's taken care of in sdev's mount for the GZ.
+	 */
+	mutex_enter(&sdev_plugin_lock);
+	list_insert_tail(&sdev_plugin_list, spp);
+	mutex_exit(&sdev_plugin_lock);
+
+	return (0);
+}
+
+/*
+ * We need to match off of the sdev_path, not the sdev_name. We are only allowed
+ * to exist directly under /dev.
+ */
+static sdev_plugin_t *
+sdev_match(sdev_node_t *dv)
+{
+	int vlen;
+	const char *path;
+	sdev_plugin_t *spp;
+
+	if (strlen(dv->sdev_path) <= 5)
+		return (NULL);
+
+	if (strncmp(dv->sdev_path, "/dev/", 5) != 0)
+		return (NULL);
+	path = dv->sdev_path + 5;
+
+	mutex_enter(&sdev_plugin_lock);
+
+	for (spp = list_head(&sdev_plugin_list); spp != NULL;
+	    spp = list_next(&sdev_plugin_list, spp)) {
+		if (strcmp(spp->sp_name, path) == 0) {
+			mutex_exit(&sdev_plugin_lock);
+			return (spp);
+		}
+
+		if (spp->sp_nflags & SDEV_SUBDIR) {
+			vlen = strlen(spp->sp_name);
+			if ((strncmp(spp->sp_name, path,
+			    vlen - 1) == 0) && path[vlen] == '/') {
+				mutex_exit(&sdev_plugin_lock);
+				return (spp);
+			}
+
+		}
+	}
+
+	mutex_exit(&sdev_plugin_lock);
+	return (NULL);
+}
+
+void
+sdev_set_no_negcache(sdev_node_t *dv)
+{
+	char *path;
+	sdev_plugin_t *spp;
+
+	ASSERT(dv->sdev_path);
+	path = dv->sdev_path + strlen("/dev/");
+
+	mutex_enter(&sdev_plugin_lock);
+	for (spp = list_head(&sdev_plugin_list); spp != NULL;
+	    spp = list_next(&sdev_plugin_list, spp)) {
+		if (strcmp(spp->sp_name, path) == 0) {
+			if (spp->sp_nflags & SDEV_NO_NCACHE)
+				dv->sdev_flags |= SDEV_NO_NCACHE;
+			break;
+		}
+	}
+	mutex_exit(&sdev_plugin_lock);
+}
+
+struct vnodeops *
+sdev_get_vop(sdev_node_t *dv)
+{
+	char *path;
+	sdev_plugin_t *spp;
+
+	path = dv->sdev_path;
+	ASSERT(path);
+
+	/* gets the relative path to /dev/ */
+	path += 5;
+
+	if ((spp = sdev_match(dv)) != NULL) {
+		dv->sdev_flags |= spp->sp_nflags;
+		if (SDEV_IS_PERSIST(dv->sdev_dotdot) &&
+		    (SDEV_IS_PERSIST(dv) || !SDEV_IS_DYNAMIC(dv)))
+			dv->sdev_flags |= SDEV_PERSIST;
+		return (spp->sp_vnops);
+	}
+
+	/* child inherits the persistence of the parent */
+	if (SDEV_IS_PERSIST(dv->sdev_dotdot))
+		dv->sdev_flags |= SDEV_PERSIST;
+	return (sdev_vnodeops);
+}
+
+void *
+sdev_get_vtor(sdev_node_t *dv)
+{
+	sdev_plugin_t *spp;
+
+	if (dv->sdev_private == NULL) {
+		spp = sdev_match(dv);
+		if (spp == NULL)
+			return (NULL);
+	} else {
+		spp = dv->sdev_private;
+	}
+
+	if (spp->sp_islegacy)
+		return ((void *)spp->sp_lvtor);
+	else
+		return ((void *)sdev_plugin_validate);
+}
+
+void
+sdev_plugin_nodeready(sdev_node_t *sdp)
+{
+	sdev_plugin_t *spp;
+
+	ASSERT(RW_WRITE_HELD(&sdp->sdev_contents));
+	ASSERT(sdp->sdev_private == NULL);
+
+	spp = sdev_match(sdp);
+	if (spp == NULL)
+		return;
+	if (spp->sp_islegacy)
+		return;
+	sdp->sdev_private = spp;
+	mutex_enter(&spp->sp_lock);
+	spp->sp_nnodes++;
+	mutex_exit(&spp->sp_lock);
+}
+
+int
+sdev_plugin_init(void)
+{
+	sdev_vop_table_t *vtp;
+	fs_operation_def_t *templ;
+
+	sdev_plugin_cache = kmem_cache_create("sdev_plugin",
+	    sizeof (sdev_plugin_t), 0, sdev_plugin_cache_constructor,
+	    sdev_plugin_cache_destructor, NULL, NULL, NULL, 0);
+	if (sdev_plugin_cache == NULL)
+		return (1);
+	mutex_init(&sdev_plugin_lock, NULL, MUTEX_DRIVER, NULL);
+	list_create(&sdev_plugin_list, sizeof (sdev_plugin_t),
+	    offsetof(sdev_plugin_t, sp_link));
+
+	/*
+	 * Register all of the legacy vnops
+	 */
+	for (vtp = &vtab[0]; vtp->vt_name != NULL; vtp++)
+		if (sdev_plugin_register_legacy(vtp) != 0)
+			return (1);
+
+	templ = sdev_merge_vtab(sdev_plugin_vnodeops_tbl);
+	if (vn_make_ops("sdev_plugin",
+	    (const fs_operation_def_t *)templ,
+	    &sdev_plugin_vnops) != 0) {
+		sdev_free_vtab(templ);
+		return (1);
+	}
+
+	sdev_free_vtab(templ);
+	return (0);
+}

--- a/usr/src/uts/common/fs/dev/sdev_subr.c
+++ b/usr/src/uts/common/fs/dev/sdev_subr.c
@@ -151,12 +151,6 @@ vattr_t sdev_vattr_chr = {
 kmem_cache_t	*sdev_node_cache;	/* sdev_node cache */
 int		devtype;		/* fstype */
 
-/* static */
-static struct vnodeops *sdev_get_vop(struct sdev_node *);
-static void sdev_set_no_negcache(struct sdev_node *);
-static fs_operation_def_t *sdev_merge_vtab(const fs_operation_def_t []);
-static void sdev_free_vtab(fs_operation_def_t *);
-
 static void
 sdev_prof_free(struct sdev_node *dv)
 {
@@ -314,6 +308,7 @@ sdev_nodeinit(struct sdev_node *ddv, char *nm, struct sdev_node **newdv,
 	(void) snprintf(dv->sdev_path, len, "%s/%s", ddv->sdev_path, nm);
 	/* overwritten for VLNK nodes */
 	dv->sdev_symlink = NULL;
+	list_link_init(&dv->sdev_plist);
 
 	vp = SDEVTOV(dv);
 	vn_reinit(vp);
@@ -402,6 +397,7 @@ sdev_nodeready(struct sdev_node *dv, struct vattr *vap, struct vnode *avp,
 	} else {
 		dv->sdev_nlink = 1;
 	}
+	sdev_plugin_nodeready(dv);
 
 	if (!(SDEV_IS_GLOBAL(dv))) {
 		dv->sdev_origin = (struct sdev_node *)args;
@@ -498,37 +494,22 @@ sdev_mkroot(struct vfs *vfsp, dev_t devdev, struct vnode *mvp,
 	return (dv);
 }
 
-/* directory dependent vop table */
-struct sdev_vop_table {
-	char *vt_name;				/* subdirectory name */
-	const fs_operation_def_t *vt_service;	/* vnodeops table */
-	struct vnodeops *vt_vops;		/* constructed vop */
-	struct vnodeops **vt_global_vops;	/* global container for vop */
-	int (*vt_vtor)(struct sdev_node *);	/* validate sdev_node */
-	int vt_flags;
-};
-
-/*
- * A nice improvement would be to provide a plug-in mechanism
- * for this table instead of a const table.
- */
-static struct sdev_vop_table vtab[] =
-{
-	{ "pts", devpts_vnodeops_tbl, NULL, &devpts_vnodeops, devpts_validate,
+struct sdev_vop_table vtab[] = {
+	{ "pts", devpts_vnodeops_tbl, &devpts_vnodeops, devpts_validate,
 	SDEV_DYNAMIC | SDEV_VTOR },
 
-	{ "vt", devvt_vnodeops_tbl, NULL, &devvt_vnodeops, devvt_validate,
+	{ "vt", devvt_vnodeops_tbl, &devvt_vnodeops, devvt_validate,
 	SDEV_DYNAMIC | SDEV_VTOR },
 
-	{ "zvol", devzvol_vnodeops_tbl, NULL, &devzvol_vnodeops,
+	{ "zvol", devzvol_vnodeops_tbl, &devzvol_vnodeops,
 	devzvol_validate, SDEV_ZONED | SDEV_DYNAMIC | SDEV_VTOR | SDEV_SUBDIR },
 
-	{ "zcons", NULL, NULL, NULL, NULL, SDEV_NO_NCACHE },
+	{ "zcons", NULL, NULL, NULL, SDEV_NO_NCACHE },
 
-	{ "net", devnet_vnodeops_tbl, NULL, &devnet_vnodeops, devnet_validate,
+	{ "net", devnet_vnodeops_tbl, &devnet_vnodeops, devnet_validate,
 	SDEV_DYNAMIC | SDEV_VTOR },
 
-	{ "ipnet", devipnet_vnodeops_tbl, NULL, &devipnet_vnodeops,
+	{ "ipnet", devipnet_vnodeops_tbl, &devipnet_vnodeops,
 	devipnet_validate, SDEV_DYNAMIC | SDEV_VTOR | SDEV_NO_NCACHE },
 
 	/*
@@ -543,132 +524,14 @@ static struct sdev_vop_table vtab[] =
 	 * preventing a mkdir.
 	 */
 
-	{ "lofi", NULL, NULL, NULL, NULL,
+	{ "lofi", NULL, NULL, NULL,
 	    SDEV_ZONED | SDEV_DYNAMIC | SDEV_PERSIST },
-	{ "rlofi", NULL, NULL, NULL, NULL,
+	{ "rlofi", NULL, NULL, NULL,
 	    SDEV_ZONED | SDEV_DYNAMIC | SDEV_PERSIST },
 
-	{ NULL, NULL, NULL, NULL, NULL, 0}
+	{ NULL, NULL, NULL, NULL, 0}
 };
 
-/*
- * We need to match off of the sdev_path, not the sdev_name. We are only allowed
- * to exist directly under /dev.
- */
-struct sdev_vop_table *
-sdev_match(struct sdev_node *dv)
-{
-	int vlen;
-	int i;
-	const char *path;
-
-	if (strlen(dv->sdev_path) <= 5)
-		return (NULL);
-
-	if (strncmp(dv->sdev_path, "/dev/", 5) != 0)
-		return (NULL);
-	path = dv->sdev_path + 5;
-
-	for (i = 0; vtab[i].vt_name; i++) {
-		if (strcmp(vtab[i].vt_name, path) == 0)
-			return (&vtab[i]);
-		if (vtab[i].vt_flags & SDEV_SUBDIR) {
-			vlen = strlen(vtab[i].vt_name);
-			if ((strncmp(vtab[i].vt_name, path,
-			    vlen - 1) == 0) && path[vlen] == '/')
-				return (&vtab[i]);
-		}
-
-	}
-	return (NULL);
-}
-
-/*
- *  sets a directory's vnodeops if the directory is in the vtab;
- */
-static struct vnodeops *
-sdev_get_vop(struct sdev_node *dv)
-{
-	struct sdev_vop_table *vtp;
-	char *path;
-
-	path = dv->sdev_path;
-	ASSERT(path);
-
-	/* gets the relative path to /dev/ */
-	path += 5;
-
-	/* gets the vtab entry it matches */
-	if ((vtp = sdev_match(dv)) != NULL) {
-		dv->sdev_flags |= vtp->vt_flags;
-		if (SDEV_IS_PERSIST(dv->sdev_dotdot) &&
-		    (SDEV_IS_PERSIST(dv) || !SDEV_IS_DYNAMIC(dv)))
-			dv->sdev_flags |= SDEV_PERSIST;
-
-		if (vtp->vt_vops) {
-			if (vtp->vt_global_vops)
-				*(vtp->vt_global_vops) = vtp->vt_vops;
-
-			return (vtp->vt_vops);
-		}
-
-		if (vtp->vt_service) {
-			fs_operation_def_t *templ;
-			templ = sdev_merge_vtab(vtp->vt_service);
-			if (vn_make_ops(vtp->vt_name,
-			    (const fs_operation_def_t *)templ,
-			    &vtp->vt_vops) != 0) {
-				cmn_err(CE_PANIC, "%s: malformed vnode ops\n",
-				    vtp->vt_name);
-				/*NOTREACHED*/
-			}
-			if (vtp->vt_global_vops) {
-				*(vtp->vt_global_vops) = vtp->vt_vops;
-			}
-			sdev_free_vtab(templ);
-
-			return (vtp->vt_vops);
-		}
-
-		return (sdev_vnodeops);
-	}
-
-	/* child inherits the persistence of the parent */
-	if (SDEV_IS_PERSIST(dv->sdev_dotdot))
-		dv->sdev_flags |= SDEV_PERSIST;
-
-	return (sdev_vnodeops);
-}
-
-static void
-sdev_set_no_negcache(struct sdev_node *dv)
-{
-	int i;
-	char *path;
-
-	ASSERT(dv->sdev_path);
-	path = dv->sdev_path + strlen("/dev/");
-
-	for (i = 0; vtab[i].vt_name; i++) {
-		if (strcmp(vtab[i].vt_name, path) == 0) {
-			if (vtab[i].vt_flags & SDEV_NO_NCACHE)
-				dv->sdev_flags |= SDEV_NO_NCACHE;
-			break;
-		}
-	}
-}
-
-void *
-sdev_get_vtor(struct sdev_node *dv)
-{
-	struct sdev_vop_table *vtp;
-
-	vtp = sdev_match(dv);
-	if (vtp)
-		return ((void *)vtp->vt_vtor);
-	else
-		return (NULL);
-}
 
 /*
  * Build the base root inode
@@ -948,8 +811,11 @@ sdev_nodedestroy(struct sdev_node *dv, uint_t flags)
 		dv->sdev_path = NULL;
 	}
 
-	if (!SDEV_IS_GLOBAL(dv))
+	if (!SDEV_IS_GLOBAL(dv)) {
 		sdev_prof_free(dv);
+		if (dv->sdev_vnode->v_type != VLNK && dv->sdev_origin != NULL)
+			SDEV_RELE(dv->sdev_origin);
+	}
 
 	if (SDEVTOV(dv)->v_type == VDIR) {
 		ASSERT(SDEV_FIRST_ENTRY(dv) == NULL);
@@ -2944,46 +2810,6 @@ sdev_modctl_devexists(const char *path)
 		VN_RELE(vp);
 
 	return (error);
-}
-
-extern int sdev_vnodeops_tbl_size;
-
-/*
- * construct a new template with overrides from vtab
- */
-static fs_operation_def_t *
-sdev_merge_vtab(const fs_operation_def_t tab[])
-{
-	fs_operation_def_t *new;
-	const fs_operation_def_t *tab_entry;
-
-	/* make a copy of standard vnode ops table */
-	new = kmem_alloc(sdev_vnodeops_tbl_size, KM_SLEEP);
-	bcopy((void *)sdev_vnodeops_tbl, new, sdev_vnodeops_tbl_size);
-
-	/* replace the overrides from tab */
-	for (tab_entry = tab; tab_entry->name != NULL; tab_entry++) {
-		fs_operation_def_t *std_entry = new;
-		while (std_entry->name) {
-			if (strcmp(tab_entry->name, std_entry->name) == 0) {
-				std_entry->func = tab_entry->func;
-				break;
-			}
-			std_entry++;
-		}
-		if (std_entry->name == NULL)
-			cmn_err(CE_NOTE, "sdev_merge_vtab: entry %s unused.",
-			    tab_entry->name);
-	}
-
-	return (new);
-}
-
-/* free memory allocated by sdev_merge_vtab */
-static void
-sdev_free_vtab(fs_operation_def_t *new)
-{
-	kmem_free(new, sdev_vnodeops_tbl_size);
 }
 
 /*

--- a/usr/src/uts/common/io/pciex/pcie.c
+++ b/usr/src/uts/common/io/pciex/pcie.c
@@ -1318,14 +1318,15 @@ pcie_get_rc_dip(dev_info_t *dip)
 	return (rcdip);
 }
 
-static boolean_t
+boolean_t
 pcie_is_pci_device(dev_info_t *dip)
 {
 	dev_info_t	*pdip;
 	char		*device_type;
 
 	pdip = ddi_get_parent(dip);
-	ASSERT(pdip);
+	if (pdip == NULL)
+		return (B_FALSE);
 
 	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, pdip, DDI_PROP_DONTPASS,
 	    "device_type", &device_type) != DDI_PROP_SUCCESS)

--- a/usr/src/uts/common/sys/Makefile
+++ b/usr/src/uts/common/sys/Makefile
@@ -842,6 +842,7 @@ FSHDRS=				\
 	decomp.h		\
 	dv_node.h		\
 	sdev_impl.h		\
+	sdev_plugin.h		\
 	fifonode.h		\
 	hsfs_isospec.h		\
 	hsfs_node.h		\

--- a/usr/src/uts/common/sys/fs/sdev_impl.h
+++ b/usr/src/uts/common/sys/fs/sdev_impl.h
@@ -37,6 +37,7 @@ extern "C" {
 #include <sys/vfs_opreg.h>
 #include <sys/list.h>
 #include <sys/nvpair.h>
+#include <sys/fs/sdev_plugin.h>
 #include <sys/sunddi.h>
 
 /*
@@ -129,6 +130,21 @@ typedef struct sdev_local_data {
 	struct sdev_dprof sdev_lprof;	/* profile for multi-inst */
 } sdev_local_data_t;
 
+/* sdev_flags */
+typedef enum sdev_flags {
+	SDEV_BUILD =		0x0001,	/* directory cache out-of-date */
+	SDEV_GLOBAL =		0x0002,	/* global /dev nodes */
+	SDEV_PERSIST =		0x0004,	/* backing store persisted node */
+	SDEV_NO_NCACHE = 	0x0008,	/* do not include in neg. cache */
+	SDEV_DYNAMIC =		0x0010,	/* special-purpose vnode ops */
+					/* (ex: pts) */
+	SDEV_VTOR =		0x0020,	/* validate sdev_nodes during search */
+	SDEV_ATTR_INVALID =	0x0040,	/* invalid node attributes, */
+					/* need update */
+	SDEV_SUBDIR =		0x0080,	/* match all subdirs under here */
+	SDEV_ZONED =		0x0100	/* zoned subdir */
+} sdev_flags_t;
+
 /*
  * /dev filesystem sdev_node defines
  */
@@ -151,7 +167,7 @@ typedef struct sdev_node {
 	ino64_t		sdev_ino;	/* inode */
 	uint_t		sdev_nlink;	/* link count */
 	int		sdev_state;	/* state of this node */
-	int		sdev_flags;	/* flags bit */
+	sdev_flags_t	sdev_flags;	/* flags bit */
 
 	kmutex_t	sdev_lookup_lock; /* node creation synch lock */
 	kcondvar_t	sdev_lookup_cv;	/* node creation sync cv */
@@ -162,7 +178,7 @@ typedef struct sdev_node {
 		struct sdev_global_data	sdev_globaldata;
 		struct sdev_local_data	sdev_localdata;
 	} sdev_instance_data;
-
+	list_node_t	sdev_plist;	/* link on plugin list */
 	void		*sdev_private;
 } sdev_node_t;
 
@@ -193,28 +209,10 @@ typedef enum {
 	SDEV_READY
 } sdev_node_state_t;
 
-/* sdev_flags */
-#define	SDEV_BUILD		0x0001	/* directory cache out-of-date */
-#define	SDEV_GLOBAL		0x0002	/* global /dev nodes */
-#define	SDEV_PERSIST		0x0004	/* backing store persisted node */
-#define	SDEV_NO_NCACHE		0x0008	/* do not include in neg. cache */
-#define	SDEV_DYNAMIC		0x0010	/* special-purpose vnode ops */
-					/* (ex: pts) */
-#define	SDEV_VTOR		0x0020	/* validate sdev_nodes during search */
-#define	SDEV_ATTR_INVALID	0x0040	/* invalid node attributes, */
-					/* need update */
-#define	SDEV_SUBDIR		0x0080	/* match all subdirs under here */
-#define	SDEV_ZONED		0x0100  /* zoned subdir */
-
 /* sdev_lookup_flags */
 #define	SDEV_LOOKUP	0x0001	/* node creation in progress */
 #define	SDEV_READDIR	0x0002	/* VDIR readdir in progress */
 #define	SDEV_LGWAITING	0x0004	/* waiting for devfsadm completion */
-
-#define	SDEV_VTOR_INVALID	-1
-#define	SDEV_VTOR_SKIP		0
-#define	SDEV_VTOR_VALID		1
-#define	SDEV_VTOR_STALE		2
 
 /* convenient macros */
 #define	SDEV_IS_GLOBAL(dv)	\
@@ -368,8 +366,13 @@ extern void sdev_devfsadmd_thread(struct sdev_node *, struct sdev_node *,
 extern int devname_profile_update(char *, size_t);
 extern struct sdev_data *sdev_find_mntinfo(char *);
 void sdev_mntinfo_rele(struct sdev_data *);
+typedef void (*sdev_mnt_walk_f)(struct sdev_node *, void *);
+void sdev_mnt_walk(sdev_mnt_walk_f, void *);
 extern struct vnodeops *devpts_getvnodeops(void);
 extern struct vnodeops *devvt_getvnodeops(void);
+extern void sdev_plugin_nodeready(struct sdev_node *);
+extern int sdev_plugin_init(void);
+extern int sdev_plugin_fini(void);
 
 /*
  * boot states - warning, the ordering here is significant
@@ -515,6 +518,23 @@ extern void sdev_nc_path_exists(sdev_nc_list_t *, char *);
 extern void sdev_modctl_dump_files(void);
 
 /*
+ * plugin and legacy vtab stuff
+ */
+/* directory dependent vop table */
+typedef struct sdev_vop_table {
+	char *vt_name;				/* subdirectory name */
+	const fs_operation_def_t *vt_service;	/* vnodeops table */
+	struct vnodeops **vt_global_vops;	/* global container for vop */
+	int (*vt_vtor)(struct sdev_node *);	/* validate sdev_node */
+	int vt_flags;
+} sdev_vop_table_t;
+
+extern struct sdev_vop_table vtab[];
+extern struct vnodeops *sdev_get_vop(struct sdev_node *);
+extern void sdev_set_no_negcache(struct sdev_node *);
+extern void *sdev_get_vtor(struct sdev_node *dv);
+
+/*
  * globals
  */
 extern kmutex_t sdev_lock;
@@ -527,6 +547,7 @@ extern struct vnodeops		*devipnet_vnodeops;
 extern struct vnodeops		*devvt_vnodeops;
 extern struct sdev_data *sdev_origins; /* mount info for global /dev instance */
 extern struct vnodeops		*devzvol_vnodeops;
+extern int			sdev_vnodeops_tbl_size;
 
 extern const fs_operation_def_t	sdev_vnodeops_tbl[];
 extern const fs_operation_def_t	devpts_vnodeops_tbl[];

--- a/usr/src/uts/common/sys/fs/sdev_plugin.h
+++ b/usr/src/uts/common/sys/fs/sdev_plugin.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright (c) 2014 Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #ifndef _SYS_SDEV_PLUGIN_H
@@ -88,8 +88,8 @@ typedef enum sdev_ctx_flags {
 extern sdev_ctx_flags_t sdev_ctx_flags(sdev_ctx_t);
 extern const char *sdev_ctx_name(sdev_ctx_t);
 extern const char *sdev_ctx_path(sdev_ctx_t);
+extern int sdev_ctx_minor(sdev_ctx_t, minor_t *);
 extern enum vtype sdev_ctx_vtype(sdev_ctx_t);
-extern const void *sdev_ctx_vtype_data(sdev_ctx_t);
 
 /*
  * Callbacks to manipulate nodes

--- a/usr/src/uts/common/sys/fs/sdev_plugin.h
+++ b/usr/src/uts/common/sys/fs/sdev_plugin.h
@@ -1,0 +1,106 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2014 Joyent, Inc.  All rights reserved.
+ */
+
+#ifndef _SYS_SDEV_PLUGIN_H
+#define	_SYS_SDEV_PLUGIN_H
+
+/*
+ * Kernel sdev plugin interface
+ */
+
+#ifdef _KERNEL
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/vnode.h>
+
+#endif	/* _KERNEL */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _KERNEL
+
+typedef uintptr_t sdev_plugin_hdl_t;
+typedef uintptr_t sdev_ctx_t;
+
+/*
+ * Valid return values for sdev_plugin_validate_t.
+ */
+typedef enum sdev_plugin_validate {
+	SDEV_VTOR_INVALID = -1,
+	SDEV_VTOR_SKIP = 0,
+	SDEV_VTOR_VALID	= 1,
+	SDEV_VTOR_STALE	= 2
+} sdev_plugin_validate_t;
+
+/*
+ * Valid flags
+ */
+typedef enum sdev_plugin_flags {
+	SDEV_PLUGIN_NO_NCACHE = 0x1,
+	SDEV_PLUGIN_SUBDIR = 0x2
+} sdev_plugin_flags_t;
+
+#define	SDEV_PLUGIN_FLAGS_MASK	0x3
+
+/*
+ * Functions a module must implement
+ */
+typedef sdev_plugin_validate_t (*sp_valid_f)(sdev_ctx_t);
+typedef int (*sp_filldir_f)(sdev_ctx_t);
+typedef void (*sp_inactive_f)(sdev_ctx_t);
+
+#define	SDEV_PLUGIN_VERSION	1
+
+typedef struct sdev_plugin_ops {
+	int spo_version;
+	sdev_plugin_flags_t spo_flags;
+	sp_valid_f spo_validate;
+	sp_filldir_f spo_filldir;
+	sp_inactive_f spo_inactive;
+} sdev_plugin_ops_t;
+
+extern sdev_plugin_hdl_t sdev_plugin_register(const char *, sdev_plugin_ops_t *,
+    int *);
+extern int sdev_plugin_unregister(sdev_plugin_hdl_t);
+
+typedef enum sdev_ctx_flags {
+	SDEV_CTX_GLOBAL = 0x2	/* node belongs to the GZ */
+} sdev_ctx_flags_t;
+
+/*
+ * Context helper functions
+ */
+extern sdev_ctx_flags_t sdev_ctx_flags(sdev_ctx_t);
+extern const char *sdev_ctx_name(sdev_ctx_t);
+extern const char *sdev_ctx_path(sdev_ctx_t);
+extern enum vtype sdev_ctx_vtype(sdev_ctx_t);
+extern const void *sdev_ctx_vtype_data(sdev_ctx_t);
+
+/*
+ * Callbacks to manipulate nodes
+ */
+extern int sdev_plugin_mkdir(sdev_ctx_t, char *);
+extern int sdev_plugin_mknod(sdev_ctx_t, char *, mode_t, dev_t);
+
+#endif	/* _KERNEL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_SDEV_PLUGIN_H */

--- a/usr/src/uts/common/sys/pcie.h
+++ b/usr/src/uts/common/sys/pcie.h
@@ -140,6 +140,8 @@ extern "C" {
 #define	PCIE_DEVCAP_PLMT_SCL_1_BY_1000	0xC000000	/* 0.001x Scale */
 #define	PCIE_DEVCAP_PLMT_SCL_MASK	0xC000000	/* Power Limit Scale */
 
+#define	PCIE_DEVCAP_FLR			0x10000000 /* Function Level Reset */
+
 /*
  * Device Control Register (2 bytes)
  */
@@ -173,6 +175,8 @@ extern "C" {
 #define	PCIE_DEVCTL_MAX_READ_REQ_4096	0x5000
 #define	PCIE_DEVCTL_MAX_READ_REQ_MASK	0x7000	/* Max_Read_Request_Size */
 #define	PCIE_DEVCTL_MAX_READ_REQ_SHIFT	0xC
+
+#define	PCIE_DEVCTL_INITIATE_FLR	0x8000
 
 /*
  * Device Status Register (2 bytes)
@@ -386,6 +390,7 @@ extern "C" {
 /*
  * Device Control 2 Register (2 bytes)
  */
+#define	PCIE_DEVCTL2_COM_TO_RANGE_MASK	0xf
 #define	PCIE_DEVCTL2_COM_TO_RANGE_0	0x0
 #define	PCIE_DEVCTL2_COM_TO_RANGE_1	0x1
 #define	PCIE_DEVCTL2_COM_TO_RANGE_2	0x2

--- a/usr/src/uts/common/sys/pcie_impl.h
+++ b/usr/src/uts/common/sys/pcie_impl.h
@@ -525,6 +525,7 @@ extern void pcie_enable_errors(dev_info_t *dip);
 extern void pcie_disable_errors(dev_info_t *dip);
 extern int pcie_enable_ce(dev_info_t *dip);
 extern boolean_t pcie_bridge_is_link_disabled(dev_info_t *);
+extern boolean_t pcie_is_pci_device(dev_info_t *dip);
 
 extern pcie_bus_t *pcie_init_bus(dev_info_t *dip, pcie_req_id_t bdf,
     uint8_t flags);

--- a/usr/src/uts/common/vm/vm_page.c
+++ b/usr/src/uts/common/vm/vm_page.c
@@ -22,7 +22,7 @@
  * Copyright (c) 1986, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
  * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989  AT&T	*/
@@ -441,10 +441,26 @@ init_pages_pp_maximum()
 	}
 }
 
+/*
+ * In the past, we limited the maximum pages that could be gotten to essentially
+ * 1/2 of the total pages on the system. However, this is too conservative for
+ * some cases. For example, if we want to host a large virtual machine which
+ * needs to use a significant portion of the system's memory. In practice,
+ * allowing more than 1/2 of the total pages is fine, but becomes problematic
+ * as we approach or exceed 75% of the pages on the system. Thus, we limit the
+ * maximum to 23/32 of the total pages, which is ~72%.
+ */
 void
 set_max_page_get(pgcnt_t target_total_pages)
 {
-	max_page_get = target_total_pages / 2;
+	max_page_get = (target_total_pages >> 5) * 23;
+	ASSERT3U(max_page_get, >, 0);
+}
+
+pgcnt_t
+get_max_page_get()
+{
+	return (max_page_get);
 }
 
 static pgcnt_t pending_delete;

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -23,7 +23,7 @@
 # Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
 #
 # Copyright (c) 2010, Intel Corporation.
-# Copyright 2017 Joyent, Inc.
+# Copyright 2018 Joyent, Inc.
 #
 #	This Makefile defines file modules in the directory uts/i86pc
 #	and its children. These are the source files which are i86pc
@@ -112,6 +112,7 @@ CORE_OBJS +=			\
 	pmem.o			\
 	ppage.o			\
 	pwrnow.o		\
+	seg_vmm.o		\
 	speedstep.o		\
 	ssp.o			\
 	startup.o		\

--- a/usr/src/uts/i86pc/io/apix/apix.c
+++ b/usr/src/uts/i86pc/io/apix/apix.c
@@ -25,9 +25,7 @@
 /*
  * Copyright (c) 2010, Intel Corporation.
  * All rights reserved.
- */
-/*
- * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -167,6 +165,8 @@ static struct	psm_ops apix_ops = {
 	apix_intr_ops,		/* Advanced DDI Interrupt framework */
 	apic_state,		/* save, restore apic state for S3 */
 	apic_cpu_ops,		/* CPU control interface. */
+
+	apic_cached_ipivect,
 };
 
 struct psm_ops *psmops = &apix_ops;

--- a/usr/src/uts/i86pc/io/pcplusmp/apic.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic.c
@@ -25,9 +25,7 @@
 /*
  * Copyright (c) 2010, Intel Corporation.
  * All rights reserved.
- */
-/*
- * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -202,6 +200,8 @@ static struct	psm_ops apic_ops = {
 	apic_intr_ops,			/* Advanced DDI Interrupt framework */
 	apic_state,			/* save, restore apic state for S3 */
 	apic_cpu_ops,			/* CPU control interface. */
+
+	apic_cached_ipivect,
 };
 
 struct psm_ops *psmops = &apic_ops;

--- a/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
@@ -1706,4 +1706,15 @@ apic_get_ioapicid(uchar_t ioapicindex)
 	ASSERT(ioapicindex < MAX_IO_APIC);
 
 	return (apic_io_id[ioapicindex]);
+}
+
+int
+apic_cached_ipivect(int ipl, int type)
+{
+	uchar_t vector = 0;
+
+	if (type != -1 && ipl >= 0 && ipl <= MAXIPL) {
+		vector = apic_resv_vector[ipl];
+	}
+	return ((vector != 0) ? vector : -1);
 }

--- a/usr/src/uts/i86pc/io/psm/uppc.c
+++ b/usr/src/uts/i86pc/io/psm/uppc.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #define	PSMI_1_7
@@ -174,7 +175,9 @@ static struct	psm_ops uppc_ops = {
 	    psm_intr_op_t, int *))NULL,		/* psm_intr_ops		*/
 
 	uppc_state,				/* psm_state		*/
-	(int (*)(psm_cpu_request_t *))NULL	/* psm_cpu_ops		*/
+	(int (*)(psm_cpu_request_t *))NULL,	/* psm_cpu_ops		*/
+
+	(int (*)(int, int))NULL,		/* psm_cached_ipivect	*/
 };
 
 

--- a/usr/src/uts/i86pc/os/mp_machdep.c
+++ b/usr/src/uts/i86pc/os/mp_machdep.c
@@ -25,6 +25,7 @@
 /*
  * Copyright (c) 2009-2010, Intel Corporation.
  * All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #define	PSMI_1_7
@@ -145,6 +146,7 @@ void (*gethrestimef)(timestruc_t *) = pc_gethrestime;
 void (*psm_notify_error)(int, char *) = (void (*)(int, char *))NULL;
 int (*psm_get_clockirq)(int) = NULL;
 int (*psm_get_ipivect)(int, int) = NULL;
+int (*psm_cached_ipivect)(int, int) = NULL;
 uchar_t (*psm_get_ioapicid)(uchar_t) = NULL;
 uint32_t (*psm_get_localapicid)(uint32_t) = NULL;
 uchar_t (*psm_xlate_vector_by_irq)(uchar_t) = NULL;
@@ -1153,6 +1155,7 @@ mach_smpinit(void)
 	}
 
 	psm_get_ipivect = pops->psm_get_ipivect;
+	psm_cached_ipivect = pops->psm_cached_ipivect;
 
 	(void) add_avintr((void *)NULL, XC_HI_PIL, xc_serv, "xc_intr",
 	    (*pops->psm_get_ipivect)(XC_HI_PIL, PSM_INTR_IPI_HI),

--- a/usr/src/uts/i86pc/sys/apic_common.h
+++ b/usr/src/uts/i86pc/sys/apic_common.h
@@ -22,7 +22,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _SYS_APIC_COMMON_H
@@ -182,6 +182,7 @@ extern void	apic_shutdown(int cmd, int fcn);
 extern void	apic_preshutdown(int cmd, int fcn);
 extern processorid_t	apic_get_next_processorid(processorid_t cpun);
 extern uint_t	apic_calibrate(volatile uint32_t *, uint16_t *);
+extern int	apic_cached_ipivect(int, int);
 
 extern int apic_error_intr();
 extern void apic_cpcovf_mask_clear(void);

--- a/usr/src/uts/i86pc/sys/psm_types.h
+++ b/usr/src/uts/i86pc/sys/psm_types.h
@@ -26,6 +26,7 @@
 /*
  * Copyright (c) 2010, Intel Corporation.
  * All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_SYS_PSM_TYPES_H
@@ -190,6 +191,8 @@ struct 	psm_ops {
 #endif
 #if defined(PSMI_1_7)
 	int	(*psm_cpu_ops)(psm_cpu_request_t *reqp);
+
+	int	(*psm_cached_ipivect)(int ipl, int type);
 #endif
 };
 

--- a/usr/src/uts/i86pc/sys/smp_impldefs.h
+++ b/usr/src/uts/i86pc/sys/smp_impldefs.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _SYS_SMP_IMPLDEFS_H
@@ -64,6 +65,7 @@ extern void (*psm_enable_intr)(processorid_t); /* enable intr to cpu	*/
 extern int (*psm_get_clockirq)(int); /* get clock vector		*/
 extern int (*psm_get_ipivect)(int, int); /* get interprocessor intr vec */
 extern int (*psm_clkinit)(int);	/* timer init entry point		*/
+extern int (*psm_cached_ipivect)(int, int); /* get cached ipi vec	*/
 extern void (*psm_timer_reprogram)(hrtime_t); /* timer reprogram	*/
 extern void (*psm_timer_enable)(void);		/* timer enable		*/
 extern void (*psm_timer_disable)(void);		/* timer disable	*/

--- a/usr/src/uts/i86pc/vm/seg_vmm.c
+++ b/usr/src/uts/i86pc/vm/seg_vmm.c
@@ -1,0 +1,468 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+/*
+ * VM - Virtual-Machine-Memory segment
+ *
+ * The vmm segment driver was designed for mapping regions of kernel memory
+ * allocated to an HVM instance into userspace for manipulation there.  It
+ * draws direct lineage from the umap segment driver, but meant for larger
+ * mappings with fewer restrictions.
+ */
+
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/errno.h>
+#include <sys/cred.h>
+#include <sys/kmem.h>
+#include <sys/lgrp.h>
+#include <sys/mman.h>
+
+#include <vm/hat.h>
+#include <vm/hat_pte.h>
+#include <vm/htable.h>
+#include <vm/as.h>
+#include <vm/seg.h>
+#include <vm/seg_kmem.h>
+#include <vm/seg_vmm.h>
+
+
+static int segvmm_dup(struct seg *, struct seg *);
+static int segvmm_unmap(struct seg *, caddr_t, size_t);
+static void segvmm_free(struct seg *);
+static faultcode_t segvmm_fault(struct hat *, struct seg *, caddr_t, size_t,
+    enum fault_type, enum seg_rw);
+static faultcode_t segvmm_faulta(struct seg *, caddr_t);
+static int segvmm_setprot(struct seg *, caddr_t, size_t, uint_t);
+static int segvmm_checkprot(struct seg *, caddr_t, size_t, uint_t);
+static int segvmm_sync(struct seg *, caddr_t, size_t, int, uint_t);
+static size_t segvmm_incore(struct seg *, caddr_t, size_t, char *);
+static int segvmm_lockop(struct seg *, caddr_t, size_t, int, int, ulong_t *,
+    size_t);
+static int segvmm_getprot(struct seg *, caddr_t, size_t, uint_t *);
+static u_offset_t segvmm_getoffset(struct seg *, caddr_t);
+static int segvmm_gettype(struct seg *, caddr_t);
+static int segvmm_getvp(struct seg *, caddr_t, struct vnode **);
+static int segvmm_advise(struct seg *, caddr_t, size_t, uint_t);
+static void segvmm_dump(struct seg *);
+static int segvmm_pagelock(struct seg *, caddr_t, size_t, struct page ***,
+    enum lock_type, enum seg_rw);
+static int segvmm_setpagesize(struct seg *, caddr_t, size_t, uint_t);
+static int segvmm_getmemid(struct seg *, caddr_t, memid_t *);
+static int segvmm_capable(struct seg *, segcapability_t);
+
+static struct seg_ops segvmm_ops = {
+	.dup		= segvmm_dup,
+	.unmap		= segvmm_unmap,
+	.free		= segvmm_free,
+	.fault		= segvmm_fault,
+	.faulta		= segvmm_faulta,
+	.setprot	= segvmm_setprot,
+	.checkprot	= segvmm_checkprot,
+	.kluster	= NULL,
+	.swapout	= NULL,
+	.sync		= segvmm_sync,
+	.incore		= segvmm_incore,
+	.lockop		= segvmm_lockop,
+	.getprot	= segvmm_getprot,
+	.getoffset	= segvmm_getoffset,
+	.gettype	= segvmm_gettype,
+	.getvp		= segvmm_getvp,
+	.advise		= segvmm_advise,
+	.dump		= segvmm_dump,
+	.pagelock	= segvmm_pagelock,
+	.setpagesize	= segvmm_setpagesize,
+	.getmemid	= segvmm_getmemid,
+	.getpolicy	= NULL,
+	.capable	= segvmm_capable,
+	.inherit	= seg_inherit_notsup
+};
+
+
+/*
+ * Create a kernel/user-mapped segment.
+ */
+int
+segvmm_create(struct seg **segpp, void *argsp)
+{
+	struct seg *seg = *segpp;
+	segvmm_crargs_t *cra = argsp;
+	segvmm_data_t *data;
+
+	/*
+	 * Check several aspects of the mapping request to ensure validity:
+	 * - kernel pages must reside entirely in kernel space
+	 * - target protection must be user-accessible
+	 * - kernel address must be page-aligned
+	 */
+	if ((uintptr_t)cra->kaddr <= _userlimit ||
+	    ((uintptr_t)cra->kaddr + seg->s_size) < (uintptr_t)cra->kaddr ||
+	    (cra->prot & PROT_USER) == 0 ||
+	    ((uintptr_t)cra->kaddr & PAGEOFFSET) != 0) {
+		return (EINVAL);
+	}
+
+	data = kmem_zalloc(sizeof (*data), KM_SLEEP);
+	rw_init(&data->svmd_lock, NULL, RW_DEFAULT, NULL);
+	data->svmd_kaddr = (uintptr_t)cra->kaddr;
+	data->svmd_prot = cra->prot;
+	data->svmd_cookie = cra->cookie;
+	data->svmd_hold = cra->hold;
+	data->svmd_rele = cra->rele;
+
+	/* Since initial checks have passed, grab a reference on the cookie */
+	if (data->svmd_hold != NULL) {
+		data->svmd_hold(data->svmd_cookie);
+	}
+
+	seg->s_ops = &segvmm_ops;
+	seg->s_data = data;
+	return (0);
+}
+
+static int
+segvmm_dup(struct seg *seg, struct seg *newseg)
+{
+	segvmm_data_t *svmd = seg->s_data;
+	segvmm_data_t *newsvmd;
+
+	ASSERT(seg->s_as && AS_WRITE_HELD(seg->s_as));
+
+	newsvmd = kmem_zalloc(sizeof (segvmm_data_t), KM_SLEEP);
+	rw_init(&newsvmd->svmd_lock, NULL, RW_DEFAULT, NULL);
+	newsvmd->svmd_kaddr = svmd->svmd_kaddr;
+	newsvmd->svmd_prot = svmd->svmd_prot;
+	newsvmd->svmd_cookie = svmd->svmd_cookie;
+	newsvmd->svmd_hold = svmd->svmd_hold;
+	newsvmd->svmd_rele = svmd->svmd_rele;
+
+	/* Grab another hold for the duplicate segment */
+	if (svmd->svmd_hold != NULL) {
+		newsvmd->svmd_hold(newsvmd->svmd_cookie);
+	}
+
+	newseg->s_ops = seg->s_ops;
+	newseg->s_data = newsvmd;
+	return (0);
+}
+
+static int
+segvmm_unmap(struct seg *seg, caddr_t addr, size_t len)
+{
+	segvmm_data_t *svmd = seg->s_data;
+
+	ASSERT(seg->s_as && AS_WRITE_HELD(seg->s_as));
+
+	/* Only allow unmap of entire segment */
+	if (addr != seg->s_base || len != seg->s_size) {
+		return (EINVAL);
+	}
+	if (svmd->svmd_softlockcnt != 0) {
+		return (EAGAIN);
+	}
+
+	/* Unconditionally unload the entire segment range.  */
+	hat_unload(seg->s_as->a_hat, addr, len, HAT_UNLOAD_UNMAP);
+
+	/* Release the hold this segment possessed */
+	if (svmd->svmd_rele != NULL) {
+		svmd->svmd_rele(svmd->svmd_cookie);
+	}
+
+	seg_free(seg);
+	return (0);
+}
+
+static void
+segvmm_free(struct seg *seg)
+{
+	segvmm_data_t *data = seg->s_data;
+
+	ASSERT(data != NULL);
+
+	rw_destroy(&data->svmd_lock);
+	VERIFY(data->svmd_softlockcnt == 0);
+	kmem_free(data, sizeof (*data));
+	seg->s_data = NULL;
+}
+
+static int
+segvmm_fault_in(struct hat *hat, struct seg *seg, uintptr_t va, size_t len)
+{
+	segvmm_data_t *svmd = seg->s_data;
+	const uintptr_t koff = svmd->svmd_kaddr - (uintptr_t)seg->s_base;
+	const uintptr_t end = va + len;
+	const uintptr_t prot = svmd->svmd_prot;
+
+	/* Stick to the simple non-large-page case for now */
+	va &= PAGEMASK;
+
+	do {
+		htable_t *ht;
+		uint_t entry, lvl;
+		size_t psz;
+		pfn_t pfn;
+		const uintptr_t kaddr = va + koff;
+
+		ASSERT(kaddr >= (uintptr_t)svmd->svmd_kaddr);
+		ASSERT(kaddr < ((uintptr_t)svmd->svmd_kaddr + seg->s_size));
+
+		ht = htable_getpage(kas.a_hat, kaddr, &entry);
+		if (ht == NULL) {
+			return (-1);
+		}
+		lvl = ht->ht_level;
+		pfn = PTE2PFN(x86pte_get(ht, entry), lvl);
+		htable_release(ht);
+		if (pfn == PFN_INVALID) {
+			return (-1);
+		}
+
+		/* For the time being, handling for large pages is absent. */
+		psz = PAGESIZE;
+		pfn += mmu_btop(kaddr & LEVEL_OFFSET(lvl));
+
+		hat_devload(hat, (caddr_t)va, psz, pfn, prot, HAT_LOAD);
+
+		va = va + psz;
+	} while (va < end);
+
+	return (0);
+}
+
+/* ARGSUSED */
+static faultcode_t
+segvmm_fault(struct hat *hat, struct seg *seg, caddr_t addr, size_t len,
+    enum fault_type type, enum seg_rw tw)
+{
+	segvmm_data_t *svmd = seg->s_data;
+	int err = 0;
+
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	if (type == F_PROT) {
+		/*
+		 * Since protection on the segment is fixed, there is nothing
+		 * to do but report an error for protection faults.
+		 */
+		return (FC_PROT);
+	} else if (type == F_SOFTUNLOCK) {
+		size_t plen = btop(len);
+
+		rw_enter(&svmd->svmd_lock, RW_WRITER);
+		VERIFY(svmd->svmd_softlockcnt >= plen);
+		svmd->svmd_softlockcnt -= plen;
+		rw_exit(&svmd->svmd_lock);
+		return (0);
+	}
+
+	VERIFY(type == F_INVAL || type == F_SOFTLOCK);
+	rw_enter(&svmd->svmd_lock, RW_WRITER);
+
+	err = segvmm_fault_in(hat, seg, (uintptr_t)addr, len);
+	if (type == F_SOFTLOCK && err == 0) {
+		size_t nval = svmd->svmd_softlockcnt + btop(len);
+
+		if (svmd->svmd_softlockcnt >= nval) {
+			rw_exit(&svmd->svmd_lock);
+			return (FC_MAKE_ERR(EOVERFLOW));
+		}
+		svmd->svmd_softlockcnt = nval;
+	}
+
+	rw_exit(&svmd->svmd_lock);
+	return (err);
+}
+
+/* ARGSUSED */
+static faultcode_t
+segvmm_faulta(struct seg *seg, caddr_t addr)
+{
+	/* Do nothing since asynch pagefault should not load translation. */
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+segvmm_setprot(struct seg *seg, caddr_t addr, size_t len, uint_t prot)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	/* The seg_vmm driver does not yet allow protection to be changed. */
+	return (EACCES);
+}
+
+/* ARGSUSED */
+static int
+segvmm_checkprot(struct seg *seg, caddr_t addr, size_t len, uint_t prot)
+{
+	segvmm_data_t *svmd = seg->s_data;
+	int error = 0;
+
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	rw_enter(&svmd->svmd_lock, RW_READER);
+	if ((svmd->svmd_prot & prot) != prot) {
+		error = EACCES;
+	}
+	rw_exit(&svmd->svmd_lock);
+	return (error);
+}
+
+/* ARGSUSED */
+static int
+segvmm_sync(struct seg *seg, caddr_t addr, size_t len, int attr, uint_t flags)
+{
+	/* Always succeed since there are no backing store to sync */
+	return (0);
+}
+
+/* ARGSUSED */
+static size_t
+segvmm_incore(struct seg *seg, caddr_t addr, size_t len, char *vec)
+{
+	size_t sz = 0;
+
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	len = (len + PAGEOFFSET) & PAGEMASK;
+	while (len > 0) {
+		*vec = 1;
+		sz += PAGESIZE;
+		vec++;
+		len -= PAGESIZE;
+	}
+	return (sz);
+}
+
+/* ARGSUSED */
+static int
+segvmm_lockop(struct seg *seg, caddr_t addr, size_t len, int attr, int op,
+    ulong_t *lockmap, size_t pos)
+{
+	/* Report success since kernel pages are always in memory. */
+	return (0);
+}
+
+static int
+segvmm_getprot(struct seg *seg, caddr_t addr, size_t len, uint_t *protv)
+{
+	segvmm_data_t *svmd = seg->s_data;
+	size_t pgno;
+	uint_t prot;
+
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	rw_enter(&svmd->svmd_lock, RW_READER);
+	prot = svmd->svmd_prot;
+	rw_exit(&svmd->svmd_lock);
+
+	/*
+	 * Reporting protection is simple since it is not tracked per-page.
+	 */
+	pgno = seg_page(seg, addr + len) - seg_page(seg, addr) + 1;
+	while (pgno > 0) {
+		protv[--pgno] = prot;
+	}
+	return (0);
+}
+
+/* ARGSUSED */
+static u_offset_t
+segvmm_getoffset(struct seg *seg, caddr_t addr)
+{
+	/*
+	 * To avoid leaking information about the layout of the kernel address
+	 * space, always report '0' as the offset.
+	 */
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+segvmm_gettype(struct seg *seg, caddr_t addr)
+{
+	/*
+	 * Since already-existing kernel pages are being mapped into userspace,
+	 * always report the segment type as shared.
+	 */
+	return (MAP_SHARED);
+}
+
+/* ARGSUSED */
+static int
+segvmm_getvp(struct seg *seg, caddr_t addr, struct vnode **vpp)
+{
+	ASSERT(seg->s_as && AS_LOCK_HELD(seg->s_as));
+
+	*vpp = NULL;
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+segvmm_advise(struct seg *seg, caddr_t addr, size_t len, uint_t behav)
+{
+	if (behav == MADV_PURGE) {
+		/* Purge does not make sense for this mapping */
+		return (EINVAL);
+	}
+	/* Indicate success for everything else. */
+	return (0);
+}
+
+/* ARGSUSED */
+static void
+segvmm_dump(struct seg *seg)
+{
+	/*
+	 * Since this is a mapping to share kernel data with userspace, nothing
+	 * additional should be dumped.
+	 */
+}
+
+/* ARGSUSED */
+static int
+segvmm_pagelock(struct seg *seg, caddr_t addr, size_t len, struct page ***ppp,
+    enum lock_type type, enum seg_rw rw)
+{
+	return (ENOTSUP);
+}
+
+/* ARGSUSED */
+static int
+segvmm_setpagesize(struct seg *seg, caddr_t addr, size_t len, uint_t szc)
+{
+	return (ENOTSUP);
+}
+
+static int
+segvmm_getmemid(struct seg *seg, caddr_t addr, memid_t *memidp)
+{
+	segvmm_data_t *svmd = seg->s_data;
+
+	memidp->val[0] = (uintptr_t)svmd->svmd_kaddr;
+	memidp->val[1] = (uintptr_t)(addr - seg->s_base);
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+segvmm_capable(struct seg *seg, segcapability_t capability)
+{
+	/* no special capablities */
+	return (0);
+}

--- a/usr/src/uts/i86pc/vm/seg_vmm.h
+++ b/usr/src/uts/i86pc/vm/seg_vmm.h
@@ -1,0 +1,50 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#ifndef	_VM_SEG_VMM_H
+#define	_VM_SEG_VMM_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef struct segvmm_crargs {
+	caddr_t	kaddr;
+	uchar_t	prot;			/* protection */
+	void	*cookie;		/* opaque resource backing memory */
+	void	(*hold)(void *);	/* add reference to cookie */
+	void	(*rele)(void *);	/* release reference to cookie */
+} segvmm_crargs_t;
+
+typedef void (*segvmm_holdfn_t)(void *);
+typedef void (*segvmm_relefn_t)(void *);
+
+typedef struct segvmm_data {
+	krwlock_t	svmd_lock;
+	uintptr_t	svmd_kaddr;
+	uchar_t		svmd_prot;
+	void		*svmd_cookie;
+	segvmm_holdfn_t	svmd_hold;
+	segvmm_relefn_t	svmd_rele;
+	size_t		svmd_softlockcnt;
+} segvmm_data_t;
+
+extern int segvmm_create(struct seg **, void *);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _VM_SEG_VMM_H */

--- a/usr/src/uts/i86xpv/io/psm/xpv_psm.c
+++ b/usr/src/uts/i86xpv/io/psm/xpv_psm.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #define	PSMI_1_7
@@ -1673,7 +1674,9 @@ static struct psm_ops xen_psm_ops = {
 	(void (*)(int, int))NULL,		/* psm_preshutdown	*/
 	xen_intr_ops,			/* Advanced DDI Interrupt framework */
 	(int (*)(psm_state_request_t *))NULL,	/* psm_state		*/
-	(int (*)(psm_cpu_request_t *))NULL	/* psm_cpu_ops		*/
+	(int (*)(psm_cpu_request_t *))NULL,	/* psm_cpu_ops		*/
+
+	(int (*)(int, int))NULL,		/* psm_cached_ipivect	*/
 };
 
 static struct psm_info xen_psm_info = {

--- a/usr/src/uts/i86xpv/io/psm/xpv_uppc.c
+++ b/usr/src/uts/i86xpv/io/psm/xpv_uppc.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #define	PSMI_1_7
@@ -892,7 +893,9 @@ static struct psm_ops xen_uppc_ops = {
 	(int (*)(dev_info_t *, ddi_intr_handle_impl_t *,
 	    psm_intr_op_t, int *))NULL,		/* psm_intr_ops		*/
 	(int (*)(psm_state_request_t *))NULL,	/* psm_state		*/
-	(int (*)(psm_cpu_request_t *))NULL	/* psm_cpu_ops		*/
+	(int (*)(psm_cpu_request_t *))NULL,	/* psm_cpu_ops		*/
+
+	(int (*)(int, int))NULL,		/* psm_cached_ipivect	*/
 };
 
 static struct psm_info xen_uppc_info = {

--- a/usr/src/uts/intel/dev/Makefile
+++ b/usr/src/uts/intel/dev/Makefile
@@ -71,6 +71,7 @@ LINTTAGS	+= -erroff=E_STATIC_UNUSED
 CERRWARN	+= -_gcc=-Wno-parentheses
 CERRWARN	+= -_gcc=-Wno-unused-label
 CERRWARN	+= -_gcc=-Wno-uninitialized
+CERRWARN	+= -_gcc=-Wno-unused-function
 
 #
 #	Default build targets.


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018022101

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2018022101-cb8946e3da i86pc i386 i86pc

bloody% pfexec mdb -k
> sdev_plugin_list::walk sdev_plugin | ::print sdev_plugin_t sp_name
sp_name = [ "rlofi" ]
sp_name = [ "lofi" ]
sp_name = [ "ipnet" ]
sp_name = [ "net" ]
sp_name = [ "zcons" ]
sp_name = [ "zvol" ]
sp_name = [ "vt" ]
sp_name = [ "pts" ]
```

## mail_msg

```

==== Nightly distributed build started:   Wed Feb 21 18:40:03 GMT 2018 ====
==== Nightly distributed build completed: Wed Feb 21 19:48:08 GMT 2018 ====

==== Total build time ====

real    1:08:04

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-4e54e9404d i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_161-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   1125

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018022101-cb8946e3da

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:04.8
user  1:08:54.0
sys     11:25.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:31.0
user    57:59.9
sys      7:38.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    24:08.0
user    41:31.4
sys      9:48.3

==== lint warnings src ====


==== lint noise differences src ====

1,2d0
< "../../common/sys/ctype.h", line 105: warning: static unused: isalnum (E_STATIC_UNUSED)
< "/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/usr/include/sys/ctype.h", line 105: warning: static unused: isalnum (E_STATIC_UNUSED)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
