### PR TITLE
Upstream merge upstream_merge/2018032201

### DIFF
--- a/usr/src/cmd/mdb/common/modules/zfs/zfs.c
+++ b/usr/src/cmd/mdb/common/modules/zfs/zfs.c
@@ -396,7 +396,7 @@ zfs_params(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 		"zfs_read_chunk_size",
 		"zfs_nocacheflush",
 		"zil_replay_disable",
-		"metaslab_gang_bang",
+		"metaslab_force_ganging",
 		"metaslab_df_alloc_threshold",
 		"metaslab_df_free_pct",
 		"zio_injection_enabled",

--- a/usr/src/cmd/stat/arcstat/arcstat.pl
+++ b/usr/src/cmd/stat/arcstat/arcstat.pl
@@ -166,8 +166,11 @@ sub init {
 	detailed_usage() if $vflag;
 	@hdr = @xhdr if $xflag;		#reset headers to xhdr
 
-	# check if L2ARC exists
+	# we want to capture the stats here, so that we can use them to check
+	# if an L2ARC device exists; but more importantly, so that we print
+	# the stats since boot as the first line of output from main().
 	snap_stats();
+
 	if (defined $cur{"l2_size"}) {
 		$l2exist = 1;
 	}
@@ -353,12 +356,12 @@ sub main {
 	if ($count > 0) { $count_flag = 1; }
 	while (1) {
 		print_header() if ($i == 0);
-		snap_stats();
 		calculate();
 		print_values();
 		last if ($count_flag == 1 && $count-- <= 1);
 		$i = (($i == $hdr_intr) && (not $raw_output)) ? 0 : $i+1;
 		sleep($int);
+		snap_stats();
 	}
 	close($out) if defined $out;
 }

--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -5186,8 +5186,8 @@ main(int argc, char **argv)
 		    (dump_opt['X'] ? ZPOOL_EXTREME_REWIND : 0);
 
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME_TYPE, 0) != 0 ||
-	    nvlist_add_uint64(policy, ZPOOL_REWIND_REQUEST_TXG, max_txg) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_REWIND_REQUEST, rewind) != 0)
+	    nvlist_add_uint64(policy, ZPOOL_LOAD_REQUEST_TXG, max_txg) != 0 ||
+	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY, rewind) != 0)
 		fatal("internal error: %s", strerror(ENOMEM));
 
 	error = 0;
