### PR TITLE
Prevent logging INVPCID in-use when KPTI is disabled

### DIFF
--- a/usr/src/uts/i86pc/os/mp_startup.c
+++ b/usr/src/uts/i86pc/os/mp_startup.c
@@ -1534,10 +1534,10 @@ start_other_cpus(int cprboot)
 	 */
 	cmn_err(CE_CONT, "?KPTI %s (PCID %s, INVPCID %s)\n",
 	    kpti_enable ? "enabled" : "disabled",
-	    x86_use_pcid ? "in use" :
+	    x86_use_pcid == 1 ? "in use" :
 	    (is_x86_feature(x86_featureset, X86FSET_PCID) ? "disabled" :
 	    "not supported"),
-	    x86_use_invpcid ? "in use" :
+	    x86_use_pcid == 1 && x86_use_invpcid == 1 ? "in use" :
 	    (is_x86_feature(x86_featureset, X86FSET_INVPCID) ? "disabled" :
 	    "not supported"));
 


### PR DESCRIPTION
When KPTI is disabled, the `x86_use_invpcid` variable remains set to -1 which makes the logging code output:

`May  2 11:27:54 omniosce unix: [ID 551322 kern.info] KPTI disabled (PCID disabled, INVPCID in use)`

Test non-debug build done, requires backport to r151026.