### PR TITLE
9194 mechanism to override ashift at pool creation time

### DIFF
--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -95,6 +95,8 @@ int vdev_dtl_sm_blksz = (1 << 12);
  */
 int vdev_standard_sm_blksz = (1 << 17);
 
+int zfs_ashift_min;
+
 /*PRINTFLIKE2*/
 void
 vdev_dbgmsg(vdev_t *vd, const char *fmt, ...)
@@ -1465,6 +1467,7 @@ vdev_open(vdev_t *vd)
 		vd->vdev_asize = asize;
 		vd->vdev_max_asize = max_asize;
 		vd->vdev_ashift = MAX(ashift, vd->vdev_ashift);
+		vd->vdev_ashift = MAX(zfs_ashift_min, vd->vdev_ashift);
 	} else {
 		/*
 		 * Detect if the alignment requirement has increased.


### PR DESCRIPTION
Simple back-port, required to fix https://github.com/omniosorg/kayak/issues/72 for r151026.