### PR TITLE
Upstream merge joyent_merge/2018100401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 0a51b8dc40c8d4c15f71e64bc2126489a45d11ce
+Last illumos-joyent commit: eee2da8296e69bdb47747ea36f4d186e6a133c96
 

--- a/usr/src/lib/brand/lx/lx_brand/sys/lx_misc.h
+++ b/usr/src/lib/brand/lx/lx_brand/sys/lx_misc.h
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _SYS_LX_H
@@ -149,6 +149,7 @@ extern void lx_stack_postfork(void);
 
 extern void lx_block_all_signals();
 extern void lx_unblock_all_signals();
+extern int lx_all_signals_blocked();
 
 /*
  * NO_UUCOPY disables calls to the uucopy* system calls to help with

--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2017, Joyent, Inc. All rights reserved.
+ * Copyright 2018, Joyent, Inc. All rights reserved.
  */
 
 /*
@@ -1889,6 +1889,16 @@ lx_brandsys(int cmd, int64_t *rval, uintptr_t arg1, uintptr_t arg2,
 			pd->l_block_all_signals--;
 			result = 0;
 		}
+		mutex_exit(&p->p_lock);
+		return (result);
+	}
+
+	case B_ALL_SIGS_BLOCKED: {
+		uint_t result;
+
+		mutex_enter(&p->p_lock);
+		pd = ptolxproc(p);
+		result = pd->l_block_all_signals;
 		mutex_exit(&p->p_lock);
 		return (result);
 	}

--- a/usr/src/uts/common/brand/lx/sys/lx_brand.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_brand.h
@@ -103,7 +103,7 @@ extern "C" {
 #define	B_STORE_ARGS		137
 #define	B_GETPID		138
 #define	B_JUMP_TO_LINUX		139
-/* formerly B_SET_THUNK_PID	140 */
+#define	B_ALL_SIGS_BLOCKED	140
 #define	B_EXIT_AS_SIG		141
 /* formerly B_HELPER_WAITID	142 */
 #define	B_HELPER_CLONE		143

--- a/usr/src/uts/common/brand/lx/syscall/lx_poll.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_poll.c
@@ -178,6 +178,11 @@ lx_poll_common(pollfd_t *fds, nfds_t nfds, timespec_t *tsp, k_sigset_t *ksetp)
 	 * Initialize pollstate and copy in pollfd data if present.
 	 */
 	if (nfds != 0) {
+		/*
+		 * Cap the number of FDs they can give us so we don't go
+		 * allocating a huge chunk of memory. Note that this is *not*
+		 * the RLIMIT_NOFILE rctl.
+		 */
 		if (nfds > lx_poll_max_fds) {
 			error = EINVAL;
 			goto pollout;
@@ -589,6 +594,11 @@ lx_select_common(int nfds, long *rfds, long *wfds, long *efds,
 	 * Initialize pollstate and copy in pollfd data if present.
 	 */
 	if (nfds != 0) {
+		/*
+		 * Cap the number of FDs they can give us so we don't go
+		 * allocating a huge chunk of memory. Note that this is *not*
+		 * the RLIMIT_NOFILE rctl.
+		 */
 		if (nfds > lx_poll_max_fds) {
 			error = EINVAL;
 			goto out;

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -408,6 +408,7 @@ typedef struct viona_vring {
 		uint64_t	rs_indir_bad_next;
 		uint64_t	rs_no_space;
 		uint64_t	rs_too_many_desc;
+		uint64_t	rs_desc_bad_len;
 
 		uint64_t	rs_bad_ring_addr;
 
@@ -1603,6 +1604,13 @@ vq_popchain(viona_vring_t *ring, struct iovec *iov, int niov, uint16_t *cookie)
 
 		vdir = ring->vr_descr[next];
 		if ((vdir.vd_flags & VRING_DESC_F_INDIRECT) == 0) {
+			if (vdir.vd_len == 0) {
+				VIONA_PROBE2(desc_bad_len,
+				    viona_vring_t *, ring,
+				    uint32_t, vdir.vd_len);
+				VIONA_RING_STAT_INCR(ring, desc_bad_len);
+				goto bail;
+			}
 			buf = viona_gpa2kva(link, vdir.vd_addr, vdir.vd_len);
 			if (buf == NULL) {
 				VIONA_PROBE_BAD_RING_ADDR(ring, vdir.vd_addr);
@@ -1647,6 +1655,13 @@ vq_popchain(viona_vring_t *ring, struct iovec *iov, int niov, uint16_t *cookie)
 					    viona_vring_t *, ring);
 					VIONA_RING_STAT_INCR(ring,
 					    indir_bad_nest);
+					goto bail;
+				} else if (vp.vd_len == 0) {
+					VIONA_PROBE2(desc_bad_len,
+					    viona_vring_t *, ring,
+					    uint32_t, vp.vd_len);
+					VIONA_RING_STAT_INCR(ring,
+					    desc_bad_len);
 					goto bail;
 				}
 				buf = viona_gpa2kva(link, vp.vd_addr,


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018100401

## Backports

To r151028:
* BHYVE: OS-7255 viona should ignore zero-length descrs  …
* LX: OS-7121 lx vfork and signal handling still racey  …

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2018100401-c6cc2b6b38 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Oct  4 08:13:15 GMT 2018 ====
==== Nightly distributed build completed: Thu Oct  4 09:53:14 GMT 2018 ====

==== Total build time ====

real    1:39:58

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-98a7b6c321 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

32-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

64-bit compiler
/data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/cw -_gcc
cw version 1.30 (SHADOW MODE DISABLED)
primary: /opt/gcc-4.4.4//bin/gcc
gcc (GCC) 4.4.4

/usr/java/bin/javac
openjdk full version "1.7.0_191-b02"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   585

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018100401-c6cc2b6b38

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    32:11.4
user  1:07:43.4
sys     14:11.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    25:26.6
user    59:27.9
sys     12:38.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    26:12.7
user    42:44.9
sys     10:28.9

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
