### PR TITLE
 9317 FMD crashes with zero-length allocation (r151024)

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -47,6 +47,14 @@ Packages:
 Archive:
  > https://downloads.omniosce.org/pkg/8806-backport_r24.p5p
 
+## 9317 FMD crashes with zero-length allocation
+
+Packages:
+ > system/library
+
+Archive:
+ > https://downloads.omniosce.org/pkg/r151024/9317-ses2.p5p
+
 =======================================================================
 
 =============================

--- a/usr/src/lib/scsi/plugins/ses/ses2/common/ses2_element.c
+++ b/usr/src/lib/scsi/plugins/ses/ses2/common/ses2_element.c
@@ -21,10 +21,9 @@
 
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  * Use is subject to license terms.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <sys/types.h>
 #include <stddef.h>
@@ -871,6 +870,9 @@ elem_parse_aes_misc(const ses2_aes_descr_eip_impl_t *dep, nvlist_t *nvl,
 	nphy = MIN(s1p->sadsi_n_phy_descriptors,
 	    (len - offsetof(ses2_aes_descr_sas1_impl_t,
 	    sadsi_phys)) / sizeof (ses2_aes_phy1_descr_impl_t));
+
+	if (nphy == 0)
+		return (0);
 
 	nva = ses_zalloc(nphy * sizeof (nvlist_t *));
 	if (nva == NULL)


### PR DESCRIPTION
Reviewed by: C Fraire <cfraire@me.com>
Reviewed by: Ken Mays <maybird1776@yahoo.com>
Reviewed by: Igor Kozhukhov <igor@dilos.org>
Reviewed by: Toomas Soome <tsoome@me.com>
Approved by: Dan McDonald <danmcd@joyent.com>