### PR TITLE
Update README.OmniOS

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -7,22 +7,13 @@ to the IPS repository.
 This file is used to track packages that need to be published as part
 of the next reboot-required update for this branch. Archives that fix
 specific problems or are generally useful will be advertised on the
-web page and other mediums so users are no expected to monitor this
+web page and other mediums so users are not expected to monitor this
 file. However, some brief notes on how to install a package archive
 are included at the end of this file.
 
 =======================================================================
 
-## 7941 cannot use crypto lofi on a block/character device
-
-Commits:
- > 7941 cannot use crypto lofi on a block/character device
-
-Packages:
- > SUNWcs
-
-Archive:
- > https://downloads.omniosce.org/pkg/r151026/7941-backport_r26.p5p
+No pending updates.
 
 =======================================================================
 


### PR DESCRIPTION
The fix for 7941 will be rolled out as part of r151026m. Removing the tracking information from the README.OmniOS file.