### PR TITLE
Backports r22

### DIFF
--- a/usr/src/cmd/mdb/i86pc/modules/unix/unix.c
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/unix.c
@@ -906,9 +906,11 @@ x86_featureset_cmd(uintptr_t addr, uint_t flags, int argc,
 #ifdef _KMDB
 /* ARGSUSED */
 static int
-crregs_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+sysregs_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
 	ulong_t cr0, cr2, cr3, cr4;
+	desctbr_t gdtr;
+
 	static const mdb_bitmask_t cr0_flag_bits[] = {
 		{ "PE",		CR0_PE,		CR0_PE },
 		{ "MP",		CR0_MP,		CR0_MP },
@@ -955,6 +957,9 @@ crregs_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	cr2 = kmdb_unix_getcr2();
 	cr3 = kmdb_unix_getcr3();
 	cr4 = kmdb_unix_getcr4();
+
+	kmdb_unix_getgdtr(&gdtr);
+
 	mdb_printf("%%cr0 = 0x%lx <%b>\n", cr0, cr0, cr0_flag_bits);
 	mdb_printf("%%cr2 = 0x%lx <%a>\n", cr2, cr2);
 
@@ -967,6 +972,9 @@ crregs_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	}
 
 	mdb_printf("%%cr4 = 0x%lx <%b>\n", cr4, cr4, cr4_flag_bits);
+
+	mdb_printf("%%gdtr.base = 0x%lx, %%gdtr.limit = 0x%hx\n",
+	    gdtr.dtr_base, gdtr.dtr_limit);
 
 	return (DCMD_OK);
 }
@@ -999,7 +1007,7 @@ static const mdb_dcmd_t dcmds[] = {
 	{ "x86_featureset", NULL, "dump the x86_featureset vector",
 		x86_featureset_cmd },
 #ifdef _KMDB
-	{ "crregs", NULL, "dump control registers", crregs_dcmd },
+	{ "sysregs", NULL, "dump system registers", sysregs_dcmd },
 #endif
 	{ "sec", "?[-p]", "print security patch summary", sec_dcmd, sec_help },
 	{ NULL }

--- a/usr/src/cmd/mdb/i86pc/modules/unix/unix_sup.h
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/unix_sup.h
@@ -21,6 +21,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/segments.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +31,7 @@ extern ulong_t kmdb_unix_getcr0(void);
 extern ulong_t kmdb_unix_getcr2(void);
 extern ulong_t kmdb_unix_getcr3(void);
 extern ulong_t kmdb_unix_getcr4(void);
+extern void kmdb_unix_getgdtr(desctbr_t *);
 
 #ifdef __cplusplus
 }

--- a/usr/src/cmd/mdb/i86pc/modules/unix/unix_sup.s
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/unix_sup.s
@@ -13,35 +13,20 @@
  * Copyright 2018 Joyent, Inc.
  */
 
-#if !defined(__lint)
-	.file	"unix_sup.s"
-#endif /* __lint */
-
 /*
  * Support routines for the unix kmdb module
  */
-
-#include <sys/asm_linkage.h>
 
 #if defined(__lint)
 
 #include <sys/types.h>
 
-ulong_t
-kmdb_unix_getcr0(void)
-{ return (0); }
+#else
 
-ulong_t
-kmdb_unix_getcr3(void)
-{ return (0); }
+#include <sys/asm_linkage.h>
 
-ulong_t
-kmdb_unix_getcr4(void)
-{ return (0); }
+	.file	"unix_sup.s"
 
-#else	/* __lint */
-
-#if defined(__amd64)
 	ENTRY(kmdb_unix_getcr0)
 	movq %cr0, %rax
 	ret
@@ -62,27 +47,9 @@ kmdb_unix_getcr4(void)
 	ret
 	SET_SIZE(kmdb_unix_getcr4)
 
-#elif defined (__i386)
-	ENTRY(kmdb_unix_getcr0)
-	movl %cr0, %eax
+	ENTRY(kmdb_unix_getgdtr)
+	sgdt (%rdi)
 	ret
-	SET_SIZE(kmdb_unix_getcr0)
+	SET_SIZE(kmdb_unix_getgdtr)
 
