### PR TITLE
Joyent merge/2018061401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 788e26d53d698f1ae7fc91da6c1c4cd40d05dfd8
+Last illumos-joyent commit: 8118caaf6ac0df6a54351bfd800aea92a6ac3cca
 

--- a/usr/src/cmd/bhyve/block_if.h
+++ b/usr/src/cmd/bhyve/block_if.h
@@ -67,7 +67,12 @@ int	blockif_queuesz(struct blockif_ctxt *bc);
 int	blockif_is_ro(struct blockif_ctxt *bc);
 int	blockif_candelete(struct blockif_ctxt *bc);
 int	blockif_read(struct blockif_ctxt *bc, struct blockif_req *breq);
+#ifdef __FreeBSD__
 int	blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq);
+#else
+int	blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq,
+    boolean_t sync);
+#endif
 int	blockif_flush(struct blockif_ctxt *bc, struct blockif_req *breq);
 int	blockif_delete(struct blockif_ctxt *bc, struct blockif_req *breq);
 int	blockif_cancel(struct blockif_ctxt *bc, struct blockif_req *breq);

--- a/usr/src/cmd/bhyve/pci_ahci.c
+++ b/usr/src/cmd/bhyve/pci_ahci.c
@@ -738,7 +738,16 @@ ahci_handle_rw(struct ahci_port *p, int slot, uint8_t *cfis, uint32_t done)
 	if (readop)
 		err = blockif_read(p->bctx, breq);
 	else
+#ifdef __FreeBSD__
 		err = blockif_write(p->bctx, breq);
+#else
+		/*
+		 * XXX: We currently don't handle disabling of the write cache.
+		 * Once this is fixed we need to revisit this code to do sync
+		 * writes when the cache is disabled.
+		 */
+		err = blockif_write(p->bctx, breq, B_FALSE);
+#endif
 	assert(err == 0);
 }
 

--- a/usr/src/cmd/bhyve/pci_virtio_block.c
+++ b/usr/src/cmd/bhyve/pci_virtio_block.c
@@ -280,7 +280,12 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 		err = blockif_read(sc->bc, &io->io_req);
 		break;
 	case VBH_OP_WRITE:
+#ifdef __FreeBSD__
 		err = blockif_write(sc->bc, &io->io_req);
+#else
+		err = blockif_write(sc->bc, &io->io_req,
+		    (sc->vbsc_vs.vs_negotiated_caps & VTBLK_F_FLUSH) == 0);
+#endif
 		break;
 	case VBH_OP_FLUSH:
 	case VBH_OP_FLUSH_OUT:

--- a/usr/src/cmd/mdb/intel/mdb/proc_amd64dep.c
+++ b/usr/src/cmd/mdb/intel/mdb/proc_amd64dep.c
@@ -24,7 +24,7 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright 2015 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /*
@@ -74,9 +74,9 @@ const mdb_tgt_regdesc_t pt_regdesc[] = {
 	{ "r10w",	REG_R10,	MDB_TGT_R_EXPORT | MDB_TGT_R_16 },
 	{ "r10l",	REG_R10,	MDB_TGT_R_EXPORT | MDB_TGT_R_8L },
 	{ "r9",		REG_R9,		MDB_TGT_R_EXPORT },
-	{ "r9d",	REG_R8,		MDB_TGT_R_EXPORT | MDB_TGT_R_32 },
-	{ "r9w",	REG_R8,		MDB_TGT_R_EXPORT | MDB_TGT_R_16 },
-	{ "r9l",	REG_R8,		MDB_TGT_R_EXPORT | MDB_TGT_R_8L },
+	{ "r9d",	REG_R9,		MDB_TGT_R_EXPORT | MDB_TGT_R_32 },
+	{ "r9w",	REG_R9,		MDB_TGT_R_EXPORT | MDB_TGT_R_16 },
+	{ "r9l",	REG_R9,		MDB_TGT_R_EXPORT | MDB_TGT_R_8L },
 	{ "r8",		REG_R8,		MDB_TGT_R_EXPORT },
 	{ "r8d",	REG_R8,		MDB_TGT_R_EXPORT | MDB_TGT_R_32 },
 	{ "r8w",	REG_R8,		MDB_TGT_R_EXPORT | MDB_TGT_R_16 },

--- a/usr/src/cmd/mdb/intel/modules/genunix/gcore_isadep.c
+++ b/usr/src/cmd/mdb/intel/modules/genunix/gcore_isadep.c
@@ -10,6 +10,7 @@
  */
 /*
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #include <mdb/mdb_modapi.h>
@@ -71,7 +72,7 @@ gcore_getgregs(mdb_klwp_t *lwp, gregset_t grp)
 	grp[REG_R15] = rp->r_r15;
 	grp[REG_FSBASE] = pcb->pcb_fsbase;
 	grp[REG_GSBASE] = pcb->pcb_gsbase;
-	if (pcb->pcb_rupdate == 1) {
+	if (PCB_NEED_UPDATE_SEGS(pcb)) {
 		grp[REG_DS] = pcb->pcb_ds;
 		grp[REG_ES] = pcb->pcb_es;
 		grp[REG_FS] = pcb->pcb_fs;

--- a/usr/src/cmd/ptools/pargs/pargs.c
+++ b/usr/src/cmd/ptools/pargs/pargs.c
@@ -23,7 +23,7 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /*
@@ -306,15 +306,15 @@ unctrl_str(const char *src, int escape_slash, int *unprintable)
  * a set of safe characters and adding those few common punctuation characters
  * which are known to be safe.  The rules are:
  *
- * 	If this is a printable character (graph), and not punctuation, it is
- * 	safe to leave unquoted.
+ *	If this is a printable character (graph), and not punctuation, it is
+ *	safe to leave unquoted.
  *
- * 	If it's one of known hard-coded safe characters, it's also safe to leave
- * 	unquoted.
+ *	If it's one of the known hard-coded safe characters, it's also safe to
+ *	leave unquoted.
  *
- * 	Otherwise, the entire argument must be quoted.
+ *	Otherwise, the entire argument must be quoted.
  *
- * This will cause some strings to be unecessarily quoted, but it is safer than
+ * This will cause some strings to be unnecessarily quoted, but it is safer than
  * having a character unintentionally interpreted by the shell.
  */
 static int
@@ -357,12 +357,12 @@ quote_string_ascii(pargs_data_t *datap, char *src)
 	 * with by unctrl_str().  We make the following subtitution when we
 	 * encounter a single quote:
 	 *
-	 * 	' = '"'"'
+	 *	' = '"'"'
 	 *
 	 * In addition, we put single quotes around the entire argument.  For
 	 * example:
 	 *
-	 * 	foo'bar = 'foo'"'"'bar'
+	 *	foo'bar = 'foo'"'"'bar'
 	 */
 	dstlen = strlen(src) + 3 + 4 * quote_count;
 	dst = safe_zalloc(dstlen);
@@ -711,7 +711,7 @@ at_str(long val, char *instr, size_t n, char *str)
  */
 
 #define	FMT_AV(s, n, hwcap, mask, name)				\
-	if ((hwcap) & (mask)) 					\
+	if ((hwcap) & (mask))					\
 		(void) snprintf(s, n, "%s" name " | ", s)
 
 /*ARGSUSED*/
@@ -840,7 +840,9 @@ static struct aux_id aux_arr[] = {
 	{ AT_SUN_BRAND_AUX2,	"AT_SUN_BRAND_AUX2",	at_null	},
 	{ AT_SUN_BRAND_AUX3,	"AT_SUN_BRAND_AUX3",	at_null	},
 	{ AT_SUN_BRAND_AUX4,	"AT_SUN_BRAND_AUX4",	at_null	},
-	{ AT_SUN_COMMPAGE,	"AT_SUN_COMMPAGE",	at_null	}
+	{ AT_SUN_COMMPAGE,	"AT_SUN_COMMPAGE",	at_null	},
+	{ AT_SUN_FPTYPE,	"AT_SUN_FPTYPE",	at_null },
+	{ AT_SUN_FPSIZE,	"AT_SUN_FPSIZE",	at_null }
 };
 
 #define	N_AT_ENTS (sizeof (aux_arr) / sizeof (struct aux_id))

--- a/usr/src/cmd/sgs/elfdump/common/corenote.c
+++ b/usr/src/cmd/sgs/elfdump/common/corenote.c
@@ -25,7 +25,7 @@
  */
 /*
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
- * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #include <stdlib.h>
@@ -498,6 +498,8 @@ dump_auxv(note_state_t *state, const char *title)
 		case AT_SUN_GID:
 		case AT_SUN_RGID:
 		case AT_SUN_LPAGESZ:
+		case AT_SUN_FPSIZE:
+		case AT_SUN_FPTYPE:
 			num_fmt = SL_FMT_NUM_DEC;
 			break;
 

--- a/usr/src/cmd/sgs/include/conv.h
+++ b/usr/src/cmd/sgs/include/conv.h
@@ -25,6 +25,7 @@
  *
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  * Copyright 2016 RackTop Systems.
  */
 
@@ -170,7 +171,7 @@ typedef union {
 	char				buf[CONV_CAP_VAL_HW1_BUFSIZE];
 } Conv_cap_val_hw1_buf_t;
 
-#define	CONV_CAP_VAL_HW2_BUFSIZE	CONV_INV_BUFSIZE	/* for now */
+#define	CONV_CAP_VAL_HW2_BUFSIZE	350
 typedef union {
 	Conv_inv_buf_t			inv_buf;
 	char				buf[CONV_CAP_VAL_HW2_BUFSIZE];

--- a/usr/src/cmd/sgs/libconv/common/corenote.c
+++ b/usr/src/cmd/sgs/libconv/common/corenote.c
@@ -25,7 +25,7 @@
  */
 /*
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
- * Copyright 2018 Joyent, Inc.
+ * Copyright (c) 2018 Joyent, Inc.
  */
 
 /*
@@ -106,21 +106,22 @@ conv_cnote_auxv_type(Word type, Conv_fmt_flags_t fmt_flags,
 	static const conv_ds_msg_t ds_types_2000_2011 = {
 	    CONV_DS_MSG_INIT(2000, types_2000_2011) };
 
-	static const Msg	types_2014_2026[] = {
+	static const Msg	types_2014_2028[] = {
 		MSG_AUXV_AT_SUN_EXECNAME,	MSG_AUXV_AT_SUN_MMU,
 		MSG_AUXV_AT_SUN_LDDATA,		MSG_AUXV_AT_SUN_AUXFLAGS,
 		MSG_AUXV_AT_SUN_EMULATOR,	MSG_AUXV_AT_SUN_BRANDNAME,
 		MSG_AUXV_AT_SUN_BRAND_AUX1,	MSG_AUXV_AT_SUN_BRAND_AUX2,
 		MSG_AUXV_AT_SUN_BRAND_AUX3,	MSG_AUXV_AT_SUN_HWCAP2,
 		MSG_AUXV_AT_SUN_BRAND_NROOT,	MSG_AUXV_AT_SUN_BRAND_AUX4,
-		MSG_AUXV_AT_SUN_COMMPAGE
+		MSG_AUXV_AT_SUN_COMMPAGE,	MSG_AUXV_AT_SUN_FPTYPE,
+		MSG_AUXV_AT_SUN_FPSIZE
 	};
-	static const conv_ds_msg_t ds_types_2014_2026 = {
-	    CONV_DS_MSG_INIT(2014, types_2014_2026) };
+	static const conv_ds_msg_t ds_types_2014_2028 = {
+	    CONV_DS_MSG_INIT(2014, types_2014_2028) };
 
 	static const conv_ds_t	*ds[] = {
 		CONV_DS_ADDR(ds_types_0_25), CONV_DS_ADDR(ds_types_2000_2011),
-		CONV_DS_ADDR(ds_types_2014_2026), NULL };
+		CONV_DS_ADDR(ds_types_2014_2028), NULL };
 
 	return (conv_map_ds(ELFOSABI_NONE, EM_NONE, type, ds, fmt_flags,
 	    inv_buf));
@@ -1174,7 +1175,7 @@ conv_cnote_pr_flags(int flags, Conv_fmt_flags_t fmt_flags,
     Conv_cnote_pr_flags_buf_t *cnote_pr_flags_buf)
 {
 	static const Val_desc vda[] = {
-		{ PR_STOPPED, 		MSG_PR_FLAGS_STOPPED },
+		{ PR_STOPPED,		MSG_PR_FLAGS_STOPPED },
 		{ PR_ISTOP,		MSG_PR_FLAGS_ISTOP },
 		{ PR_DSTOP,		MSG_PR_FLAGS_DSTOP },
 		{ PR_STEP,		MSG_PR_FLAGS_STEP },
@@ -1333,7 +1334,7 @@ conv_cnote_proc_flag(int flags, Conv_fmt_flags_t fmt_flags,
 	 * their numeric value.
 	 */
 	static const Val_desc vda[] = {
-		{ 0x00000001, 		MSG_PROC_FLAG_SSYS },
+		{ 0x00000001,		MSG_PROC_FLAG_SSYS },
 		{ 0x02000000,		MSG_PROC_FLAG_SMSACCT },
 		{ 0,			0 }
 	};

--- a/usr/src/cmd/sgs/libconv/common/corenote.c
+++ b/usr/src/cmd/sgs/libconv/common/corenote.c
@@ -25,7 +25,7 @@
  */
 /*
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -106,20 +106,21 @@ conv_cnote_auxv_type(Word type, Conv_fmt_flags_t fmt_flags,
 	static const conv_ds_msg_t ds_types_2000_2011 = {
 	    CONV_DS_MSG_INIT(2000, types_2000_2011) };
 
-	static const Msg	types_2014_2025[] = {
+	static const Msg	types_2014_2026[] = {
 		MSG_AUXV_AT_SUN_EXECNAME,	MSG_AUXV_AT_SUN_MMU,
 		MSG_AUXV_AT_SUN_LDDATA,		MSG_AUXV_AT_SUN_AUXFLAGS,
 		MSG_AUXV_AT_SUN_EMULATOR,	MSG_AUXV_AT_SUN_BRANDNAME,
 		MSG_AUXV_AT_SUN_BRAND_AUX1,	MSG_AUXV_AT_SUN_BRAND_AUX2,
 		MSG_AUXV_AT_SUN_BRAND_AUX3,	MSG_AUXV_AT_SUN_HWCAP2,
-		MSG_AUXV_AT_SUN_BRAND_NROOT,	MSG_AUXV_AT_SUN_COMMPAGE
+		MSG_AUXV_AT_SUN_BRAND_NROOT,	MSG_AUXV_AT_SUN_BRAND_AUX4,
+		MSG_AUXV_AT_SUN_COMMPAGE
 	};
-	static const conv_ds_msg_t ds_types_2014_2025 = {
-	    CONV_DS_MSG_INIT(2014, types_2014_2025) };
+	static const conv_ds_msg_t ds_types_2014_2026 = {
+	    CONV_DS_MSG_INIT(2014, types_2014_2026) };
 
 	static const conv_ds_t	*ds[] = {
 		CONV_DS_ADDR(ds_types_0_25), CONV_DS_ADDR(ds_types_2000_2011),
-		CONV_DS_ADDR(ds_types_2014_2025), NULL };
+		CONV_DS_ADDR(ds_types_2014_2026), NULL };
 
 	return (conv_map_ds(ELFOSABI_NONE, EM_NONE, type, ds, fmt_flags,
 	    inv_buf));

--- a/usr/src/cmd/sgs/libconv/common/corenote.msg
+++ b/usr/src/cmd/sgs/libconv/common/corenote.msg
@@ -24,7 +24,7 @@
 # Use is subject to license terms.
 #
 # Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
-# Copyright 2016 Joyent, Inc.
+# Copyright 2018 Joyent, Inc.
 #
 
 @ MSG_NT_PRSTATUS		"[ NT_PRSTATUS ]"
@@ -105,6 +105,7 @@
 @ MSG_AUXV_AT_SUN_BRAND_AUX3		"SUN_BRAND_AUX3"
 @ MSG_AUXV_AT_SUN_HWCAP2		"SUN_HWCAP2"
 @ MSG_AUXV_AT_SUN_BRAND_NROOT		"SUN_BRAND_NROOT"
+@ MSG_AUXV_AT_SUN_BRAND_AUX4		"SUN_BRAND_AUX4"
 @ MSG_AUXV_AT_SUN_COMMPAGE		"SUN_COMMPAGE"
 
 @ MSG_CC_CONTENT_STACK		"STACK"

--- a/usr/src/cmd/sgs/libconv/common/corenote.msg
+++ b/usr/src/cmd/sgs/libconv/common/corenote.msg
@@ -24,7 +24,7 @@
 # Use is subject to license terms.
 #
 # Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
-# Copyright 2018 Joyent, Inc.
+# Copyright (c) 2018 Joyent, Inc.
 #
 
 @ MSG_NT_PRSTATUS		"[ NT_PRSTATUS ]"
@@ -107,6 +107,8 @@
 @ MSG_AUXV_AT_SUN_BRAND_NROOT		"SUN_BRAND_NROOT"
 @ MSG_AUXV_AT_SUN_BRAND_AUX4		"SUN_BRAND_AUX4"
 @ MSG_AUXV_AT_SUN_COMMPAGE		"SUN_COMMPAGE"
+@ MSG_AUXV_AT_SUN_FPTYPE		"SUN_FPTYPE"
+@ MSG_AUXV_AT_SUN_FPSIZE		"SUN_FPSIZE"
 
 @ MSG_CC_CONTENT_STACK		"STACK"
 @ MSG_CC_CONTENT_HEAP		"HEAP"
@@ -343,7 +345,7 @@
 @ MSG_REG_AMD64_R12		"[ r12 ]"
 @ MSG_REG_AMD64_R11		"[ r11 ]"
 @ MSG_REG_AMD64_R10		"[ r10 ]"
-@ MSG_REG_AMD64_R9 		"[ r9 ]" 
+@ MSG_REG_AMD64_R9		"[ r9 ]"
 @ MSG_REG_AMD64_R8		"[ r8 ]"
 @ MSG_REG_AMD64_RDI		"[ rdi ]"
 @ MSG_REG_AMD64_RSI		"[ rsi ]"
@@ -710,7 +712,7 @@
 @ MSG_SYS_FCNTL				"[ fcntl ]"			# 62
 @ MSG_SYS_FCNTL_ALT			"fcntl"
 @ MSG_SYS_ULIMIT			"[ ulimit ]"			# 63
-@ MSG_SYS_ULIMIT_ALT			"ulimit"	
+@ MSG_SYS_ULIMIT_ALT			"ulimit"
 @ MSG_SYS_RENAMEAT			"[ renameat ]"			# 64
 @ MSG_SYS_RENAMEAT_ALT			"renameat"
 @ MSG_SYS_UNLINKAT			"[ unlinkat ]"			# 65
@@ -734,7 +736,7 @@
 @ MSG_SYS_RCTLSYS			"[ rctlsys ]"			# 74
 @ MSG_SYS_RCTLSYS_ALT			"rctlsys	"
 @ MSG_SYS_SIDSYS			"[ sidsys ]"			# 75
-@ MSG_SYS_SIDSYS_ALT			"sidsys"	
+@ MSG_SYS_SIDSYS_ALT			"sidsys"
 @ MSG_SYS_76				"76"				# 76 (u)
 @ MSG_SYS_LWP_PARK			"[ lwp_park ]"			# 77
 @ MSG_SYS_LWP_PARK_ALT			"lwp_park"

--- a/usr/src/common/elfcap/elfcap.c
+++ b/usr/src/common/elfcap/elfcap.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /* LINTLIBRARY */
@@ -377,8 +377,8 @@ static const elfcap_desc_t hw2_386[ELFCAP_NUM_HW2_386] = {
 		STRDESC("AVX512VBMI"), STRDESC("avx512vbmi"),
 	},
 	{						/* 0x00020000 */
-		AV_386_2_AVX512VPOPCDQ, STRDESC("AV_386_2_AVX512VPOPCDQ"),
-		STRDESC("AVX512VPOPCDQ"), STRDESC("avx512_vpopcntdq"),
+		AV_386_2_AVX512VPOPCDQ, STRDESC("AV_386_2_AVX512_VPOPCDQ"),
+		STRDESC("AVX512_VPOPCDQ"), STRDESC("avx512_vpopcntdq"),
 	},
 	{						/* 0x00040000 */
 		AV_386_2_AVX512_4NNIW, STRDESC("AV_386_2_AVX512_4NNIW"),

--- a/usr/src/compat/freebsd/amd64/machine/fpu.h
+++ b/usr/src/compat/freebsd/amd64/machine/fpu.h
@@ -11,12 +11,11 @@
 
 /*
  * Copyright 2014 Pluribus Networks Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #ifndef _COMPAT_FREEBSD_AMD64_MACHINE_FPU_H_
 #define	_COMPAT_FREEBSD_AMD64_MACHINE_FPU_H_
-
-#define	XSAVE_AREA_ALIGN	64
 
 void	fpuexit(kthread_t *td);
 void	fpurestore(void *);

--- a/usr/src/lib/libvmmapi/common/vmmapi.h
+++ b/usr/src/lib/libvmmapi/common/vmmapi.h
@@ -78,7 +78,12 @@ enum vm_mmap_style {
  * - the remaining identifiers can be used to create devmem segments.
  */
 enum {
+#ifdef __FreeBSD__
 	VM_SYSMEM,
+#else
+	VM_LOWMEM,
+	VM_HIGHMEM,
+#endif
 	VM_BOOTROM,
 	VM_FRAMEBUFFER,
 };

--- a/usr/src/pkg/manifests/system-test-ostest.mf
+++ b/usr/src/pkg/manifests/system-test-ostest.mf
@@ -12,7 +12,7 @@
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
-# Copyright 2017 Joyent, Inc.
+# Copyright 2018 Joyent, Inc.
 #
 
 set name=pkg.fmri value=pkg:/system/test/ostest@$(PKGVERS)
@@ -26,6 +26,7 @@ dir path=opt/os-tests/bin
 dir path=opt/os-tests/runfiles
 dir path=opt/os-tests/tests
 dir path=opt/os-tests/tests/file-locking
+$(i386_ONLY)dir path=opt/os-tests/tests/i386
 dir path=opt/os-tests/tests/pf_key
 dir path=opt/os-tests/tests/sdevfs
 dir path=opt/os-tests/tests/secflags
@@ -41,6 +42,7 @@ file path=opt/os-tests/tests/file-locking/acquire-lock.32 mode=0555
 file path=opt/os-tests/tests/file-locking/acquire-lock.64 mode=0555
 file path=opt/os-tests/tests/file-locking/runtests.32 mode=0555
 file path=opt/os-tests/tests/file-locking/runtests.64 mode=0555
+$(i386_ONLY)file path=opt/os-tests/tests/i386/ldt mode=0555
 file path=opt/os-tests/tests/pf_key/acquire-compare mode=0555
 file path=opt/os-tests/tests/pf_key/acquire-spray mode=0555
 file path=opt/os-tests/tests/pf_key/eacq-enabler mode=0555

--- a/usr/src/test/os-tests/runfiles/default.run
+++ b/usr/src/test/os-tests/runfiles/default.run
@@ -11,7 +11,7 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
-# Copyright 2017 Joyent, Inc.
+# Copyright 2018 Joyent, Inc.
 #
 
 [DEFAULT]
@@ -66,3 +66,11 @@ tests = ['conn', 'dgram', 'drop_priv', 'nosignal', 'sockpair']
 [/opt/os-tests/tests/pf_key]
 user = root
 tests = ['acquire-compare', 'acquire-spray']
+
+[/opt/os-tests/tests/OS-6097.32]
+[/opt/os-tests/tests/OS-6097.64]
+
+[/opt/os-tests/tests/i386]
+user = root
+arch = i86pc
+tests = ['ldt']

--- a/usr/src/test/os-tests/tests/i386/Makefile
+++ b/usr/src/test/os-tests/tests/i386/Makefile
@@ -10,13 +10,37 @@
 #
 
 #
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2018 Joyent, Inc.
 #
 
-SUBDIRS_i386 = i386
-
-SUBDIRS = poll secflags sigqueue spoof-ras sdevfs sockfs stress timer tmpfs \
-	file-locking pf_key $(SUBDIRS_$(MACH))
-
+include $(SRC)/cmd/Makefile.cmd
 include $(SRC)/test/Makefile.com
+
+PROG +=	ldt
+
+ROOTOPTPKG = $(ROOT)/opt/os-tests
+TESTDIR = $(ROOTOPTPKG)/tests/i386
+
+CSTD = $(CSTD_GNU99)
+
+CMDS = $(PROG:%=$(TESTDIR)/%)
+$(CMDS) := FILEMODE = 0555
+
+all: $(PROG)
+
+install: all $(CMDS)
+
+lint:
+
+clobber: clean
+	-$(RM) $(PROG)
+
+clean:
+
+$(CMDS): $(TESTDIR) $(PROG)
+
+$(TESTDIR):
+	$(INS.dir)
+
+$(TESTDIR)/%: %
+	$(INS.file)

--- a/usr/src/test/os-tests/tests/i386/ldt.c
+++ b/usr/src/test/os-tests/tests/i386/ldt.c
@@ -1,0 +1,80 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#include <sys/types.h>
+#include <sys/sysi86.h>
+#include <sys/segments.h>
+#include <sys/segment.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <pthread.h>
+#include <err.h>
+
+char foo[4096];
+
+static void *
+donothing(void *nothing)
+{
+	sleep(5);
+	return (NULL);
+}
+
+int
+main(void)
+{
+	pthread_t tid;
+
+	/*
+	 * This first is similar to what sbcl does in some variants.  Note the
+	 * SDT_MEMRW (not SDT_MEMRWA) so we check that the kernel is forcing the
+	 * 'accessed' bit too.
+	 */
+	int sel = SEL_LDT(7);
+
+	struct ssd ssd = { sel, (unsigned long)&foo, 4096,
+	    SDT_MEMRW | (SEL_UPL << 5) | (1 << 7), 0x4 };
+
+	if (sysi86(SI86DSCR, &ssd) < 0)
+		err(-1, "failed to setup segment");
+
+	__asm__ __volatile__("mov %0, %%fs" : : "r" (sel));
+
+	ssd.acc1 = 0;
+
+	if (sysi86(SI86DSCR, &ssd) == 0)
+		errx(-1, "removed in-use segment?");
+
+	__asm__ __volatile__("mov %0, %%fs" : : "r" (0));
+
+	if (sysi86(SI86DSCR, &ssd) < 0)
+		err(-1, "failed to remove segment");
+
+	for (int i = 0; i < MAXNLDT; i++) {
+		ssd.sel = SEL_LDT(i);
+		(void) sysi86(SI86DSCR, &ssd);
+	}
+
+	for (int i = 0; i < 10; i++)
+		pthread_create(&tid, NULL, donothing, NULL);
+
+	if (forkall() == 0) {
+		sleep(2);
+		_exit(0);
+	}
+
+	sleep(6);
+	return (0);
+}

--- a/usr/src/test/test-runner/cmd/run
+++ b/usr/src/test/test-runner/cmd/run
@@ -12,6 +12,7 @@
 #
 
 #
+# Copyright 2018 Joyent, Inc.
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
 #
@@ -19,6 +20,7 @@
 import ConfigParser
 import os
 import logging
+import platform
 from logging.handlers import WatchedFileHandler
 from datetime import datetime
 from optparse import OptionParser
@@ -564,6 +566,10 @@ class TestRun(object):
         self.outputdir = os.path.join(self.outputdir, self.timestamp)
 
         for section in config.sections():
+            if ('arch' in config.options(section) and
+                platform.machine() != config.get(section, 'arch')):
+                continue
+
             if 'tests' in config.options(section):
                 testgroup = TestGroup(section)
                 for prop in TestGroup.props:

--- a/usr/src/uts/common/brand/lx/syscall/lx_thread_area.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_thread_area.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -65,7 +65,7 @@ lx_arch_prctl(int code, ulong_t addr)
 			/*
 			 * Ensure we go out via update_sregs.
 			 */
-			pcb->pcb_rupdate = 1;
+			PCB_SET_UPDATE_SEGS(pcb);
 		}
 		kpreempt_enable();
 		break;
@@ -87,7 +87,7 @@ lx_arch_prctl(int code, ulong_t addr)
 			/*
 			 * Ensure we go out via update_sregs.
 			 */
-			pcb->pcb_rupdate = 1;
+			PCB_SET_UPDATE_SEGS(pcb);
 		}
 		kpreempt_enable();
 		break;

