### PR TITLE
Upstream merge/2018030101

### DIFF
--- a/exception_lists/check_rtime
+++ b/exception_lists/check_rtime
@@ -142,6 +142,7 @@ UNUSED_RPATH	/usr/ccs/lib.*\ from\ .*/usr/lib/mps
 UNUSED_RPATH	/usr/gnu/lib.*\ from\ .*/usr/lib/libpython2\..
 UNUSED_RPATH	/usr/gnu/lib.*\ from\ .*/usr/lib/64/libpython2\..
 UNUSED_RPATH	/usr/snadm/lib.*\ from\ .*/usr/snadm/lib/libspmicommon\.so\.1
+UNUSED_RPATH	/usr/gcc/.*/lib.*\ from\ .*
 
 
 # Unused runpaths for reasons not captured above

--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2018.2.11.1
+BOOT_VERSION = $(LOADER_VERSION)-2018.2.22.1

--- a/usr/src/boot/sys/boot/common/disk.c
+++ b/usr/src/boot/sys/boot/common/disk.c
@@ -131,11 +131,16 @@ ptable_print(void *arg, const char *pname, const struct ptable_entry *part)
 		dev.d_partition = -1;
 		if (disk_open(&dev, part->end - part->start + 1,
 		    od->sectorsize) == 0) {
+			enum ptable_type pt = PTABLE_NONE;
+
 			table = ptable_open(&dev, part->end - part->start + 1,
 			    od->sectorsize, ptblread);
-			if (table != NULL &&
-			    (ptable_gettype(table) == PTABLE_BSD ||
-			    ptable_gettype(table) == PTABLE_VTOC8)) {
+			if (table != NULL)
+				pt = ptable_gettype(table);
+
+			if (pt == PTABLE_BSD ||
+			    pt == PTABLE_VTOC8 ||
+			    pt == PTABLE_VTOC) {
 				sprintf(line, "  %s%s", pa->prefix, pname);
 				bsd.dev = &dev;
 				bsd.prefix = line;

--- a/usr/src/boot/sys/boot/forth/support.4th
+++ b/usr/src/boot/sys/boot/forth/support.4th
@@ -533,8 +533,8 @@ also parser definitions
   line_pointer
   begin
     end_of_line? if 0 else
-      letter? digit? underscore? dot? dash?
-      or or or or
+      letter? digit? underscore? dot? dash? comma?
+      or or or or or
     then
   while
     skip_character

--- a/usr/src/boot/sys/boot/i386/gptzfsboot/zfsboot.c
+++ b/usr/src/boot/sys/boot/i386/gptzfsboot/zfsboot.c
@@ -613,7 +613,9 @@ probe_partition(void *arg, const char *partname,
 		table = ptable_open(&pa, part->end - part->start + 1,
 		    ppa->secsz, parttblread);
 		if (table != NULL) {
-			if (ptable_gettype(table) == PTABLE_VTOC8) {
+			enum ptable_type pt = ptable_gettype(table);
+
+			if (pt == PTABLE_VTOC8 || pt == PTABLE_VTOC) {
 				ret = ptable_iterate(table, &pa,
 				    probe_partition);
 				ptable_close(table);

--- a/usr/src/boot/sys/boot/zfs/zfs.c
+++ b/usr/src/boot/sys/boot/zfs/zfs.c
@@ -516,7 +516,9 @@ zfs_probe_partition(void *arg, const char *partname,
 		table = ptable_open(&pa, part->end - part->start + 1,
 		    ppa->secsz, zfs_diskread);
 		if (table != NULL) {
-			if (ptable_gettype(table) == PTABLE_VTOC8)
+			enum ptable_type pt = ptable_gettype(table);
+
+			if (pt == PTABLE_VTOC8 || pt == PTABLE_VTOC)
 				ptable_iterate(table, &pa, zfs_probe_partition);
 			ptable_close(table);
 		}

--- a/usr/src/cmd/cmd-crypto/tpmadm/main.c
+++ b/usr/src/cmd/cmd-crypto/tpmadm/main.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 
@@ -147,7 +148,7 @@ print_error(TSS_RESULT ret, char *msg)
 
 int
 get_tpm_capability(TSS_HCONTEXT hContext, TSS_HOBJECT hTPM, UINT32 cap,
-UINT32 subcap, void *buf, size_t bufsize)
+    UINT32 subcap, void *buf, size_t bufsize)
 {
 	TSS_RESULT ret;
 	UINT32 datalen;
@@ -179,7 +180,7 @@ UINT32 subcap, void *buf, size_t bufsize)
 
 int
 set_policy_options(TSS_HPOLICY hPolicy, TSS_FLAG mode, char *prompt,
-UINT32 secret_len, BYTE *secret)
+    UINT32 secret_len, BYTE *secret)
 {
 	TSS_RESULT ret;
 	BYTE *unicode_prompt;
@@ -206,7 +207,7 @@ UINT32 secret_len, BYTE *secret)
 
 int
 set_object_policy(TSS_HOBJECT handle, TSS_FLAG mode, char *prompt,
-UINT32 secret_len, BYTE *secret)
+    UINT32 secret_len, BYTE *secret)
 {
 	TSS_HPOLICY hPolicy;
 	TSS_RESULT ret;

--- a/usr/src/common/crypto/ecc/ec2_163.c
+++ b/usr/src/common/crypto/ecc/ec2_163.c
@@ -44,8 +44,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "ec2.h"
 #include "mp_gf2m.h"
 #include "mp_gf2m-priv.h"
@@ -197,15 +195,20 @@ ec_GF2m_163_mul(const mp_int *a, const mp_int *b, mp_int *r,
 #ifdef ECL_THIRTY_TWO_BIT
 		case 6:
 			a5 = MP_DIGIT(a, 5);
+			/* FALLTHROUGH */
 		case 5:
 			a4 = MP_DIGIT(a, 4);
+			/* FALLTHROUGH */
 		case 4:
 			a3 = MP_DIGIT(a, 3);
 #endif
+			/* FALLTHROUGH */
 		case 3:
 			a2 = MP_DIGIT(a, 2);
+			/* FALLTHROUGH */
 		case 2:
 			a1 = MP_DIGIT(a, 1);
+			/* FALLTHROUGH */
 		default:
 			a0 = MP_DIGIT(a, 0);
 		}
@@ -213,15 +216,20 @@ ec_GF2m_163_mul(const mp_int *a, const mp_int *b, mp_int *r,
 #ifdef ECL_THIRTY_TWO_BIT
 		case 6:
 			b5 = MP_DIGIT(b, 5);
+			/* FALLTHROUGH */
 		case 5:
 			b4 = MP_DIGIT(b, 4);
+			/* FALLTHROUGH */
 		case 4:
 			b3 = MP_DIGIT(b, 3);
 #endif
+			/* FALLTHROUGH */
 		case 3:
 			b2 = MP_DIGIT(b, 2);
+			/* FALLTHROUGH */
 		case 2:
 			b1 = MP_DIGIT(b, 1);
+			/* FALLTHROUGH */
 		default:
 			b0 = MP_DIGIT(b, 0);
 		}

--- a/usr/src/common/crypto/ecc/ec2_193.c
+++ b/usr/src/common/crypto/ecc/ec2_193.c
@@ -44,8 +44,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "ec2.h"
 #include "mp_gf2m.h"
 #include "mp_gf2m-priv.h"
@@ -206,17 +204,23 @@ ec_GF2m_193_mul(const mp_int *a, const mp_int *b, mp_int *r,
 #ifdef ECL_THIRTY_TWO_BIT
 		case 7:
 			a6 = MP_DIGIT(a, 6);
+			/* FALLTHROUGH */
 		case 6:
 			a5 = MP_DIGIT(a, 5);
+			/* FALLTHROUGH */
 		case 5:
 			a4 = MP_DIGIT(a, 4);
 #endif
+			/* FALLTHROUGH */
 		case 4:
 			a3 = MP_DIGIT(a, 3);
+			/* FALLTHROUGH */
 		case 3:
 			a2 = MP_DIGIT(a, 2);
+			/* FALLTHROUGH */
 		case 2:
 			a1 = MP_DIGIT(a, 1);
+			/* FALLTHROUGH */
 		default:
 			a0 = MP_DIGIT(a, 0);
 		}
@@ -224,17 +228,23 @@ ec_GF2m_193_mul(const mp_int *a, const mp_int *b, mp_int *r,
 #ifdef ECL_THIRTY_TWO_BIT
 		case 7:
 			b6 = MP_DIGIT(b, 6);
+			/* FALLTHROUGH */
 		case 6:
 			b5 = MP_DIGIT(b, 5);
+			/* FALLTHROUGH */
 		case 5:
 			b4 = MP_DIGIT(b, 4);
 #endif
+			/* FALLTHROUGH */
 		case 4:
 			b3 = MP_DIGIT(b, 3);
+			/* FALLTHROUGH */
 		case 3:
 			b2 = MP_DIGIT(b, 2);
+			/* FALLTHROUGH */
 		case 2:
 			b1 = MP_DIGIT(b, 1);
+			/* FALLTHROUGH */
 		default:
 			b0 = MP_DIGIT(b, 0);
 		}

--- a/usr/src/common/crypto/ecc/ec2_233.c
+++ b/usr/src/common/crypto/ecc/ec2_233.c
@@ -44,8 +44,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "ec2.h"
 #include "mp_gf2m.h"
 #include "mp_gf2m-priv.h"
@@ -225,19 +223,26 @@ ec_GF2m_233_mul(const mp_int *a, const mp_int *b, mp_int *r,
 #ifdef ECL_THIRTY_TWO_BIT
 		case 8:
 			a7 = MP_DIGIT(a, 7);
+			/* FALLTHROUGH */
 		case 7:
 			a6 = MP_DIGIT(a, 6);
+			/* FALLTHROUGH */
 		case 6:
 			a5 = MP_DIGIT(a, 5);
+			/* FALLTHROUGH */
 		case 5:
 			a4 = MP_DIGIT(a, 4);
 #endif
+			/* FALLTHROUGH */
 		case 4:
 			a3 = MP_DIGIT(a, 3);
+			/* FALLTHROUGH */
 		case 3:
 			a2 = MP_DIGIT(a, 2);
+			/* FALLTHROUGH */
 		case 2:
 			a1 = MP_DIGIT(a, 1);
+			/* FALLTHROUGH */
 		default:
 			a0 = MP_DIGIT(a, 0);
 		}
@@ -245,19 +250,26 @@ ec_GF2m_233_mul(const mp_int *a, const mp_int *b, mp_int *r,
 #ifdef ECL_THIRTY_TWO_BIT
 		case 8:
 			b7 = MP_DIGIT(b, 7);
+			/* FALLTHROUGH */
 		case 7:
 			b6 = MP_DIGIT(b, 6);
+			/* FALLTHROUGH */
 		case 6:
 			b5 = MP_DIGIT(b, 5);
+			/* FALLTHROUGH */
 		case 5:
 			b4 = MP_DIGIT(b, 4);
 #endif
+			/* FALLTHROUGH */
 		case 4:
 			b3 = MP_DIGIT(b, 3);
+			/* FALLTHROUGH */
 		case 3:
 			b2 = MP_DIGIT(b, 2);
+			/* FALLTHROUGH */
 		case 2:
 			b1 = MP_DIGIT(b, 1);
+			/* FALLTHROUGH */
 		default:
 			b0 = MP_DIGIT(b, 0);
 		}

--- a/usr/src/common/crypto/ecc/ecl_gf.c
+++ b/usr/src/common/crypto/ecc/ecl_gf.c
@@ -43,8 +43,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "mpi.h"
 #include "mp_gf2m.h"
 #include "ecl-priv.h"
@@ -280,16 +278,20 @@ ec_GFp_add_3(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 3:
 		a2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		a1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		a0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 3:
 		r2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(b,0);
 	}
@@ -363,20 +365,26 @@ ec_GFp_add_4(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 4:
 		a3 = MP_DIGIT(a,3);
+		/* FALLTHROUGH */
 	case 3:
 		a2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		a1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		a0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 4:
 		r3 = MP_DIGIT(b,3);
+		/* FALLTHROUGH */
 	case 3:
 		r2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(b,0);
 	}
@@ -457,24 +465,32 @@ ec_GFp_add_5(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 5:
 		a4 = MP_DIGIT(a,4);
+		/* FALLTHROUGH */
 	case 4:
 		a3 = MP_DIGIT(a,3);
+		/* FALLTHROUGH */
 	case 3:
 		a2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		a1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		a0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 5:
 		r4 = MP_DIGIT(b,4);
+		/* FALLTHROUGH */
 	case 4:
 		r3 = MP_DIGIT(b,3);
+		/* FALLTHROUGH */
 	case 3:
 		r2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(b,0);
 	}
@@ -534,28 +550,38 @@ ec_GFp_add_6(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 6:
 		a5 = MP_DIGIT(a,5);
+		/* FALLTHROUGH */
 	case 5:
 		a4 = MP_DIGIT(a,4);
+		/* FALLTHROUGH */
 	case 4:
 		a3 = MP_DIGIT(a,3);
+		/* FALLTHROUGH */
 	case 3:
 		a2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		a1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		a0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 6:
 		r5 = MP_DIGIT(b,5);
+		/* FALLTHROUGH */
 	case 5:
 		r4 = MP_DIGIT(b,4);
+		/* FALLTHROUGH */
 	case 4:
 		r3 = MP_DIGIT(b,3);
+		/* FALLTHROUGH */
 	case 3:
 		r2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(b,0);
 	}
@@ -625,16 +651,20 @@ ec_GFp_sub_3(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 3:
 		r2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 3:
 		b2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		b1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		b0 = MP_DIGIT(b,0);
 	}
@@ -709,20 +739,26 @@ ec_GFp_sub_4(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 4:
 		r3 = MP_DIGIT(a,3);
+		/* FALLTHROUGH */
 	case 3:
 		r2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 4:
 		b3 = MP_DIGIT(b,3);
+		/* FALLTHROUGH */
 	case 3:
 		b2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		b1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		b0 = MP_DIGIT(b,0);
 	}
@@ -802,24 +838,32 @@ ec_GFp_sub_5(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 5:
 		r4 = MP_DIGIT(a,4);
+		/* FALLTHROUGH */
 	case 4:
 		r3 = MP_DIGIT(a,3);
+		/* FALLTHROUGH */
 	case 3:
 		r2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 5:
 		b4 = MP_DIGIT(b,4);
+		/* FALLTHROUGH */
 	case 4:
 		b3 = MP_DIGIT(b,3);
+		/* FALLTHROUGH */
 	case 3:
 		b2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		b1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		b0 = MP_DIGIT(b,0);
 	}
@@ -870,28 +914,38 @@ ec_GFp_sub_6(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 6:
 		r5 = MP_DIGIT(a,5);
+		/* FALLTHROUGH */
 	case 5:
 		r4 = MP_DIGIT(a,4);
+		/* FALLTHROUGH */
 	case 4:
 		r3 = MP_DIGIT(a,3);
+		/* FALLTHROUGH */
 	case 3:
 		r2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 6:
 		b5 = MP_DIGIT(b,5);
+		/* FALLTHROUGH */
 	case 5:
 		b4 = MP_DIGIT(b,4);
+		/* FALLTHROUGH */
 	case 4:
 		b3 = MP_DIGIT(b,3);
+		/* FALLTHROUGH */
 	case 3:
 		b2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		b1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		b0 = MP_DIGIT(b,0);
 	}

--- a/usr/src/common/crypto/ecc/ecp_192.c
+++ b/usr/src/common/crypto/ecc/ecp_192.c
@@ -42,8 +42,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "ecp.h"
 #include "mpi.h"
 #include "mplogic.h"
@@ -96,14 +94,19 @@ ec_GFp_nistp192_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		switch (a_used) {
 		case 12:
 			a5b = MP_DIGIT(a, 11);
+			/* FALLTHROUGH */
 		case 11:
 			a5a = MP_DIGIT(a, 10);
+			/* FALLTHROUGH */
 		case 10:
 			a4b = MP_DIGIT(a, 9);
+			/* FALLTHROUGH */
 		case 9:
 			a4a = MP_DIGIT(a, 8);
+			/* FALLTHROUGH */
 		case 8:
 			a3b = MP_DIGIT(a, 7);
+			/* FALLTHROUGH */
 		case 7:
 			a3a = MP_DIGIT(a, 6);
 		}
@@ -186,8 +189,10 @@ ec_GFp_nistp192_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		switch (a_used) {
 		case 6:
 			a5 = MP_DIGIT(a, 5);
+			/* FALLTHROUGH */
 		case 5:
 			a4 = MP_DIGIT(a, 4);
+			/* FALLTHROUGH */
 		case 4:
 			a3 = MP_DIGIT(a, 3);
 		}
@@ -308,16 +313,20 @@ ec_GFp_nistp192_add(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 3:
 		a2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		a1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		a0 = MP_DIGIT(a,0);
 	}
 	switch(MP_USED(b)) {
 	case 3:
 		r2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(b,0);
 	}
@@ -389,8 +398,10 @@ ec_GFp_nistp192_sub(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(a)) {
 	case 3:
 		r2 = MP_DIGIT(a,2);
+		/* FALLTHROUGH */
 	case 2:
 		r1 = MP_DIGIT(a,1);
+		/* FALLTHROUGH */
 	case 1:
 		r0 = MP_DIGIT(a,0);
 	}
@@ -398,8 +409,10 @@ ec_GFp_nistp192_sub(const mp_int *a, const mp_int *b, mp_int *r,
 	switch(MP_USED(b)) {
 	case 3:
 		b2 = MP_DIGIT(b,2);
+		/* FALLTHROUGH */
 	case 2:
 		b1 = MP_DIGIT(b,1);
+		/* FALLTHROUGH */
 	case 1:
 		b0 = MP_DIGIT(b,0);
 	}

--- a/usr/src/common/crypto/ecc/ecp_224.c
+++ b/usr/src/common/crypto/ecc/ecp_224.c
@@ -42,8 +42,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "ecp.h"
 #include "mpi.h"
 #include "mplogic.h"
@@ -90,16 +88,22 @@ ec_GFp_nistp224_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		switch (a_used) {
 		case 14:
 			a6b = MP_DIGIT(a, 13);
+			/* FALLTHROUGH */
 		case 13:
 			a6a = MP_DIGIT(a, 12);
+			/* FALLTHROUGH */
 		case 12:
 			a5b = MP_DIGIT(a, 11);
+			/* FALLTHROUGH */
 		case 11:
 			a5a = MP_DIGIT(a, 10);
+			/* FALLTHROUGH */
 		case 10:
 			a4b = MP_DIGIT(a, 9);
+			/* FALLTHROUGH */
 		case 9:
 			a4a = MP_DIGIT(a, 8);
+			/* FALLTHROUGH */
 		case 8:
 			a3b = MP_DIGIT(a, 7);
 		}
@@ -212,6 +216,7 @@ ec_GFp_nistp224_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 			a6 = MP_DIGIT(a, 6);
 			a6b = a6 >> 32;
 			a6a_a5b = a6 << 32;
+			/* FALLTHROUGH */
 		case 6:
 			a5 = MP_DIGIT(a, 5);
 			a5b = a5 >> 32;
@@ -219,10 +224,12 @@ ec_GFp_nistp224_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 			a5b = a5b << 32;
 			a5a_a4b = a5 << 32;
 			a5a = a5 & 0xffffffff;
+			/* FALLTHROUGH */
 		case 5:
 			a4 = MP_DIGIT(a, 4);
 			a5a_a4b |= a4 >> 32;
 			a4a_a3b = a4 << 32;
+			/* FALLTHROUGH */
 		case 4:
 			a3b = MP_DIGIT(a, 3) >> 32;
 			a4a_a3b |= a3b;

--- a/usr/src/common/crypto/ecc/ecp_256.c
+++ b/usr/src/common/crypto/ecc/ecp_256.c
@@ -42,8 +42,6 @@
  * Sun elects to use this software under the MPL license.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include "ecp.h"
 #include "mpi.h"
 #include "mplogic.h"
@@ -87,18 +85,25 @@ ec_GFp_nistp256_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		switch (a_used) {
 		case 16:
 			a15 = MP_DIGIT(a,15);
+			/* FALLTHROUGH */
 		case 15:
 			a14 = MP_DIGIT(a,14);
+			/* FALLTHROUGH */
 		case 14:
 			a13 = MP_DIGIT(a,13);
+			/* FALLTHROUGH */
 		case 13:
 			a12 = MP_DIGIT(a,12);
+			/* FALLTHROUGH */
 		case 12:
 			a11 = MP_DIGIT(a,11);
+			/* FALLTHROUGH */
 		case 11:
 			a10 = MP_DIGIT(a,10);
+			/* FALLTHROUGH */
 		case 10:
 			a9 = MP_DIGIT(a,9);
+			/* FALLTHROUGH */
 		case 9:
 			a8 = MP_DIGIT(a,8);
 		}
@@ -270,10 +275,13 @@ ec_GFp_nistp256_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		switch (a_used) {
 		case 8:
 			a7 = MP_DIGIT(a,7);
+			/* FALLTHROUGH */
 		case 7:
 			a6 = MP_DIGIT(a,6);
+			/* FALLTHROUGH */
 		case 6:
 			a5 = MP_DIGIT(a,5);
+			/* FALLTHROUGH */
 		case 5:
 			a4 = MP_DIGIT(a,4);
 		}

--- a/usr/src/lib/cfgadm_plugins/pci/common/cfga.c
+++ b/usr/src/lib/cfgadm_plugins/pci/common/cfga.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  *	Plugin Library for PCI Hot-Plug Controller
  */
@@ -332,7 +330,7 @@ get_occupants(const char *ap_id, hpc_occupant_info_t *occupant)
 			break;
 		}
 		occupant->id[occupant->i] = (char *)malloc(
-			strlen(prop_data) + sizeof ("/devices"));
+		    strlen(prop_data) + sizeof ("/devices"));
 		(void) snprintf(occupant->id[occupant->i], strlen(prop_data) +
 		    sizeof ("/devices"), "/devices%s", prop_data);
 		DBG(1, ("%s\n", occupant->id[occupant->i]));
@@ -706,8 +704,7 @@ cfga_change_state(cfga_cmd_t state_change_cmd, const char *ap_id,
 			rv = CFGA_ERROR;
 			cfga_err(errstring, CMD_SLOT_CONFIGURE, 0);
 			if ((rs == AP_RSTATE_DISCONNECTED) &&
-					(devctl_ap_disconnect(dcp, NULL)
-								== -1)) {
+			    (devctl_ap_disconnect(dcp, NULL) == -1)) {
 				rv = CFGA_ERROR;
 				cfga_err(errstring,
 				    CMD_SLOT_CONFIGURE, 0);
@@ -1038,19 +1035,19 @@ cfga_private_func(const char *function, const char *ap_id,
 	switch (i) {
 		case ENABLE_SLOT:
 			build_control_data(&iocdata,
-				HPC_CTRL_ENABLE_SLOT, 0);
+			    HPC_CTRL_ENABLE_SLOT, 0);
 			break;
 		case DISABLE_SLOT:
 			build_control_data(&iocdata,
-				HPC_CTRL_DISABLE_SLOT, 0);
+			    HPC_CTRL_DISABLE_SLOT, 0);
 			break;
 		case ENABLE_AUTOCNF:
 			build_control_data(&iocdata,
-				HPC_CTRL_ENABLE_AUTOCFG, 0);
+			    HPC_CTRL_ENABLE_AUTOCFG, 0);
 			break;
 		case DISABLE_AUTOCNF:
 			build_control_data(&iocdata,
-				HPC_CTRL_DISABLE_AUTOCFG, 0);
+			    HPC_CTRL_DISABLE_AUTOCFG, 0);
 			break;
 		case LED:
 			/* set mode */
@@ -1082,11 +1079,10 @@ cfga_private_func(const char *function, const char *ap_id,
 				len = strlen(func_strs[MODE]);
 				if ((strncmp(str, func_strs[MODE], len) == 0) &&
 				    (*(str+(len)) == '=')) {
-				    for (str = (str+(++len)), i = 0;
-					*str != NULL; i++, str++) {
+					for (str = (str+(++len)), i = 0;
+					    *str != NULL; i++, str++) {
 						buf[i] = *str;
-
-				    }
+					}
 				}
 				buf[i] = '\0';
 				DBG(2, ("buf_mode= %s\n", buf));
@@ -1111,6 +1107,7 @@ cfga_private_func(const char *function, const char *ap_id,
 				return (prt_led_mode(ap_id, repeat, errstring,
 				    msgp));
 			}
+			/* FALLTHROUGH */
 		default:
 			DBG(1, ("default\n"));
 			errno = EINVAL;
@@ -1278,8 +1275,7 @@ find_physical_slot_names(const char *devcomp, struct searcharg *slotarg)
 
 	DBG(1, ("find_physical_slot_names\n"));
 
-	if ((root_node = di_init("/", DINFOCPYALL|DINFOPATH))
-		== DI_NODE_NIL) {
+	if ((root_node = di_init("/", DINFOCPYALL|DINFOPATH)) == DI_NODE_NIL) {
 		DBG(1, ("di_init() failed\n"));
 		return (NULL);
 	}
@@ -1293,7 +1289,7 @@ find_physical_slot_names(const char *devcomp, struct searcharg *slotarg)
 	}
 
 	(void) di_walk_minor(root_node, "ddi_ctl:attachment_point:pci",
-		0, (void *)slotarg, find_slotname);
+	    0, (void *)slotarg, find_slotname);
 
 	di_prom_fini(slotarg->promp);
 	di_fini(root_node);

--- a/usr/src/lib/cfgadm_plugins/sbd/common/ap_seq.c
+++ b/usr/src/lib/cfgadm_plugins/sbd/common/ap_seq.c
@@ -332,8 +332,8 @@ ap_seq_exec(apd_t *a, int cmd, int first, int last)
 			    SCF_SUCCESS) {
 				fastreboot_disabled = 1;
 			}
-			/* FALLTHROUGH */
 #endif	/* __x86 */
+			/* FALLTHROUGH */
 
 		default:
 			rc = ap_ioctl(a, c);

--- a/usr/src/lib/cfgadm_plugins/shp/common/shp.c
+++ b/usr/src/lib/cfgadm_plugins/shp/common/shp.c
@@ -983,6 +983,7 @@ cfga_private_func(const char *function, const char *ap_id,
 				return (prt_led_mode(ap_id, repeat, errstring,
 				    msgp));
 			}
+			/* FALLTHROUGH */
 		default:
 			DBG(1, ("default\n"));
 			errno = EINVAL;

--- a/usr/src/lib/libcurses/screen/scr_reset.c
+++ b/usr/src/lib/libcurses/screen/scr_reset.c
@@ -37,8 +37,6 @@
  * contributors.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*LINTLIBRARY*/
 
 #include	"curses_inc.h"
@@ -97,13 +95,13 @@ scr_reset(FILE *filep, int type)
 	}
 
 	/* check magic number */
-	if (fread((char *) &magic, sizeof (short), 1, filep) != 1)
+	if (fread((char *)&magic, sizeof (short), 1, filep) != 1)
 		goto err;
 	if (magic != SVR3_DUMP_MAGIC_NUMBER)
 		goto err;
 
 	/* get modification time of image in file */
-	if (fread((char *) &ttytime, sizeof (time_t), 1, filep) != 1)
+	if (fread((char *)&ttytime, sizeof (time_t), 1, filep) != 1)
 		goto err;
 
 	if ((type != 1) && ((ttyname(cur_term->Filedes) == NULL) ||
@@ -128,13 +126,13 @@ scr_reset(FILE *filep, int type)
 	    ((type == 2) && ((win1 = dupwin(win)) == NULL)) ||
 	    (win->_maxy != curscr->_maxy) || (win->_maxx != curscr->_maxx) ||
 	    /* soft labels */
-	    (fread((char *) &magic, sizeof (int), 1, filep) != 1))
+	    (fread((char *)&magic, sizeof (int), 1, filep) != 1))
 		goto err;
 
 	/*
-	* if soft labels were dumped, we would like either read them
-	* or advance the file pointer pass them
-	*/
+	 * if soft labels were dumped, we would like either read them
+	 * or advance the file pointer pass them
+	 */
 	if (magic) {
 		short	i, labmax, lablen;
 		SLK_MAP	*slk = SP->slk;
@@ -144,10 +142,10 @@ scr_reset(FILE *filep, int type)
 		 */
 		/*
 		 * char	**labdis = SP->slk->_ldis, **labval = SP->slk->_lval;
-		*/
+		 */
 
-		if ((fread((char *) &labmax, sizeof (short), 1, filep) != 1) ||
-		    (fread((char *) &lablen, sizeof (short), 1, filep) != 1)) {
+		if ((fread((char *)&labmax, sizeof (short), 1, filep) != 1) ||
+		    (fread((char *)&lablen, sizeof (short), 1, filep) != 1)) {
 			goto err;
 		}
 
@@ -162,7 +160,7 @@ scr_reset(FILE *filep, int type)
 				 * filep) != lablen) ||
 				 * (fread(labval[i], sizeof (char), lablen,
 				 * filep != lablen))
-				*/
+				 */
 				if ((fread(slk->_ldis[i], sizeof (char),
 				    lablen, filep) != lablen) ||
 				    (fread(slk->_lval[i],
@@ -172,7 +170,7 @@ scr_reset(FILE *filep, int type)
 			}
 			(*_do_slk_tch)();
 		} else {
-			if (fseek(filep, (long) (2 * labmax * lablen *
+			if (fseek(filep, (long)(2 * labmax * lablen *
 			    sizeof (char)), 1) != 0)
 				goto err;
 		}
@@ -180,7 +178,7 @@ scr_reset(FILE *filep, int type)
 
 	/* read the color information(if any) from the file 		*/
 
-	if (fread((char *) &magic, sizeof (int), 1, filep) != 1)
+	if (fread((char *)&magic, sizeof (int), 1, filep) != 1)
 		goto err;
 
 	if (magic) {
@@ -196,15 +194,15 @@ scr_reset(FILE *filep, int type)
 	/* new terminal doesn't support color, in order to know how to   */
 	/* deal with the rest of the file				 */
 
-		if ((fread((char *) &colors, sizeof (int), 1, filep) != 1) ||
-		    (fread((char *) &color_pairs, sizeof (int), 1,
-		    filep) != 1) || (fread((char *) &could_change,
+		if ((fread((char *)&colors, sizeof (int), 1, filep) != 1) ||
+		    (fread((char *)&color_pairs, sizeof (int), 1,
+		    filep) != 1) || (fread((char *)&could_change,
 		    sizeof (char), 1, filep) != 1))
 			goto err;
 
 		if (max_pairs == -1 || cur_term->_pairs_tbl == NULL ||
 		    colors > max_colors || color_pairs > max_pairs) {
-			if (fseek(filep, (long) (colors * sizeof (_Color) +
+			if (fseek(filep, (long)(colors * sizeof (_Color) +
 			    color_pairs * sizeof (_Color_pair)), 1) != 0)
 				goto err;
 		} else {
@@ -237,7 +235,7 @@ scr_reset(FILE *filep, int type)
 		/* the old terminal could modify colors, by the new one */
 		/* cannot skip over color_table info.			*/
 
-					if (fseek(filep, (long) (colors *
+					if (fseek(filep, (long)(colors *
 					    sizeof (_Color)), 1) != 0)
 						goto err;
 				}
@@ -265,7 +263,7 @@ err:
 				if (ptp->init)
 					/* LINTED */
 					(void) init_pair((short)i,
-					     ptp->foreground, ptp->background);
+					    ptp->foreground, ptp->background);
 			}
 			free(save_ptp);
 		}
@@ -289,7 +287,7 @@ err:
 			/* clear the hash table */
 			for (y = curscr->_maxy; y > 0; --y)
 				*hash++ = _NOHASH;
-		/* LINTED */ /* Known fall-through on case statement. */
+			/* FALLTHROUGH */
 		case 0:
 			{
 			int	saveflag = curscr->_flags & _CANT_BE_IMMED;

--- a/usr/src/lib/libdhcputil/common/dhcp_inittab.c
+++ b/usr/src/lib/libdhcputil/common/dhcp_inittab.c
@@ -1398,8 +1398,7 @@ inittab_msg(const char *fmt, ...)
 		}
 
 		action = INITTAB_MSG_OUTPUT;
-
-		/* FALLTHRU into INITTAB_MSG_OUTPUT */
+		/* FALLTHROUGH */
 
 	case INITTAB_MSG_OUTPUT:
 

--- a/usr/src/lib/libeti/form/common/regex.c
+++ b/usr/src/lib/libeti/form/common/regex.c
@@ -28,8 +28,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*LINTLIBRARY*/
 
 #include <sys/types.h>
@@ -173,6 +171,7 @@ __advance(char *alp, char *aep)
 
 	case EGRP|STAR:
 		(void) __xpop(0);
+		/* FALLTHROUGH */
 	case EGRP|PLUS:
 		(void) __xpush(0, ++ep);
 		return ((intptr_t)lp);
@@ -276,17 +275,21 @@ __advance(char *alp, char *aep)
 	case CDOT|PLUS:
 		if (*lp++ == '\0')
 			return (0);
+		/* FALLTHROUGH */
 	case CDOT|STAR:
 		curlp = lp;
-		while (*lp++);
+		while (*lp++)
+			;
 		goto star;
 
 	case CCHR|PLUS:
 		if (*lp++ != *ep)
 			return (0);
+		/* FALLTHROUGH */
 	case CCHR|STAR:
 		curlp = lp;
-		while (*lp++ == *ep);
+		while (*lp++ == *ep)
+			;
 		ep++;
 		goto star;
 
@@ -296,6 +299,7 @@ __advance(char *alp, char *aep)
 	case PGRP|A768:
 		if (!(lp = (char *)__advance(lp, ep+1)))
 			return (0);
+		/* FALLTHROUGH */
 	case SGRP|A768:
 	case SGRP|A512:
 	case SGRP|A256:
@@ -314,11 +318,13 @@ __advance(char *alp, char *aep)
 	case NCCL|PLUS:
 		if (!__cclass(ep, *lp++, ep[-1] == (CCL | PLUS)))
 			return (0);
+		/* FALLTHROUGH */
 	case CCL|STAR:
 	case NCCL|STAR:
 		curlp = lp;
 		while (__cclass(ep, *lp++, ((ep[-1] == (CCL | STAR)) ||
-			(ep[-1] == (CCL | PLUS)))));
+		    (ep[-1] == (CCL | PLUS)))))
+			;
 		ep += *ep;
 		goto star;
 

--- a/usr/src/lib/libldap5/sources/ldap/ber/io.c
+++ b/usr/src/lib/libldap5/sources/ldap/ber/io.c
@@ -870,7 +870,7 @@ ber_sockbuf_set_option( Sockbuf *sb, int option, void *value )
 	switch ( option ) {
 	case LBER_SOCKBUF_OPT_MAX_INCOMING_SIZE:
 		sb->sb_max_incoming = *((ber_uint_t *) value);
-		/* FALL */
+		/* FALLTHROUGH */
 	case LBER_SOCKBUF_OPT_TO_FILE:
 	case LBER_SOCKBUF_OPT_TO_FILE_ONLY:
 	case LBER_SOCKBUF_OPT_NO_READ_AHEAD:

--- a/usr/src/lib/libldap5/sources/ldap/common/friendly.c
+++ b/usr/src/lib/libldap5/sources/ldap/common/friendly.c
@@ -2,8 +2,6 @@
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * The contents of this file are subject to the Netscape Public
  * License Version 1.1 (the "License"); you may not use this file
@@ -33,12 +31,6 @@
  *  friendly.c
  */
 
-#if 0
-#ifndef lint 
-static char copyright[] = "@(#) Copyright (c) 1993 Regents of the University of Michigan.\nAll rights reserved.\n";
-#endif
-#endif
-
 #include "ldap-int.h"
 
 char *
@@ -53,10 +45,9 @@ ldap_friendly_name( char *filename, char *name, FriendlyMap *map )
 	if ( map == NULL ) {
 		return( name );
 	}
-    if ( NULL == name)
-    {
-        return (name);
-    }
+	if ( name == NULL ) {
+		return(name);
+	}
 
 	if ( *map == NULL ) {
 		if ( (fp = fopen( filename, "rF" )) == NULL )
@@ -98,7 +89,7 @@ ldap_friendly_name( char *filename, char *name, FriendlyMap *map )
 					case '"':
 						if ( !esc )
 							found = 1;
-						/* FALL */
+						/* FALLTHROUGH */
 					default:
 						esc = 0;
 						break;

--- a/usr/src/lib/libldap5/sources/ldap/common/getdn.c
+++ b/usr/src/lib/libldap5/sources/ldap/common/getdn.c
@@ -3,8 +3,6 @@
  * All rights reserved.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * The contents of this file are subject to the Netscape Public
  * License Version 1.1 (the "License"); you may not use this file
@@ -33,12 +31,6 @@
 /*
  *  getdn.c
  */
-
-#if 0
-#ifndef lint 
-static char copyright[] = "@(#) Copyright (c) 1990 Regents of the University of Michigan.\nAll rights reserved.\n";
-#endif
-#endif
 
 #include "ldap-int.h"
 
@@ -238,6 +230,7 @@ ldap_explode( const char *dn, const int notypes, const int nametype )
 				state = INQUOTE;
 			break;
 		case '+': if ( nametype != LDAP_RDN ) break;
+			/* FALLTHROUGH */
 		case ';':
 		case ',':
 		case '\0':
@@ -323,7 +316,7 @@ ldap_explode( const char *dn, const int notypes, const int nametype )
 			if ( state == OUTQUOTE ) {
 				goteq = 1;
 			}
-			/* FALL */
+			/* FALLTHROUGH */
 		default:
 			plen = LDAP_UTF8LEN(p);
 			break;

--- a/usr/src/lib/libldap5/sources/ldap/common/ldaputf8.c
+++ b/usr/src/lib/libldap5/sources/ldap/common/ldaputf8.c
@@ -1,5 +1,3 @@
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * The contents of this file are subject to the Netscape Public
  * License Version 1.1 (the "License"); you may not use this file
@@ -51,10 +49,15 @@ ldap_utf8next (char* s)
     switch (UTF8len [(*next >> 2) & 0x3F]) {
       case 0: /* erroneous: s points to the middle of a character. */
       case 6: if ((*++next & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 5: if ((*++next & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 4: if ((*++next & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 3: if ((*++next & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 2: if ((*++next & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 1: ++next;
     }
     return (char*) next;
@@ -88,10 +91,15 @@ ldap_utf8copy (char* dst, const char* src)
     switch (UTF8len [(*s >> 2) & 0x3F]) {
       case 0: /* erroneous: s points to the middle of a character. */
       case 6: *dst++ = *s++; if ((*s & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 5: *dst++ = *s++; if ((*s & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 4: *dst++ = *s++; if ((*s & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 3: *dst++ = *s++; if ((*s & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 2: *dst++ = *s++; if ((*s & 0xC0) != 0x80) break;
+	/* FALLTHROUGH */
       case 1: *dst   = *s++;
     }
     return s - (const unsigned char*)src;

--- a/usr/src/lib/libtecla/common/expand.c
+++ b/usr/src/lib/libtecla/common/expand.c
@@ -29,8 +29,6 @@
  * of the copyright holder.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * If file-system access is to be excluded, this module has no function,
  * so all of its code should be excluded.
@@ -887,6 +885,7 @@ static int ef_string_matches_pattern(const char *file, const char *pattern,
 /*
  * A normal character to be matched explicitly.
  */
+      /* FALLTHROUGH */
     default:
       if(*fptr == *pptr) {
         fptr++;

--- a/usr/src/lib/libtecla/common/getline.c
+++ b/usr/src/lib/libtecla/common/getline.c
@@ -35,8 +35,6 @@
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * Standard headers.
  */
@@ -6481,6 +6479,7 @@ static int _gl_parse_config_line(GetLine *gl, void *stream, GlcGetcFn *getc_fn,
     switch(argc) {
     case 3:
       action = argv[2];
+      /* FALLTHROUGH */
     case 2:              /* Note the intentional fallthrough */
       keyseq = argv[1];
 /*

--- a/usr/src/lib/libtecla/common/history.c
+++ b/usr/src/lib/libtecla/common/history.c
@@ -34,8 +34,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -2722,6 +2720,7 @@ static int glh_line_matches_glob(GlhLineStream *lstr, GlhLineStream *pstr)
 /*
  * A normal character to be matched explicitly.
  */
+      /* FALLTHROUGH */
     default:
       if(lstr->c == pstr->c) {
 	glh_step_stream(lstr);

--- a/usr/src/lib/pkcs11/libpkcs11/common/metaAttrManager.c
+++ b/usr/src/lib/pkcs11/libpkcs11/common/metaAttrManager.c
@@ -136,6 +136,7 @@ get_master_attributes_by_template(
 		case CKO_DATA:
 			/* CKO_DATA has no subtype, just pretend it is found  */
 			found = B_TRUE;
+			break;
 		default:
 			/* unknown object class */
 			return (CKR_ATTRIBUTE_VALUE_INVALID);

--- a/usr/src/lib/sun_sas/common/devtree_device_disco.c
+++ b/usr/src/lib/sun_sas/common/devtree_device_disco.c
@@ -718,7 +718,7 @@ get_attached_paths_info(di_path_t path, struct sun_sas_port *port_ptr)
 				break;
 			}
 		}
-		if (charptr != '\0') {
+		if (*charptr != '\0') {
 			tmpAddr = htonll(strtoll(charptr, NULL, 16));
 			(void) memcpy(&SASAddress.wwn[0], &tmpAddr, 8);
 		} else {

--- a/usr/src/lib/sun_sas/common/sun_sas.c
+++ b/usr/src/lib/sun_sas/common/sun_sas.c
@@ -277,6 +277,7 @@ lock(mutex_t *mp)
 			case ENOTRECOVERABLE:
 				log(LOG_DEBUG, ROUTINE,
 				    "Lock failed: not recoverable 0x%x", mp);
+				break;
 			default:
 				if (loop > DEADLOCK_WARNING) {
 					log(LOG_DEBUG, ROUTINE,

--- a/usr/src/tools/quick/make-smbsrv
+++ b/usr/src/tools/quick/make-smbsrv
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
 #
 
 # Use distributed make (dmake) by default.
@@ -32,12 +32,14 @@ cpu=`uname -p`
 case $cpu in
 i386)
 	x=intel
+	kmdb_arch="amd64"
 	mdb_arch="ia32 amd64"
 	arch64=amd64
 	;;
 sparc)
 	x=sparc
-	mdb_arch=v9
+	kmdb_arch=v9
+	mdb_arch="v7 v9"
 	arch64=sparcv9
 	;;
 *)  echo "Huh?" ; exit 1;;
@@ -195,7 +197,9 @@ esac
 
 # Build the MDB modules, WITH the linktest
 (cd $SRC/cmd/mdb/tools && $make $1)
-for a in $mdb_arch
+
+# kmdb_arch is 64-bit only
+for a in $kmdb_arch
 do
   case $1 in
   install|lint)
@@ -207,15 +211,19 @@ do
 	$make -k $1 )
     ;;
   esac
-
   (cd $SRC/cmd/mdb/$x/$a/nsmb &&
 	$make $1 KMDB_LINKTEST_ENABLE= )
   (cd $SRC/cmd/mdb/$x/$a/smbfs &&
 	$make $1 KMDB_LINKTEST_ENABLE= )
   (cd $SRC/cmd/mdb/$x/$a/smbsrv &&
 	$make $1 KMDB_LINKTEST_ENABLE= )
+done
+
+# mdb_arch is both 32-bit & 64-bit
+for a in $mdb_arch
+do
   (cd $SRC/cmd/mdb/$x/$a/libfksmbsrv &&
-	$make $1 KMDB_LINKTEST_ENABLE= )
+	$make $1 )
 
 # We build these libraries (to the proto area), so we need to
 # build the mdb modules too so mdb will load them.
@@ -271,14 +279,11 @@ do_tar() {
 	files="
 lib/svc/manifest/network/smb/server.xml
 usr/kernel/drv/$arch64/smbsrv
-usr/kernel/drv/smbsrv
 usr/kernel/kmdb/$arch64/smbsrv
-usr/kernel/kmdb/smbsrv
 usr/lib/fs/smb/$arch64/libshare_smb.so.1
 usr/lib/fs/smb/libshare_smb.so.1
 usr/lib/libsmbfs.so.1
 usr/lib/mdb/kvm/$arch64/smbsrv.so
-usr/lib/mdb/kvm/smbsrv.so
 usr/lib/reparse/libreparse_smb.so.1
 usr/lib/security/pam_smb_passwd.so.1
 usr/lib/smbsrv/dtrace

--- a/usr/src/tools/quick/make-zfs
+++ b/usr/src/tools/quick/make-zfs
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
 #
 
 # Use distributed make (dmake) by default.
@@ -29,13 +29,15 @@ cpu=`uname -p`
 case $cpu in
 i386)
 	x=intel
+	kmdb_arch="amd64"
 	mdb_arch="ia32 amd64"
 	arch32=i86
 	arch64=amd64
 	;;
 sparc)
 	x=sparc
-	mdb_arch=v9
+	kmdb_arch=v9
+	mdb_arch="v7 v9"
 	arch32=sparc
 	arch64=sparcv9
 	;;
@@ -225,7 +227,9 @@ esac
 
 # Build the MDB modules, WITH the linktest
 (cd $SRC/cmd/mdb/tools && $make $1)
-for a in $mdb_arch
+
+# kmdb_arch is 64-bit only
+for a in $kmdb_arch
 do
   case $1 in
   install|lint)
@@ -241,6 +245,11 @@ do
   (cd $SRC/cmd/mdb/$x/$a/zfs &&
 	$make $1 KMDB_LINKTEST_ENABLE= )
 
+done
+
+# mdb_arch is both 32-bit & 64-bit
+for a in $mdb_arch
+do
   (cd $SRC/cmd/mdb/$x/$a/libzpool &&
 	$make $1 )
 
@@ -304,11 +313,8 @@ do_tar() {
 	git_rev=`git rev-parse --short=8 HEAD`
 	files="
 kernel/drv/$arch64/zfs
-kernel/drv/zfs
 kernel/fs/$arch64/zfs
-kernel/fs/zfs
 kernel/kmdb/$arch64/zfs
-kernel/kmdb/zfs
 lib/$arch64/libzfs.so.1
 lib/$arch64/libzfs_core.so.1
 lib/libzfs.so.1
@@ -323,7 +329,6 @@ usr/lib/fs/zfs/fstyp.so.1
 usr/lib/libzfs_jni.so.1
 usr/lib/libzpool.so.1
 usr/lib/mdb/kvm/$arch64/zfs.so
-usr/lib/mdb/kvm/zfs.so
 usr/lib/mdb/proc/$arch64/libzpool.so
 usr/lib/mdb/proc/libzpool.so
 sbin/zfs

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -1478,14 +1478,6 @@ vdev_open(vdev_t *vd)
 		return (error);
 	}
 
-	if (vd->vdev_top == vd && vd->vdev_ashift != 0 &&
-	    !vd->vdev_isl2cache && !vd->vdev_islog) {
-		if (vd->vdev_ashift > spa->spa_max_ashift)
-			spa->spa_max_ashift = vd->vdev_ashift;
-		if (vd->vdev_ashift < spa->spa_min_ashift)
-			spa->spa_min_ashift = vd->vdev_ashift;
-	}
-
 	/*
 	 * Track the min and max ashift values for normal data devices.
 	 */


### PR DESCRIPTION
Weekly merge from `illumos-gate`

### Backports

* none

### ONU

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2018030101-3775b4609b i86pc i386 i86pc
```

### mail_msg

```
==== Nightly distributed build started:   Thu Mar  1 12:30:47 CET 2018 ====
==== Nightly distributed build completed: Thu Mar  1 13:23:29 CET 2018 ====

==== Total build time ====

real    0:52:42

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-4e54e9404d i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_161-b01"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   78

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018030101-3775b4609b

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:41.8
user    53:48.3
sys      5:00.0

==== Build noise differences (non-DEBUG) ====

1c1
< 	-classpath /build/illumos-omnios/usr/src/lib/libdtrace_jni/java/classes:/build/illumos-omnios/usr/src/lib/libdtrace_jni/java/src -d /build/illumos-omnios/proto/root_i386/usr/share/lib/java/javadoc/dtrace/api \
---
> 	-classpath /build/illumos-omnios/usr/src/lib/libdtrace_jni/java/classes:/build/illumos-omnios/usr/src/lib/libdtrace_jni/java/src -d /build/illumos-omnios/proto/root_i386-nd/usr/share/lib/java/javadoc/dtrace/api \
68d67
< ln: /build/illumos-omnios/proto/root_i386/usr/bin/plgrp: File exists

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:10.8
user    46:54.1
sys      4:47.3

==== Build noise differences (DEBUG) ====

0a1
> 	-classpath /build/illumos-omnios/usr/src/lib/libdtrace_jni/java/classes:/build/illumos-omnios/usr/src/lib/libdtrace_jni/java/src -d /build/illumos-omnios/proto/root_i386/usr/share/lib/java/javadoc/dtrace/api \
28a30,32
> : libcommon.a
> : libdrivers.a
> : libgrub.a

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====

3054a3055
> lib/amd64/libefi.so.1: NEEDED=libsmbios.so.1
10124a10126
> lib/libefi.so.1: NEEDED=libsmbios.so.1
28026d28027
< usr/lib/security/amd64/pkcs11_tpm.so.1: NEEDED=libcrypto.so.1.0.0
28027a28029
> usr/lib/security/amd64/pkcs11_tpm.so.1: NEEDED=libsoftcrypto.so.1
28679d28680
< usr/lib/security/pkcs11_tpm.so.1: NEEDED=libcrypto.so.1.0.0
28680a28682
> usr/lib/security/pkcs11_tpm.so.1: NEEDED=libsoftcrypto.so.1

==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    14:56.5
user    25:15.8
sys      2:43.2

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```