### PR TITLE
Remove "vm" brand

### DIFF
--- a/usr/src/lib/libbe/common/libbe_priv.h
+++ b/usr/src/lib/libbe/common/libbe_priv.h
@@ -74,7 +74,7 @@ extern "C" {
 
 #define	BE_ZONE_PARENTBE_PROPERTY	"org.opensolaris.libbe:parentbe"
 #define	BE_ZONE_ACTIVE_PROPERTY		"org.opensolaris.libbe:active"
-#define	BE_ZONE_SUPPORTED_BRANDS	"ipkg labeled lipkg sparse vm kvm bhyve"
+#define	BE_ZONE_SUPPORTED_BRANDS	"ipkg labeled lipkg sparse kvm bhyve"
 #define	BE_ZONE_SUPPORTED_BRANDS_DELIM	" "
 
 /* Maximum length for the BE name. */

--- a/usr/src/tools/scripts/onu.sh.in
+++ b/usr/src/tools/scripts/onu.sh.in
@@ -34,7 +34,7 @@ DEFAULTONPUB="omnios"
 DEFAULTCONS="osnet"
 NATIVE_BRAND="ipkg"
 # Keep the leading and trailing spaces in this definition
-LINKED_BRANDS=" lipkg sparse vm kvm bhyve "
+LINKED_BRANDS=" lipkg sparse kvm bhyve "
 
 banner()
 {


### PR DESCRIPTION
`vm` is a further cut-down version of the sparse `brand` that was experimented with early in this bloody cycle. It is now not going to be used.