--- a/usr/src/uts/common/brand/solaris10/s10_brand.c
+++ b/usr/src/uts/common/brand/solaris10/s10_brand.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2013, OmniTI Computer Consulting, Inc. All rights reserved.
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017, Joyent, Inc.
+ * Copyright 2018, Joyent, Inc.
  */
 
 #include <sys/errno.h>
@@ -229,7 +229,7 @@ s10_amd64_correct_fsreg(klwp_t *l)
 	if (lwp_getdatamodel(l) == DATAMODEL_NATIVE) {
 		kpreempt_disable();
 		l->lwp_pcb.pcb_fs = LWPFS_SEL;
-		l->lwp_pcb.pcb_rupdate = 1;
+		PCB_SET_UPDATE_SEGS(&l->lwp_pcb);
 		lwptot(l)->t_post_sys = 1;	/* Guarantee update_sregs() */
 		kpreempt_enable();
 	}

--- a/usr/src/uts/common/exec/elf/elf.c
+++ b/usr/src/uts/common/exec/elf/elf.c
@@ -26,7 +26,7 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -70,6 +70,7 @@
 
 #if defined(__x86)
 #include <sys/comm_page_util.h>
+#include <sys/fp.h>
 #endif /* defined(__x86) */
 
 
@@ -361,8 +362,8 @@ elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
     int *brand_action)
 {
 	caddr_t		phdrbase = NULL;
-	caddr_t 	bssbase = 0;
-	caddr_t 	brkbase = 0;
+	caddr_t		bssbase = 0;
+	caddr_t		brkbase = 0;
 	size_t		brksize = 0;
 	ssize_t		dlnsize, nsize = 0;
 	aux_entry_t	*aux;
@@ -633,9 +634,12 @@ elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
 	 * On supported kernels (x86_64) make room in the auxv for the
 	 * AT_SUN_COMMPAGE entry.  This will go unpopulated on i86xpv systems
 	 * which do not provide such functionality.
+	 *
+	 * Additionally cover the floating point information AT_SUN_FPSIZE and
+	 * AT_SUN_FPTYPE.
 	 */
 #if defined(__amd64)
-	args->auxsize += sizeof (aux_entry_t);
+	args->auxsize += 3 * sizeof (aux_entry_t);
 #endif /* defined(__amd64) */
 
 	/*
@@ -970,6 +974,8 @@ elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
 
 	if (hasauxv) {
 		int auxf = AF_SUN_HWCAPVERIFY;
+		size_t fpsize;
+		int fptype;
 
 		/*
 		 * Note: AT_SUN_PLATFORM, AT_SUN_EXECNAME and AT_RANDOM were
@@ -1059,7 +1065,8 @@ elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
 		}
 
 		/*
-		 * Add the comm page auxv entry, mapping it in if needed.
+		 * Add the comm page auxv entry, mapping it in if needed. Also
+		 * take care of the FPU entries.
 		 */
 #if defined(__amd64)
 		if (args->commpage != NULL ||
@@ -1070,6 +1077,16 @@ elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
 			 * If the comm page cannot be mapped, pad out the auxv
 			 * to satisfy later size checks.
 			 */
+			ADDAUX(aux, AT_NULL, 0)
+		}
+
+		fptype = AT_386_FPINFO_NONE;
+		fpu_auxv_info(&fptype, &fpsize);
+		if (fptype != AT_386_FPINFO_NONE) {
+			ADDAUX(aux, AT_SUN_FPTYPE, fptype)
+			ADDAUX(aux, AT_SUN_FPSIZE, fpsize)
+		} else {
+			ADDAUX(aux, AT_NULL, 0)
 			ADDAUX(aux, AT_NULL, 0)
 		}
 #endif /* defined(__amd64) */

--- a/usr/src/uts/common/sys/auxv.h
+++ b/usr/src/uts/common/sys/auxv.h
@@ -29,7 +29,7 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #ifndef	_SYS_AUXV_H
@@ -207,13 +207,11 @@ extern uint_t getisax(uint32_t *, uint_t);
 #define	AT_SUN_COMMPAGE		2026
 
 /*
- * Aux vector for comm page
+ * These two AUX vectors are generally used to define information about the FPU.
+ * These values are currently only used on the x86 platform.
  */
-#define	AT_SUN_COMMPAGE		2026
-
-/*
- * Note that 2023 is reserved for the AT_SUN_HWCAP2 word defined above.
- */
+#define	AT_SUN_FPTYPE		2027
+#define	AT_SUN_FPSIZE		2028
 
 /*
  * The kernel is in a better position to determine whether a process needs to

--- a/usr/src/uts/common/sys/auxv_386.h
+++ b/usr/src/uts/common/sys/auxv_386.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #ifndef	_SYS_AUXV_386_H
@@ -112,6 +112,19 @@ extern "C" {
 	"\021avx512vbmi\020avx512vl\017avx512bw\016avx512cd"		\
 	"\015avx512er\014avx512pf\013avx512ifma\012avx512dq\011avx512f"	\
 	"\010rdseed\07adx\06avx2\05fma\04bmi2\03bmi1\02rdrand\01f16c"
+
+/*
+ * Flags used in AT_SUN_FPTYPE on x86.
+ *
+ * We don't currently support xsavec in illumos. However, when we do, then we
+ * should add this to the type list and extend our primary consumer (rtld) to
+ * use it. xsaveopt is not in this list because it is not appropriate for the
+ * stack based storage.
+ */
+#define	AT_386_FPINFO_NONE		0
+#define	AT_386_FPINFO_FXSAVE		1
+#define	AT_386_FPINFO_XSAVE		2
+#define	AT_386_FPINFO_XSAVE_AMD		3
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/common/sys/proc.h
+++ b/usr/src/uts/common/sys/proc.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -308,7 +308,8 @@ typedef struct	proc {
 	 */
 	kmutex_t	p_ldtlock;	/* protects the following fields */
 	user_desc_t	*p_ldt;		/* Pointer to private LDT */
-	system_desc_t	p_ldt_desc;	/* segment descriptor for private LDT */
+	uint64_t	p_unused1;	/* no longer used */
+	uint64_t	p_unused2;	/* no longer used */
 	ushort_t	p_ldtlimit;	/* highest selector used */
 #endif
 	size_t p_swrss;			/* resident set size before last swap */

--- a/usr/src/uts/common/sys/user.h
+++ b/usr/src/uts/common/sys/user.h
@@ -26,7 +26,7 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved	*/
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 
@@ -111,7 +111,7 @@ typedef struct uf_entry {
 	short		uf_busy;	/* file is allocated [grow, fork] */
 	kcondvar_t	uf_wanted_cv;	/* waiting for setf() [never copied] */
 	kcondvar_t	uf_closing_cv;	/* waiting for close() [never copied] */
-	struct portfd 	*uf_portfd;	/* associated with port [grow] */
+	struct portfd	*uf_portfd;	/* associated with port [grow] */
 	uf_entry_gen_t	uf_gen;		/* assigned fd generation [grow,fork] */
 	/* Avoid false sharing - pad to coherency granularity (64 bytes) */
 	char		uf_pad[64 - sizeof (kmutex_t) - 2 * sizeof (void*) -
@@ -204,7 +204,7 @@ typedef struct {		/* kernel syscall set type */
 #if defined(__sparc)
 #define	__KERN_NAUXV_IMPL 24
 #elif defined(__i386) || defined(__amd64)
-#define	__KERN_NAUXV_IMPL 26
+#define	__KERN_NAUXV_IMPL 28
 #endif
 
 struct execsw;

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -64,6 +64,7 @@ CORE_OBJS +=			\
 	hardclk.o		\
 	hat_i86.o		\
 	hat_kdi.o		\
+	hma_fpu.o		\
 	hment.o			\
 	hold_page.o		\
 	hrtimers.o		\

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -262,6 +262,7 @@ VMM_OBJS += vmm.o \
 	vmx.o \
 	vmx_support.o \
 	vtd.o \
+	vtd_sol.o \
 	svm.o \
 	svm_msr.o \
 	npt.o \

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.c
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.c
@@ -311,6 +311,9 @@ static int vmx_getreg(void *arg, int vcpu, int reg, uint64_t *retval);
 static int vmxctx_setreg(struct vmxctx *vmxctx, int reg, uint64_t val);
 static void vmx_inject_pir(struct vlapic *vlapic);
 static void vmx_flush_pir_prio(struct vlapic *vlapic);
+#ifndef __FreeBSD__
+static int vmx_apply_tsc_adjust(struct vmx *, int);
+#endif /* __FreeBSD__ */
 
 #ifdef KTR
 static const char *
@@ -980,15 +983,6 @@ vmx_vminit(struct vm *vm, pmap_t pmap)
 	struct vmcs *vmcs;
 	uint32_t exc_bitmap;
 
-#ifndef __FreeBSD__
-	/*
-	 * Grab an initial TSC reading to apply as an offset so the guest
-	 * TSC(s) appear to start from a zeroed value.
-	 */
-	uint64_t init_time = rdtsc();
-#endif
-
-
 	vmx = malloc(sizeof(struct vmx), M_VMX, M_WAITOK | M_ZERO);
 	if ((uintptr_t)vmx & PAGE_MASK) {
 		panic("malloc of struct vmx not aligned on %d byte boundary",
@@ -1099,15 +1093,6 @@ vmx_vminit(struct vm *vm, pmap_t pmap)
 		error += vmwrite(VMCS_MSR_BITMAP, msr_bitmap_pa);
 #endif
 		error += vmwrite(VMCS_VPID, vpid[i]);
-
-#ifndef __FreeBSD__
-		/*
-		 * Record initial TSC offset.  It will be loaded into the VMCS
-		 * during each setup for VMX entry.
-		 */
-		vmx->tsc_offset[i] = (uint64_t)(-init_time);
-		VERIFY(procbased_ctls & PROCBASED_TSC_OFFSET);
-#endif
 
 		/* exception bitmap */
 		if (vcpu_trace_exceptions(vm, i))
@@ -1281,30 +1266,6 @@ vmx_invvpid(struct vmx *vmx, int vcpu, pmap_t pmap, int running)
 	}
 }
 
-#ifndef __FreeBSD__
-/*
- * Set the TSC adjustment, taking into account the offsets measured between
- * host physical CPUs.  This is required even if the guest has not set a TSC
- * offset since vCPUs inherit the TSC offset of whatever physical CPU it has
- * migrated onto.  Without this mitigation, un-synched host TSCs will convey
- * the appearance of TSC time-travel to the guest as its vCPUs migrate.
- */
-static int
-vmx_apply_tsc_adjust(struct vmx *vmx, int vcpu)
-{
-	extern hrtime_t tsc_gethrtime_tick_delta(void);
-	uint64_t host_offset = (uint64_t)tsc_gethrtime_tick_delta();
-	uint64_t guest_offset = vmx->tsc_offset[vcpu];
-	int error;
-
-	ASSERT(vmx->cap[vcpu].proc_ctls & PROCBASED_TSC_OFFSET);
-
-	error = vmwrite(VMCS_TSC_OFFSET, guest_offset + host_offset);
-
-	return (error);
-}
-#endif
-
 static void
 vmx_set_pcpu_defaults(struct vmx *vmx, int vcpu, pmap_t pmap)
 {
@@ -1318,6 +1279,12 @@ vmx_set_pcpu_defaults(struct vmx *vmx, int vcpu, pmap_t pmap)
 	 * trip into the critical section.
 	 */
 	vmcs_write(VMCS_HOST_IA32_SYSENTER_ESP, rdmsr(MSR_SYSENTER_ESP_MSR));
+
+	/*
+	 * Perform any needed TSC_OFFSET adjustment based on TSC_MSR writes or
+	 * migration between host CPUs with differing TSC values.
+	 */
+	VERIFY0(vmx_apply_tsc_adjust(vmx, vcpu));
 #endif
 
 	vmxstate = &vmx->state[vcpu];
@@ -1336,10 +1303,6 @@ vmx_set_pcpu_defaults(struct vmx *vmx, int vcpu, pmap_t pmap)
 	vmcs_write(VMCS_HOST_GDTR_BASE, vmm_get_host_gdtrbase());
 	vmcs_write(VMCS_HOST_GS_BASE, vmm_get_host_gsbase());
 	vmx_invvpid(vmx, vcpu, pmap, 1);
-
-#ifndef __FreeBSD__
-	VERIFY0(vmx_apply_tsc_adjust(vmx, vcpu));
-#endif
 }
 
 /*
@@ -1391,12 +1354,12 @@ vmx_clear_nmi_window_exiting(struct vmx *vmx, int vcpu)
 	VCPU_CTR0(vmx->vm, vcpu, "Disabling NMI window exiting");
 }
 
+#ifdef __FreeBSD__
 int
 vmx_set_tsc_offset(struct vmx *vmx, int vcpu, uint64_t offset)
 {
 	int error;
 
-#ifdef __FreeBSD__
 	if ((vmx->cap[vcpu].proc_ctls & PROCBASED_TSC_OFFSET) == 0) {
 		vmx->cap[vcpu].proc_ctls |= PROCBASED_TSC_OFFSET;
 		vmcs_write(VMCS_PRI_PROC_BASED_CTLS, vmx->cap[vcpu].proc_ctls);
@@ -1404,13 +1367,35 @@ vmx_set_tsc_offset(struct vmx *vmx, int vcpu, uint64_t offset)
 	}
 
 	error = vmwrite(VMCS_TSC_OFFSET, offset);
-#else /* __FreeBSD__ */
-	vmx->tsc_offset[vcpu] = offset;
-	error = vmx_apply_tsc_adjust(vmx, vcpu);
-#endif /* __FreeBSD__ */
 
 	return (error);
 }
+#else /* __FreeBSD__ */
+/*
+ * Set the TSC adjustment, taking into account the offsets measured between
+ * host physical CPUs.  This is required even if the guest has not set a TSC
+ * offset since vCPUs inherit the TSC offset of whatever physical CPU it has
+ * migrated onto.  Without this mitigation, un-synched host TSCs will convey
+ * the appearance of TSC time-travel to the guest as its vCPUs migrate.
+ */
+static int
+vmx_apply_tsc_adjust(struct vmx *vmx, int vcpu)
+{
+	extern hrtime_t tsc_gethrtime_tick_delta(void);
+	const uint64_t target_offset = (vcpu_tsc_offset(vmx->vm, vcpu) +
+	    (uint64_t)tsc_gethrtime_tick_delta());
+	int error = 0;
+
+	ASSERT(vmx->cap[vcpu].proc_ctls & PROCBASED_TSC_OFFSET);
+
+	if (vmx->tsc_offset_active[vcpu] != target_offset) {
+		error = vmwrite(VMCS_TSC_OFFSET, target_offset);
+		vmx->tsc_offset_active[vcpu] = target_offset;
+	}
+
+	return (error);
+}
+#endif /* __FreeBSD__ */
 
 #define	NMI_BLOCKING	(VMCS_INTERRUPTIBILITY_NMI_BLOCKING |		\
 			 VMCS_INTERRUPTIBILITY_MOVSS_BLOCKING)

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.h
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.h
@@ -135,7 +135,7 @@ struct vmx {
 	uint64_t	guest_msrs[VM_MAXCPU][GUEST_MSR_NUM];
 #ifndef	__FreeBSD__
 	uint64_t	host_msrs[VM_MAXCPU][GUEST_MSR_NUM];
-	uint64_t	tsc_offset[VM_MAXCPU];
+	uint64_t	tsc_offset_active[VM_MAXCPU];
 	boolean_t	ctx_loaded[VM_MAXCPU];
 #endif
 	struct vmxctx	ctx[VM_MAXCPU];

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx_msr.c
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx_msr.c
@@ -502,9 +502,11 @@ vmx_wrmsr(struct vmx *vmx, int vcpuid, u_int num, uint64_t val, bool *retu)
 		else
 			vm_inject_gp(vmx->vm, vcpuid);
 		break;
+#ifdef __FreeBSD__
 	case MSR_TSC:
 		error = vmx_set_tsc_offset(vmx, vcpuid, val - rdtsc());
 		break;
+#endif /* __FreeBSD__ */
 	default:
 		error = EINVAL;
 		break;

--- a/usr/src/uts/i86pc/io/vmm/intel/vtd_sol.c
+++ b/usr/src/uts/i86pc/io/vmm/intel/vtd_sol.c
@@ -1,0 +1,83 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#include <sys/sunndi.h>
+#include <contrib/dev/acpica/include/acpi.h>
+
+dev_info_t *
+vtd_get_dip(ACPI_DMAR_HARDWARE_UNIT *drhd, int unit)
+{
+	dev_info_t *dip;
+	struct ddi_parent_private_data *pdptr;
+	struct regspec reg;
+	int circ;
+
+	/*
+	 * Try to find an existing devinfo node for this vtd unit.
+	 */
+	ndi_devi_enter(ddi_root_node(), &circ);
+	dip = ddi_find_devinfo("vtd", unit, 0);
+	ndi_devi_exit(ddi_root_node(), circ);
+
+	if (dip != NULL)
+		return (dip);
+
+	/*
+	 * None found, construct a devinfo node for this vtd unit.
+	 */
+	dip = ddi_add_child(ddi_root_node(), "vtd",
+	    DEVI_SID_NODEID, unit);
+
+	reg.regspec_bustype = 0;
+	reg.regspec_addr = drhd->Address;
+	reg.regspec_size = PAGE_SIZE;
+
+	/*
+	 * update the reg properties
+	 *
+	 *   reg property will be used for register
+	 *   set access
+	 *
+	 * refer to the bus_map of root nexus driver
+	 * I/O or memory mapping:
+	 *
+	 * <bustype=0, addr=x, len=x>: memory
+	 * <bustype=1, addr=x, len=x>: i/o
+	 * <bustype>1, addr=0, len=x>: x86-compatibility i/o
+	 */
+	(void) ndi_prop_update_int_array(DDI_DEV_T_NONE,
+	    dip, "reg", (int *)&reg,
+	    sizeof (struct regspec) / sizeof (int));
+
+	/*
+	 * This is an artificially constructed dev_info, and we
+	 * need to set a few more things to be able to use it
+	 * for ddi_dma_alloc_handle/free_handle.
+	 */
+	ddi_set_driver(dip, ddi_get_driver(ddi_root_node()));
+	DEVI(dip)->devi_bus_dma_allochdl =
+	    DEVI(ddi_get_driver((ddi_root_node())));
+
+	pdptr = kmem_zalloc(sizeof (struct ddi_parent_private_data)
+	    + sizeof (struct regspec), KM_SLEEP);
+	pdptr->par_nreg = 1;
+	pdptr->par_reg = (struct regspec *)(pdptr + 1);
+	pdptr->par_reg->regspec_bustype = 0;
+	pdptr->par_reg->regspec_addr = drhd->Address;
+	pdptr->par_reg->regspec_size = PAGE_SIZE;
+	ddi_set_parent_data(dip, pdptr);
+
+	return (dip);
+}

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -1282,7 +1282,14 @@ save_guest_fpustate(struct vcpu *vcpu)
 	/* save guest FPU state */
 	fpu_stop_emulating();
 	fpusave(vcpu->guestfpu);
+#ifdef __FreeBSD__
 	fpu_start_emulating();
+#else
+	/*
+	 * When the host state has been restored, we should not re-enable
+	 * CR0.TS on illumos for eager FPU.
+	 */
+#endif
 }
 
 static VMM_STAT(VCPU_IDLE_TICKS, "number of ticks vcpu was idle");
@@ -2015,7 +2022,7 @@ restart:
 	set_pcb_flags(pcb, PCB_FULL_IRET);
 #else
 	/* Force a trip through update_sregs to reload %fs/%gs and friends */
-	ttolwp(curthread)->lwp_pcb.pcb_rupdate = 1;
+	PCB_SET_UPDATE_SEGS(&ttolwp(curthread)->lwp_pcb);
 #endif
 
 #ifdef	__FreeBSD__

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -146,7 +146,11 @@ struct mem_seg {
 	bool	sysmem;
 	struct vm_object *object;
 };
+#ifdef __FreeBSD__
 #define	VM_MAX_MEMSEGS	3
+#else
+#define	VM_MAX_MEMSEGS	4
+#endif
 
 struct mem_map {
 	vm_paddr_t	gpa;

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -497,6 +497,7 @@ vmm_mod_unload()
 {
 	int	error;
 
+	iommu_cleanup();
 	error = VMM_CLEANUP();
 	if (error)
 		return (error);

--- a/usr/src/uts/i86pc/ml/offsets.in
+++ b/usr/src/uts/i86pc/ml/offsets.in
@@ -75,8 +75,6 @@ proc		PROCSIZE
 	p_as
 	p_lockp
 	p_user
-	p_ldt
-	p_ldt_desc
 	p_model
 	p_pctx
 	p_agenttp

--- a/usr/src/uts/i86pc/ml/syscall_asm_amd64.s
+++ b/usr/src/uts/i86pc/ml/syscall_asm_amd64.s
@@ -271,7 +271,18 @@
  * between entering privileged mode and performing the assertion,
  * otherwise we may perform a context switch on the thread, which
  * will end up setting pcb_rupdate to 1 again.
+ *
+ * ASSERT(%cr0 & CR0_TS == 0);
+ * Preconditions:
+ *	(%rsp is ready for normal call sequence)
+ * Postconditions (if assertion is true):
+ *      (specified register is clobbered)
+ *
+ * Check to make sure that we are returning to user land and that CR0.TS
+ * is not set. This is required as part of the eager FPU (see
+ * uts/intel/ia32/os/fpu.c for more information).
  */
+
 #if defined(DEBUG)
 
 #if !defined(__lint)
@@ -284,6 +295,9 @@ __codesel_msg:
 
 __no_rupdate_msg:
 	.string	"syscall_asm_amd64.s:%d lwp %p, pcb_rupdate != 0"
+
+__bad_ts_msg:
+	.string "sysscall_asm_amd64.s:%d CR0.TS set on user return"
 
 #endif	/* !__lint */
 
@@ -310,9 +324,20 @@ __no_rupdate_msg:
 	call	panic;					\
 8:
 
+#define	ASSERT_CR0TS_ZERO(reg)				\
+	movq	%cr0, reg;				\
+	testq	$CR0_TS, reg;				\
+	jz	9f;					\
+	leaq	__bad_ts_msg(%rip), %rdi;		\
+	movl	$__LINE__, %esi;			\
+	xorl	%eax, %eax;				\
+	call	panic;					\
+9:
+
 #else
 #define	ASSERT_LWPTOREGS(lwp, rp)
 #define	ASSERT_NO_RUPDATE_PENDING(lwp)
+#define	ASSERT_CR0TS_ZERO(reg)
 #endif
 
 /*
@@ -648,6 +673,11 @@ _syscall_after_brand:
 	movq	%r13, REGOFF_RDX(%rsp)
 
 	/*
+	 * Clobber %r11 as we check CR0.TS.
+	 */
+	ASSERT_CR0TS_ZERO(%r11)
+
+	/*
 	 * To get back to userland, we need the return %rip in %rcx and
 	 * the return %rfl in %r11d.  The sysretq instruction also arranges
 	 * to fix up %cs and %ss; everything else is our responsibility.
@@ -972,6 +1002,11 @@ _syscall32_after_brand:
 	SIMPLE_SYSCALL_POSTSYS(%r15, %r14, %bx)
 
 	/*
+	 * Clobber %r11 as we check CR0.TS.
+	 */
+	ASSERT_CR0TS_ZERO(%r11)
+
+	/*
 	 * To get back to userland, we need to put the return %rip in %rcx and
 	 * the return %rfl in %r11d.  The sysret instruction also arranges
 	 * to fix up %cs and %ss; everything else is our responsibility.
@@ -1261,6 +1296,11 @@ sys_sysenter()
 	 * doesn't enable interrupts too soon.
 	 */
 	andq	$_BITNOT(PS_IE), REGOFF_RFL(%rsp)
+
+	/*
+	 * Clobber %r11 as we check CR0.TS.
+	 */
+	ASSERT_CR0TS_ZERO(%r11)
 
 	/*
 	 * (There's no point in loading up %edx because the sysexit

--- a/usr/src/uts/i86pc/os/fpu_subr.c
+++ b/usr/src/uts/i86pc/os/fpu_subr.c
@@ -148,8 +148,7 @@ fpu_probe(void)
 		ENABLE_SSE();
 
 		if (is_x86_feature(x86_featureset, X86FSET_AVX)) {
-			ASSERT(is_x86_feature(x86_featureset,
-			    X86FSET_XSAVE));
+			ASSERT(is_x86_feature(x86_featureset, X86FSET_XSAVE));
 			fp_kind |= __FP_AVX;
 		}
 
@@ -180,7 +179,7 @@ fpu_probe(void)
 					fpsave_ctxt = xsave_ctxt;
 				}
 			}
-			patch_xsave();
+			fprestore_ctxt = xrestore_ctxt;
 			fpsave_cachep = kmem_cache_create("xsave_cache",
 			    cpuid_get_xsave_size(), XSAVE_ALIGN,
 			    NULL, NULL, NULL, NULL, NULL, 0);

--- a/usr/src/uts/i86pc/os/hma_fpu.c
+++ b/usr/src/uts/i86pc/os/hma_fpu.c
@@ -1,0 +1,224 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2018, Joyent, Inc.
+ */
+
+/*
+ * This implements the hypervisor multiplexor FPU API. Its purpose is to make it
+ * easy to switch between the host and guest hypervisor while hiding all the
+ * details about CR0.TS and how to save the host's state as required.
+ */
+
+#include <sys/pcb.h>
+#include <sys/kmem.h>
+#include <sys/debug.h>
+#include <sys/cmn_err.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/hma.h>
+#include <sys/x86_archext.h>
+#include <sys/archsystm.h>
+
+struct hma_fpu {
+	fpu_ctx_t	hf_guest_fpu;
+	kthread_t	*hf_curthread;
+	boolean_t	hf_inguest;
+};
+
+int
+hma_fpu_init(hma_fpu_t *fpu)
+{
+	struct xsave_state *xs;
+
+	ASSERT0(fpu->hf_inguest);
+
+	switch (fp_save_mech) {
+	case FP_FXSAVE:
+		bcopy(&sse_initial, fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_fx,
+		    sizeof (struct fxsave_state));
+		fpu->hf_guest_fpu.fpu_xsave_mask = 0;
+		break;
+	case FP_XSAVE:
+		/*
+		 * Zero everything in the xsave case as we may have data in
+		 * the structure that's not part of the initial value (which
+		 * only really deals with a small portion of the xsave state).
+		 */
+		xs = fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_xs;
+		bzero(xs, cpuid_get_xsave_size());
+		bcopy(&avx_initial, xs, sizeof (*xs));
+		xs->xs_xstate_bv = XFEATURE_LEGACY_FP | XFEATURE_SSE;
+		fpu->hf_guest_fpu.fpu_xsave_mask = XFEATURE_FP_ALL;
+		break;
+	default:
+		panic("Invalid fp_save_mech");
+	}
+
+	fpu->hf_guest_fpu.fpu_flags = FPU_EN | FPU_VALID;
+
+	return (0);
+}
+
+void
+hma_fpu_free(hma_fpu_t *fpu)
+{
+	if (fpu == NULL)
+		return;
+
+	ASSERT3P(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic, !=, NULL);
+	kmem_cache_free(fpsave_cachep,
+	    fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic);
+	kmem_free(fpu, sizeof (*fpu));
+}
+
+hma_fpu_t *
+hma_fpu_alloc(int kmflag)
+{
+	hma_fpu_t *fpu;
+
+	fpu = kmem_zalloc(sizeof (hma_fpu_t), kmflag);
+	if (fpu == NULL)
+		return (NULL);
+
+	fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic =
+	    kmem_cache_alloc(fpsave_cachep, kmflag);
+	if (fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic == NULL) {
+		kmem_free(fpu, sizeof (hma_fpu_t));
+		return (NULL);
+	}
+	fpu->hf_inguest = B_FALSE;
+
+	/*
+	 * Make sure the entire structure is zero.
+	 */
+	switch (fp_save_mech) {
+	case FP_FXSAVE:
+		bzero(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic,
+		    sizeof (struct fxsave_state));
+	case FP_XSAVE:
+		bzero(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic,
+		    cpuid_get_xsave_size());
+		break;
+	default:
+		panic("Invalid fp_save_mech");
+	}
+
+	return (fpu);
+}
+
+void
+hma_fpu_start_guest(hma_fpu_t *fpu)
+{
+	/*
+	 * Note, we don't check / assert whether or not t_prempt is true because
+	 * there are contexts where this is safe to call (from a context op)
+	 * where t_preempt may not be set.
+	 */
+	ASSERT3S(fpu->hf_inguest, ==, B_FALSE);
+	ASSERT3P(fpu->hf_curthread, ==, NULL);
+	ASSERT3P(curthread->t_lwp, !=, NULL);
+	ASSERT3U(fpu->hf_guest_fpu.fpu_flags & FPU_EN, !=, 0);
+	ASSERT3U(fpu->hf_guest_fpu.fpu_flags & FPU_VALID, !=, 0);
+
+	fpu->hf_inguest = B_TRUE;
+	fpu->hf_curthread = curthread;
+
+
+	fp_save(&curthread->t_lwp->lwp_pcb.pcb_fpu);
+	fp_restore(&fpu->hf_guest_fpu);
+	fpu->hf_guest_fpu.fpu_flags &= ~FPU_VALID;
+}
+
+void
+hma_fpu_stop_guest(hma_fpu_t *fpu)
+{
+	ASSERT3S(fpu->hf_inguest, ==, B_TRUE);
+	ASSERT3P(fpu->hf_curthread, ==, curthread);
+	ASSERT3U(fpu->hf_guest_fpu.fpu_flags & FPU_EN, !=, 0);
+	ASSERT3U(fpu->hf_guest_fpu.fpu_flags & FPU_VALID, ==, 0);
+
+	/*
+	 * Note, we can't use fp_save because it assumes that we're saving to
+	 * the thread's PCB and not somewhere else. Because this is a different
+	 * FPU context, we instead have to do this ourselves.
+	 */
+	switch (fp_save_mech) {
+	case FP_FXSAVE:
+		fpxsave(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_fx);
+		break;
+	case FP_XSAVE:
+		xsavep(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_xs,
+		    fpu->hf_guest_fpu.fpu_xsave_mask);
+		break;
+	default:
+		panic("Invalid fp_save_mech");
+		/*NOTREACHED*/
+	}
+	fpu->hf_guest_fpu.fpu_flags |= FPU_VALID;
+
+	fp_restore(&curthread->t_lwp->lwp_pcb.pcb_fpu);
+
+	fpu->hf_inguest = B_FALSE;
+	fpu->hf_curthread = NULL;
+}
+
+void
+hma_fpu_get_fxsave_state(const hma_fpu_t *fpu, struct fxsave_state *fx)
+{
+	const struct fxsave_state *guest;
+
+	ASSERT3S(fpu->hf_inguest, ==, B_FALSE);
+
+	guest = fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_fx;
+	bcopy(guest, fx, sizeof (*fx));
+}
+
+int
+hma_fpu_set_fxsave_state(hma_fpu_t *fpu, const struct fxsave_state *fx)
+{
+	struct fxsave_state *gfx;
+	struct xsave_state *gxs;
+
+	ASSERT3S(fpu->hf_inguest, ==, B_FALSE);
+
+	/*
+	 * If reserved bits are set in fx_mxcsr, then we will take a #GP when
+	 * we restore them. Reject this outright.
+	 *
+	 * We do not need to check if we are dealing with state that has pending
+	 * exceptions. This was only the case with the original FPU save and
+	 * restore mechanisms (fsave/frstor). When using fxsave/fxrstor and
+	 * xsave/xrstor they will be deferred to the user using the FPU, which
+	 * is what we'd want here (they'd be used in guest context).
+	 */
+	if ((fx->fx_mxcsr & ~sse_mxcsr_mask) != 0)
+		return (EINVAL);
+
+	switch (fp_save_mech) {
+	case FP_FXSAVE:
+		gfx = fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_fx;
+		bcopy(fx, gfx, sizeof (*fx));
+		break;
+	case FP_XSAVE:
+		gxs = fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_xs;
+		bzero(gxs, cpuid_get_xsave_size());
+		bcopy(fx, &gxs->xs_fxsave, sizeof (*fx));
+		gxs->xs_xstate_bv = XFEATURE_LEGACY_FP | XFEATURE_SSE;
+		break;
+	default:
+		panic("Invalid fp_save_mech");
+		/* NOTREACHED */
+	}
+
+	return (0);
+}

--- a/usr/src/uts/i86pc/os/hma_fpu.c
+++ b/usr/src/uts/i86pc/os/hma_fpu.c
@@ -105,6 +105,7 @@ hma_fpu_alloc(int kmflag)
 	case FP_FXSAVE:
 		bzero(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic,
 		    sizeof (struct fxsave_state));
+		break;
 	case FP_XSAVE:
 		bzero(fpu->hf_guest_fpu.fpu_regs.kfpu_u.kfpu_generic,
 		    cpuid_get_xsave_size());

--- a/usr/src/uts/i86pc/os/mlsetup.c
+++ b/usr/src/uts/i86pc/os/mlsetup.c
@@ -362,11 +362,6 @@ mlsetup(struct regs *rp)
 	CPU->cpu_pri = 12;		/* initial PIL for the boot CPU */
 
 	/*
-	 * The kernel doesn't use LDTs unless a process explicitly requests one.
-	 */
-	p0.p_ldt_desc = null_sdesc;
-
-	/*
 	 * Initialize thread/cpu microstate accounting
 	 */
 	init_mstate(&t0, LMS_SYSTEM);

--- a/usr/src/uts/i86pc/os/mp_startup.c
+++ b/usr/src/uts/i86pc/os/mp_startup.c
@@ -2054,9 +2054,8 @@ mp_cpu_faulted_exit(struct cpu *cp)
  * syscall features.
  */
 
-/*ARGSUSED*/
 void
-cpu_fast_syscall_disable(void *arg)
+cpu_fast_syscall_disable(void)
 {
 	if (is_x86_feature(x86_featureset, X86FSET_MSR) &&
 	    is_x86_feature(x86_featureset, X86FSET_SEP))
@@ -2066,9 +2065,8 @@ cpu_fast_syscall_disable(void *arg)
 		cpu_asysc_disable();
 }
 
-/*ARGSUSED*/
 void
-cpu_fast_syscall_enable(void *arg)
+cpu_fast_syscall_enable(void)
 {
 	if (is_x86_feature(x86_featureset, X86FSET_MSR) &&
 	    is_x86_feature(x86_featureset, X86FSET_SEP))

--- a/usr/src/uts/i86pc/os/trap.c
+++ b/usr/src/uts/i86pc/os/trap.c
@@ -1005,50 +1005,25 @@ trap(struct regs *rp, caddr_t addr, processorid_t cpuid)
 		fault = FLTIOVF;
 		break;
 
+	/*
+	 * When using an eager FPU on x86, the #NM trap is no longer meaningful.
+	 * Userland should not be able to trigger it. Anything that does
+	 * represents a fatal error in the kernel and likely in the register
+	 * state of the system. User FPU state should always be valid.
+	 */
 	case T_NOEXTFLT + USER:	/* math coprocessor not available */
-		if (tudebug && tudebugfpe)
-			showregs(type, rp, addr);
-		if (fpnoextflt(rp)) {
-			siginfo.si_signo = SIGILL;
-			siginfo.si_code  = ILL_ILLOPC;
-			siginfo.si_addr  = (caddr_t)rp->r_pc;
-			fault = FLTILL;
-		}
+	case T_NOEXTFLT:
+		(void) die(type, rp, addr, cpuid);
 		break;
 
-	case T_EXTOVRFLT:	/* extension overrun fault */
-		/* check if we took a kernel trap on behalf of user */
-		{
-			extern  void ndptrap_frstor(void);
-			if (rp->r_pc != (uintptr_t)ndptrap_frstor) {
-				sti(); /* T_EXTOVRFLT comes in via cmninttrap */
-				(void) die(type, rp, addr, cpuid);
-			}
-			type |= USER;
-		}
-		/*FALLTHROUGH*/
-	case T_EXTOVRFLT + USER:	/* extension overrun fault */
-		if (tudebug && tudebugfpe)
-			showregs(type, rp, addr);
-		if (fpextovrflt(rp)) {
-			siginfo.si_signo = SIGSEGV;
-			siginfo.si_code  = SEGV_MAPERR;
-			siginfo.si_addr  = (caddr_t)rp->r_pc;
-			fault = FLTBOUNDS;
-		}
-		break;
-
+	/*
+	 * Kernel threads leveraging floating point need to mask the exceptions
+	 * or ensure that they cannot happen. There is no recovery from this.
+	 */
 	case T_EXTERRFLT:	/* x87 floating point exception pending */
-		/* check if we took a kernel trap on behalf of user */
-		{
-			extern  void ndptrap_frstor(void);
-			if (rp->r_pc != (uintptr_t)ndptrap_frstor) {
-				sti(); /* T_EXTERRFLT comes in via cmninttrap */
-				(void) die(type, rp, addr, cpuid);
-			}
-			type |= USER;
-		}
-		/*FALLTHROUGH*/
+		sti(); /* T_EXTERRFLT comes in via cmninttrap */
+		(void) die(type, rp, addr, cpuid);
+		break;
 
 	case T_EXTERRFLT + USER: /* x87 floating point exception pending */
 		if (tudebug && tudebugfpe)
@@ -1951,7 +1926,7 @@ kern_gpfault(struct regs *rp)
 	}
 
 #if defined(__amd64)
-	if (trp == NULL && lwp->lwp_pcb.pcb_rupdate != 0) {
+	if (trp == NULL && PCB_NEED_UPDATE_SEGS(&lwp->lwp_pcb)) {
 
 		/*
 		 * This is the common case -- we're trying to load

--- a/usr/src/uts/i86pc/sys/hma.h
+++ b/usr/src/uts/i86pc/sys/hma.h
@@ -1,0 +1,103 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2018, Joyent, Inc.
+ */
+
+#ifndef _SYS_HMA_H
+#define	_SYS_HMA_H
+
+/*
+ * Hypervisor Multiplexor API
+ *
+ * This provides a set of APIs that are usable by hypervisor implementations
+ * that allows them to coexist and to make sure that they are all in a
+ * consistent state.
+ */
+
+#include <sys/fp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * FPU related management. These functions provide a set of APIs to manage the
+ * FPU state and switch between host and guest management of this state.
+ */
+
+typedef struct hma_fpu hma_fpu_t;
+
+/*
+ * Allocate and free FPU state management structures.
+ */
+extern hma_fpu_t *hma_fpu_alloc(int);
+extern void hma_fpu_free(hma_fpu_t *);
+
+/*
+ * Resets the FPU to the standard x86 default state. This should be called after
+ * allocation and whenever the guest needs to logically reset the state (when
+ * the CPU is reset, etc.). If the system supports xsave, then the xbv state
+ * will be set to have the x87 and SSE portions as valid and the rest will be
+ * set to their initial states (regardless of whether or not they will be
+ * advertised in the host).
+ */
+extern int hma_fpu_init(hma_fpu_t *);
+
+/*
+ * Save the current host's FPU state and restore the guest's state in the FPU.
+ * At this point, CR0.TS will not be set. The caller must not use the FPU in any
+ * way before entering the guest.
+ *
+ * This should be used in normal operation before entering the guest. It should
+ * also be used in a thread context operation when the thread is being scheduled
+ * again. This interface has an implicit assumption that a given guest state
+ * will be mapped to only one specific OS thread at any given time.
+ *
+ * This must be called with preemption disabled.
+ */
+extern void hma_fpu_start_guest(hma_fpu_t *);
+
+/*
+ * Save the current guest's FPU state and restore the host's state in the FPU.
+ * By the time the thread returns to userland, the FPU will be in a usable
+ * state; however, the FPU will not be usable while inside the kernel (CR0.TS
+ * will be set).
+ *
+ * This should be used in normal operation after leaving the guest and returning
+ * to user land. It should also be used in a thread context operation when the
+ * thread is being descheduled. Like the hma_fpu_start_guest() interface, this
+ * interface has an implicit assumption that a given guest state will be mapped
+ * to only a single OS thread at any given time.
+ *
+ * This must be called with preemption disabled.
+ */
+extern void hma_fpu_stop_guest(hma_fpu_t *);
+
+/*
+ * Get and set the contents of the FPU save area. This sets the fxsave style
+ * information. In all cases when this is in use, if an XSAVE state is actually
+ * used by the host, then this will end up zeroing all of the non-fxsave state
+ * and it will reset the xbv to indicate that the legacy x87 and SSE portions
+ * are valid.
+ *
+ * These functions cannot be called while the FPU is in use by the guest. It is
+ * up to callers to guarantee this fact.
+ */
+extern void hma_fpu_get_fxsave_state(const hma_fpu_t *, struct fxsave_state *);
+extern int hma_fpu_set_fxsave_state(hma_fpu_t *, const struct fxsave_state *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_HMA_H */

--- a/usr/src/uts/i86pc/sys/vmm.h
+++ b/usr/src/uts/i86pc/sys/vmm.h
@@ -343,6 +343,9 @@ enum vcpu_state {
 int vcpu_set_state(struct vm *vm, int vcpu, enum vcpu_state state,
     bool from_idle);
 enum vcpu_state vcpu_get_state(struct vm *vm, int vcpu, int *hostcpu);
+#ifndef __FreeBSD__
+uint64_t vcpu_tsc_offset(struct vm *vm, int vcpuid);
+#endif
 
 static __inline int
 vcpu_is_running(struct vm *vm, int vcpu, int *hostcpu)

--- a/usr/src/uts/intel/brand/lx/lx_archdep.c
+++ b/usr/src/uts/intel/brand/lx/lx_archdep.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -391,7 +391,7 @@ lx_get_user_regs32(lx_lwp_data_t *lwpd, lx_user_regs32_t *lxrp)
 	lxrp->lxur_xss = (int32_t)rp->r_ss;
 
 	kpreempt_disable();
-	if (pcb->pcb_rupdate == 1) {
+	if (PCB_NEED_UPDATE_SEGS(pcb)) {
 		lxrp->lxur_xds = pcb->pcb_ds;
 		lxrp->lxur_xes = pcb->pcb_es;
 		lxrp->lxur_xfs = pcb->pcb_fs;
@@ -523,7 +523,7 @@ lx_set_user_regs32(lx_lwp_data_t *lwpd, lx_user_regs32_t *lxrp)
 	    DATAMODEL_ILP32);
 
 	kpreempt_disable();
-	pcb->pcb_rupdate = 1;
+	PCB_SET_UPDATE_SEGS(pcb);
 	pcb->pcb_ds = fix_segreg(lxrp->lxur_xds, IS_NOT_CS, DATAMODEL_ILP32);
 	pcb->pcb_es = fix_segreg(lxrp->lxur_xes, IS_NOT_CS, DATAMODEL_ILP32);
 	pcb->pcb_fs = fix_segreg(lxrp->lxur_xfs, IS_NOT_CS, DATAMODEL_ILP32);
@@ -738,7 +738,7 @@ lx_get_user_regs64(lx_lwp_data_t *lwpd, lx_user_regs64_t *lxrp)
 	}
 
 	kpreempt_disable();
-	if (pcb->pcb_rupdate == 1) {
+	if (PCB_NEED_UPDATE_SEGS(pcb)) {
 		lxrp->lxur_xds = pcb->pcb_ds;
 		lxrp->lxur_xes = pcb->pcb_es;
 		lxrp->lxur_xfs = pcb->pcb_fs;
@@ -915,7 +915,7 @@ lx_set_user_regs64(lx_lwp_data_t *lwpd, lx_user_regs64_t *lxrp)
 	pcb->pcb_gsbase = lxrp->lxur_xgs_base;
 
 	kpreempt_disable();
-	pcb->pcb_rupdate = 1;
+	PCB_SET_UPDATE_SEGS(pcb);
 	pcb->pcb_ds = fix_segreg(lxrp->lxur_xds, IS_NOT_CS, DATAMODEL_LP64);
 	pcb->pcb_es = fix_segreg(lxrp->lxur_xes, IS_NOT_CS, DATAMODEL_LP64);
 	pcb->pcb_fs = fix_segreg(lxrp->lxur_xfs, IS_NOT_CS, DATAMODEL_LP64);
@@ -1271,7 +1271,7 @@ lx_switch_to_native(klwp_t *lwp)
 		 * is loaded:
 		 */
 		kpreempt_disable();
-		if (pcb->pcb_rupdate == 1) {
+		if (PCB_NEED_UPDATE_SEGS(pcb)) {
 			/*
 			 * If we are already flushing the segment registers,
 			 * then ensure we are flushing the native %gs.
@@ -1290,7 +1290,7 @@ lx_switch_to_native(klwp_t *lwp)
 				/*
 				 * Ensure we go out via update_sregs.
 				 */
-				pcb->pcb_rupdate = 1;
+				PCB_SET_UPDATE_SEGS(pcb);
 			}
 		}
 		kpreempt_enable();
@@ -1314,7 +1314,7 @@ lx_switch_to_native(klwp_t *lwp)
 				/*
 				 * Ensure we go out via update_sregs.
 				 */
-				pcb->pcb_rupdate = 1;
+				PCB_SET_UPDATE_SEGS(pcb);
 			}
 			kpreempt_enable();
 		}
@@ -1331,7 +1331,7 @@ lx_switch_to_native(klwp_t *lwp)
 				/*
 				 * Ensure we go out via update_sregs.
 				 */
-				pcb->pcb_rupdate = 1;
+				PCB_SET_UPDATE_SEGS(pcb);
 			}
 			kpreempt_enable();
 		}

--- a/usr/src/uts/intel/ia32/ml/float.s
+++ b/usr/src/uts/intel/ia32/ml/float.s
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /*      Copyright (c) 1990, 1991 UNIX System Laboratories, Inc. */
@@ -79,191 +79,12 @@ fxsave_insn(struct fxsave_state *fx)
 
 #else	/* __lint */
 
-#if defined(__amd64)
-
 	ENTRY_NP(fxsave_insn)
 	fxsaveq (%rdi)
 	ret
 	SET_SIZE(fxsave_insn)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fxsave_insn)
-	movl	4(%esp), %eax
-	fxsave	(%eax)
-	ret
-	SET_SIZE(fxsave_insn)
-
-#endif
-
 #endif	/* __lint */
-
-#if defined(__i386)
-
-/*
- * If (num1/num2 > num1/num3) the FPU has the FDIV bug.
- */
-
-#if defined(__lint)
-
-int
-fpu_probe_pentium_fdivbug(void)
-{ return (0); }
-
-#else	/* __lint */
-
-	ENTRY_NP(fpu_probe_pentium_fdivbug)
-	fldl	.num1
-	fldl	.num2
-	fdivr	%st(1), %st
-	fxch	%st(1)
-	fdivl	.num3
-	fcompp
-	fstsw	%ax
-	sahf
-	jae	0f
-	movl	$1, %eax
-	ret
-
-0:	xorl	%eax, %eax
-	ret
-
-	.align	4
-.num1:	.4byte	0xbce4217d	/* 4.999999 */
-	.4byte	0x4013ffff
-.num2:	.4byte	0x0		/* 15.0 */
-	.4byte	0x402e0000
-.num3:	.4byte	0xde7210bf	/* 14.999999 */
-	.4byte	0x402dffff
-	SET_SIZE(fpu_probe_pentium_fdivbug)
-
-#endif	/* __lint */
-
-/*
- * To cope with processors that do not implement fxsave/fxrstor
- * instructions, patch hot paths in the kernel to use them only
- * when that feature has been detected.
- */
-
-#if defined(__lint)
-
-void
-patch_sse(void)
-{}
-
-void
-patch_sse2(void)
-{}
-
-void
-patch_xsave(void)
-{}
-
-#else	/* __lint */
-
-	ENTRY_NP(patch_sse)
-	_HOT_PATCH_PROLOG
-	/
-	/	frstor (%ebx); nop	-> fxrstor (%ebx)
-	/
-	_HOT_PATCH(_fxrstor_ebx_insn, _patch_fxrstor_ebx, 3)
-	/
-	/	lock; xorl $0, (%esp)	-> sfence; ret
-	/
-	_HOT_PATCH(_sfence_ret_insn, _patch_sfence_ret, 4)
-	_HOT_PATCH_EPILOG
-	ret
-_fxrstor_ebx_insn:			/ see ndptrap_frstor()
-	fxrstor	(%ebx)
-_ldmxcsr_ebx_insn:			/ see resume_from_zombie()
-	ldmxcsr	(%ebx)
-_sfence_ret_insn:			/ see membar_producer()
-	sfence
-	ret
-	SET_SIZE(patch_sse)
-
-	ENTRY_NP(patch_sse2)
-	_HOT_PATCH_PROLOG
-	/
-	/	lock; xorl $0, (%esp)	-> lfence; ret
-	/
-	_HOT_PATCH(_lfence_ret_insn, _patch_lfence_ret, 4)
-	_HOT_PATCH_EPILOG
-	ret
-_lfence_ret_insn:			/ see membar_consumer()
-	lfence
-	ret
-	SET_SIZE(patch_sse2)
-
-	/*
-	 * Patch lazy fp restore instructions in the trap handler
-	 * to use xrstor instead of frstor
-	 */
-	ENTRY_NP(patch_xsave)
-	_HOT_PATCH_PROLOG
-	/
-	/	frstor (%ebx); nop	-> xrstor (%ebx)
-	/
-	_HOT_PATCH(_xrstor_ebx_insn, _patch_xrstor_ebx, 3)
-	_HOT_PATCH_EPILOG
-	ret
-_xrstor_ebx_insn:			/ see ndptrap_frstor()
-	xrstor (%ebx)
-	SET_SIZE(patch_xsave)
-
-#endif	/* __lint */
-#endif	/* __i386 */
-
-#if defined(__amd64)
-#if defined(__lint)
-
-void
-patch_xsave(void)
-{}
-
-#else	/* __lint */
-
-	/*
-	 * Patch lazy fp restore instructions in the trap handler
-	 * to use xrstor instead of fxrstorq
-	 */
-	ENTRY_NP(patch_xsave)
-	pushq	%rbx
-	pushq	%rbp
-	pushq	%r15
-	/
-	/	fxrstorq (%rbx);	-> nop; xrstor (%rbx)
-	/ loop doing the following for 4 bytes:
-	/     hot_patch_kernel_text(_patch_xrstorq_rbx, _xrstor_rbx_insn, 1)
-	/
-	leaq	_patch_xrstorq_rbx(%rip), %rbx
-	leaq	_xrstor_rbx_insn(%rip), %rbp
-	movq	$4, %r15
-1:
-	movq	%rbx, %rdi			/* patch address */
-	movzbq	(%rbp), %rsi			/* instruction byte */
-	movq	$1, %rdx			/* count */
-	call	hot_patch_kernel_text
-	addq	$1, %rbx
-	addq	$1, %rbp
-	subq	$1, %r15
-	jnz	1b
-
-	popq	%r15
-	popq	%rbp
-	popq	%rbx
-	ret
-
-_xrstor_rbx_insn:			/ see ndptrap_frstor()
-	# Because the fxrstorq instruction we're patching is 4 bytes long, due
-	# to the 0x48 prefix (indicating 64-bit operand size), we patch 4 bytes
-	# too.
-	nop
-	xrstor (%rbx)
-	SET_SIZE(patch_xsave)
-
-#endif	/* __lint */
-#endif	/* __amd64 */
 
 /*
  * One of these routines is called from any lwp with floating
@@ -287,14 +108,7 @@ void
 fpxsave_ctxt(void *arg)
 {}
 
-/*ARGSUSED*/
-void
-fpnsave_ctxt(void *arg)
-{}
-
 #else	/* __lint */
-
-#if defined(__amd64)
 
 /*
  * These three functions define the Intel "xsave" handling for CPUs with
@@ -305,7 +119,7 @@ fpnsave_ctxt(void *arg)
 	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%rdi)
 	jne	1f
 	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%rdi)
-	movq	FPU_CTX_FPU_REGS(%rdi), %rdi /* fpu_regs.kfpu_u.kfpu_fn ptr */
+	movq	FPU_CTX_FPU_REGS(%rdi), %rdi /* fpu_regs.kfpu_u.kfpu_fx ptr */
 	fxsaveq	(%rdi)
 	STTS(%rsi)	/* trap on next fpu touch */
 1:	rep;	ret	/* use 2 byte return instruction when branch target */
@@ -352,7 +166,7 @@ fpnsave_ctxt(void *arg)
 	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%rdi)
 	jne	1f
 	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%rdi)
-	movq	FPU_CTX_FPU_REGS(%rdi), %rdi /* fpu_regs.kfpu_u.kfpu_fn ptr */
+	movq	FPU_CTX_FPU_REGS(%rdi), %rdi /* fpu_regs.kfpu_u.kfpu_fx ptr */
 	fxsaveq	(%rdi)
 	/*
 	 * To ensure that we don't leak these values into the next context
@@ -405,126 +219,6 @@ fpnsave_ctxt(void *arg)
 1:	ret
 	SET_SIZE(xsaveopt_excp_clr_ctxt)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fpnsave_ctxt)
-	movl	4(%esp), %eax		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%eax)
-	jne	1f
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%eax)
-	movl	FPU_CTX_FPU_REGS(%eax), %eax /* fpu_regs.kfpu_u.kfpu_fx ptr */
-	fnsave	(%eax)
-			/* (fnsave also reinitializes x87 state) */
-	STTS(%edx)	/* trap on next fpu touch */
-1:	rep;	ret	/* use 2 byte return instruction when branch target */
-			/* AMD Software Optimization Guide - Section 6.2 */
-	SET_SIZE(fpnsave_ctxt)
-
-	ENTRY_NP(fpxsave_ctxt)
-	movl	4(%esp), %eax		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%eax)
-	jne	1f
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%eax)
-	movl	FPU_CTX_FPU_REGS(%eax), %eax /* fpu_regs.kfpu_u.kfpu_fn ptr */
-	fxsave	(%eax)
-	STTS(%edx)	/* trap on next fpu touch */
-1:	rep;	ret	/* use 2 byte return instruction when branch target */
-			/* AMD Software Optimization Guide - Section 6.2 */
-	SET_SIZE(fpxsave_ctxt)
-
-	ENTRY_NP(xsave_ctxt)
-	movl	4(%esp), %ecx		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%ecx)
-	jne	1f
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%ecx)
-	movl	FPU_CTX_FPU_XSAVE_MASK(%ecx), %eax
-	movl	FPU_CTX_FPU_XSAVE_MASK+4(%ecx), %edx
-	movl	FPU_CTX_FPU_REGS(%ecx), %ecx /* fpu_regs.kfpu_u.kfpu_xs ptr */
-	xsave	(%ecx)
-	STTS(%edx)	/* trap on next fpu touch */
-1:	ret
-	SET_SIZE(xsave_ctxt)
-
-	ENTRY_NP(xsaveopt_ctxt)
-	movl	4(%esp), %ecx		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%ecx)
-	jne	1f
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%ecx)
-	movl	FPU_CTX_FPU_XSAVE_MASK(%ecx), %eax
-	movl	FPU_CTX_FPU_XSAVE_MASK+4(%ecx), %edx
-	movl	FPU_CTX_FPU_REGS(%ecx), %ecx /* fpu_regs.kfpu_u.kfpu_xs ptr */
-	xsaveopt (%ecx)
-	STTS(%edx)	/* trap on next fpu touch */
-1:	ret
-	SET_SIZE(xsaveopt_ctxt)
-
-/*
- * See comment above the __amd64 implementation of fpxsave_excp_clr_ctxt()
- * for details about the following threee functions for AMD "exception pointer"
- * handling.
- */
-
-	ENTRY_NP(fpxsave_excp_clr_ctxt)
-	movl	4(%esp), %eax		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%eax)
-	jne	1f
-
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%eax)
-	movl	FPU_CTX_FPU_REGS(%eax), %eax /* fpu_regs.kfpu_u.kfpu_fn ptr */
-	fxsave	(%eax)
-	btw	$7, FXSAVE_STATE_FSW(%eax)	/* Test saved ES bit */
-	jnc	0f				/* jump if ES = 0 */
-	fnclex		/* clear pending x87 exceptions */
-0:	ffree	%st(7)	/* clear tag bit to remove possible stack overflow */
-	fildl	.fpzero_const
-			/* dummy load changes all exception pointers */
-	STTS(%edx)	/* trap on next fpu touch */
-1:	rep;	ret	/* use 2 byte return instruction when branch target */
-			/* AMD Software Optimization Guide - Section 6.2 */
-	SET_SIZE(fpxsave_excp_clr_ctxt)
-
-	ENTRY_NP(xsave_excp_clr_ctxt)
-	movl	4(%esp), %ecx		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%ecx)
-	jne	1f
-
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%ecx)
-	movl	FPU_CTX_FPU_XSAVE_MASK(%ecx), %eax
-	movl	FPU_CTX_FPU_XSAVE_MASK+4(%ecx), %edx
-	movl	FPU_CTX_FPU_REGS(%ecx), %ecx /* fpu_regs.kfpu_u.kfpu_xs ptr */
-	xsave	(%ecx)
-	btw	$7, FXSAVE_STATE_FSW(%ecx)	/* Test saved ES bit */
-	jnc	0f				/* jump if ES = 0 */
-	fnclex		/* clear pending x87 exceptions */
-0:	ffree	%st(7)	/* clear tag bit to remove possible stack overflow */
-	fildl	.fpzero_const
-			/* dummy load changes all exception pointers */
-	STTS(%edx)	/* trap on next fpu touch */
-1:	ret
-	SET_SIZE(xsave_excp_clr_ctxt)
-
-	ENTRY_NP(xsaveopt_excp_clr_ctxt)
-	movl	4(%esp), %ecx		/* a struct fpu_ctx */
-	cmpl	$FPU_EN, FPU_CTX_FPU_FLAGS(%ecx)
-	jne	1f
-
-	movl	$_CONST(FPU_VALID|FPU_EN), FPU_CTX_FPU_FLAGS(%ecx)
-	movl	FPU_CTX_FPU_XSAVE_MASK(%ecx), %eax
-	movl	FPU_CTX_FPU_XSAVE_MASK+4(%ecx), %edx
-	movl	FPU_CTX_FPU_REGS(%ecx), %ecx /* fpu_regs.kfpu_u.kfpu_xs ptr */
-	xsaveopt (%ecx)
-	btw	$7, FXSAVE_STATE_FSW(%ecx)	/* Test saved ES bit */
-	jnc	0f				/* jump if ES = 0 */
-	fnclex		/* clear pending x87 exceptions */
-0:	ffree	%st(7)	/* clear tag bit to remove possible stack overflow */
-	fildl	.fpzero_const
-			/* dummy load changes all exception pointers */
-	STTS(%edx)	/* trap on next fpu touch */
-1:	ret
-	SET_SIZE(xsaveopt_excp_clr_ctxt)
-
-#endif	/* __i386 */
-
 	.align	8
 .fpzero_const:
 	.4byte	0x0
