### PR TITLE
Upstream merge joyent_merge/2018060801

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 21e2c666e809045ac5b02a65fa8b9c6708909804
+Last illumos-joyent commit: 788e26d53d698f1ae7fc91da6c1c4cd40d05dfd8
 

--- a/usr/src/uts/i86pc/io/vmm/intel/vtd.c
+++ b/usr/src/uts/i86pc/io/vmm/intel/vtd.c
@@ -705,6 +705,7 @@ vtd_create_domain(vm_paddr_t maxaddr)
 	if ((uintptr_t)dom->ptp & PAGE_MASK)
 		panic("vtd_create_domain: ptp (%p) not page aligned", dom->ptp);
 
+#ifdef __FreeBSD__
 #ifdef notyet
 	/*
 	 * XXX superpage mappings for the iommu do not work correctly.
@@ -719,6 +720,18 @@ vtd_create_domain(vm_paddr_t maxaddr)
 	 *
 	 * There is not any code to deal with the demotion at the moment
 	 * so we disable superpage mappings altogether.
+	 */
+	dom->spsmask = VTD_CAP_SPS(vtdmap->cap);
+#endif
+#else
+	/*
+	 * On illumos we decidedly do not remove memory mapped to a VM's domain
+	 * from the host_domain, so we don't have to deal with page demotion and
+	 * can just use large pages.
+	 *
+	 * Since VM memory is currently allocated as 4k pages and mapped into
+	 * the VM domain page by page, the use of large pages is essentially
+	 * limited to the host_domain.
 	 */
 	dom->spsmask = VTD_CAP_SPS(vtdmap->cap);
 #endif

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c
@@ -51,6 +51,7 @@
 #include <sys/id_space.h>
 #include <sys/psm_defs.h>
 #include <sys/smp_impldefs.h>
+#include <sys/modhash.h>
 
 #include <sys/x86_archext.h>
 
@@ -155,12 +156,50 @@ smp_rendezvous(void (* setup_func)(void *), void (* action_func)(void *),
 
 struct kmem_item {
 	void			*addr;
-	void			*paddr;
 	size_t			size;
-	LIST_ENTRY(kmem_item)	next;
 };
 static kmutex_t kmem_items_lock;
-static LIST_HEAD(, kmem_item) kmem_items;
+
+static mod_hash_t *vmm_alloc_hash;
+uint_t vmm_alloc_hash_nchains = 16381;
+uint_t vmm_alloc_hash_size = PAGESIZE;
+
+static void
+vmm_alloc_hash_valdtor(mod_hash_val_t val)
+{
+	struct kmem_item *i = (struct kmem_item *)val;
+
+	kmem_free(i->addr, i->size);
+	kmem_free(i, sizeof (struct kmem_item));
+}
+
+static void
+vmm_alloc_init(void)
+{
+	vmm_alloc_hash = mod_hash_create_ptrhash("vmm_alloc_hash",
+	    vmm_alloc_hash_nchains, vmm_alloc_hash_valdtor,
+	    vmm_alloc_hash_size);
+
+	VERIFY(vmm_alloc_hash != NULL);
+}
+
+static uint_t
+vmm_alloc_check(mod_hash_key_t key, mod_hash_val_t *val, void *unused)
+{
+	struct kmem_item *i = (struct kmem_item *)val;
+
+	cmn_err(CE_PANIC, "!vmm_alloc_check: hash not empty: %p, %d", i->addr,
+	    i->size);
+
+	return (MH_WALK_TERMINATE);
+}
+
+static void
+vmm_alloc_cleanup(void)
+{
+	mod_hash_walk(vmm_alloc_hash, vmm_alloc_check, NULL);
+	mod_hash_destroy_ptrhash(vmm_alloc_hash);
+}
 
 void *
 malloc(unsigned long size, struct malloc_type *mtp, int flags)
@@ -173,18 +212,28 @@ malloc(unsigned long size, struct malloc_type *mtp, int flags)
 		kmem_flag = KM_NOSLEEP;
 
 	if (flags & M_ZERO) {
-		p = kmem_zalloc(size + sizeof (struct kmem_item), kmem_flag);
+		p = kmem_zalloc(size, kmem_flag);
 	} else {
-		p = kmem_alloc(size + sizeof (struct kmem_item), kmem_flag);
+		p = kmem_alloc(size, kmem_flag);
+	}
+
+	if (p == NULL)
+		return (NULL);
+
+	i = kmem_zalloc(sizeof (struct kmem_item), kmem_flag);
+
+	if (i == NULL) {
+		kmem_free(p, size);
+		return (NULL);
 	}
 
 	mutex_enter(&kmem_items_lock);
-	i = p + size;
 	i->addr = p;
-	i->paddr = (void *)PHYS_TO_DMAP(vtophys(p));
 	i->size = size;
 
-	LIST_INSERT_HEAD(&kmem_items, i, next);
+	VERIFY(mod_hash_insert(vmm_alloc_hash,
+	    (mod_hash_key_t)PHYS_TO_DMAP(vtophys(p)), (mod_hash_val_t)i) == 0);
+
 	mutex_exit(&kmem_items_lock);
 
 	return (p);
@@ -193,19 +242,10 @@ malloc(unsigned long size, struct malloc_type *mtp, int flags)
 void
 free(void *addr, struct malloc_type *mtp)
 {
-	struct kmem_item	*i;
-
 	mutex_enter(&kmem_items_lock);
-	LIST_FOREACH(i, &kmem_items, next) {
-		if (i->addr == addr ||
-		    i->paddr == addr)
-			break;
-	}
-	VERIFY(i != NULL);
-	LIST_REMOVE(i, next);
+	VERIFY(mod_hash_destroy(vmm_alloc_hash,
+	    (mod_hash_key_t)PHYS_TO_DMAP(vtophys(addr))) == 0);
 	mutex_exit(&kmem_items_lock);
-
-	kmem_free(i->addr, i->size + sizeof (struct kmem_item));
 }
 
 extern void *contig_alloc(size_t, ddi_dma_attr_t *, uintptr_t, int);
@@ -620,6 +660,7 @@ fpusave(void *arg)
 void
 vmm_sol_glue_init(void)
 {
+	vmm_alloc_init();
 	vmm_cpuid_init();
 	fpu_save_area_init();
 	unr_idx = 0;
@@ -629,6 +670,7 @@ void
 vmm_sol_glue_cleanup(void)
 {
 	fpu_save_area_cleanup();
+	vmm_alloc_cleanup();
 }
 
 


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018060801

## Backports

None

## onu

```
SunOS bloody 5.11 omnios-joyent_merge-2018060801-260ec7f002 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Jun  7 10:12:47 GMT 2018 ====
==== Nightly distributed build completed: Thu Jun  7 11:41:46 GMT 2018 ====

==== Total build time ====

real    1:28:58

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-9b1f5bc1cf i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.1.0h  27 Mar 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   240

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018060701-3f51dc779b

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:05.9
user  1:09:19.9
sys     11:55.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    20:08.9
user  1:00:24.7
sys     10:58.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    25:19.5
user    41:46.9
sys      9:44.5

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
