### PR TITLE
Fix zone shutdown script

### DIFF
--- a/usr/src/cmd/zoneadm/svc-zones
+++ b/usr/src/cmd/zoneadm/svc-zones
@@ -22,23 +22,21 @@
 #
 # Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2014 Nexenta Systems, Inc. All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 . /lib/svc/share/smf_include.sh
 
 #
 # Return a list of running, non-global zones for which a shutdown via
-# "/sbin/init 0" may work (typically only Solaris zones.)
+# "/sbin/init 0" (or the command defined in the brand config.xml) may work.
 #
 shutdown_zones()
 {
-	zoneadm list -p | nawk -F: '{
-		if (($5 != "lx") && ($2 != "global")) {
-			print $2
-		}
-	}'
+	# id:name:state:path:uuid:brand:ip:did
+	zoneadm list -p | nawk -F: '$2 != "global" { print $2 }'
 }
 
-[ ! -x /usr/sbin/zoneadm ] && exit 0	# SUNWzoneu not installed
+[ ! -x /usr/sbin/zoneadm ] && exit 0	# system/zones not installed
 
 if [ -z "$SMF_FMRI" ]; then
 	echo "this script can only be invoked by smf(5)"	


### PR DESCRIPTION
The current script attempts to avoid trying to shut down lx zones cleanly, when that will work fine. However the logic is broken (checks wrong field) so that we are already doing shutdown for lx - this PR just cleans up the logic.

In future we should ensure that all new brands support clean shutdown or revisit this file.