### PR TITLE
Upstream merge joyent_merge/2018070601

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 8118caaf6ac0df6a54351bfd800aea92a6ac3cca
+Last illumos-joyent commit: eebde15ca4eb2442e9bbce950bbf9782b60ec1a5
 

--- a/usr/src/cmd/mdb/common/modules/genunix/ctxop.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/ctxop.c
@@ -23,56 +23,97 @@
  * Copyright (c) 2000 by Sun Microsystems, Inc.
  * All rights reserved.
  */
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
-#include <sys/mdb_modapi.h>
-#include <sys/thread.h>
+#include <mdb/mdb_modapi.h>
+#include <mdb/mdb_ctf.h>
 #include "ctxop.h"
+
+struct ctxop_walk_state {
+	uintptr_t	cws_head;
+	uint_t		cws_next_offset;
+};
 
 int
 ctxop_walk_init(mdb_walk_state_t *wsp)
 {
-	kthread_t thread, *tp = &thread;
+	struct ctxop_walk_state *priv;
+	int offset;
+	uintptr_t addr;
 
 	if (wsp->walk_addr == NULL) {
 		mdb_warn("must specify thread for ctxop walk\n");
 		return (WALK_ERR);
 	}
-	if (mdb_vread(tp, sizeof (*tp), wsp->walk_addr) == -1) {
-		mdb_warn("failed to read thread at %p", wsp->walk_addr);
+
+	offset = mdb_ctf_offsetof_by_name("kthread_t", "t_ctx");
+	if (offset == -1)
+		return (WALK_ERR);
+
+	if (mdb_vread(&addr, sizeof (addr),
+	    wsp->walk_addr + offset) != sizeof (addr)) {
+		mdb_warn("failed to read thread %p", wsp->walk_addr);
 		return (WALK_ERR);
 	}
 
-	wsp->walk_data = mdb_alloc(sizeof (ctxop_t), UM_SLEEP);
-	wsp->walk_addr = (uintptr_t)tp->t_ctx;
+	/* No further work for threads with a NULL t_ctx */
+	if (addr == 0) {
+		wsp->walk_data = NULL;
+		return (WALK_DONE);
+	}
 
+	/* rely on CTF for the offset of the 'next' pointer */
+	offset = mdb_ctf_offsetof_by_name("struct ctxop", "next");
+	if (offset == -1)
+		return (WALK_ERR);
+
+	priv = mdb_alloc(sizeof (*priv), UM_SLEEP);
+	priv->cws_head = addr;
+	priv->cws_next_offset = (uint_t)offset;
+
+	wsp->walk_data = priv;
+	wsp->walk_addr = addr;
 	return (WALK_NEXT);
 }
 
 int
 ctxop_walk_step(mdb_walk_state_t *wsp)
 {
+	struct ctxop_walk_state *priv = wsp->walk_data;
+	uintptr_t next;
 	int status;
 
-	if (wsp->walk_addr == NULL)
-		return (WALK_DONE);
-
-	if (mdb_vread(wsp->walk_data,
-	    sizeof (ctxop_t), wsp->walk_addr) == -1) {
-		mdb_warn("failed to read ctxop at %p", wsp->walk_addr);
+	if (mdb_vread(&next, sizeof (next),
+	    wsp->walk_addr + priv->cws_next_offset) == -1) {
+		mdb_warn("failed to read ctxop`next at %p",
+		    wsp->walk_addr + priv->cws_next_offset);
 		return (WALK_DONE);
 	}
 
-	status = wsp->walk_callback(wsp->walk_addr, wsp->walk_data,
-	    wsp->walk_cbdata);
+	status = wsp->walk_callback(wsp->walk_addr, NULL, wsp->walk_cbdata);
 
-	wsp->walk_addr = (uintptr_t)(((ctxop_t *)wsp->walk_data)->next);
+	if (status == WALK_NEXT) {
+		/*
+		 * If a NULL terminator or a loop back to the head element is
+		 * encountered, the walk is done.
+		 */
+		if (next == 0 || next == priv->cws_head) {
+			status = WALK_DONE;
+		}
+	}
+
+	wsp->walk_addr = next;
 	return (status);
 }
 
 void
 ctxop_walk_fini(mdb_walk_state_t *wsp)
 {
-	mdb_free(wsp->walk_data, sizeof (ctxop_t));
+	struct ctxop_walk_state *priv = wsp->walk_data;
+
+	if (priv != NULL) {
+		mdb_free(priv, sizeof (*priv));
+	}
 }

--- a/usr/src/cmd/mdb/common/modules/genunix/ctxop.h
+++ b/usr/src/cmd/mdb/common/modules/genunix/ctxop.h
@@ -27,8 +27,6 @@
 #ifndef	_MDB_CTXOP_H
 #define	_MDB_CTXOP_H
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <mdb/mdb_modapi.h>
 
 #ifdef	__cplusplus

--- a/usr/src/compat/freebsd/sys/time.h
+++ b/usr/src/compat/freebsd/sys/time.h
@@ -100,6 +100,16 @@ bttosbt(const struct bintime bt)
 	return (((sbintime_t)bt.sec << 32) + (bt.frac >> 32));
 }
 
+static __inline struct bintime
+sbttobt(sbintime_t _sbt)
+{
+	struct bintime _bt;
+
+	_bt.sec = _sbt >> 32;
+	_bt.frac = _sbt << 32;
+	return (_bt);
+}
+
 static __inline sbintime_t
 sbinuptime(void)
 {

--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -1804,7 +1804,7 @@ lx_netlink_au_emit_cb(void *s, uint_t type, const char *msg, uint_t size)
 	hdr = (lx_netlink_hdr_t *)mp->b_rptr;
 	hdr->lxnh_flags = LX_NETLINK_NLM_F_MULTI;
 	hdr->lxnh_len = len;
-	hdr->lxnh_type = (msg == NULL ? LX_NETLINK_NLMSG_DONE : type);
+	hdr->lxnh_type = (msg == NULL ? LX_NETLINK_NLMSG_DONE : type & 0xffff);
 	hdr->lxnh_seq = 0;
 	hdr->lxnh_pid = 0;
 

--- a/usr/src/uts/common/brand/lx/os/lx_audit.c
+++ b/usr/src/uts/common/brand/lx/os/lx_audit.c
@@ -1,0 +1,1603 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+/*
+ * The Linux auditing system provides a fairly complex rule-based syntax
+ * for configuring what actions are to be audited. The user-level details
+ * are generally described in the Linux audit.rules(7), auditctl(8), and
+ * auditd(8) man pages. The user/kernel netlink API does not seem to be
+ * documented. The Linux kernel source and the user-level auditd source must
+ * be used to understand the interface we have to emulate. The relevant Linux
+ * source files are:
+ *   include/uapi/linux/audit.h
+ *   include/linux/audit.h
+ *   kernel/audit.c
+ *
+ * The lx_netlink module implements the API used for getting or changing the
+ * audit configuration. For rule-oriented operations (list, append, delete),
+ * an lx_audit_rule_t structure (or sequence when listing) is passed in/out of
+ * the kernel. The netlink code calls into the lx_audit_append_rule or
+ * lx_audit_delete_rule functions here to perform the relevant operation.
+ * Within the lx_audit_rule_t structure, each member has the following
+ * meaning:
+ * lxar_flag:	corresponds to user-level list (e.g. "exit" for syscall return)
+ * lxar_action:	user-level action (e.g. "always")
+ * lxar_fld_cnt: number of fields specified in lxar_fields, lxar_values, and
+ *		lxar_flg_flag arrays
+ * lxar_mask:	syscall number bitmask the rule applies to (bit position in
+ *		the array corresponds to the syscall number)
+ * laxr_fields:	array of fields in the rule (i.e. each -F on user-level rule).
+ *		A numeric code (e.g. LX_RF_AUDIT_ARCH) is assigned to each
+ *		possible field.
+ * lxar_values:	array of numeric field values (e.g. the internal b64 value on
+ *		the -F AUDIT_ARCH=b64 rule)
+ * lxar_fld_flag: array of field operators (e.g. the '=' operator on the
+ *		-F AUDIT_ARCH=b64 rule)
+ * lxar_buflen:	length of the buffer data immediately following
+ * lxar_buf:	A variable amount of additional field string data. Non-numeric
+ *		field values are passed here. For example, the string associated
+ *		with the '-F key=...' or -F path=...' rules. For string values,
+ *		the corresponding lxar_values entry is the length of the string.
+ *		The strings in lxar_buf are not C strings because they are not
+ *		NULL terminated. The character data is pulled out of lxar_buf
+ *		in chunks specified by the value and the pointer into the buf
+ *		is advanced accordingly.
+ *
+ * There are two primary kinds of actions which we are currently interested in
+ * auditing;
+ * 1) system call return
+ *    this corresponds to user-level "exit" rule actions
+ * 2) file system related actions
+ *    this corresponds to user-level file system watch rules (-w)
+ *
+ * Only system call return is currently implemented, and only a very limited
+ * subset of all of the possible rule selection behavior.
+ *
+ * The Linux audit rule syntax defines that all selection criteria within a
+ * rule is ANDed together before an audit record is created. However, multiple
+ * rules can be defined for a specific syscall. For example, this user-level
+ * syntax defines two different rules for the "open" syscall:
+ *     -a always,exit -F arch=b64 -S open -F auid>=1000 -F key=user-open
+ *     -a always,exit -F arch=b64 -S open -F auid=0 -F key=priv-open
+ * The first rule would cause an audit record to be created when an "open"
+ * syscall returns and the syscall was performed by a process with a
+ * loginuid >= 1000. The key added to that audit record would be "user-open".
+ * The second rule would create an audit record if the loginuid was 0 and the
+ * record's key would be "priv-open".
+ *
+ * When auditing is enabled for a syscall return, we have to look at multiple
+ * rules and create an audit record for each rule that matches the selection
+ * criteria.
+ *
+ * Although the current implementation is limited, the overall structure is
+ * designed to be enhanced as more auditing support is added over time.
+ *
+ * By default, auditing is not enabled for a zone and no internal audit data
+ * exists. When the first netlink audit msg is received, the zone's audit state
+ * (lx_audit_state_t) is allocated (via lx_audit_init) and attached to the
+ * zone's lx brand-specific data (lxzd_audit_state). Once allocated, the audit
+ * data will persist until the zone halts.
+ *
+ * Audit records are enqueued onto the lxast_ev_queue and a worker thread
+ * (lx_audit_worker) is responsible for dequeueing the audit records and
+ * sending them up to the user-level auditd.
+ *
+ * Audit rules are stored in the lxast_rules list. This is an internal list
+ * consisting of elements of type lx_audit_rule_ent_t. Each element contains
+ * the input rule (lxare_rule) along with some additional data parsed out of
+ * the rule when it is appended (currently only the arch and key).
+ *
+ * When auditing is enabled for a syscall, the appropriate entry in the
+ * lxast_sys64_rulep (or lxast_sys32_rulep) array will point to the first
+ * rule that is applicable to the syscall. When that syscall returns, rule
+ * matching proceeds from that rule to the end of the rule list.
+ *
+ * New rules are always appended at the end of the list and Linux expects that
+ * rules are matched in order.
+ *
+ * If the rule list ever gets large enough that a linear search, anchored off
+ * the syscall pointer, becomes a performance bottleneck, then we'll have to
+ * explore alternate implementations. However, use of auditing is not that
+ * common to begin with, and most syscalls are typically not audited, so as
+ * long as the number of rules is in the order of tens, then the current
+ * implementation should be fine.
+ *
+ * When a rule is deleted, all associated syscall entries (lxast_sys64_rulep or
+ * lxast_sys32_rulep) are cleared, then the rule list is searched to see if
+ * there are any remaining rules which are applicable to the syscall(s). If so,
+ * pointers are reestablished in the relevant lxast_sys64_rulep (or 32) array.
+ */
+
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/systm.h>
+#include <sys/proc.h>
+#include <sys/ddi.h>
+#include <sys/zone.h>
+#include <sys/strsubr.h>
+#include <sys/socket.h>
+#include <sys/socketvar.h>
+#include <sys/sunddi.h>
+#include <sys/strsun.h>
+#include <sys/tihdr.h>
+#include <sys/sockio.h>
+#include <sys/brand.h>
+#include <sys/debug.h>
+#include <sys/ucred.h>
+#include <sys/session.h>
+#include <sys/lx_types.h>
+#include <sys/lx_audit.h>
+#include <sys/lx_brand.h>
+#include <sys/lx_misc.h>
+#include <sys/lx_socket.h>
+#include <sys/bitmap.h>
+#include <sockcommon.h>
+
+#define	LX_AUDIT_FEATURE_VERSION	1
+
+/*
+ * Audit status mask values (lxas_mask in structure defined below)
+ * See Linux include/uapi/linux/audit.h
+ */
+#define	LX_AUDIT_STATUS_ENABLED			0x001
+#define	LX_AUDIT_STATUS_FAILURE			0x002
+#define	LX_AUDIT_STATUS_PID			0x004
+#define	LX_AUDIT_STATUS_RATE_LIMIT		0x008
+#define	LX_AUDIT_STATUS_BACKLOG_LIMIT		0x010
+#define	LX_AUDIT_STATUS_BACKLOG_WAIT_TIME	0x020
+#define	LX_AUDIT_STATUS_LOST			0x040
+
+/*
+ * Audit features
+ * See Linux include/uapi/linux/audit.h
+ */
+#define	LX_AUDIT_F_BACKLOG_LIMIT	0x001
+#define	LX_AUDIT_F_BACKLOG_WAIT_TIME	0x002
+#define	LX_AUDIT_F_EXECUTABLE_PATH	0x004
+#define	LX_AUDIT_F_EXCLUDE_EXTEND	0x008
+#define	LX_AUDIT_F_SESSIONID_FILTER	0x010
+#define	LX_AUDIT_F_LOST_RESET		0x020
+#define	LX_AUDIT_F_FILTER_FS		0x040
+
+#define	LX_AUDIT_FEATURE_ALL	(LX_AUDIT_F_BACKLOG_LIMIT | \
+	LX_AUDIT_F_BACKLOG_WAIT_TIME | LX_AUDIT_F_EXECUTABLE_PATH | \
+	LX_AUDIT_F_EXCLUDE_EXTEND | LX_AUDIT_F_SESSIONID_FILTER | \
+	LX_AUDIT_F_LOST_RESET | LX_AUDIT_F_FILTER_FS)
+
+
+/* Audit events */
+#define	LX_AUDIT_SYSCALL	1300	/* syscall */
+#define	LX_AUDIT_PATH		1302	/* file path */
+#define	LX_AUDIT_CONFIG_CHANGE	1305	/* configuration change */
+#define	LX_AUDIT_CWD		1307	/* current working directory */
+#define	LX_AUDIT_EXECVE		1309	/* exec args */
+#define	LX_AUDIT_EOE		1320	/* end of multi-record event */
+
+#define	LX_AUDIT_BITMASK_SIZE		64
+#define	LX_AUDIT_MAX_KEY_LEN		256
+
+/* Audit rule filter type */
+#define	LX_AUDIT_FILTER_USER		0	/* user generated msgs */
+#define	LX_AUDIT_FILTER_TASK		1	/* task creation */
+#define	LX_AUDIT_FILTER_ENTRY		2	/* syscall entry - obsolete */
+#define	LX_AUDIT_FILTER_WATCH		3	/* fs watch */
+#define	LX_AUDIT_FILTER_EXIT		4	/* syscall return */
+#define	LX_AUDIT_FILTER_TYPE		5	/* audit log start */
+#define	LX_AUDIT_FILTER_FS		6	/* audit inode child */
+
+/* Audit rule action type */
+#define	LX_AUDIT_ACT_NEVER		0
+#define	LX_AUDIT_ACT_POSSIBLE		1
+#define	LX_AUDIT_ACT_ALWAYS		2	/* the common case */
+
+#define	LX_AUDIT_RULE_MAX_FIELDS	64
+
+/* Linux defaults */
+#define	LX_AUDIT_DEF_BACKLOG_LIMIT	64
+#define	LX_AUDIT_DEF_WAIT_TIME		(60 * HZ_TO_LX_USERHZ(hz))
+
+/*
+ * Audit rule field types
+ * Linux defines a lot of Rule Field values in include/uapi/linux/audit.h.
+ * We currently only handle a few.
+ */
+#define	LX_RF_AUDIT_LOGINUID	9	/* e.g. auid>=1000 */
+#define	LX_RF_AUDIT_ARCH	11	/* e.g.	-F arch=b64 */
+#define	LX_RF_AUDIT_WATCH	105	/* user-level -w rule */
+#define	LX_RF_AUDIT_PERM	106	/* user-level -p option */
+#define	LX_RF_AUDIT_FILTERKEY	210	/* user-level -k key option */
+
+/*
+ * Audit rule field operators
+ * Linux defines the operator values in include/uapi/linux/audit.h.
+ * These 4 bits are combined in various ways for additional operators.
+ */
+#define	LX_OF_AUDIT_BM	0x08000000			/* bit mask (&) */
+#define	LX_OF_AUDIT_LT	0x10000000
+#define	LX_OF_AUDIT_GT	0x20000000
+#define	LX_OF_AUDIT_EQ	0x40000000
+#define	LX_OF_AUDIT_NE	(LX_OF_AUDIT_LT | LX_OF_AUDIT_GT)
+#define	LX_OF_AUDIT_BT	(LX_OF_AUDIT_BM | LX_OF_AUDIT_EQ) /* bit test (&=) */
+#define	LX_OF_AUDIT_LE	(LX_OF_AUDIT_LT | LX_OF_AUDIT_EQ)
+#define	LX_OF_AUDIT_GE	(LX_OF_AUDIT_GT | LX_OF_AUDIT_EQ)
+#define	LX_OF_AUDIT_ALL	(LX_OF_AUDIT_EQ | LX_OF_AUDIT_NE | LX_OF_AUDIT_BM)
+
+/*
+ * Audit rule arch specification
+ * See Linux __AUDIT_ARCH_64BIT, __AUDIT_ARCH_LE, EM_X86_64 and EM_386 defs.
+ * -F arch=b64 looks like: 0xc000003e
+ * -F arch=b32 looks like: 0x40000003
+ */
+#define	LX_AUDIT_VAL_B64	0x80000000
+#define	LX_AUDIT_VAL_B32	0x40000000
+#define	LX_AUDIT_ARCH64		0xc000003e
+#define	LX_AUDIT_ARCH32		0x40000003
+
+/*
+ * See Linux include/uapi/linux/audit.h, AUDIT_MESSAGE_TEXT_MAX is 8560.
+ * The auditd src has MAX_AUDIT_MESSAGE_LENGTH as 8970.
+ * Until necessary, we'll limit ourselves to a smaller length.
+ */
+#define	LX_AUDIT_MESSAGE_TEXT_MAX	1024
+
+typedef struct lx_audit_features {
+	uint32_t	lxaf_version;
+	uint32_t	lxaf_mask;
+	uint32_t	lxaf_features;
+	uint32_t	lxaf_lock;
+} lx_audit_features_t;
+
+typedef struct lx_audit_status {
+	uint32_t	lxas_mask;
+	uint32_t	lxas_enabled;
+	uint32_t	lxas_failure;
+	uint32_t	lxas_pid;
+	uint32_t	lxas_rate_limit;
+	uint32_t	lxas_backlog_limit;
+	uint32_t	lxas_lost;
+	uint32_t	lxas_backlog;
+	/* LINTED: E_ANONYMOUS_UNION_DECL */
+	union {
+		uint32_t	lxas_version;
+		uint32_t	lxas_feature_bitmap;
+	};
+	uint32_t	lxas_backlog_wait_time;
+} lx_audit_status_t;
+
+typedef struct lx_audit_rule {
+	uint32_t	lxar_flag;
+	uint32_t	lxar_action;
+	uint32_t	lxar_fld_cnt;
+	uint32_t	lxar_mask[LX_AUDIT_BITMASK_SIZE];
+	uint32_t	lxar_fields[LX_AUDIT_RULE_MAX_FIELDS];
+	uint32_t	lxar_values[LX_AUDIT_RULE_MAX_FIELDS];
+	uint32_t	lxar_fld_flag[LX_AUDIT_RULE_MAX_FIELDS];
+	uint32_t	lxar_buflen;
+	/* LINTED: E_ZERO_OR_NEGATIVE_SUBSCRIPT */
+	char		lxar_buf[0];
+} lx_audit_rule_t;
+
+/*
+ * Internal structure for an audit rule.
+ * Each rule is on the zone's top-level list of all rules (lxast_rules).
+ * This structure also holds the parsed character string fields from the
+ * original input rule (lxar_buf) so that we don't need to re-parse that
+ * data on every match.
+ */
+typedef struct lx_audit_rule_ent {
+	list_node_t	lxare_link;
+	lx_audit_rule_t lxare_rule;
+	char		*lxare_buf;
+	boolean_t	lxare_is32bit;
+	char		*lxare_key;
+} lx_audit_rule_ent_t;
+
+typedef enum lx_audit_fail {
+	LXAE_SILENT,
+	LXAE_PRINT,	/* default */
+	LXAE_PANIC	/* reboot the zone */
+} lx_audit_fail_t;
+
+typedef struct lx_audit_record {
+	list_node_t	lxar_link;
+	uint32_t	lxar_type;
+	char		*lxar_msg;
+} lx_audit_record_t;
+
+/*
+ * Per-zone audit state
+ * Lazy allocated when first needed.
+ *
+ * lxast_rate_limit
+ *    Currently unused, but can be get/set. Linux default is 0.
+ * lxast_backlog_limit
+ *    The maximum number of outstanding audit events allowed (the Linux kernel
+ *    default is 64). If the limit is reached, lxast_failure determines what
+ *    to do.
+ * lxast_backlog_wait_time
+ *    Currently unused, but can be get/set. Linux default is 60HZ.
+ */
+typedef struct lx_audit_state {
+	lx_audit_fail_t	lxast_failure;		/* failure behavior */
+	uint32_t	lxast_rate_limit;
+	uint32_t	lxast_backlog_limit;
+	uint32_t	lxast_backlog_wait_time;
+	lx_audit_rule_ent_t *lxast_sys32_rulep[LX_NSYSCALLS];
+	lx_audit_rule_ent_t *lxast_sys64_rulep[LX_NSYSCALLS];
+	kcondvar_t	lxast_worker_cv;
+	kmutex_t	lxast_lock;		/* protects members below */
+	pid_t		lxast_pid;		/* auditd pid */
+	uint64_t	lxast_seq;		/* event sequence num */
+	uint32_t	lxast_backlog;		/* num of queued events */
+	uint32_t	lxast_lost;		/* num of lost events */
+	void		*lxast_sock;		/* auditd lx_netlink_sock_t */
+	boolean_t	lxast_exit;		/* taskq worker should quit */
+	boolean_t	lxast_panicing;		/* audit forcing reboot? */
+	kthread_t	*lxast_worker;
+	list_t		lxast_ev_queue;		/* audit record queue */
+	list_t		lxast_rules;		/* the list of rules */
+} lx_audit_state_t;
+
+/*
+ * Function pointer to netlink function used by audit worker threads to send
+ * audit messages up to the user-level auditd.
+ */
+static int (*lx_audit_emit_msg)(void *, uint_t, const char *, uint_t);
+static kmutex_t	lx_audit_em_lock;		/* protects emit_msg above */
+
+/* From uts/common/brand/lx/syscall/lx_socket.c */
+extern long lx_socket(int, int, int);
+/* From uts/common/syscall/close.c */
+extern int close(int);
+
+static int
+lx_audit_emit_syscall_event(uint_t mtype, void *lxsock, const char *msg)
+{
+	int err;
+
+	err = lx_audit_emit_msg(lxsock, mtype, msg, LX_AUDIT_MESSAGE_TEXT_MAX);
+	if (err != 0)
+		return (err);
+	err = lx_audit_emit_msg(lxsock, 0, NULL, 0);
+	return (err);
+}
+
+/*
+ * Worker thread for audit record output up to user-level auditd.
+ */
+static void
+lx_audit_worker(void *a)
+{
+	lx_audit_state_t *asp = (lx_audit_state_t *)a;
+	lx_audit_record_t *rp;
+	int err;
+
+	VERIFY(asp != NULL);
+
+	mutex_enter(&asp->lxast_lock);
+
+	while (!asp->lxast_exit) {
+
+		if (asp->lxast_backlog == 0 || asp->lxast_sock == NULL ||
+		    asp->lxast_pid == 0) {
+			cv_wait(&asp->lxast_worker_cv, &asp->lxast_lock);
+			continue;
+		}
+
+		rp = list_remove_head(&asp->lxast_ev_queue);
+		asp->lxast_backlog--;
+
+		err = lx_audit_emit_syscall_event(rp->lxar_type,
+		    asp->lxast_sock, rp->lxar_msg);
+		if (err != ENOMEM) {
+			kmem_free(rp->lxar_msg, LX_AUDIT_MESSAGE_TEXT_MAX);
+			kmem_free(rp, sizeof (lx_audit_record_t));
+		} else {
+			/*
+			 * Put it back on the list, drop the mutex so that
+			 * any other audit-related action could occur (such as
+			 * socket deletion), then wait briefly before retry.
+			 */
+			list_insert_head(&asp->lxast_ev_queue, rp);
+			asp->lxast_backlog++;
+			mutex_exit(&asp->lxast_lock);
+			/* wait 1/10th second and try again */
+			delay(drv_usectohz(100000));
+			mutex_enter(&asp->lxast_lock);
+		}
+	}
+
+	/* Leave state ready for new worker when auditing restarted */
+	asp->lxast_exit = B_FALSE;
+	mutex_exit(&asp->lxast_lock);
+
+	thread_exit();
+}
+
+static void
+lx_audit_set_worker(uint32_t pid, void *lxsock,
+    void (*cb)(void *, boolean_t))
+{
+	lx_audit_state_t *asp = ztolxzd(curzone)->lxzd_audit_state;
+
+	ASSERT(asp != NULL);
+	ASSERT(MUTEX_HELD(&asp->lxast_lock));
+
+	/* First, stop any existing worker thread */
+	while (asp->lxast_sock != NULL) {
+		mutex_exit(&asp->lxast_lock);
+		lx_audit_stop_worker(NULL, cb);
+		mutex_enter(&asp->lxast_lock);
+		/* unlikely we loop, but handle racing setters */
+	}
+
+	VERIFY(asp->lxast_pid == 0);
+	VERIFY(asp->lxast_sock == NULL);
+	VERIFY(asp->lxast_exit == B_FALSE);
+	VERIFY(asp->lxast_worker == NULL);
+	if (pid != 0) {
+		/* Start a worker with the new socket */
+		asp->lxast_sock = lxsock;
+		cb(asp->lxast_sock, B_TRUE);
+		asp->lxast_pid = pid;
+		asp->lxast_worker = thread_create(NULL, 0, lx_audit_worker,
+		    asp, 0, curzone->zone_zsched, TS_RUN, minclsyspri);
+	}
+}
+
+static boolean_t
+lx_audit_match_val(uint32_t op, uint32_t ruleval, uint32_t curval)
+{
+	switch (op) {
+	case LX_OF_AUDIT_LT:
+		return (curval < ruleval);
+	case LX_OF_AUDIT_GT:
+		return (curval > ruleval);
+	case LX_OF_AUDIT_EQ:
+		return (curval == ruleval);
+	case LX_OF_AUDIT_NE:
+		return (curval != ruleval);
+	case LX_OF_AUDIT_LE:
+		return (curval <= ruleval);
+	case LX_OF_AUDIT_GE:
+		return (curval >= ruleval);
+	case LX_OF_AUDIT_BM:	/* bit mask - any bit is set? */
+		return ((curval & ruleval) != 0);
+	case LX_OF_AUDIT_BT:	/* bit test - all bits must be set */
+		return ((curval & ruleval) == ruleval);
+	default:
+		break;
+	}
+	return (B_FALSE);
+}
+
+/*
+ * Per the Linux audit.rules(7) man page, a rule with an auid of -1 means the
+ * process does not have a loginuid. We'll use the absence of a session on the
+ * process to mimic this behavior.
+ */
+static uint32_t
+lx_audit_get_auid()
+{
+	sess_t *s;
+	uint32_t v;
+
+	/*
+	 * A process with no session has:
+	 * s_dev == 0xffffffffffffffff
+	 * s_vp == NULL
+	 * s_cred == NULL
+	 */
+	s = curproc->p_sessp;
+	if (s != NULL && s->s_vp != NULL) {
+		v = crgetsuid(CRED());
+	} else {
+		v = UINT32_MAX;	/* emulate auid of -1 */
+	}
+
+	return (v);
+}
+
+/*
+ * Determine if the rule matches.
+ * Currently, we're actually just checking LX_RF_AUDIT_LOGINUID (-F auid)
+ * fields, but as we add support for additional field matching, this function
+ * should be enhanced.
+ */
+static boolean_t
+lx_audit_syscall_rule_match(lx_audit_rule_ent_t *erp)
+{
+	uint32_t i, v;
+	lx_audit_rule_t *rp = &erp->lxare_rule;
+
+	for (i = 0; i < rp->lxar_fld_cnt; i++) {
+		uint32_t ftype, fval, fop;
+
+		ftype = rp->lxar_fields[i];
+		if (ftype != LX_RF_AUDIT_LOGINUID)
+			continue;
+
+		fop = rp->lxar_fld_flag[i];
+		fval = rp->lxar_values[i];
+		v = lx_audit_get_auid();
+
+		if (!lx_audit_match_val(fop, fval, v))
+			return (B_FALSE);
+	}
+	return (B_TRUE);
+}
+
+static int
+lx_audit_write(file_t *fp, const char *msg)
+{
+	int fflag;
+	ssize_t count;
+	size_t nwrite = 0;
+	struct uio auio;
+	struct iovec aiov;
+
+	count = strlen(msg);
+	fflag = fp->f_flag;
+
+	aiov.iov_base = (void *) msg;
+	aiov.iov_len = count;
+	auio.uio_iov = &aiov;
+	auio.uio_iovcnt = 1;
+	auio.uio_loffset = fp->f_offset;
+	auio.uio_resid = count;
+	auio.uio_segflg = UIO_SYSSPACE;
+	auio.uio_llimit = curproc->p_fsz_ctl;
+	auio.uio_fmode = fflag;
+	auio.uio_extflg = UIO_COPY_DEFAULT;
+
+	return (lx_write_common(fp, &auio, &nwrite, B_FALSE));
+}
+
+/*
+ * We first try to send the msg out to the zone's logging service, then
+ * fallback to the zone's console, although in practice, that is unlikely to
+ * be useful to most users.
+ */
+static void
+lx_audit_log_msg(const char *msg)
+{
+	int fd;
+	struct sockaddr_un addr;
+	struct sonode *so;
+	uint_t alen;
+	uint_t sizediff = (sizeof (addr) - sizeof (addr.sun_path));
+	file_t *fp;
+	int err;
+	vnode_t *vp;
+
+	ttolwp(curthread)->lwp_errno = 0;
+	fd = lx_socket(LX_AF_UNIX, LX_SOCK_DGRAM, 0);
+	if (ttolwp(curthread)->lwp_errno != 0)
+		goto trycons;
+
+	bzero((char *)&addr, sizeof (addr));
+	addr.sun_family = AF_UNIX;
+	(void) strncpy(addr.sun_path, "/dev/log", sizeof (addr.sun_path) - 1);
+	alen = strlen(addr.sun_path) + 1 + sizediff;
+
+	/*
+	 * We can't use lx_connect here since that expects to be called from
+	 * user-land, so we do the (streamlined) connect ourselves.
+	 */
+	if ((so = getsonode(fd, &err, &fp)) == NULL) {
+		(void) close(fd);
+		goto trycons;
+	}
+
+	err = socket_connect(so, (struct sockaddr *)&addr, alen, fp->f_flag,
+	    _SOCONNECT_XPG4_2, CRED());
+
+	if (err == 0)
+		err = lx_audit_write(fp, msg);
+
+	releasef(fd);		/* release getsonode hold */
+	(void) close(fd);
+
+	if (err == 0)
+		return;
+
+trycons:
+	/* "open" the console device */
+	if (lookupnameatcred("/dev/console", UIO_SYSSPACE, FOLLOW, NULLVPP,
+	    &vp, NULL, CRED()) != 0)
+		return;
+
+	if (falloc(vp, FWRITE, &fp, &fd) != 0) {
+		VN_RELE(vp);
+		return;
+	}
+	mutex_exit(&fp->f_tlock);
+	setf(fd, fp);
+
+	/* nothing left to do if console write fails */
+	(void) lx_audit_write(fp, msg);
+	close(fd);
+}
+
+static void
+lx_audit_fail(lx_audit_state_t *asp, const char *msg)
+{
+	ASSERT(MUTEX_HELD(&asp->lxast_lock));
+
+	if (asp->lxast_failure == LXAE_PRINT ||
+	    asp->lxast_failure == LXAE_PANIC) {
+		/*
+		 * Linux can ratelimit the amount of log spam here, so we'll
+		 * do something similar, especially since this could be called
+		 * on many syscall returns if the audit daemon is down or
+		 * not consuming audit records for some other reason.
+		 */
+		if (asp->lxast_lost % 100 == 0)
+			lx_audit_log_msg(msg);
+		if (asp->lxast_failure == LXAE_PANIC &&
+		    !asp->lxast_panicing) {
+			/*
+			 * Reboot the zone so that no audit records are lost.
+			 * We delay a second to give the zone's logger a chance
+			 * to handle the log message. We have to drop the lock
+			 * here in case the zone's logger itself is making
+			 * syscalls which would be audited, although that
+			 * wouldn't be the ideal configuration.
+			 */
+			asp->lxast_panicing = B_TRUE;
+			mutex_exit(&asp->lxast_lock);
+			lx_audit_log_msg("audit: panic");
+			delay(drv_usectohz(1000000));
+			zone_kadmin(A_SHUTDOWN, AD_BOOT, NULL, kcred);
+			mutex_enter(&asp->lxast_lock);
+		}
+	}
+	asp->lxast_lost++;
+}
+
+/*
+ * This formats the input string into a format that matches Linux. The input
+ * strings are small right now (<= PSARGSZ) so for simpicity we're using
+ * a temporary buffer of adequate size.
+ */
+static void
+lx_audit_fmt_str(char *dst, char *str, uint_t dlen)
+{
+	char *sp, tmp[100];
+
+	(void) strlcpy(tmp, str, sizeof (tmp));
+	if ((sp = strchr(tmp, ' ')) != NULL)
+		*sp = '\0';
+
+	if ((sp = strchr(tmp, '"')) == NULL) {
+		(void) snprintf(dst, dlen, "\"%s\"", tmp);
+	} else {
+		char *p, *dp;
+		uint_t olen = 0;
+
+		ASSERT(dlen > 2);
+		dlen -= 2;	/* leave room for terminating nul */
+		dp = dst;
+		for (p = str; *p != '\0' && olen < dlen; p++) {
+			(void) sprintf(dp, "%02x", *p);
+			dp += 2;
+			olen += 2;
+		}
+		*dp = '\0';
+	}
+}
+
+/*
+ * Format and enqueue a syscall audit record.
+ */
+static void
+lx_audit_syscall_fmt_rcd(int sysnum, long ret, lx_audit_state_t *asp,
+    lx_audit_rule_ent_t *erp, uint64_t seq, timestruc_t *tsp)
+{
+	klwp_t *lwp;
+	proc_t *p;
+	uint32_t items, sessid;
+	lx_lwp_data_t *lwpd;
+	lx_audit_record_t *rp;
+	boolean_t is_32bit = erp->lxare_is32bit;
+	cred_t *cr = CRED();
+	minor_t minor;
+	char key[LX_AUDIT_MAX_KEY_LEN + 6]; /* for key="%s" formatting */
+	char exe[PSARGSZ * 2 + 8], comm[MAXCOMLEN * 2 + 8];
+
+	ASSERT(MUTEX_HELD(&asp->lxast_lock));
+
+	if (asp->lxast_backlog >= asp->lxast_backlog_limit) {
+		lx_audit_fail(asp, "audit: backlog limit exceeded");
+		return;
+	}
+
+	if (is_32bit) {
+		items = MIN(4, lx_sysent32[sysnum].sy_narg);
+	} else {
+		items = MIN(4, lx_sysent64[sysnum].sy_narg);
+	}
+
+	lwp = ttolwp(curthread);
+	lwpd = lwptolxlwp(lwp);
+	p = curproc;
+
+	/*
+	 * For the key, if no key has been set on the rule, Linux formats the
+	 * string "(null)" (with no quotes - i.e. key=(null)).
+	 */
+	if (erp->lxare_key != NULL) {
+		(void) snprintf(key, sizeof (key), "key=\"%s\"",
+		    erp->lxare_key);
+	} else {
+		(void) snprintf(key, sizeof (key), "key=(null)");
+	}
+
+	rp = kmem_alloc(sizeof (lx_audit_record_t), KM_NOSLEEP);
+	if (rp == NULL) {
+		lx_audit_fail(asp, "audit: no kernel memory");
+		return;
+	}
+	rp->lxar_msg = kmem_zalloc(LX_AUDIT_MESSAGE_TEXT_MAX, KM_NOSLEEP);
+	if (rp->lxar_msg == NULL) {
+		kmem_free(rp, sizeof (lx_audit_record_t));
+		lx_audit_fail(asp, "audit: no kernel memory");
+		return;
+	}
+	rp->lxar_type = LX_AUDIT_SYSCALL;
+
+	mutex_enter(&p->p_splock);
+	sessid = p->p_sessp->s_sid;
+	minor = getminor(p->p_sessp->s_dev);
+	mutex_exit(&p->p_splock);
+
+	mutex_enter(&p->p_lock);
+	lx_audit_fmt_str(exe, p->p_user.u_psargs, sizeof (exe));
+	lx_audit_fmt_str(comm, p->p_user.u_comm, sizeof (comm));
+	mutex_exit(&p->p_lock);
+
+	/*
+	 * See Linux audit_log_exit() for how a syscall exit record is
+	 * formatted.
+	 *
+	 * For "arch" value, see Linux AUDIT_ARCH_IA64, AUDIT_ARCH_I386,
+	 * __AUDIT_ARCH_64BIT and __AUDIT_ARCH_LE definitions.
+	 *
+	 * For fsuid/fsgid, see lx_setfsuid/lx_setfsgid for how we handle that.
+	 */
+	(void) snprintf(rp->lxar_msg, LX_AUDIT_MESSAGE_TEXT_MAX,
+	    "audit(%lu.%03lu:%lu): arch=%x syscall=%u "
+	    "success=%s exit=%ld a0=%lu a1=%lu a2=%lu a3=%lu items=%u "
+	    "ppid=%u pid=%u auid=%u uid=%u gid=%u euid=%u suid=%u "
+	    "fsuid=%u egid=%u sgid=%u fsgid=%u tty=pts%u ses=%u "
+	    "comm=%s exe=%s %s",
+	    (uint64_t)tsp->tv_sec,			/* zone's timestamp */
+	    (uint64_t)tsp->tv_nsec / 1000000,
+	    seq,					/* serial number */
+	    (is_32bit ? LX_AUDIT_ARCH32 : LX_AUDIT_ARCH64), /* arch */
+	    sysnum,					/* syscall */
+	    (lwp->lwp_errno == 0 ? "yes" : "no"),	/* success */
+	    ret,					/* exit */
+	    lwpd->br_syscall_args[0],			/* a0 */
+	    lwpd->br_syscall_args[1],			/* a1 */
+	    lwpd->br_syscall_args[2],			/* a2 */
+	    lwpd->br_syscall_args[3],			/* a3 */
+	    items,					/* items */
+	    lx_lwp_ppid(lwp, NULL, NULL),		/* ppid */
+	    (lwpd->br_pid == curzone->zone_proc_initpid ? 1 : lwpd->br_pid),
+	    lx_audit_get_auid(),			/* auid */
+	    crgetruid(cr),				/* uid */
+	    crgetrgid(cr),				/* gid */
+	    crgetuid(cr),				/* euid */
+	    crgetsuid(cr),				/* saved uid */
+	    crgetuid(cr),				/* fsuid */
+	    crgetgid(cr),				/* egid */
+	    crgetsgid(cr),				/* saved gid */
+	    crgetgid(cr),				/* fsgid */
+	    minor,					/* tty */
+	    sessid,					/* ses */
+	    comm,					/* comm */
+	    exe,					/* exe */
+	    key);					/* key="VAL" */
+
+	list_insert_tail(&asp->lxast_ev_queue, rp);
+	if (asp->lxast_backlog == 0)
+		cv_signal(&asp->lxast_worker_cv);
+	asp->lxast_backlog++;
+}
+
+/*
+ * Get the next rule in the list that is generally applicable to the given
+ * syscall.
+ */
+static lx_audit_rule_ent_t *
+lx_audit_next_applicable_rule(int sysnum, lx_audit_state_t *asp,
+    lx_audit_rule_ent_t *erp)
+{
+	boolean_t is_32bit = erp->lxare_is32bit;
+
+	ASSERT(MUTEX_HELD(&asp->lxast_lock));
+
+	for (erp = list_next(&asp->lxast_rules, erp);
+	    erp != NULL;
+	    erp = list_next(&asp->lxast_rules, erp)) {
+		lx_audit_rule_t *r = &erp->lxare_rule;
+
+		/* Determine if the rule in the list has the same ARCH. */
+		if (erp->lxare_is32bit != is_32bit)
+			continue;
+
+		/* Determine if this rule applies to the relevant syscall. */
+		if (BT_TEST32(r->lxar_mask, sysnum))
+			return (erp);
+	}
+
+	return (NULL);
+}
+
+void
+lx_audit_syscall_exit(int sysnum, long ret)
+{
+	lx_zone_data_t *lxzd = ztolxzd(curzone);
+	lx_audit_state_t *asp;
+	uint64_t seq;
+	lx_audit_rule_ent_t *erp;
+	timestruc_t ts;
+	boolean_t is_32bit;
+
+	if (lxzd->lxzd_audit_enabled == LXAE_DISABLED)
+		return;
+
+	asp = lxzd->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	is_32bit = (get_udatamodel() == DATAMODEL_ILP32);
+
+	/*
+	 * Fast top-level check to see if we're auditing this syscall.
+	 * We don't take the mutex for this since there is no need.
+	 */
+	if (is_32bit) {
+		if (asp->lxast_sys32_rulep[sysnum] == NULL)
+			return;
+	} else {
+		if (asp->lxast_sys64_rulep[sysnum] == NULL)
+			return;
+	}
+
+	mutex_enter(&asp->lxast_lock);
+	if (is_32bit) {
+		erp = asp->lxast_sys32_rulep[sysnum];
+	} else {
+		erp = asp->lxast_sys64_rulep[sysnum];
+	}
+
+	if (erp == NULL) {
+		/* Hit a race and the syscall is no longer being audited */
+		mutex_exit(&asp->lxast_lock);
+		return;
+	}
+
+	/*
+	 * All of the records in the set (i.e. same serial number) have
+	 * the same timestamp.
+	 */
+	seq = asp->lxast_seq++;
+	gethrestime(&ts);
+	ts.tv_sec -= curzone->zone_boot_time;
+
+	/*
+	 * We have to determine if the first rule associated with the syscall,
+	 * or any subsequent applicable rules, match.
+	 *
+	 * The first rule associated with the syscall may (or may not) match,
+	 * but there can be additional rules which might also match. The first
+	 * possible rule is always the one that enables the syscall auditing,
+	 * but we also have to iterate to the end of the list to see if any
+	 * other rules are applicable to this syscall.
+	 */
+	for (; erp != NULL;
+	    erp = lx_audit_next_applicable_rule(sysnum, asp, erp)) {
+		if (!lx_audit_syscall_rule_match(erp))
+			continue;
+
+		lx_audit_syscall_fmt_rcd(sysnum, ret, asp, erp, seq, &ts);
+	}
+
+	/*
+	 * TODO: Currently we only output a single SYSCALL record.
+	 * Real Linux emits a set of audit records for a syscall exit event
+	 * (e.g. for an unlink syscall):
+	 * type=SYSCALL
+	 * type=CWD
+	 * type=PATH - one for the parent dir
+	 * type=PATH - one for the actual file unlinked
+	 * type=PROCTITLE - (this one seems worthless)
+	 * followed by an AUDIT_EOE message (which seems to be ignored).
+	 *
+	 * For syscalls that don't change files in the file system (e.g. ioctl)
+	 * there are no PATH records.
+	 */
+	mutex_exit(&asp->lxast_lock);
+}
+
+/*
+ * Determine which syscalls this rule applies to and setup a fast pointer for
+ * the syscall to enable it's rule match.
+ *
+ * We have to look at each bit and translate the external syscall bits into the
+ * internal syscall number.
+ */
+static void
+lx_enable_syscall_rule(lx_audit_state_t *asp, lx_audit_rule_t *rulep,
+    lx_audit_rule_ent_t *rp)
+{
+	uint_t sysnum;
+	boolean_t is_32bit = rp->lxare_is32bit;
+
+	ASSERT(MUTEX_HELD(&asp->lxast_lock));
+
+	for (sysnum = 0; sysnum < LX_NSYSCALLS; sysnum++) {
+		if (BT_TEST32(rulep->lxar_mask, sysnum)) {
+			if (is_32bit) {
+				if (asp->lxast_sys32_rulep[sysnum] == NULL)
+					asp->lxast_sys32_rulep[sysnum] = rp;
+			} else {
+				if (asp->lxast_sys64_rulep[sysnum] == NULL)
+					asp->lxast_sys64_rulep[sysnum] = rp;
+			}
+		}
+	}
+}
+
+int
+lx_audit_append_rule(void *r, uint_t datalen)
+{
+	lx_audit_rule_t *rulep = (lx_audit_rule_t *)r;
+	char *datap;
+	uint_t i;
+	lx_audit_rule_ent_t *rp;
+	lx_audit_state_t *asp;
+	boolean_t is_32bit = B_FALSE, sys_found = B_FALSE, arch_found = B_FALSE;
+	char *tdp;
+	char key[LX_AUDIT_MAX_KEY_LEN + 1];
+	uint32_t tlen;
+
+	if (ztolxzd(curproc->p_zone)->lxzd_audit_enabled == LXAE_LOCKED)
+		return (EPERM);
+
+	if (datalen < sizeof (lx_audit_rule_t))
+		return (EINVAL);
+	datalen -= sizeof (lx_audit_rule_t);
+
+	if (rulep->lxar_fld_cnt > LX_AUDIT_RULE_MAX_FIELDS)
+		return (EINVAL);
+
+	if (rulep->lxar_buflen > datalen)
+		return (EINVAL);
+
+	datap = rulep->lxar_buf;
+
+	/*
+	 * First check the rule to determine if we support the flag, actions,
+	 * and all of the fields specified (since currently, our rule support
+	 * is incomplete).
+	 *
+	 * NOTE: We currently only handle syscall exit rules.
+	 */
+	if (rulep->lxar_flag != LX_AUDIT_FILTER_EXIT ||
+	    rulep->lxar_action != LX_AUDIT_ACT_ALWAYS)
+		return (ENOTSUP);
+	if (rulep->lxar_fld_cnt > LX_AUDIT_RULE_MAX_FIELDS)
+		return (EINVAL);
+	tdp = datap;
+	tlen = rulep->lxar_buflen;
+	key[0] = '\0';
+	for (i = 0; i < rulep->lxar_fld_cnt; i++) {
+		uint32_t ftype, fval, fop;
+
+		fop = rulep->lxar_fld_flag[i];
+		ftype = rulep->lxar_fields[i];
+		fval = rulep->lxar_values[i];
+		DTRACE_PROBE3(lx__audit__field, uint32_t, fop,
+		    uint32_t, ftype, uint32_t, fval);
+
+		if (ftype == LX_RF_AUDIT_ARCH) {
+			if (fop != LX_OF_AUDIT_EQ)
+				return (ENOTSUP);
+			if ((fval & (LX_AUDIT_VAL_B64 | LX_AUDIT_VAL_B32)) == 0)
+				return (ENOTSUP);
+			if (arch_found)
+				return (EINVAL);
+			arch_found = B_TRUE;
+			/* while we're here, record the arch */
+			if (fval & LX_AUDIT_VAL_B64) {
+				is_32bit = B_FALSE;
+			} else {
+				is_32bit = B_TRUE;
+			}
+		} else if (ftype == LX_RF_AUDIT_LOGINUID) {
+			if ((fop & LX_OF_AUDIT_ALL) == 0)
+				return (ENOTSUP);
+		} else if (ftype == LX_RF_AUDIT_FILTERKEY) {
+			if (fop != LX_OF_AUDIT_EQ)
+				return (ENOTSUP);
+			if (tlen < fval || fval > LX_AUDIT_MAX_KEY_LEN)
+				return (EINVAL);
+			if (key[0] != '\0')
+				return (EINVAL);
+			/* while we're here, save the parsed key */
+			bcopy(tdp, key, fval);
+			key[fval] = '\0';
+			tdp += fval;
+			tlen -= fval;
+		} else {
+			/*
+			 * TODO: expand the support for additional Linux field
+			 * options.
+			 */
+			return (ENOTSUP);
+		}
+	}
+	for (i = 0; i < LX_NSYSCALLS; i++) {
+		if (BT_TEST32(rulep->lxar_mask, i)) {
+			/* At least one syscall enabled in this mask entry */
+			sys_found = B_TRUE;
+			break;
+		}
+	}
+	if (!sys_found)
+		return (ENOTSUP);
+
+	asp = ztolxzd(curzone)->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	/*
+	 * We have confirmed that we can handle the rule specified.
+	 * Before taking the lock, allocate and setup the internal rule struct.
+	 */
+	rp = kmem_alloc(sizeof (lx_audit_rule_ent_t), KM_SLEEP);
+	bcopy(rulep, &rp->lxare_rule, sizeof (lx_audit_rule_t));
+	rp->lxare_buf = kmem_alloc(rulep->lxar_buflen, KM_SLEEP);
+	bcopy(datap, rp->lxare_buf, rulep->lxar_buflen);
+	rp->lxare_is32bit = is_32bit;
+	if (key[0] == '\0') {
+		rp->lxare_key = NULL;
+	} else {
+		int slen = strlen(key);
+		rp->lxare_key = kmem_alloc(slen + 1, KM_SLEEP);
+		(void) strlcpy(rp->lxare_key, key, slen + 1);
+	}
+
+	mutex_enter(&asp->lxast_lock);
+	/* Save the rule on our top-level list. */
+	list_insert_tail(&asp->lxast_rules, rp);
+	/* Enable tracing on the relevant syscalls. */
+	lx_enable_syscall_rule(asp, rulep, rp);
+	mutex_exit(&asp->lxast_lock);
+
+	return (0);
+}
+
+int
+lx_audit_delete_rule(void *r, uint_t datalen)
+{
+	lx_audit_rule_t *rulep = (lx_audit_rule_t *)r;
+	char *datap;
+	uint_t sysnum;
+	lx_audit_state_t *asp;
+	lx_audit_rule_ent_t *erp;
+	boolean_t is_32bit;
+	uint32_t match_arch = 0;
+
+	if (ztolxzd(curproc->p_zone)->lxzd_audit_enabled == LXAE_LOCKED)
+		return (EPERM);
+
+	if (datalen < sizeof (lx_audit_rule_t))
+		return (EINVAL);
+	datalen -= sizeof (lx_audit_rule_t);
+
+	if (rulep->lxar_fld_cnt > LX_AUDIT_RULE_MAX_FIELDS)
+		return (EINVAL);
+
+	if (rulep->lxar_buflen > datalen)
+		return (EINVAL);
+
+	datap = rulep->lxar_buf;
+
+	asp = ztolxzd(curzone)->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	mutex_enter(&asp->lxast_lock);
+
+	/* Find the matching rule from the rule list */
+	for (erp = list_head(&asp->lxast_rules);
+	    erp != NULL;
+	    erp = list_next(&asp->lxast_rules, erp)) {
+		lx_audit_rule_t *r;
+		uint_t i;
+		boolean_t mtch;
+
+		r = &erp->lxare_rule;
+		if (rulep->lxar_flag != r->lxar_flag)
+			continue;
+		if (rulep->lxar_action != r->lxar_action)
+			continue;
+		if (rulep->lxar_fld_cnt != r->lxar_fld_cnt)
+			continue;
+		for (i = 0, mtch = B_TRUE; i < LX_AUDIT_BITMASK_SIZE; i++) {
+			if (rulep->lxar_mask[i] != r->lxar_mask[i]) {
+				mtch = B_FALSE;
+				break;
+			}
+		}
+		if (!mtch)
+			continue;
+
+		for (i = 0, mtch = B_TRUE; i < rulep->lxar_fld_cnt; i++) {
+			if (rulep->lxar_fields[i] != r->lxar_fields[i] ||
+			    rulep->lxar_values[i] != r->lxar_values[i] ||
+			    rulep->lxar_fld_flag[i] != r->lxar_fld_flag[i]) {
+				mtch = B_FALSE;
+				break;
+			}
+
+			/* while we're here, remember the ARCH */
+			if (rulep->lxar_fields[i] == LX_RF_AUDIT_ARCH)
+				match_arch = rulep->lxar_values[i];
+		}
+		if (!mtch)
+			continue;
+		if (rulep->lxar_buflen != r->lxar_buflen)
+			continue;
+		if (bcmp(datap, erp->lxare_buf, r->lxar_buflen) == 0)
+			break;
+	}
+
+	/* There is no matching rule */
+	if (erp == NULL) {
+		mutex_exit(&asp->lxast_lock);
+		return (ENOENT);
+	}
+
+	if (match_arch & LX_AUDIT_VAL_B64) {
+		is_32bit = B_FALSE;
+	} else {
+		is_32bit = B_TRUE;
+	}
+
+	/*
+	 * Disable each relevant syscall enabling.
+	 */
+	for (sysnum = 0; sysnum < LX_NSYSCALLS; sysnum++) {
+		if (BT_TEST32(rulep->lxar_mask, sysnum)) {
+			/*
+			 * If this was the first rule on the list for the
+			 * given syscall (likely, since usually only one rule
+			 * per syscall) then either disable tracing for that
+			 * syscall, or point to the next applicable rule in the
+			 * list.
+			 */
+			if (is_32bit) {
+				if (asp->lxast_sys32_rulep[sysnum] == erp) {
+					asp->lxast_sys32_rulep[sysnum] =
+					    lx_audit_next_applicable_rule(
+					    sysnum, asp, erp);
+				}
+			} else {
+				if (asp->lxast_sys64_rulep[sysnum] == erp) {
+					asp->lxast_sys64_rulep[sysnum] =
+					    lx_audit_next_applicable_rule(
+					    sysnum, asp, erp);
+				}
+			}
+		}
+	}
+
+	/* Remove the rule from the top-level list */
+	list_remove(&asp->lxast_rules, erp);
+
+	kmem_free(erp->lxare_buf, erp->lxare_rule.lxar_buflen);
+	if (erp->lxare_key != NULL)
+		kmem_free(erp->lxare_key, strlen(erp->lxare_key) + 1);
+	kmem_free(erp, sizeof (lx_audit_rule_ent_t));
+
+	mutex_exit(&asp->lxast_lock);
+	return (0);
+}
+
+void
+lx_audit_emit_user_msg(uint_t mtype, uint_t len, char *datap)
+{
+	lx_zone_data_t *lxzd = ztolxzd(curzone);
+	lx_audit_state_t *asp;
+	lx_audit_record_t *rp;
+	timestruc_t ts;
+	uint_t sessid;
+	proc_t *p = curproc;
+	lx_lwp_data_t *lwpd = lwptolxlwp(ttolwp(curthread));
+	uint_t prelen, alen;
+	char msg[LX_AUDIT_MESSAGE_TEXT_MAX];
+
+	/*
+	 * For user messages, auditing may not actually be initialized. If not,
+	 * just return.
+	 */
+	if (lxzd->lxzd_audit_enabled == LXAE_DISABLED ||
+	    lxzd->lxzd_audit_state == NULL)
+		return;
+
+	mutex_enter(&p->p_splock);
+	sessid = p->p_sessp->s_sid;
+	mutex_exit(&p->p_splock);
+
+	asp = lxzd->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	mutex_enter(&asp->lxast_lock);
+
+	if (asp->lxast_backlog >= asp->lxast_backlog_limit) {
+		lx_audit_fail(asp, "audit: backlog limit exceeded");
+		mutex_exit(&asp->lxast_lock);
+		return;
+	}
+
+	rp = kmem_alloc(sizeof (lx_audit_record_t), KM_NOSLEEP);
+	if (rp == NULL) {
+		lx_audit_fail(asp, "audit: no kernel memory");
+		mutex_exit(&asp->lxast_lock);
+		return;
+	}
+	rp->lxar_msg = kmem_zalloc(LX_AUDIT_MESSAGE_TEXT_MAX, KM_NOSLEEP);
+	if (rp->lxar_msg == NULL) {
+		lx_audit_fail(asp, "audit: no kernel memory");
+		mutex_exit(&asp->lxast_lock);
+		kmem_free(rp, sizeof (lx_audit_record_t));
+		return;
+	}
+	rp->lxar_type = mtype;
+	bcopy(datap, msg, len);
+	msg[len] = '\0';
+
+	gethrestime(&ts);
+	ts.tv_sec -= curzone->zone_boot_time;
+
+	(void) snprintf(rp->lxar_msg, LX_AUDIT_MESSAGE_TEXT_MAX,
+	    "audit(%lu.%03lu:%lu): pid=%u uid=%u auid=%u ses=%u msg=\'",
+	    (uint64_t)ts.tv_sec,			/* zone's timestamp */
+	    (uint64_t)ts.tv_nsec / 1000000,
+	    asp->lxast_seq++,				/* serial number */
+	    (lwpd->br_pid == curzone->zone_proc_initpid ? 1 : lwpd->br_pid),
+	    crgetruid(CRED()),				/* uid */
+	    lx_audit_get_auid(),			/* auid */
+	    sessid);					/* ses */
+
+	prelen = strlen(rp->lxar_msg);
+	alen = LX_AUDIT_MESSAGE_TEXT_MAX - prelen - 2;
+	(void) strlcat(rp->lxar_msg + prelen, msg, alen);
+	(void) strlcat(rp->lxar_msg, "\'", LX_AUDIT_MESSAGE_TEXT_MAX);
+
+	list_insert_tail(&asp->lxast_ev_queue, rp);
+	if (asp->lxast_backlog == 0)
+		cv_signal(&asp->lxast_worker_cv);
+	asp->lxast_backlog++;
+	mutex_exit(&asp->lxast_lock);
+}
+
+void
+lx_audit_list_rules(void *reply,
+    void (*cb)(void *, void *, uint_t, void *, uint_t))
+{
+	lx_audit_state_t *asp;
+	lx_audit_rule_ent_t *rp;
+
+	asp = ztolxzd(curzone)->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	/*
+	 * Output the rule list
+	 */
+	mutex_enter(&asp->lxast_lock);
+	for (rp = list_head(&asp->lxast_rules); rp != NULL;
+	    rp = list_next(&asp->lxast_rules, rp)) {
+		cb(reply, &rp->lxare_rule, sizeof (lx_audit_rule_t),
+		    rp->lxare_buf, rp->lxare_rule.lxar_buflen);
+	}
+	mutex_exit(&asp->lxast_lock);
+}
+
+void
+lx_audit_get_feature(void *reply, void (*cb)(void *, void *, uint_t))
+{
+	lx_audit_features_t af;
+
+	af.lxaf_version = LX_AUDIT_FEATURE_VERSION;
+	af.lxaf_mask = 0xffffffff;
+	af.lxaf_features = 0;
+	af.lxaf_lock = 0;
+
+	cb(reply, &af, sizeof (af));
+}
+
+void
+lx_audit_get(void *reply, void (*cb)(void *, void *, uint_t))
+{
+	lx_audit_status_t status;
+	lx_zone_data_t *lxzd;
+	lx_audit_state_t *asp;
+
+	lxzd = ztolxzd(curproc->p_zone);
+	asp = lxzd->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	bzero(&status, sizeof (status));
+
+	mutex_enter(&asp->lxast_lock);
+	status.lxas_enabled = lxzd->lxzd_audit_enabled;
+	status.lxas_failure = asp->lxast_failure;
+	status.lxas_pid = asp->lxast_pid;
+	status.lxas_rate_limit = asp->lxast_rate_limit;
+	status.lxas_backlog_limit = asp->lxast_backlog_limit;
+	status.lxas_lost = asp->lxast_lost;
+	status.lxas_backlog = asp->lxast_backlog;
+	status.lxas_backlog_wait_time = asp->lxast_backlog_wait_time;
+	status.lxas_feature_bitmap = LX_AUDIT_FEATURE_ALL;
+	mutex_exit(&asp->lxast_lock);
+
+	cb(reply, &status, sizeof (status));
+}
+
+int
+lx_audit_set(void *lxsock, void *s, uint_t datalen,
+    void (*cb)(void *, boolean_t))
+{
+	lx_audit_status_t *statusp = (lx_audit_status_t *)s;
+	lx_zone_data_t *lxzd;
+	lx_audit_state_t *asp;
+
+	/*
+	 * Unfortunately, some user-level code does not send down a full
+	 * lx_audit_status_t structure in the message (e.g. this occurs on
+	 * CentOS7). Only the structure up to, but not including, the embedded
+	 * union is being sent in. This appears to be a result of the user-level
+	 * code being built for older versions of the kernel. To handle this,
+	 * we have to subtract the last 8 bytes from the size in order to
+	 * accomodate this code. We'll revalidate with the full size if
+	 * LX_AUDIT_STATUS_BACKLOG_WAIT_TIME were to be set in the mask.
+	 */
+	if (datalen < sizeof (lx_audit_status_t) - 8)
+		return (EINVAL);
+
+	lxzd = ztolxzd(curproc->p_zone);
+	asp = lxzd->lxzd_audit_state;
+	ASSERT(asp != NULL);
+
+	/* Once the config is locked, we only allow changing the auditd pid */
+	mutex_enter(&asp->lxast_lock);
+	if (lxzd->lxzd_audit_enabled == LXAE_LOCKED &&
+	    (statusp->lxas_mask & ~LX_AUDIT_STATUS_PID)) {
+		mutex_exit(&asp->lxast_lock);
+		return (EPERM);
+	}
+
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_FAILURE) {
+		switch (statusp->lxas_failure) {
+		case LXAE_SILENT:
+		case LXAE_PRINT:
+		case LXAE_PANIC:
+			asp->lxast_failure = statusp->lxas_failure;
+			break;
+		default:
+			mutex_exit(&asp->lxast_lock);
+			return (EINVAL);
+		}
+	}
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_PID) {
+		/*
+		 * The process that sets the pid is the daemon, so this is the
+		 * socket we'll write audit records out to.
+		 */
+		lx_audit_set_worker(statusp->lxas_pid, lxsock, cb);
+	}
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_RATE_LIMIT) {
+		asp->lxast_rate_limit = statusp->lxas_rate_limit;
+	}
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_BACKLOG_LIMIT) {
+		asp->lxast_backlog_limit = statusp->lxas_backlog_limit;
+	}
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_BACKLOG_WAIT_TIME) {
+		/*
+		 * See the comment above. We have to revalidate the full struct
+		 * size since we previously only validated for a shorter struct.
+		 */
+		if (datalen < sizeof (lx_audit_status_t)) {
+			mutex_exit(&asp->lxast_lock);
+			return (EINVAL);
+		}
+		asp->lxast_backlog_wait_time = statusp->lxas_backlog_wait_time;
+	}
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_LOST) {
+		asp->lxast_lost = statusp->lxas_lost;
+	}
+
+	if (statusp->lxas_mask & LX_AUDIT_STATUS_ENABLED) {
+		switch (statusp->lxas_enabled) {
+		case 0:
+			lxzd->lxzd_audit_enabled = LXAE_DISABLED;
+			break;
+		case 1:
+			lxzd->lxzd_audit_enabled = LXAE_ENABLED;
+			break;
+		case 2:
+			lxzd->lxzd_audit_enabled = LXAE_LOCKED;
+			break;
+		default:
+			mutex_exit(&asp->lxast_lock);
+			return (EINVAL);
+		}
+	}
+	mutex_exit(&asp->lxast_lock);
+
+	return (0);
+}
+
+void
+lx_audit_stop_worker(void *s, void (*cb)(void *, boolean_t))
+{
+	lx_audit_state_t *asp = ztolxzd(curzone)->lxzd_audit_state;
+	kt_did_t tid = 0;
+
+	ASSERT(asp != NULL);
+	mutex_enter(&asp->lxast_lock);
+	if (s == NULL) {
+		s = asp->lxast_sock;
+	} else {
+		VERIFY(s == asp->lxast_sock);
+	}
+	asp->lxast_sock = NULL;
+	asp->lxast_pid = 0;
+	if (asp->lxast_worker != NULL) {
+		tid = asp->lxast_worker->t_did;
+		asp->lxast_worker = NULL;
+		asp->lxast_exit = B_TRUE;
+		cv_signal(&asp->lxast_worker_cv);
+	}
+	if (s != NULL)
+		cb(s, B_FALSE);
+	mutex_exit(&asp->lxast_lock);
+
+	if (tid != 0)
+		thread_join(tid);
+}
+
+/*
+ * Called when audit netlink message received, in order to perform lazy
+ * allocation of audit state for the zone. We also perform the one-time step to
+ * cache the netlink callback used by the audit worker thread to send messages
+ * up to the auditd.
+ */
+void
+lx_audit_init(int (*cb)(void *, uint_t, const char *, uint_t))
+{
+	lx_zone_data_t *lxzd = ztolxzd(curzone);
+	lx_audit_state_t *asp;
+
+	mutex_enter(&lxzd->lxzd_lock);
+
+	if (lxzd->lxzd_audit_state != NULL) {
+		mutex_exit(&lxzd->lxzd_lock);
+		return;
+	}
+
+	asp = kmem_zalloc(sizeof (lx_audit_state_t), KM_SLEEP);
+
+	mutex_init(&asp->lxast_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&asp->lxast_worker_cv, NULL, CV_DEFAULT, NULL);
+	list_create(&asp->lxast_ev_queue, sizeof (lx_audit_record_t),
+	    offsetof(lx_audit_record_t, lxar_link));
+	list_create(&asp->lxast_rules, sizeof (lx_audit_rule_ent_t),
+	    offsetof(lx_audit_rule_ent_t, lxare_link));
+	asp->lxast_failure = LXAE_PRINT;
+	asp->lxast_backlog_limit = LX_AUDIT_DEF_BACKLOG_LIMIT;
+	asp->lxast_backlog_wait_time = LX_AUDIT_DEF_WAIT_TIME;
+
+	lxzd->lxzd_audit_state = asp;
+
+	mutex_exit(&lxzd->lxzd_lock);
+
+	mutex_enter(&lx_audit_em_lock);
+	if (lx_audit_emit_msg == NULL)
+		lx_audit_emit_msg = cb;
+	mutex_exit(&lx_audit_em_lock);
+}
+
+/*
+ * Called when netlink module is unloading so that we can clear the cached
+ * netlink callback used by the audit worker thread to send messages up to the
+ * auditd.
+ */
+void
+lx_audit_cleanup(void)
+{
+	mutex_enter(&lx_audit_em_lock);
+	lx_audit_emit_msg = NULL;
+	mutex_exit(&lx_audit_em_lock);
+}
+
+/*
+ * Called when the zone is being destroyed, not when auditing is being disabled.
+ * Note that zsched has already exited and any lxast_worker thread has exited.
+ */
+void
+lx_audit_fini(zone_t *zone)
+{
+	lx_zone_data_t *lxzd = ztolxzd(zone);
+	lx_audit_state_t *asp;
+	lx_audit_record_t *rp;
+	lx_audit_rule_ent_t *erp;
+
+	ASSERT(MUTEX_HELD(&lxzd->lxzd_lock));
+
+	if ((asp = lxzd->lxzd_audit_state) == NULL)
+		return;
+
+	mutex_enter(&asp->lxast_lock);
+
+	VERIFY(asp->lxast_worker == NULL);
+
+	rp = list_remove_head(&asp->lxast_ev_queue);
+	while (rp != NULL) {
+		kmem_free(rp->lxar_msg, LX_AUDIT_MESSAGE_TEXT_MAX);
+		kmem_free(rp, sizeof (lx_audit_record_t));
+		rp = list_remove_head(&asp->lxast_ev_queue);
+	}
+
+	list_destroy(&asp->lxast_ev_queue);
+	asp->lxast_backlog = 0;
+	asp->lxast_pid = 0;
+
+	erp = list_remove_head(&asp->lxast_rules);
+	while (erp != NULL) {
+		kmem_free(erp->lxare_buf, erp->lxare_rule.lxar_buflen);
+		if (erp->lxare_key != NULL)
+			kmem_free(erp->lxare_key, strlen(erp->lxare_key) + 1);
+		kmem_free(erp, sizeof (lx_audit_rule_ent_t));
+		erp = list_remove_head(&asp->lxast_rules);
+	}
+	list_destroy(&asp->lxast_rules);
+
+	mutex_exit(&asp->lxast_lock);
+
+	cv_destroy(&asp->lxast_worker_cv);
+	mutex_destroy(&asp->lxast_lock);
+	lxzd->lxzd_audit_state = NULL;
+	kmem_free(asp, sizeof (lx_audit_state_t));
+}
+
+/*
+ * Audit initialization/cleanup when lx brand module is loaded and
+ * unloaded.
+ */
+void
+lx_audit_ld()
+{
+	mutex_init(&lx_audit_em_lock, NULL, MUTEX_DEFAULT, NULL);
+}
+
+void
+lx_audit_unld()
+{
+	mutex_destroy(&lx_audit_em_lock);
+}

