### PR TITLE
Add support for CPIO boot archives

### DIFF
--- a/usr/src/cmd/boot/bootadm/Makefile
+++ b/usr/src/cmd/boot/bootadm/Makefile
@@ -43,7 +43,7 @@ POFILE= bootadm_cmd.po
 
 LDLIBS_i386= -lfdisk
 LDLIBS += -lficl-sys -lmd -lcryptoutil -lnvpair -lgen -ladm -lefi
-LDLIBS += -lz -lbe -lzfs -lofmt $(LDLIBS_$(MACH))
+LDLIBS += -lscf -lz -lbe -lzfs -lofmt $(LDLIBS_$(MACH))
 
 # Writing into string literals is incorrect.  We need to match gcc's
 # behavior, which causes us to take SIGSEGV on such a write.

--- a/usr/src/cmd/boot/scripts/create_ramdisk.ksh
+++ b/usr/src/cmd/boot/scripts/create_ramdisk.ksh
@@ -36,28 +36,33 @@ compress=yes
 dirsize=0
 
 usage() {
-	echo "This utility is a component of the bootadm(1M) implementation"
-	echo "and it is not recommended for stand-alone use."
-	echo "Please use bootadm(1M) instead."
-	echo ""
-	echo "Usage: ${0##*/}: [-R <root>] [-p <platform>] [--nocompress]"
-	echo "where <platform> is one of i86pc, sun4u or sun4v"
+	cat <<- EOM
+This utility is a component of the bootadm(1M) implementation and it is not
+recommended for stand-alone use. Please use bootadm(1M) instead.
+
+Usage: ${0##*/}: [-R <root>] [-p <platform>] [ -f <format> ] [--nocompress]
+where <platform> is one of i86pc, sun4u or sun4v
+  and <format> is one of ufs or cpio
+	EOM
 	exit
 }
 
 # default platform is what we're running on
 PLATFORM=`uname -m`
 
+FORMAT=`svcprop -p config/format system/boot-archive`
+[[ "$FORMAT" =~ ^(cpio|ufs|ufs-nocompress)$ ]] || FORMAT=cpio
+
 export PATH=/usr/sbin:/usr/bin:/sbin
 export GZIP_CMD=/usr/bin/gzip
+export CPIO_CMD=/usr/bin/cpio
 
 EXTRACT_FILELIST="/boot/solaris/bin/extract_boot_filelist"
 
 #
 # Parse options
 #
-while [ "$1" != "" ]
-do
+while [ -n "$1" ]; do
         case $1 in
         -R)	shift
 		ALT_ROOT="$1"
@@ -72,6 +77,9 @@ do
 	-p)	shift
 		PLATFORM="$1"
 		EXTRACT_ARGS="${EXTRACT_ARGS} -p ${PLATFORM}"
+		;;
+	-f)	shift
+		FORMAT="$1"
 		;;
         *)      usage
 		;;
@@ -91,7 +99,6 @@ i386|i86pc)	PLATFORM=i86pc
 		ISA=i386
 		ARCH64=amd64
 		BOOT_ARCHIVE_SUFFIX=$ARCH64/boot_archive
-		compress=yes
 		;;
 sun4u|sun4v)	ISA=sparc
 		ARCH64=sparcv9
@@ -104,39 +111,20 @@ esac
 
 BOOT_ARCHIVE=platform/$PLATFORM/$BOOT_ARCHIVE_SUFFIX
 
+function fatal_error
+{
+	print -u2 $*
+	exit 1
+}
+
 [ -x $GZIP_CMD ] || compress=no
 
-function cleanup
-{
-	umount -f "$rdmnt" 2>/dev/null
-	lofiadm -d "$rdfile" 2>/dev/null
-	[ -n "$rddir" ] && rm -fr "$rddir" 2> /dev/null
-	[ -n "$new_rddir" ] && rm -fr "$new_rddir" 2>/dev/null
-}
-
-function getsize
-{
-	# Estimate image size and add 10% overhead for ufs stuff.
-	# Note, we can't use du here in case we're on a filesystem, e.g. zfs,
-	# in which the disk usage is less than the sum of the file sizes.
-	# The nawk code
-	#
-	#	{t += ($5 % 1024) ? (int($5 / 1024) + 1) * 1024 : $5}
-	#
-	# below rounds up the size of a file/directory, in bytes, to the
-	# next multiple of 1024.  This mimics the behavior of ufs especially
-	# with directories.  This results in a total size that's slightly
-	# bigger than if du was called on a ufs directory.
-	size=$(cat "$list" | xargs -I {} ls -lLd "{}" 2> /dev/null |
-		nawk '{t += ($5 % 1024) ? (int($5 / 1024) + 1) * 1024 : $5}
-		END {print int(t * 1.10 / 1024)}')
-	(( size += dirsize ))
-	(( total_size = size ))
-	# If compression is enabled, then each file within the archive will
-	# be individually compressed. The compression ratio is around 60%
-	# across the archive so make the image smaller.
-	[ $compress = yes ] && (( total_size = total_size / 2 ))
-}
+case $FORMAT in
+cpio)		[ -x $CPIO_CMD ] || FORMAT=ufs ;;
+ufs-nocompress)	FORMAT=ufs; compress=no ;;
+ufs)		;;
+*)		fatal_error "Unsupport archive format, $1" ;;
+esac
 
 #
 # Copies all desired files to a target directory.  One argument should be
