### PR TITLE
Move DEBUG/non-DEBUG label to aid "omni bw"

### DIFF
--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -187,7 +187,7 @@ function build {
 	#
 	#	Build OS-Networking source
 	#
-	echo "\n==== Building OS-Net source at `date` ($LABEL) ====\n" \
+	echo "\n==== Building $LABEL OS-Net source at `date` ====\n" \
 		>> $LOGFILE
 
 	rm -f $SRC/${INSTALLOG}.out
@@ -228,7 +228,7 @@ function build {
 		this_build_ok=n
 	fi
 
-	echo "\n==== Ended OS-Net source build at `date` ($LABEL) ====\n" \
+	echo "\n==== Ended $LABEL OS-Net source build at `date` ====\n" \
 		>> $LOGFILE
 
 	echo "\n==== Elapsed build time ($LABEL) ====\n" >>$mail_msg_file


### PR DESCRIPTION
`omni build_world` only shows the start of nightly log message lines so it is not possible to determine which build is in progress. (c.f. the packaging log lines which already include the token near to the start)