--- a/usr/src/uts/common/brand/lx/os/lx_audit.c
+++ b/usr/src/uts/common/brand/lx/os/lx_audit.c
@@ -402,7 +402,7 @@ lx_audit_worker(void *a)
 
 		err = lx_audit_emit_syscall_event(rp->lxar_type,
 		    asp->lxast_sock, rp->lxar_msg);
-		if (err != ENOMEM) {
+		if (err != ENOMEM && err != ENOSPC) {
 			kmem_free(rp->lxar_msg, LX_AUDIT_MESSAGE_TEXT_MAX);
 			kmem_free(rp, sizeof (lx_audit_record_t));
 		} else {

--- a/usr/src/uts/common/brand/lx/os/lx_audit.c
+++ b/usr/src/uts/common/brand/lx/os/lx_audit.c
@@ -629,7 +629,7 @@ trycons:
 
 	/* nothing left to do if console write fails */
 	(void) lx_audit_write(fp, msg);
-	close(fd);
+	(void) close(fd);
 }
 
 static void

--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -1278,6 +1278,7 @@ lx_free_brand_data(zone_t *zone)
 	lx_zone_data_t *data = ztolxzd(zone);
 	ASSERT(data != NULL);
 	mutex_enter(&data->lxzd_lock);
+	lx_audit_fini(zone);
 	if (data->lxzd_ioctl_sock != NULL) {
 		/*
 		 * Since zone_kcred has been cleaned up already, close the
@@ -2623,6 +2624,7 @@ _init(void)
 	lx_futex_init();
 	lx_ptrace_init();
 	lx_socket_init();
+	lx_audit_ld();
 
 	err = mod_install(&modlinkage);
 	if (err != 0) {
@@ -2666,6 +2668,7 @@ _fini(void)
 	lx_pid_fini();
 	lx_ioctl_fini();
 	lx_socket_fini();
+	lx_audit_unld();
 
 	if ((err = lx_futex_fini()) != 0) {
 		goto done;

--- a/usr/src/uts/common/brand/lx/os/lx_syscall.c
+++ b/usr/src/uts/common/brand/lx/os/lx_syscall.c
@@ -245,6 +245,11 @@ lx_syscall_return(klwp_t *lwp, int syscall_num, long ret)
 	(void) lx_ptrace_stop(LX_PR_SYSEXIT);
 
 	/*
+	 * Emit audit record, if necessary.
+	 */
+	lx_audit_syscall_exit(syscall_num, ret);
+
+	/*
 	 * Fire the DTrace "lx-syscall:::return" probe:
 	 */
 	lx_trace_sysreturn(syscall_num, ret);
@@ -371,6 +376,10 @@ lx_syscall_enter(void)
 	 */
 	error = lx_emulate_args(lwp, s, args);
 	lx_trace_sysenter(syscall_num, args);
+	lwpd->br_syscall_args[0] = args[0];
+	lwpd->br_syscall_args[1] = args[1];
+	lwpd->br_syscall_args[2] = args[2];
+	lwpd->br_syscall_args[3] = args[3];
 	if (error != 0) {
 		/*
 		 * Could not read and process the arguments.  Return the error

--- a/usr/src/uts/common/brand/lx/sys/lx_audit.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_audit.h
@@ -1,0 +1,38 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+/*
+ * Copyright 2018 Joyent, Inc.  All rights reserved.
+ */
+
+#ifndef	_LX_AUDIT_H
+#define	_LX_AUDIT_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+extern void lx_audit_init(int (*)(void *, uint_t, const char *, uint_t));
+extern void lx_audit_cleanup(void);
+extern void lx_audit_stop_worker(void *, void (*)(void *, boolean_t));
+extern int lx_audit_append_rule(void *, uint_t);
+extern int lx_audit_delete_rule(void *, uint_t);
+extern void lx_audit_list_rules(void *,
+    void (*)(void *, void *, uint_t, void *, uint_t));
+extern void lx_audit_get_feature(void *, void (*)(void *, void *, uint_t));
+extern void lx_audit_get(void *, void (*)(void *, void *, uint_t));
+extern int lx_audit_set(void *, void *, uint_t, void (*cb)(void *, boolean_t));
+extern void lx_audit_emit_user_msg(uint_t, uint_t, char *);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _LX_AUDIT_H */

--- a/usr/src/uts/common/disp/thread.c
+++ b/usr/src/uts/common/disp/thread.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2018 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -1054,7 +1054,37 @@ installctx(
 	ctx->exit_op = exit;
 	ctx->free_op = free;
 	ctx->arg = arg;
-	ctx->next = t->t_ctx;
+	ctx->save_ts = 0;
+	ctx->restore_ts = 0;
+
+	/*
+	 * Keep ctxops in a doubly-linked list to allow traversal in both
+	 * directions.  Using only the newest-to-oldest ordering was adequate
+	 * previously, but reversing the order for restore_op actions is
+	 * necessary if later-added ctxops depends on earlier ones.
+	 *
+	 * One example of such a dependency:  Hypervisor software handling the
+	 * guest FPU expects that it save FPU state prior to host FPU handling
+	 * and consequently handle the guest logic _after_ the host FPU has
+	 * been restored.
+	 *
+	 * The t_ctx member points to the most recently added ctxop or is NULL
+	 * if no ctxops are associated with the thread.  The 'next' pointers
+	 * form a loop of the ctxops in newest-to-oldest order.  The 'prev'
+	 * pointers form a loop in the reverse direction, where t_ctx->prev is
+	 * the oldest entry associated with the thread.
+	 */
+	if (t->t_ctx == NULL) {
+		ctx->next = ctx;
+		ctx->prev = ctx;
+	} else {
+		struct ctxop *head = t->t_ctx, *tail = t->t_ctx->prev;
+
+		ctx->next = head;
+		ctx->prev = tail;
+		head->prev = ctx;
+		tail->next = ctx;
+	}
 	t->t_ctx = ctx;
 }
 
@@ -1072,7 +1102,7 @@ removectx(
 	void	(*exit)(void *),
 	void	(*free)(void *, int))
 {
-	struct ctxop *ctx, *prev_ctx;
+	struct ctxop *ctx, *head;
 
 	/*
 	 * The incoming kthread_t (which is the thread for which the
@@ -1097,17 +1127,31 @@ removectx(
 	 * and the target thread from racing with each other during lwp exit.
 	 */
 	mutex_enter(&t->t_ctx_lock);
-	prev_ctx = NULL;
 	kpreempt_disable();
-	for (ctx = t->t_ctx; ctx != NULL; ctx = ctx->next) {
+
+	if (t->t_ctx == NULL) {
+		mutex_exit(&t->t_ctx_lock);
+		kpreempt_enable();
+		return (0);
+	}
+
+	ctx = head = t->t_ctx;
+	do {
 		if (ctx->save_op == save && ctx->restore_op == restore &&
 		    ctx->fork_op == fork && ctx->lwp_create_op == lwp_create &&
 		    ctx->exit_op == exit && ctx->free_op == free &&
 		    ctx->arg == arg) {
-			if (prev_ctx)
-				prev_ctx->next = ctx->next;
-			else
+			ctx->prev->next = ctx->next;
+			ctx->next->prev = ctx->prev;
+			if (ctx->next == ctx) {
+				/* last remaining item */
+				t->t_ctx = NULL;
+			} else if (ctx == t->t_ctx) {
+				/* fix up head of list */
 				t->t_ctx = ctx->next;
+			}
+			ctx->next = ctx->prev = NULL;
+
 			mutex_exit(&t->t_ctx_lock);
 			if (ctx->free_op != NULL)
 				(ctx->free_op)(ctx->arg, 0);
@@ -1115,44 +1159,70 @@ removectx(
 			kpreempt_enable();
 			return (1);
 		}
-		prev_ctx = ctx;
-	}
+
+		ctx = ctx->next;
+	} while (ctx != head);
+
 	mutex_exit(&t->t_ctx_lock);
 	kpreempt_enable();
-
 	return (0);
 }
 
 void
 savectx(kthread_t *t)
 {
-	struct ctxop *ctx;
-
 	ASSERT(t == curthread);
-	for (ctx = t->t_ctx; ctx != 0; ctx = ctx->next)
-		if (ctx->save_op != NULL)
-			(ctx->save_op)(ctx->arg);
+
+	if (t->t_ctx != NULL) {
+		struct ctxop *ctx, *head;
+
+		/* Forward traversal */
+		ctx = head = t->t_ctx;
+		do {
+			if (ctx->save_op != NULL) {
+				ctx->save_ts = gethrtime_unscaled();
+				(ctx->save_op)(ctx->arg);
+			}
+			ctx = ctx->next;
+		} while (ctx != head);
+	}
 }
 
 void
 restorectx(kthread_t *t)
 {
-	struct ctxop *ctx;
-
 	ASSERT(t == curthread);
-	for (ctx = t->t_ctx; ctx != 0; ctx = ctx->next)
-		if (ctx->restore_op != NULL)
-			(ctx->restore_op)(ctx->arg);
+
+	if (t->t_ctx != NULL) {
+		struct ctxop *ctx, *tail;
+
+		/* Backward traversal (starting at the tail) */
+		ctx = tail = t->t_ctx->prev;
+		do {
+			if (ctx->restore_op != NULL) {
+				ctx->restore_ts = gethrtime_unscaled();
+				(ctx->restore_op)(ctx->arg);
+			}
+			ctx = ctx->prev;
+		} while (ctx != tail);
+	}
 }
 
 void
 forkctx(kthread_t *t, kthread_t *ct)
 {
-	struct ctxop *ctx;
+	if (t->t_ctx != NULL) {
+		struct ctxop *ctx, *head;
 
-	for (ctx = t->t_ctx; ctx != NULL; ctx = ctx->next)
-		if (ctx->fork_op != NULL)
-			(ctx->fork_op)(t, ct);
+		/* Forward traversal */
+		ctx = head = t->t_ctx;
+		do {
+			if (ctx->fork_op != NULL) {
+				(ctx->fork_op)(t, ct);
+			}
+			ctx = ctx->next;
+		} while (ctx != head);
+	}
 }
 
 /*
@@ -1163,11 +1233,18 @@ forkctx(kthread_t *t, kthread_t *ct)
 void
 lwp_createctx(kthread_t *t, kthread_t *ct)
 {
-	struct ctxop *ctx;
+	if (t->t_ctx != NULL) {
+		struct ctxop *ctx, *head;
 
-	for (ctx = t->t_ctx; ctx != NULL; ctx = ctx->next)
-		if (ctx->lwp_create_op != NULL)
-			(ctx->lwp_create_op)(t, ct);
+		/* Forward traversal */
+		ctx = head = t->t_ctx;
+		do {
+			if (ctx->lwp_create_op != NULL) {
+				(ctx->lwp_create_op)(t, ct);
+			}
+			ctx = ctx->next;
+		} while (ctx != head);
+	}
 }
 
 /*
@@ -1180,11 +1257,18 @@ lwp_createctx(kthread_t *t, kthread_t *ct)
 void
 exitctx(kthread_t *t)
 {
-	struct ctxop *ctx;
+	if (t->t_ctx != NULL) {
+		struct ctxop *ctx, *head;
 
-	for (ctx = t->t_ctx; ctx != NULL; ctx = ctx->next)
-		if (ctx->exit_op != NULL)
-			(ctx->exit_op)(t);
+		/* Forward traversal */
+		ctx = head = t->t_ctx;
+		do {
+			if (ctx->exit_op != NULL) {
+				(ctx->exit_op)(t);
+			}
+			ctx = ctx->next;
+		} while (ctx != head);
+	}
 }
 
 /*
@@ -1194,14 +1278,21 @@ exitctx(kthread_t *t)
 void
 freectx(kthread_t *t, int isexec)
 {
-	struct ctxop *ctx;
-
 	kpreempt_disable();
-	while ((ctx = t->t_ctx) != NULL) {
-		t->t_ctx = ctx->next;
-		if (ctx->free_op != NULL)
-			(ctx->free_op)(ctx->arg, isexec);
-		kmem_free(ctx, sizeof (struct ctxop));
+	if (t->t_ctx != NULL) {
+		struct ctxop *ctx, *head;
+
+		ctx = head = t->t_ctx;
+		t->t_ctx = NULL;
+		do {
+			struct ctxop *next = ctx->next;
+
+			if (ctx->free_op != NULL) {
+				(ctx->free_op)(ctx->arg, isexec);
+			}
+			kmem_free(ctx, sizeof (struct ctxop));
+			ctx = next;
+		} while (ctx != head);
 	}
 	kpreempt_enable();
 }
@@ -1216,17 +1307,22 @@ freectx(kthread_t *t, int isexec)
 void
 freectx_ctx(struct ctxop *ctx)
 {
-	struct ctxop *nctx;
+	struct ctxop *head = ctx;
 
 	ASSERT(ctx != NULL);
 
 	kpreempt_disable();
+
+	head = ctx;
 	do {
-		nctx = ctx->next;
-		if (ctx->free_op != NULL)
+		struct ctxop *next = ctx->next;
+
+		if (ctx->free_op != NULL) {
 			(ctx->free_op)(ctx->arg, 0);
+		}
 		kmem_free(ctx, sizeof (struct ctxop));
-	} while ((ctx = nctx) != NULL);
+		ctx = next;
+	} while (ctx != head);
 	kpreempt_enable();
 }
 

--- a/usr/src/uts/common/sys/thread.h
+++ b/usr/src/uts/common/sys/thread.h
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2017, Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_SYS_THREAD_H
@@ -71,7 +71,10 @@ typedef struct ctxop {
 	void	(*exit_op)(void *);	/* invoked during {thread,lwp}_exit() */
 	void	(*free_op)(void *, int); /* function which frees the context */
 	void	*arg;		/* argument to above functions, ctx pointer */