@@ -182,17 +170,112 @@ function copy_files
 
 }
 
-function create_ufs
+function ufs_cleanup
 {
-	archive=$1
-	lofidev=$2
+	umount -f "$rdmnt" 2>/dev/null
+	lofiadm -d "$rdfile" 2>/dev/null
+	[ -n "$rddir" ] && rm -fr "$rddir" 2> /dev/null
+	[ -n "$new_rddir" ] && rm -fr "$new_rddir" 2>/dev/null
+}
+
+function ufs_getsize
+{
+	# Estimate image size and add 10% overhead for ufs stuff.
+	# Note, we can't use du here in case we're on a filesystem, e.g. zfs,
+	# in which the disk usage is less than the sum of the file sizes.
+	# The nawk code
+	#
+	#	{t += ($5 % 1024) ? (int($5 / 1024) + 1) * 1024 : $5}
+	#
+	# below rounds up the size of a file/directory, in bytes, to the
+	# next multiple of 1024.  This mimics the behavior of ufs especially
+	# with directories.  This results in a total size that's slightly
+	# bigger than if du was called on a ufs directory.
+	size=$(cat "$list" | xargs -I {} ls -lLd "{}" 2> /dev/null |
+		nawk '{t += ($5 % 1024) ? (int($5 / 1024) + 1) * 1024 : $5}
+		END {print int(t * 1.10 / 1024)}')
+	(( size += dirsize ))
+	(( total_size = size ))
+	# If compression is enabled, then each file within the archive will
+	# be individually compressed. The compression ratio is around 60%
+	# across the archive so make the image smaller.
+	[ $compress = yes ] && (( total_size = total_size / 2 ))
+}
+
+function create_ufs_archive
+{
+	typeset archive="$BOOT_ARCHIVE"
+
+	[ "$compress" = yes ] && \
+	    echo "updating $archive (UFS)" || \
+	    echo "updating $archive (UFS-nocompress)"
+
+	#
+	# We use /tmp/ for scratch space now.  This will be changed later to
+	# $ALT_ROOT/var/tmp if there is insufficient space in /tmp/.
+	#
+	rddir="/tmp/create_ramdisk.$$.tmp"
+	new_rddir=
+	rm -rf "$rddir"
+	mkdir "$rddir" || fatal_error "Could not create directory $rddir"
+
+	# Clean up upon exit.
+	trap 'ufs_cleanup' EXIT
+
+	list="$rddir/filelist"
+
+	cd "/$ALT_ROOT" || fatal_error "Cannot chdir to $ALT_ROOT"
+	find $filelist -print 2>/dev/null | while read path; do
+		if [ -d "$path" ]; then
+			size=`ls -lLd "$path" | nawk '
+		    {print ($5 % 1024) ? (int($5 / 1024) + 1) * 1024 : $5}'`
+			(( dirsize += size / 1024 ))
+		else
+			print "$path"
+		fi
+	done >"$list"
+
+	# calculate image size
+	ufs_getsize
+
+	# check to see if there is sufficient space in tmpfs
+	#
+	tmp_free=`df -b /tmp | tail -1 | awk '{ print $2 }'`
+	(( tmp_free = tmp_free / 3 ))
+
+	if [ $total_size -gt $tmp_free ] ; then
+		echo "Insufficient space in /tmp, using $ALT_ROOT/var/tmp"
+		# assumes we have enough scratch space on $ALT_ROOT
+		new_rddir="/$ALT_ROOT/var/tmp/create_ramdisk.$$.tmp"
+		rm -rf "$new_rddir"
+		mkdir "$new_rddir" || fatal_error \
+		    "Could not create temporary directory $new_rddir"
+
+		# Save the file lists
+		mv "$list" "$new_rddir"/
+		list="/$new_rddir/filelist"
+
+		# Remove the old $rddir and set the new value of rddir
+		rm -rf "$rddir"
+		rddir="$new_rddir"
+		new_rddir=
+	fi
+
+	rdfile="$rddir/rd.file"
+	rdmnt="$rddir/rd.mount"
+	errlog="$rddir/rd.errlog"
+	lofidev=""
+
+	mkfile ${total_size}k "$rdfile" || \
+	    fatal_error "Could not create backing file"
+	lofidev=`lofiadm -a "$rdfile"` || \
+	    fatal_error "Could not create lofi device"
 
 	NOINUSE_CHECK=1 newfs -m 0 $lofidev < /dev/null 2> /dev/null
 	mkdir "$rdmnt"
 	mount -F mntfs mnttab /etc/mnttab > /dev/null 2>&1
 	mount -F ufs -o nologging $lofidev "$rdmnt"
 	rm -rf "$rdmnt/lost+found"
-	files=
 
 	# do the actual copy
 	copy_files "$list"
@@ -201,10 +284,12 @@ function create_ufs
 
 	if [ $ISA = sparc ] ; then
 		rlofidev="${lofidev/lofi/rlofi}"
-		bb="$ALT_ROOT/platform/$PLATFORM/lib/fs/ufs/bootblk"
+		bb="/$ALT_ROOT/platform/$PLATFORM/lib/fs/ufs/bootblk"
 		# installboot is not available on all platforms
 		dd if=$bb of=$rlofidev bs=1b oseek=1 count=15 conv=sync 2>&1
 	fi
+
+	lofiadm -d "$rdfile"
 
 	#
 	# Check if gzip exists in /usr/bin, so we only try to run gzip
@@ -224,16 +309,6 @@ function create_ufs
 	if [ $? -ne 0 ] ; then
 		rm -f "${archive}-new"
 	fi
-}
-
-function create_archive
-{
-	archive=$1
-	lofidev=$2
-
-	echo "updating $archive"
-
-	create_ufs "$archive" "$lofidev"
 
 	# sanity check the archive before moving it into place
 	#
@@ -260,15 +335,54 @@ function create_archive
 		lockfs -f "/$ALT_ROOT" 2>/dev/null
 		rm -f "$archive.hash"
 		mv "${archive}-new" "$archive"
-		digest -a sha1 "$archive" > "$archive.hash"
+		digest -a sha1 "$rdfile" > "$archive.hash"
 		lockfs -f "/$ALT_ROOT" 2>/dev/null
 	fi
+	[ -n "$rddir" ] && rm -rf "$rddir"
 }
 
-function fatal_error
+function cpio_cleanup
 {
-	print -u2 $*
-	exit 1
+	[ -f "/$ALT_ROOT/$tarchive" ] && rm -f "/$ALT_ROOT/$tarchive"
+	[ -f "/$ALT_ROOT/$tarchive.cpio" ] && rm -f "/$ALT_ROOT/$tarchive.cpio"
+	[ -f "/$ALT_ROOT/$tarchive.hash" ] && rm -f "/$ALT_ROOT/$tarchive.hash"
+}
+
+function create_cpio_archive
+{
+	typeset archive="$BOOT_ARCHIVE"
+
+	echo "updating $archive (CPIO)"
+
+	tarchive="$archive.$$.new"
+
+	# Clean up upon exit.
+	trap 'cpio_cleanup' EXIT
+
+	cd "/$ALT_ROOT" || fatal_error "Cannot chdir to $ALT_ROOT"
+
+	touch "$tarchive" \
+	    || fatal_error "Cannot create temporary archive $tarchive"
+
+	find $filelist 2>/dev/null | cpio -qo -H odc > "$tarchive.cpio" \
+	    || fatal_error "Problem creating archive"
+
+	[ -x /usr/bin/digest ] \
+	    && /usr/bin/digest -a sha1 "$tarchive.cpio" \
+	    > "$tarchive.hash"
+
+	if [ -x "$GZIP_CMD" ]; then
+		$GZIP_CMD -c "$tarchive.cpio" > "$tarchive"
+		rm -f "$tarchive.cpio"
+	else
+		mv "$tarchive.cpio" "$tarchive"
+	fi
+
+	# Move new archive into place
+	[ -f "$archive.hash" ] && rm -f "$archive.hash"
+	mv "$tarchive" "$archive"
+	[ $? -eq 0 -a  -f "$tarchive.hash" ] \
+	    && mv "$tarchive.hash" "$archive.hash"
 }
 
 #
@@ -285,65 +399,12 @@ filelist=$($EXTRACT_FILELIST $EXTRACT_ARGS \
 	/etc/boot/solaris/filelist.ramdisk \
 		2>/dev/null | sort -u)
 
-#
-# We use /tmp/ for scratch space now.  This will be changed later to
-# $ALT_ROOT/var/tmp if there is insufficient space in /tmp/.
-#
-rddir="/tmp/create_ramdisk.$$.tmp"
-new_rddir=
-rm -rf "$rddir"
-mkdir "$rddir" || fatal_error "Could not create temporary directory $rddir"
+# Now that we have the list of files, we can create the archive.
 
-# Clean up upon exit.
-trap 'cleanup' EXIT
-
-list="$rddir/filelist"
-
-cd "/$ALT_ROOT"
-find $filelist -print 2>/dev/null | while read path; do
-	if [ -d "$path" ]; then
-		size=`ls -lLd "$path" | nawk '
-		    {print ($5 % 1024) ? (int($5 / 1024) + 1) * 1024 : $5}'`
-		(( dirsize += size / 1024 ))
-	else
-		print "$path"
-	fi
-done >"$list"
-
-# calculate image size
-getsize
-
-# check to see if there is sufficient space in tmpfs
-#
-tmp_free=`df -b /tmp | tail -1 | awk '{ print $2 }'`
-(( tmp_free = tmp_free / 3 ))
-
-if [ $total_size -gt $tmp_free ] ; then
-	# assumes we have enough scratch space on $ALT_ROOT
-	new_rddir="/$ALT_ROOT/var/tmp/create_ramdisk.$$.tmp"
-	rm -rf "$new_rddir"
-	mkdir "$new_rddir" || fatal_error \
-	    "Could not create temporary directory $new_rddir"
-
-	# Save the file lists
-	mv "$list" "$new_rddir"/
-	list="/$new_rddir/filelist"
-
-	# Remove the old $rddir and set the new value of rddir
-	rm -rf "$rddir"
-	rddir="$new_rddir"
-	new_rddir=
-fi
-
-rdfile="$rddir/rd.file"
-rdmnt="$rddir/rd.mount"
-errlog="$rddir/rd.errlog"
-lofidev=""
-
-mkfile ${total_size}k "$rdfile" || fatal_error "Could not create backing file"
-lofidev=`lofiadm -a "$rdfile"` || fatal_error "Could not create lofi device"
-create_archive "$ALT_ROOT/$BOOT_ARCHIVE" $lofidev
-lofiadm -d "$rdfile"
+case "$FORMAT" in
+	cpio)	create_cpio_archive ;;
+	ufs)	create_ufs_archive ;;
+esac
 
 #
 # For the diskless case, hardlink archive to /boot to make it
