### PR TITLE
Upstream merge r151026 backports

### DIFF
--- a/usr/src/cmd/cmd-inet/usr.bin/netstat/netstat.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/netstat/netstat.c
@@ -23,7 +23,7 @@
  * Copyright (c) 1990  Mentat Inc.
  * netstat.c 2.2, last change 9/9/91
  * MROUTING Revision 3.5
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2018, Joyent, Inc.
  */
 
 /*
@@ -236,6 +236,7 @@ static void 		fatal(int errcode, char *str1, ...);
 
 
 static	boolean_t	Aflag = B_FALSE;	/* All sockets/ifs/rtng-tbls */
+static	boolean_t	CIDRflag = B_FALSE;	/* CIDR for IPv4 -i/-r addrs */
 static	boolean_t	Dflag = B_FALSE;	/* DCE info */
 static	boolean_t	Iflag = B_FALSE;	/* IP Traffic Interfaces */
 static	boolean_t	Mflag = B_FALSE;	/* STREAMS Memory Statistics */
@@ -446,10 +447,14 @@ main(int argc, char **argv)
 	(void) setlocale(LC_ALL, "");
 	(void) textdomain(TEXT_DOMAIN);
 
-	while ((c = getopt(argc, argv, "adimnrspMgvxf:P:I:DRT:")) != -1) {
+	while ((c = getopt(argc, argv, "acdimnrspMgvxf:P:I:DRT:")) != -1) {
 		switch ((char)c) {
 		case 'a':		/* all connections */
 			Aflag = B_TRUE;
+			break;
+
+		case 'c':
+			CIDRflag = B_TRUE;
 			break;
 
 		case 'd':		/* DCE info */
@@ -3340,7 +3345,7 @@ if_report_ip4(mib2_ipAddrEntry_t *ap,
     boolean_t ksp_not_null)
 {
 
-	char abuf[MAXHOSTNAMELEN + 1];
+	char abuf[MAXHOSTNAMELEN + 4];	/* Include /<num> for CIDR-printing. */
 	char dstbuf[MAXHOSTNAMELEN + 1];
 
 	if (ksp_not_null) {
@@ -4439,7 +4444,7 @@ static boolean_t
 ire_report_item_v4(const mib2_ipRouteEntry_t *rp, boolean_t first,
     const sec_attr_list_t *attrs)
 {
-	char			dstbuf[MAXHOSTNAMELEN + 1];
+	char			dstbuf[MAXHOSTNAMELEN + 4]; /* + "/<num>" */
 	char			maskbuf[MAXHOSTNAMELEN + 1];
 	char			gwbuf[MAXHOSTNAMELEN + 1];
 	char			ifname[LIFNAMSIZ + 1];
@@ -5557,7 +5562,7 @@ mrt_report(mib_item_t *item)
 	struct mfcctl	*mfccp;
 	int		numvifs = 0;
 	int		nmfc = 0;
-	char		abuf[MAXHOSTNAMELEN + 1];
+	char		abuf[MAXHOSTNAMELEN + 4]; /* Include CIDR /<num>. */
 
 	if (!(family_selected(AF_INET)))
 		return;
@@ -5976,6 +5981,57 @@ pr_ap6(const in6_addr_t *addr, uint_t port, char *proto,
 }
 
 /*
+ * Returns -2 to indicate a discontiguous mask.  Otherwise returns between
+ * 0 and 32.
+ */
+static int
+v4_cidr_len(uint_t mask)
+{
+	int rc = 0;
+	int i;
+
+	for (i = 0; i < 32; i++) {
+		if (mask & 0x1)
+			rc++;
+		else if (rc > 0)
+			return (-2);	/* Discontiguous IPv4 netmask. */
+
+		mask >>= 1;
+	}
+
+	return (rc);
+}
+
+static void
+append_v4_cidr_len(char *dst, uint_t dstlen, int prefixlen)
+{
+	char *prefixptr;
+
+	/* 4 bytes leaves room for '/' 'N' 'N' '\0' */
+	if (strlen(dst) <= dstlen - 4) {
+		prefixptr = dst + strlen(dst);
+	} else {
+		/*
+		 * Cut off last 3 chars of very-long DNS name.  All callers
+		 * should give us enough room, but name services COULD give us
+		 * a way-too-big name (see above).
+		 */
+		prefixptr = dst + strlen(dst) - 3;
+	}
+	/* At this point "prefixptr" is guaranteed to point to 4 bytes. */
+
+	if (prefixlen >= 0) {
+		if (prefixlen > 32)	/* Shouldn't happen, but... */
+			prefixlen = 32;
+		(void) snprintf(prefixptr, 4, "/%d", prefixlen);
+	} else if (prefixlen == -2) {
+		/* "/NM" == Noncontiguous Mask. */
+		(void) strcat(prefixptr, "/NM");
+	}
+	/* Else print nothing extra. */
+}
+
+/*
  * Return the name of the network whose address is given. The address is
  * assumed to be that of a net or subnet, not a host.
  */
@@ -5988,12 +6044,16 @@ pr_net(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 	uint_t		net;
 	int		subnetshift;
 	int		error_num;
+	int		prefixlen = -1;	/* -1 == Don't print prefix! */
+					/* -2 == Noncontiguous mask... */
 
 	if (addr == INADDR_ANY && mask == INADDR_ANY) {
-		(void) strncpy(dst, "default", dstlen);
-		dst[dstlen - 1] = 0;
+		(void) strlcpy(dst, "default", dstlen);
 		return (dst);
 	}
+
+	if (CIDRflag)
+		prefixlen = v4_cidr_len(ntohl(mask));
 
 	if (!Nflag && addr) {
 		if (mask == 0) {
@@ -6016,6 +6076,8 @@ pr_net(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 			while (addr & ~mask)
 				/* compiler doesn't sign extend! */
 				mask = (mask | ((int)mask >> subnetshift));
+			if (CIDRflag)
+				prefixlen = v4_cidr_len(mask);
 		}
 		net = addr & mask;
 		while ((mask & 1) == 0)
@@ -6038,11 +6100,13 @@ pr_net(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 		}
 	}
 	if (cp != NULL) {
-		(void) strncpy(dst, cp, dstlen);
-		dst[dstlen - 1] = 0;
+		(void) strlcpy(dst, cp, dstlen);
 	} else {
 		(void) inet_ntop(AF_INET, (char *)&addr, dst, dstlen);
 	}
+
+	append_v4_cidr_len(dst, dstlen, prefixlen);
+
 	if (hp != NULL)
 		freehostent(hp);
 	return (dst);
@@ -6064,14 +6128,18 @@ pr_netaddr(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 	struct in_addr in;
 	int		error_num;
 	uint_t		nbo_addr = addr;	/* network byte order */
+	int		prefixlen = -1;	/* -1 == Don't print prefix! */
+					/* -2 == Noncontiguous mask... */
 
 	addr = ntohl(addr);
 	mask = ntohl(mask);
 	if (addr == INADDR_ANY && mask == INADDR_ANY) {
-		(void) strncpy(dst, "default", dstlen);
-		dst[dstlen - 1] = 0;
+		(void) strlcpy(dst, "default", dstlen);
 		return (dst);
 	}
+
+	if (CIDRflag)
+		prefixlen = v4_cidr_len(mask);
 
 	/* Figure out network portion of address (with host portion = 0) */
 	if (addr) {
@@ -6096,6 +6164,8 @@ pr_netaddr(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 			while (addr & ~mask)
 				/* compiler doesn't sign extend! */
 				mask = (mask | ((int)mask >> subnetshift));
+			if (CIDRflag)
+				prefixlen = v4_cidr_len(mask);
 		}
 		net = netshifted = addr & mask;
 		while ((mask & 1) == 0)
@@ -6124,8 +6194,8 @@ pr_netaddr(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 		}
 
 		if (cp != NULL) {
-			(void) strncpy(dst, cp, dstlen);
-			dst[dstlen - 1] = 0;
+			(void) strlcpy(dst, cp, dstlen);
+			append_v4_cidr_len(dst, dstlen, prefixlen);
 			if (hp != NULL)
 				freehostent(hp);
 			return (dst);
@@ -6138,6 +6208,7 @@ pr_netaddr(uint_t addr, uint_t mask, char *dst, uint_t dstlen)
 
 	in.s_addr = htonl(net);
 	(void) inet_ntop(AF_INET, (char *)&in, dst, dstlen);
+	append_v4_cidr_len(dst, dstlen, prefixlen);
 	if (hp != NULL)
 		freehostent(hp);
 	return (dst);

--- a/usr/src/cmd/smbsrv/smbd/server.xml
+++ b/usr/src/cmd/smbsrv/smbd/server.xml
@@ -22,8 +22,8 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
-Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
 
 NOTE:  This service manifest is not editable; its contents will
 be overwritten by package or patch operations, including
@@ -154,7 +154,7 @@ file.
 		<propval name='value_authorization' type='astring'
 			value='solaris.smf.value.smb' />
 		<propval name='oplock_enable' type='boolean'
-			value='true' override='true'/>
+			value='false' override='true'/>
 		<propval name='autohome_map' type='astring'
 			value='/etc' override='true'/>
 		<propval name='debug' type='integer'

--- a/usr/src/man/man1m/netstat.1m
+++ b/usr/src/man/man1m/netstat.1m
@@ -1,4 +1,5 @@
 '\" te
+.\" Copyright 2018, Joyent, Inc.
 .\" Copyright (C) 2002, Sun Microsystems, Inc. All Rights Reserved
 .\" Copyright 1989 AT&T
 .\" Copyright (c) 1983 Regents of the University of California. All rights reserved. The Berkeley software License Agreement specifies the terms and conditions for redistribution.
@@ -34,18 +35,18 @@ netstat \- show network status
 
 .LP
 .nf
-\fBnetstat\fR \fB-i\fR [\fB-I\fR \fIinterface\fR] [\fB-an\fR] [\fB-f\fR \fIaddress_family\fR]
+\fBnetstat\fR \fB-i\fR [\fB-I\fR \fIinterface\fR] [\fB-acn\fR] [\fB-f\fR \fIaddress_family\fR]
      [\fB-T\fR u | d ] [\fIinterval\fR [\fIcount\fR]]
 .fi
 
 .LP
 .nf
-\fBnetstat\fR \fB-r\fR [\fB-anvR\fR] [\fB-f\fR \fIaddress_family\fR | \fIfilter\fR]
+\fBnetstat\fR \fB-r\fR [\fB-acnvR\fR] [\fB-f\fR \fIaddress_family\fR | \fIfilter\fR]
 .fi
 
 .LP
 .nf
-\fBnetstat\fR \fB-M\fR [\fB-ns\fR] [\fB-f\fR \fIaddress_family\fR]
+\fBnetstat\fR \fB-M\fR [\fB-cns\fR] [\fB-f\fR \fIaddress_family\fR]
 .fi
 
 .LP
@@ -122,6 +123,19 @@ Show the state of all sockets, all routing table entries, or all interfaces,
 both physical and logical. Normally, listener sockets used by server processes
 are not shown. Under most conditions, only interface, host, network, and
 default routes are shown and only the status of physical interfaces is shown.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-c\fR\fR
+.ad
+.sp .6
+.RS 4n
+Print IPv4 networks using CIDR (x.y.z.a/NN) notation with the \fB-i\fR,
+\fB-r\fR, and \fB-M\fR options. IPv6 networks default to this, but due to
+backward compatibility, IPv4 ones do not without this flag.  A noncontiguous
+IPv4 netmask will print "/NM" if this flag is enabled.
 .RE
 
 .sp

--- a/usr/src/tools/scripts/bldenv.sh
+++ b/usr/src/tools/scripts/bldenv.sh
@@ -293,6 +293,7 @@ if "${flags.t}" ; then
 
 	export CTFCONVERT="${TOOLS_PROTO}/opt/onbld/bin/${MACH}/ctfconvert"
 	export CTFMERGE="${TOOLS_PROTO}/opt/onbld/bin/${MACH}/ctfmerge"
+	export NDRGEN="${TOOLS_PROTO}/opt/onbld/bin/${MACH}/ndrgen"
 
 	PATH="${TOOLS_PROTO}/opt/onbld/bin/${MACH}:${PATH}"
 	PATH="${TOOLS_PROTO}/opt/onbld/bin:${PATH}"

--- a/usr/src/uts/common/sys/pci.h
+++ b/usr/src/uts/common/sys/pci.h
@@ -582,6 +582,7 @@ extern "C" {
 #define	PCI_BASE_TYPE_M		0x00000006  /* type indicator mask */
 #define	PCI_BASE_PREF_M		0x00000008  /* prefetch mask */
 #define	PCI_BASE_M_ADDR_M	0xfffffff0  /* memory address mask */
+#define	PCI_BASE_M_ADDR64_M	0xfffffffffffffff0ULL /* 64bit mem addr mask */
 #define	PCI_BASE_IO_ADDR_M	0xfffffffe  /* I/O address mask */
 
 #define	PCI_BASE_ROM_ADDR_M	0xfffff800  /* ROM address mask */

--- a/usr/src/uts/common/sys/pci_impl.h
+++ b/usr/src/uts/common/sys/pci_impl.h
@@ -107,7 +107,7 @@ struct pci_bus_resource {
 	boolean_t io_reprogram;	/* need io reprog on this bus */
 	boolean_t mem_reprogram;	/* need mem reprog on this bus */
 	boolean_t subtractive;	/* subtractive PPB */
-	uint_t mem_size;	/* existing children required MEM space size */
+	uint64_t mem_size;	/* existing children required MEM space size */
 	uint_t io_size;		/* existing children required I/O space size */
 };
 

--- a/usr/src/uts/i86pc/io/vmm/amd/svm.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm.c
@@ -24,6 +24,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
@@ -2268,5 +2272,14 @@ struct vmm_ops vmm_ops_amd = {
 	svm_npt_alloc,
 	svm_npt_free,
 	svm_vlapic_init,
-	svm_vlapic_cleanup	
+	svm_vlapic_cleanup,
+
+#ifndef __FreeBSD__
+	/*
+	 * When SVM support is wired up and tested, it is likely to require
+	 * savectx/restorectx functions similar to VMX.
+	 */
+	NULL,
+	NULL,
+#endif
 };

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.h
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.h
@@ -27,7 +27,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _VMX_H_
@@ -123,6 +123,7 @@ struct vmx {
 #ifndef	__FreeBSD__
 	uint64_t	host_msrs[VM_MAXCPU][GUEST_MSR_NUM];
 	uint64_t	tsc_offset[VM_MAXCPU];
+	boolean_t	ctx_loaded[VM_MAXCPU];
 #endif
 	struct vmxctx	ctx[VM_MAXCPU];
 	struct vmxcap	cap[VM_MAXCPU];

--- a/usr/src/uts/i86pc/sys/vmm.h
+++ b/usr/src/uts/i86pc/sys/vmm.h
@@ -160,6 +160,10 @@ typedef struct vmspace * (*vmi_vmspace_alloc)(vm_offset_t min, vm_offset_t max);
 typedef void	(*vmi_vmspace_free)(struct vmspace *vmspace);
 typedef struct vlapic * (*vmi_vlapic_init)(void *vmi, int vcpu);
 typedef void	(*vmi_vlapic_cleanup)(void *vmi, struct vlapic *vlapic);
+#ifndef __FreeBSD__
+typedef void	(*vmi_savectx)(void *vmi, int vcpu);
+typedef void	(*vmi_restorectx)(void *vmi, int vcpu);
+#endif
 
 struct vmm_ops {
 	vmm_init_func_t		init;		/* module wide initialization */
@@ -179,6 +183,11 @@ struct vmm_ops {
 	vmi_vmspace_free	vmspace_free;
 	vmi_vlapic_init		vlapic_init;
 	vmi_vlapic_cleanup	vlapic_cleanup;
+
+#ifndef __FreeBSD__
+	vmi_savectx		vmsavectx;
+	vmi_restorectx		vmrestorectx;
+#endif
 };
 
 extern struct vmm_ops vmm_ops_intel;

--- a/usr/src/uts/intel/io/pci/pci_boot.c
+++ b/usr/src/uts/intel/io/pci/pci_boot.c
@@ -893,8 +893,9 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 {
 	uchar_t bus, dev, func;
 	uchar_t parbus, subbus;
-	uint_t io_base, io_limit, mem_base, mem_limit;
-	uint_t io_size, mem_size, io_align, mem_align;
+	uint_t io_base, io_limit, mem_base;
+	uint_t io_size, io_align;
+	uint64_t mem_size, mem_align, mem_limit;
 	uint64_t addr = 0;
 	int *regp = NULL;
 	uint_t reglen;
@@ -1049,9 +1050,9 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 				    pci_bus_res[parbus].io_reprogram;
 
 				cmn_err(CE_NOTE, "!add io-range on subtractive"
-				    " ppb[%x/%x/%x]: 0x%x ~ 0x%x\n",
-				    bus, dev, func, (uint32_t)addr,
-				    (uint32_t)addr + io_size - 1);
+				    " ppb[%x/%x/%x]: "
+				    "0x%"PRIx64" ~ 0x%"PRIx64"\n",
+				    bus, dev, func, addr, addr + io_size - 1);
 			}
 		}
 		/*
@@ -1066,9 +1067,10 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 				    pci_bus_res[parbus].mem_reprogram;
 
 				cmn_err(CE_NOTE, "!add mem-range on "
-				    "subtractive ppb[%x/%x/%x]: 0x%x ~ 0x%x\n",
-				    bus, dev, func, (uint32_t)addr,
-				    (uint32_t)addr + mem_size - 1);
+				    "subtractive ppb[%x/%x/%x]: "
+				    "0x%"PRIx64" ~ 0x%"PRIx64"\n",
+				    bus, dev, func,
+				    addr, addr + mem_size - 1);
 			}
 		}
 
@@ -1197,15 +1199,15 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 				if (is_vga(list, MEM))
 					continue;
 				if (mem_base == 0) {
-					mem_base = (uint_t)list->ml_address;
+					mem_base = list->ml_address;
 					mem_base = P2ALIGN(mem_base,
 					    PPB_MEM_ALIGNMENT);
-					mem_limit = (uint_t)(list->ml_address +
+					mem_limit = (list->ml_address +
 					    list->ml_size - 1);
 				} else {
 					if ((list->ml_address + list->ml_size) >
 					    mem_limit) {
-						mem_limit = (uint_t)
+						mem_limit =
 						    (list->ml_address +
 						    list->ml_size - 1);
 					}
@@ -1265,7 +1267,7 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 			add_ranges_prop(secbus, 1);
 
 			cmn_err(CE_NOTE, "!reprogram mem-range on"
-			    " ppb[%x/%x/%x]: 0x%x ~ 0x%x\n",
+			    " ppb[%x/%x/%x]: 0x%x ~ 0x%"PRIx64"\n",
 			    bus, dev, func, mem_base, mem_limit);
 		}
 	}
@@ -2360,7 +2362,8 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 {
 	uchar_t baseclass, subclass, progclass, header;
 	ushort_t bar_sz;
-	uint_t value = 0, len, devloc;
+	uint64_t value = 0;
+	uint_t devloc;
 	uint_t base, base_hi, type;
 	ushort_t offset, end;
 	int max_basereg, j, reprogram = 0;
@@ -2444,6 +2447,7 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 		/* construct phys hi,med.lo, size hi, lo */
 		if ((pciide && j < 4) || (base & PCI_BASE_SPACE_IO)) {
 			int hard_decode = 0;
+			uint_t len;
 
 			/* i/o space */
 			bar_sz = PCI_BAR_SZ_32;
@@ -2528,26 +2532,33 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 			nreg++, nasgn++;
 
 		} else {
+			uint64_t len;
 			/* memory space */
 			if ((base & PCI_BASE_TYPE_M) == PCI_BASE_TYPE_ALL) {
 				bar_sz = PCI_BAR_SZ_64;
 				base_hi = pci_getl(bus, dev, func, offset + 4);
+				pci_putl(bus, dev, func, offset + 4, 0xffffffff);
+				value |= (uint64_t)pci_getl(bus, dev, func,
+				    offset + 4) << 32;
+				pci_putl(bus, dev, func, offset + 4, base_hi);
 				phys_hi = PCI_ADDR_MEM64;
+				value &= PCI_BASE_M_ADDR64_M;
 			} else {
 				bar_sz = PCI_BAR_SZ_32;
 				base_hi = 0;
 				phys_hi = PCI_ADDR_MEM32;
+				value &= PCI_BASE_M_ADDR_M;
 			}
 
 			/* skip base regs with size of 0 */
-			value &= PCI_BASE_M_ADDR_M;
-
 			if (value == 0)
 				continue;
 
 			len = ((value ^ (value-1)) + 1) >> 1;
 			regs[nreg].pci_size_low =
-			    assigned[nasgn].pci_size_low = len;
+			    assigned[nasgn].pci_size_low = len & 0xffffffff;
+			regs[nreg].pci_size_hi =
+			    assigned[nasgn].pci_size_hi = len >> 32;
 
 			phys_hi |= (devloc | offset);
 			if (base & PCI_BASE_PREF_M)
@@ -2644,7 +2655,7 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 				} else
 					cmn_err(CE_WARN, "failed to program "
 					    "mem space [%d/%d/%d] BAR@0x%x"
-					    " length 0x%x",
+					    " length 0x%"PRIx64,
 					    bus, dev, func, offset, len);
 			}
 			assigned[nasgn].pci_phys_low = base;
@@ -2677,6 +2688,8 @@ add_reg_props(dev_info_t *dip, uchar_t bus, uchar_t dev, uchar_t func,
 		value = 0;
 
 	if (value != 0) {
+		uint_t len;
+
 		regs[nreg].pci_phys_hi = (PCI_ADDR_MEM32 | devloc) + offset;
 		assigned[nasgn].pci_phys_hi = (PCI_RELOCAT_B |
 		    PCI_ADDR_MEM32 | devloc) + offset;

--- a/usr/src/uts/intel/io/pci/pci_pci.c
+++ b/usr/src/uts/intel/io/pci/pci_pci.c
@@ -561,12 +561,21 @@ ppb_ctlops(dev_info_t *dip, dev_info_t *rdip,
 	if (ctlop == DDI_CTLOPS_NREGS)
 		*(int *)result = totreg;
 	else if (ctlop == DDI_CTLOPS_REGSIZE) {
+		uint64_t rs;
+
 		rn = *(int *)arg;
 		if (rn >= totreg) {
 			kmem_free(drv_regp, reglen);
 			return (DDI_FAILURE);
 		}
-		*(off_t *)result = drv_regp[rn].pci_size_low;
+
+		rs = drv_regp[rn].pci_size_low |
+		    ((uint64_t)drv_regp[rn].pci_size_hi << 32);
+		if (rs > OFF_MAX) {
+			kmem_free(drv_regp, reglen);
+			return (DDI_FAILURE);
+		}
+		*(off_t *)result = rs;
 	}
 
 	kmem_free(drv_regp, reglen);


### PR DESCRIPTION
Backports for r151026 from weekly upstream merge.

## Affected packages:

* `SUNWcs` - netstat
* `system/kernel` - PCI changes
* `system/kernel/platform` - CTF due to PCI changes
* `service/file-system/smb` - oplocks default to false
* `developer/build/onbld` - bldenv
* `system/bhyve`

## mail_msg

```
==== Nightly distributed build started:   Wed Apr 11 13:35:43 GMT 2018 ====
==== Nightly distributed build completed: Wed Apr 11 14:52:54 GMT 2018 ====

==== Total build time ====

real    1:17:11

==== Build environment ====

/usr/bin/uname
SunOS r151026 5.11 omnios-r151026-dff7dcea85 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/r151026/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/r151026/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   1531

==== Nightly argument issues ====


==== Build version ====

omnios-backportr26-25a6f08529

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:55.6
user  1:13:27.5
sys     12:27.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:25.7
user  1:04:17.7
sys     11:40.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    24:35.9
user    46:39.7
sys     11:08.0

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