-	ENTRY(kmdb_unix_getcr2)
-	movl %cr2, %eax
-	ret
-	SET_SIZE(kmdb_unix_getcr2)
-
-	ENTRY(kmdb_unix_getcr3)
-	movl %cr3, %eax
-	ret
-	SET_SIZE(kmdb_unix_getcr3)
-
-	ENTRY(kmdb_unix_getcr4)
-	movl %cr4, %eax
-	ret
-	SET_SIZE(kmdb_unix_getcr4)
-
-#endif	/* __i386 */
-
-#endif /* __lint */
+#endif /* !__lint */

--- a/usr/src/test/os-tests/runfiles/default.run
+++ b/usr/src/test/os-tests/runfiles/default.run
@@ -65,4 +65,4 @@ tests = ['acquire-compare', 'acquire-spray']
 [/opt/os-tests/tests/i386]
 user = root
 arch = i86pc
-tests = ['ldt']
+tests = ['ldt', 'badseg']

--- a/usr/src/test/os-tests/tests/i386/Makefile
+++ b/usr/src/test/os-tests/tests/i386/Makefile
@@ -16,28 +16,29 @@
 include $(SRC)/cmd/Makefile.cmd
 include $(SRC)/test/Makefile.com
 
-PROG +=	ldt
+PROGS += ldt badseg
 
 ROOTOPTPKG = $(ROOT)/opt/os-tests
 TESTDIR = $(ROOTOPTPKG)/tests/i386
+ROOTOPTPROGS = $(PROGS:%=$(TESTDIR)/%)
 
 CSTD = $(CSTD_GNU99)
 
-CMDS = $(PROG:%=$(TESTDIR)/%)
-$(CMDS) := FILEMODE = 0555
+# for badseg
+COPTFLAG =
 
-all: $(PROG)
+all: $(PROGS)
 
-install: all $(CMDS)
+install: all $(ROOTOPTPROGS)
 
 lint:
 
 clobber: clean
-	-$(RM) $(PROG)
+	-$(RM) $(PROGS)
 
 clean:
 
-$(CMDS): $(TESTDIR) $(PROG)
+$(ROOTOPTPROGS): $(TESTDIR) $(PROGS)
 
 $(TESTDIR):
 	$(INS.dir)

--- a/usr/src/test/os-tests/tests/i386/badseg.c
+++ b/usr/src/test/os-tests/tests/i386/badseg.c
@@ -1,0 +1,146 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#include <stdlib.h>
+#include <ucontext.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <sys/regset.h>
+
+/*
+ * Load a bunch of bad selectors into the seg regs: this will typically cause
+ * the child process to core dump, but it shouldn't panic the kernel...
+ *
+ * It's especially interesting to run this on CPU0.
+ */
+
+unsigned short selector;
+
+static void badds(void)
+{
+	__asm__ volatile("movw %0, %%ds" : : "r" (selector));
+}
+
+static void bades(void)
+{
+	__asm__ volatile("movw %0, %%es" : : "r" (selector));
+}
+
+static void badfs(void)
+{
+	__asm__ volatile("movw %0, %%fs" : : "r" (selector));
+}
+
+static void badgs(void)
+{
+	__asm__ volatile("movw %0, %%gs" : : "r" (selector));
+}
+
+static void badss(void)
+{
+	__asm__ volatile("movw %0, %%ss" : : "r" (selector));
+}
+
+static void
+resetseg(uint_t seg)
+{
+	ucontext_t ucp;
+	int done = 0;
+
+	int rc = getcontext(&ucp);
+	if (done) {
+		rc = getcontext(&ucp);
+		return;
+	}
+
+	done = 1;
+	ucp.uc_mcontext.gregs[seg] = selector;
+	setcontext(&ucp);
+	abort();
+}
+
+static void
+resetcs(void)
+{
+	return (resetseg(CS));
+}
+
+static void
+resetds(void)
+{
+	return (resetseg(DS));
+}
+
+static void
+resetes(void)
+{
+	return (resetseg(ES));
+}
+
+static void
+resetfs(void)
+{
+	return (resetseg(FS));
+}
+
+static void
+resetgs(void)
+{
+	return (resetseg(GS));
+}
+
+static void
+resetss(void)
+{
+	return (resetseg(SS));
+}
+
+static void
+inchild(void (*func)())
+{
+	pid_t pid;
+
+	switch ((pid = fork())) {
+	case 0:
+		func();
+		exit(0);
+	case -1:
+		exit(1);
+	default:
+		(void) waitpid(pid, NULL, 0);
+		return;
+	}
+
+}
+
+int
+main(int argc, char *argv[])
+{
+	for (selector = 0; selector < 8194; selector++) {
+		inchild(resetcs);
+		inchild(resetds);
+		inchild(resetes);
+		inchild(resetfs);
+		inchild(resetgs);
+		inchild(resetss);
+		inchild(badds);
+		inchild(bades);
+		inchild(badfs);
+		inchild(badgs);
+		inchild(badss);
+	}
+
+	exit(0);
+}