@@ -355,4 +416,3 @@ if [ $? = 0 ]; then
 	rm -f "$ALT_ROOT/boot/$BOOT_ARCHIVE_SUFFIX"
 	ln "$ALT_ROOT/$BOOT_ARCHIVE" "$ALT_ROOT/boot/$BOOT_ARCHIVE_SUFFIX"
 fi
-[ -n "$rddir" ] && rm -rf "$rddir"

--- a/usr/src/cmd/svc/milestone/boot-archive.xml
+++ b/usr/src/cmd/svc/milestone/boot-archive.xml
@@ -71,6 +71,10 @@
 		<propval name='duration' type='astring' value='transient' />
 	</property_group>
 
+	<property_group name='config' type='application'>
+		<propval name='format' type='astring' value='cpio' />
+	</property_group>
+
 	<stability value='Unstable' />
 
 	<template>

--- a/usr/src/man/man1m/bootadm.1m
+++ b/usr/src/man/man1m/bootadm.1m
@@ -4,13 +4,14 @@
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
 .\" Copyright 2016 Toomas Soome <tsoome@me.com>
-.TH BOOTADM 1M "Aug 18, 2016"
+.\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+.TH BOOTADM 1M "Jul 05, 2018"
 .SH NAME
 bootadm \- manage bootability of the operating system
 .SH SYNOPSIS
 .LP
 .nf
