### PR TITLE
dtrace requires cpp(1) for -C option

### DIFF
--- a/usr/src/pkg/manifests/developer-dtrace.mf
+++ b/usr/src/pkg/manifests/developer-dtrace.mf
@@ -670,6 +670,7 @@ link path=usr/lib/$(ARCH64)/libdtrace.so target=libdtrace.so.1
 link path=usr/lib/$(ARCH64)/libdtrace_jni.so target=libdtrace_jni.so.1
 link path=usr/lib/libdtrace.so target=libdtrace.so.1
 link path=usr/lib/libdtrace_jni.so target=libdtrace_jni.so.1
+depend fmri=developer/macro/cpp type=require
 # cross zone dependency on linked image metadata
 # libdtrace depends on running kernel version
 depend fmri=feature/package/dependency/self type=parent \


### PR DESCRIPTION
As per https://github.com/omniosorg/omnios-build/issues/991