@@ -556,8 +250,6 @@ xsaveopt(struct xsave_state *f, uint64_t m)
 {}
 
 #else	/* __lint */
-
-#if defined(__amd64)
 
 	ENTRY_NP(fpxsave)
 	CLTS
@@ -591,58 +283,55 @@ xsaveopt(struct xsave_state *f, uint64_t m)
 	ret
 	SET_SIZE(xsaveopt)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fpsave)
-	CLTS
-	movl	4(%esp), %eax
-	fnsave	(%eax)
-	STTS(%eax)			/* set TS bit in %cr0 (disable FPU) */
-	ret
-	SET_SIZE(fpsave)
-
-	ENTRY_NP(fpxsave)
-	CLTS
-	movl	4(%esp), %eax
-	fxsave	(%eax)
-	fninit				/* clear exceptions, init x87 tags */
-	STTS(%eax)			/* set TS bit in %cr0 (disable FPU) */
-	ret
-	SET_SIZE(fpxsave)
-
-	ENTRY_NP(xsave)
-	CLTS
-	movl	4(%esp), %ecx
-	movl	8(%esp), %eax
-	movl	12(%esp), %edx
-	xsave	(%ecx)
-
-	fninit				/* clear exceptions, init x87 tags */
-	STTS(%eax)			/* set TS bit in %cr0 (disable FPU) */
-	ret
-	SET_SIZE(xsave)
-
-	ENTRY_NP(xsaveopt)
-	CLTS
-	movl	4(%esp), %ecx
-	movl	8(%esp), %eax
-	movl	12(%esp), %edx
-	xsaveopt (%ecx)
-
-	fninit				/* clear exceptions, init x87 tags */
-	STTS(%eax)			/* set TS bit in %cr0 (disable FPU) */
-	ret
-	SET_SIZE(xsaveopt)
-
-#endif	/* __i386 */
 #endif	/* __lint */