-	struct ctxop *next;	/* next context ops */
+	struct ctxop *next;		/* next context ops */
+	struct ctxop *prev;		/* previous context ops */
+	hrtime_t save_ts;		/* timestamp of last save */
+	hrtime_t restore_ts;		/* timestamp of last restore */
 } ctxop_t;
 
 /*

--- a/usr/src/uts/i86pc/io/vmm/io/ppt.c
+++ b/usr/src/uts/i86pc/io/vmm/io/ppt.c
@@ -406,7 +406,7 @@ ppt_bar_crawl(struct pptdev *ppt)
 	}
 
 	VERIFY3S(rlen, >, 0);
-	rcount = (rlen * sizeof (int)) / sizeof (pci_regspec_t);
+	rcount = rlen / sizeof (pci_regspec_t);
 	for (i = 0; i < rcount; i++) {
 		pci_regspec_t *reg = &regs[i];
 		struct pptbar *pbar;

--- a/usr/src/uts/i86pc/io/vmm/io/vatpit.c
+++ b/usr/src/uts/i86pc/io/vmm/io/vatpit.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2018 Joyent, Inc.
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2011 NetApp, Inc.
  * All rights reserved.
@@ -78,7 +79,7 @@ struct vatpit_callout_arg {
 struct channel {
 	int		mode;
 	uint16_t	initial;	/* initial counter value */
