### PR TITLE
Joyent merge/2018091401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 8e7167ad0ea919e3af46eebdd1ccdaba3dd93acc
+Last illumos-joyent commit: 38be33872536bcc6b9b3d97d8ad4b0612822dcec
 

--- a/usr/src/cmd/bhyve/block_if.c
+++ b/usr/src/cmd/bhyve/block_if.c
@@ -66,7 +66,12 @@ __FBSDID("$FreeBSD$");
 #define BLOCKIF_SIG	0xb109b109
 
 #define BLOCKIF_NUMTHR	8
+#ifdef __FreeBSD__
 #define BLOCKIF_MAXREQ	(64 + BLOCKIF_NUMTHR)
+#else
+/* Enlarge to keep pace with the virtio-block ring size */
+#define BLOCKIF_MAXREQ	(128 + BLOCKIF_NUMTHR)
+#endif
 
 enum blockop {
 	BOP_READ,

--- a/usr/src/cmd/bhyve/block_if.h
+++ b/usr/src/cmd/bhyve/block_if.h
@@ -44,7 +44,12 @@
 #ifdef	__FreeBSD__
 #define BLOCKIF_IOV_MAX		33	/* not practical to be IOV_MAX */
 #else
-#define BLOCKIF_IOV_MAX		17	/* not practical to be IOV_MAX */
+/*
+ * Upstream is in the process of bumping this up to 128 for several reasons,
+ * including Windows compatibility.  For the sake of our Windows support, we
+ * will use the higher value now.
+ */
+#define	BLOCKIF_IOV_MAX		128
 #endif
 
 struct blockif_req {

--- a/usr/src/cmd/bhyve/pci_virtio_block.c
+++ b/usr/src/cmd/bhyve/pci_virtio_block.c
@@ -69,7 +69,12 @@ __FBSDID("$FreeBSD$");
 #include "virtio.h"
 #include "block_if.h"
 
+#ifdef __FreeBSD__
 #define VTBLK_RINGSZ	64
+#else
+/* Enlarge to match bigger BLOCKIF_IOV_MAX */
+#define VTBLK_RINGSZ	128
+#endif
 
 #define VTBLK_S_OK	0
 #define VTBLK_S_IOERR	1
@@ -416,7 +421,18 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	/* setup virtio block config space */
 	sc->vbsc_cfg.vbc_capacity = size / DEV_BSIZE; /* 512-byte units */
 	sc->vbsc_cfg.vbc_size_max = 0;	/* not negotiated */
+#ifdef __FreeBSD__
 	sc->vbsc_cfg.vbc_seg_max = BLOCKIF_IOV_MAX;
+#else
+	/*
+	 * If Linux is presented with a seg_max greater than the virtio queue
+	 * size, it can stumble into situations where it violates its own
+	 * invariants and panics.  For safety, we keep seg_max clamped, paying
+	 * heed to the two extra descriptors needed for the header and status
+	 * of a request.
+	 */
+	sc->vbsc_cfg.vbc_seg_max = MIN(VTBLK_RINGSZ - 2, BLOCKIF_IOV_MAX);
+#endif
 	sc->vbsc_cfg.vbc_geometry.cylinders = 0;	/* no geometry */
 	sc->vbsc_cfg.vbc_geometry.heads = 0;
 	sc->vbsc_cfg.vbc_geometry.sectors = 0;

--- a/usr/src/cmd/bhyve/pci_virtio_viona.c
+++ b/usr/src/cmd/bhyve/pci_virtio_viona.c
@@ -779,6 +779,9 @@ pci_viona_read(struct vmctx *ctx, int vcpu, struct pci_devinst *pi,
 		assert(size == 1);
 		value = sc->vsc_isr;
 		sc->vsc_isr = 0;	/* a read clears this flag */
+		if (value != 0) {
+			pci_lintr_deassert(pi);
+		}
 		break;
 	case VTCFG_R_CFGVEC:
 		assert(size == 2);

--- a/usr/src/cmd/bhyve/uart_emul.c
+++ b/usr/src/cmd/bhyve/uart_emul.c
@@ -519,6 +519,16 @@ uart_write(struct uart_softc *sc, int offset, uint8_t value)
 		sc->thre_int_pending = true;
 		break;
 	case REG_IER:
+#ifndef	__FreeBSD__
+		/*
+		 * Assert an interrupt if re-enabling the THRE intr, since we
+		 * always report THRE as active in the status register.
+		 */
+		if ((sc->ier & IER_ETXRDY) == 0 &&
+		    (value & IER_ETXRDY) != 0) {
+			sc->thre_int_pending = true;
+		}
+#endif
 		/*
 		 * Apply mask so that bits 4-7 are 0
 		 * Also enables bits 0-3 only if they're 1

--- a/usr/src/compat/freebsd/sys/mutex.h
+++ b/usr/src/compat/freebsd/sys/mutex.h
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2014 Pluribus Networks Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _COMPAT_FREEBSD_SYS_MUTEX_H_
@@ -33,7 +34,6 @@ void mtx_destroy(struct mtx *);
 #ifdef	_KERNEL
 
 struct mtx {
-	kmutex_type_t	t;
 	kmutex_t	m;
 };
 

--- a/usr/src/uts/common/disp/thread.c
+++ b/usr/src/uts/common/disp/thread.c
@@ -487,15 +487,9 @@ thread_create(
 	curthread->t_prev = t;
 
 	/*
-	 * Threads should never have a NULL t_cpu pointer so assign it
-	 * here.  If the thread is being created with state TS_RUN a
-	 * better CPU may be chosen when it is placed on the run queue.
-	 *
-	 * We need to keep kernel preemption disabled when setting all
-	 * three fields to keep them in sync.  Also, always create in
-	 * the default partition since that's where kernel threads go
-	 * (if this isn't a kernel thread, t_cpupart will be changed
-	 * in lwp_create before setting the thread runnable).
+	 * We'll always create in the default partition since that's where
+	 * kernel threads go (we'll change this later if needed, in
+	 * lwp_create()).
 	 */
 	t->t_cpupart = &cp_default;
 
@@ -504,20 +498,23 @@ thread_create(
 	 * Since the kernel does not (presently) allocate its memory
 	 * in a locality aware fashion, the root is an appropriate home.
 	 * If this thread is later associated with an lwp, it will have
-	 * it's lgroup re-assigned at that time.
+	 * its lgroup re-assigned at that time.
 	 */
 	lgrp_move_thread(t, &cp_default.cp_lgrploads[LGRP_ROOTID], 1);
 
 	/*
-	 * Inherit the current cpu.  If this cpu isn't part of the chosen
-	 * lgroup, a new cpu will be chosen by cpu_choose when the thread
-	 * is ready to run.
+	 * If the current CPU is in the default cpupart, use it.  Otherwise,
+	 * pick one that is; before entering the dispatcher code, we'll
+	 * make sure to keep the invariant that ->t_cpu is set.  (In fact, we
+	 * rely on this, in ht_should_run(), in the call tree of
+	 * disp_lowpri_cpu().)
 	 */
-	if (CPU->cpu_part == &cp_default)
+	if (CPU->cpu_part == &cp_default) {
 		t->t_cpu = CPU;
-	else
-		t->t_cpu = disp_lowpri_cpu(cp_default.cp_cpulist, t,
-		    t->t_pri);
+	} else {
+		t->t_cpu = cp_default.cp_cpulist;
+		t->t_cpu = disp_lowpri_cpu(t->t_cpu, t, t->t_pri);
+	}
 
 	t->t_disp_queue = t->t_cpu->cpu_disp;
 	kpreempt_enable();
@@ -870,12 +867,12 @@ thread_zone_destroy(zoneid_t zoneid, void *unused)
 
 	/*
 	 * Guard against race condition in mutex_owner_running:
-	 * 	thread=owner(mutex)
-	 * 	<interrupt>
-	 * 				thread exits mutex
-	 * 				thread exits
-	 * 				thread reaped
-	 * 				thread struct freed
+	 *	thread=owner(mutex)
+	 *	<interrupt>
+	 *				thread exits mutex
+	 *				thread exits
+	 *				thread reaped
+	 *				thread struct freed
 	 * cpu = thread->t_cpu <- BAD POINTER DEREFERENCE.
 	 * A cross call to all cpus will cause the interrupt handler
 	 * to reset the PC if it is in mutex_owner_running, refreshing
@@ -932,12 +929,12 @@ thread_reaper()
 
 		/*
 		 * Guard against race condition in mutex_owner_running:
-		 * 	thread=owner(mutex)
-		 * 	<interrupt>
-		 * 				thread exits mutex
-		 * 				thread exits
-		 * 				thread reaped
-		 * 				thread struct freed
+		 *	thread=owner(mutex)
+		 *	<interrupt>
+		 *				thread exits mutex
+		 *				thread exits
+		 *				thread reaped
+		 *				thread struct freed
 		 * cpu = thread->t_cpu <- BAD POINTER DEREFERENCE.
 		 * A cross call to all cpus will cause the interrupt handler
 		 * to reset the PC if it is in mutex_owner_running, refreshing
@@ -1526,7 +1523,7 @@ thread_create_intr(struct cpu *cp)
 static kmutex_t		tsd_mutex;	 /* linked list spin lock */
 static uint_t		tsd_nkeys;	 /* size of destructor array */
 /* per-key destructor funcs */
-static void 		(**tsd_destructor)(void *);
+static void		(**tsd_destructor)(void *);
 /* list of tsd_thread's */
 static struct tsd_thread	*tsd_list;
 

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.h
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.h
@@ -126,6 +126,14 @@ enum {
 	GUEST_MSR_NUM		/* must be the last enumeration */
 };
 
+#ifndef	__FreeBSD__
+typedef enum {
+	VS_NONE		= 0x0,
+	VS_LAUNCHED	= 0x1,
+	VS_LOADED	= 0x2
+} vmcs_state_t;
+#endif /* __FreeBSD__ */
+
 /* virtual machine softc */
 struct vmx {
 	struct vmcs	vmcs[VM_MAXCPU];	/* one vmcs per virtual cpu */
@@ -136,7 +144,7 @@ struct vmx {
 #ifndef	__FreeBSD__
 	uint64_t	host_msrs[VM_MAXCPU][GUEST_MSR_NUM];
 	uint64_t	tsc_offset_active[VM_MAXCPU];
-	boolean_t	ctx_loaded[VM_MAXCPU];
+	vmcs_state_t	vmcs_state[VM_MAXCPU];
 #endif
 	struct vmxctx	ctx[VM_MAXCPU];
 	struct vmxcap	cap[VM_MAXCPU];

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c
@@ -294,12 +294,15 @@ contigfree(void *addr, unsigned long size, struct malloc_type *type)
 void
 mtx_init(struct mtx *mtx, char *name, const char *type_name, int opts)
 {
-	if (opts & MTX_SPIN) {
-		mutex_init(&mtx->m, name, MUTEX_SPIN,
-		    (ddi_iblock_cookie_t)ipltospl(DISP_LEVEL));
-	} else {
-		mutex_init(&mtx->m, name, MUTEX_DRIVER, NULL);
-	}
+	/*
+	 * Requests that a mutex be initialized to the MTX_SPIN type are
+	 * ignored.  The limitations which may have required spinlocks on
+	 * FreeBSD do not apply to how bhyve has been structured here.
+	 *
+	 * Adaptive mutexes are required to avoid deadlocks when certain
+	 * cyclics behavior interacts with interrupts and contended locks.
+	 */
+	mutex_init(&mtx->m, name, MUTEX_ADAPTIVE, NULL);
 }
 
 void


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018081501

## Backports to r22/r26

* L1TF: OS-7222 thread_create() should ensure ->t_cpu is set 

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2018091401-d5ba6e167b i86pc i386 i86pc
```
## mail_msg

```
==== Nightly distributed build started:   Sat Sep 15 00:22:07 CEST 2018 ====
==== Nightly distributed build completed: Sat Sep 15 01:18:29 CEST 2018 ====

==== Total build time ====

real    0:56:21

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-36eb49126f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_191-b02"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   79

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018091401-d5ba6e167b

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    17:51.6
user  1:00:57.1
sys      6:11.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    15:37.0
user    51:48.7
sys      5:39.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    15:15.3
user    27:40.4
sys      3:27.8

==== lint warnings src ====


==== lint noise differences src ====

2c2
< "../../i86pc/io/vmm/vmm_sol_glue.c", line 636: warning: logical expression always false: op "&&" (E_FALSE_LOGICAL_EXPR)
---
> "../../i86pc/io/vmm/vmm_sol_glue.c", line 639: warning: logical expression always false: op "&&" (E_FALSE_LOGICAL_EXPR)
7,9c7,9
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2982: warning: function argument type inconsistent with format: panic(arg 2) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2982) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 2982: warning: function argument type inconsistent with format: panic(arg 3) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(2982) (E_BAD_FORMAT_ARG_TYPE2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 3154: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 3170: warning: function argument type inconsistent with format: panic(arg 2) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(3170) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 3170: warning: function argument type inconsistent with format: panic(arg 3) struct pmap * and (format) void * in /build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c(3170) (E_BAD_FORMAT_ARG_TYPE2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 3365: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
12d11
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 1011: warning: function returns value which is always ignored: ppt_flr (E_FUNC_RET_ALWAYS_IGNOR2)
14c13
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vatpit.c", line 327: warning: function returns value which is sometimes ignored: pit_update_counter (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vhpet.c", line 242: warning: function returns value which is sometimes ignored: lapic_intr_msi (E_FUNC_RET_MAYBE_IGNORED2)
19d17
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 634: warning: function returns value which is always ignored: ppt_unassign_all (E_FUNC_RET_ALWAYS_IGNOR2)
22c20
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c", line 477: warning: function returns value which is always ignored: hma_fpu_init (E_FUNC_RET_ALWAYS_IGNOR2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c", line 480: warning: function returns value which is always ignored: hma_fpu_init (E_FUNC_RET_ALWAYS_IGNOR2)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```