+
+/*
+ * These functions are used when restoring the FPU as part of the epilogue of a
+ * context switch.
+ */
 
 #if defined(__lint)
 
 /*ARGSUSED*/
 void
-fprestore(struct fnsave_state *f)
+fpxrestore_ctxt(void *arg)
 {}
+
+/*ARGSUSED*/
+void
+xrestore_ctxt(void *arg)
+{}
+
+#else	/* __lint */
+
+	ENTRY(fpxrestore_ctxt)
+	cmpl	$_CONST(FPU_EN|FPU_VALID), FPU_CTX_FPU_FLAGS(%rdi)
+	jne	1f
+	movl	$_CONST(FPU_EN), FPU_CTX_FPU_FLAGS(%rdi)
+	movq	FPU_CTX_FPU_REGS(%rdi), %rdi /* fpu_regs.kfpu_u.kfpu_fx ptr */
+	CLTS
+	fxrstorq	(%rdi)
+1:
+	ret
+	SET_SIZE(fpxrestore_ctxt)
+
+	ENTRY(xrestore_ctxt)
+	cmpl	$_CONST(FPU_EN|FPU_VALID), FPU_CTX_FPU_FLAGS(%rdi)
+	jne	1f
+	movl	$_CONST(FPU_EN), FPU_CTX_FPU_FLAGS(%rdi)
+	movl	FPU_CTX_FPU_XSAVE_MASK(%rdi), %eax /* xsave flags in EDX:EAX */
+	movl	FPU_CTX_FPU_XSAVE_MASK+4(%rdi), %edx
+	movq	FPU_CTX_FPU_REGS(%rdi), %rdi /* fpu_regs.kfpu_u.kfpu_xs ptr */
+	CLTS
+	xrstor	(%rdi)
+1:
+	ret
+	SET_SIZE(xrestore_ctxt)
+
+#endif	/* __lint */
+
+
+#if defined(__lint)
 
 /*ARGSUSED*/
 void
