### PR TITLE
Want option to explicitly set bhyve disk serial number

### DIFF
--- a/usr/src/cmd/bhyve/pci_virtio_block.c
+++ b/usr/src/cmd/bhyve/pci_virtio_block.c
@@ -37,6 +37,7 @@
  *
  * Copyright 2014 Pluribus Networks Inc.
  * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/cdefs.h>
@@ -318,10 +319,39 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	off_t size;
 	int i, sectsz, sts, sto;
 
+#if !defined(__FreeBSD__) && !defined(__JOYENT__)
+	char *tmpopts, *opt, *nextopt, *path = NULL, *serial = NULL;
+
+	if ((tmpopts = strdup(opts)) == NULL)
+		return (-1);
+
+	for (nextopt = tmpopts, opt = strsep(&nextopt, ",");
+	    opt != NULL; opt = strsep(&nextopt, ",")) {
+		if (path == NULL && *opt == '/') {
+			path = opt;
+			continue;
+		}
+		if (!strncmp(opt, "serial=", 7)) {
+			serial = opt + 7;
+			continue;
+		}
+
+		printf("virtio-block: unknown option '%s'\n", opt);
+		free(tmpopts);
+		return (-1);
+	}
+	if (path == NULL) {
+		printf("virtio-block: backing device required\n");
+		free(tmpopts);
+		return (1);
+	}
+	opts = path;
+#else
 	if (opts == NULL) {
 		printf("virtio-block: backing device required\n");
 		return (1);
 	}
+#endif
 
 	/*
 	 * The supplied backing file has to exist
@@ -330,6 +360,9 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	bctxt = blockif_open(opts, bident);
 	if (bctxt == NULL) {       	
 		perror("Could not open backing file");
+#if !defined(__FreeBSD__) && !defined(__JOYENT__)
+		free(tmpopts);
+#endif
 		return (1);
 	}
 
@@ -365,6 +398,13 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	MD5Final(digest, &mdctx);	
 	sprintf(sc->vbsc_ident, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
+#if !defined(__FreeBSD__) && !defined(__JOYENT__)
+	if (serial != NULL) {
+		bzero(sc->vbsc_ident, sizeof(sc->vbsc_ident));
+		strlcpy(sc->vbsc_ident, serial, sizeof(sc->vbsc_ident));
+	}
+	free(tmpopts);
+#endif
 
 	/* setup virtio block config space */
 	sc->vbsc_cfg.vbc_capacity = size / DEV_BSIZE; /* 512-byte units */


### PR DESCRIPTION
By default, bhyve sets a virtio-blk disk device serial number (and hence device ID) to BHYVE followed by the first 12 digits of the md5 checksum of the backing store. This is much better than what KVM did which was to set a blank serial number, causing problems for things such as the enumeration framework used by `diskinfo`. Recent versions of kvmadm set a serial number based on the disk index by default but allow it to be overridden.

e.g.

```
bhyve% echo '/dev/zvol/rdsk/rpool/hdd-omnios\c' | digest -a md5 | cut -c1-12
a61dba9b18ef

root@omniosce:~# iostat -En | grep Block
Vendor: Virtio Product: Block Device Revision: 0000 Serial No: BHYVE-A61D-BA9B-18EF

root@omniosce:~# prtconf -v /dev/dsk/c3t0d0 | grep -A1 devid
        name='devid' type=string items=1
            value='id1,kdev@ABHYVE-A61D-BA9B-18EF'
```

To aid with migrating VMs from KVM to bhyve, it would be useful to have the option to override the serial number set by bhyve. This helps with ZFS root pool import as the device ID stored in the leaf VDEV label is the first thing it uses to try and find the disks.

Tested by setting `serial=0`:

```
root@omniosce:~# prtconf -v /dev/dsk/c3t0d0 | grep -A1 devid
        name='devid' type=string items=1
            value='id1,kdev@A0~~~~~~~~~~~~~~~~~~~'
```

which matches the output from the same disk under KVM.
