### PR TITLE
Add config/parallel to svc:/system/filesystem/local

### DIFF
--- a/usr/src/cmd/svc/milestone/fs-local
+++ b/usr/src/cmd/svc/milestone/fs-local
@@ -87,6 +87,11 @@ fi
 # Mount all ZFS filesystems.
 
 if [ -x /usr/sbin/zfs ]; then
+	parallel=`svcprop -p config/parallel $SMF_FMRI`
+	if [ "$val" = "false" ]; then
+		ZFS_SERIAL_MOUNT=1
+		export ZFS_SERIAL_MOUNT
+	fi
 	/usr/sbin/zfs mount -va >/dev/msglog 2>&1
 	rc=$?
 	if [ $rc -ne 0 ]; then

--- a/usr/src/cmd/svc/milestone/local-fs.xml
+++ b/usr/src/cmd/svc/milestone/local-fs.xml
@@ -68,6 +68,10 @@
 		<propval name='duration' type='astring' value='transient' />
 	</property_group>
 
+	<property_group name='config' type='application'>
+		<propval name='parallel' type='boolean' value='true' />
+	</property_group>
+
 	<stability value='Unstable' />
 
 	<template>

--- a/usr/src/lib/libzfs/common/libzfs_mount.c
+++ b/usr/src/lib/libzfs/common/libzfs_mount.c
@@ -1403,6 +1403,10 @@ zfs_foreach_mountpoint(libzfs_handle_t *hdl, zfs_handle_t **handles,
 	 * The ZFS_SERIAL_MOUNT environment variable is an undocumented
 	 * variable that can be used as a convenience to do a/b comparison
 	 * of serial vs. parallel mounting.
+	 *
+	 * In OmniOS, this is set by /lib/svc/method/fs-local if the
+	 * config/parallel option of svc:/system/filesystem/local:default
+	 * is set to false.
 	 */
 	boolean_t serial_mount = !parallel ||
 	    (getenv("ZFS_SERIAL_MOUNT") != NULL);


### PR DESCRIPTION
Adding an escape hatch to disable parallel ZFS mounts in case of any problems for users upgrading to r151028. This /should/ be fixed through #286, but just in case...