@@ -655,8 +344,6 @@ xrestore(struct xsave_state *f, uint64_t m)
 {}
 
 #else	/* __lint */
-
-#if defined(__amd64)
 
 	ENTRY_NP(fpxrestore)
 	CLTS
@@ -673,32 +360,6 @@ xrestore(struct xsave_state *f, uint64_t m)
 	ret
 	SET_SIZE(xrestore)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fprestore)
-	CLTS
-	movl	4(%esp), %eax
-	frstor	(%eax)
-	ret
-	SET_SIZE(fprestore)
-
-	ENTRY_NP(fpxrestore)
-	CLTS
-	movl	4(%esp), %eax
-	fxrstor	(%eax)
-	ret
-	SET_SIZE(fpxrestore)
-
-	ENTRY_NP(xrestore)
-	CLTS
-	movl	4(%esp), %ecx
-	movl	8(%esp), %eax
-	movl	12(%esp), %edx
-	xrstor	(%ecx)
-	ret
-	SET_SIZE(xrestore)
-
-#endif	/* __i386 */
 #endif	/* __lint */
 
 /*
@@ -713,21 +374,11 @@ fpdisable(void)
 
 #else	/* __lint */
 
-#if defined(__amd64)
-
 	ENTRY_NP(fpdisable)
 	STTS(%rdi)			/* set TS bit in %cr0 (disable FPU) */ 
 	ret
 	SET_SIZE(fpdisable)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fpdisable)
-	STTS(%eax)
-	ret
-	SET_SIZE(fpdisable)
-
-#endif	/* __i386 */
 #endif	/* __lint */
 
 /*
@@ -741,8 +392,6 @@ fpinit(void)
 {}
 
 #else	/* __lint */
-
-#if defined(__amd64)
 
 	ENTRY_NP(fpinit)
 	CLTS
@@ -765,38 +414,6 @@ fpinit(void)
 	ret
 	SET_SIZE(fpinit)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fpinit)
-	CLTS
-	cmpl	$FP_FXSAVE, fp_save_mech
-	je	1f
-	cmpl	$FP_XSAVE, fp_save_mech
-	je	2f
-
-	/* fnsave */
-	fninit
-	movl	$x87_initial, %eax
-	frstor	(%eax)			/* load clean initial state */
-	ret
-
-1:	/* fxsave */
-	movl	$sse_initial, %eax
-	fxrstor	(%eax)			/* load clean initial state */
-	ret
-
-2:	/* xsave */
-	movl	$avx_initial, %ecx
-	xorl	%edx, %edx
-	movl	$XFEATURE_AVX, %eax
-	bt	$X86FSET_AVX, x86_featureset
-	cmovael	%edx, %eax
-	orl	$(XFEATURE_LEGACY_FP | XFEATURE_SSE), %eax
-	xrstor (%ecx)
-	ret
-	SET_SIZE(fpinit)
-
-#endif	/* __i386 */
 #endif	/* __lint */
 
 /*
@@ -815,8 +432,6 @@ fpxerr_reset(void)
 { return (0); }
 
 #else	/* __lint */
-
-#if defined(__amd64)
 
 	ENTRY_NP(fperr_reset)
 	CLTS
@@ -839,28 +454,6 @@ fpxerr_reset(void)
 	ret
 	SET_SIZE(fpxerr_reset)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fperr_reset)
-	CLTS
-	xorl	%eax, %eax
-	fnstsw	%ax
-	fnclex
-	ret
-	SET_SIZE(fperr_reset)
-
-	ENTRY_NP(fpxerr_reset)
-	CLTS
-	subl	$4, %esp		/* make some temporary space */
-	stmxcsr	(%esp)
-	movl	(%esp), %eax
-	andl	$_BITNOT(SSE_MXCSR_EFLAGS), (%esp)
-	ldmxcsr	(%esp)			/* clear processor exceptions */
-	addl	$4, %esp
-	ret
-	SET_SIZE(fpxerr_reset)
-
-#endif	/* __i386 */
 #endif	/* __lint */
 
 #if defined(__lint)
@@ -872,8 +465,6 @@ fpgetcwsw(void)
 }
 
 #else   /* __lint */
-
-#if defined(__amd64)
 
 	ENTRY_NP(fpgetcwsw)
 	pushq	%rbp
@@ -887,19 +478,6 @@ fpgetcwsw(void)
 	ret
 	SET_SIZE(fpgetcwsw)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fpgetcwsw)
-	CLTS
-	subl	$4, %esp		/* make some temporary space	*/
-	fnstsw	(%esp)			/* store the status word	*/
-	fnstcw	2(%esp)			/* store the control word	*/
-	movl	(%esp), %eax		/* put both in %eax		*/
-	addl	$4, %esp
-	ret
-	SET_SIZE(fpgetcwsw)
-
-#endif	/* __i386 */
 #endif  /* __lint */
 
 /*
@@ -916,8 +494,6 @@ fpgetmxcsr(void)
 
 #else   /* __lint */
 
-#if defined(__amd64)
-
 	ENTRY_NP(fpgetmxcsr)
 	pushq	%rbp
 	movq	%rsp, %rbp
@@ -929,16 +505,4 @@ fpgetmxcsr(void)
 	ret
 	SET_SIZE(fpgetmxcsr)
 
-#elif defined(__i386)
-
-	ENTRY_NP(fpgetmxcsr)
-	CLTS
-	subl	$4, %esp		/* make some temporary space */
-	stmxcsr	(%esp)
-	movl	(%esp), %eax
-	addl	$4, %esp
-	ret
-	SET_SIZE(fpgetmxcsr)
-
-#endif	/* __i386 */
 #endif  /* __lint */

--- a/usr/src/uts/intel/ia32/os/archdep.c
+++ b/usr/src/uts/intel/ia32/os/archdep.c
@@ -25,7 +25,7 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  * Copyright 2012 Nexenta Systems, Inc.  All rights reserved.
  */
 
@@ -67,9 +67,6 @@
 #include <sys/brand.h>
 #include <sys/machbrand.h>
 #include <sys/cmn_err.h>
-
-extern const struct fnsave_state x87_initial;
-extern const struct fxsave_state sse_initial;
 
 /*
  * Map an fnsave-formatted save area into an fxsave-formatted save area.

--- a/usr/src/uts/intel/ia32/os/archdep.c
+++ b/usr/src/uts/intel/ia32/os/archdep.c
@@ -317,6 +317,7 @@ setfpregs(klwp_t *lwp, fpregset_t *fp)
 
 	fpu->fpu_regs.kfpu_status = fp->fp_reg_set.fpchip_state.status;
 	fpu->fpu_flags |= FPU_VALID;
+	PCB_SET_UPDATE_FPU(&lwp->lwp_pcb);
 }
 
 /*
@@ -464,7 +465,7 @@ getgregs(klwp_t *lwp, gregset_t grp)
 	grp[REG_GSBASE] = pcb->pcb_gsbase;
 	if (thisthread)
 		kpreempt_disable();
-	if (pcb->pcb_rupdate == 1) {
+	if (PCB_NEED_UPDATE_SEGS(pcb)) {
 		grp[REG_DS] = pcb->pcb_ds;
 		grp[REG_ES] = pcb->pcb_es;
 		grp[REG_FS] = pcb->pcb_fs;
@@ -500,7 +501,7 @@ getgregs32(klwp_t *lwp, gregset32_t grp)
 
 	if (thisthread)
 		kpreempt_disable();
-	if (pcb->pcb_rupdate == 1) {
+	if (PCB_NEED_UPDATE_SEGS(pcb)) {
 		grp[GS] = (uint16_t)pcb->pcb_gs;
 		grp[FS] = (uint16_t)pcb->pcb_fs;
 		grp[DS] = (uint16_t)pcb->pcb_ds;
@@ -775,7 +776,7 @@ setgregs(klwp_t *lwp, gregset_t grp)
 		/*
 		 * Ensure that we go out via update_sregs
 		 */
-		pcb->pcb_rupdate = 1;
+		PCB_SET_UPDATE_SEGS(pcb);
 		lwptot(lwp)->t_post_sys = 1;
 		if (thisthread)
 			kpreempt_enable();
@@ -812,7 +813,7 @@ setgregs(klwp_t *lwp, gregset_t grp)
 		/*
 		 * Ensure that we go out via update_sregs
 		 */
-		pcb->pcb_rupdate = 1;
+		PCB_SET_UPDATE_SEGS(pcb);
 		lwptot(lwp)->t_post_sys = 1;
 		if (thisthread)
 			kpreempt_enable();

--- a/usr/src/uts/intel/ia32/os/fpu.c
+++ b/usr/src/uts/intel/ia32/os/fpu.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /*	Copyright (c) 1990, 1991 UNIX System Laboratories, Inc. */
@@ -237,7 +237,7 @@ fp_new_lwp(kthread_id_t t, kthread_id_t ct)
 		cfx->fx_mxcsr = fx->fx_mxcsr & ~SSE_MXCSR_EFLAGS;
 		cfx->fx_fcw = fx->fx_fcw;
 		cxs->xs_xstate_bv |= (get_xcr(XFEATURE_ENABLED_MASK) &
-		    XFEATURE_FP_ALL);
+		    XFEATURE_FP_INITIAL);
 		break;
 	default:
 		panic("Invalid fp_save_mech");
