### PR TITLE
Joyent merge/2018042501

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 78dc0130d5402f19783b696837ada4e5880726be
+Last illumos-joyent commit: 59125e10a9de77326891a4062d145db60313894d
 

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -412,6 +412,7 @@ typedef struct viona_vring {
 		uint64_t	rs_bad_rx_frame;
 		uint64_t	rs_rx_merge_overrun;
 		uint64_t	rs_rx_merge_underrun;
+		uint64_t	rs_rx_pad_short;
 		uint64_t	rs_too_short;
 		uint64_t	rs_tx_absent;
 	} vr_stats;
@@ -1795,6 +1796,8 @@ viona_recv_plain(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	caddr_t buf = NULL;
 	boolean_t end = B_FALSE;
 
+	ASSERT(msz >= MIN_BUF_SIZE);
+
 	n = vq_popchain(ring, iov, VTNET_MAXSEGS, &cookie);
 	if (n <= 0) {
 		/* Without available buffers, the frame must be dropped. */
@@ -1832,11 +1835,8 @@ viona_recv_plain(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 		copied += viona_copy_mblk(mp, copied, buf, len, &end);
 	}
 
-	/*
-	 * Is the copied data long enough to be considered an ethernet frame of
-	 * the minimum length?  Does it match the total length of the mblk?
-	 */
-	if (copied < MIN_BUF_SIZE || copied != msz) {
+	/* Was the expected amount of data copied? */
+	if (copied != msz) {
 		VIONA_PROBE5(too_short, viona_vring_t *, ring,
 		    uint16_t, cookie, mblk_t *, mp, size_t, copied,
 		    size_t, msz);
@@ -1884,6 +1884,8 @@ viona_recv_merged(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	struct virtio_net_mrgrxhdr *hdr = NULL;
 	const size_t hdr_sz = sizeof (struct virtio_net_mrgrxhdr);
 	boolean_t end = B_FALSE;
+
+	ASSERT(msz >= MIN_BUF_SIZE);
 
 	n = vq_popchain(ring, iov, VTNET_MAXSEGS, &cookie);
 	if (n <= 0) {
@@ -1975,16 +1977,15 @@ viona_recv_merged(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	uelem[0].len += hdr_sz;
 
 	/*
-	 * Is the copied data long enough to be considered an ethernet frame of
-	 * the minimum length?  Does it match the total length of the mblk?
+	 * If no other errors were encounted during the copy, was the expected
+	 * amount of data transfered?
 	 */
-	if (copied < MIN_BUF_SIZE || copied != msz) {
-		/* Do not override an existing error */
+	if (err == 0 && copied != msz) {
 		VIONA_PROBE5(too_short, viona_vring_t *, ring,
 		    uint16_t, cookie, mblk_t *, mp, size_t, copied,
 		    size_t, msz);
 		VIONA_RING_STAT_INCR(ring, too_short);
-		err = (err == 0) ? EINVAL : err;
+		err = EINVAL;
 	}
 
 	/* Add chksum bits, if needed */
@@ -2046,10 +2047,16 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 		size = msgsize(mp);
 
 		/*
-		 * Stripping the VLAN tag off already-small frames can cause
-		 * them to fall below the minimum size.  If this happens, pad
-		 * them out as they would have been if they lacked the tag in
-		 * the first place.
+		 * Ethernet frames are expected to be padded out in order to
+		 * meet the minimum size.
+		 *
+		 * A special case is made for frames which are short by
+		 * VLAN_TAGSZ, having been stripped of their VLAN tag while
+		 * traversing MAC.  A preallocated (and recycled) mblk is used
+		 * for that specific condition.
+		 *
+		 * All other frames that fall short on length will have custom
+		 * zero-padding allocated appended to them.
 		 */
 		if (size == NEED_VLAN_PAD_SIZE) {
 			ASSERT(MBLKL(viona_vlan_pad_mp) == VLAN_TAGSZ);
@@ -2060,6 +2067,23 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 
 			pad->b_cont = viona_vlan_pad_mp;
 			size += VLAN_TAGSZ;
+		} else if (size < MIN_BUF_SIZE) {
+			const size_t pad_size = MIN_BUF_SIZE - size;
+			mblk_t *zero_mp;
+
+			zero_mp = allocb(pad_size, BPRI_MED);
+			if (zero_mp == NULL) {
+				err = ENOMEM;
+				goto pad_drop;
+			}
+
+			VIONA_PROBE3(rx_pad_short, viona_vring_t *, ring,
+			    mblk_t *, mp, size_t, pad_size);
+			VIONA_RING_STAT_INCR(ring, rx_pad_short);
+			zero_mp->b_wptr += pad_size;
+			bzero(zero_mp->b_rptr, pad_size);
+			linkb(mp, zero_mp);
+			size += pad_size;
 		}
 
 		if (do_merge) {
@@ -2070,12 +2094,16 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 
 		/*
 		 * The VLAN padding mblk is meant for continual reuse, so
-		 * remove it from the chain to prevent it from being freed
+		 * remove it from the chain to prevent it from being freed.
+		 *
+		 * Custom allocated padding does not require this treatment and
+		 * is freed normally.
 		 */
 		if (pad != NULL) {
 			pad->b_cont = NULL;
 		}
 
+pad_drop:
 		if (err != 0) {
 			*mpdrop_prevp = mp;
 			mpdrop_prevp = &mp->b_next;


### PR DESCRIPTION
Weekly upstream from `illumos-joyent`

## Backports r26

* BHYVE: OS-6815 viona should pad short frames
* BHYVE: OS-6738 bhyve ppt should not use /dev/mem

## Backports r22/r24

* none

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2018042501-c0629d90db i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Wed Apr 25 14:25:40 CEST 2018 ====
==== Nightly distributed build completed: Wed Apr 25 15:19:57 CEST 2018 ====

==== Total build time ====

real    0:54:17

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-acb2e0e30f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   112

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018042501-c0629d90db

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:46.9
user    52:53.5
sys      4:59.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    14:49.6
user    48:42.1
sys      5:20.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    15:30.1
user    26:41.1
sys      3:05.5

==== lint warnings src ====


==== lint noise differences src ====

1c1
< "../../i86pc/io/vmm/io/ppt.c", line 441: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
---
> "../../i86pc/io/vmm/io/ppt.c", line 500: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
14,17c14,16
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 819: warning: function returns value which is sometimes ignored: ddi_intr_block_disable (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 823: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 824: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 947: warning: function returns value which is always ignored: ppt_flr (E_FUNC_RET_ALWAYS_IGNOR2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 1006: warning: function returns value which is always ignored: ppt_flr (E_FUNC_RET_ALWAYS_IGNOR2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 882: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 883: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
24d22
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 568: warning: function returns value which is always ignored: ppt_unassign_all (E_FUNC_RET_ALWAYS_IGNOR2)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```