-	sbintime_t	now_sbt;	/* uptime when counter was loaded */
+	struct bintime	now_bt;		/* uptime when counter was loaded */
 	uint8_t		cr[2];
 	uint8_t		ol[2];
 	bool		slatched;	/* status latched */
@@ -87,7 +88,7 @@ struct channel {
 	int		olbyte;
 	int		frbyte;
 	struct callout	callout;
-	sbintime_t	callout_sbt;	/* target time */
+	struct bintime	callout_bt;	/* target time */
 	struct vatpit_callout_arg callout_arg;
 };
 
@@ -95,26 +96,41 @@ struct vatpit {
 	struct vm	*vm;
 	struct mtx	mtx;
 
-	sbintime_t	freq_sbt;
+	struct bintime	freq_bt;
 
 	struct channel	channel[3];
 };
 
 static void pit_timer_start_cntr0(struct vatpit *vatpit);
 
+static uint64_t
+vatpit_delta_ticks(struct vatpit *vatpit, struct channel *c)
+{
+	struct bintime delta;
+	uint64_t result;
+
+	binuptime(&delta);
+	bintime_sub(&delta, &c->now_bt);
+
+	result = delta.sec * PIT_8254_FREQ;
+	result += delta.frac / vatpit->freq_bt.frac;
+
+	return (result);
+}
+
 static int
 vatpit_get_out(struct vatpit *vatpit, int channel)
 {
 	struct channel *c;
-	sbintime_t delta_ticks;
+	uint64_t delta_ticks;
 	int out;
 
 	c = &vatpit->channel[channel];
 
 	switch (c->mode) {
 	case TIMER_INTTC:
-		delta_ticks = (sbinuptime() - c->now_sbt) / vatpit->freq_sbt;
-		out = ((c->initial - delta_ticks) <= 0);
+		delta_ticks = vatpit_delta_ticks(vatpit, c);
+		out = (delta_ticks >= c->initial);
 		break;
 	default:
 		out = 0;
@@ -164,24 +180,28 @@ static void
 pit_timer_start_cntr0(struct vatpit *vatpit)
 {
 	struct channel *c;
-	sbintime_t now, delta, precision;
 
 	c = &vatpit->channel[0];
 	if (c->initial != 0) {
-		delta = c->initial * vatpit->freq_sbt;
-		precision = delta >> tc_precexp;
-		c->callout_sbt = c->callout_sbt + delta;
+		sbintime_t precision;
+		struct bintime now, delta;
+
+		delta.sec = 0;
+		delta.frac = vatpit->freq_bt.frac * c->initial;
+		bintime_add(&c->callout_bt, &delta);
+		precision = bttosbt(delta) >> tc_precexp;
 
 		/*
-		 * Reset 'callout_sbt' if the time that the callout
-		 * was supposed to fire is more than 'c->initial'
-		 * ticks in the past.
+		 * Reset 'callout_bt' if the time that the callout was supposed
+		 * to fire is more than 'c->initial' ticks in the past.
 		 */
-		now = sbinuptime();
-		if (c->callout_sbt < now)
-			c->callout_sbt = now + delta;
+		binuptime(&now);
+		if (bintime_cmp(&c->callout_bt, &now, <)) {
+			c->callout_bt = now;
+			bintime_add(&c->callout_bt, &delta);
+		}
 
-		callout_reset_sbt(&c->callout, c->callout_sbt,
+		callout_reset_sbt(&c->callout, bttosbt(c->callout_bt),
 		    precision, vatpit_callout_handler, &c->callout_arg,
 		    C_ABSOLUTE);
 	}
@@ -191,7 +211,7 @@ static uint16_t
 pit_update_counter(struct vatpit *vatpit, struct channel *c, bool latch)
 {
 	uint16_t lval;
-	sbintime_t delta_ticks;
+	uint64_t delta_ticks;
 
 	/* cannot latch a new value until the old one has been consumed */
 	if (latch && c->olbyte != 0)
@@ -207,12 +227,11 @@ pit_update_counter(struct vatpit *vatpit, struct channel *c, bool latch)
 		 * here.
 		 */
 		c->initial = TIMER_DIV(PIT_8254_FREQ, 100);
-		c->now_sbt = sbinuptime();
+		binuptime(&c->now_bt);
 		c->status &= ~TIMER_STS_NULLCNT;
 	}
 
-	delta_ticks = (sbinuptime() - c->now_sbt) / vatpit->freq_sbt;
-
+	delta_ticks = vatpit_delta_ticks(vatpit, c);
 	lval = c->initial - delta_ticks % c->initial;
 
 	if (latch) {
@@ -383,10 +402,10 @@ vatpit_handler(struct vm *vm, int vcpuid, bool in, int port, int bytes,
 			c->frbyte = 0;
 			c->crbyte = 0;
 			c->initial = c->cr[0] | (uint16_t)c->cr[1] << 8;
-			c->now_sbt = sbinuptime();
+			binuptime(&c->now_bt);
 			/* Start an interval timer for channel 0 */
 			if (port == TIMER_CNTR0) {
-				c->callout_sbt = c->now_sbt;
+				c->callout_bt = c->now_bt;
 				pit_timer_start_cntr0(vatpit);
 			}
 			if (c->initial == 0)
@@ -423,7 +442,6 @@ struct vatpit *
 vatpit_init(struct vm *vm)
 {
 	struct vatpit *vatpit;
-	struct bintime bt;
 	struct vatpit_callout_arg *arg;
 	int i;
 
@@ -432,8 +450,7 @@ vatpit_init(struct vm *vm)
 
 	mtx_init(&vatpit->mtx, "vatpit lock", NULL, MTX_SPIN);
 
-	FREQ2BT(PIT_8254_FREQ, &bt);
-	vatpit->freq_sbt = bttosbt(bt);
+	FREQ2BT(PIT_8254_FREQ, &vatpit->freq_bt);
 
 	for (i = 0; i < 3; i++) {
 		callout_init(&vatpit->channel[i].callout, 1);
@@ -455,3 +472,16 @@ vatpit_cleanup(struct vatpit *vatpit)
 
 	free(vatpit, M_VATPIT);
 }
+
+#ifndef __FreeBSD__
+void
+vatpit_localize_resources(struct vatpit *vatpit)
+{
+	for (uint_t i = 0; i < 3; i++) {
+		/* Only localize channels which might be running */
+		if (vatpit->channel[i].mode != 0) {
+			vmm_glue_callout_localize(&vatpit->channel[i].callout);
+		}
+	}
+}
+#endif /* __FreeBSD */

--- a/usr/src/uts/i86pc/io/vmm/io/vatpit.h
+++ b/usr/src/uts/i86pc/io/vmm/io/vatpit.h
@@ -42,4 +42,8 @@ int vatpit_handler(struct vm *vm, int vcpuid, bool in, int port, int bytes,
 int vatpit_nmisc_handler(struct vm *vm, int vcpuid, bool in, int port,
     int bytes, uint32_t *eax);
 
+#ifndef __FreeBSD__
+void vatpit_localize_resources(struct vatpit *);
+#endif
+
 #endif	/* _VATPIT_H_ */

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -760,11 +760,20 @@ vm_alloc_memseg(struct vm *vm, int ident, size_t len, bool sysmem)
 	struct mem_seg *seg;
 	vm_object_t obj;
 
+#ifndef __FreeBSD__
+	extern pgcnt_t get_max_page_get(void);
+#endif
+
 	if (ident < 0 || ident >= VM_MAX_MEMSEGS)
 		return (EINVAL);
 
 	if (len == 0 || (len & PAGE_MASK))
 		return (EINVAL);
+
+#ifndef __FreeBSD__
+	if (len > ptob(get_max_page_get()))
+		return (EINVAL);
+#endif
 
 	seg = &vm->mem_segs[ident];
 	if (seg->object != NULL) {

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -1888,6 +1888,7 @@ vm_localize_resources(struct vm *vm, struct vcpu *vcpu)
 	if (vcpu == &vm->vcpu[0]) {
 		vhpet_localize_resources(vm->vhpet);
 		vrtc_localize_resources(vm->vrtc);
+		vatpit_localize_resources(vm->vatpit);
 	}
 
 	vlapic_localize_resources(vcpu->vlapic);

--- a/usr/src/uts/i86pc/ml/offsets.in
+++ b/usr/src/uts/i86pc/ml/offsets.in
@@ -128,9 +128,6 @@ _kthread	THREAD_SIZE
 	t_useracc
 #endif
 
-ctxop
-	save_op			CTXOP_SAVE
-
 as
 	a_hat
 

--- a/usr/src/uts/i86pc/os/cpuid.c
+++ b/usr/src/uts/i86pc/os/cpuid.c
@@ -59,6 +59,7 @@
 #include <sys/pci_cfgspace.h>
 #include <sys/comm_page.h>
 #include <sys/mach_mmu.h>
+#include <sys/ucode.h>
 #include <sys/tsc.h>
 
 #ifdef __xpv
@@ -207,6 +208,16 @@ static char *x86_feature_names[NUM_X86_FEATURES] = {
 	"ospke",
 	"pcid",
 	"invpcid",
+	"ibrs",
+	"ibpb",
+	"stibp",
+	"ssbd",
+	"ssbd_virt",
+	"rdcl_no",
+	"ibrs_all",
+	"rsba",
+	"ssb_no",
+	"stibp_all"
 };
 
 boolean_t
@@ -974,6 +985,86 @@ cpuid_amd_getids(cpu_t *cpu)
 	    cpi->cpi_procnodeid / cpi->cpi_procnodes_per_pkg;
 }
 
+static void
+cpuid_scan_security(cpu_t *cpu, uchar_t *featureset)
+{
+	struct cpuid_info *cpi = cpu->cpu_m.mcpu_cpi;
+
+	if (cpi->cpi_vendor == X86_VENDOR_AMD &&
+	    cpi->cpi_xmaxeax >= 0x80000008) {
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_IBPB)
+			add_x86_feature(featureset, X86FSET_IBPB);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_IBRS)
+			add_x86_feature(featureset, X86FSET_IBRS);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_STIBP)
+			add_x86_feature(featureset, X86FSET_STIBP);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_IBRS_ALL)
+			add_x86_feature(featureset, X86FSET_IBRS_ALL);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_STIBP_ALL)
+			add_x86_feature(featureset, X86FSET_STIBP_ALL);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_PREFER_IBRS)
+			add_x86_feature(featureset, X86FSET_RSBA);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_SSBD)
+			add_x86_feature(featureset, X86FSET_SSBD);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_VIRT_SSBD)
+			add_x86_feature(featureset, X86FSET_SSBD_VIRT);
+		if (cpi->cpi_extd[8].cp_ebx & CPUID_AMD_EBX_SSB_NO)
+			add_x86_feature(featureset, X86FSET_SSB_NO);
+	} else if (cpi->cpi_vendor == X86_VENDOR_Intel &&
+	    cpi->cpi_maxeax >= 7) {
+		struct cpuid_regs *ecp;
+		ecp = &cpi->cpi_std[7];
+
+		if (ecp->cp_edx & CPUID_INTC_EDX_7_0_SPEC_CTRL) {
+			add_x86_feature(featureset, X86FSET_IBRS);
+			add_x86_feature(featureset, X86FSET_IBPB);
+		}
+
+		if (ecp->cp_edx & CPUID_INTC_EDX_7_0_STIBP) {
+			add_x86_feature(featureset, X86FSET_STIBP);
+		}
+
+		/*
+		 * Don't read the arch caps MSR on xpv where we lack the
+		 * on_trap().
+		 */
+#ifndef __xpv
+		if (ecp->cp_edx & CPUID_INTC_EDX_7_0_ARCH_CAPS) {
+			on_trap_data_t otd;
+
+			/*
+			 * Be paranoid and assume we'll get a #GP.
+			 */
+			if (!on_trap(&otd, OT_DATA_ACCESS)) {
+				uint64_t reg;
+
+				reg = rdmsr(MSR_IA32_ARCH_CAPABILITIES);
+				if (reg & IA32_ARCH_CAP_RDCL_NO) {
+					add_x86_feature(featureset,
+					    X86FSET_RDCL_NO);
+				}
+				if (reg & IA32_ARCH_CAP_IBRS_ALL) {
+					add_x86_feature(featureset,
+					    X86FSET_IBRS_ALL);
+				}
+				if (reg & IA32_ARCH_CAP_RSBA) {
+					add_x86_feature(featureset,
+					    X86FSET_RSBA);
+				}
+				if (reg & IA32_ARCH_CAP_SSB_NO) {
+					add_x86_feature(featureset,
+					    X86FSET_SSB_NO);
+				}
+			}
+			no_trap();
+		}
+#endif	/* !__xpv */
+
+		if (ecp->cp_edx & CPUID_INTC_EDX_7_0_SSBD)
+			add_x86_feature(featureset, X86FSET_SSBD);
+	}
+}
+
 /*
  * Setup XFeature_Enabled_Mask register. Required by xsave feature.
  */
