### PR TITLE
Joyent merge/2018041101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 7d4764a8704691712ae06535d720ae917acb4699
+Last illumos-joyent commit: 9f9eb51579cad092cf3b3070d80becbe3355cc3d
 

--- a/usr/src/uts/common/sys/pci.h
+++ b/usr/src/uts/common/sys/pci.h
@@ -582,6 +582,7 @@ extern "C" {
 #define	PCI_BASE_TYPE_M		0x00000006  /* type indicator mask */
 #define	PCI_BASE_PREF_M		0x00000008  /* prefetch mask */
 #define	PCI_BASE_M_ADDR_M	0xfffffff0  /* memory address mask */
+#define	PCI_BASE_M_ADDR64_M	0xfffffffffffffff0ULL /* 64bit mem addr mask */
 #define	PCI_BASE_IO_ADDR_M	0xfffffffe  /* I/O address mask */
 
 #define	PCI_BASE_ROM_ADDR_M	0xfffff800  /* ROM address mask */

--- a/usr/src/uts/common/sys/pci_impl.h
+++ b/usr/src/uts/common/sys/pci_impl.h
@@ -107,7 +107,7 @@ struct pci_bus_resource {
 	boolean_t io_reprogram;	/* need io reprog on this bus */
 	boolean_t mem_reprogram;	/* need mem reprog on this bus */
 	boolean_t subtractive;	/* subtractive PPB */
-	uint_t mem_size;	/* existing children required MEM space size */
+	uint64_t mem_size;	/* existing children required MEM space size */
 	uint_t io_size;		/* existing children required I/O space size */
 };
 

--- a/usr/src/uts/i86pc/io/vmm/amd/svm.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm.c
@@ -24,6 +24,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -2268,5 +2272,14 @@ struct vmm_ops vmm_ops_amd = {
 	svm_npt_alloc,
 	svm_npt_free,
 	svm_vlapic_init,
-	svm_vlapic_cleanup	
+	svm_vlapic_cleanup,
+
+#ifndef __FreeBSD__
+	/*
+	 * When SVM support is wired up and tested, it is likely to require
+	 * savectx/restorectx functions similar to VMX.
+	 */
+	NULL,
+	NULL,
+#endif
 };

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.h
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.h
@@ -27,7 +27,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _VMX_H_
@@ -123,6 +123,7 @@ struct vmx {
 #ifndef	__FreeBSD__
 	uint64_t	host_msrs[VM_MAXCPU][GUEST_MSR_NUM];
 	uint64_t	tsc_offset[VM_MAXCPU];
+	boolean_t	ctx_loaded[VM_MAXCPU];
 #endif
 	struct vmxctx	ctx[VM_MAXCPU];
 	struct vmxcap	cap[VM_MAXCPU];

--- a/usr/src/uts/i86pc/sys/vmm.h
+++ b/usr/src/uts/i86pc/sys/vmm.h
@@ -160,6 +160,10 @@ typedef struct vmspace * (*vmi_vmspace_alloc)(vm_offset_t min, vm_offset_t max);
 typedef void	(*vmi_vmspace_free)(struct vmspace *vmspace);
 typedef struct vlapic * (*vmi_vlapic_init)(void *vmi, int vcpu);
 typedef void	(*vmi_vlapic_cleanup)(void *vmi, struct vlapic *vlapic);
+#ifndef __FreeBSD__
+typedef void	(*vmi_savectx)(void *vmi, int vcpu);
+typedef void	(*vmi_restorectx)(void *vmi, int vcpu);
+#endif
 
 struct vmm_ops {
 	vmm_init_func_t		init;		/* module wide initialization */
@@ -179,6 +183,11 @@ struct vmm_ops {
 	vmi_vmspace_free	vmspace_free;
 	vmi_vlapic_init		vlapic_init;
 	vmi_vlapic_cleanup	vlapic_cleanup;
+
+#ifndef __FreeBSD__
+	vmi_savectx		vmsavectx;
+	vmi_restorectx		vmrestorectx;
+#endif
 };
 
 extern struct vmm_ops vmm_ops_intel;

--- a/usr/src/uts/intel/io/pci/pci_boot.c
+++ b/usr/src/uts/intel/io/pci/pci_boot.c
@@ -893,8 +893,9 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 {
 	uchar_t bus, dev, func;
 	uchar_t parbus, subbus;
-	uint_t io_base, io_limit, mem_base, mem_limit;
-	uint_t io_size, mem_size, io_align, mem_align;
+	uint_t io_base, io_limit, mem_base;
+	uint_t io_size, io_align;
+	uint64_t mem_size, mem_align, mem_limit;
 	uint64_t addr = 0;
 	int *regp = NULL;
 	uint_t reglen;
@@ -1049,9 +1050,9 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 				    pci_bus_res[parbus].io_reprogram;
 
 				cmn_err(CE_NOTE, "!add io-range on subtractive"
-				    " ppb[%x/%x/%x]: 0x%x ~ 0x%x\n",
-				    bus, dev, func, (uint32_t)addr,
-				    (uint32_t)addr + io_size - 1);
+				    " ppb[%x/%x/%x]: "
+				    "0x%"PRIx64" ~ 0x%"PRIx64"\n",
+				    bus, dev, func, addr, addr + io_size - 1);
 			}
 		}
 		/*
@@ -1066,9 +1067,10 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 				    pci_bus_res[parbus].mem_reprogram;
 
 				cmn_err(CE_NOTE, "!add mem-range on "
-				    "subtractive ppb[%x/%x/%x]: 0x%x ~ 0x%x\n",
-				    bus, dev, func, (uint32_t)addr,
-				    (uint32_t)addr + mem_size - 1);
+				    "subtractive ppb[%x/%x/%x]: "
+				    "0x%"PRIx64" ~ 0x%"PRIx64"\n",
+				    bus, dev, func,
+				    addr, addr + mem_size - 1);
 			}
 		}
 
@@ -1197,15 +1199,15 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 				if (is_vga(list, MEM))
 					continue;
 				if (mem_base == 0) {
-					mem_base = (uint_t)list->ml_address;
+					mem_base = list->ml_address;
 					mem_base = P2ALIGN(mem_base,
 					    PPB_MEM_ALIGNMENT);
-					mem_limit = (uint_t)(list->ml_address +
+					mem_limit = (list->ml_address +
 					    list->ml_size - 1);
 				} else {
 					if ((list->ml_address + list->ml_size) >
 					    mem_limit) {
-						mem_limit = (uint_t)
+						mem_limit =
 						    (list->ml_address +
 						    list->ml_size - 1);
 					}
@@ -1265,7 +1267,7 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 			add_ranges_prop(secbus, 1);
 
 			cmn_err(CE_NOTE, "!reprogram mem-range on"
-			    " ppb[%x/%x/%x]: 0x%x ~ 0x%x\n",
+			    " ppb[%x/%x/%x]: 0x%x ~ 0x%"PRIx64"\n",
 			    bus, dev, func, mem_base, mem_limit);
 		}
 	}
@@ -2360,7 +2362,8 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 {
 	uchar_t baseclass, subclass, progclass, header;
 	ushort_t bar_sz;
-	uint_t value = 0, len, devloc;
+	uint64_t value = 0;
+	uint_t devloc;
 	uint_t base, base_hi, type;
 	ushort_t offset, end;
 	int max_basereg, j, reprogram = 0;
@@ -2444,6 +2447,7 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 		/* construct phys hi,med.lo, size hi, lo */
 		if ((pciide && j < 4) || (base & PCI_BASE_SPACE_IO)) {
 			int hard_decode = 0;
+			uint_t len;
 
 			/* i/o space */
 			bar_sz = PCI_BAR_SZ_32;
@@ -2528,26 +2532,33 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 			nreg++, nasgn++;
 
 		} else {
+			uint64_t len;
 			/* memory space */
 			if ((base & PCI_BASE_TYPE_M) == PCI_BASE_TYPE_ALL) {
 				bar_sz = PCI_BAR_SZ_64;
 				base_hi = pci_getl(bus, dev, func, offset + 4);
+				pci_putl(bus, dev, func, offset + 4, 0xffffffff);
+				value |= (uint64_t)pci_getl(bus, dev, func,
+				    offset + 4) << 32;
+				pci_putl(bus, dev, func, offset + 4, base_hi);
 				phys_hi = PCI_ADDR_MEM64;
+				value &= PCI_BASE_M_ADDR64_M;
 			} else {
 				bar_sz = PCI_BAR_SZ_32;
 				base_hi = 0;
 				phys_hi = PCI_ADDR_MEM32;
+				value &= PCI_BASE_M_ADDR_M;
 			}
 
 			/* skip base regs with size of 0 */
-			value &= PCI_BASE_M_ADDR_M;
-
 			if (value == 0)
 				continue;
 
 			len = ((value ^ (value-1)) + 1) >> 1;
 			regs[nreg].pci_size_low =
-			    assigned[nasgn].pci_size_low = len;
+			    assigned[nasgn].pci_size_low = len & 0xffffffff;
+			regs[nreg].pci_size_hi =
+			    assigned[nasgn].pci_size_hi = len >> 32;
 
 			phys_hi |= (devloc | offset);
 			if (base & PCI_BASE_PREF_M)
@@ -2644,7 +2655,7 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 				} else
 					cmn_err(CE_WARN, "failed to program "
 					    "mem space [%d/%d/%d] BAR@0x%x"
-					    " length 0x%x",
+					    " length 0x%"PRIx64,
 					    bus, dev, func, offset, len);
 			}
 			assigned[nasgn].pci_phys_low = base;
