### PR TITLE
Upstream merge joyent_merge/2018071901

### DIFF
--- a/usr/src/lib/libvmmapi/common/vmmapi.c
+++ b/usr/src/lib/libvmmapi/common/vmmapi.c
@@ -455,6 +455,14 @@ vm_setup_memory(struct vmctx *ctx, size_t memsize, enum vm_mmap_style vms)
 	 */
 	len = VM_MMAP_GUARD_SIZE + objsize + VM_MMAP_GUARD_SIZE;
 	flags = MAP_PRIVATE | MAP_ANON | MAP_NOCORE | MAP_ALIGNED_SUPER;
+#ifndef __FreeBSD__
+	/*
+	 * There is no need to reserve swap for the guest physical memory and
+	 * guard regions. Actual memory is allocated and mapped later through
+	 * vm_alloc_memseg() and setup_memory_segment().
+	 */
+	flags |= MAP_NORESERVE;
+#endif
 	ptr = mmap(NULL, len, PROT_NONE, flags, -1, 0);
 	if (ptr == MAP_FAILED)
 		return (-1);

--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -923,6 +923,23 @@ lx_netlink_reply_done(lx_netlink_reply_t *reply)
 		hdr->lxnh_seq = reply->lxnr_hdr.lxnh_seq;
 		hdr->lxnh_pid = lxsock->lxns_port;
 	} else {
+		uint32_t status = 0;
+
+		/*
+		 * More recent versions of the iproute2 utils expect a status
+		 * value after the header, even in the absence of errors.
+		 */
+		lx_netlink_reply_add(reply, &status, sizeof (status));
+
+		/*
+		 * "done" is also the most minimal response possible.  If
+		 * lx_netlink_reply_msg() does not set lxnr_errno, we should
+		 * be guaranteed enough room to hold this (i.e. our
+		 * lx_netlink_reply_add() call should never end up setting
+		 * lxnr_errno).
+		 */
+		VERIFY0(reply->lxnr_errno);
+
 		mp = reply->lxnr_mp;
 		VERIFY(mp != NULL);
 		reply->lxnr_mp = NULL;

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -102,7 +102,7 @@
  *        |---* ring worker thread begins execution	|
  *        |						|
  *        +-------------------------------------------->+
- *        |	      | 				^
+ *        |	      |					^
  *        |	      |
  *        |	      *	If ring shutdown is requested (by ioctl or impending
  *        |		bhyve process death) while the worker thread is
@@ -1749,7 +1749,7 @@ viona_copy_mblk(const mblk_t *mp, size_t seek, caddr_t buf, size_t len,
 
 	/* Seek past already-consumed data */
 	while (seek > 0 && mp != NULL) {
-		size_t chunk = MBLKL(mp);
+		const size_t chunk = MBLKL(mp);
 
 		if (chunk > seek) {
 			off = seek;
@@ -1768,17 +1768,31 @@ viona_copy_mblk(const mblk_t *mp, size_t seek, caddr_t buf, size_t len,
 		buf += to_copy;
 		len -= to_copy;
 
+		/*
+		 * If all the remaining data in the mblk_t was copied, move on
+		 * to the next one in the chain.  Any seek offset applied to
+		 * the first mblk copy is zeroed out for subsequent operations.
+		 */
+		if (chunk == to_copy) {
+			mp = mp->b_cont;
+			off = 0;
+		}
+#ifdef DEBUG
+		else {
+			/*
+			 * The only valid reason for the copy to consume less
+			 * than the entire contents of the mblk_t is because
+			 * the output buffer has been filled.
+			 */
+			ASSERT0(len);
+		}
+#endif
+
 		/* Go no further if the buffer has been filled */
 		if (len == 0) {
 			break;
 		}
 
-		/*
-		 * Any offset into the initially chosen mblk_t buffer is
-		 * consumed on the first copy operation.
-		 */
-		off = 0;
-		mp = mp->b_cont;
 	}
 	*end = (mp == NULL);
 	return (copied);

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -2324,9 +2324,7 @@ nested_fault(struct vm *vm, int vcpuid, uint64_t info1, uint64_t info2,
 	if (type1 == VM_INTINFO_HWEXCEPTION && vector1 == IDT_DF) {
 		VCPU_CTR2(vm, vcpuid, "triple fault: info1(%#lx), info2(%#lx)",
 		    info1, info2);
-#ifdef	__FreeBSD__
 		vm_suspend(vm, VM_SUSPEND_TRIPLEFAULT);
-#endif
 		*retinfo = 0;
 		return (0);
 	}

--- a/usr/src/uts/intel/kdi/kdi_idt.c
+++ b/usr/src/uts/intel/kdi/kdi_idt.c
@@ -164,8 +164,8 @@ struct idt_description {
 	{ T_GPFLT, 0,		kdi_traperr13, NULL },
 	{ T_PGFLT, 0,		kdi_traperr14, NULL },
 	{ 15, 0,		kdi_invaltrap, NULL },
-	{ T_EXTERRFLT, 0, 	kdi_trap16, NULL },
-	{ T_ALIGNMENT, 0, 	kdi_traperr17, NULL },
+	{ T_EXTERRFLT, 0,	kdi_trap16, NULL },
+	{ T_ALIGNMENT, 0,	kdi_traperr17, NULL },
 	{ T_MCE, 0,		kdi_trap18, NULL },
 	{ T_SIMDFPE, 0,		kdi_trap19, NULL },
 	{ T_DBGENTR, 0,		kdi_trap20, NULL },
@@ -366,14 +366,16 @@ kdi_deactivate(void)
 }
 
 /*
- * We receive all breakpoints and single step traps.  Some of them,
- * including those from userland and those induced by DTrace providers,
- * are intended for the kernel, and must be processed there.  We adopt
- * this ours-until-proven-otherwise position due to the painful
- * consequences of sending the kernel an unexpected breakpoint or
- * single step.  Unless someone can prove to us that the kernel is
- * prepared to handle the trap, we'll assume there's a problem and will
- * give the user a chance to debug it.
+ * We receive all breakpoints and single step traps.  Some of them, including
+ * those from userland and those induced by DTrace providers, are intended for
+ * the kernel, and must be processed there.  We adopt this
+ * ours-until-proven-otherwise position due to the painful consequences of
+ * sending the kernel an unexpected breakpoint or single step.  Unless someone
+ * can prove to us that the kernel is prepared to handle the trap, we'll assume
+ * there's a problem and will give the user a chance to debug it.
+ *
+ * If we return 2, then the calling code should restore the trap-time %cr3: that
+ * is, it really is a kernel-originated trap.
  */
 int
 kdi_trap_pass(kdi_cpusave_t *cpusave)
@@ -390,7 +392,7 @@ kdi_trap_pass(kdi_cpusave_t *cpusave)
 
 	if (tt == T_BPTFLT && kdi_dtrace_get_state() ==
 	    KDI_DTSTATE_DTRACE_ACTIVE)
-		return (1);
+		return (2);
 
 	/*
 	 * See the comments in the kernel's T_SGLSTP handler for why we need to


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018071901. Straightforward, no conflicts.

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2018071901-de5bff4a2f i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Jul 19 08:23:35 GMT 2018 ====
==== Nightly distributed build completed: Thu Jul 19 10:08:49 GMT 2018 ====

==== Total build time ====

real    1:45:13

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-01856b5361 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_181-b01"

/usr/bin/openssl
OpenSSL 1.1.0h  27 Mar 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   207

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018071901-de5bff4a2f

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:37.0
user  1:08:06.8
sys     11:17.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    34:36.5
user    59:50.6
sys     10:52.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    27:23.8
user    43:27.1
sys      9:41.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