@@ -1296,6 +1387,7 @@ cpuid_pass1(cpu_t *cpu, uchar_t *featureset)
 		ecp->cp_eax = 7;
 		ecp->cp_ecx = 0;
 		(void) __cpuid_insn(ecp);
+
 		/*
 		 * If XSAVE has been disabled, just ignore all of the
 		 * extended-save-area dependent flags here.
@@ -1918,6 +2010,11 @@ cpuid_pass1(cpu_t *cpu, uchar_t *featureset)
 		}
 	}
 
+	/*
+	 * Check the processor leaves that are used for security features.
+	 */
+	cpuid_scan_security(cpu, featureset);
+
 pass1_done:
 	cpi->cpi_pass = 1;
 }
@@ -1955,6 +2052,12 @@ cpuid_pass2(cpu_t *cpu)
 		cp->cp_eax = n;
 
 		/*
+		 * n == 7 was handled in pass 1
+		 */
+		if (n == 7)
+			continue;
+
+		/*
 		 * CPUID function 4 expects %ecx to be initialized
 		 * with an index which indicates which cache to return
 		 * information about. The OS is expected to call function 4
@@ -1968,10 +2071,8 @@ cpuid_pass2(cpu_t *cpu)
 		 *
 		 * Note: we need to explicitly initialize %ecx here, since
 		 * function 4 may have been previously invoked.
-		 *
-		 * The same is all true for CPUID function 7.
 		 */
