### PR TITLE
9228 zone_getattr(ZONE_ATTR_NETWORK) returns uninitialised value

### DIFF
--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2018, Joyent Inc.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -6155,6 +6156,8 @@ zone_getattr(zoneid_t zoneid, int attr, void *buf, size_t bufsize)
 			error = zone_get_network(zoneid, zbuf);
 			if (error == 0 && copyout(zbuf, buf, bufsize) != 0)
 				error = EFAULT;
+			else
+				size = bufsize;
 		}
 		kmem_free(zbuf, bufsize);
 		break;


### PR DESCRIPTION
... which causes consumers such as `ipadm enable-if` to fail mostly..
except when run under dtrace or truss of course...

https://www.illumos.org/issues/9228