### PR TITLE
Joyent merge/2018092701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 38be33872536bcc6b9b3d97d8ad4b0612822dcec
+Last illumos-joyent commit: 7e59066e705035a23aa219d7693f61d200ae378c
 

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -229,6 +229,9 @@
 #include <sys/mac_provider.h>
 #include <sys/mac_client_priv.h>
 #include <sys/vlan.h>
+#include <inet/ip.h>
+#include <inet/ip_impl.h>
+#include <inet/tcp.h>
 
 #include <sys/vmm_drv.h>
 #include <sys/viona_io.h>
@@ -240,6 +243,8 @@
 #define	VIONA_NAME		"Virtio Network Accelerator"
 #define	VIONA_CTL_MINOR		0
 #define	VIONA_CLI_NAME		"viona"		/* MAC client name */
+#define VIONA_MAX_HDRS_LEN	(sizeof (struct ether_vlan_header) + \
+	IP_MAX_HDR_LENGTH + TCP_MAX_HDR_LENGTH)
 
 #define	VTNET_MAXSEGS		32
 
@@ -445,6 +450,7 @@ struct viona_desb {
 	uint_t			d_ref;
 	uint32_t		d_len;
 	uint16_t		d_cookie;
+	uchar_t			*d_headers;
 };
 
 typedef struct viona_soft_state {
@@ -1026,6 +1032,19 @@ viona_ring_alloc(viona_link_t *link, viona_vring_t *ring)
 }
 
 static void
+viona_ring_desb_free(viona_vring_t *ring)
+{
+	viona_desb_t *dp = ring->vr_desb;
+
+	for (uint_t i = 0; i < ring->vr_size; i++, dp++) {
+		kmem_free(dp->d_headers, VIONA_MAX_HDRS_LEN);
+	}
+
+	kmem_free(ring->vr_desb, sizeof (viona_desb_t) * ring->vr_size);
+	ring->vr_desb = NULL;
+}
+
+static void
 viona_ring_free(viona_vring_t *ring)
 {
 	mutex_destroy(&ring->vr_lock);
@@ -1135,16 +1154,17 @@ viona_ioc_ring_init(viona_link_t *link, void *udata, int md)
 
 	/* Allocate desb handles for TX ring if packet copying not disabled */
 	if (kri.ri_index == VIONA_VQ_TX && !viona_force_copy_tx_mblks) {
-		viona_desb_t *desb, *dp;
+		viona_desb_t *dp;
 
-		desb = kmem_zalloc(sizeof (viona_desb_t) * cnt, KM_SLEEP);
-		dp = desb;
+		dp = kmem_zalloc(sizeof (viona_desb_t) * cnt, KM_SLEEP);
+		ring->vr_desb = dp;
 		for (uint_t i = 0; i < cnt; i++, dp++) {
 			dp->d_frtn.free_func = viona_desb_release;
 			dp->d_frtn.free_arg = (void *)dp;
 			dp->d_ring = ring;
+			dp->d_headers = kmem_zalloc(VIONA_MAX_HDRS_LEN,
+			    KM_SLEEP);
 		}
-		ring->vr_desb = desb;
 	}
 
 	/* Zero out MSI-X configuration */
@@ -1167,8 +1187,7 @@ viona_ioc_ring_init(viona_link_t *link, void *udata, int md)
 
 fail:
 	if (ring->vr_desb != NULL) {
-		kmem_free(ring->vr_desb, sizeof (viona_desb_t) * cnt);
-		ring->vr_desb = NULL;
+		viona_ring_desb_free(ring);
 	}
 	ring->vr_size = 0;
 	ring->vr_mask = 0;
@@ -1413,8 +1432,7 @@ viona_worker_tx(viona_vring_t *ring, viona_link_t *link)
 
 	/* Free any desb resources before the ring is completely stopped */
 	if (ring->vr_desb != NULL) {
-		kmem_free(ring->vr_desb, sizeof (viona_desb_t) * ring->vr_size);
-		ring->vr_desb = NULL;
+		viona_ring_desb_free(ring);
 	}
 }
 
@@ -1462,8 +1480,7 @@ cleanup:
 	/* Free any desb resources before the ring is completely stopped */
 	if (ring->vr_desb != NULL) {
 		VERIFY(ring->vr_xfer_outstanding == 0);
-		kmem_free(ring->vr_desb, sizeof (viona_desb_t) * ring->vr_size);
-		ring->vr_desb = NULL;
+		viona_ring_desb_free(ring);
 	}
 
 	ring->vr_cur_aidx = 0;
@@ -2287,8 +2304,9 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 {
 	struct iovec		iov[VTNET_MAXSEGS];
 	uint16_t		cookie;
-	int			n;
-	uint32_t		len;
+	int			i, n;
+	uint32_t		len, base_off = 0;
+	uint32_t		min_copy = VIONA_MAX_HDRS_LEN;
 	mblk_t			*mp_head, *mp_tail, *mp;
 	viona_desb_t		*dp = NULL;
 	mac_client_handle_t	link_mch = link->l_mch;
@@ -2303,6 +2321,14 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 		return;
 	}
 
+	/* Grab the header and ensure it is of adequate length */
+	hdr = (const struct virtio_net_hdr *)iov[0].iov_base;
+	len = iov[0].iov_len;
+	if (len < sizeof (struct virtio_net_hdr)) {
+		goto drop_fail;
+	}
+
+	/* Make sure the packet headers are always in the first mblk. */
 	if (ring->vr_desb != NULL) {
 		dp = &ring->vr_desb[cookie];
 
@@ -2317,42 +2343,87 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 			dp = NULL;
 			goto drop_fail;
 		}
