### PR TITLE
grep segfaults when you ask for context (r151026)

### DIFF
--- a/usr/src/cmd/grep/grep.c
+++ b/usr/src/cmd/grep/grep.c
@@ -35,6 +35,7 @@
  */
 
 /*
+ * Copyright 2018 RackTop Systems.
  * Copyright 2018 Nexenta Systems, Inc.
  * Copyright 2013 Damian Bogel. All rights reserved.
  */
@@ -1277,8 +1278,8 @@ L_start_process:
 			goto L_next_line;
 
 		/* Do we have room to add this line to the context buffer? */
-		if ((line_len + 1) > (conbuflen -
-		    (conptrend >= conptr) ? conptrend - conbuf : 0)) {
+		while ((line_len + 1) > (conbuflen -
+		    ((conptrend >= conptr) ? conptrend - conbuf : 0))) {
 			char *oldconbuf = conbuf;
 			char *oldconptr = conptr;
 			long tmp = matchptr - conptr;


### PR DESCRIPTION
Backport from bloody, fixes https://github.com/omniosorg/illumos-omnios/issues/229

Before:
```
reaper# prtconf -v | grep -A 1 d@n5000c5007f0373b7
            value='id1,sd@n5000c5007f0373b7/a'
        name='keyboard-layout' type=string items=1
--
                            value='id1,sd@n5000c5007f0373b7'
                        name='inquiry-revision-id' type=string items=1
zsh: broken pipe                       prtconf -v |
zsh: segmentation fault (core dumped)  grep -A 1 d@n5000c5007f0373b7
```
After:
```
reaper# prtconf -v | /data/zone/build/root/data/omnios-build/omniosorg/r151026/illumos/usr/src/cmd/grep/grep -A 1 d@n5000c5007f0373b7
            value='id1,sd@n5000c5007f0373b7/a'
        name='keyboard-layout' type=string items=1
--
                            value='id1,sd@n5000c5007f0373b7'
                        name='inquiry-revision-id' type=string items=1
```