### PR TITLE
Add -e flag to prtvtoc to show extended information for EFI

### DIFF
--- a/usr/src/man/man1m/prtvtoc.1m
+++ b/usr/src/man/man1m/prtvtoc.1m
@@ -3,13 +3,14 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH PRTVTOC 1M "Jul 25, 2002"
+.\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+.TH PRTVTOC 1M "Mar 21, 2018"
 .SH NAME
 prtvtoc \- report information about a disk geometry and partitioning
 .SH SYNOPSIS
 .LP
 .nf
-\fBprtvtoc\fR [\fB-fhs\fR] [\fB-t\fR \fIvfstab\fR] [\fB-m\fR \fImnttab\fR] \fIdevice\fR
+\fBprtvtoc\fR [\fB-fhse\fR] [\fB-t\fR \fIvfstab\fR] [\fB-m\fR \fImnttab\fR] \fIdevice\fR
 .fi
 
 .SH DESCRIPTION
@@ -26,6 +27,15 @@ of \fB/dev/dsk/c?t?d?s2\fR.
 .sp
 .LP
 The following options are supported:
+.sp
+.ne 2
+.na
+\fB\fB-e\fR\fR
+.ad
+.RS 13n
+Include extended partition table information if available.
+.RE
+
 .sp
 .ne 2
 .na

--- a/usr/src/uts/common/sys/vtoc.h
+++ b/usr/src/uts/common/sys/vtoc.h
@@ -87,6 +87,11 @@ extern "C" {
 #define	V_RESERVED	0x0b		/* SMI reserved data */
 #define	V_SYSTEM	0x0c		/* EFI/GPT system partition */
 #define	V_BIOS_BOOT	0x18		/* BIOS Boot partition */
+#define	V_FREEBSD_BOOT	0x19		/* FreeBSD Boot */
+#define	V_FREEBSD_SWAP	0x1a		/* FreeBSD Swap */
+#define	V_FREEBSD_UFS	0x1b		/* FreeBSD UFS */
+#define	V_FREEBSD_VINUM	0x1c		/* FreeBSD VINUM */
+#define	V_FREEBSD_ZFS	0x1d		/* FreeBSD ZFS */
 
 #define	V_UNKNOWN	0xff		/* Unknown partition */
 


### PR DESCRIPTION
partition labels.