@@ -5204,7 +5204,7 @@ main(int argc, char **argv)
 			}
 
 			if (nvlist_add_nvlist(cfg,
-			    ZPOOL_REWIND_POLICY, policy) != 0) {
+			    ZPOOL_LOAD_POLICY, policy) != 0) {
 				fatal("can't open '%s': %s",
 				    target, strerror(ENOMEM));
 			}

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -2325,8 +2325,9 @@ zpool_do_import(int argc, char **argv)
 
 	/* In the future, we can capture further policy and include it here */
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0 ||
-	    nvlist_add_uint64(policy, ZPOOL_REWIND_REQUEST_TXG, txg) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_REWIND_REQUEST, rewind_policy) != 0)
+	    nvlist_add_uint64(policy, ZPOOL_LOAD_REQUEST_TXG, txg) != 0 ||
+	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY,
+	    rewind_policy) != 0)
 		goto error;
 
 	if (searchdirs == NULL) {
@@ -2451,7 +2452,7 @@ zpool_do_import(int argc, char **argv)
 		if (do_destroyed && pool_state != POOL_STATE_DESTROYED)
 			continue;
 
-		verify(nvlist_add_nvlist(config, ZPOOL_REWIND_POLICY,
+		verify(nvlist_add_nvlist(config, ZPOOL_LOAD_POLICY,
 		    policy) == 0);
 
 		if (argc == 0) {
@@ -3939,8 +3940,10 @@ zpool_do_clear(int argc, char **argv)
 
 	/* In future, further rewind policy choices can be passed along here */
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0 ||
-	    nvlist_add_uint32(policy, ZPOOL_REWIND_REQUEST, rewind_policy) != 0)
+	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY,
+	    rewind_policy) != 0) {
 		return (1);
+	}
 
 	pool = argv[0];
 	device = argc == 2 ? argv[1] : NULL;

--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -162,7 +162,7 @@ typedef struct ztest_shared_opts {
 	int zo_init;
 	uint64_t zo_time;
 	uint64_t zo_maxloops;
-	uint64_t zo_metaslab_gang_bang;
+	uint64_t zo_metaslab_force_ganging;
 } ztest_shared_opts_t;
 
 static const ztest_shared_opts_t ztest_opts_defaults = {
@@ -184,10 +184,10 @@ static const ztest_shared_opts_t ztest_opts_defaults = {
 	.zo_init = 1,
 	.zo_time = 300,			/* 5 minutes */
 	.zo_maxloops = 50,		/* max loops during spa_freeze() */
-	.zo_metaslab_gang_bang = 32 << 10
+	.zo_metaslab_force_ganging = 32 << 10
 };
 
-extern uint64_t metaslab_gang_bang;
+extern uint64_t metaslab_force_ganging;
 extern uint64_t metaslab_df_alloc_threshold;
 extern uint64_t zfs_deadman_synctime_ms;
 extern int metaslab_preload_limit;
@@ -565,12 +565,12 @@ usage(boolean_t requested)
 	const ztest_shared_opts_t *zo = &ztest_opts_defaults;
 
 	char nice_vdev_size[NN_NUMBUF_SZ];
-	char nice_gang_bang[NN_NUMBUF_SZ];
+	char nice_force_ganging[NN_NUMBUF_SZ];
 	FILE *fp = requested ? stdout : stderr;
 
 	nicenum(zo->zo_vdev_size, nice_vdev_size, sizeof (nice_vdev_size));
-	nicenum(zo->zo_metaslab_gang_bang, nice_gang_bang,
-	    sizeof (nice_gang_bang));
+	nicenum(zo->zo_metaslab_force_ganging, nice_force_ganging,
+	    sizeof (nice_force_ganging));
 
 	(void) fprintf(fp, "Usage: %s\n"
 	    "\t[-v vdevs (default: %llu)]\n"
@@ -605,7 +605,7 @@ usage(boolean_t requested)
 	    zo->zo_raidz_parity,			/* -R */
 	    zo->zo_datasets,				/* -d */
 	    zo->zo_threads,				/* -t */
-	    nice_gang_bang,				/* -g */
+	    nice_force_ganging,				/* -g */
 	    zo->zo_init,				/* -i */
 	    (u_longlong_t)zo->zo_killrate,		/* -k */
 	    zo->zo_pool,				/* -p */
@@ -674,8 +674,8 @@ process_options(int argc, char **argv)
 			zo->zo_threads = MAX(1, value);
 			break;
 		case 'g':
-			zo->zo_metaslab_gang_bang = MAX(SPA_MINBLOCKSIZE << 1,
-			    value);
+			zo->zo_metaslab_force_ganging =
+			    MAX(SPA_MINBLOCKSIZE << 1, value);
 			break;
 		case 'i':
 			zo->zo_init = value;
@@ -6422,7 +6422,7 @@ main(int argc, char **argv)
 	zs = ztest_shared;
 
 	if (fd_data_str) {
-		metaslab_gang_bang = ztest_opts.zo_metaslab_gang_bang;
+		metaslab_force_ganging = ztest_opts.zo_metaslab_force_ganging;
 		metaslab_df_alloc_threshold =
 		    zs->zs_metaslab_df_alloc_threshold;
 

--- a/usr/src/common/zfs/zfs_comutil.c
+++ b/usr/src/common/zfs/zfs_comutil.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -67,17 +67,17 @@ zfs_allocatable_devs(nvlist_t *nv)
 }
 
 void
-zpool_get_rewind_policy(nvlist_t *nvl, zpool_rewind_policy_t *zrpp)
+zpool_get_load_policy(nvlist_t *nvl, zpool_load_policy_t *zlpp)
 {
 	nvlist_t *policy;
 	nvpair_t *elem;
 	char *nm;
 
 	/* Defaults */
-	zrpp->zrp_request = ZPOOL_NO_REWIND;
-	zrpp->zrp_maxmeta = 0;
-	zrpp->zrp_maxdata = UINT64_MAX;
-	zrpp->zrp_txg = UINT64_MAX;
+	zlpp->zlp_rewind = ZPOOL_NO_REWIND;
+	zlpp->zlp_maxmeta = 0;
+	zlpp->zlp_maxdata = UINT64_MAX;
+	zlpp->zlp_txg = UINT64_MAX;
 
 	if (nvl == NULL)
 		return;
@@ -85,24 +85,24 @@ zpool_get_rewind_policy(nvlist_t *nvl, zpool_rewind_policy_t *zrpp)
 	elem = NULL;
 	while ((elem = nvlist_next_nvpair(nvl, elem)) != NULL) {
 		nm = nvpair_name(elem);
-		if (strcmp(nm, ZPOOL_REWIND_POLICY) == 0) {
+		if (strcmp(nm, ZPOOL_LOAD_POLICY) == 0) {
 			if (nvpair_value_nvlist(elem, &policy) == 0)
-				zpool_get_rewind_policy(policy, zrpp);
+				zpool_get_load_policy(policy, zlpp);
 			return;
-		} else if (strcmp(nm, ZPOOL_REWIND_REQUEST) == 0) {
-			if (nvpair_value_uint32(elem, &zrpp->zrp_request) == 0)
-				if (zrpp->zrp_request & ~ZPOOL_REWIND_POLICIES)
-					zrpp->zrp_request = ZPOOL_NO_REWIND;
-		} else if (strcmp(nm, ZPOOL_REWIND_REQUEST_TXG) == 0) {
-			(void) nvpair_value_uint64(elem, &zrpp->zrp_txg);
-		} else if (strcmp(nm, ZPOOL_REWIND_META_THRESH) == 0) {
-			(void) nvpair_value_uint64(elem, &zrpp->zrp_maxmeta);
-		} else if (strcmp(nm, ZPOOL_REWIND_DATA_THRESH) == 0) {
-			(void) nvpair_value_uint64(elem, &zrpp->zrp_maxdata);
+		} else if (strcmp(nm, ZPOOL_LOAD_REWIND_POLICY) == 0) {
+			if (nvpair_value_uint32(elem, &zlpp->zlp_rewind) == 0)
+				if (zlpp->zlp_rewind & ~ZPOOL_REWIND_POLICIES)
+					zlpp->zlp_rewind = ZPOOL_NO_REWIND;
+		} else if (strcmp(nm, ZPOOL_LOAD_REQUEST_TXG) == 0) {
+			(void) nvpair_value_uint64(elem, &zlpp->zlp_txg);
+		} else if (strcmp(nm, ZPOOL_LOAD_META_THRESH) == 0) {
+			(void) nvpair_value_uint64(elem, &zlpp->zlp_maxmeta);
+		} else if (strcmp(nm, ZPOOL_LOAD_DATA_THRESH) == 0) {
+			(void) nvpair_value_uint64(elem, &zlpp->zlp_maxdata);
 		}
 	}
-	if (zrpp->zrp_request == 0)
-		zrpp->zrp_request = ZPOOL_NO_REWIND;
+	if (zlpp->zlp_rewind == 0)
+		zlpp->zlp_rewind = ZPOOL_NO_REWIND;
 }
 
 typedef struct zfs_version_spa_map {

--- a/usr/src/common/zfs/zfs_comutil.h
+++ b/usr/src/common/zfs/zfs_comutil.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 #ifndef	_ZFS_COMUTIL_H
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 extern boolean_t zfs_allocatable_devs(nvlist_t *);
-extern void zpool_get_rewind_policy(nvlist_t *, zpool_rewind_policy_t *);
+extern void zpool_get_load_policy(nvlist_t *, zpool_load_policy_t *);
 
 extern int zfs_zpl_version_map(int spa_version);
 extern int zfs_spa_version_map(int zpl_version);

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -393,7 +393,7 @@ typedef struct importargs {
 	int can_be_active : 1;	/* can the pool be active?		*/
 	int unique : 1;		/* does 'poolname' already exist?	*/
 	int exists : 1;		/* set on return if pool already exists	*/
-	nvlist_t *policy;	/* rewind policy (rewind txg, etc.)	*/
+	nvlist_t *policy;	/* load policy (max txg, rewind, etc.)	*/
 } importargs_t;
 
 extern nvlist_t *zpool_search_import(libzfs_handle_t *, importargs_t *);

--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright 2015 RackTop Systems.
  * Copyright 2017 Nexenta Systems, Inc.
  */
@@ -748,7 +748,7 @@ get_configs(libzfs_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 		}
 
 		if (policy != NULL) {
-			if (nvlist_add_nvlist(config, ZPOOL_REWIND_POLICY,
+			if (nvlist_add_nvlist(config, ZPOOL_LOAD_POLICY,
 			    policy) != 0)
 				goto nomem;
 		}

--- a/usr/src/lib/libzfs/common/libzfs_pool.c
+++ b/usr/src/lib/libzfs/common/libzfs_pool.c
@@ -396,6 +396,8 @@ static boolean_t
 bootfs_name_valid(const char *pool, char *bootfs)
 {
 	int len = strlen(pool);
+	if (bootfs[0] == '\0')
+		return (B_TRUE);
 
 	if (!zfs_name_valid(bootfs, ZFS_TYPE_FILESYSTEM|ZFS_TYPE_SNAPSHOT))
 		return (B_FALSE);
@@ -549,8 +551,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			 * bootfs property value has to be a dataset name and
 			 * the dataset has to be in the same pool as it sets to.
 			 */
-			if (strval[0] != '\0' && !bootfs_name_valid(poolname,
-			    strval)) {
+			if (!bootfs_name_valid(poolname, strval)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "'%s' "
 				    "is an invalid name"), strval);
 				(void) zfs_error(hdl, EZFS_INVALIDNAME, errbuf);
@@ -1714,7 +1715,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
     nvlist_t *props, int flags)
 {
 	zfs_cmd_t zc = { 0 };
-	zpool_rewind_policy_t policy;
+	zpool_load_policy_t policy;
 	nvlist_t *nv = NULL;
 	nvlist_t *nvinfo = NULL;
 	nvlist_t *missing = NULL;
@@ -1786,7 +1787,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 	zcmd_free_nvlists(&zc);
 
-	zpool_get_rewind_policy(config, &policy);
+	zpool_get_load_policy(config, &policy);
 
 	if (error) {
 		char desc[1024];
@@ -1795,7 +1796,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 		 * Dry-run failed, but we print out what success
 		 * looks like if we found a best txg
 		 */
-		if (policy.zrp_request & ZPOOL_TRY_REWIND) {
+		if (policy.zlp_rewind & ZPOOL_TRY_REWIND) {
 			zpool_rewind_exclaim(hdl, newname ? origname : thename,
 			    B_TRUE, nv);
 			nvlist_free(nv);
@@ -1888,10 +1889,10 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			ret = -1;
 		else if (zhp != NULL)
 			zpool_close(zhp);
-		if (policy.zrp_request &
+		if (policy.zlp_rewind &
 		    (ZPOOL_DO_REWIND | ZPOOL_TRY_REWIND)) {
 			zpool_rewind_exclaim(hdl, newname ? origname : thename,
-			    ((policy.zrp_request & ZPOOL_TRY_REWIND) != 0), nv);
+			    ((policy.zlp_rewind & ZPOOL_TRY_REWIND) != 0), nv);
 		}
 		nvlist_free(nv);
 		return (0);
@@ -3268,7 +3269,7 @@ zpool_clear(zpool_handle_t *zhp, const char *path, nvlist_t *rewindnvl)
 	zfs_cmd_t zc = { 0 };
 	char msg[1024];
 	nvlist_t *tgt;
-	zpool_rewind_policy_t policy;
+	zpool_load_policy_t policy;
 	boolean_t avail_spare, l2cache;
 	libzfs_handle_t *hdl = zhp->zpool_hdl;
 	nvlist_t *nvi = NULL;
@@ -3300,8 +3301,8 @@ zpool_clear(zpool_handle_t *zhp, const char *path, nvlist_t *rewindnvl)
 		    &zc.zc_guid) == 0);
 	}
 
-	zpool_get_rewind_policy(rewindnvl, &policy);
-	zc.zc_cookie = policy.zrp_request;
+	zpool_get_load_policy(rewindnvl, &policy);
+	zc.zc_cookie = policy.zlp_rewind;
 
 	if (zcmd_alloc_dst_nvlist(hdl, &zc, zhp->zpool_config_size * 2) != 0)
 		return (-1);
@@ -3317,13 +3318,13 @@ zpool_clear(zpool_handle_t *zhp, const char *path, nvlist_t *rewindnvl)
 		}
 	}
 
-	if (!error || ((policy.zrp_request & ZPOOL_TRY_REWIND) &&
+	if (!error || ((policy.zlp_rewind & ZPOOL_TRY_REWIND) &&
 	    errno != EPERM && errno != EACCES)) {
-		if (policy.zrp_request &
+		if (policy.zlp_rewind &
 		    (ZPOOL_DO_REWIND | ZPOOL_TRY_REWIND)) {
 			(void) zcmd_read_dst_nvlist(hdl, &zc, &nvi);
 			zpool_rewind_exclaim(hdl, zc.zc_name,
-			    ((policy.zrp_request & ZPOOL_TRY_REWIND) != 0),
+			    ((policy.zlp_rewind & ZPOOL_TRY_REWIND) != 0),
 			    nvi);
 			nvlist_free(nvi);
 		}

--- a/usr/src/lib/libzpool/common/llib-lzpool
+++ b/usr/src/lib/libzpool/common/llib-lzpool
@@ -24,7 +24,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 /* LINTLIBRARY */
@@ -64,7 +64,7 @@
 #include <sys/abd.h>
 #include <libcmdutils.h>
 
-extern uint64_t metaslab_gang_bang;
+extern uint64_t metaslab_force_ganging;
 extern uint64_t metaslab_df_alloc_threshold;
 extern boolean_t zfeature_checks_disable;
 extern uint64_t zfs_deadman_synctime_ms;

--- a/usr/src/lib/scsi/plugins/ses/ses2/common/ses2_element.c
+++ b/usr/src/lib/scsi/plugins/ses/ses2/common/ses2_element.c
@@ -21,10 +21,9 @@
 
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  * Use is subject to license terms.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <sys/types.h>
 #include <stddef.h>
@@ -871,6 +870,9 @@ elem_parse_aes_misc(const ses2_aes_descr_eip_impl_t *dep, nvlist_t *nvl,
 	nphy = MIN(s1p->sadsi_n_phy_descriptors,
 	    (len - offsetof(ses2_aes_descr_sas1_impl_t,
 	    sadsi_phys)) / sizeof (ses2_aes_phy1_descr_impl_t));
+
+	if (nphy == 0)
+		return (0);
 
 	nva = ses_zalloc(nphy * sizeof (nvlist_t *));
 	if (nva == NULL)

--- a/usr/src/test/zfs-tests/include/commands.cfg
+++ b/usr/src/test/zfs-tests/include/commands.cfg
@@ -62,6 +62,7 @@ export USR_BIN_FILES='awk
     isainfo
     kill
     ksh
+    kstat
     ln
     logname
     ls

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.kshlib
@@ -23,6 +23,9 @@
 #
 function cleanup
 {
+	# clear any remaining zinjections
+	log_must zinject -c all > /dev/null
+
 	destroy_pool $TESTPOOL1
 
 	log_must rm -f $CPATH $CPATHBKP $CPATHBKP2 $MD5FILE $MD5FILE2

--- a/usr/src/test/zfs-tests/tests/functional/removal/removal_with_ganging.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/removal/removal_with_ganging.ksh
@@ -15,26 +15,26 @@
 #
 
 #
-# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2014, 2017 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/removal/removal.kshlib
 
-function set_metaslab_gang_bang # new_value
+function set_metaslab_force_ganging # new_value
 {
 	typeset new_value=$1
-	echo "metaslab_gang_bang/W $new_value" | mdb -kw
+	echo "metaslab_force_ganging/W $new_value" | mdb -kw
 }
 
 function cleanup
 {
-	log_must set_metaslab_gang_bang 0t$((2**17 + 1))
+	log_must set_metaslab_force_ganging 0t$((2**17 + 1))
 	default_cleanup_noexit
 }
 
 default_setup_noexit "$DISKS"
-log_must set_metaslab_gang_bang 0t$((2**12))
+log_must set_metaslab_force_ganging 0t$((2**14))
 log_onexit cleanup
 
 FILE_CONTENTS="Leeloo Dallas mul-ti-pass."

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_reads.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_reads.ksh
@@ -25,6 +25,15 @@
 # for all fio runs. The ARC is cleared with `zinject -a` prior to each run
 # so reads will go to disk.
 #
+# Thread/Concurrency settings:
+#    PERF_NTHREADS defines the number of files created in the test filesystem,
+#    as well as the number of threads that will simultaneously drive IO to
+#    those files.  The settings chosen are from measurements in the
+#    PerfAutoESX/ZFSPerfESX Environments, selected at concurrency levels that
+#    are at peak throughput but lowest latency.  Higher concurrency introduces
+#    queue time latency and would reduce the impact of code-induced performance
+#    regressions.
+#
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/perf/perf.shlib
@@ -48,13 +57,13 @@ export TOTAL_SIZE=$(($(get_prop avail $TESTFS) * 3 / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'64 128'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'16 32'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
 fi

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_readwrite.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_readwrite.ksh
@@ -25,6 +25,15 @@
 # and used for all fio runs. The ARC is cleared with `zinject -a` prior to
 # each run so reads will go to disk.
 #
+# Thread/Concurrency settings:
+#    PERF_NTHREADS defines the number of files created in the test filesystem,
+#    as well as the number of threads that will simultaneously drive IO to
+#    those files.  The settings chosen are from measurements in the
+#    PerfAutoESX/ZFSPerfESX Environments, selected at concurrency levels that
+#    are at peak throughput but lowest latency.  Higher concurrency introduces
+#    queue time latency and would reduce the impact of code-induced performance
+#    regressions.
+#
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/perf/perf.shlib
@@ -48,13 +57,13 @@ export TOTAL_SIZE=$(($(get_prop avail $TESTFS) * 3 / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'4 8 16 64'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'0 1'}
 	export PERF_IOSIZES=''		# bssplit used instead
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'64 128'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'32 64'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=''		# bssplit used instead
 fi

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_writes.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_writes.ksh
@@ -24,6 +24,15 @@
 # Prior to each fio run the dataset is recreated, and fio writes new files
 # into an otherwise empty pool.
 #
+# Thread/Concurrency settings:
+#    PERF_NTHREADS defines the number of files created in the test filesystem,
+#    as well as the number of threads that will simultaneously drive IO to
+#    those files.  The settings chosen are from measurements in the
+#    PerfAutoESX/ZFSPerfESX Environments, selected at concurrency levels that
+#    are at peak throughput but lowest latency.  Higher concurrency introduces
+#    queue time latency and would reduce the impact of code-induced performance
+#    regressions.
+#
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/perf/perf.shlib
@@ -47,13 +56,13 @@ export TOTAL_SIZE=$(($(get_prop avail $TESTFS) * 3 / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'1 4 8 16 32 64 128'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'0 1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'64 128'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'32 128'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
 fi

--- a/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads.ksh
@@ -25,6 +25,15 @@
 # for all fio runs. The ARC is cleared with `zinject -a` prior to each run
 # so reads will go to disk.
 #
+# Thread/Concurrency settings:
+#    PERF_NTHREADS defines the number of files created in the test filesystem,
+#    as well as the number of threads that will simultaneously drive IO to
+#    those files.  The settings chosen are from measurements in the
+#    PerfAutoESX/ZFSPerfESX Environments, selected at concurrency levels that
+#    are at peak throughput but lowest latency.  Higher concurrency introduces
+#    queue time latency and would reduce the impact of code-induced performance
+#    regressions.
+#
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/perf/perf.shlib
@@ -48,13 +57,13 @@ export TOTAL_SIZE=$(($(get_prop avail $TESTFS) * 3 / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'16 64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'64k 128k 1m'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'64 128'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'128k 1m'}
 fi

--- a/usr/src/test/zfs-tests/tests/perf/regression/sequential_writes.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/sequential_writes.ksh
@@ -24,6 +24,15 @@
 # Prior to each fio run the dataset is recreated, and fio writes new files
 # into an otherwise empty pool.
 #
+# Thread/Concurrency settings:
+#    PERF_NTHREADS defines the number of files created in the test filesystem,
+#    as well as the number of threads that will simultaneously drive IO to
+#    those files.  The settings chosen are from measurements in the
+#    PerfAutoESX/ZFSPerfESX Environments, selected at concurrency levels that
+#    are at peak throughput but lowest latency.  Higher concurrency introduces
+#    queue time latency and would reduce the impact of code-induced performance
+#    regressions.
+#
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/perf/perf.shlib
@@ -47,13 +56,13 @@ export TOTAL_SIZE=$(($(get_prop avail $TESTFS) * 3 / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'1 4 8 16 32 64 128'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'0 1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 128k 1m'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'64 128'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'16 32'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 128k 1m'}
 fi

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs.h
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs.h
@@ -94,6 +94,7 @@ struct smb_share;
 #define	SMI_NOAC	0x10		/* don't cache attributes */
 #define	SMI_LLOCK	0x80		/* local locking only */
 #define	SMI_ACL		0x2000		/* share supports ACLs */
+#define	SMI_DIRECTIO	0x40000		/* do direct I/O */
 #define	SMI_EXTATTR	0x80000		/* share supports ext. attrs */
 #define	SMI_DEAD	0x200000	/* mount has been terminated */
 

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_client.c
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_client.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  *
- *  	Copyright (c) 1983,1984,1985,1986,1987,1988,1989  AT&T.
+ *	Copyright (c) 1983,1984,1985,1986,1987,1988,1989  AT&T.
  *	All rights reserved.
  */
 
@@ -68,9 +68,13 @@
 #include <vm/seg_map.h>
 #include <vm/seg_vn.h>
 
+#define	ATTRCACHE_VALID(vp)	(gethrtime() < VTOSMB(vp)->r_attrtime)
+
 static int smbfs_getattr_cache(vnode_t *, smbfattr_t *);
 static void smbfattr_to_vattr(vnode_t *, smbfattr_t *, vattr_t *);
 static void smbfattr_to_xvattr(smbfattr_t *, vattr_t *);
+static int smbfs_getattr_otw(vnode_t *, struct smbfattr *, cred_t *);
+
 
 /*
  * The following code provide zone support in order to perform an action
@@ -102,35 +106,75 @@ static zone_key_t smi_list_key;
  */
 
 /*
- * Validate caches by checking cached attributes. If they have timed out
- * get the attributes from the server and compare mtimes. If mtimes are
- * different purge all caches for this vnode.
+ * Helper for _validate_caches
+ */
+int
+smbfs_waitfor_purge_complete(vnode_t *vp)
+{
+	smbnode_t *np;
+	k_sigset_t smask;
+
+	np = VTOSMB(vp);
+	if (np->r_serial != NULL && np->r_serial != curthread) {
+		mutex_enter(&np->r_statelock);
+		sigintr(&smask, VTOSMI(vp)->smi_flags & SMI_INT);
+		while (np->r_serial != NULL) {
+			if (!cv_wait_sig(&np->r_cv, &np->r_statelock)) {
+				sigunintr(&smask);
+				mutex_exit(&np->r_statelock);
+				return (EINTR);
+			}
+		}
+		sigunintr(&smask);
+		mutex_exit(&np->r_statelock);
+	}
+	return (0);
+}
+
+/*
+ * Validate caches by checking cached attributes. If the cached
+ * attributes have timed out, then get new attributes from the server.
+ * As a side affect, this will do cache invalidation if the attributes
+ * have changed.
+ *
+ * If the attributes have not timed out and if there is a cache
+ * invalidation being done by some other thread, then wait until that
+ * thread has completed the cache invalidation.
  */
 int
 smbfs_validate_caches(
 	struct vnode *vp,
 	cred_t *cr)
 {
-	struct vattr va;
+	struct smbfattr fa;
+	int error;
 
-	va.va_mask = AT_SIZE;
-	return (smbfsgetattr(vp, &va, cr));
+	if (ATTRCACHE_VALID(vp)) {
+		error = smbfs_waitfor_purge_complete(vp);
+		if (error)
+			return (error);
+		return (0);
+	}
+
+	return (smbfs_getattr_otw(vp, &fa, cr));
 }
 
 /*
  * Purge all of the various data caches.
+ *
+ * Here NFS also had a flags arg to control what gets flushed.
+ * We only have the page cache, so no flags arg.
  */
-/*ARGSUSED*/
+/* ARGSUSED */
 void
-smbfs_purge_caches(struct vnode *vp)
+smbfs_purge_caches(struct vnode *vp, cred_t *cr)
 {
-#if 0	/* not yet: mmap support */
+
 	/*
-	 * NFS: Purge the DNLC for this vp,
+	 * Here NFS has: Purge the DNLC for this vp,
 	 * Clear any readdir state bits,
 	 * the readlink response cache, ...
 	 */
-	smbnode_t *np = VTOSMB(vp);
 
 	/*
 	 * Flush the page cache.
@@ -138,18 +182,31 @@ smbfs_purge_caches(struct vnode *vp)
 	if (vn_has_cached_data(vp)) {
 		(void) VOP_PUTPAGE(vp, (u_offset_t)0, 0, B_INVAL, cr, NULL);
 	}
-#endif	/* not yet */
+
+	/*
+	 * Here NFS has: Flush the readdir response cache.
+	 * No readdir cache in smbfs.
+	 */
 }
+
+/*
+ * Here NFS has:
+ * nfs_purge_rddir_cache()
+ * nfs3_cache_post_op_attr()
+ * nfs3_cache_post_op_vattr()
+ * nfs3_cache_wcc_data()
+ */
 
 /*
  * Check the attribute cache to see if the new attributes match
  * those cached.  If they do, the various `data' caches are
  * considered to be good.  Otherwise, purge the cached data.
  */
-void
+static void
 smbfs_cache_check(
 	struct vnode *vp,
-	struct smbfattr *fap)
+	struct smbfattr *fap,
+	cred_t *cr)
 {
 	smbnode_t *np;
 	int purge_data = 0;
@@ -174,37 +231,20 @@ smbfs_cache_check(
 		purge_acl = 1;
 
 	if (purge_acl) {
-		/* just invalidate r_secattr (XXX: OK?) */
 		np->r_sectime = gethrtime();
 	}
 
 	mutex_exit(&np->r_statelock);
 
 	if (purge_data)
-		smbfs_purge_caches(vp);
+		smbfs_purge_caches(vp, cr);
 }
-
-/*
- * Set attributes cache for given vnode using vnode attributes.
- * From NFS: nfs_attrcache_va
- */
-#if 0 	/* not yet (not sure if we need this) */
-void
-smbfs_attrcache_va(vnode_t *vp, struct vattr *vap)
-{
-	smbfattr_t fa;
-	smbnode_t *np;
-
-	vattr_to_fattr(vp, vap, &fa);
-	smbfs_attrcache_fa(vp, &fa);
-}
-#endif	/* not yet */
 
 /*
  * Set attributes cache for given vnode using SMB fattr
  * and update the attribute cache timeout.
  *
- * From NFS: nfs_attrcache, nfs_attrcache_va
+ * Based on NFS: nfs_attrcache, nfs_attrcache_va
  */
 void
 smbfs_attrcache_fa(vnode_t *vp, struct smbfattr *fap)
@@ -293,18 +333,21 @@ smbfs_attrcache_fa(vnode_t *vp, struct smbfattr *fap)
 	if (vtype == VDIR && newsize < DEV_BSIZE)
 		newsize = DEV_BSIZE;
 
-	if (np->r_size != newsize) {
-#if 0	/* not yet: mmap support */
-		if (!vn_has_cached_data(vp) || ...)
-			/* XXX: See NFS page cache code. */
-#endif	/* not yet */
+	if (np->r_size != newsize &&
+	    (!vn_has_cached_data(vp) ||
+	    (!(np->r_flags & RDIRTY) && np->r_count == 0))) {
 		/* OK to set the size. */
 		np->r_size = newsize;
 	}
 
-	/* NFS: np->r_flags &= ~RWRITEATTR; */
-	np->n_flag &= ~NATTRCHANGED;
+	/*
+	 * Here NFS has:
+	 * nfs_setswaplike(vp, va);
+	 * np->r_flags &= ~RWRITEATTR;
+	 * (not needed here)
+	 */
 
+	np->n_flag &= ~NATTRCHANGED;
 	mutex_exit(&np->r_statelock);
 
 	if (oldvt != vtype) {
@@ -348,7 +391,7 @@ smbfs_getattr_cache(vnode_t *vp, struct smbfattr *fap)
  * Return 0 if successful, otherwise error.
  * From NFS: nfs_getattr_otw
  */
-int
+static int
 smbfs_getattr_otw(vnode_t *vp, struct smbfattr *fap, cred_t *cr)
 {
 	struct smbnode *np;
@@ -358,7 +401,7 @@ smbfs_getattr_otw(vnode_t *vp, struct smbfattr *fap, cred_t *cr)
 	np = VTOSMB(vp);
 
 	/*
-	 * NFS uses the ACL rpc here (if smi_flags & SMI_ACL)
+	 * Here NFS uses the ACL RPC (if smi_flags & SMI_ACL)
 	 * With SMB, getting the ACL is a significantly more
 	 * expensive operation, so we do that only when asked
 	 * for the uid/gid.  See smbfsgetattr().
@@ -376,7 +419,7 @@ smbfs_getattr_otw(vnode_t *vp, struct smbfattr *fap, cred_t *cr)
 	smbfs_rw_exit(&np->r_lkserlock);
 
 	if (error) {
-		/* NFS had: PURGE_STALE_FH(error, vp, cr) */
+		/* Here NFS has: PURGE_STALE_FH(error, vp, cr) */
 		smbfs_attrcache_remove(np);
 		if (error == ENOENT || error == ENOTDIR) {
 			/*
@@ -390,19 +433,19 @@ smbfs_getattr_otw(vnode_t *vp, struct smbfattr *fap, cred_t *cr)
 	}
 
 	/*
-	 * NFS: smbfs_cache_fattr(vap, fa, vap, t, cr);
+	 * Here NFS has: nfs_cache_fattr(vap, fa, vap, t, cr);
 	 * which did: fattr_to_vattr, nfs_attr_cache.
 	 * We cache the fattr form, so just do the
 	 * cache check and store the attributes.
 	 */
-	smbfs_cache_check(vp, fap);
+	smbfs_cache_check(vp, fap, cr);
 	smbfs_attrcache_fa(vp, fap);
 
 	return (0);
 }
 
 /*
- * Return either cached or remote attributes. If get remote attr
+ * Return either cached or remote attributes. If we get remote attrs,
  * use them to check and invalidate caches, then cache the new attributes.
  *
  * From NFS: nfsgetattr()
@@ -547,6 +590,75 @@ smbfattr_to_xvattr(struct smbfattr *fa, struct vattr *vap)
 		xoap->xoa_hidden =
 		    ((fa->fa_attr & SMB_FA_HIDDEN) != 0);
 		XVA_SET_RTN(xvap, XAT_HIDDEN);
+	}
+}
+
+/*
+ * Here NFS has:
+ *	nfs_async_... stuff
+ * which we're not using (no async I/O), and:
+ *	writerp(),
+ *	nfs_putpages()
+ *	nfs_invalidate_pages()
+ * which we have in smbfs_vnops.c, and
+ *	nfs_printfhandle()
+ *	nfs_write_error()
+ * not needed here.
+ */
+
+/*
+ * Helper function for smbfs_sync
+ *
+ * Walk the per-zone list of smbfs mounts, calling smbfs_rflush
+ * on each one.  This is a little tricky because we need to exit
+ * the list mutex before each _rflush call and then try to resume
+ * where we were in the list after re-entering the mutex.
+ */
+void
+smbfs_flushall(cred_t *cr)
+{
+	smi_globals_t *smg;
+	smbmntinfo_t *tmp_smi, *cur_smi, *next_smi;
+
+	smg = zone_getspecific(smi_list_key, crgetzone(cr));
+	ASSERT(smg != NULL);
+
+	mutex_enter(&smg->smg_lock);
+	cur_smi = list_head(&smg->smg_list);
+	if (cur_smi == NULL) {
+		mutex_exit(&smg->smg_lock);
+		return;
+	}
+	VFS_HOLD(cur_smi->smi_vfsp);
+	mutex_exit(&smg->smg_lock);
+
+flush:
+	smbfs_rflush(cur_smi->smi_vfsp, cr);
+
+	mutex_enter(&smg->smg_lock);
+	/*
+	 * Resume after cur_smi if that's still on the list,
+	 * otherwise restart at the head.
+	 */
+	for (tmp_smi = list_head(&smg->smg_list);
+	    tmp_smi != NULL;
+	    tmp_smi = list_next(&smg->smg_list, tmp_smi))
+		if (tmp_smi == cur_smi)
+			break;
+	if (tmp_smi != NULL)
+		next_smi = list_next(&smg->smg_list, tmp_smi);
+	else
+		next_smi = list_head(&smg->smg_list);
+
+	if (next_smi != NULL)
+		VFS_HOLD(next_smi->smi_vfsp);
+	VFS_RELE(cur_smi->smi_vfsp);
+
+	mutex_exit(&smg->smg_lock);
+
+	if (next_smi != NULL) {
+		cur_smi = next_smi;
+		goto flush;
 	}
 }
 

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_node.c
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_node.c
@@ -202,11 +202,6 @@ smbfs_nget(vnode_t *dvp, const char *name, int nmlen,
 }
 
 /*
- * smbfs_attrcache_enter, smbfs_attrcache_lookup replaced by
- * code more closely resembling NFS.  See smbfs_client.c
- */
-
-/*
  * Update the local notion of the mtime of some directory.
  * See comments re. r_mtime in smbfs_node.h
  */

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_node.h
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_node.h
@@ -186,7 +186,7 @@ typedef struct smbfs_node_hdr {
  * be held whenever any kind of access of r_size is made.
  *
  * Lock ordering:
- * 	r_rwlock > r_lkserlock > r_statelock
+ *	r_rwlock > r_lkserlock > r_statelock
  */
 
 typedef struct smbnode {
@@ -232,15 +232,17 @@ typedef struct smbnode {
 	cred_t		*r_cred;	/* current credentials */
 	u_offset_t	r_nextr;	/* next read offset (read-ahead) */
 	long		r_mapcnt;	/* count of mmapped pages */
+	uint_t		r_inmap;	/* to serialize read/write and mmap */
 	uint_t		r_count;	/* # of refs not reflect in v_count */
 	uint_t		r_awcount;	/* # of outstanding async write */
 	uint_t		r_gcount;	/* getattrs waiting to flush pages */
 	uint_t		r_flags;	/* flags, see below */
-	uint32_t	n_flag;		/* NXXX flags below */
+	uint32_t	n_flag;		/* N--- flags below */
 	uint_t		r_error;	/* async write error */
 	kcondvar_t	r_cv;		/* condvar for blocked threads */
 	avl_tree_t	r_dir;		/* cache of readdir responses */
 	rddir_cache	*r_direof;	/* pointer to the EOF entry */
+	u_offset_t	r_modaddr;	/* address for page in writenp */
 	kthread_t	*r_serial;	/* id of purging thread */
 	list_t		r_indelmap;	/* list of delmap callers */
 
@@ -282,7 +284,7 @@ typedef struct smbnode {
 #define	NATTRCHANGED	0x02000 /* kill cached attributes at close */
 #define	NALLOC		0x04000 /* being created */
 #define	NWALLOC		0x08000 /* awaiting creation */
-#define	N_XATTR 	0x10000 /* extended attribute (dir or file) */
+#define	N_XATTR		0x10000 /* extended attribute (dir or file) */
 
 /*
  * Flag bits in: smbnode_t .r_flags

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_subr.h
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_subr.h
@@ -33,7 +33,7 @@
  */
 
 /*
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2012 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -134,7 +134,7 @@ struct smbfs_fctx {
 	int		f_left;		/* entries left */
 	int		f_ecnt;		/* entries left in current response */
 	int		f_eofs;		/* entry offset in data block */
-	uchar_t 	f_skey[SMB_SKEYLEN]; /* server side search context */
+	uchar_t		f_skey[SMB_SKEYLEN]; /* server side search context */
 	uchar_t		f_fname[8 + 1 + 3 + 1]; /* for 8.3 filenames */
 	uint16_t	f_Sid;		/* Search handle (like a FID) */
 	uint16_t	f_infolevel;
@@ -237,6 +237,9 @@ void smbfs_zonelist_remove(smbmntinfo_t *smi);
 int smbfs_check_table(struct vfs *vfsp, struct smbnode *srp);
 void smbfs_destroy_table(struct vfs *vfsp);
 void smbfs_rflush(struct vfs *vfsp, cred_t *cr);
+void smbfs_flushall(cred_t *cr);
+
+int smbfs_directio(vnode_t *vp, int cmd, cred_t *cr);
 
 uint32_t smbfs_newnum(void);
 int smbfs_newname(char *buf, size_t buflen);
@@ -254,7 +257,9 @@ void smbfs_attrcache_rm_locked(struct smbnode *np);
 #endif
 void smbfs_attr_touchdir(struct smbnode *dnp);
 void smbfs_attrcache_fa(vnode_t *vp, struct smbfattr *fap);
-void smbfs_cache_check(struct vnode *vp, struct smbfattr *fap);
+
+int smbfs_validate_caches(struct vnode *vp, cred_t *cr);
+void smbfs_purge_caches(struct vnode *vp, cred_t *cr);
 
 void smbfs_addfree(struct smbnode *sp);
 void smbfs_rmhash(struct smbnode *);
@@ -282,6 +287,8 @@ int smbfs_readvnode(vnode_t *, uio_t *, cred_t *, struct vattr *);
 int smbfs_writevnode(vnode_t *vp, uio_t *uiop, cred_t *cr,
 			int ioflag, int timo);
 int smbfsgetattr(vnode_t *vp, struct vattr *vap, cred_t *cr);
+
+void smbfs_invalidate_pages(vnode_t *vp, u_offset_t off, cred_t *cr);
 
 /* smbfs ACL support */
 int smbfs_acl_getids(vnode_t *, cred_t *);

--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -275,6 +275,7 @@
 #endif
 #include <sys/callb.h>
 #include <sys/kstat.h>
+#include <sys/zthr.h>
 #include <zfs_fletcher.h>
 #include <sys/aggsum.h>
 #include <sys/cityhash.h>
@@ -285,10 +286,22 @@ boolean_t arc_watch = B_FALSE;
 int arc_procfd;
 #endif
 
-static kmutex_t		arc_reclaim_lock;
-static kcondvar_t	arc_reclaim_thread_cv;
-static boolean_t	arc_reclaim_thread_exit;
-static kcondvar_t	arc_reclaim_waiters_cv;
+/*
+ * This thread's job is to keep enough free memory in the system, by
+ * calling arc_kmem_reap_now() plus arc_shrink(), which improves
+ * arc_available_memory().
+ */
+static zthr_t		*arc_reap_zthr;
+
+/*
+ * This thread's job is to keep arc_size under arc_c, by calling
+ * arc_adjust(), which improves arc_is_overflowing().
+ */
+static zthr_t		*arc_adjust_zthr;
+
+static kmutex_t		arc_adjust_lock;
+static kcondvar_t	arc_adjust_waiters_cv;
+static boolean_t	arc_adjust_needed = B_FALSE;
 
 uint_t arc_reduce_dnlc_percent = 3;
 
@@ -302,19 +315,23 @@ uint_t arc_reduce_dnlc_percent = 3;
 int zfs_arc_evict_batch_limit = 10;
 
 /* number of seconds before growing cache again */
-static int		arc_grow_retry = 60;
+int arc_grow_retry = 60;
 
-/* number of milliseconds before attempting a kmem-cache-reap */
-static int		arc_kmem_cache_reap_retry_ms = 1000;
+/*
+ * Minimum time between calls to arc_kmem_reap_soon().  Note that this will
+ * be converted to ticks, so with the default hz=100, a setting of 15 ms
+ * will actually wait 2 ticks, or 20ms.
+ */
+int arc_kmem_cache_reap_retry_ms = 1000;
 
 /* shift of arc_c for calculating overflow limit in arc_get_data_impl */
-int		zfs_arc_overflow_shift = 8;
+int zfs_arc_overflow_shift = 8;
 
 /* shift of arc_c for calculating both min and max arc_p */
-static int		arc_p_min_shift = 4;
+int arc_p_min_shift = 4;
 
 /* log2(fraction of arc to reclaim) */
-static int		arc_shrink_shift = 7;
+int arc_shrink_shift = 7;
 
 /*
  * log2(fraction of ARC which must be free to allow growing).
@@ -339,7 +356,7 @@ static int		arc_min_prefetch_lifespan;
  */
 int arc_lotsfree_percent = 10;
 
-static int arc_dead;
+static boolean_t arc_initialized;
 
 /*
  * The arc has filled available memory and has now warmed up.
@@ -841,6 +858,7 @@ aggsum_t astat_other_size;
 aggsum_t astat_l2_hdr_size;
 
 static int		arc_no_grow;	/* Don't try to grow cache size */
+static hrtime_t		arc_growtime;
 static uint64_t		arc_tempreserve;
 static uint64_t		arc_loaned_bytes;
 
@@ -1400,8 +1418,8 @@ hdr_recl(void *unused)
 	 * umem calls the reclaim func when we destroy the buf cache,
 	 * which is after we do arc_fini().
 	 */
-	if (!arc_dead)
-		cv_signal(&arc_reclaim_thread_cv);
+	if (arc_initialized)
+		zthr_wakeup(arc_reap_zthr);
 }
 
 static void
@@ -2558,7 +2576,7 @@ arc_loan_buf(spa_t *spa, boolean_t is_metadata, int size)
 	arc_buf_t *buf = arc_alloc_buf(spa, arc_onloan_tag,
 	    is_metadata ? ARC_BUFC_METADATA : ARC_BUFC_DATA, size);
 
-	arc_loaned_bytes_update(size);
+	arc_loaned_bytes_update(arc_buf_size(buf));
 
 	return (buf);
 }
@@ -2570,7 +2588,7 @@ arc_loan_compressed_buf(spa_t *spa, uint64_t psize, uint64_t lsize,
 	arc_buf_t *buf = arc_alloc_compressed_buf(spa, arc_onloan_tag,
 	    psize, lsize, compression_type);
 
-	arc_loaned_bytes_update(psize);
+	arc_loaned_bytes_update(arc_buf_size(buf));
 
 	return (buf);
 }
@@ -3414,13 +3432,14 @@ arc_evict_state_impl(multilist_t *ml, int idx, arc_buf_hdr_t *marker,
 			 * function should proceed in this case).
 			 *
 			 * If threads are left sleeping, due to not
-			 * using cv_broadcast, they will be woken up
-			 * just before arc_reclaim_thread() sleeps.
+			 * using cv_broadcast here, they will be woken
+			 * up via cv_broadcast in arc_adjust_cb() just
+			 * before arc_adjust_zthr sleeps.
 			 */
-			mutex_enter(&arc_reclaim_lock);
+			mutex_enter(&arc_adjust_lock);
 			if (!arc_is_overflowing())
-				cv_signal(&arc_reclaim_waiters_cv);
-			mutex_exit(&arc_reclaim_lock);
+				cv_signal(&arc_adjust_waiters_cv);
+			mutex_exit(&arc_adjust_lock);
 		} else {
 			ARCSTAT_BUMP(arcstat_mutex_miss);
 		}
@@ -3893,8 +3912,8 @@ arc_flush(spa_t *spa, boolean_t retry)
 	(void) arc_flush_state(arc_mfu_ghost, guid, ARC_BUFC_METADATA, retry);
 }
 
-void
-arc_shrink(int64_t to_free)
+static void
+arc_reduce_target_size(int64_t to_free)
 {
 	uint64_t asize = aggsum_value(&arc_size);
 	if (arc_c > arc_c_min) {
@@ -3913,8 +3932,13 @@ arc_shrink(int64_t to_free)
 		ASSERT((int64_t)arc_p >= 0);
 	}
 
-	if (asize > arc_c)
-		(void) arc_adjust();
+	if (asize > arc_c) {
+		/* See comment in arc_adjust_cb_check() on why lock+flag */
+		mutex_enter(&arc_adjust_lock);
+		arc_adjust_needed = B_TRUE;
+		mutex_exit(&arc_adjust_lock);
+		zthr_wakeup(arc_adjust_zthr);
+	}
 }
 
 typedef enum free_memory_reason_t {
@@ -4066,7 +4090,7 @@ arc_reclaim_needed(void)
 }
 
 static void
-arc_kmem_reap_now(void)
+arc_kmem_reap_soon(void)
 {
 	size_t			i;
 	kmem_cache_t		*prev_cache = NULL;
@@ -4091,16 +4115,6 @@ arc_kmem_reap_now(void)
 	kmem_reap();
 #endif
 #endif
-
-	/*
-	 * If a kmem reap is already active, don't schedule more.  We must
-	 * check for this because kmem_cache_reap_soon() won't actually
-	 * block on the cache being reaped (this is to prevent callers from
-	 * becoming implicitly blocked by a system-wide kmem reap -- which,
-	 * on a system with many, many full magazines, can take minutes).
-	 */
-	if (kmem_cache_reap_active())
-		return;
 
 	for (i = 0; i < SPA_MAXBLOCKSIZE >> SPA_MINBLOCKSHIFT; i++) {
 		if (zio_buf_cache[i] != prev_cache) {
@@ -4127,139 +4141,162 @@ arc_kmem_reap_now(void)
 	}
 }
 
+/* ARGSUSED */
+static boolean_t
+arc_adjust_cb_check(void *arg, zthr_t *zthr)
+{
+	/*
+	 * This is necessary in order for the mdb ::arc dcmd to
+	 * show up to date information. Since the ::arc command
+	 * does not call the kstat's update function, without
+	 * this call, the command may show stale stats for the
+	 * anon, mru, mru_ghost, mfu, and mfu_ghost lists. Even
+	 * with this change, the data might be up to 1 second
+	 * out of date(the arc_adjust_zthr has a maximum sleep
+	 * time of 1 second); but that should suffice.  The
+	 * arc_state_t structures can be queried directly if more
+	 * accurate information is needed.
+	 */
+	if (arc_ksp != NULL)
+		arc_ksp->ks_update(arc_ksp, KSTAT_READ);
+
+	/*
+	 * We have to rely on arc_get_data_impl() to tell us when to adjust,
+	 * rather than checking if we are overflowing here, so that we are
+	 * sure to not leave arc_get_data_impl() waiting on
+	 * arc_adjust_waiters_cv.  If we have become "not overflowing" since
+	 * arc_get_data_impl() checked, we need to wake it up.  We could
+	 * broadcast the CV here, but arc_get_data_impl() may have not yet
+	 * gone to sleep.  We would need to use a mutex to ensure that this
+	 * function doesn't broadcast until arc_get_data_impl() has gone to
+	 * sleep (e.g. the arc_adjust_lock).  However, the lock ordering of
+	 * such a lock would necessarily be incorrect with respect to the
+	 * zthr_lock, which is held before this function is called, and is
+	 * held by arc_get_data_impl() when it calls zthr_wakeup().
+	 */
+	return (arc_adjust_needed);
+}
+
 /*
- * Threads can block in arc_get_data_impl() waiting for this thread to evict
- * enough data and signal them to proceed. When this happens, the threads in
- * arc_get_data_impl() are sleeping while holding the hash lock for their
- * particular arc header. Thus, we must be careful to never sleep on a
- * hash lock in this thread. This is to prevent the following deadlock:
- *
- *  - Thread A sleeps on CV in arc_get_data_impl() holding hash lock "L",
- *    waiting for the reclaim thread to signal it.
- *
- *  - arc_reclaim_thread() tries to acquire hash lock "L" using mutex_enter,
- *    fails, and goes to sleep forever.
- *
- * This possible deadlock is avoided by always acquiring a hash lock
- * using mutex_tryenter() from arc_reclaim_thread().
+ * Keep arc_size under arc_c by running arc_adjust which evicts data
+ * from the ARC.
  */
 /* ARGSUSED */
-static void
-arc_reclaim_thread(void *unused)
+static int
+arc_adjust_cb(void *arg, zthr_t *zthr)
 {
-	hrtime_t		growtime = 0;
-	hrtime_t		kmem_reap_time = 0;
-	callb_cpr_t		cpr;
+	uint64_t evicted = 0;
 
-	CALLB_CPR_INIT(&cpr, &arc_reclaim_lock, callb_generic_cpr, FTAG);
+	/* Evict from cache */
+	evicted = arc_adjust();
 
-	mutex_enter(&arc_reclaim_lock);
-	while (!arc_reclaim_thread_exit) {
-		uint64_t evicted = 0;
-
+	/*
+	 * If evicted is zero, we couldn't evict anything
+	 * via arc_adjust(). This could be due to hash lock
+	 * collisions, but more likely due to the majority of
+	 * arc buffers being unevictable. Therefore, even if
+	 * arc_size is above arc_c, another pass is unlikely to
+	 * be helpful and could potentially cause us to enter an
+	 * infinite loop.  Additionally, zthr_iscancelled() is
+	 * checked here so that if the arc is shutting down, the
+	 * broadcast will wake any remaining arc adjust waiters.
+	 */
+	mutex_enter(&arc_adjust_lock);
+	arc_adjust_needed = !zthr_iscancelled(arc_adjust_zthr) &&
+	    evicted > 0 && aggsum_compare(&arc_size, arc_c) > 0;
+	if (!arc_adjust_needed) {
 		/*
-		 * This is necessary in order for the mdb ::arc dcmd to
-		 * show up to date information. Since the ::arc command
-		 * does not call the kstat's update function, without
-		 * this call, the command may show stale stats for the
-		 * anon, mru, mru_ghost, mfu, and mfu_ghost lists. Even
-		 * with this change, the data might be up to 1 second
-		 * out of date; but that should suffice. The arc_state_t
-		 * structures can be queried directly if more accurate
-		 * information is needed.
+		 * We're either no longer overflowing, or we
+		 * can't evict anything more, so we should wake
+		 * up any waiters.
 		 */
-		if (arc_ksp != NULL)
-			arc_ksp->ks_update(arc_ksp, KSTAT_READ);
+		cv_broadcast(&arc_adjust_waiters_cv);
+	}
+	mutex_exit(&arc_adjust_lock);
 
-		mutex_exit(&arc_reclaim_lock);
+	return (0);
+}
 
+/* ARGSUSED */
+static boolean_t
+arc_reap_cb_check(void *arg, zthr_t *zthr)
+{
+	int64_t free_memory = arc_available_memory();
+
+	/*
+	 * If a kmem reap is already active, don't schedule more.  We must
+	 * check for this because kmem_cache_reap_soon() won't actually
+	 * block on the cache being reaped (this is to prevent callers from
+	 * becoming implicitly blocked by a system-wide kmem reap -- which,
+	 * on a system with many, many full magazines, can take minutes).
+	 */
+	if (!kmem_cache_reap_active() &&
+	    free_memory < 0) {
+		arc_no_grow = B_TRUE;
+		arc_warm = B_TRUE;
 		/*
-		 * We call arc_adjust() before (possibly) calling
-		 * arc_kmem_reap_now(), so that we can wake up
-		 * arc_get_data_impl() sooner.
+		 * Wait at least zfs_grow_retry (default 60) seconds
+		 * before considering growing.
 		 */
-		evicted = arc_adjust();
-
-		int64_t free_memory = arc_available_memory();
-		if (free_memory < 0) {
-			hrtime_t curtime = gethrtime();
-			arc_no_grow = B_TRUE;
-			arc_warm = B_TRUE;
-
-			/*
-			 * Wait at least zfs_grow_retry (default 60) seconds
-			 * before considering growing.
-			 */
-			growtime = curtime + SEC2NSEC(arc_grow_retry);
-
-			/*
-			 * Wait at least arc_kmem_cache_reap_retry_ms
-			 * between arc_kmem_reap_now() calls. Without
-			 * this check it is possible to end up in a
-			 * situation where we spend lots of time
-			 * reaping caches, while we're near arc_c_min.
-			 */
-			if (curtime >= kmem_reap_time) {
-				arc_kmem_reap_now();
-				kmem_reap_time = gethrtime() +
-				    MSEC2NSEC(arc_kmem_cache_reap_retry_ms);
-			}
-
-			/*
-			 * If we are still low on memory, shrink the ARC
-			 * so that we have arc_shrink_min free space.
-			 */
-			free_memory = arc_available_memory();
-
-			int64_t to_free =
-			    (arc_c >> arc_shrink_shift) - free_memory;
-			if (to_free > 0) {
-#ifdef _KERNEL
-				to_free = MAX(to_free, ptob(needfree));
-#endif
-				arc_shrink(to_free);
-			}
-		} else if (free_memory < arc_c >> arc_no_grow_shift) {
-			arc_no_grow = B_TRUE;
-		} else if (gethrtime() >= growtime) {
-			arc_no_grow = B_FALSE;
-		}
-
-		mutex_enter(&arc_reclaim_lock);
-
-		/*
-		 * If evicted is zero, we couldn't evict anything via
-		 * arc_adjust(). This could be due to hash lock
-		 * collisions, but more likely due to the majority of
-		 * arc buffers being unevictable. Therefore, even if
-		 * arc_size is above arc_c, another pass is unlikely to
-		 * be helpful and could potentially cause us to enter an
-		 * infinite loop.
-		 */
-		if (aggsum_compare(&arc_size, arc_c) <= 0|| evicted == 0) {
-			/*
-			 * We're either no longer overflowing, or we
-			 * can't evict anything more, so we should wake
-			 * up any threads before we go to sleep.
-			 */
-			cv_broadcast(&arc_reclaim_waiters_cv);
-
-			/*
-			 * Block until signaled, or after one second (we
-			 * might need to perform arc_kmem_reap_now()
-			 * even if we aren't being signalled)
-			 */
-			CALLB_CPR_SAFE_BEGIN(&cpr);
-			(void) cv_timedwait_hires(&arc_reclaim_thread_cv,
-			    &arc_reclaim_lock, SEC2NSEC(1), MSEC2NSEC(1), 0);
-			CALLB_CPR_SAFE_END(&cpr, &arc_reclaim_lock);
-		}
+		arc_growtime = gethrtime() + SEC2NSEC(arc_grow_retry);
+		return (B_TRUE);
+	} else if (free_memory < arc_c >> arc_no_grow_shift) {
+		arc_no_grow = B_TRUE;
+	} else if (gethrtime() >= arc_growtime) {
+		arc_no_grow = B_FALSE;
 	}
 
-	arc_reclaim_thread_exit = B_FALSE;
-	cv_broadcast(&arc_reclaim_thread_cv);
-	CALLB_CPR_EXIT(&cpr);		/* drops arc_reclaim_lock */
-	thread_exit();
+	return (B_FALSE);
+}
+
+/*
+ * Keep enough free memory in the system by reaping the ARC's kmem
+ * caches.  To cause more slabs to be reapable, we may reduce the
+ * target size of the cache (arc_c), causing the arc_adjust_cb()
+ * to free more buffers.
+ */
+/* ARGSUSED */
+static int
+arc_reap_cb(void *arg, zthr_t *zthr)
+{
+	int64_t free_memory;
+
+	/*
+	 * Kick off asynchronous kmem_reap()'s of all our caches.
+	 */
+	arc_kmem_reap_soon();
+
+	/*
+	 * Wait at least arc_kmem_cache_reap_retry_ms between
+	 * arc_kmem_reap_soon() calls. Without this check it is possible to
+	 * end up in a situation where we spend lots of time reaping
+	 * caches, while we're near arc_c_min.  Waiting here also gives the
+	 * subsequent free memory check a chance of finding that the
+	 * asynchronous reap has already freed enough memory, and we don't
+	 * need to call arc_reduce_target_size().
+	 */
+	delay((hz * arc_kmem_cache_reap_retry_ms + 999) / 1000);
+
+	/*
+	 * Reduce the target size as needed to maintain the amount of free
+	 * memory in the system at a fraction of the arc_size (1/128th by
+	 * default).  If oversubscribed (free_memory < 0) then reduce the
+	 * target arc_size by the deficit amount plus the fractional
+	 * amount.  If free memory is positive but less then the fractional
+	 * amount, reduce by what is needed to hit the fractional amount.
+	 */
+	free_memory = arc_available_memory();
+
+	int64_t to_free =
+	    (arc_c >> arc_shrink_shift) - free_memory;
+	if (to_free > 0) {
+#ifdef _KERNEL
+		to_free = MAX(to_free, ptob(needfree));
+#endif
+		arc_reduce_target_size(to_free);
+	}
+
+	return (0);
 }
 
 /*
@@ -4303,10 +4340,14 @@ arc_adapt(int bytes, arc_state_t *state)
 	}
 	ASSERT((int64_t)arc_p >= 0);
 
+	/*
+	 * Wake reap thread if we do not have any available memory
+	 */
 	if (arc_reclaim_needed()) {
-		cv_signal(&arc_reclaim_thread_cv);
+		zthr_wakeup(arc_reap_zthr);
 		return;
 	}
+
 
 	if (arc_no_grow)
 		return;
@@ -4411,7 +4452,7 @@ arc_get_data_impl(arc_buf_hdr_t *hdr, uint64_t size, void *tag)
 	 * overflowing; thus we don't use a while loop here.
 	 */
 	if (arc_is_overflowing()) {
-		mutex_enter(&arc_reclaim_lock);
+		mutex_enter(&arc_adjust_lock);
 
 		/*
 		 * Now that we've acquired the lock, we may no longer be
@@ -4425,11 +4466,12 @@ arc_get_data_impl(arc_buf_hdr_t *hdr, uint64_t size, void *tag)
 		 * shouldn't cause any harm.
 		 */
 		if (arc_is_overflowing()) {
-			cv_signal(&arc_reclaim_thread_cv);
-			cv_wait(&arc_reclaim_waiters_cv, &arc_reclaim_lock);
+			arc_adjust_needed = B_TRUE;
+			zthr_wakeup(arc_adjust_zthr);
+			(void) cv_wait(&arc_adjust_waiters_cv,
+			    &arc_adjust_lock);
 		}
-
-		mutex_exit(&arc_reclaim_lock);
+		mutex_exit(&arc_adjust_lock);
 	}
 
 	VERIFY3U(hdr->b_type, ==, type);
@@ -6090,10 +6132,8 @@ arc_init(void)
 #else
 	uint64_t allmem = (physmem * PAGESIZE) / 2;
 #endif
-
-	mutex_init(&arc_reclaim_lock, NULL, MUTEX_DEFAULT, NULL);
-	cv_init(&arc_reclaim_thread_cv, NULL, CV_DEFAULT, NULL);
-	cv_init(&arc_reclaim_waiters_cv, NULL, CV_DEFAULT, NULL);
+	mutex_init(&arc_adjust_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&arc_adjust_waiters_cv, NULL, CV_DEFAULT, NULL);
 
 	/* Convert seconds to clock ticks */
 	arc_min_prefetch_lifespan = 1 * hz;
@@ -6178,9 +6218,14 @@ arc_init(void)
 		arc_c = arc_c_min;
 
 	arc_state_init();
-	buf_init();
 
-	arc_reclaim_thread_exit = B_FALSE;
+	/*
+	 * The arc must be "uninitialized", so that hdr_recl() (which is
+	 * registered by buf_init()) will not access arc_reap_zthr before
+	 * it is created.
+	 */
+	ASSERT(!arc_initialized);
+	buf_init();
 
 	arc_ksp = kstat_create("zfs", 0, "arcstats", "misc", KSTAT_TYPE_NAMED,
 	    sizeof (arc_stats) / sizeof (kstat_named_t), KSTAT_FLAG_VIRTUAL);
@@ -6191,10 +6236,12 @@ arc_init(void)
 		kstat_install(arc_ksp);
 	}
 
-	(void) thread_create(NULL, 0, arc_reclaim_thread, NULL, 0, &p0,
-	    TS_RUN, minclsyspri);
+	arc_adjust_zthr = zthr_create(arc_adjust_cb_check,
+	    arc_adjust_cb, NULL);
+	arc_reap_zthr = zthr_create_timer(arc_reap_cb_check,
+	    arc_reap_cb, NULL, SEC2NSEC(1));
 
-	arc_dead = B_FALSE;
+	arc_initialized = B_TRUE;
 	arc_warm = B_FALSE;
 
 	/*
@@ -6216,31 +6263,24 @@ arc_init(void)
 void
 arc_fini(void)
 {
-	mutex_enter(&arc_reclaim_lock);
-	arc_reclaim_thread_exit = B_TRUE;
-	/*
-	 * The reclaim thread will set arc_reclaim_thread_exit back to
-	 * B_FALSE when it is finished exiting; we're waiting for that.
-	 */
-	while (arc_reclaim_thread_exit) {
-		cv_signal(&arc_reclaim_thread_cv);
-		cv_wait(&arc_reclaim_thread_cv, &arc_reclaim_lock);
-	}
-	mutex_exit(&arc_reclaim_lock);
-
 	/* Use B_TRUE to ensure *all* buffers are evicted */
 	arc_flush(NULL, B_TRUE);
 
-	arc_dead = B_TRUE;
+	arc_initialized = B_FALSE;
 
 	if (arc_ksp != NULL) {
 		kstat_delete(arc_ksp);
 		arc_ksp = NULL;
 	}
 
-	mutex_destroy(&arc_reclaim_lock);
-	cv_destroy(&arc_reclaim_thread_cv);
-	cv_destroy(&arc_reclaim_waiters_cv);
+	(void) zthr_cancel(arc_adjust_zthr);
+	zthr_destroy(arc_adjust_zthr);
+
+	(void) zthr_cancel(arc_reap_zthr);
+	zthr_destroy(arc_reap_zthr);
+
+	mutex_destroy(&arc_adjust_lock);
+	cv_destroy(&arc_adjust_waiters_cv);
 
 	arc_state_fini();
 	buf_fini();

--- a/usr/src/uts/common/fs/zfs/dbuf.c
+++ b/usr/src/uts/common/fs/zfs/dbuf.c
@@ -85,10 +85,10 @@ static boolean_t dbuf_evict_thread_exit;
  */
 static multilist_t *dbuf_cache;
 static refcount_t dbuf_cache_size;
-uint64_t dbuf_cache_max_bytes = 100 * 1024 * 1024;
+uint64_t dbuf_cache_max_bytes = 0;
 
-/* Cap the size of the dbuf cache to log2 fraction of arc size. */
-int dbuf_cache_max_shift = 5;
+/* Set the default size of the dbuf cache to log2 fraction of arc size. */
+int dbuf_cache_shift = 5;
 
 /*
  * The dbuf cache uses a three-stage eviction policy:
@@ -600,11 +600,15 @@ retry:
 		mutex_init(&h->hash_mutexes[i], NULL, MUTEX_DEFAULT, NULL);
 
 	/*
-	 * Setup the parameters for the dbuf cache. We cap the size of the
-	 * dbuf cache to 1/32nd (default) of the size of the ARC.
+	 * Setup the parameters for the dbuf cache. We set the size of the
+	 * dbuf cache to 1/32nd (default) of the size of the ARC. If the value
+	 * has been set in /etc/system and it's not greater than the size of
+	 * the ARC, then we honor that value.
 	 */
-	dbuf_cache_max_bytes = MIN(dbuf_cache_max_bytes,
-	    arc_max_bytes() >> dbuf_cache_max_shift);
+	if (dbuf_cache_max_bytes == 0 ||
+	    dbuf_cache_max_bytes >= arc_max_bytes())  {
+		dbuf_cache_max_bytes = arc_max_bytes() >> dbuf_cache_shift;
+	}
 
 	/*
 	 * All entries are queued via taskq_dispatch_ent(), so min/maxalloc

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -41,7 +41,7 @@
 	((flags) & (METASLAB_GANG_CHILD | METASLAB_GANG_HEADER))
 
 uint64_t metaslab_aliquot = 512ULL << 10;
-uint64_t metaslab_gang_bang = SPA_MAXBLOCKSIZE + 1;	/* force gang blocks */
+uint64_t metaslab_force_ganging = SPA_MAXBLOCKSIZE + 1;	/* force gang blocks */
 
 /*
  * Since we can touch multiple metaslabs (and their respective space maps)
@@ -3080,7 +3080,7 @@ metaslab_alloc_dva(spa_t *spa, metaslab_class_t *mc, uint64_t psize,
 	/*
 	 * For testing, make some blocks above a certain size be gang blocks.
 	 */
-	if (psize >= metaslab_gang_bang && (ddi_get_lbolt() & 3) == 0) {
+	if (psize >= metaslab_force_ganging && (ddi_get_lbolt() & 3) == 0) {
 		metaslab_trace_add(zal, NULL, NULL, psize, d, TRACE_FORCE_GANG);
 		return (SET_ERROR(ENOSPC));
 	}

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -1814,6 +1814,7 @@ spa_check_for_missing_logs(spa_t *spa)
 
 		if (idx > 0) {
 			spa_load_failed(spa, "some log devices are missing");
+			vdev_dbgmsg_print_tree(rvd, 2);
 			return (SET_ERROR(ENXIO));
 		}
 	} else {
@@ -1825,6 +1826,7 @@ spa_check_for_missing_logs(spa_t *spa)
 				spa_set_log_state(spa, SPA_LOG_CLEAR);
 				spa_load_note(spa, "some log devices are "
 				    "missing, ZIL is dropped.");
+				vdev_dbgmsg_print_tree(rvd, 2);
 				break;
 			}
 		}
@@ -2019,13 +2021,13 @@ spa_load_verify(spa_t *spa)
 {
 	zio_t *rio;
 	spa_load_error_t sle = { 0 };
-	zpool_rewind_policy_t policy;
+	zpool_load_policy_t policy;
 	boolean_t verify_ok = B_FALSE;
 	int error = 0;
 
-	zpool_get_rewind_policy(spa->spa_config, &policy);
+	zpool_get_load_policy(spa->spa_config, &policy);
 
-	if (policy.zrp_request & ZPOOL_NEVER_REWIND)
+	if (policy.zlp_rewind & ZPOOL_NEVER_REWIND)
 		return (0);
 
 	dsl_pool_config_enter(spa->spa_dsl_pool, FTAG);
@@ -2064,8 +2066,8 @@ spa_load_verify(spa_t *spa)
 	}
 
 	if (spa_load_verify_dryrun ||
-	    (!error && sle.sle_meta_count <= policy.zrp_maxmeta &&
-	    sle.sle_data_count <= policy.zrp_maxdata)) {
+	    (!error && sle.sle_meta_count <= policy.zlp_maxmeta &&
+	    sle.sle_data_count <= policy.zlp_maxdata)) {
 		int64_t loss = 0;
 
 		verify_ok = B_TRUE;
@@ -2765,17 +2767,17 @@ spa_ld_trusted_config(spa_t *spa, spa_import_type_t type,
 	/*
 	 * We will use spa_config if we decide to reload the spa or if spa_load
 	 * fails and we rewind. We must thus regenerate the config using the
-	 * MOS information with the updated paths. Rewind policy is an import
-	 * setting and is not in the MOS. We copy it over to our new, trusted
-	 * config.
+	 * MOS information with the updated paths. ZPOOL_LOAD_POLICY is used to
+	 * pass settings on how to load the pool and is not stored in the MOS.
+	 * We copy it over to our new, trusted config.
 	 */
 	mos_config_txg = fnvlist_lookup_uint64(mos_config,
 	    ZPOOL_CONFIG_POOL_TXG);
 	nvlist_free(mos_config);
 	mos_config = spa_config_generate(spa, NULL, mos_config_txg, B_FALSE);
-	if (nvlist_lookup_nvlist(spa->spa_config, ZPOOL_REWIND_POLICY,
+	if (nvlist_lookup_nvlist(spa->spa_config, ZPOOL_LOAD_POLICY,
 	    &policy) == 0)
-		fnvlist_add_nvlist(mos_config, ZPOOL_REWIND_POLICY, policy);
+		fnvlist_add_nvlist(mos_config, ZPOOL_LOAD_POLICY, policy);
 	spa_config_set(spa, mos_config);
 	spa->spa_config_source = SPA_CONFIG_SRC_MOS;
 
@@ -4034,11 +4036,11 @@ spa_open_common(const char *pool, spa_t **spapp, void *tag, nvlist_t *nvpolicy,
 	}
 
 	if (spa->spa_state == POOL_STATE_UNINITIALIZED) {
-		zpool_rewind_policy_t policy;
+		zpool_load_policy_t policy;
 
-		zpool_get_rewind_policy(nvpolicy ? nvpolicy : spa->spa_config,
+		zpool_get_load_policy(nvpolicy ? nvpolicy : spa->spa_config,
 		    &policy);
-		if (policy.zrp_request & ZPOOL_DO_REWIND)
+		if (policy.zlp_rewind & ZPOOL_DO_REWIND)
 			state = SPA_LOAD_RECOVER;
 
 		spa_activate(spa, spa_mode_global);
@@ -4048,8 +4050,8 @@ spa_open_common(const char *pool, spa_t **spapp, void *tag, nvlist_t *nvpolicy,
 		spa->spa_config_source = SPA_CONFIG_SRC_CACHEFILE;
 
 		zfs_dbgmsg("spa_open_common: opening %s", pool);
-		error = spa_load_best(spa, state, policy.zrp_txg,
-		    policy.zrp_request);
+		error = spa_load_best(spa, state, policy.zlp_txg,
+		    policy.zlp_rewind);
 
 		if (error == EBADF) {
 			/*
@@ -5016,7 +5018,7 @@ spa_import(const char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 	spa_t *spa;
 	char *altroot = NULL;
 	spa_load_state_t state = SPA_LOAD_IMPORT;
-	zpool_rewind_policy_t policy;
+	zpool_load_policy_t policy;
 	uint64_t mode = spa_mode_global;
 	uint64_t readonly = B_FALSE;
 	int error;
@@ -5067,8 +5069,8 @@ spa_import(const char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 	 */
 	spa_async_suspend(spa);
 
-	zpool_get_rewind_policy(config, &policy);
-	if (policy.zrp_request & ZPOOL_DO_REWIND)
+	zpool_get_load_policy(config, &policy);
+	if (policy.zlp_rewind & ZPOOL_DO_REWIND)
 		state = SPA_LOAD_RECOVER;
 
 	spa->spa_config_source = SPA_CONFIG_SRC_TRYIMPORT;
@@ -5078,9 +5080,9 @@ spa_import(const char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 		zfs_dbgmsg("spa_import: importing %s", pool);
 	} else {
 		zfs_dbgmsg("spa_import: importing %s, max_txg=%lld "
-		    "(RECOVERY MODE)", pool, (longlong_t)policy.zrp_txg);
+		    "(RECOVERY MODE)", pool, (longlong_t)policy.zlp_txg);
 	}
-	error = spa_load_best(spa, state, policy.zrp_txg, policy.zrp_request);
+	error = spa_load_best(spa, state, policy.zlp_txg, policy.zlp_rewind);
 
 	/*
 	 * Propagate anything learned while loading the pool and pass it
@@ -5202,7 +5204,7 @@ spa_tryimport(nvlist_t *tryconfig)
 	spa_t *spa;
 	uint64_t state;
 	int error;
-	zpool_rewind_policy_t policy;
+	zpool_load_policy_t policy;
 
 	if (nvlist_lookup_string(tryconfig, ZPOOL_CONFIG_POOL_NAME, &poolname))
 		return (NULL);
@@ -5218,16 +5220,14 @@ spa_tryimport(nvlist_t *tryconfig)
 	spa_activate(spa, FREAD);
 
 	/*
-	 * Rewind pool if a max txg was provided. Note that even though we
-	 * retrieve the complete rewind policy, only the rewind txg is relevant
-	 * for tryimport.
+	 * Rewind pool if a max txg was provided.
 	 */
-	zpool_get_rewind_policy(spa->spa_config, &policy);
-	if (policy.zrp_txg != UINT64_MAX) {
-		spa->spa_load_max_txg = policy.zrp_txg;
+	zpool_get_load_policy(spa->spa_config, &policy);
+	if (policy.zlp_txg != UINT64_MAX) {
+		spa->spa_load_max_txg = policy.zlp_txg;
 		spa->spa_extreme_rewind = B_TRUE;
 		zfs_dbgmsg("spa_tryimport: importing %s, max_txg=%lld",
-		    poolname, (longlong_t)policy.zrp_txg);
+		    poolname, (longlong_t)policy.zlp_txg);
 	} else {
 		zfs_dbgmsg("spa_tryimport: importing %s", poolname);
 	}

--- a/usr/src/uts/common/fs/zfs/sys/zthr.h
+++ b/usr/src/uts/common/fs/zfs/sys/zthr.h
@@ -29,6 +29,7 @@ struct zthr {
 	kmutex_t	zthr_lock;
 	kcondvar_t	zthr_cv;
 	boolean_t	zthr_cancel;
+	hrtime_t	zthr_wait_time;
 
 	zthr_checkfunc_t	*zthr_checkfunc;
 	zthr_func_t	*zthr_func;
@@ -38,6 +39,9 @@ struct zthr {
 
 extern zthr_t *zthr_create(zthr_checkfunc_t checkfunc,
     zthr_func_t *func, void *arg);
+extern zthr_t *zthr_create_timer(zthr_checkfunc_t *checkfunc,
+    zthr_func_t *func, void *arg, hrtime_t nano_wait);
+
 extern void zthr_exit(zthr_t *t, int rc);
 extern void zthr_destroy(zthr_t *t);
 

--- a/usr/src/uts/common/fs/zfs/vdev_label.c
+++ b/usr/src/uts/common/fs/zfs/vdev_label.c
@@ -540,6 +540,7 @@ vdev_label_read_config(vdev_t *vd, uint64_t txg)
 	abd_t *vp_abd;
 	zio_t *zio;
 	uint64_t best_txg = 0;
+	uint64_t label_txg = 0;
 	int error = 0;
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL |
 	    ZIO_FLAG_SPECULATIVE;
@@ -565,8 +566,6 @@ retry:
 		if (zio_wait(zio) == 0 &&
 		    nvlist_unpack(vp->vp_nvlist, sizeof (vp->vp_nvlist),
 		    &label, 0) == 0) {
-			uint64_t label_txg = 0;
-
 			/*
 			 * Auxiliary vdevs won't have txg values in their
 			 * labels and newly added vdevs may not have been
@@ -595,6 +594,15 @@ retry:
 	if (config == NULL && !(flags & ZIO_FLAG_TRYHARD)) {
 		flags |= ZIO_FLAG_TRYHARD;
 		goto retry;
+	}
+
+	/*
+	 * We found a valid label but it didn't pass txg restrictions.
+	 */
+	if (config == NULL && label_txg != 0) {
+		vdev_dbgmsg(vd, "label discarded as txg is too large "
+		    "(%llu > %llu)", (u_longlong_t)label_txg,
+		    (u_longlong_t)txg);
 	}
 
 	abd_free(vp_abd);

--- a/usr/src/uts/common/fs/zfs/zthr.c
+++ b/usr/src/uts/common/fs/zfs/zthr.c
@@ -47,6 +47,10 @@
  * 3] When the zthr is done, it changes the indicator to stopped, allowing
  *    a new cycle to start.
  *
+ * Besides being awakened by other threads, a zthr can be configured
+ * during creation to wakeup on it's own after a specified interval
+ * [see zthr_create_timer()].
+ *
  * == ZTHR creation
  *
  * Every zthr needs three inputs to start running:
@@ -74,6 +78,9 @@
  *
  * To start a zthr:
  *     zthr_t *zthr_pointer = zthr_create(checkfunc, func, args);
+ * or
+ *     zthr_t *zthr_pointer = zthr_create_timer(checkfunc, func,
+ *         args, max_sleep);
  *
  * After that you should be able to wakeup, cancel, and resume the
  * zthr from another thread using zthr_pointer.
@@ -189,7 +196,13 @@ zthr_procedure(void *arg)
 			mutex_enter(&t->zthr_lock);
 		} else {
 			/* go to sleep */
-			cv_wait(&t->zthr_cv, &t->zthr_lock);
+			if (t->zthr_wait_time == 0) {
+				cv_wait(&t->zthr_cv, &t->zthr_lock);
+			} else {
+				(void) cv_timedwait_hires(&t->zthr_cv,
+				    &t->zthr_lock, t->zthr_wait_time,
+				    MSEC2NSEC(1), 0);
+			}
 		}
 	}
 	mutex_exit(&t->zthr_lock);
@@ -200,6 +213,18 @@ zthr_procedure(void *arg)
 zthr_t *
 zthr_create(zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg)
 {
+	return (zthr_create_timer(checkfunc, func, arg, (hrtime_t)0));
+}
+
+/*
+ * Create a zthr with specified maximum sleep time.  If the time
+ * in sleeping state exceeds max_sleep, a wakeup(do the check and
+ * start working if required) will be triggered.
+ */
+zthr_t *
+zthr_create_timer(zthr_checkfunc_t *checkfunc, zthr_func_t *func,
+    void *arg, hrtime_t max_sleep)
+{
 	zthr_t *t = kmem_zalloc(sizeof (*t), KM_SLEEP);
 	mutex_init(&t->zthr_lock, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&t->zthr_cv, NULL, CV_DEFAULT, NULL);
@@ -208,6 +233,7 @@ zthr_create(zthr_checkfunc_t *checkfunc, zthr_func_t *func, void *arg)
 	t->zthr_checkfunc = checkfunc;
 	t->zthr_func = func;
 	t->zthr_arg = arg;
+	t->zthr_wait_time = max_sleep;
 
 	t->zthr_thread = thread_create(NULL, 0, zthr_procedure, t,
 	    0, &p0, TS_RUN, minclsyspri);

--- a/usr/src/uts/common/sys/fs/zfs.h
+++ b/usr/src/uts/common/sys/fs/zfs.h
@@ -491,7 +491,7 @@ typedef enum {
 #define	ZPL_VERSION_USERSPACE		ZPL_VERSION_4
 #define	ZPL_VERSION_SA			ZPL_VERSION_5
 
-/* Rewind request information */
+/* Rewind policy information */
 #define	ZPOOL_NO_REWIND		1  /* No policy - default behavior */
 #define	ZPOOL_NEVER_REWIND	2  /* Do not search for best txg or rewind */
 #define	ZPOOL_TRY_REWIND	4  /* Search for best txg, but do not rewind */
@@ -500,12 +500,12 @@ typedef enum {
 #define	ZPOOL_REWIND_MASK	28 /* All the possible rewind bits */
 #define	ZPOOL_REWIND_POLICIES	31 /* All the possible policy bits */
 
-typedef struct zpool_rewind_policy {
-	uint32_t	zrp_request;	/* rewind behavior requested */
-	uint64_t	zrp_maxmeta;	/* max acceptable meta-data errors */
-	uint64_t	zrp_maxdata;	/* max acceptable data errors */
-	uint64_t	zrp_txg;	/* specific txg to load */
-} zpool_rewind_policy_t;
+typedef struct zpool_load_policy {
+	uint32_t	zlp_rewind;	/* rewind policy requested */
+	uint64_t	zlp_maxmeta;	/* max acceptable meta-data errors */
+	uint64_t	zlp_maxdata;	/* max acceptable data errors */
+	uint64_t	zlp_txg;	/* specific txg to load */
+} zpool_load_policy_t;
 
 /*
  * The following are configuration names used in the nvlist describing a pool's
@@ -593,12 +593,12 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_FRU		"fru"
 #define	ZPOOL_CONFIG_AUX_STATE		"aux_state"
 
-/* Rewind policy parameters */
-#define	ZPOOL_REWIND_POLICY		"rewind-policy"
-#define	ZPOOL_REWIND_REQUEST		"rewind-request"
-#define	ZPOOL_REWIND_REQUEST_TXG	"rewind-request-txg"
-#define	ZPOOL_REWIND_META_THRESH	"rewind-meta-thresh"
-#define	ZPOOL_REWIND_DATA_THRESH	"rewind-data-thresh"
+/* Pool load policy parameters */
+#define	ZPOOL_LOAD_POLICY		"load-policy"
+#define	ZPOOL_LOAD_REWIND_POLICY	"load-rewind-policy"
+#define	ZPOOL_LOAD_REQUEST_TXG		"load-request-txg"
+#define	ZPOOL_LOAD_META_THRESH		"load-meta-thresh"
+#define	ZPOOL_LOAD_DATA_THRESH		"load-data-thresh"
 
 /* Rewind data discovered */
 #define	ZPOOL_CONFIG_LOAD_TIME		"rewind_txg_ts"


### PR DESCRIPTION
Weekly upstream for upstream_merge/2018032201

## Backports

* 9317 FMD crashes with zero-length allocation

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2018032201-fb4894f027 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Mar 22 12:28:07 GMT 2018 ====
==== Nightly distributed build completed: Thu Mar 22 13:38:46 GMT 2018 ====

==== Total build time ====

real    1:10:38

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-5cae57a473 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2n  7 Dec 2017

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   2300

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018032201-fb4894f027

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    16:06.2
user  1:08:42.0
sys     12:04.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:01.2
user    59:51.7
sys     11:14.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    27:23.2
user    44:50.7
sys      9:55.1

==== lint warnings src ====

"../../i86pc/io/vmm/amd/svm_support.s", line 40: warning: undefined or missing type for: pa (E_UNDEFINED_OR_MISSING_TYPE)
"../../i86pc/io/vmm/amd/svm_support.s", line 40: warning: undefined or missing type for: struct (E_UNDEFINED_OR_MISSING_TYPE)
"../../i86pc/io/vmm/io/ppt.c", line 416: warning: suspicious comparison of unsigned with negative constant: op "==" (E_SUSPICIOUS_COMPARISON)
"../../i86pc/io/vmm/io/ppt.c", line 423: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
"../../i86pc/io/vmm/vmm_sol_glue.c", line 776: warning: logical expression always false: op "&&" (E_FALSE_LOGICAL_EXPR)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/common/fs/dev/sdev_plugin.c", line 614: warning: function returns value which is always ignored: pn_get_buf (E_FUNC_RET_ALWAYS_IGNOR2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/common/sys/fs/ufs_inode.h", line 872: warning: function declared with variable number of args: free in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c(183) and /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/common/sys/fs/ufs_inode.h(872) (E_FUNC_DECL_VAR_ARG2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 1775: warning: function argument type inconsistent with format: panic(arg 3) unsigned long  and (format) int  in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.c(1775) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 2040: warning: function called with variable number of args: svm_launch in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm_support.s(40) and /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.c(2040) (E_FUNC_USED_VAR_ARG2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.h", line 57: warning: function declared with variable number of args: svm_launch in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm_support.s(40) and /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.h(57) (E_FUNC_DECL_VAR_ARG2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmcs.h", line 142: warning: function argument type inconsistent with format: panic(arg 3) struct vmcs * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmcs.h(142) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmcs.h", line 156: warning: function argument type inconsistent with format: panic(arg 3) struct vmcs * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmcs.h(156) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2782: warning: function argument type inconsistent with format: panic(arg 2) struct pmap * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2782) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2782: warning: function argument type inconsistent with format: panic(arg 3) struct pmap * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2782) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2913: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vtd.c", line 704: warning: function argument type inconsistent with format: panic(arg 2) unsigned long * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/intel/vtd.c(704) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 811: warning: function returns value which is sometimes ignored: ddi_intr_block_disable (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 813: warning: function returns value which is sometimes ignored: ddi_intr_disable (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 815: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 816: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 260: warning: function returns value which is sometimes ignored: lapic_set_local_intr (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vatpit.c", line 155: warning: function returns value which is sometimes ignored: vatpic_pulse_irq (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 313: warning: function argument type inconsistent with format: panic(arg 2) struct vhpet * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vhpet.c(313) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 1597: warning: function returns value which is sometimes ignored: lapic_set_intr (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 476: warning: function returns value which is sometimes ignored: vm_inject_nmi (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 479: warning: function returns value which is always ignored: vm_inject_extint (E_FUNC_RET_ALWAYS_IGNOR2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm.c", line 1464: warning: function returns value which is sometimes ignored: vm_suspend (E_FUNC_RET_MAYBE_IGNORED2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm.c", line 467: warning: function returns value which is always ignored: vmmdev_cleanup (E_FUNC_RET_ALWAYS_IGNOR2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c", line 1325: warning: function returns value which is always ignored: vmm_zsd_add_vm (E_FUNC_RET_ALWAYS_IGNOR2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 607: warning: function argument type inconsistent with format: panic(arg 2) unsigned long * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(607) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 643: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(643) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 692: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(692) (E_BAD_FORMAT_ARG_TYPE2)
"/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 750: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(750) (E_BAD_FORMAT_ARG_TYPE2)

==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
