### PR TITLE
Backport 20180425 r26

### DIFF
--- a/usr/src/cmd/boot/bootadm/bootadm.c
+++ b/usr/src/cmd/boot/bootadm/bootadm.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2015 by Delphix. All rights reserved.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -4075,7 +4076,7 @@ update_archive(char *root, char *opt)
 	/*
 	 * Never update non-BE root in update_all
 	 */
-	if (!is_be(root) && bam_update_all)
+	if (bam_update_all && !is_be(root))
 		return (BAM_SUCCESS);
 	/*
 	 * root must belong to a boot archive based OS,

--- a/usr/src/uts/common/io/nvme/nvme.c
+++ b/usr/src/uts/common/io/nvme/nvme.c
@@ -2554,6 +2554,13 @@ nvme_init(nvme_t *nvme)
 	 * Identify Namespaces
 	 */
 	nvme->n_namespace_count = nvme->n_idctl->id_nn;
+
+	if (nvme->n_namespace_count == 0) {
+		dev_err(nvme->n_dip, CE_WARN,
+		    "!controllers without namespaces are not supported");
+		goto fail;
+	}
+
 	if (nvme->n_namespace_count > NVME_MINOR_MAX) {
 		dev_err(nvme->n_dip, CE_WARN,
 		    "!too many namespaces: %d, limiting to %d\n",

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -412,6 +412,7 @@ typedef struct viona_vring {
 		uint64_t	rs_bad_rx_frame;
 		uint64_t	rs_rx_merge_overrun;
 		uint64_t	rs_rx_merge_underrun;
+		uint64_t	rs_rx_pad_short;
 		uint64_t	rs_too_short;
 		uint64_t	rs_tx_absent;
 	} vr_stats;
@@ -1795,6 +1796,8 @@ viona_recv_plain(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	caddr_t buf = NULL;
 	boolean_t end = B_FALSE;
 
+	ASSERT(msz >= MIN_BUF_SIZE);
+
 	n = vq_popchain(ring, iov, VTNET_MAXSEGS, &cookie);
 	if (n <= 0) {
 		/* Without available buffers, the frame must be dropped. */
@@ -1832,11 +1835,8 @@ viona_recv_plain(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 		copied += viona_copy_mblk(mp, copied, buf, len, &end);
 	}
 
-	/*
-	 * Is the copied data long enough to be considered an ethernet frame of
-	 * the minimum length?  Does it match the total length of the mblk?
-	 */
-	if (copied < MIN_BUF_SIZE || copied != msz) {
+	/* Was the expected amount of data copied? */
+	if (copied != msz) {
 		VIONA_PROBE5(too_short, viona_vring_t *, ring,
 		    uint16_t, cookie, mblk_t *, mp, size_t, copied,
 		    size_t, msz);
@@ -1884,6 +1884,8 @@ viona_recv_merged(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	struct virtio_net_mrgrxhdr *hdr = NULL;
 	const size_t hdr_sz = sizeof (struct virtio_net_mrgrxhdr);
 	boolean_t end = B_FALSE;
+
+	ASSERT(msz >= MIN_BUF_SIZE);
 
 	n = vq_popchain(ring, iov, VTNET_MAXSEGS, &cookie);
 	if (n <= 0) {
@@ -1975,16 +1977,15 @@ viona_recv_merged(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	uelem[0].len += hdr_sz;
 
 	/*
-	 * Is the copied data long enough to be considered an ethernet frame of
-	 * the minimum length?  Does it match the total length of the mblk?
+	 * If no other errors were encounted during the copy, was the expected
+	 * amount of data transfered?
 	 */
-	if (copied < MIN_BUF_SIZE || copied != msz) {
-		/* Do not override an existing error */
+	if (err == 0 && copied != msz) {
 		VIONA_PROBE5(too_short, viona_vring_t *, ring,
 		    uint16_t, cookie, mblk_t *, mp, size_t, copied,
 		    size_t, msz);
 		VIONA_RING_STAT_INCR(ring, too_short);
-		err = (err == 0) ? EINVAL : err;
+		err = EINVAL;
 	}
 
 	/* Add chksum bits, if needed */
@@ -2046,10 +2047,16 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 		size = msgsize(mp);
 
 		/*
-		 * Stripping the VLAN tag off already-small frames can cause
-		 * them to fall below the minimum size.  If this happens, pad
-		 * them out as they would have been if they lacked the tag in
-		 * the first place.
+		 * Ethernet frames are expected to be padded out in order to
+		 * meet the minimum size.
+		 *
+		 * A special case is made for frames which are short by
+		 * VLAN_TAGSZ, having been stripped of their VLAN tag while
+		 * traversing MAC.  A preallocated (and recycled) mblk is used
+		 * for that specific condition.
+		 *
+		 * All other frames that fall short on length will have custom
+		 * zero-padding allocated appended to them.
 		 */
 		if (size == NEED_VLAN_PAD_SIZE) {
 			ASSERT(MBLKL(viona_vlan_pad_mp) == VLAN_TAGSZ);
@@ -2060,6 +2067,23 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 
 			pad->b_cont = viona_vlan_pad_mp;
 			size += VLAN_TAGSZ;
+		} else if (size < MIN_BUF_SIZE) {
+			const size_t pad_size = MIN_BUF_SIZE - size;
+			mblk_t *zero_mp;
+
+			zero_mp = allocb(pad_size, BPRI_MED);
+			if (zero_mp == NULL) {
+				err = ENOMEM;
+				goto pad_drop;
+			}
+
+			VIONA_PROBE3(rx_pad_short, viona_vring_t *, ring,
+			    mblk_t *, mp, size_t, pad_size);
+			VIONA_RING_STAT_INCR(ring, rx_pad_short);
+			zero_mp->b_wptr += pad_size;
+			bzero(zero_mp->b_rptr, pad_size);
+			linkb(mp, zero_mp);
+			size += pad_size;
 		}
 
 		if (do_merge) {
@@ -2070,12 +2094,16 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 
 		/*
 		 * The VLAN padding mblk is meant for continual reuse, so
-		 * remove it from the chain to prevent it from being freed
+		 * remove it from the chain to prevent it from being freed.
+		 *
+		 * Custom allocated padding does not require this treatment and
+		 * is freed normally.
 		 */
 		if (pad != NULL) {
 			pad->b_cont = NULL;
 		}
 
+pad_drop:
 		if (err != 0) {
 			*mpdrop_prevp = mp;
 			mpdrop_prevp = &mp->b_next;


### PR DESCRIPTION
## packages to publish:
- driver/storage/nvme
- SUNWcs
- system/bhyve 

## mail_msg:
```
==== Nightly distributed build started:   Wed Apr 25 12:46:04 UTC 2018 ====
==== Nightly distributed build completed: Wed Apr 25 15:04:55 UTC 2018 ====

==== Total build time ====

real    2:18:51

==== Build environment ====

/usr/bin/uname
SunOS r151026-build 5.11 omnios-r151026-e80cb0301a i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   70

==== Nightly argument issues ====


==== Build version ====

omnios-backport_20180425_r26-1addc4c3a3

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    37:42.3
user  1:48:43.1
sys     27:07.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    39:25.6
user  1:42:12.7
sys     35:51.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    37:38.0
user  1:05:59.4
sys     18:08.0

==== lint warnings src ====


==== lint noise differences src ====

1c1
< "../../i86pc/io/vmm/io/ppt.c", line 403: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
---
> "../../i86pc/io/vmm/io/ppt.c", line 500: warning: assignment operator "=" found where "==" was expected (E_EQUALITY_NOT_ASSIGNMENT)
4,23c4,22
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 1775: warning: function argument type inconsistent with format: panic(arg 3) unsigned long  and (format) int  in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c(1775) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 982: warning: function returns value which is sometimes ignored: vm_exit_intinfo (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h", line 142: warning: function argument type inconsistent with format: panic(arg 3) struct vmcs * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h(142) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h", line 156: warning: function argument type inconsistent with format: panic(arg 3) struct vmcs * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h(156) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2796: warning: function argument type inconsistent with format: panic(arg 2) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2796) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2796: warning: function argument type inconsistent with format: panic(arg 3) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2796) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2927: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx_msr.c", line 151: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vtd.c", line 704: warning: function argument type inconsistent with format: panic(arg 2) unsigned long * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vtd.c(704) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 781: warning: function returns value which is sometimes ignored: ddi_intr_block_disable (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 783: warning: function returns value which is sometimes ignored: ddi_intr_disable (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 785: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 786: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 240: warning: function returns value which is sometimes ignored: lapic_intr_msi (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 313: warning: function argument type inconsistent with format: panic(arg 2) struct vhpet * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c(313) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 1597: warning: function returns value which is sometimes ignored: lapic_set_intr (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 476: warning: function returns value which is sometimes ignored: vm_inject_nmi (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 479: warning: function returns value which is always ignored: vm_inject_extint (E_FUNC_RET_ALWAYS_IGNOR2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vrtc.c", line 974: warning: function returns value which is sometimes ignored: vrtc_set_reg_b (E_FUNC_RET_MAYBE_IGNORED2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 554: warning: function returns value which is always ignored: ppt_unassign_all (E_FUNC_RET_ALWAYS_IGNOR2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 1743: warning: function argument type inconsistent with format: panic(arg 3) unsigned long  and (format) int  in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c(1743) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 990: warning: function returns value which is sometimes ignored: vm_exit_intinfo (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h", line 144: warning: function argument type inconsistent with format: panic(arg 3) struct vmcs * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h(144) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h", line 158: warning: function argument type inconsistent with format: panic(arg 3) struct vmcs * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmcs.h(158) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2872: warning: function argument type inconsistent with format: panic(arg 2) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2872) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2872: warning: function argument type inconsistent with format: panic(arg 3) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2872) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 3015: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx_msr.c", line 155: warning: function returns value which is sometimes ignored: memset (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx_msr.c", line 344: warning: function returns value which is sometimes ignored: msr_bitmap_change_access (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vtd.c", line 706: warning: function argument type inconsistent with format: panic(arg 2) unsigned long * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vtd.c(706) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 1006: warning: function returns value which is always ignored: ppt_flr (E_FUNC_RET_ALWAYS_IGNOR2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 882: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 883: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 260: warning: function returns value which is sometimes ignored: lapic_set_local_intr (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 261: warning: function returns value which is sometimes ignored: vioapic_pulse_irq (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 257: warning: function returns value which is sometimes ignored: vioapic_assert_irq (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 315: warning: function argument type inconsistent with format: panic(arg 2) struct vhpet * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c(315) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 1599: warning: function returns value which is sometimes ignored: lapic_set_intr (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 2328: warning: function returns value which is sometimes ignored: vm_restart_instruction (E_FUNC_RET_MAYBE_IGNORED2)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```