-		if (n == 4 || n == 7)
+		if (n == 4)
 			cp->cp_ecx = 0;
 
 		(void) __cpuid_insn(cp);
@@ -5254,4 +5355,145 @@ cpuid_get_ext_topo(uint_t vendor, uint_t *core_nbits, uint_t *strand_nbits)
 			}
 		}
 	}
+}
+
+void
+cpuid_pass_ucode(cpu_t *cpu, uchar_t *fset)
+{
+	struct cpuid_info *cpi = cpu->cpu_m.mcpu_cpi;
+	struct cpuid_regs cp;
+
+	/*
+	 * Reread the CPUID portions that we need for various security
+	 * information.
+	 */
+	if (cpi->cpi_vendor == X86_VENDOR_Intel) {
+		/*
+		 * Check if we now have leaf 7 available to us.
+		 */
+		if (cpi->cpi_maxeax < 7) {
+			bzero(&cp, sizeof (cp));
+			cp.cp_eax = 0;
+			cpi->cpi_maxeax = __cpuid_insn(&cp);
+			if (cpi->cpi_maxeax < 7)
+				return;
+		}
+
+		bzero(&cp, sizeof (cp));
+		cp.cp_eax = 7;
+		cp.cp_ecx = 0;
+		(void) __cpuid_insn(&cp);
+		cpi->cpi_std[7] = cp;
+	} else if (cpi->cpi_vendor == X86_VENDOR_AMD) {
+		/* No xcpuid support */
+		if (cpi->cpi_family < 5 ||
+		    (cpi->cpi_family == 5 && cpi->cpi_model < 1))
+			return;
+
+		if (cpi->cpi_xmaxeax < 0x80000008) {
+			bzero(&cp, sizeof (cp));
+			cp.cp_eax = 0x80000000;
+			cpi->cpi_xmaxeax = __cpuid_insn(&cp);
+			if (cpi->cpi_xmaxeax < 0x80000008) {
+				return;
+			}
+		}
+
+		bzero(&cp, sizeof (cp));
+		cp.cp_eax = 0x80000008;
+		(void) __cpuid_insn(&cp);
+		platform_cpuid_mangle(cpi->cpi_vendor, 0x80000008, &cp);
+		cpi->cpi_extd[8] = cp;
+	} else {
+		/*
+		 * Nothing to do here. Return an empty set which has already
+		 * been zeroed for us.
+		 */
+		return;
+	}
+	cpuid_scan_security(cpu, fset);
+}
+
+static int
+cpuid_post_ucodeadm_xc(xc_arg_t arg0, xc_arg_t arg1, xc_arg_t arg2)
+{
+	uchar_t *fset;
+
+	fset = (uchar_t *)(arg0 + sizeof (x86_featureset) * CPU->cpu_id);
+	cpuid_pass_ucode(CPU, fset);
+
+	return (0);
+}
+
+/*
+ * After a microcode update where the version has changed, then we need to
+ * rescan CPUID. To do this we check every CPU to make sure that they have the
+ * same microcode. Then we perform a cross call to all such CPUs. It's the
+ * caller's job to make sure that no one else can end up doing an update while
+ * this is going on.
+ *
+ * We assume that the system is microcode capable if we're called.
+ */
+void
+cpuid_post_ucodeadm(void)
+{
+	uint32_t rev;
+	int i;
+	struct cpu *cpu;
+	cpuset_t cpuset;
+	void *argdata;
+	uchar_t *f0;
+
+	argdata = kmem_zalloc(sizeof (x86_featureset) * NCPU, KM_SLEEP);
+
+	mutex_enter(&cpu_lock);
+	cpu = cpu_get(0);
+	rev = cpu->cpu_m.mcpu_ucode_info->cui_rev;
+	CPUSET_ONLY(cpuset, 0);
+	for (i = 1; i < max_ncpus; i++) {
+		if ((cpu = cpu_get(i)) == NULL)
+			continue;
+
+		if (cpu->cpu_m.mcpu_ucode_info->cui_rev != rev) {
+			panic("post microcode update CPU %d has differing "
+			    "microcode revision (%u) from CPU 0 (%u)",
+			    i, cpu->cpu_m.mcpu_ucode_info->cui_rev, rev);
+		}
+		CPUSET_ADD(cpuset, i);
+	}
+
+	kpreempt_disable();
+	xc_sync((xc_arg_t)argdata, 0, 0, CPUSET2BV(cpuset),
+	    cpuid_post_ucodeadm_xc);
+	kpreempt_enable();
+
+	/*
+	 * OK, now look at each CPU and see if their feature sets are equal.
+	 */
+	f0 = argdata;
+	for (i = 1; i < max_ncpus; i++) {
+		uchar_t *fset;
+		if (!CPU_IN_SET(cpuset, i))
+			continue;
+
+		fset = (uchar_t *)((uintptr_t)argdata +
+		    sizeof (x86_featureset) * i);
+
+		if (!compare_x86_featureset(f0, fset)) {
+			panic("Post microcode update CPU %d has "
+			    "differing security feature (%p) set from CPU 0 "
+			    "(%p), not appending to feature set", i, fset, f0);
+		}
+	}
+
+	mutex_exit(&cpu_lock);
+
+	for (i = 0; i < NUM_X86_FEATURES; i++) {
+		cmn_err(CE_CONT, "?post-ucode x86_feature: %s\n",
+		    x86_feature_names[i]);
+		if (is_x86_feature(f0, i)) {
+			add_x86_feature(x86_featureset, i);
+		}
+	}
+	kmem_free(argdata, sizeof (x86_featureset) * NCPU);
 }