@@ -383,8 +383,7 @@ fp_seed(void)
 	 * Always initialize a new context and initialize the hardware.
 	 */
 	if (fp_save_mech == FP_XSAVE) {
-		fp->fpu_xsave_mask = get_xcr(XFEATURE_ENABLED_MASK) &
-		    XFEATURE_FP_ALL;
+		fp->fpu_xsave_mask = XFEATURE_FP_ALL;
 	}
 
 	installctx(curthread, fp,

--- a/usr/src/uts/intel/ia32/os/fpu.c
+++ b/usr/src/uts/intel/ia32/os/fpu.c
@@ -61,10 +61,387 @@
 #include <sys/sysmacros.h>
 #include <sys/cmn_err.h>
 
+/*
+ * FPU Management Overview
+ * -----------------------
+ *
+ * The x86 FPU has evolved substantially since its days as the x87 coprocessor;
+ * however, many aspects of its life as a coprocessor still still around in x86.
+ *
+ * Today, when we refer to the 'FPU', we don't just mean the original x87 FPU.
+ * While that state still exists, there is much more that is covered by the FPU.
+ * Today, this includes not just traditional FPU state, but also supervisor only
+ * state. The following state is currently managed and covered logically by the
+ * idea of the FPU registers:
+ *
+ *    o Traditional x87 FPU
+ *    o Vector Registers (%xmm, %ymm, %zmm)
+ *    o Memory Protection Extensions (MPX) Bounds Registers
+ *    o Protected Key Rights Registers (PKRU)
+ *    o Processor Trace data
+ *
+ * The rest of this covers how the FPU is managed and controlled, how state is
+ * saved and restored between threads, interactions with hypervisors, and other
+ * information exported to user land through aux vectors. A lot of background
+ * information is here to synthesize major parts of the Intel SDM, but
+ * unfortunately, it is not a replacement for reading it.
+ *
+ * FPU Control Registers
+ * ---------------------
+ *
+ * Because the x87 FPU began its life as a co-processor and the FPU was
+ * optional there are several bits that show up in %cr0 that we have to
+ * manipulate when dealing with the FPU. These are:
+ *
+ *   o CR0.ET	The 'extension type' bit. This was used originally to indicate
+ *   		that the FPU co-processor was present. Now it is forced on for
+ *   		compatibility. This is often used to verify whether or not the
+ *   		FPU is present.
+ *
+ *   o CR0.NE	The 'native error' bit. Used to indicate that native error
+ *		mode should be enabled. This indicates that we should take traps
+ *		on FPU errors. The OS enables this early in boot.
+ *
+ *   o CR0.MP	The 'Monitor Coprocessor' bit. Used to control whether or not
+ *   		wait/fwait instructions generate a #NM if CR0.TS is set.
+ *
+ *   o CR0.EM	The 'Emulation' bit. This is used to cause floating point
+ *		operations (x87 through SSE4) to trap with a #UD so they can be
+ *		emulated. The system never sets this bit, but makes sure it is
+ *		clear on processor start up.
+ *
+ *   o CR0.TS	The 'Task Switched' bit. When this is turned on, a floating
+ *		point operation will generate a #NM. An fwait will as well,
+ *		depending on the value in CR0.MP.
+ *
+ * Our general policy is that CR0.ET, CR0.NE, and CR0.MP are always set by
+ * the system. Similarly CR0.EM is always unset by the system. CR0.TS has a more
+ * complicated role. Historically it has been used to allow running systems to
+ * restore the FPU registers lazily. This will be discussed in greater depth
+ * later on.
+ *
+ * %cr4 is also used as part of the FPU control. Specifically we need to worry
+ * about the following bits in the system:
+ *
+ *   o CR4.OSFXSR	This bit is used to indicate that the OS understands and
+ *			supports the execution of the fxsave and fxrstor
+ *			instructions. This bit is required to be set to enable
+ *			the use of the SSE->SSE4 instructions.
+ *
+ *   o CR4.OSXMMEXCPT	This bit is used to indicate that the OS can understand
+ *			and take a SIMD floating point exception (#XM). This bit
+ *			is always enabled by the system.
+ *
+ *   o CR4.OSXSAVE	This bit is used to indicate that the OS understands and
+ *			supports the execution of the xsave and xrstor family of
+ *			instructions. This bit is required to use any of the AVX
+ *			and newer feature sets.
+ *
+ * Because all supported processors are 64-bit, they'll always support the XMM
+ * extensions and we will enable both CR4.OXFXSR and CR4.OSXMMEXCPT in boot.
+ * CR4.OSXSAVE will be enabled and used whenever xsave is reported in cpuid.
+ *
+ * %xcr0 is used to manage the behavior of the xsave feature set and is only
+ * present on the system if xsave is supported. %xcr0 is read and written to
+ * through by the xgetbv and xsetbv instructions. This register is present
+ * whenever the xsave feature set is supported. Each bit in %xcr0 refers to a
+ * different component of the xsave state and controls whether or not that
+ * information is saved and restored. For newer feature sets like AVX and MPX,
+ * it also controls whether or not the corresponding instructions can be
+ * executed (much like CR0.OSFXSR does for the SSE feature sets).
+ *
+ * Everything in %xcr0 is around features available to users. There is also the
+ * IA32_XSS MSR which is used to control supervisor-only features that are still
+ * part of the xsave state. Bits that can be set in %xcr0 are reserved in
+ * IA32_XSS and vice versa. This is an important property that is particularly
+ * relevant to how the xsave instructions operate.
+ *
+ * Save Mechanisms
+ * ---------------
+ *
+ * When switching between running threads the FPU state needs to be saved and
+ * restored by the OS. If this state was not saved, users would rightfully
+ * complain about corrupt state. There are three mechanisms that exist on the
+ * processor for saving and restoring these state images:
+ *
+ *   o fsave
+ *   o fxsave
+ *   o xsave
+ *
+ * fsave saves and restores only the x87 FPU and is the oldest of these
+ * mechanisms. This mechanism is never used in the kernel today because we are
+ * always running on systems that support fxsave.
+ *
+ * The fxsave and fxrstor mechanism allows the x87 FPU and the SSE register
+ * state to be saved and restored to and from a struct fxsave_state. This is the
+ * default mechanism that is used to save and restore the FPU on amd64. An
+ * important aspect of fxsave that was different from the original i386 fsave
+ * mechanism is that the restoring of FPU state with pending exceptions will not
+ * generate an exception, it will be deferred to the next use of the FPU.
+ *
+ * The final and by far the most complex mechanism is that of the xsave set.
+ * xsave allows for saving and restoring all of the traditional x86 pieces (x87
+ * and SSE), while allowing for extensions that will save the %ymm, %zmm, etc.
+ * registers.
+ *
+ * Data is saved and restored into and out of a struct xsave_state. The first
+ * part of the struct xsave_state is equivalent to the struct fxsave_state.
+ * After that, there is a header which is used to describe the remaining
+ * portions of the state. The header is a 64-byte value of which the first two
+ * uint64_t values are defined and the rest are reserved and must be zero. The
+ * first uint64_t is the xstate_bv member. This describes which values in the
+ * xsave_state are actually valid and present. This is updated on a save and
+ * used on restore. The second member is the xcomp_bv member. Its last bit
+ * determines whether or not a compressed version of the structure is used.
+ *
+ * When the uncompressed structure is used (currently the only format we
+ * support), then each state component is at a fixed offset in the structure,
+ * even if it is not being used. For example, if you only saved the AVX related
+ * state, but did not save the MPX related state, the offset would not change
+ * for any component. With the compressed format, components that aren't used
+ * are all elided (though the x87 and SSE state are always there).
+ *
+ * Unlike fxsave which saves all state, the xsave family does not always save
+ * and restore all the state that could be covered by the xsave_state. The
+ * instructions all take an argument which is a mask of what to consider. This
+ * is the same mask that will be used in the xstate_bv vector and it is also the
+ * same values that are present in %xcr0 and IA32_XSS. Though IA32_XSS is only
+ * considered with the xsaves and xrstors instructions.
+ *
+ * When a save or restore is requested, a bitwise and is performed between the
+ * requested bits and those that have been enabled in %xcr0. Only the bits that
+ * match that are then saved or restored. Others will be silently ignored by
+ * the processor. This idea is used often in the OS. We will always request that
+ * we save and restore all of the state, but only those portions that are
+ * actually enabled in %xcr0 will be touched.
+ *
+ * If a feature has been asked to be restored that is not set in the xstate_bv
+ * feature vector of the save state, then it will be set to its initial state by
+ * the processor (usually zeros). Also, when asked to save state, the processor
+ * may not write out data that is in its initial state as an optimization. This
+ * optimization only applies to saving data and not to restoring data.
+ *
+ * There are a few different variants of the xsave and xrstor instruction. They
+ * are:
+ *
+ *   o xsave	This is the original save instruction. It will save all of the
+ *		requested data in the xsave state structure. It only saves data
+ *		in the uncompressed (xcomp_bv[63] is zero) format. It may be
+ *		executed at all privilege levels.
+ *
+ *   o xrstor	This is the original restore instruction. It will restore all of
+ *		the requested data. The xrstor function can handle both the
+ *		compressed and uncompressed formats. It may be executed at all
+ *		privilege levels.
+ *
+ *   o xsaveopt	This is a variant of the xsave instruction that employs
+ *		optimizations to try and only write out state that has been
+ *		modified since the last time an xrstor instruction was called.
+ *		The processor tracks a tuple of information about the last
+ *		xrstor and tries to ensure that the same buffer is being used
+ *		when this optimization is being used. However, because of the
+ *		way that it tracks the xrstor buffer based on the address of it,
+ *		it is not suitable for use if that buffer can be easily reused.
+ *		The most common case is trying to save data to the stack in
+ *		rtld. It may be executed at all privilege levels.
+ *
+ *   o xsavec	This is a variant of the xsave instruction that writes out the
+ *		compressed form of the xsave_state. Otherwise it behaves as
+ *		xsave. It may be executed at all privilege levels.
+ *
+ *   o xsaves	This is a variant of the xsave instruction. It is similar to
+ *		xsavec in that it always writes the compressed form of the
+ *		buffer. Unlike all the other forms, this instruction looks at
+ *		both the user (%xcr0) and supervisor (IA32_XSS MSR) to determine
+ *		what to save and restore. xsaves also implements the same
+ *		optimization that xsaveopt does around modified pieces. User
+ *		land may not execute the instruction.
+ *
+ *   o xrstors	This is a variant of the xrstor instruction. Similar to xsaves
+ *		it can save and restore both the user and privileged states.
+ *		Unlike xrstor it can only operate on the compressed form.
+ *		User land may not execute the instruction.
+ *
+ * Based on all of these, the kernel has a precedence for what it will use.
+ * Basically, xsaves (not supported) is preferred to xsaveopt, which is
+ * preferred to xsave. A similar scheme is used when informing rtld (more later)
+ * about what it should use. xsavec is preferred to xsave. xsaveopt is not
+ * recommended due to the modified optimization not being appropriate for this
+ * use.
+ *
+ * Finally, there is one last gotcha with the xsave state. Importantly some AMD
+ * processors did not always save and restore some of the FPU exception state in
+ * some cases like Intel did. In those cases the OS will make up for this fact
+ * itself.
+ *
+ * FPU Initialization
+ * ------------------
+ *
+ * One difference with the FPU registers is that not all threads have FPU state,
+ * only those that have an lwp. Generally this means kernel threads, which all
+ * share p0 and its lwp, do not have FPU state. Though there are definitely
+ * exceptions such as kcfpoold. In the rest of this discussion we'll use thread
+ * and lwp interchangeably, just think of thread meaning a thread that has a
+ * lwp.
+ *
+ * Each lwp has its FPU state allocated in its pcb (process control block). The
+ * actual storage comes from the fpsave_cachep kmem cache. This cache is sized
+ * dynamically at start up based on the save mechanism that we're using and the
+ * amount of memory required for it. This is dynamic because the xsave_state
+ * size varies based on the supported feature set.
+ *
+ * The hardware side of the FPU is initialized early in boot before we mount the
+ * root file system. This is effectively done in fpu_probe(). This is where we
+ * make the final decision about what the save and restore mechanisms we should
+ * use are, create the fpsave_cachep kmem cache, and initialize a number of
+ * function pointers that use save and restoring logic.
+ *
+ * The thread/lwp side is a a little more involved. There are two different
+ * things that we need to concern ourselves with. The first is how the FPU
+ * resources are allocated and the second is how the FPU state is initialized
+ * for a given lwp.
+ *
+ * We allocate the FPU save state from our kmem cache as part of lwp_fp_init().
+ * This is always called unconditionally by the system as part of creating an
+ * LWP.
+ *
+ * There are three different initialization paths that we deal with. The first
+ * is when we are executing a new process. As part of exec all of the register
+ * state is reset. The exec case is particularly important because init is born
+ * like Athena, sprouting from the head of the kernel, without any true parent
+ * to fork from. The second is used whenever we fork or create a new lwp.  The
+ * third is to deal with special lwps like the agent lwp.
+ *
+ * During exec, we will call fp_exec() which will initialize and set up the FPU
+ * state for the process. That will fill in the initial state for the FPU and
+ * also set that state in the FPU itself. As part of fp_exec() we also install a
+ * thread context operations vector that takes care of dealing with the saving
+ * and restoring of the FPU. These context handlers will also be called whenever
+ * an lwp is created or forked. In those cases, to initialize the FPU we will
+ * call fp_new_lwp(). Like fp_exec(), fp_new_lwp() will install a context
+ * operations vector for the new thread.
+ *
+ * Next we'll end up in the context operation fp_new_lwp(). This saves the
+ * current thread's state, initializes the new thread's state, and copies over
+ * the relevant parts of the originating thread's state. It's as this point that
+ * we also install the FPU context operations into the new thread, which ensures
+ * that all future threads that are descendants of the current one get the
+ * thread context operations (unless they call exec).
+ *
+ * To deal with some things like the agent lwp, we double check the state of the
+ * FPU in sys_rtt_common() to make sure that it has been enabled before
+ * returning to user land. In general, this path should be rare, but it's useful
+ * for the odd lwp here and there.
+ *
+ * The FPU state will remain valid most of the time. There are times that
+ * the state will be rewritten. For example in restorecontext, due to /proc, or
+ * the lwp calls exec(). Whether the context is being freed or we are resetting
+ * the state, we will call fp_free() to disable the FPU and our context.
+ *
+ * Finally, when the lwp is destroyed, it will actually destroy and free the FPU
+ * state by calling fp_lwp_cleanup().
+ *
+ * Kernel FPU Multiplexing
+ * -----------------------
+ *
+ * Just as the kernel has to maintain all of the general purpose registers when
+ * switching between scheduled threads, the same is true of the FPU registers.
+ *
+ * When a thread has FPU state, it also has a set of context operations
+ * installed. These context operations take care of making sure that the FPU is
+ * properly saved and restored during a context switch (fpsave_ctxt and
+ * fprestore_ctxt respectively). This means that the current implementation of
+ * the FPU is 'eager', when a thread is running the CPU will have its FPU state
+ * loaded. While this is always true when executing in userland, there are a few
+ * cases where this is not true in the kernel.
+ *
+ * This was not always the case. Traditionally on x86 a 'lazy' FPU restore was
+ * employed. This meant that the FPU would be saved on a context switch and the
+ * CR0.TS bit would be set. When a thread next tried to use the FPU, it would
+ * then take a #NM trap, at which point we would restore the FPU from the save
+ * area and return to user land. Given the frequency of use of the FPU alone by
+ * libc, there's no point returning to user land just to trap again.
+ *
+ * There are a few cases though where the FPU state may need to be changed for a
+ * thread on its behalf. The most notable cases are in the case of processes
+ * using /proc, restorecontext, forking, etc. In all of these cases the kernel
+ * will force a threads FPU state to be saved into the PCB through the fp_save()
+ * function. Whenever the FPU is saved, then the FPU_VALID flag is set on the
+ * pcb. This indicates that the save state holds currently valid data. As a side
+ * effect of this, CR0.TS will be set. To make sure that all of the state is
+ * updated before returning to user land, in these cases, we set a flag on the
+ * PCB that says the FPU needs to be updated. This will make sure that we take
+ * the slow path out of a system call to fix things up for the thread. Due to
+ * the fact that this is a rather rare case, effectively setting the equivalent
+ * of t_postsys is acceptable.
+ *
+ * CR0.TS will be set after a save occurs and cleared when a restore occurs.
+ * Generally this means it will be cleared immediately by the new thread that is
+ * running in a context switch. However, this isn't the case for kernel threads.
+ * They currently operate with CR0.TS set as no kernel state is restored for
+ * them. This means that using the FPU will cause a #NM and panic.
+ *
+ * The FPU_VALID flag on the currently executing thread's pcb is meant to track
+ * what the value of CR0.TS should be. If it is set, then CR0.TS will be set.
+ * However, because we eagerly restore, the only time that CR0.TS should be set
+ * for a non-kernel thread is during operations where it will be cleared before
+ * returning to user land and importantly, the only data that is in it is its
+ * own.
+ *
+ * FPU Exceptions
+ * --------------
+ *
+ * Certain operations can cause the kernel to take traps due to FPU activity.
+ * Generally these events will cause a user process to receive a SIGFPU and if
+ * the kernel receives it in kernel context, we will die. Traditionally the #NM
+ * (Device Not Available / No Math) exception generated by CR0.TS would have
+ * caused us to restore the FPU. Now it is a fatal event regardless of whether
+ * or not user land causes it.
+ *
+ * While there are some cases where the kernel uses the FPU, it is up to the
+ * kernel to use the FPU in a way such that it cannot receive a trap or to use
+ * the appropriate trap protection mechanisms.
+ *
+ * Hypervisors
+ * -----------
+ *
+ * When providing support for hypervisors things are a little bit more
+ * complicated because the FPU is not virtualized at all. This means that they
+ * need to save and restore the FPU and %xcr0 across entry and exit to the
+ * guest. To facilitate this, we provide a series of APIs in <sys/hma.h>. These
+ * allow us to use the full native state to make sure that we are always saving
+ * and restoring the full FPU that the host sees, even when the guest is using a
+ * subset.
+ *
+ * One tricky aspect of this is that the guest may be using a subset of %xcr0
+ * and therefore changing our %xcr0 on the fly. It is vital that when we're
+ * saving and restoring the FPU that we always use the largest %xcr0 contents
+ * otherwise we will end up leaving behind data in it.
+ *
+ * ELF PLT Support
+ * ---------------
+ *
+ * rtld has to preserve a subset of the FPU when it is saving and restoring
+ * registers due to the amd64 SYS V ABI. See cmd/sgs/rtld/amd64/boot_elf.s for
+ * more information. As a result, we set up an aux vector that contains
+ * information about what save and restore mechanisms it should be using and
+ * the sizing thereof based on what the kernel supports. This is passed down in
+ * a series of aux vectors SUN_AT_FPTYPE and SUN_AT_FPSIZE. This information is
+ * initialized in fpu_subr.c.
+ */
+
 kmem_cache_t *fpsave_cachep;
 
 /* Legacy fxsave layout + xsave header + ymm */
 #define	AVX_XSAVE_SIZE		(512 + 64 + 256)
+
+/*
+ * Various sanity checks.
+ */
+CTASSERT(sizeof (struct fxsave_state) == 512);
+CTASSERT(sizeof (struct fnsave_state) == 108);
+CTASSERT((offsetof(struct fxsave_state, fx_xmm[0]) & 0xf) == 0);
+CTASSERT(sizeof (struct xsave_state) >= AVX_XSAVE_SIZE);
 
 /*CSTYLED*/
 #pragma	align 16 (sse_initial)
@@ -150,20 +527,12 @@ const struct fnsave_state x87_initial = {
 	/* rest of structure is zero */
 };
 
-#if defined(__amd64)
 /*
  * This vector is patched to xsave_ctxt() if we discover we have an
  * XSAVE-capable chip in fpu_probe.
  */
 void (*fpsave_ctxt)(void *) = fpxsave_ctxt;
-#elif defined(__i386)
-/*
- * This vector is patched to fpxsave_ctxt() if we discover we have an
- * SSE-capable chip in fpu_probe(). It is patched to xsave_ctxt
- * if we discover we have an XSAVE-capable chip in fpu_probe.
- */
-void (*fpsave_ctxt)(void *) = fpnsave_ctxt;
-#endif
+void (*fprestore_ctxt)(void *) = fpxrestore_ctxt;
 
 /*
  * This function pointer is changed to xsaveopt if the CPU is xsaveopt capable.
@@ -187,9 +556,6 @@ fp_new_lwp(kthread_id_t t, kthread_id_t ct)
 	struct fpu_ctx *fp;		/* parent fpu context */
 	struct fpu_ctx *cfp;		/* new fpu context */
 	struct fxsave_state *fx, *cfx;
-#if defined(__i386)
-	struct fnsave_state *fn, *cfn;
-#endif
 	struct xsave_state *cxs;
 
 	ASSERT(fp_kind != FP_NO);
@@ -207,15 +573,13 @@ fp_new_lwp(kthread_id_t t, kthread_id_t ct)
 	cfp->fpu_regs.kfpu_status = 0;
 	cfp->fpu_regs.kfpu_xstatus = 0;
 
+	/*
+	 * Make sure that the child's FPU is cleaned up and made ready for user
+	 * land.
+	 */
+	PCB_SET_UPDATE_FPU(&ct->t_lwp->lwp_pcb);
+
 	switch (fp_save_mech) {
-#if defined(__i386)
-	case FP_FNSAVE:
-		fn = fp->fpu_regs.kfpu_u.kfpu_fn;
-		cfn = cfp->fpu_regs.kfpu_u.kfpu_fn;
-		bcopy(&x87_initial, cfn, sizeof (*cfn));
-		cfn->f_fcw = fn->f_fcw;
-		break;
-#endif
 	case FP_FXSAVE:
 		fx = fp->fpu_regs.kfpu_u.kfpu_fx;
 		cfx = cfp->fpu_regs.kfpu_u.kfpu_fx;
@@ -244,14 +608,13 @@ fp_new_lwp(kthread_id_t t, kthread_id_t ct)
 		/*NOTREACHED*/
 	}
 
-	installctx(ct, cfp,
-	    fpsave_ctxt, NULL, fp_new_lwp, fp_new_lwp, NULL, fp_free);
 	/*
-	 * Now, when the new lwp starts running, it will take a trap
-	 * that will be handled inline in the trap table to cause
-	 * the appropriate f*rstor instruction to load the save area we
-	 * constructed above directly into the hardware.
+	 * Mark that both the parent and child need to have the FPU cleaned up
+	 * before returning to user land.
 	 */
+
+	installctx(ct, cfp, fpsave_ctxt, fprestore_ctxt, fp_new_lwp,
+	    fp_new_lwp, NULL, fp_free);
 }
 
 /*
@@ -313,11 +676,6 @@ fp_save(struct fpu_ctx *fp)
 	ASSERT(curthread->t_lwp && fp == &curthread->t_lwp->lwp_pcb.pcb_fpu);
 
 	switch (fp_save_mech) {
-#if defined(__i386)
-	case FP_FNSAVE:
-		fpsave(fp->fpu_regs.kfpu_u.kfpu_fn);
-		break;
-#endif
 	case FP_FXSAVE:
 		fpxsave(fp->fpu_regs.kfpu_u.kfpu_fx);
 		break;
@@ -331,6 +689,18 @@ fp_save(struct fpu_ctx *fp)
 	}
 
 	fp->fpu_flags |= FPU_VALID;
+
+	/*
+	 * We save the FPU as part of forking, execing, modifications via /proc,
+	 * restorecontext, etc. As such, we need to make sure that we return to
+	 * userland with valid state in the FPU. If we're context switched out
+	 * before we hit sys_rtt_common() we'll end up having restored the FPU
+	 * as part of the context ops operations. The restore logic always makes
+	 * sure that FPU_VALID is set before doing a restore so we don't restore
+	 * it a second time.
+	 */
+	PCB_SET_UPDATE_FPU(&curthread->t_lwp->lwp_pcb);
+
 	kpreempt_enable();
 }
 
