### PR TITLE
Do not consider a missing openssl-version target a compiler failure

### DIFF
--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -1677,7 +1677,7 @@ fi
 	if $MAKE -K $TMPDIR/make-state -e $target 2>/dev/null; then
 		continue
 	fi
-	touch $TMPDIR/nocompiler
+	[[ "$target" != openssl* ]] && touch $TMPDIR/nocompiler
   done
   echo
 ) | tee -a $build_environ_file >> $LOGFILE


### PR DESCRIPTION
This allows for building older versions of illumos-omnios with the latest `nightly`.