-\fB/sbin/bootadm\fR update-archive [\fB-vn\fR] [\fB-R\fR \fIaltroot\fR [\fB-p\fR \fIplatform\fR]]
+\fB/sbin/bootadm\fR update-archive [\fB-vnf\fR] [\fB-R\fR \fIaltroot\fR [\fB-p\fR \fIplatform\fR]]
 .fi
 
 .LP
@@ -87,7 +88,68 @@ The \fBbootadm\fR command has the following subcommands:
 .sp .6
 .RS 4n
 Updates current boot archive if required. Applies to both SPARC and x86
-platforms.
+platforms. The boot archive can be created in a number of different formats;
+the default format is an IEEE/P1003 Data Interchange Standard cpio archive.
+The format is configured through the following service management facility
+(\fBsmf\fR(5)) property:
+.sp
+.in +2
+.nf
+svc:/system/boot-archive:default/config/format
+.fi
+.in -2
+
+.sp
+.LP
+This property takes one of the following values:
+.RS 8n
+
+.sp
+.ne 2
+.na
+\fBcpio\fR
+.ad
+.sp .6
+.RS 4n
+IEEE/P1003 Data Interchange Standard cpio archive (default).
+.RE
+
+.sp
+.ne 2
+.na
+\fBhsfs\fR
+.ad
+.sp .6
+.RS 4n
+ISO 9660 filesystem image (only supported if \fI/usr/bin/mkisofs\fR is
+available).
+.RE
+
+.sp
+.ne 2
+.na
+\fBufs\fR
+.ad
+.sp .6
+.RS 4n
+UFS filesystem in which the files within are compressed using gzip if
+\fI/usr/bin/gzip\fR is available.
+.RE
+
+.sp
+.ne 2
+.na
+\fBufs-nocompress\fR
+.ad
+.sp .6
+.RS 4n
+UFS filesystem. The files within are not compressed but the resulting overall
+boot archive will still be compressed if \fI/usr/bin/gzip\fR is available.
+.RE
+.RE
+
+See \fBEXAMPLES\fR for how to change this value.
+
 .RE
 
 .sp
@@ -170,6 +232,9 @@ The \fBbootadm\fR command has the following options:
 .ad
 .sp .6
 .RS 4n
+In an \fBupdate-archive\fR operation, force re-generation of the boot-archive
+even if no files have changed.
+
 In an \fBinstall-bootloader\fR operation, override the boot loader versioning
 constraints.
 .RE
@@ -367,7 +432,22 @@ user selects test-183 (item 1).
 .in -2
 
 .LP
-\fBExample 5 \fRDetailed information about menu entry.
+\fBExample 5 \fRChanging archive format
+.sp
+.LP
+The following command changes the boot archive format to \fIufs\fR
+
+.sp
+.in +2
+.nf
+# svccfg -s system/boot-archive:default setprop config/format = ufs
+# svcadm refresh system/boot-archive:default
+# bootadm update-archive -f
+.fi
+.in -2
+
+.LP
+\fBExample 6 \fRDetailed information about menu entry.
 .sp
 .LP
 The following command lists more detailed information about a boot menu entry:

--- a/usr/src/uts/common/krtld/bootrd.c
+++ b/usr/src/uts/common/krtld/bootrd.c
@@ -22,6 +22,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2013 Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
  */
 
 
@@ -37,12 +38,14 @@
 extern void (*_kobj_printf)(void *, const char *fmt, ...);
 extern int get_weakish_int(int *);
 extern struct bootops *ops;
-extern struct boot_fs_ops bufs_ops, bhsfs_ops, bbootfs_ops;
+extern struct boot_fs_ops bufs_ops, bhsfs_ops, bbootfs_ops, bcpio_ops;
 extern int kmem_ready;
 
 static uint64_t rd_start, rd_end;
 struct boot_fs_ops *bfs_ops;
-struct boot_fs_ops *bfs_tab[] = {&bufs_ops, &bhsfs_ops, &bbootfs_ops, NULL};
+struct boot_fs_ops *bfs_tab[] = {
+	&bufs_ops, &bhsfs_ops, &bbootfs_ops, &bcpio_ops, NULL,
+};
 
 static uintptr_t scratch_max = 0;
 

--- a/usr/src/uts/common/krtld/bootrd_cpio.c
+++ b/usr/src/uts/common/krtld/bootrd_cpio.c
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2011-2018 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <sys/stdbool.h>
+#include <sys/sysmacros.h>
+#include <sys/bootvfs.h>
+#include <sys/filep.h>
+#include <sys/sunddi.h>
+#include <sys/ccompile.h>
+
+/*
+ * A cpio archive is just a sequence of files, each consisting of a header
+ * (struct cpio_hdr) and the file contents.
+ */
+
+struct cpio_hdr {
+	uint8_t		magic[6];
+	uint8_t		dev[6];
+	uint8_t		ino[6];
+	uint8_t		mode[6];
+	uint8_t		uid[6];
+	uint8_t		gid[6];
+	uint8_t		nlink[6];
+	uint8_t		rdev[6];
+	uint8_t		mtime[11];
+	uint8_t		namesize[6];
+	uint8_t		filesize[11];
+	char		data[];
+};
+
+struct cpio_file {
+	/* pointers into the archive */
+	const struct cpio_hdr *hdr;
+	const char *path;
+	const uint8_t *data;
+
+	int fd;
+	off_t off;
+	struct bootstat stat;
+
+	struct cpio_file *next;
+};
+
+extern void *bkmem_alloc(size_t);
+extern void bkmem_free(void *, size_t);
+extern void (*_kobj_printf)(void *, const char *, ...);
+extern struct bootops *ops;
+
+/* Linked list of open files in reverse order of opening. */
+static struct cpio_file *bcpio_open_files = NULL;
+static bool bcpio_mounted = false;
+
+#ifdef KOBJ_DEBUG
+static uint64_t bcpio_open_success = 0;
+static uint64_t bcpio_open_fail = 0;
+static uint64_t bcpio_open_max = 0;
+#endif
+
+static int
+cpio_strcmp(const char *a, const char *b)
+{
+	while ((*a != '\0') && (*b != '\0') && (*a == *b)) {
+		a++;
+		b++;
+	}
+
+	if (*a == *b)
+		return (0);
+	if (*a < *b)
+		return (-1);
+	return (1);
+}
+
+/*
+ * Returns the parsed number on success, or UINT64_MAX on error.  This is
+ * ok because we will never deal with numbers that large in a cpio archive.
+ */
+static uint64_t
+__get_uint64(const uint8_t *str, size_t len, const size_t output_size)
+{
+	uint64_t v;
+
+	/* check that we can represent every number */
+	if (len * 3 > output_size)
+		return (UINT64_MAX);
+
+	for (v = 0; len > 0; len--, str++) {
+		const uint8_t c = *str;
+
+		if ((c < '0') || (c > '7'))
+			return (UINT64_MAX);
+
+		v = (v * 8) + (c - '0');
+	}
+
+	return (v);
+}
+
+static bool
+get_uint64(const uint8_t *str, size_t len, uint64_t *out)
+{
+	*out = __get_uint64(str, len, NBBY * sizeof (*out));
+	return (*out != UINT64_MAX);
+}
+
+static bool
+get_int64(const uint8_t *str, size_t len, int64_t *out)
+{
+	uint64_t tmp;
+
+	tmp = __get_uint64(str, len, NBBY * sizeof (*out) - 1);
+
+	*out = tmp;
+
+	return (tmp != UINT64_MAX);
+}
+
+static bool
+get_uint32(const uint8_t *str, size_t len, uint32_t *out)
+{
+	uint64_t tmp;
+
+	tmp = __get_uint64(str, len, NBBY * sizeof (*out));
+
+	*out = tmp;
+
+	return (tmp != UINT64_MAX);
+}
+
+static bool
+get_int32(const uint8_t *str, size_t len, int32_t *out)
+{
+	uint64_t tmp;
+
+	tmp = __get_uint64(str, len, NBBY * sizeof (*out) - 1);
+
+	*out = tmp;
+
+	return (tmp != UINT64_MAX);
+}
+
+static void
+add_open_file(struct cpio_file *file)
+{
+#ifdef KOBJ_DEBUG
+	struct cpio_file *p;
+	uint64_t c;
+
+	for (p = bcpio_open_files; p; p = p->next)
+		c++;
+	bcpio_open_max = MAX(c, bcpio_open_max);
+#endif
+
+	file->next = bcpio_open_files;
+	bcpio_open_files = file;
+}
+
+static void
+remove_open_file(struct cpio_file *file)
+{
+	struct cpio_file **p;
+
+	for (p = &bcpio_open_files; *p != NULL; p = &((*p)->next)) {
+		if (*p == file) {
+			*p = file->next;
+			return;
+		}
+	}
+}
+
+static struct cpio_file *
+find_open_file(int fd)
+{
+	struct cpio_file *file;
+
+	if (fd < 1)
+		return (NULL);
+
+	for (file = bcpio_open_files; file != NULL; file = file->next)
+		if (file->fd == fd)
+			return (file);
+
+	return (NULL);
+}
+
+static const void *
+read_ramdisk(size_t off, size_t len)
+{
+	const size_t first_block_offset = off % DEV_BSIZE;
+	fileid_t tmpfile;
+
+	/* return a dummy non-NULL pointer */
+	if (len == 0)
+		return ("");
+
+	/* we have to read the stuff before the desired location as well */
+	len += first_block_offset;
+
+	tmpfile.fi_blocknum = off / DEV_BSIZE;
+	tmpfile.fi_count = P2ROUNDUP_TYPED(len, DEV_BSIZE, size_t);
+	tmpfile.fi_memp = NULL;
+
+	if (diskread(&tmpfile) != 0)
+		return (NULL);
+
+	return (tmpfile.fi_memp + first_block_offset);
+}
+
+static bool
+parse_stat(const struct cpio_hdr *hdr, struct bootstat *stat)
+{
+	if (!get_uint64(hdr->dev, sizeof (hdr->dev), &stat->st_dev))
+		return (false);
+	if (!get_uint64(hdr->ino, sizeof (hdr->ino), &stat->st_ino))
+		return (false);
+	if (!get_uint32(hdr->mode, sizeof (hdr->mode), &stat->st_mode))
+		return (false);
+	if (!get_int32(hdr->uid, sizeof (hdr->uid), &stat->st_uid))
+		return (false);
+	if (!get_int32(hdr->gid, sizeof (hdr->gid), &stat->st_gid))
+		return (false);
+	if (!get_uint32(hdr->nlink, sizeof (hdr->nlink), &stat->st_nlink))
+		return (false);
+	if (!get_uint64(hdr->rdev, sizeof (hdr->rdev), &stat->st_rdev))
+		return (false);
+
+	stat->st_mtim.tv_nsec = 0;
+	if (!get_int64(hdr->mtime, sizeof (hdr->mtime), &stat->st_mtim.tv_sec))
+		return (false);
+
+	stat->st_atim = stat->st_mtim;
+	stat->st_ctim = stat->st_mtim;
+
+	if (!get_uint64(hdr->filesize, sizeof (hdr->filesize), &stat->st_size))
+		return (false);
+
+	stat->st_blksize = DEV_BSIZE;
+	stat->st_blocks = P2ROUNDUP(stat->st_size, DEV_BSIZE);
+
+	return (true);
+}
+
+/*
+ * Check if specified header is for a file with a specific path.  If so,
+ * fill in the file struct and return 0.  If not, return number of bytes to
+ * skip over to get to the next header.  If an error occurs, -1 is returned.
+ * If end of archive is reached, return -2 instead.
+ */
+static ssize_t
+scan_archive_hdr(const struct cpio_hdr *hdr, size_t off,
+    struct cpio_file *file, const char *wanted_path)
+{
+	struct bootstat stat;
+	uint32_t namesize;
+	uint64_t filesize;
+	const char *path;
+	const void *data;
+
+	if ((hdr->magic[0] != '0') || (hdr->magic[1] != '7') ||
+	    (hdr->magic[2] != '0') || (hdr->magic[3] != '7') ||
+	    (hdr->magic[4] != '0') || (hdr->magic[5] != '7'))
+		return (-1);
+
+	if (!get_uint32(hdr->namesize, sizeof (hdr->namesize), &namesize))
+		return (-1);
+	if (!get_uint64(hdr->filesize, sizeof (hdr->filesize), &filesize))
+		return (-1);
+
+	/*
+	 * We have the two sizes, let's try to read the name and file
+	 * contents to make sure they are part of the ramdisk.
+	 */
+
+	off += offsetof(struct cpio_hdr, data[0]);
+	path = read_ramdisk(off, namesize);
+	data = read_ramdisk(off + namesize, filesize);
+
+	/* either read failing is fatal */
+	if (path == NULL || data == NULL)
+		return (-1);
+
+	if (cpio_strcmp(path, "TRAILER!!!") == 0)
+		return (-2);
+
+	if (cpio_strcmp(path, wanted_path) != 0)
+		return (offsetof(struct cpio_hdr, data[namesize + filesize]));
+
+	/*
+	 * This is the file we want!
+	 */
+
+	if (!parse_stat(hdr, &stat))
+		return (-1);
+
+	file->hdr = hdr;
+	file->path = path;
+	file->data = data;
+	file->stat = stat;
+
+	return (0);
+}
+
+static int
+find_filename(char *path, struct cpio_file *file)
+{
+	size_t off;
+
+	/*
+	 * The paths in the cpio boot archive omit the leading '/'.  So,
+	 * skip checking for it.  If the searched for path does not include
+	 * the leading path (it's a relative path), fail the lookup.
+	 */
+	if (path[0] != '/')
+		return (-1);
+
+	path++;
+
+	/* now scan the archive for the relevant file */
+
+	off = 0;
+
+	for (;;) {
+		const struct cpio_hdr *hdr;
+		ssize_t size;
+
+		hdr = read_ramdisk(off, sizeof (struct cpio_hdr));
+		if (hdr == NULL)
+			return (-1);
+
+		size = scan_archive_hdr(hdr, off, file, path);
+		if (size <= 0)
+			return (size);
+
+		off += size;
+	}
+}
+
+static int
+/* LINTED E_FUNC_ARG_UNUSED */
+bcpio_mountroot(char *str __unused)
+{
+	if (bcpio_mounted)
+		return (-1);
+
+	bcpio_mounted = true;
+
+	return (0);
+}
+
+static int
+bcpio_unmountroot(void)
+{
+	if (!bcpio_mounted)
+		return (-1);
+
+	bcpio_mounted = false;
+
+	return (0);
+}
+
+static int
+bcpio_open(char *path,
+    /* LINTED E_FUNC_ARG_UNUSED */
+    int flags __unused)
+{
+	static int filedes = 1;
+	struct cpio_file temp_file;
+	struct cpio_file *file;
+
+	if (find_filename(path, &temp_file) != 0) {
+#ifdef KOBJ_DEBUG
+		bcpio_open_fail++;
+		_kobj_printf(ops, "F %s\n", path);
+#endif
+		return (-1);
+	}
+
+	file = bkmem_alloc(sizeof (struct cpio_file));
+	file->hdr = temp_file.hdr;
+	file->path = temp_file.path;
+	file->data = temp_file.data;
+	file->stat = temp_file.stat;
+	file->fd = filedes++;
+	file->off = 0;
+
+	add_open_file(file);
+
+#ifdef KOBJ_DEBUG
+	bcpio_open_success++;
+#endif
+
+	return (file->fd);
+}
+
+static int
+bcpio_close(int fd)
+{
+	struct cpio_file *file;
+
+	file = find_open_file(fd);
+	if (file == NULL)
+		return (-1);
+
+	remove_open_file(file);
+
+	bkmem_free(file, sizeof (struct cpio_file));
+
+	return (0);
+}
+
+static void
+/* LINTED E_FUNC_ARG_UNUSED */
+bcpio_closeall(int flag __unused)
+{
+	struct cpio_file *file, *next;
+
+	file = bcpio_open_files;
+
+	while (file != NULL) {
+		int fd = file->fd;
+
+		next = file->next;
+
+		if (bcpio_close(fd) != 0)
+			printf("closeall invoked close(%d) failed\n", fd);
+
+		file = next;
+	}
+}
+
+static ssize_t
+bcpio_read(int fd, caddr_t buf, size_t size)
+{
+	struct cpio_file *file;
+
+	file = find_open_file(fd);
+	if (file == NULL)
+		return (-1);
+
+	if (size == 0)
+		return (0);
+
+	if (file->off + size > file->stat.st_size)
+		size = file->stat.st_size - file->off;
+
+	bcopy(file->data + file->off, buf, size);
+
+	file->off += size;
+
+	return (size);
+}
+
+static off_t
+bcpio_lseek(int fd, off_t addr, int whence)
+{
+	struct cpio_file *file;
+
+	file = find_open_file(fd);
+	if (file == NULL)
+		return (-1);
+
+	switch (whence) {
+		case SEEK_CUR:
+			file->off += addr;
+			break;
+		case SEEK_SET:
+			file->off = addr;
+			break;
+		case SEEK_END:
+			file->off = file->stat.st_size;
+			break;
+		default:
+			printf("lseek(): invalid whence value %d\n", whence);
+			return (-1);
+	}
+
+	return (0);
+}
+
+static int
+bcpio_fstat(int fd, struct bootstat *buf)
+{
+	const struct cpio_file *file;
+
+	file = find_open_file(fd);
+	if (file == NULL)
+		return (-1);
+
+	*buf = file->stat;
+
+	return (0);
+}
+
+struct boot_fs_ops bcpio_ops = {
+	.fsw_name		= "boot_cpio",
+	.fsw_mountroot		= bcpio_mountroot,
+	.fsw_unmountroot	= bcpio_unmountroot,
+	.fsw_open		= bcpio_open,
+	.fsw_close		= bcpio_close,
+	.fsw_closeall		= bcpio_closeall,
+	.fsw_read		= bcpio_read,
+	.fsw_lseek		= bcpio_lseek,
+	.fsw_fstat		= bcpio_fstat,
+};