@@ -344,11 +714,6 @@ void
 fp_restore(struct fpu_ctx *fp)
 {
 	switch (fp_save_mech) {
-#if defined(__i386)
-	case FP_FNSAVE:
-		fprestore(fp->fpu_regs.kfpu_u.kfpu_fn);
-		break;
-#endif
 	case FP_FXSAVE:
 		fpxrestore(fp->fpu_regs.kfpu_u.kfpu_fx);
 		break;
@@ -364,6 +729,33 @@ fp_restore(struct fpu_ctx *fp)
 	fp->fpu_flags &= ~FPU_VALID;
 }
 
+/*
+ * Reset the FPU such that it is in a valid state for a new thread that is
+ * coming out of exec. The FPU will be in a usable state at this point. At this
+ * point we know that the FPU state has already been allocated and if this
+ * wasn't an init process, then it will have had fp_free() previously called.
+ */
+void
+fp_exec(void)
+{
+	struct fpu_ctx *fp = &ttolwp(curthread)->lwp_pcb.pcb_fpu;
+
+	if (fp_save_mech == FP_XSAVE) {
+		fp->fpu_xsave_mask = XFEATURE_FP_ALL;
+	}
+
+	/*
+	 * Make sure that we're not preempted in the middle of initializing the
+	 * FPU on CPU.
+	 */
+	kpreempt_disable();
+	installctx(curthread, fp, fpsave_ctxt, fprestore_ctxt, fp_new_lwp,
+	    fp_new_lwp, NULL, fp_free);
+	fpinit();
+	fp->fpu_flags = FPU_EN;
+	kpreempt_enable();
+}
+
 
 /*
  * Seeds the initial state for the current thread.  The possibilities are:
@@ -371,7 +763,7 @@ fp_restore(struct fpu_ctx *fp)
  *         initialization: Load the FPU state from the LWP state.
  *      2. The FPU state has not been externally modified:  Load a clean state.
  */
-static void
+void
 fp_seed(void)
 {
 	struct fpu_ctx *fp = &ttolwp(curthread)->lwp_pcb.pcb_fpu;
@@ -386,8 +778,8 @@ fp_seed(void)
 		fp->fpu_xsave_mask = XFEATURE_FP_ALL;
 	}
 
-	installctx(curthread, fp,
-	    fpsave_ctxt, NULL, fp_new_lwp, fp_new_lwp, NULL, fp_free);
+	installctx(curthread, fp, fpsave_ctxt, fprestore_ctxt, fp_new_lwp,
+	    fp_new_lwp, NULL, fp_free);
 	fpinit();
 
 	/*
@@ -452,11 +844,6 @@ fp_lwp_dup(struct _klwp *lwp)
 	size_t sz;
 
 	switch (fp_save_mech) {
-#if defined(__i386)
-	case FP_FNSAVE:
-		sz = sizeof (struct fnsave_state);
-		break;
-#endif
 	case FP_FXSAVE:
 		sz = sizeof (struct fxsave_state);
 		break;
@@ -472,119 +859,6 @@ fp_lwp_dup(struct _klwp *lwp)
 	bcopy(lwp->lwp_pcb.pcb_fpu.fpu_regs.kfpu_u.kfpu_generic, xp, sz);
 	/* now restore the pointer */
 	lwp->lwp_pcb.pcb_fpu.fpu_regs.kfpu_u.kfpu_generic = xp;
-}
-
-
-/*
- * This routine is called from trap() when User thread takes No Extension
- * Fault. The possiblities are:
- *	1. User thread has executed a FP instruction for the first time.
- *	   Save current FPU context if any. Initialize FPU, setup FPU
- *	   context for the thread and enable FP hw.
- *	2. Thread's pcb has a valid FPU state: Restore the FPU state and
- *	   enable FP hw.
- *
- * Note that case #2 is inlined in the trap table.
- */
-int
-fpnoextflt(struct regs *rp)
-{
-	struct fpu_ctx *fp = &ttolwp(curthread)->lwp_pcb.pcb_fpu;
-
-#if !defined(__lint)
-	ASSERT(sizeof (struct fxsave_state) == 512 &&
-	    sizeof (struct fnsave_state) == 108);
-	ASSERT((offsetof(struct fxsave_state, fx_xmm[0]) & 0xf) == 0);
-
-	ASSERT(sizeof (struct xsave_state) >= AVX_XSAVE_SIZE);
-
-#if defined(__i386)
-	ASSERT(sizeof (struct _fpu) == sizeof (struct __old_fpu));
-#endif	/* __i386 */
-#endif	/* !__lint */
-
-	kpreempt_disable();
-	/*
-	 * Now we can enable the interrupts.
-	 * (NOTE: fp-no-coprocessor comes thru interrupt gate)
-	 */
-	sti();
-
-	if (!fpu_exists) { /* check for FPU hw exists */
-		if (fp_kind == FP_NO) {
-			uint32_t inst;
-
-			/*
-			 * When the system has no floating point support,
-			 * i.e. no FP hardware and no emulator, skip the
-			 * two kinds of FP instruction that occur in
-			 * fpstart.  Allows processes that do no real FP
-			 * to run normally.
-			 */
-			if (fuword32((void *)rp->r_pc, &inst) != -1 &&
-			    ((inst & 0xFFFF) == 0x7dd9 ||
-			    (inst & 0xFFFF) == 0x6dd9)) {
-				rp->r_pc += 3;
-				kpreempt_enable();
-				return (0);
-			}
-		}
-
-		/*
-		 * If we have neither a processor extension nor
-		 * an emulator, kill the process OR panic the kernel.
-		 */
-		kpreempt_enable();
-		return (1); /* error */
-	}
-
-#if !defined(__xpv)	/* XXPV	Is this ifdef needed now? */
-	/*
-	 * A paranoid cross-check: for the SSE case, ensure that %cr4 is
-	 * configured to enable fully fledged (%xmm) fxsave/fxrestor on
-	 * this CPU.  For the non-SSE case, ensure that it isn't.
-	 */
-	ASSERT(((fp_kind & __FP_SSE) &&
-	    (getcr4() & CR4_OSFXSR) == CR4_OSFXSR) ||
-	    (!(fp_kind & __FP_SSE) &&
-	    (getcr4() & (CR4_OSXMMEXCPT|CR4_OSFXSR)) == 0));
-#endif
-
-	if (fp->fpu_flags & FPU_EN) {
-		/* case 2 */
-		fp_restore(fp);
-	} else {
-		/* case 1 */
-		fp_seed();
-	}
-	kpreempt_enable();
-	return (0);
-}
-
-
-/*
- * Handle a processor extension overrun fault
- * Returns non zero for error.
- *
- * XXX	Shouldn't this just be abolished given that we're not supporting
- *	anything prior to Pentium?
- */
-
-/* ARGSUSED */
-int
-fpextovrflt(struct regs *rp)
-{
-#if !defined(__xpv)		/* XXPV	Do we need this ifdef either */
-	ulong_t cur_cr0;
-
-	ASSERT(fp_kind != FP_NO);
-
-	cur_cr0 = getcr0();
-	fpinit();		/* initialize the FPU hardware */
-	setcr0(cur_cr0);
-#endif
-	sti();
-	return (1); 		/* error, send SIGSEGV signal to the thread */
 }
 
 /*
@@ -622,14 +896,6 @@ fpexterrflt(struct regs *rp)
 
 	/* clear exception flags in saved state, as if by fnclex */
 	switch (fp_save_mech) {
-#if defined(__i386)
-	case FP_FNSAVE:
-		fpsw = fp->fpu_regs.kfpu_u.kfpu_fn->f_fsw;
-		fpcw = fp->fpu_regs.kfpu_u.kfpu_fn->f_fcw;
-		fp->fpu_regs.kfpu_u.kfpu_fn->f_fsw &= ~FPS_SW_EFLAGS;
-		break;
-#endif
-
 	case FP_FXSAVE:
 		fpsw = fp->fpu_regs.kfpu_u.kfpu_fx->fx_fsw;
 		fpcw = fp->fpu_regs.kfpu_u.kfpu_fx->fx_fcw;
@@ -811,11 +1077,6 @@ fpsetcw(uint16_t fcw, uint32_t mxcsr)
 	fp_save(fp);
 
 	switch (fp_save_mech) {
-#if defined(__i386)
-	case FP_FNSAVE:
-		fp->fpu_regs.kfpu_u.kfpu_fn->f_fcw = fcw;
-		break;
-#endif
 	case FP_FXSAVE:
 		fx = fp->fpu_regs.kfpu_u.kfpu_fx;
 		fx->fx_fcw = fcw;

--- a/usr/src/uts/intel/ia32/os/sundep.c
+++ b/usr/src/uts/intel/ia32/os/sundep.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*	Copyright (c) 1990, 1991 UNIX System Laboratories, Inc. */
@@ -393,12 +393,12 @@ lwp_forkregs(klwp_t *lwp, klwp_t *clwp)
 	struct pcb *pcb = &clwp->lwp_pcb;
 	struct regs *rp = lwptoregs(lwp);
 
-	if (pcb->pcb_rupdate == 0) {
+	if (!PCB_NEED_UPDATE_SEGS(pcb)) {
 		pcb->pcb_ds = rp->r_ds;
 		pcb->pcb_es = rp->r_es;
 		pcb->pcb_fs = rp->r_fs;
 		pcb->pcb_gs = rp->r_gs;
-		pcb->pcb_rupdate = 1;
+		PCB_SET_UPDATE_SEGS(pcb);
 		lwptot(clwp)->t_post_sys = 1;
 	}
 	ASSERT(lwptot(clwp)->t_post_sys);
@@ -436,22 +436,22 @@ lwp_pcb_exit(void)
  * as a segment-not-present trap.
  *
  * Here we save the current values from the lwp regs into the pcb
- * and set pcb->pcb_rupdate to 1 to tell the rest of the kernel
- * that the pcb copy of the segment registers is the current one.
- * This ensures the lwp's next trip to user land via update_sregs.
- * Finally we set t_post_sys to ensure that no system call fast-path's
- * its way out of the kernel via sysret.
+ * and or PCB_UPDATE_SEGS (1) in pcb->pcb_rupdate to tell the rest
+ * of the kernel that the pcb copy of the segment registers is the
+ * current one.  This ensures the lwp's next trip to user land via
+ * update_sregs.  Finally we set t_post_sys to ensure that no
+ * system call fast-path's its way out of the kernel via sysret.
  *
- * (This means that we need to have interrupts disabled when we test
- * t->t_post_sys in the syscall handlers; if the test fails, we need
- * to keep interrupts disabled until we return to userland so we can't
- * be switched away.)
+ * (This means that we need to have interrupts disabled when we
+ * test t->t_post_sys in the syscall handlers; if the test fails,
+ * we need to keep interrupts disabled until we return to userland
+ * so we can't be switched away.)
  *
- * As a result of all this, we don't really have to do a whole lot if
- * the thread is just mucking about in the kernel, switching on and
- * off the cpu for whatever reason it feels like. And yet we still
- * preserve fast syscalls, cause if we -don't- get descheduled,
- * we never come here either.
+ * As a result of all this, we don't really have to do a whole lot
+ * if the thread is just mucking about in the kernel, switching on
+ * and off the cpu for whatever reason it feels like. And yet we
+ * still preserve fast syscalls, cause if we -don't- get
+ * descheduled, we never come here either.
  */
 
 #define	VALID_LWP_DESC(udp) ((udp)->usd_type == SDT_MEMRWA && \
@@ -468,7 +468,7 @@ lwp_segregs_save(klwp_t *lwp)
 	ASSERT(VALID_LWP_DESC(&pcb->pcb_fsdesc));
 	ASSERT(VALID_LWP_DESC(&pcb->pcb_gsdesc));
 
-	if (pcb->pcb_rupdate == 0) {
+	if (!PCB_NEED_UPDATE_SEGS(pcb)) {
 		rp = lwptoregs(lwp);
 
 		/*
@@ -482,7 +482,7 @@ lwp_segregs_save(klwp_t *lwp)
 		pcb->pcb_es = rp->r_es;
 		pcb->pcb_fs = rp->r_fs;
 		pcb->pcb_gs = rp->r_gs;
-		pcb->pcb_rupdate = 1;
+		PCB_SET_UPDATE_SEGS(pcb);
 		lwp->lwp_thread->t_post_sys = 1;
 	}
 #endif	/* __amd64 */
@@ -833,7 +833,8 @@ lwp_installctx(klwp_t *lwp)
 	 * On the amd64 kernel, the context handlers are responsible for
 	 * virtualizing %ds, %es, %fs, and %gs to the lwp.  The register
 	 * values are only ever changed via sys_rtt when the
-	 * pcb->pcb_rupdate == 1.  Only sys_rtt gets to clear the bit.
+	 * PCB_UPDATE_SEGS bit (1) is set in pcb->pcb_rupdate. Only
+	 * sys_rtt gets to clear the bit.
 	 *
 	 * On the i386 kernel, the context handlers are responsible for
 	 * virtualizing %gs/%fs to the lwp by updating the per-cpu GDTs
@@ -964,7 +965,7 @@ setregs(uarg_t *args)
 
 	pcb->pcb_ds = rp->r_ds;
 	pcb->pcb_es = rp->r_es;
-	pcb->pcb_rupdate = 1;
+	PCB_SET_UPDATE_SEGS(pcb);
 
 #elif defined(__i386)
 
@@ -991,17 +992,15 @@ setregs(uarg_t *args)
 	t->t_post_sys = 1;
 
 	/*
-	 * Here we initialize minimal fpu state.
-	 * The rest is done at the first floating
-	 * point instruction that a process executes.
-	 */
-	pcb->pcb_fpu.fpu_flags = 0;
-
-	/*
 	 * Add the lwp context handlers that virtualize segment registers,
 	 * and/or system call stacks etc.
 	 */
 	lwp_installctx(lwp);
+
+	/*
+	 * Reset the FPU flags and then initialize the FPU for this lwp.
+	 */
+	fp_exec();
 }
 
 user_desc_t *

--- a/usr/src/uts/intel/ia32/os/sysi86.c
+++ b/usr/src/uts/intel/ia32/os/sysi86.c
@@ -620,7 +620,7 @@ setdscr(struct ssd *ssd)
 			}
 
 #if defined(__amd64)
-			if (pcb->pcb_rupdate == 1) {
+			if (PCB_NEED_UPDATE_SEGS(pcb)) {
 				if (ssd->sel == pcb->pcb_ds ||
 				    ssd->sel == pcb->pcb_es ||
 				    ssd->sel == pcb->pcb_fs ||

--- a/usr/src/uts/intel/ia32/os/sysi86.c
+++ b/usr/src/uts/intel/ia32/os/sysi86.c
@@ -348,8 +348,7 @@ static void
 ldt_load(void)
 {
 #if defined(__xpv)
-	xen_set_ldt(get_ssd_base(&curproc->p_ldt_desc),
-	    curproc->p_ldtlimit + 1);
+	xen_set_ldt(curproc->p_ldt, curproc->p_ldtlimit + 1);
 #else
 	size_t len;
 	system_desc_t desc;
@@ -415,7 +414,7 @@ ldt_savectx(proc_t *p)
 #endif
 
 	ldt_unload();
-	cpu_fast_syscall_enable(NULL);
+	cpu_fast_syscall_enable();
 }
 
 static void
@@ -425,30 +424,34 @@ ldt_restorectx(proc_t *p)
 	ASSERT(p == curproc);
 
 	ldt_load();
-	cpu_fast_syscall_disable(NULL);
+	cpu_fast_syscall_disable();
 }
 
 /*
- * When a process with a private LDT execs, fast syscalls must be enabled for
- * the new process image.
+ * At exec time, we need to clear up our LDT context and re-enable fast syscalls
+ * for the new process image.
+ *
+ * The same is true for the other case, where we have:
+ *
+ * proc_exit()
+ *  ->exitpctx()->ldt_savectx()
+ *  ->freepctx()->ldt_freectx()
+ *
+ * Because pre-emption is not prevented between the two callbacks, we could have
+ * come off CPU, and brought back LDT context when coming back on CPU via
+ * ldt_restorectx().
  */
 /* ARGSUSED */
 static void
 ldt_freectx(proc_t *p, int isexec)
 {
-	ASSERT(p->p_ldt);
+	ASSERT(p->p_ldt != NULL);
+	ASSERT(p == curproc);
 
-	if (isexec) {
-		kpreempt_disable();
-		cpu_fast_syscall_enable(NULL);
-		kpreempt_enable();
-	}
-
-	/*
-	 * ldt_free() will free the memory used by the private LDT, reset the
-	 * process's descriptor, and re-program the LDTR.
-	 */
+	kpreempt_disable();
 	ldt_free(p);
+	cpu_fast_syscall_enable();
+	kpreempt_enable();
 }
 
 /*
@@ -500,10 +503,10 @@ ldt_installctx(proc_t *p, proc_t *cp)
 int
 setdscr(struct ssd *ssd)
 {
-	ushort_t seli; 		/* selector index */
+	ushort_t seli;		/* selector index */
 	user_desc_t *ldp;	/* descriptor pointer */
 	user_desc_t ndesc;	/* new descriptor */
-	proc_t	*pp = ttoproc(curthread);
+	proc_t	*pp = curproc;
 	int	rc = 0;
 
 	/*
@@ -544,11 +547,12 @@ setdscr(struct ssd *ssd)
 		 */
 		kpreempt_disable();
 		ldt_installctx(pp, NULL);
-		cpu_fast_syscall_disable(NULL);
+		cpu_fast_syscall_disable();
 		ASSERT(curthread->t_post_sys != 0);
 		kpreempt_enable();
 
 	} else if (seli > pp->p_ldtlimit) {
+		ASSERT(pp->p_pctx != NULL);
 
 		/*
 		 * Increase size of ldt to include seli.
@@ -650,10 +654,14 @@ setdscr(struct ssd *ssd)
 	}
 
 	/*
-	 * If acc1 is zero, clear the descriptor (including the 'present' bit)
+	 * If acc1 is zero, clear the descriptor (including the 'present' bit).
+	 * Make sure we update the CPU-private copy of the LDT.
 	 */
 	if (ssd->acc1 == 0) {
 		rc  = ldt_update_segd(ldp, &null_udesc);
+		kpreempt_disable();
+		ldt_load();
+		kpreempt_enable();
 		mutex_exit(&pp->p_ldtlock);
 		return (rc);
 	}
@@ -667,7 +675,6 @@ setdscr(struct ssd *ssd)
 		return (EINVAL);
 	}
 
-#if defined(__amd64)
 	/*
 	 * Do not allow 32-bit applications to create 64-bit mode code
 	 * segments.
@@ -677,50 +684,34 @@ setdscr(struct ssd *ssd)
 		mutex_exit(&pp->p_ldtlock);
 		return (EINVAL);
 	}
-#endif /* __amd64 */
 
 	/*
-	 * Set up a code or data user segment descriptor.
+	 * Set up a code or data user segment descriptor, making sure to update
+	 * the CPU-private copy of the LDT.
 	 */
 	if (SI86SSD_ISUSEG(ssd)) {
 		ssd_to_usd(ssd, &ndesc);
 		rc = ldt_update_segd(ldp, &ndesc);
+		kpreempt_disable();
+		ldt_load();
+		kpreempt_enable();
 		mutex_exit(&pp->p_ldtlock);
 		return (rc);
 	}
-
-#if defined(__i386)
-	/*
-	 * Allow a call gate only if the destination is in the LDT
-	 * and the system is running in 32-bit legacy mode.
-	 *
-	 * In long mode 32-bit call gates are redefined as 64-bit call
-	 * gates and the hw enforces that the target code selector
-	 * of the call gate must be 64-bit selector. A #gp fault is
-	 * generated if otherwise. Since we do not allow 32-bit processes
-	 * to switch themselves to 64-bits we never allow call gates
-	 * on 64-bit system system.
-	 */
-	if (SI86SSD_TYPE(ssd) == SDT_SYSCGT && SELISLDT(ssd->ls)) {
-
-
-		ssd_to_sgd(ssd, (gate_desc_t *)&ndesc);
-		rc = ldt_update_segd(ldp, &ndesc);
-		mutex_exit(&pp->p_ldtlock);
-		return (rc);
-	}
-#endif	/* __i386 */
 
 	mutex_exit(&pp->p_ldtlock);
 	return (EINVAL);
 }
 
 /*
- * Allocate new LDT for process just large enough to contain seli.
- * Note we allocate and grow LDT in PAGESIZE chunks. We do this
- * to simplify the implementation and because on the hypervisor it's
- * required, since the LDT must live on pages that have PROT_WRITE
- * removed and which are given to the hypervisor.
+ * Allocate new LDT for process just large enough to contain seli.  Note we
+ * allocate and grow LDT in PAGESIZE chunks. We do this to simplify the
+ * implementation and because on the hypervisor it's required, since the LDT
+ * must live on pages that have PROT_WRITE removed and which are given to the
+ * hypervisor.
+ *
+ * Note that we don't actually load the LDT into the current CPU here: it's done
+ * later by our caller.
  */
 static void
 ldt_alloc(proc_t *pp, uint_t seli)
@@ -751,13 +742,6 @@ ldt_alloc(proc_t *pp, uint_t seli)
 
 	pp->p_ldt = ldt;
 	pp->p_ldtlimit = nsels - 1;
-	set_syssegd(&pp->p_ldt_desc, ldt, ldtsz - 1, SDT_SYSLDT, SEL_KPL);
-
-	if (pp == curproc) {
-		kpreempt_disable();
-		ldt_load();
-		kpreempt_enable();
-	}
 }
 
 static void
@@ -776,7 +760,6 @@ ldt_free(proc_t *pp)
 
 	pp->p_ldt = NULL;
 	pp->p_ldtlimit = 0;
-	pp->p_ldt_desc = null_sdesc;
 	mutex_exit(&pp->p_ldtlock);
 
 	if (pp == curproc) {
@@ -841,6 +824,14 @@ ldt_dup(proc_t *pp, proc_t *cp)
 
 }
 
+/*
+ * Note that we don't actually load the LDT into the current CPU here: it's done
+ * later by our caller - unless we take an error.  This works out because
+ * ldt_load() does a copy of ->p_ldt instead of directly loading it into the GDT
+ * (and therefore can't be using the freed old LDT), and by definition if the
+ * new entry didn't pass validation, then the proc shouldn't be referencing an
+ * entry in the extended region.
+ */
 static void
 ldt_grow(proc_t *pp, uint_t seli)
 {
@@ -890,18 +881,6 @@ ldt_grow(proc_t *pp, uint_t seli)
 
 	pp->p_ldt = nldt;
 	pp->p_ldtlimit = nsels - 1;
-
-	/*
-	 * write new ldt segment descriptor.
-	 */
-	set_syssegd(&pp->p_ldt_desc, nldt, nldtsz - 1, SDT_SYSLDT, SEL_KPL);
-
-	/*
-	 * load the new ldt.
-	 */
-	kpreempt_disable();
-	ldt_load();
-	kpreempt_enable();
 
 	kmem_free(oldt, oldtsz);
 }

--- a/usr/src/uts/intel/ia32/syscall/lwp_private.c
+++ b/usr/src/uts/intel/ia32/syscall/lwp_private.c
@@ -21,9 +21,8 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2018, Joyent, Inc.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <sys/param.h>
 #include <sys/types.h>
@@ -72,12 +71,12 @@ lwp_setprivate(klwp_t *lwp, int which, uintptr_t base)
 	 * of zero for %fs and %gs to use the 64-bit fs_base and gs_base
 	 * respectively.
 	 */
-	if (pcb->pcb_rupdate == 0) {
+	if (!PCB_NEED_UPDATE_SEGS(pcb)) {
 		pcb->pcb_ds = rp->r_ds;
 		pcb->pcb_es = rp->r_es;
 		pcb->pcb_fs = rp->r_fs;
 		pcb->pcb_gs = rp->r_gs;
-		pcb->pcb_rupdate = 1;
+		PCB_SET_UPDATE_SEGS(pcb);
 		t->t_post_sys = 1;
 	}
 	ASSERT(t->t_post_sys);
@@ -171,7 +170,7 @@ lwp_getprivate(klwp_t *lwp, int which, uintptr_t base)
 	case _LWP_FSBASE:
 		if ((sbase = pcb->pcb_fsbase) != 0) {
 			if (lwp_getdatamodel(lwp) == DATAMODEL_NATIVE) {
-				if (pcb->pcb_rupdate == 1) {
+				if (PCB_NEED_UPDATE_SEGS(pcb)) {
 					if (pcb->pcb_fs == 0)
 						break;
 				} else {
@@ -179,7 +178,7 @@ lwp_getprivate(klwp_t *lwp, int which, uintptr_t base)
 						break;
 				}
 			} else {
-				if (pcb->pcb_rupdate == 1) {
+				if (PCB_NEED_UPDATE_SEGS(pcb)) {
 					if (pcb->pcb_fs == LWPFS_SEL)
 						break;
 				} else {
@@ -193,7 +192,7 @@ lwp_getprivate(klwp_t *lwp, int which, uintptr_t base)
 	case _LWP_GSBASE:
 		if ((sbase = pcb->pcb_gsbase) != 0) {
 			if (lwp_getdatamodel(lwp) == DATAMODEL_NATIVE) {
-				if (pcb->pcb_rupdate == 1) {
+				if (PCB_NEED_UPDATE_SEGS(pcb)) {
 					if (pcb->pcb_gs == 0)
 						break;
 				} else {
@@ -201,7 +200,7 @@ lwp_getprivate(klwp_t *lwp, int which, uintptr_t base)
 						break;
 				}
 			} else {
-				if (pcb->pcb_rupdate == 1) {
+				if (PCB_NEED_UPDATE_SEGS(pcb)) {
 					if (pcb->pcb_gs == LWPGS_SEL)
 						break;
 				} else {

--- a/usr/src/uts/intel/sys/archsystm.h
+++ b/usr/src/uts/intel/sys/archsystm.h
@@ -55,11 +55,8 @@ extern void mfence_insn(void);
 extern uint16_t getgs(void);
 extern void setgs(uint16_t);
 
-extern void patch_sse(void);
-extern void patch_sse2(void);
 #endif
 
-extern void patch_xsave(void);
 extern kmem_cache_t *fpsave_cachep;
 
 extern void cli(void);

--- a/usr/src/uts/intel/sys/fp.h
+++ b/usr/src/uts/intel/sys/fp.h
@@ -345,6 +345,9 @@ extern void fp_lwp_init(struct _klwp *);
 extern void fp_lwp_cleanup(struct _klwp *);
 extern void fp_lwp_dup(struct _klwp *);
 
+extern const struct fxsave_state sse_initial;
+extern const struct xsave_state avx_initial;
+
 #endif	/* _KERNEL */
 
 #ifdef __cplusplus

--- a/usr/src/uts/intel/sys/fp.h
+++ b/usr/src/uts/intel/sys/fp.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  *
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  */
@@ -140,8 +140,8 @@ extern "C" {
 /*
  * masks and flags for SSE/SSE2 MXCSR
  */
-#define	SSE_IE 	0x00000001	/* invalid operation			*/
-#define	SSE_DE 	0x00000002	/* denormalized operand			*/
+#define	SSE_IE	0x00000001	/* invalid operation			*/
+#define	SSE_DE	0x00000002	/* denormalized operand			*/
 #define	SSE_ZE	0x00000004	/* zero divide				*/
 #define	SSE_OE	0x00000008	/* overflow				*/
 #define	SSE_UE	0x00000010	/* underflow				*/
@@ -156,7 +156,7 @@ extern "C" {
 #define	SSE_RC	0x00006000	/* rounding control			*/
 #define	SSE_RD	0x00002000	/* rounding control: round down		*/
 #define	SSE_RU	0x00004000	/* rounding control: round up		*/
-#define	SSE_FZ	0x00008000	/* flush to zero for masked underflow 	*/
+#define	SSE_FZ	0x00008000	/* flush to zero for masked underflow	*/
 
 #define	SSE_MXCSR_EFLAGS	\
 	(SSE_IE|SSE_DE|SSE_ZE|SSE_OE|SSE_UE|SSE_PE)	/* 0x3f */
@@ -302,6 +302,8 @@ extern uint32_t sse_mxcsr_mask;
 extern void fpu_probe(void);
 extern uint_t fpu_initial_probe(void);
 extern int fpu_probe_pentium_fdivbug(void);
+
+extern void fpu_auxv_info(int *, size_t *);
 
 extern void fpnsave_ctxt(void *);
 extern void fpxsave_ctxt(void *);

--- a/usr/src/uts/intel/sys/fp.h
+++ b/usr/src/uts/intel/sys/fp.h
@@ -236,13 +236,14 @@ struct fxsave_state {
  * 13.4.2 of the Intel 64 and IA-32 Architectures Software Developer’s Manual,
  * Volume 1 (IASDv1). The extended portion is documented in section 13.4.3.
  *
- * Our size is at least AVX_XSAVE_SIZE (832 bytes), asserted in fpnoextflt().
- * Enabling additional xsave-related CPU features requires an increase in the
- * size. We dynamically allocate the per-lwp xsave area at runtime, based on
- * the size needed for the CPU-specific features. This xsave_state structure
- * simply defines our historical layout for the beginning of the xsave area. The
- * locations and size of new, extended, components is determined dynamically by
- * querying the CPU. See the xsave_info structure in cpuid.c.
+ * Our size is at least AVX_XSAVE_SIZE (832 bytes), which is asserted
+ * statically.  Enabling additional xsave-related CPU features requires an
+ * increase in the size. We dynamically allocate the per-lwp xsave area at
+ * runtime, based on the size needed for the CPU-specific features. This
+ * xsave_state structure simply defines our historical layout for the beginning
+ * of the xsave area. The locations and size of new, extended, components is
+ * determined dynamically by querying the CPU. See the xsave_info structure in
+ * cpuid.c.
  *
  * xsave component usage is tracked using bits in the xs_xstate_bv field. The
  * components are documented in section 13.1 of IASDv1. For easy reference,
@@ -301,7 +302,6 @@ extern uint32_t sse_mxcsr_mask;
 
 extern void fpu_probe(void);
 extern uint_t fpu_initial_probe(void);
-extern int fpu_probe_pentium_fdivbug(void);
 
 extern void fpu_auxv_info(int *, size_t *);
 
@@ -314,6 +314,10 @@ extern void xsave_excp_clr_ctxt(void *);
 extern void xsaveopt_excp_clr_ctxt(void *);
 extern void (*fpsave_ctxt)(void *);
 extern void (*xsavep)(struct xsave_state *, uint64_t);
+
+extern void fpxrestore_ctxt(void *);
+extern void xrestore_ctxt(void *);
+extern void (*fprestore_ctxt)(void *);
 
 extern void fxsave_insn(struct fxsave_state *);
 extern void fpsave(struct fnsave_state *);
@@ -335,11 +339,11 @@ extern uint32_t fpgetcwsw(void);
 extern uint32_t fpgetmxcsr(void);
 
 struct regs;
-extern int fpnoextflt(struct regs *);
-extern int fpextovrflt(struct regs *);
 extern int fpexterrflt(struct regs *);
 extern int fpsimderrflt(struct regs *);
 extern void fpsetcw(uint16_t, uint32_t);
+extern void fp_seed(void);
+extern void fp_exec(void);
 struct _klwp;
 extern void fp_lwp_init(struct _klwp *);
 extern void fp_lwp_cleanup(struct _klwp *);

--- a/usr/src/uts/intel/sys/pcb.h
+++ b/usr/src/uts/intel/sys/pcb.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #ifndef _SYS_PCB_H
@@ -51,7 +52,6 @@ typedef struct pcb {
 	uint_t		pcb_flags;	/* state flags; cleared on fork */
 	greg_t		pcb_drstat;	/* status debug register (%dr6) */
 	unsigned char	pcb_instr;	/* /proc: instruction at stop */
-#if defined(__amd64)
 	unsigned char	pcb_rupdate;	/* new register values in pcb -> regs */
 	uintptr_t	pcb_fsbase;
 	uintptr_t	pcb_gsbase;
@@ -59,7 +59,6 @@ typedef struct pcb {
 	selector_t	pcb_es;
 	selector_t	pcb_fs;
 	selector_t	pcb_gs;
-#endif /* __amd64 */
 	user_desc_t	pcb_fsdesc;	/* private per-lwp %fs descriptors */
 	user_desc_t	pcb_gsdesc;	/* private per-lwp %gs descriptors */
 } pcb_t;
@@ -76,6 +75,21 @@ typedef struct pcb {
 #define	REQUEST_STEP	0x100	/* request pending to single-step this lwp */
 #define	REQUEST_NOSTEP	0x200	/* request pending to disable single-step */
 #define	ASYNC_HWERR	0x400	/* hardware error has corrupted context  */
+
+/* pcb_rupdate values */
+#define	PCB_UPDATE_SEGS	0x01	/* Update segment registers */
+#define	PCB_UPDATE_FPU	0x02	/* Update FPU registers */
+
+#define	PCB_SET_UPDATE_SEGS(pcb)	((pcb)->pcb_rupdate |= PCB_UPDATE_SEGS)
+#define	PCB_SET_UPDATE_FPU(pcb)		((pcb)->pcb_rupdate |= PCB_UPDATE_FPU)
+#define	PCB_NEED_UPDATE_SEGS(pcb)	\
+	(((pcb)->pcb_rupdate & PCB_UPDATE_SEGS) != 0)
+#define	PCB_NEED_UPDATE_FPU(pcb)	\
+	(((pcb)->pcb_rupdate & PCB_UPDATE_FPU) != 0)
+#define	PCB_NEED_UPDATE(pcb)		\
+	(PCB_NEED_UPDATE_FPU(pcb) || PCB_NEED_UPDATE_SEGS(pcb))
+#define	PCB_CLEAR_UPDATE_SEGS(pcb)	((pcb)->pcb_rupdate &= ~PCB_UPDATE_SEGS)
+#define	PCB_CLEAR_UPDATE_FPU(pcb)	((pcb)->pcb_rupdate &= ~PCB_UPDATE_FPU)
 
 /* fpu_flags */
 #define	FPU_EN		0x1	/* flag signifying fpu in use */

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -690,6 +690,17 @@ extern "C" {
 	(XFEATURE_LEGACY_FP | XFEATURE_SSE | XFEATURE_AVX | XFEATURE_MPX | \
 	XFEATURE_AVX512 | XFEATURE_PKRU)
 
+/*
+ * Define the set of xfeature flags that should be considered valid in the xsave
+ * state vector when we initialize an lwp. This is distinct from the full set so
+ * that all of the processor's normal logic and tracking of the xsave state is
+ * usable. This should correspond to the state that's been initialized by the
+ * ABI to hold meaningful values. Adding additional bits here can have serious
+ * performance implications and cause performance degradations when using the
+ * FPU vector (xmm) registers.
+ */
+#define	XFEATURE_FP_INITIAL	(XFEATURE_LEGACY_FP | XFEATURE_SSE)
+
 #if !defined(_ASM)
 
 #if defined(_KERNEL) || defined(_KMEMUSER)

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -762,8 +762,8 @@ extern void setcr4(ulong_t);
 
 extern void mtrr_sync(void);
 
-extern void cpu_fast_syscall_enable(void *);
-extern void cpu_fast_syscall_disable(void *);
+extern void cpu_fast_syscall_enable(void);
+extern void cpu_fast_syscall_disable(void);
 
 struct cpu;
 


### PR DESCRIPTION
Weekly upstream from `illumos-joyent`

## Backports

Backport required for the following to r151022 & r151026:

* FPU: OS-6994 mdb: r9w isn't r8w  …
* FPU: OS-7003 Initial xsave xstate_bv should not include all features  …
* FPU/BHYVE: OS-6992 Want hypervisor API for FPU management  …
* FPU: OS-7019 missing break in hma_fpu_alloc  …
* FPU: OS-7000 Need Eager FPU  …
* KPTI: OS-6967 LDT still not happy under KPTI  …

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2018061401-d86577e937 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Jun 14 13:13:46 UTC 2018 ====
==== Nightly distributed build completed: Thu Jun 14 14:15:28 UTC 2018 ====

==== Total build time ====

real    1:01:41

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151026-d442a020ce i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   725684

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018061401-d86577e937

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:06.4
user  1:15:00.6
sys     10:47.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    12:55.4
user  1:06:17.9
sys      9:37.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    17:14.6
user    39:05.0
sys     11:28.6

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```