--- a/usr/src/uts/i86pc/os/cpuid.c
+++ b/usr/src/uts/i86pc/os/cpuid.c
@@ -5415,7 +5415,8 @@ cpuid_pass_ucode(cpu_t *cpu, uchar_t *fset)
 }
 
 static int
-cpuid_post_ucodeadm_xc(xc_arg_t arg0, xc_arg_t arg1, xc_arg_t arg2)
+/* LINTED E_FUNC_ARG_UNUSED */
+cpuid_post_ucodeadm_xc(xc_arg_t arg0,xc_arg_t arg1, xc_arg_t arg2)
 {
 	uchar_t *fset;
 
@@ -5482,7 +5483,8 @@ cpuid_post_ucodeadm(void)
 		if (!compare_x86_featureset(f0, fset)) {
 			panic("Post microcode update CPU %d has "
 			    "differing security feature (%p) set from CPU 0 "
-			    "(%p), not appending to feature set", i, fset, f0);
+			    "(%p), not appending to feature set", i,
+			    (void *)fset, (void *)f0);
 		}
 	}
 

--- a/usr/src/uts/i86pc/os/microcode.c
+++ b/usr/src/uts/i86pc/os/microcode.c
@@ -24,6 +24,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2012 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #include <sys/asm_linkage.h>
@@ -754,8 +755,15 @@ ucode_write(xc_arg_t arg1, xc_arg_t unused2, xc_arg_t unused3)
 			return (0);
 	}
 
