### PR TITLE
Clean up old 32-bit boot archives

### DIFF
--- a/usr/src/cmd/boot/scripts/boot-archive-update.ksh
+++ b/usr/src/cmd/boot/scripts/boot-archive-update.ksh
@@ -31,14 +31,18 @@ UPDATEFILE=/etc/svc/volatile/boot_archive_safefile_update
 
 smf_is_globalzone || exit $SMF_EXIT_OK
 
-# on x86 get rid of transient reboot entry in the GRUB menu
-#
 if [ `uname -p` = "i386" ]; then
+	# on x86 get rid of transient reboot entry in the GRUB menu
 	if [ -f /stubboot/boot/grub/menu.lst ]; then
 		/sbin/bootadm -m update_temp -R /stubboot
 	else
 		/sbin/bootadm -m update_temp
 	fi
+	# Remove old 32-bit archives if present.
+	plat=/platform/`uname -i`
+	[ -f $plat/boot_archive ] && rm -f $plat/boot_archive
+	[ -f $plat/boot_archive.hash ] && rm -f $plat/boot_archive.hash
+	[ -d $plat/archive_cache ] && rm -rf $plat/archive_cache
 fi
 
 if [ -f $UPDATEFILE ] || [ -f /reconfigure ]; then


### PR DESCRIPTION
Now that we only have 64-bit boot archives, we can remove any 32-bit ones from disk during startup.