--- a/usr/src/uts/intel/Makefile.files
+++ b/usr/src/uts/intel/Makefile.files
@@ -188,6 +188,7 @@ VGATEXT_OBJS += vgatext.o vgasubr.o
 KRTLD_OBJS +=		\
 	bootfsops.o	\
 	bootrd.o	\
+	bootrd_cpio.o	\
 	ufsops.o	\
 	hsfs.o		\
 	doreloc.o	\


### PR DESCRIPTION
This is a feature by Josef 'Jeff' Sipek (@jeffpc) to add support for cpio format boot archives. The kernel component is taken from his code in Unleashed with a few minor modifications. The rest (userland + man page) is mine.

At the moment we have the strange situation where boot archives are in UFS format by default unless you have the `cdrtools` package installed at which point they will be HSFS. The UFS archives are actually uncompressed but all of the files within them (apart from unix itself) are compressed with gzip.
Creating a UFS archive is quite slow since it involves estimating the required size, making an empty file, formatting it, mounting through `lofi` then copying the files across. Creating an HSFS archive requires the third-party `mkisofs` utility and also requires that the files are copied to a temporary folder.

CPIO archives are attractive since they are really quick and easy to create (find <files> | cpio -o) and the in-kernel code is pretty simple. They have one disadvantage in that hard links are not supported so there is some duplication of data within them, but the overall archive is compressed so this does not significantly increase archive size. See stats and testing information below.