-	if (!on_trap(&otd, OT_DATA_ACCESS))
+	if (!on_trap(&otd, OT_DATA_ACCESS)) {
+		/*
+		 * On some platforms a cache invalidation is required for the
+		 * ucode update to be successful due to the parts of the
+		 * processor that the microcode is updating.
+		 */
+		invalidate_cache();
 		wrmsr(ucode->write_msr, (uintptr_t)uusp->ucodep);
+	}
 
 	no_trap();
 #endif
@@ -849,6 +857,12 @@ ucode_load_intel(ucode_file_t *ufp, cpu_ucode_info_t *uinfop, cpu_t *cp)
 	uus.new_rev = uinfop->cui_rev;
 #else
 	kpreempt_disable();
+	/*
+	 * On some platforms a cache invalidation is required for the
+	 * ucode update to be successful due to the parts of the
+	 * processor that the microcode is updating.
+	 */
+	invalidate_cache();
 	wrmsr(ucode->write_msr, (uintptr_t)ucodefp->uf_body);
 	ucode->read_rev(uinfop);
 	kpreempt_enable();

--- a/usr/src/uts/i86pc/os/microcode.c
+++ b/usr/src/uts/i86pc/os/microcode.c
@@ -1145,8 +1145,11 @@ ucode_update(uint8_t *ucodep, int size)
 
 	mutex_exit(&cpu_lock);
 
-	if (!found)
+	if (!found) {
 		rc = search_rc;
+	} else if (rc == EM_OK) {
+		cpuid_post_ucodeadm();
+	}
 
 	return (rc);
 }

--- a/usr/src/uts/i86pc/os/mlsetup.c
+++ b/usr/src/uts/i86pc/os/mlsetup.c
@@ -490,6 +490,7 @@ mlsetup(struct regs *rp)
 	 * Fill out cpu_ucode_info.  Update microcode if necessary.
 	 */
 	ucode_check(CPU);
+	cpuid_pass_ucode(CPU, x86_featureset);
 
 	if (workaround_errata(CPU) != 0)
 		panic("critical workaround(s) missing for boot cpu");

--- a/usr/src/uts/i86pc/os/mp_startup.c
+++ b/usr/src/uts/i86pc/os/mp_startup.c
@@ -1755,22 +1755,6 @@ mp_startup_common(boolean_t boot)
 	sti();
 
 	/*
-	 * Do a sanity check to make sure this new CPU is a sane thing
-	 * to add to the collection of processors running this system.
-	 *
-	 * XXX	Clearly this needs to get more sophisticated, if x86
-	 * systems start to get built out of heterogenous CPUs; as is
-	 * likely to happen once the number of processors in a configuration
-	 * gets large enough.
-	 */
-	if (compare_x86_featureset(x86_featureset, new_x86_featureset) ==
-	    B_FALSE) {
-		cmn_err(CE_CONT, "cpu%d: featureset\n", cp->cpu_id);
-		print_x86_featureset(new_x86_featureset);
-		cmn_err(CE_WARN, "cpu%d feature mismatch", cp->cpu_id);
-	}
-
-	/*
 	 * There exists a small subset of systems which expose differing
 	 * MWAIT/MONITOR support between CPUs.  If MWAIT support is absent from
 	 * the boot CPU, but is found on a later CPU, the system continues to
@@ -1875,6 +1859,23 @@ mp_startup_common(boolean_t boot)
 	 * Fill out cpu_ucode_info.  Update microcode if necessary.
 	 */
 	ucode_check(cp);
+	cpuid_pass_ucode(cp, new_x86_featureset);
+
+	/*
+	 * Do a sanity check to make sure this new CPU is a sane thing
+	 * to add to the collection of processors running this system.
+	 *
+	 * XXX	Clearly this needs to get more sophisticated, if x86
+	 * systems start to get built out of heterogenous CPUs; as is
+	 * likely to happen once the number of processors in a configuration
+	 * gets large enough.
+	 */
+	if (compare_x86_featureset(x86_featureset, new_x86_featureset) ==
+	    B_FALSE) {
+		cmn_err(CE_CONT, "cpu%d: featureset\n", cp->cpu_id);
+		print_x86_featureset(new_x86_featureset);
+		cmn_err(CE_WARN, "cpu%d feature mismatch", cp->cpu_id);
+	}
 
 #ifndef __xpv
 	{

--- a/usr/src/uts/intel/Makefile.files
+++ b/usr/src/uts/intel/Makefile.files
@@ -21,7 +21,7 @@
 
 #
 # Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2017, Joyent, Inc.
+# Copyright 2018, Joyent, Inc.
 # Copyright 2018 Nexenta Systems, Inc.
 #
 
@@ -299,6 +299,7 @@ LX_BRAND_OBJS  =		\
 	lx_acl.o		\
 	lx_aio.o		\
 	lx_archdep.o		\
+	lx_audit.o		\
 	lx_auxv.o		\
 	lx_brand.o		\
 	lx_brk.o		\

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -187,7 +187,16 @@ extern "C" {
 /*
  * AMD uses %ebx for some of their features (extended function 0x80000008).
  */
-#define	CPUID_AMD_EBX_ERR_PTR_ZERO	0x00000004 /* AMD: FP Err. Ptr. Zero */
+#define	CPUID_AMD_EBX_ERR_PTR_ZERO	0x000000004 /* AMD: FP Err. Ptr. Zero */
+#define	CPUID_AMD_EBX_IBPB		0x000001000 /* AMD: IBPB */
+#define	CPUID_AMD_EBX_IBRS		0x000004000 /* AMD: IBRS */
+#define	CPUID_AMD_EBX_STIBP		0x000008000 /* AMD: STIBP */
+#define	CPUID_AMD_EBX_IBRS_ALL		0x000010000 /* AMD: Enhanced IBRS */
+#define	CPUID_AMD_EBX_STIBP_ALL		0x000020000 /* AMD: STIBP ALL */
+#define	CPUID_AMD_EBX_PREFER_IBRS	0x000040000 /* AMD: Don't retpoline */
+#define	CPUID_AMD_EBX_SSBD		0x001000000 /* AMD: SSBD */
+#define	CPUID_AMD_EBX_VIRT_SSBD		0x002000000 /* AMD: VIRT SSBD */
+#define	CPUID_AMD_EBX_SSB_NO		0x004000000 /* AMD: SSB Fixed */
 
 /*
  * Intel now seems to have claimed part of the "extended" function
@@ -243,6 +252,10 @@ extern "C" {
 
 #define	CPUID_INTC_EDX_7_0_AVX5124NNIW	0x00000004	/* AVX512 4NNIW */
 #define	CPUID_INTC_EDX_7_0_AVX5124FMAPS	0x00000008	/* AVX512 4FMAPS */
+#define	CPUID_INTC_EDX_7_0_SPEC_CTRL	0x04000000	/* Spec, IBPB, IBRS */
+#define	CPUID_INTC_EDX_7_0_STIBP	0x08000000	/* STIBP */
+#define	CPUID_INTC_EDX_7_0_ARCH_CAPS	0x20000000	/* IA32_ARCH_CAPS */
+#define	CPUID_INTC_EDX_7_0_SSBD		0x80000000	/* SSBD */
 
 #define	CPUID_INTC_EDX_7_0_ALL_AVX512 \
 	(CPUID_INTC_EDX_7_0_AVX5124NNIW | CPUID_INTC_EDX_7_0_AVX5124FMAPS)
@@ -333,6 +346,38 @@ extern "C" {
 #define	MSR_PRP4_LBSTK_TO_13	0x6cd
 #define	MSR_PRP4_LBSTK_TO_14	0x6ce
 #define	MSR_PRP4_LBSTK_TO_15	0x6cf
+
+/*
+ * General Xeon based MSRs
+ */
+#define	MSR_PPIN_CTL		0x04e
+#define	MSR_PPIN		0x04f
+#define	MSR_PLATFORM_INFO	0x0ce
+
+#define	MSR_PLATFORM_INFO_PPIN	(1 << 23)
+#define	MSR_PPIN_CTL_MASK	0x03
+#define	MSR_PPIN_CTL_LOCKED	0x01
+#define	MSR_PPIN_CTL_ENABLED	0x02
+
+/*
+ * Intel IA32_ARCH_CAPABILITIES MSR.
+ */
+#define	MSR_IA32_ARCH_CAPABILITIES	0x10a
+#define	IA32_ARCH_CAP_RDCL_NO		0x0001
+#define	IA32_ARCH_CAP_IBRS_ALL		0x0002
+#define	IA32_ARCH_CAP_RSBA		0x0004
+#define	IA32_ARCH_CAP_SSB_NO		0x0010
+
+/*
+ * Intel Speculation related MSRs
+ */
+#define	MSR_IA32_SPEC_CTRL	0x48
+#define	IA32_SPEC_CTRL_IBRS	0x01
+#define	IA32_SPEC_CTRL_STIBP	0x02
+#define	IA32_SPEC_CTRL_SSBD	0x04
+
+#define	MSR_IA32_PRED_CMD	0x49
+#define	IA32_PRED_CMD_IBPB	0x01
 
 #define	MCI_CTL_VALUE		0xffffffff
 
@@ -436,6 +481,16 @@ extern "C" {
 #define	X86FSET_OSPKE		68
 #define	X86FSET_PCID		69
 #define	X86FSET_INVPCID		70
+#define	X86FSET_IBRS		71
+#define	X86FSET_IBPB		72
+#define	X86FSET_STIBP		73
+#define	X86FSET_SSBD		74
+#define	X86FSET_SSBD_VIRT	75
+#define	X86FSET_RDCL_NO		76
+#define	X86FSET_IBRS_ALL	77
+#define	X86FSET_RSBA		78
+#define	X86FSET_SSB_NO		79
+#define	X86FSET_STIBP_ALL	80
 
 /*
  * Intel Deep C-State invariant TSC in leaf 0x80000007.
@@ -705,7 +760,7 @@ extern "C" {
 
 #if defined(_KERNEL) || defined(_KMEMUSER)
 
-#define	NUM_X86_FEATURES	71
+#define	NUM_X86_FEATURES	81
 extern uchar_t x86_featureset[];
 
 extern void free_x86_featureset(void *featureset);
@@ -818,6 +873,8 @@ extern void cpuid_pass3(struct cpu *);
 extern void cpuid_pass4(struct cpu *, uint_t *);
 extern void cpuid_set_cpu_properties(void *, processorid_t,
     struct cpuid_info *);
+extern void cpuid_pass_ucode(struct cpu *, uchar_t *);
+extern void cpuid_post_ucodeadm(void);
 
 extern void cpuid_get_addrsize(struct cpu *, uint_t *, uint_t *);
 extern uint_t cpuid_get_dtlb_nent(struct cpu *, size_t);


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018070601. Work by @hadfl, lint fix-up by me. 
In particular, please review https://github.com/omniosorg/illumos-omnios/pull/236/commits/a61e4505c38f2bcb12e6948bd5f8a754ae9da28e#diff-1d8f65082d9bd11ff531df25daf21926L1807 - the basic problem is the assignment of a 32-bit value to a 16-bit value within the struct and there are a number of ways to fix the lint warning. I've elected for this as the simplest which should still allow simple merging of any further upstream fixes.

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2018070601-861a08c186 i86pc i386 i86pc
```
## mail_msg

```
==== Nightly distributed build started:   Mon Jul  9 08:48:15 UTC 2018 ====
==== Nightly distributed build completed: Mon Jul  9 09:49:45 UTC 2018 ====

==== Total build time ====

real    1:01:30

==== Build environment ====

/usr/bin/uname
SunOS build 5.11 omnios-r151026-b6848f4455 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_171-b02"

/usr/bin/openssl
OpenSSL 1.0.2o  27 Mar 2018

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   110526

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018070601-861a08c186

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    14:25.6
user  1:14:40.5
sys     10:55.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:45.1
user  1:05:53.8
sys      9:42.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====

14643d14642
< sbin/bootadm: NEEDED=libscf.so.1

==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    18:22.9
user    40:16.3
sys     11:37.9

==== lint warnings src ====


==== lint noise differences src ====

5d4
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/amd/svm.c", line 990: warning: function returns value which is sometimes ignored: vm_exit_intinfo (E_FUNC_RET_MAYBE_IGNORED2)
12,13d10
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 1011: warning: function returns value which is always ignored: ppt_flr (E_FUNC_RET_ALWAYS_IGNOR2)
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 883: warning: function returns value which is sometimes ignored: ddi_intr_block_disable (E_FUNC_RET_MAYBE_IGNORED2)
17c14
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 261: warning: function returns value which is sometimes ignored: vioapic_pulse_irq (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 260: warning: function returns value which is sometimes ignored: lapic_set_local_intr (E_FUNC_RET_MAYBE_IGNORED2)
19a17
> "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 257: warning: function returns value which is sometimes ignored: vioapic_assert_irq (E_FUNC_RET_MAYBE_IGNORED2)
22d19
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm.c", line 1558: warning: function returns value which is sometimes ignored: vm_suspend (E_FUNC_RET_MAYBE_IGNORED2)
24d20
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm.c", line 585: warning: function returns value which is sometimes ignored: strcpy (E_FUNC_RET_MAYBE_IGNORED2)
29,33c25,28
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 615: warning: function argument type inconsistent with format: panic(arg 2) unsigned long * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(615) (E_BAD_FORMAT_ARG_TYPE2)
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 651: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(651) (E_BAD_FORMAT_ARG_TYPE2)
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 700: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(700) (E_BAD_FORMAT_ARG_TYPE2)
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 758: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(758) (E_BAD_FORMAT_ARG_TYPE2)
< "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_stat.c", line 139: warning: function returns value which is sometimes ignored: snprintf (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 616: warning: function argument type inconsistent with format: panic(arg 2) unsigned long * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(616) (E_BAD_FORMAT_ARG_TYPE2)
> "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 652: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(652) (E_BAD_FORMAT_ARG_TYPE2)
> "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 701: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(701) (E_BAD_FORMAT_ARG_TYPE2)
> "/data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c", line 759: warning: function argument type inconsistent with format: panic(arg 3) struct eptable * and (format) void * in /data/omnios-build/omniosorg/bloody/illumos/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c(759) (E_BAD_FORMAT_ARG_TYPE2)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
