### PR TITLE
Add ::sec command to mdb

### DIFF
--- a/usr/src/cmd/mdb/i86pc/modules/unix/amd64/Makefile
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/amd64/Makefile
@@ -27,7 +27,7 @@
 MODULE = unix.so
 MDBTGT = kvm
 
-MODSRCS = unix.c i86mmu.c
+MODSRCS = unix.c i86mmu.c sec.c
 MODASMSRCS = unix_sup.s
 
 include ../../../../../Makefile.cmd

--- a/usr/src/cmd/mdb/i86pc/modules/unix/sec.c
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/sec.c
@@ -1,0 +1,107 @@
+/*
+ * CDDL HEADER
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source. A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ */
+
+#include <limits.h>
+#include <sys/mdb_modapi.h>
+#include <sys/sysinfo.h>
+#include <sys/sunmdi.h>
+#include <sys/x86_archext.h>
+
+int
+/* LINTED E_FUNC_ARG_UNUSED */
+sec_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+{
+	uint64_t kpti_enable;
+	int x86_use_pcid, x86_use_invpcid;
+	void *fset;
+	GElf_Sym sym;
+	size_t sz;
+	int opt_p = FALSE;
+
+	if (mdb_getopts(argc, argv, 'p', MDB_OPT_SETBITS, TRUE, &opt_p) != argc)
+		return (DCMD_USAGE);
+
+	/* Meltdown (CVE-2017-5754) */
+
+	if (mdb_readvar(&kpti_enable, "kpti_enable") == -1)
+		kpti_enable = 2;
+	if (mdb_readvar(&x86_use_pcid, "x86_use_pcid") == -1)
+		x86_use_pcid = -1;
+	if (mdb_readvar(&x86_use_invpcid, "x86_use_invpcid") == -1)
+		x86_use_invpcid = -1;
+
+	sz = sizeof (uchar_t) * BT_SIZEOFMAP(NUM_X86_FEATURES);
+	fset = mdb_zalloc(sz, UM_NOSLEEP);
+	if (mdb_readvar(fset, "x86_featureset") != sz) {
+		mdb_warn("failed to read x86_featureset");
+		mdb_free(fset, sz);
+		return (DCMD_ERR);
+	}
+
+	if (opt_p)
+		mdb_printf("meltdown:CVE-2017-5754:%s\n",
+		    kpti_enable == 1 ? "protected" : "not-protected");
+	else
+	{
+		mdb_printf("= Meltdown (CVE-2017-5754)\n");
+		mdb_printf("    Status: %s\n",
+		    kpti_enable == 1 ? "PROTECTED" : "NOT PROTECTED");
+		mdb_printf("            KPTI is %s\n",
+		    kpti_enable == 2 ? "not available" :
+		    (kpti_enable ? "enabled" : "disabled"));
+		mdb_printf("            PCID is %s\n",
+		    !BT_TEST((ulong_t *)fset, X86FSET_PCID) ?
+		    "not supported by this processor" :
+		    (x86_use_pcid == 1 ? "in-use" : "disabled"));
+		mdb_printf("            INVPCID is %s\n",
+		    !BT_TEST((ulong_t *)fset, X86FSET_INVPCID) ?
+		    "not supported by this processor" :
+		    (x86_use_pcid == 1 && x86_use_invpcid == 1 ?
+		    "in-use" : "disabled"));
+	}
+
+	mdb_free(fset, sz);
+
+	/* Lazy FPU (CVE-2018-3665) */
+
+	int eager = mdb_lookup_by_name("fp_exec", &sym) == 0;
+
+	if (opt_p)
+		mdb_printf("lazy fpu:CVE-2018-3665:%s\n",
+		    eager ? "protected" : "not-protected");
+	else
+	{
+		mdb_printf("= Lazy FPU (CVE-2018-3665)\n");
+		mdb_printf("    Status: %s\n",
+		    eager == 1 ? "PROTECTED" : "NOT PROTECTED");
+		mdb_printf(
+		    "            System is using %s FPU register restore\n",
+		    eager ? "eager" : "lazy");
+	}
+
+	return (DCMD_OK);
+}
+
+void
+sec_help(void)
+{
+	mdb_printf(
+	    "Prints information about the status of kernel protection\n"
+	    "against processor vulnerabilities.\n");
+	mdb_printf(
+	    "    -p    Output information in a format suitable for parsing\n");
+}