@@ -2677,6 +2688,8 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 		value = 0;
 
 	if (value != 0) {
+		uint_t len;
+
 		regs[nreg].pci_phys_hi = (PCI_ADDR_MEM32 | devloc) + offset;
 		assigned[nasgn].pci_phys_hi = (PCI_RELOCAT_B |
 		    PCI_ADDR_MEM32 | devloc) + offset;

--- a/usr/src/uts/intel/io/pci/pci_pci.c
+++ b/usr/src/uts/intel/io/pci/pci_pci.c
@@ -561,12 +561,21 @@ ppb_ctlops(dev_info_t *dip, dev_info_t *rdip,
 	if (ctlop == DDI_CTLOPS_NREGS)
 		*(int *)result = totreg;
 	else if (ctlop == DDI_CTLOPS_REGSIZE) {
+		uint64_t rs;
+
 		rn = *(int *)arg;
 		if (rn >= totreg) {
 			kmem_free(drv_regp, reglen);
 			return (DDI_FAILURE);
 		}
-		*(off_t *)result = drv_regp[rn].pci_size_low;
+
+		rs = drv_regp[rn].pci_size_low |
+		    ((uint64_t)drv_regp[rn].pci_size_hi << 32);
+		if (rs > OFF_MAX) {
+			kmem_free(drv_regp, reglen);
+			return (DDI_FAILURE);
+		}
+		*(off_t *)result = rs;
 	}
 
 	kmem_free(drv_regp, reglen);


### PR DESCRIPTION
Weekly upstream from `illumos-joyent`

## Backports r26

* OS-6855 bhyve ppt should verify BAR mappings
* OS-6864 bhyve should guard against going off-cpu 
* OS-6840 want support for PCI BAR size >= 4G

## Backports r22/r24

* none

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2018041101-df4062cc40 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Wed Apr 11 15:13:51 CEST 2018 ====
==== Nightly distributed build completed: Wed Apr 11 16:05:48 CEST 2018 ====

==== Total build time ====

real    0:51:56

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-a8cc26d97f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   133

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018041101-df4062cc40

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:19.6
user    52:16.3
sys      4:34.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:37.9
user    44:55.7
sys      4:08.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    15:00.8
user    26:03.0
sys      2:54.4

==== lint warnings src ====


==== lint noise differences src ====

1c1
< "../../i86pc/io/vmm/io/ppt.c", line 403: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
---
> "../../i86pc/io/vmm/io/ppt.c", line 439: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
4,5c4
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 1775: warning: function argument type inconsistent with format: panic(arg 3) unsigned long  and (format) int  in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c(1775) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 982: warning: function returns value which is sometimes ignored: vm_exit_intinfo (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 1779: warning: function argument type inconsistent with format: panic(arg 3) unsigned long  and (format) int  in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c(1779) (E_BAD_FORMAT_ARG_TYPE2)
10c9
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2927: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2937: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
13,16c12,14
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 781: warning: function returns value which is sometimes ignored: ddi_intr_block_disable (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 783: warning: function returns value which is sometimes ignored: ddi_intr_disable (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 785: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 786: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 822: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 260: warning: function returns value which is sometimes ignored: lapic_set_local_intr (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vatpit.c", line 155: warning: function returns value which is sometimes ignored: vatpic_pulse_irq (E_FUNC_RET_MAYBE_IGNORED2)
19d16
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 1597: warning: function returns value which is sometimes ignored: lapic_set_intr (E_FUNC_RET_MAYBE_IGNORED2)
22,23c19
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vrtc.c", line 974: warning: function returns value which is sometimes ignored: vrtc_set_reg_b (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 554: warning: function returns value which is always ignored: ppt_unassign_all (E_FUNC_RET_ALWAYS_IGNOR2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 564: warning: function returns value which is always ignored: ppt_unassign_all (E_FUNC_RET_ALWAYS_IGNOR2)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
``` 