+
 		dp->d_cookie = cookie;
+		mp_head = desballoc(dp->d_headers, VIONA_MAX_HDRS_LEN, 0,
+		    &dp->d_frtn);
+
+		/* Account for the successful desballoc. */
+		if (mp_head != NULL)
+			dp->d_ref++;
+	} else {
+		mp_head = allocb(VIONA_MAX_HDRS_LEN, 0);
 	}
 
-	/* Grab the header and ensure it is of adequate length */
-	hdr = (const struct virtio_net_hdr *)iov[0].iov_base;
-	len = iov[0].iov_len;
-	if (len < sizeof (struct virtio_net_hdr)) {
+	if (mp_head == NULL)
 		goto drop_fail;
+
+	mp_tail = mp_head;
+
+	/*
+	 * We always copy enough of the guest data to cover the
+	 * headers. This protects us from TOCTOU attacks and allows
+	 * message block length assumptions to be made in subsequent
+	 * code. In many cases, this means copying more data than
+	 * strictly necessary. That's okay, as it is the larger packets
+	 * (such as LSO) that really benefit from desballoc().
+	 */
+	for (i = 1; i < n; i++) {
+		const uint32_t to_copy = MIN(min_copy, iov[i].iov_len);
+
+		bcopy(iov[i].iov_base, mp_head->b_wptr, to_copy);
+		mp_head->b_wptr += to_copy;
+		len += to_copy;
+		min_copy -= to_copy;
+
+		/*
+		 * We've met the minimum copy requirement. The rest of
+		 * the guest data can be referenced.
+		 */
+		if (min_copy == 0) {
+			/*
+			 * If we copied all contents of this
+			 * descriptor then move onto the next one.
+			 * Otherwise, record how far we are into the
+			 * current descriptor.
+			 */
+			if (iov[i].iov_len == to_copy)
+				i++;
+			else
+				base_off = to_copy;
+
+			break;
+		}
 	}
 
-	for (uint_t i = 1; i < n; i++) {
+	ASSERT3P(mp_head, !=, NULL);
+	ASSERT3P(mp_tail, !=, NULL);
+
+	for (; i < n; i++) {
+		uintptr_t base = (uintptr_t)iov[i].iov_base + base_off;
+		uint32_t chunk = iov[i].iov_len - base_off;
+
+		ASSERT3U(base_off, <, iov[i].iov_len);
+		ASSERT3U(chunk, >, 0);
+
 		if (dp != NULL) {
-			mp = desballoc((uchar_t *)iov[i].iov_base,
-			    iov[i].iov_len, BPRI_MED, &dp->d_frtn);
+			mp = desballoc((uchar_t *)base, chunk, 0, &dp->d_frtn);
 			if (mp == NULL) {
 				goto drop_fail;
 			}
 			dp->d_ref++;
 		} else {
-			mp = allocb(iov[i].iov_len, BPRI_MED);
+			mp = allocb(chunk, BPRI_MED);
 			if (mp == NULL) {
 				goto drop_fail;
 			}
-			bcopy((uchar_t *)iov[i].iov_base, mp->b_wptr,
-			    iov[i].iov_len);
+			bcopy((uchar_t *)base, mp->b_wptr, chunk);
 		}
 
-		len += iov[i].iov_len;
-		mp->b_wptr += iov[i].iov_len;
-		if (mp_head == NULL) {
-			ASSERT(mp_tail == NULL);
-			mp_head = mp;
-		} else {
-			ASSERT(mp_tail != NULL);
-			mp_tail->b_cont = mp;
-		}
+		base_off = 0;
+		len += chunk;
+		mp->b_wptr += chunk;
+		mp_tail->b_cont = mp;
 		mp_tail = mp;
 	}
 
@@ -2423,7 +2494,7 @@ drop_fail:
 		dp->d_ref = 0;
 	}
 
-	VIONA_PROBE3(tx_drop, viona_vring_t *, ring, uint_t, len,
+	VIONA_PROBE3(tx_drop, viona_vring_t *, ring, uint32_t, len,
 	    uint16_t, cookie);
 	viona_tx_done(ring, len, cookie);
 }


### PR DESCRIPTION
Weekly upstream for joyent merge/2018092701

## Backports

None

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2018092701-a052c517ba i86pc i386 i86pc
```
## mail_msg

```
==== Nightly distributed build started:   Thu Sep 27 21:34:01 CEST 2018 ====
==== Nightly distributed build completed: Thu Sep 27 22:24:52 CEST 2018 ====

==== Total build time ====

real    0:50:51

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-edcaba7bd3 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

32-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_191-b02"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   79

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018092701-a052c517ba

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:48.3
user    53:52.8
sys      4:52.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:49.1
user    45:50.8
sys      4:08.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    14:06.7
user    25:35.3
sys      3:03.7

==== lint warnings src ====


==== lint noise differences src ====

11a12,15
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 1011: warning: function returns value which is always ignored: ppt_flr (E_FUNC_RET_ALWAYS_IGNOR2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 883: warning: function returns value which is sometimes ignored: ddi_intr_block_disable (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 887: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 888: warning: function returns value which is sometimes ignored: ddi_intr_free (E_FUNC_RET_MAYBE_IGNORED2)
17a22
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 634: warning: function returns value which is always ignored: ppt_unassign_all (E_FUNC_RET_ALWAYS_IGNOR2)

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```