### PR TITLE
8450 UCODE_MAX_SIZE is too small for modern microcode

### DIFF
--- a/usr/src/uts/common/sys/ucode.h
+++ b/usr/src/uts/common/sys/ucode.h
@@ -197,7 +197,7 @@ typedef union ucode_file {
 #define	UCODE_DEFAULT_BODY_SIZE		(UCODE_KB(2) - UCODE_HEADER_SIZE_INTEL)
 
 /*
- * For a single microcode file, the minimum size is 1K, maximum size is 16K.
+ * For a single microcode file, the minimum size is 1K, maximum size is 128K.
  * Such limitations, while somewhat artificial, are not only to provide better
  * sanity checks, but also avoid wasting precious memory at startup time as the
  * microcode buffer for the first processor has to be statically allocated.
@@ -206,7 +206,7 @@ typedef union ucode_file {
  * is 16M.
  */
 #define	UCODE_MIN_SIZE			UCODE_KB(1)
-#define	UCODE_MAX_SIZE			UCODE_KB(16)
+#define	UCODE_MAX_SIZE			UCODE_KB(128)
 #define	UCODE_MAX_COMBINED_SIZE		UCODE_MB(16)
 
 #define	UCODE_SIZE_CONVERT(size, default_size) \


### PR DESCRIPTION
Before this commit:
```
omni# ucodeadm -v | head -2
CPU     Microcode Version
0       0x710
```
and after:
```
omni# ucodeadm -v | head -2
CPU     Microcode Version
0       0x714
```