--- a/usr/src/uts/i86pc/ml/kpti_trampolines.s
+++ b/usr/src/uts/i86pc/ml/kpti_trampolines.s
@@ -251,6 +251,11 @@ kpti_kbase:
  * This is used for all interrupts that can plausibly be taken inside another
  * interrupt and are using a kpti_frame stack (so #BP, #DB, #GP, #PF, #SS).
  *
+ * We also use this for #NP, even though it uses the standard IST: the
+ * additional %rsp checks below will catch when we get an exception doing an
+ * iret to userspace with a bad %cs/%ss.  This appears as a kernel trap, and
+ * only later gets redirected via kern_gpfault().
+ *
  * We check for whether we took the interrupt while in another trampoline, in
  * which case we need to use the kthread stack.
  */
@@ -649,7 +654,7 @@ tr_intr_ret_end:
 	MK_INTR_TRAMPOLINE_NOERR(invoptrap)
 	MK_INTR_TRAMPOLINE_NOERR(ndptrap)
 	MK_INTR_TRAMPOLINE(invtsstrap)
-	MK_INTR_TRAMPOLINE(segnptrap)
+	MK_DBG_INTR_TRAMPOLINE(segnptrap)
 	MK_DBG_INTR_TRAMPOLINE(stktrap)
 	MK_DBG_INTR_TRAMPOLINE(gptrap)
 	MK_DBG_INTR_TRAMPOLINE(pftrap)

--- a/usr/src/uts/i86pc/ml/locore.s
+++ b/usr/src/uts/i86pc/ml/locore.s
@@ -159,7 +159,7 @@ _locore_start(struct boot_syscalls *sysp, ulong_t rsi, struct bootops *bop)
 	 * %rdi = boot services (should die someday)
 	 * %rdx = bootops
 	 * end
-	 */	
+	 */
 
 	leaq	edata(%rip), %rbp	/* reference edata for ksyms */
 	movq	$0, (%rbp)		/* limit stack back trace */
@@ -178,7 +178,7 @@ _locore_start(struct boot_syscalls *sysp, ulong_t rsi, struct bootops *bop)
 #endif
 	/*
 	 * Save call back for special x86 boot services vector
-	 */	
+	 */
 	movq	%rdi, sysp(%rip)
 
 	movq	%rdx, bootops(%rip)		/* save bootops */
@@ -208,7 +208,7 @@ _locore_start(struct boot_syscalls *sysp, ulong_t rsi, struct bootops *bop)
 #endif	/* __xpv */
 
 	/*
-	 * (We just assert this works by virtue of being here) 
+	 * (We just assert this works by virtue of being here)
 	 */
 	bts	$X86FSET_CPUID, x86_featureset(%rip)
 
@@ -268,7 +268,7 @@ _locore_start(struct boot_syscalls *sysp, struct bootops *bop)
 	/*
 	 *	%ecx = boot services (should die someday)
 	 *	%ebx = bootops
-	 */	
+	 */
 	mov	$edata, %ebp		/ edata needs to be defined for ksyms
 	movl	$0, (%ebp)		/ limit stack back trace
 
@@ -283,14 +283,14 @@ _locore_start(struct boot_syscalls *sysp, struct bootops *bop)
 	 */
 	mov	%ecx, sysp		/ save call back for boot services
 
- 	mov	%ebx, bootops		/ save bootops
+	mov	%ebx, bootops		/ save bootops
 	movl	$bootops, bootopsp
 
 
 	/*
 	 * Save all registers and flags
 	 */
-	pushal	
+	pushal
 	pushfl
 
 #if !defined(__xpv)
@@ -443,7 +443,7 @@ port_22_free:
 	 * cycle. If the CCR index was not valid for this Cyrix model, we may
 	 * have performed an external I/O cycle as well. In these cases and
 	 * if the motherboard/chipset vendor ignores I/O address line A1,
-	 * then the PIC will have IRQ3 set at the lowest priority as a side	
+	 * then the PIC will have IRQ3 set at the lowest priority as a side
 	 * effect of the above outb. We are reasonalbly confident that there
 	 * is not an unknown device on I/O port 0x22, so there should have been
 	 * no unpredictable side-effect of the above outb.
@@ -892,7 +892,7 @@ likelyM3:
 	 * now we will call anything with a DIR0 of 0x80 or higher an MIII.
 	 * The MIII is supposed to support large pages, but we will believe
 	 * it when we see it. For now we just enable and test for MII features.
-	 */	
+	 */
 	movl	$X86_TYPE_VIA_CYRIX_III, x86_type
 	jmp	likeMII
 
@@ -930,7 +930,7 @@ coma_bug:
  * fixed this bug sometime late in 1997 and no other exploits other than
  * xchgl have been discovered is good indication that this workaround is
  * reasonable.
- */	
+ */
 
 	.set	CYRIX_DBR0, 0x30	/ Debug Register 0
 	.set	CYRIX_DBR1, 0x31	/ Debug Register 1
@@ -939,7 +939,7 @@ coma_bug:
 	.set	CYRIX_DOR, 0x3c		/ Debug Opcode Register
 
 	/*
- 	 * What is known about DBR1, DBR2, DBR3, and DOR is that for normal
+	 * What is known about DBR1, DBR2, DBR3, and DOR is that for normal
 	 * cpu execution DBR1, DBR2, and DBR3 are set to 0. To obtain opcode
 	 * serialization, DBR1, DBR2, and DBR3 are loaded with 0xb8, 0x7f,
 	 * and 0xff. Then, DOR is loaded with the one byte opcode.
@@ -999,7 +999,7 @@ coma_bug:
 	/*
 	 * write DBR1
 	 */
-	movb	$CYRIX_DBR1, %al 
+	movb	$CYRIX_DBR1, %al
 	outb	$CYRIX_CRI
 	movb	$0xf8, %al
 	outb	$CYRIX_CRD
@@ -1201,6 +1201,7 @@ cmntrap()
 	leaq	dtrace_badtrap(%rip), %rdi
 	xorl	%eax, %eax
 	call	panic
+	SET_SIZE(cmntrap_pushed)
 	SET_SIZE(cmntrap)
 	SET_SIZE(_cmntrap)
 

--- a/usr/src/uts/intel/ia32/os/desctbls.c
+++ b/usr/src/uts/intel/ia32/os/desctbls.c
@@ -1304,6 +1304,28 @@ init_desctbls(void)
 
 #endif	/* __xpv */
 
+#ifndef __xpv
+/*
+ * As per Intel Vol 3 27.5.2, the GDTR limit is reset to 64Kb on a VM exit, so
+ * we have to manually fix it up ourselves.
+ *
+ * The caller may still need to make sure that it can't go off-CPU with the
+ * incorrect limit, before calling this (such as disabling pre-emption).
+ */
+void
+reset_gdtr_limit(void)
+{
+	ulong_t flags = intr_clear();
+	desctbr_t gdtr;
+
+	rd_gdtr(&gdtr);
+	gdtr.dtr_limit = (sizeof (user_desc_t) * NGDT) - 1;
+	wr_gdtr(&gdtr);
+
+	intr_restore(flags);
+}
+#endif /* __xpv */
+
 /*
  * In the early kernel, we need to set up a simple GDT to run on.
  *

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -910,6 +910,10 @@ extern void enable_pcid(void);
 
 extern void xsave_setup_msr(struct cpu *);
 
+#if !defined(__xpv)
+extern void reset_gdtr_limit(void);
+#endif
+
 /*
  * Hypervisor signatures
  */


### PR DESCRIPTION
see: https://github.com/omniosorg/illumos-omnios/pull/248

## mail_msg:

```
==== Nightly distributed build started:   Sun Aug 12 17:56:20 CEST 2018 ====
==== Nightly distributed build completed: Sun Aug 12 18:44:27 CEST 2018 ====

==== Total build time ====

real    0:48:07

==== Build environment ====

/usr/bin/uname
SunOS r151022 5.11 omnios-r151022-89f6242508 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_141-b02"

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1755 (illumos)

Build project:  default
Build taskid:   79

==== Nightly argument issues ====


==== Build version ====

omnios-backports_r22-42b942ed03

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    14:14.9
user    48:53.3
sys      4:06.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:04.9
user    43:58.1
sys      3:47.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    14:17.8
user    25:00.4
sys      2:53.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```