--- a/usr/src/cmd/mdb/i86pc/modules/unix/sec.h
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/sec.h
@@ -1,0 +1,34 @@
+/*
+ * CDDL HEADER
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source. A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ */
+
+#ifndef	_I86SEC_H
+#define	_I86SEC_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+extern int sec_dcmd(uintptr_t addr, uint_t flags, int argc,
+	const mdb_arg_t *argv);
+
+extern void sec_help(void);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _I86SEC_H */

--- a/usr/src/cmd/mdb/i86pc/modules/unix/unix.c
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/unix.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2018 Joyent, Inc.
  */
 
@@ -37,6 +38,7 @@
 #include <sys/mutex_impl.h>
 #include "i86mmu.h"
 #include "unix_sup.h"
+#include "sec.h"
 #include <sys/apix.h>
 #include <sys/x86_archext.h>
 #include <sys/bitmap.h>
@@ -999,6 +1001,7 @@ static const mdb_dcmd_t dcmds[] = {
 #ifdef _KMDB
 	{ "crregs", NULL, "dump control registers", crregs_dcmd },
 #endif
+	{ "sec", "?[-p]", "print security patch summary", sec_dcmd, sec_help },
 	{ NULL }
 };
 

--- a/usr/src/cmd/mdb/i86xpv/modules/unix/amd64/Makefile
+++ b/usr/src/cmd/mdb/i86xpv/modules/unix/amd64/Makefile
@@ -27,7 +27,7 @@
 MODULE = unix.so
 MDBTGT = kvm
 
-MODSRCS = unix.c i86mmu.c
+MODSRCS = unix.c i86mmu.c sec.c
 MODASMSRCS = unix_sup.s
 
 include ../../../../../Makefile.cmd


### PR DESCRIPTION
Add ::sec command to mdb to summarise protection against processor security vulnerabilities.

```
% pfexec mdb -ke ::sec
= Meltdown (CVE-2017-5754)
    Status: NOT PROTECTED
            KPTI is disabled
            PCID is not supported by this processor
            INVPCID is not supported by this processor
= Lazy FPU (CVE-2018-3665)
    Status: PROTECTED
            System is using eager FPU register restore
```
```
% pfexec mdb -ke '::sec -p'
meltdown:CVE-2017-5754:not-protected
lazy fpu:CVE-2018-3665:protected
```
```
% pfexec mdb -ke '::help sec'

NAME
  sec - print security patch summary

SYNOPSIS
  [ addr ] ::sec [-p]

DESCRIPTION

  Prints information about the status of kernel protection
  against processor vulnerabilities.
      -p    Output information in a format suitable for parsing

ATTRIBUTES

  Target: kvm
  Module: unix
  Interface Stability: Unstable
```
## mail_msg

```

==== Nightly distributed build started:   Sat Jun 16 10:40:41 UTC 2018 ====
==== Nightly distributed build completed: Sat Jun 16 11:50:58 UTC 2018 ====

==== Total build time ====

real    1:10:17

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151026-d442a020ce i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   763824

==== Nightly argument issues ====


==== Build version ====

omnios-mdb_sec-1c13944403

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:38.2
user  1:15:50.4
sys     11:54.3

==== Build noise differences (non-DEBUG) ====

48,53d47
< The following command caused the error:
< collect2: ld returned 1 exit status
< dmake: Warning: Command failed for target `dmod/unix.so'
< dmake: Warning: Command failed for target `kmod/unix'
< dmake: Warning: Command failed for target `mdb'
< dmake: Warning: Target `install' not remade because of errors
55,56d48
< ld: fatal: symbol referencing errors. No output written to dmod/unix.so
< ld: fatal: symbol referencing errors. No output written to kmod/unix.linktest

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:04.4
user  1:11:54.5
sys     12:08.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    22:18.9
user    43:49.3
sys     10:46.0

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