With this change I'm adding a new property on the `system/boot-archive:default` service to specify the desired archive format; this defaults to _cpio_. This property is honoured by both the C `bootadm` code, which is responsible for building the HSFS format archives, and by the script that handles UFS and CPIO.
If the property is not present then the default is HSFS if `/usr/bin/mkisofs` is present, and CPIO otherwise. If the property is set to an unknown value then CPIO will be used.

The man page for `bootadm` has been updated to include information on the new option and also to show the `-f` option for `bootadm update-archive` (force archive creation) which was previously undocumented.

My intention is to upstream this after a period of testing in OmniOS; perhaps the default in upstream will not be cpio but that will depend on testing and feedback received.

### Testing

On my test system a boot archive contains 1056 files, 92 directories and 216 hardlinks (mostly CPU firmware).

During system boot, 2953 file opens are performed of which 2274 result in ENOENT; the total data read from the archive is 46MiB.

Testing with each of the four archive formats below shows that processing time during boot is in the range 3-9 seconds for all formats, with different boots giving different results. On average archive processing takes around 5 seconds regardless of format.

```shell
bloody% svcprop -p config/format boot-archive
cpio
```
```shell
bloody% time pfexec bootadm update-archive -f
updating platform/i86pc/amd64/boot_archive (CPIO)
pfexec bootadm update-archive -f  5.56s user 0.15s system 98% cpu 5.826 total

bloody% file /platform/i86pc/amd64/boot_archive
/platform/i86pc/amd64/boot_archive:     gzip compressed data - deflate method , original file name
bloody% gzip -dc /platform/i86pc/amd64/boot_archive > /tmp/l
bloody% file /tmp/l
/tmp/l:         ASCII cpio archive - CHR (-c) header
bloody% ls -lh /platform/i86pc/amd64/boot_archive /tmp/l
-rw-r--r--   1 root     root       31.6M Jul  5 15:45 /platform/i86pc/amd64/boot_archive
-rw-r--r--   1 af       other      83.1M Jul  5 15:45 /tmp/l
```
```shell
bloody% svccfg -s boot-archive setprop config/format = ufs
bloody% time pfexec bootadm update-archive -f
updating platform/i86pc/amd64/boot_archive (UFS)
pfexec bootadm update-archive -f  3.86s user 0.92s system 6% cpu 1:15.96 total

bloody% file /platform/i86pc/amd64/boot_archive
/platform/i86pc/amd64/boot_archive:     English text
bloody% ls -l /platform/i86pc/amd64/boot_archive
-rw-r--r--   1 root     root       45.8M Jul  5 15:48 /platform/i86pc/amd64/boot_archive
```
```shell
bloody% svccfg -s boot-archive setprop config/format = hsfs
bloody% time pfexec bootadm update-archive -f
updating //platform/i86pc/amd64/boot_archive (HSFS)
pfexec bootadm update-archive -f  0.17s user 0.12s system 1% cpu 21.938 total

bloody% file /platform/i86pc/amd64/boot_archive
/platform/i86pc/amd64/boot_archive:     ISO 9660 filesystem image
bloody% ls -lh /platform/i86pc/amd64/boot_archive
-rw-r--r--   1 root     root       36.4M Jul  5 15:46 /platform/i86pc/amd64/boot_archive
```
```shell
bloody% svccfg -s boot-archive setprop config/format = ufs-nocompress
bloody% time pfexec bootadm update-archive -f
updating platform/i86pc/amd64/boot_archive (UFS-nocompress)
pfexec bootadm update-archive -f  5.32s user 1.54s system 5% cpu 1:56.01 total

bloody% file /platform/i86pc/amd64/boot_archive
/platform/i86pc/amd64/boot_archive:     gzip compressed data - deflate method , original file name
bloody% gzip -dc /platform/i86pc/amd64/boot_archive >| /tmp/l
bloody% file /tmp/l
/tmp/l:         English text
bloody% ls -lh /platform/i86pc/amd64/boot_archive /tmp/l
-rw-r--r--   1 root     root       27.5M Jul  5 15:43 /platform/i86pc/amd64/boot_archive
-rw-r--r--   1 af       other      91.7M Jul  5 15:44 /tmp/l
```
