### PR TITLE
Upstream merge upstream_merge/2018101101

### DIFF
--- a/exception_lists/wscheck
+++ b/exception_lists/wscheck
@@ -12,6 +12,8 @@
 #
 syntax: glob
 
+usr/src/uts/common/io/qede/*
+
 usr/src/data/ucode/amd/*
 usr/src/data/ucode/intel/*
 

--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -342,9 +342,16 @@ CC32BITCALLERS=		-_gcc=-massume-32bit-callers
 # Additionally, we wish to prevent optimisations which cause GCC to clone
 # functions -- in particular, these may cause unhelpful symbols to be
 # emitted instead of function names
-CCNOAUTOINLINE= -_gcc=-fno-inline-small-functions \
+CCNOAUTOINLINE= \
+	-_gcc=-fno-inline-small-functions \
 	-_gcc=-fno-inline-functions-called-once \
-	-_gcc=-fno-ipa-cp
+	-_gcc=-fno-ipa-cp \
+	-_gcc6=-fno-ipa-icf \
+	-_gcc7=-fno-ipa-icf \
+	-_gcc8=-fno-ipa-icf \
+	-_gcc6=-fno-clone-functions \
+	-_gcc7=-fno-clone-functions \
+	-_gcc8=-fno-clone-functions
 
 # One optimization the compiler might perform is to turn this:
 #	#pragma weak foo
@@ -400,7 +407,6 @@ STAND_FLAGS_64 = $($(MACH64)_STAND_FLAGS)
 # disable the incremental linker
 ILDOFF=			-xildoff
 #
-XDEPEND=		-xdepend
 XFFLAG=			-xF=%all
 XESS=			-xs
 XSTRCONST=		-xstrconst

--- a/usr/src/cmd/boot/scripts/create_ramdisk.ksh
+++ b/usr/src/cmd/boot/scripts/create_ramdisk.ksh
@@ -362,9 +362,7 @@ function create_ufs_archive
 
 function cpio_cleanup
 {
-	[ -f "$tarchive" ] && rm -f "$tarchive"
-	[ -f "$tarchive.cpio" ] && rm -f "$tarchive.cpio"
-	[ -f "$tarchive.hash" ] && rm -f "$tarchive.hash"
+	rm -f "$tarchive" "$tarchive.cpio" "$tarchive.hash"
 }
 
 function create_cpio_archive

--- a/usr/src/cmd/ldapcachemgr/Makefile
+++ b/usr/src/cmd/ldapcachemgr/Makefile
@@ -44,9 +44,9 @@ ROOTMANIFESTDIR=	$(ROOTSVCNETWORKLDAP)
 
 OBJS=	cachemgr.o cachemgr_getldap.o cachemgr_parse.o cachemgr_change.o
 
-SRCS=	${OBJS:%.o=%.c} 
+SRCS=	${OBJS:%.o=%.c}
 
-CPPFLAGS += 	-D_REENTRANT -DSUN_THREADS \
+CPPFLAGS +=	-D_REENTRANT -DSUN_THREADS \
 		-I$(SRC)/lib/libsldap/common \
 		-I$(SRC)/lib/libldap5/include/ldap \
 		-I$(SRC)/lib/libc/port/gen
@@ -62,10 +62,8 @@ POFILES=	${OBJS:%.o=%.po}
 LINTOUT=        lint.out
 
 # TCOV_FLAG=	-ql
-# GPROF_FLAG=	-xpg
-# DEBUG_FLAG=	-g
 
-LDLIBS += 	-lumem -lsldap
+LDLIBS +=	-lumem -lsldap
 
 # install macros and rule
 #

--- a/usr/src/cmd/nscd/Makefile
+++ b/usr/src/cmd/nscd/Makefile
@@ -69,8 +69,6 @@ CERRWARN +=	-_gcc=-Wno-type-limits
 LDFLAGS +=	$(ZINTERPOSE)
 
 # TCOV_FLAG=	-ql
-# GPROF_FLAG=	-xpg
-# DEBUG_FLAG=	-g
 
 PROGLIBS=	$(LDLIBS) -lresolv -lnsl -lsocket -lumem -lscf -lavl
 
@@ -90,7 +88,7 @@ lint:
 	$(LINT.c) ${SRCS} ${PROGLIBS}
 
 cstyle:
-	${CSTYLE} ${SRCS} 
+	${CSTYLE} ${SRCS}
 
 install: all $(ROOTPROG) $(ROOTMANIFEST) $(ROOTSVCMETHOD)
 

--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -29,6 +29,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #include <assert.h>
@@ -335,7 +336,7 @@ get_usage(zfs_help_t idx)
 	case HELP_BOOKMARK:
 		return (gettext("\tbookmark <snapshot> <bookmark>\n"));
 	case HELP_CHANNEL_PROGRAM:
-		return (gettext("\tprogram [-n] [-t <instruction limit>] "
+		return (gettext("\tprogram [-jn] [-t <instruction limit>] "
 		    "[-m <memory limit (b)>] <pool> <program file> "
 		    "[lua args...]\n"));
 	}
@@ -7099,12 +7100,12 @@ zfs_do_channel_program(int argc, char **argv)
 	nvlist_t *outnvl;
 	uint64_t instrlimit = ZCP_DEFAULT_INSTRLIMIT;
 	uint64_t memlimit = ZCP_DEFAULT_MEMLIMIT;
-	boolean_t sync_flag = B_TRUE;
+	boolean_t sync_flag = B_TRUE, json_output = B_FALSE;
 	zpool_handle_t *zhp;
 
 	/* check options */
 	while (-1 !=
-	    (c = getopt(argc, argv, "nt:(instr-limit)m:(memory-limit)"))) {
+	    (c = getopt(argc, argv, "jnt:(instr-limit)m:(memory-limit)"))) {
 		switch (c) {
 		case 't':
 		case 'm': {
@@ -7144,6 +7145,10 @@ zfs_do_channel_program(int argc, char **argv)
 		}
 		case 'n': {
 			sync_flag = B_FALSE;
+			break;
+		}
+		case 'j': {
+			json_output = B_TRUE;
 			break;
 		}
 		case '?':
@@ -7264,11 +7269,14 @@ zfs_do_channel_program(int argc, char **argv)
 		    gettext("Channel program execution failed:\n%s\n"),
 		    errstring);
 	} else {
-		(void) printf("Channel program fully executed ");
-		if (nvlist_empty(outnvl)) {
-			(void) printf("with no return value.\n");
+		if (json_output) {
+			(void) nvlist_print_json(stdout, outnvl);
+		} else if (nvlist_empty(outnvl)) {
+			(void) fprintf(stdout, gettext("Channel program fully "
+			    "executed and did not produce output.\n"));
 		} else {
-			(void) printf("with return value:\n");
+			(void) fprintf(stdout, gettext("Channel program fully "
+			    "executed and produced output:\n"));
 			dump_nvlist(outnvl, 4);
 		}
 	}

--- a/usr/src/lib/fm/topo/libtopo/common/libtopo.h
+++ b/usr/src/lib/fm/topo/libtopo/common/libtopo.h
@@ -365,6 +365,7 @@ extern int topo_fmri_getpgrp(topo_hdl_t *, nvlist_t *, const char *,
     nvlist_t **, int *);
 extern int topo_fmri_setprop(topo_hdl_t *, nvlist_t *, const char *,
     nvlist_t *, int, nvlist_t *, int *);
+extern void topo_pgroup_hcset(tnode_t *, nvlist_t *);
 
 /* Property node NVL names used in topo_prop_getprops */
 #define	TOPO_PROP_GROUP		"property-group"

--- a/usr/src/lib/fm/topo/libtopo/common/mapfile-vers
+++ b/usr/src/lib/fm/topo/libtopo/common/mapfile-vers
@@ -151,6 +151,7 @@ SYMBOL_VERSION SUNWprivate {
 	topo_pgroup_create;
 	topo_pgroup_destroy;
 	topo_pgroup_info;
+	topo_pgroup_hcset;
 	topo_prop_get_fmri;
 	topo_prop_get_int32;
 	topo_prop_get_int64;

--- a/usr/src/lib/fm/topo/libtopo/common/topo_hc.h
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_hc.h
@@ -216,6 +216,14 @@ extern "C" {
 #define	TOPO_DIMM_TYPE_LPDDR3		"LPDDR3"
 #define	TOPO_DIMM_TYPE_LPDDR4		"LPDDR4"
 
+#define	TOPO_PGROUP_MOTHERBOARD		"motherboard-properties"
+#define	TOPO_PROP_MB_MANUFACTURER	"manufacturer"
+#define	TOPO_PROP_MB_PRODUCT		"product-id"
+#define	TOPO_PROP_MB_ASSET		"asset-tag"
+#define	TOPO_PROP_MB_FIRMWARE_VENDOR	"firmware-vendor"
+#define	TOPO_PROP_MB_FIRMWARE_REV	"firmware-revision"
+#define	TOPO_PROP_MB_FIRMWARE_RELDATE	"firmware-release-date"
+
 #ifdef	__cplusplus
 }
 #endif

--- a/usr/src/lib/fm/topo/libtopo/common/topo_mod.map
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_mod.map
@@ -94,4 +94,5 @@ SYMBOL_SCOPE {
 	topo_prop_set_fmri_array	{ TYPE = FUNCTION; FLAGS = extern };
 	topo_prop_inherit		{ TYPE = FUNCTION; FLAGS = extern };
 	topo_pgroup_create		{ TYPE = FUNCTION; FLAGS = extern };
+	topo_pgroup_hcset		{ TYPE = FUNCTION; FLAGS = extern };
 };

--- a/usr/src/lib/fm/topo/modules/common/smbios/smbios_enum.c
+++ b/usr/src/lib/fm/topo/modules/common/smbios/smbios_enum.c
@@ -90,7 +90,7 @@ static boolean_t
 is_valid_string(const char *str)
 {
 	if (strcmp(str, SMB_DEFAULT1) != 0 && strcmp(str, SMB_DEFAULT2) != 0 &&
-	    strlen(str) > 0)
+	    strcmp(str, SMB_DEFAULT3) != 0 && strlen(str) > 0)
 		return (B_TRUE);
 
 	return (B_FALSE);
@@ -121,9 +121,9 @@ smbios_make_slot(smb_enum_data_t *smed, smbios_memdevice_t *smb_md)
 		/* errno set */
 		return (NULL);
 	}
-	nvlist_free(auth);
 	if ((slotnode = topo_node_bind(mod, smed->sme_pnode, SLOT,
 	    smed->sme_slot_inst, fmri)) == NULL) {
+		nvlist_free(auth);
 		nvlist_free(fmri);
 		topo_mod_dprintf(mod, "topo_node_bind() failed: %s",
 		    topo_mod_errmsg(mod));
@@ -132,6 +132,10 @@ smbios_make_slot(smb_enum_data_t *smed, smbios_memdevice_t *smb_md)
 	}
 	nvlist_free(fmri);
 	fmri = NULL;
+
+	/* Create authority and system pgroups */
+	topo_pgroup_hcset(slotnode, auth);
+	nvlist_free(auth);
 
 	if (topo_node_label_set(slotnode, (char *)smb_md->smbmd_dloc, &err) !=
 	    0) {
@@ -226,17 +230,21 @@ smbios_make_dimm(smb_enum_data_t *smed, smbios_memdevice_t *smb_md)
 		/* errno set */
 		goto err;
 	}
-	nvlist_free(auth);
 
 	if (topo_node_range_create(mod, slotnode, DIMM, 0, 0) < 0 ||
 	    (dimmnode = topo_node_bind(mod, slotnode, DIMM, 0, fmri)) ==
 	    NULL) {
+		nvlist_free(auth);
 		nvlist_free(fmri);
 		topo_mod_dprintf(mod, "failed to bind dimm node: %s",
 		    topo_mod_errmsg(mod));
 		/* errno set */
 		goto err;
 	}
+
+	/* Create authority and system pgroups */
+	topo_pgroup_hcset(dimmnode, auth);
+	nvlist_free(auth);
 
 	if (topo_node_fru_set(dimmnode, fmri, NULL, &err) != 0) {
 		topo_mod_dprintf(mod, "failed to set FRU on %s: %s",
@@ -387,6 +395,145 @@ smbios_enum_memory(smbios_hdl_t *shp, const smbios_struct_t *sp, void *arg)
 	return (0);
 }
 
+static int
+smbios_enum_motherboard(smbios_hdl_t *shp, smb_enum_data_t *smed)
+{
+	smbios_struct_t sp;
+	smbios_bboard_t smb_mb;
+	smbios_bios_t smb_bios;
+	smbios_info_t smb_info;
+	const char *part = NULL, *rev = NULL, *serial = NULL;
+	char *manuf = NULL, *prod = NULL, *asset = NULL;
+	char *bios_vendor = NULL, *bios_rev = NULL, *bios_reldate = NULL;
+	nvlist_t *auth, *fmri;
+	topo_mod_t *mod = smed->sme_mod;
+	tnode_t *mbnode;
+	topo_pgroup_info_t pgi;
+	int rc = 0, err;
+
+	if (smbios_lookup_type(shp, SMB_TYPE_BASEBOARD, &sp) == 0 &&
+	    smbios_info_bboard(shp, sp.smbstr_id, &smb_mb) == 0 &&
+	    smbios_info_common(shp, sp.smbstr_id, &smb_info) == 0) {
+		if (is_valid_string(smb_info.smbi_part) == B_TRUE)
+			part = smb_info.smbi_part;
+		if (is_valid_string(smb_info.smbi_version) == B_TRUE)
+			rev = smb_info.smbi_version;
+		if (is_valid_string(smb_info.smbi_serial) == B_TRUE)
+			serial = smb_info.smbi_serial;
+		if (is_valid_string(smb_info.smbi_manufacturer) == B_TRUE)
+			manuf = topo_mod_clean_str(mod,
+			    smb_info.smbi_manufacturer);
+		if (is_valid_string(smb_info.smbi_product) == B_TRUE)
+			prod = topo_mod_clean_str(mod, smb_info.smbi_product);
+		if (is_valid_string(smb_info.smbi_asset) == B_TRUE)
+			asset = topo_mod_clean_str(mod, smb_info.smbi_asset);
+	}
+	if (smbios_lookup_type(shp, SMB_TYPE_BIOS, &sp) == 0 &&
+	    smbios_info_bios(shp, &smb_bios) == 0) {
+		if (is_valid_string(smb_bios.smbb_vendor) == B_TRUE)
+			bios_vendor = topo_mod_clean_str(mod,
+			    smb_bios.smbb_vendor);
+		if (is_valid_string(smb_bios.smbb_version) == B_TRUE)
+			bios_rev = topo_mod_clean_str(mod,
+			    smb_bios.smbb_version);
+		if (is_valid_string(smb_bios.smbb_reldate) == B_TRUE)
+			bios_reldate = topo_mod_clean_str(mod,
+			    smb_bios.smbb_reldate);
+	}
+	if ((auth = topo_mod_auth(mod, smed->sme_pnode)) == NULL) {
+		topo_mod_dprintf(mod, "topo_mod_auth() failed: %s",
+		    topo_mod_errmsg(mod));
+		/* errno set */
+		goto err;
+	}
+
+	if ((fmri = topo_mod_hcfmri(mod, NULL, FM_HC_SCHEME_VERSION,
+	    MOTHERBOARD, 0, NULL, auth, part, rev, serial)) ==
+	    NULL) {
+		nvlist_free(auth);
+		topo_mod_dprintf(mod, "topo_mod_hcfmri() failed: %s",
+		    topo_mod_errmsg(mod));
+		/* errno set */
+		goto err;
+	}
+
+	if ((mbnode = topo_node_bind(mod, smed->sme_pnode, MOTHERBOARD, 0,
+	    fmri)) == NULL) {
+		nvlist_free(auth);
+		nvlist_free(fmri);
+		topo_mod_dprintf(mod, "topo_node_bind() failed: %s",
+		    topo_mod_errmsg(mod));
+		/* errno set */
+		goto err;
+	}
+
+	/* Create authority and system pgroups */
+	topo_pgroup_hcset(mbnode, auth);
+	nvlist_free(auth);
+
+	if (topo_node_fru_set(mbnode, fmri, NULL, &err) != 0) {
+		topo_mod_dprintf(mod, "failed to set FRU on %s: %s",
+		    MOTHERBOARD, topo_strerror(err));
+		nvlist_free(fmri);
+		(void) topo_mod_seterrno(mod, err);
+		goto err;
+	}
+	nvlist_free(fmri);
+	fmri = NULL;
+
+	if (topo_node_label_set(mbnode, "MB", &err) != 0) {
+		topo_mod_dprintf(mod, "failed to set label on %s: %s",
+		    MOTHERBOARD, topo_strerror(err));
+		(void) topo_mod_seterrno(mod, err);
+		goto err;
+	}
+
+	pgi.tpi_name = TOPO_PGROUP_MOTHERBOARD;
+	pgi.tpi_namestab = TOPO_STABILITY_PRIVATE;
+	pgi.tpi_datastab = TOPO_STABILITY_PRIVATE;
+	pgi.tpi_version = TOPO_VERSION;
+	rc = topo_pgroup_create(mbnode, &pgi, &err);
+
+	if (rc == 0 && manuf != NULL)
+		rc += topo_prop_set_string(mbnode, TOPO_PGROUP_MOTHERBOARD,
+		    TOPO_PROP_MB_MANUFACTURER, TOPO_PROP_IMMUTABLE, manuf,
+		    &err);
+	if (rc == 0 && prod != NULL)
+		rc += topo_prop_set_string(mbnode, TOPO_PGROUP_MOTHERBOARD,
+		    TOPO_PROP_MB_PRODUCT, TOPO_PROP_IMMUTABLE, prod, &err);
+	if (rc == 0 && asset != NULL)
+		rc += topo_prop_set_string(mbnode, TOPO_PGROUP_MOTHERBOARD,
+		    TOPO_PROP_MB_ASSET, TOPO_PROP_IMMUTABLE, asset, &err);
+	if (rc == 0 && bios_vendor != NULL)
+		rc += topo_prop_set_string(mbnode, TOPO_PGROUP_MOTHERBOARD,
+		    TOPO_PROP_MB_FIRMWARE_VENDOR, TOPO_PROP_IMMUTABLE,
+		    bios_vendor, &err);
+	if (rc == 0 && bios_rev != NULL)
+		rc += topo_prop_set_string(mbnode, TOPO_PGROUP_MOTHERBOARD,
+		    TOPO_PROP_MB_FIRMWARE_REV, TOPO_PROP_IMMUTABLE,
+		    bios_rev, &err);
+	if (rc == 0 && bios_reldate != NULL)
+		rc += topo_prop_set_string(mbnode, TOPO_PGROUP_MOTHERBOARD,
+		    TOPO_PROP_MB_FIRMWARE_RELDATE, TOPO_PROP_IMMUTABLE,
+		    bios_reldate, &err);
+
+	if (rc != 0) {
+		topo_mod_dprintf(mod, "error setting properties on %s node",
+		    MOTHERBOARD);
+		(void) topo_mod_seterrno(mod, err);
+		goto err;
+	}
+err:
+	topo_mod_strfree(mod, manuf);
+	topo_mod_strfree(mod, prod);
+	topo_mod_strfree(mod, asset);
+	topo_mod_strfree(mod, bios_vendor);
+	topo_mod_strfree(mod, bios_rev);
+	topo_mod_strfree(mod, bios_reldate);
+
+	return (0);
+}
+
 /*
  * A system with a functional memory controller driver will have one mc device
  * node per chip instance, starting at instance 0.  The driver provides an
@@ -447,6 +594,10 @@ smbios_enum(topo_mod_t *mod, tnode_t *rnode, const char *name,
 		if (has_mc_driver() == B_TRUE)
 			return (0);
 		if (smbios_iter(smbh, smbios_enum_memory, &smed) < 0)
+			/* errno set */
+			return (-1);
+	} else if (strcmp(name, MOTHERBOARD) == 0) {
+		if (smbios_enum_motherboard(smbh, &smed) < 0)
 			/* errno set */
 			return (-1);
 	} else {

--- a/usr/src/lib/libnsl/Makefile.com
+++ b/usr/src/lib/libnsl/Makefile.com
@@ -183,11 +183,6 @@ BIGPICS =	$(GOTHOGS:%=pics/%)
 $(BIGPICS) :=	sparc_C_PICFLAGS = $(C_BIGPICFLAGS)
 $(BIGPICS) :=	i386_C_PICFLAGS = $(C_BIGPICFLAGS)
 
-# Compile C++ code without exceptions to avoid a dependence on libC.
-NOEXCEPTIONS= -noex
-CCFLAGS += $(NOEXCEPTIONS)
-CCFLAGS64 += $(NOEXCEPTIONS)
-
 CPPFLAGS +=	-I$(SRC)/lib/libnsl/include -D_REENTRANT
 CPPFLAGS +=	-I$(SRC)/lib/libnsl/dial
 

--- a/usr/src/man/man1m/zfs-program.1m
+++ b/usr/src/man/man1m/zfs-program.1m
@@ -9,6 +9,7 @@
 .\"
 .\"
 .\" Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+.\" Copyright (c) 2018 Datto Inc.
 .\"
 .Dd January 21, 2016
 .Dt ZFS-PROGRAM 1M
@@ -18,7 +19,7 @@
 .Nd executes ZFS channel programs
 .Sh SYNOPSIS
 .Cm "zfs program"
-.Op Fl n
+.Op Fl jn
 .Op Fl t Ar instruction-limit
 .Op Fl m Ar memory-limit
 .Ar pool
@@ -46,6 +47,11 @@ will be run on
 and any attempts to access or modify other pools will cause an error.
 .Sh OPTIONS
 .Bl -tag -width "-t"
+.It Fl j
+Display channel program output in JSON format.
+When this flag is specified and standard output is empty -
+channel program encountered an error.
+The details of such an error will be printed to standard error in plain text.
 .It Fl n
 Executes a read-only channel program, which runs faster.
 The program cannot change on-disk state by calling functions from the

--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -28,6 +28,7 @@
 .\" Copyright (c) 2014 Integros [integros.com]
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
+.\" Copyright (c) 2018 Datto Inc.
 .\"
 .Dd Feb 10, 2018
 .Dt ZFS 1M
@@ -271,7 +272,7 @@
 .Ar snapshot Ar snapshot Ns | Ns Ar filesystem
 .Nm
 .Cm program
-.Op Fl n
+.Op Fl jn
 .Op Fl t Ar timeout
 .Op Fl m Ar memory_limit
 .Ar pool script
@@ -3475,7 +3476,7 @@ Display the path's inode change time as the first column of output.
 .It Xo
 .Nm
 .Cm program
-.Op Fl n
+.Op Fl jn
 .Op Fl t Ar timeout
 .Op Fl m Ar memory_limit
 .Ar pool script
@@ -3496,6 +3497,11 @@ Channel programs may only be run with root privileges.
 For full documentation of the ZFS channel program interface, see the manual
 page for
 .Bl -tag -width ""
+.It Fl j
+Display channel program output in JSON format.
+When this flag is specified and standard output is empty -
+channel program encountered an error.
+The details of such an error will be printed to standard error in plain text.
 .It Fl n
 Executes a read-only channel program, which runs faster.
 The program cannot change on-disk state by calling functions from

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -14,6 +14,7 @@
 # Copyright 2015, 2016 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2018 Joyent, Inc.
+# Copyright (c) 2018 Datto Inc.
 #
 
 set name=pkg.fmri value=pkg:/system/test/zfstest@$(PKGVERS)
@@ -53,6 +54,7 @@ dir path=opt/zfs-tests/tests/functional/cli_root/zfs_destroy
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_get
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_inherit
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_mount
+dir path=opt/zfs-tests/tests/functional/cli_root/zfs_program
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_promote
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_property
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_receive
@@ -878,6 +880,11 @@ file path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail \
     mode=0555
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_mountpoints \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/cleanup \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/setup mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_promote/cleanup \
     mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -147,6 +147,9 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_012_neg',
     'zfs_mount_all_001_pos', 'zfs_mount_all_fail', 'zfs_mount_all_mountpoints']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_program]
+tests = ['zfs_program_json']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',
     'zfs_promote_004_pos', 'zfs_promote_005_pos', 'zfs_promote_006_neg',

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -140,6 +140,9 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_007_pos', 'zfs_mount_008_pos', 'zfs_mount_009_neg',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_all_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_program]
+tests = ['zfs_program_json']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',
     'zfs_promote_004_pos', 'zfs_promote_005_pos', 'zfs_promote_006_neg',

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -140,6 +140,9 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_007_pos', 'zfs_mount_008_pos', 'zfs_mount_009_neg',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_all_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_program]
+tests = ['zfs_program_json']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',
     'zfs_promote_004_pos', 'zfs_promote_005_pos', 'zfs_promote_006_neg',

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 Datto Inc.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/cli_root/zfs_program
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/cleanup.ksh
@@ -1,0 +1,30 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, usr/src/common/zfs this CDDL HEADER in each
+# file and usr/src/common/zfs the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/setup.ksh
@@ -1,0 +1,32 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, usr/src/common/zfs this CDDL HEADER in each
+# file and usr/src/common/zfs the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
@@ -1,0 +1,161 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy is of the CDDL is also available via the Internet
+# at http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# STRATEGY:
+#	1. Ensure empty JSON is printed when there is no channel program output
+#	2. Compare JSON output formatting for a channel program to template
+#	3. Using bad command line option (-Z) gives correct error output
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs destroy -r $TESTDS
+	return 0
+}
+log_onexit cleanup
+
+log_assert "Channel programs output valid JSON"
+
+TESTDS="$TESTPOOL/zcp-json"
+TESTSNAP="$TESTDS@snap0"
+log_must zfs create $TESTDS
+
+# 1. Ensure empty JSON is printed when there is no channel program output
+TESTZCP="/$TESTDS/zfs_destroy.zcp"
+cat > "$TESTZCP" << EOF
+       args = ...
+       argv = args["argv"]
+       zfs.sync.destroy(argv[1])
+EOF
+
+EMPTY_OUTPUT=("{}")
+log_must zfs snap $TESTSNAP 2>&1
+log_must zfs list $TESTSNAP 2>&1
+log_must zfs program $TESTPOOL $TESTZCP $TESTSNAP 2>&1
+log_mustnot zfs list $TESTSNAP 2>&1
+log_must zfs snap $TESTSNAP 2>&1
+log_must zfs list $TESTSNAP 2>&1
+log_must zfs program -j $TESTPOOL $TESTZCP $TESTSNAP 2>&1
+log_mustnot zfs list $TESTSNAP 2>&1
+log_must zfs snap $TESTSNAP 2>&1
+log_must zfs list $TESTSNAP 2>&1
+OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTSNAP 2>&1)
+if [ "$OUTPUT" != "$EMPTY_OUTPUT" ]; then
+       log_note "Got     :$OUTPUT"
+       log_note "Expected:$EMPTY_OUTPUT"
+       log_fail "Channel program output not empty";
+fi
+log_mustnot zfs list $TESTSNAP 2>&1
+
+# 2. Compare JSON output formatting for a channel program to template
+TESTZCP="/$TESTDS/zfs_rlist.zcp"
+cat > "$TESTZCP" << EOF
+	succeeded = {}
+	failed = {}
+
+	function list_recursive(root, prop)
+		for child in zfs.list.children(root) do
+			list_recursive(child, prop)
+		end
+		val, src  = zfs.get_prop(root, prop)
+		if (val == nil) then
+			failed[root] = val
+		else
+			succeeded[root] = val
+		end
+	end
+
+	args = ...
+
+	argv = args["argv"]
+
+	list_recursive(argv[1], argv[2])
+
+	results = {}
+	results["succeeded"] = succeeded
+	results["failed"] = failed
+	return results
+EOF
+
+typeset -a pos_cmds=("recordsize" "type")
+typeset -a pos_cmds_out=(
+"{
+    \"return\": {
+        \"failed\": {},
+        \"succeeded\": {
+            \"$TESTDS\": 131072
+        }
+    }
+}"
+"{
+    \"return\": {
+        \"failed\": {},
+        \"succeeded\": {
+            \"$TESTDS\": \"filesystem\"
+        }
+    }
+}")
+typeset -i cnt=0
+typeset cmd
+for cmd in ${pos_cmds[@]}; do
+	log_must zfs program $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
+	log_must zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
+	# json.tool is needed to guarantee consistent ordering of fields
+	# sed is needed to trim trailing space in CentOS 6's json.tool output
+	OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1 | python -m json.tool | sed 's/[[:space:]]*$//')
+	if [ "$OUTPUT" != "${pos_cmds_out[$cnt]}" ]; then
+		log_note "Got     :$OUTPUT"
+		log_note "Expected:${pos_cmds_out[$cnt]}"
+		log_fail "Unexpected channel program output";
+	fi
+	cnt=$((cnt + 1))
+done
+
+# 3. Using bad command line option (-Z) gives correct error output
+typeset -a neg_cmds=("-Z")
+typeset -a neg_cmds_out=(
+"invalid option 'Z'
+usage:
+	program [-jn] [-t <instruction limit>] [-m <memory limit (b)>] <pool> <program file> [lua args...]
+
+For the property list, run: zfs set|get
+
+For the delegated permission list, run: zfs allow|unallow")
+cnt=0
+for cmd in ${neg_cmds[@]}; do
+	log_mustnot zfs program $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1
+	log_mustnot zfs program -j $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1
+	OUTPUT=$(zfs program -j $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1)
+	if [ "$OUTPUT" != "${neg_cmds_out[$cnt]}" ]; then
+		log_note "Got     :$OUTPUT"
+		log_note "Expected:${neg_cmds_out[$cnt]}"
+		log_fail "Unexpected channel program error output";
+	fi
+	cnt=$((cnt + 1))
+done
+
+log_pass "Channel programs output valid JSON"

--- a/usr/src/tools/cw/cw.c
+++ b/usr/src/tools/cw/cw.c
@@ -37,7 +37,7 @@
  */
 
 /* If you modify this file, you must increment CW_VERSION */
-#define	CW_VERSION	"2.0"
+#define	CW_VERSION	"3.0"
 
 /*
  * -#		Verbose mode
@@ -56,8 +56,6 @@
  *		as errors
  * -fast	Optimize using a selection of options
  * -fd		Report old-style function definitions and declarations
- * -features=zla	Allow zero-length arrays
- * -flags	Show this summary of compiler options
  * -fnonstd	Initialize floating-point hardware to non-standard preferences
  * -fns[=<yes|no>] Select non-standard floating point mode
  * -fprecision=<p> Set FP rounding precision mode p(single, double, extended)
@@ -84,17 +82,12 @@
  * -native	Find available processor, generate code accordingly
  * -nofstore	Do not force floating pt. values to target precision
  *		on assignment
- * -nolib	Same as -xnolib
- * -noqueue	Disable queuing of compiler license requests
  * -norunpath	Do not build in a runtime path for shared libraries
  * -O		Use default optimization level (-xO2 or -xO3. Check man page.)
  * -o <outputfile> Set name of output file to <outputfile>
  * -P		Compile source through preprocessor only, output to .i  file
- * -PIC		Alias for -KPIC or -xcode=pic32
  * -p		Compile for profiling with prof
- * -pic		Alias for -Kpic or -xcode=pic13
  * -Q[y|n]	Emit/don't emit identification info to output file
- * -qp		Compile for profiling with prof
  * -R<dir[:dir]> Build runtime search path list into executable
  * -S		Compile and only generate assembly code (.s)
  * -s		Strip symbol table from the executable file
@@ -106,16 +99,12 @@
  * -w		Suppress compiler warning messages
  * -Xa		Compile assuming ANSI C conformance, allow K & R extensions
  *		(default mode)
- * -Xc		Compile assuming strict ANSI C conformance
  * -Xs		Compile assuming (pre-ANSI) K & R C style code
  * -Xt		Compile assuming K & R conformance, allow ANSI C
- * -x386	Generate code for the 80386 processor
- * -x486	Generate code for the 80486 processor
  * -xarch=<a>	Specify target architecture instruction set
  * -xbuiltin[=<b>] When profitable inline, or substitute intrinisic functions
  *		for system functions, b={%all,%none}
  * -xCC		Accept C++ style comments
- * -xchar_byte_order=<o> Specify multi-char byte order <o> (default, high, low)
  * -xchip=<c>	Specify the target processor for use by the optimizer
  * -xcode=<c>	Generate different code for forming addresses
  * -xcrossfile[=<n>] Enable optimization and inlining across source files,
@@ -133,15 +122,9 @@
  * -xlibmil	Inline selected libm math routines for optimization
  * -xlic_lib=sunperf	Link in the Sun supplied performance libraries
  * -xlicinfo	Show license server information
- * -xM		Generate makefile dependencies
- * -xM1		Generate makefile dependencies, but exclude /usr/include
  * -xmaxopt=[off,1,2,3,4,5] maximum optimization level allowed on #pragma opt
- * -xnolib	Do not link with default system libraries
- * -xnolibmil	Cancel -xlibmil on command line
  * -xO<n>	Generate optimized code (n={1|2|3|4|5})
  * -xP		Print prototypes for function definitions
- * -xpentium	Generate code for the pentium processor
- * -xpg		Compile for profiling with gprof
  * -xprofile=<p> Collect data for a profile or use a profile to optimize
  *		<p>={{collect,use}[:<path>],tcov}
  * -xregs=<r>	Control register allocation
@@ -155,8 +138,6 @@
  * -xtarget=<t>	Specify target system for optimization
  * -xtemp=<dir>	Set directory for temporary files to <dir>
  * -xtime	Report the execution time for each compilation phase
- * -xtransition	Emit warnings for differences between K&R C and ANSI C
- * -xtrigraphs[=<yes|no>] Enable|disable trigraph translation
  * -xunroll=n	Enable unrolling loops n times where possible
  * -Y<c>,<dir>	Specify <dir> for location of component <c> (a,l,m,p,0,h,i,u)
  * -YA,<dir>	Change default directory searched for components
@@ -184,8 +165,6 @@
  * -errwarn=%all		-Werror else -Wno-error
  * -fast			error
  * -fd				error
- * -features=zla		ignore
- * -flags			--help
  * -fnonstd			error
  * -fns[=<yes|no>]		error
  * -fprecision=<p>		error
@@ -212,16 +191,12 @@
  * -native			error
  * -nofstore			error
  * -nolib			-nodefaultlibs
- * -noqueue			ignore
  * -norunpath			ignore
  * -O				-O1 (Check the man page to be certain)
  * -o <outputfile>		pass-thru
  * -P				-E -o filename.i (or error)
- * -PIC				-fPIC (C++ only)
  * -p				pass-thru
- * -pic				-fpic (C++ only)
  * -Q[y|n]			error
- * -qp				-p
  * -R<dir[:dir]>		pass-thru
  * -S				pass-thru
  * -s				-Wl,-s
@@ -233,20 +208,15 @@
  * -Wp,<arg>			pass-thru except -xc99=<a>
  * -Wl,<arg>			pass-thru
  * -W{m,0,2,h,i,u>		error/ignore
- * -Wu,-xmodel=kernel		-ffreestanding -mcmodel=kernel -mno-red-zone
  * -xmodel=kernel		-ffreestanding -mcmodel=kernel -mno-red-zone
  * -Wu,-save_args		-msave-args
  * -w				pass-thru
  * -Xa				-std=iso9899:199409 or -ansi
- * -Xc				-ansi -pedantic
  * -Xt				error
  * -Xs				-traditional -std=c89
- * -x386			-march=i386 (x86 only)
- * -x486			-march=i486 (x86 only)
  * -xarch=<a>			table
  * -xbuiltin[=<b>]		-fbuiltin (-fno-builtin otherwise)
  * -xCC				ignore
- * -xchar_byte_order=<o>	error
  * -xchip=<c>			table
  * -xcode=<c>			table
  * -xdebugformat=<format>	ignore (always use dwarf-2 for gcc)
@@ -260,15 +230,9 @@
  * -xlibmieee			error
  * -xlibmil			error
  * -xlic_lib=sunperf		error
- * -xM				-M
- * -xM1				-MM
  * -xmaxopt=[...]		error
- * -xnolib			-nodefaultlibs
- * -xnolibmil			error
  * -xO<n>			-O<n>
  * -xP				error
- * -xpentium			-march=pentium (x86 only)
- * -xpg				error
  * -xprofile=<p>		error
  * -xregs=<r>			table
  * -xs				error
@@ -281,7 +245,6 @@
  * -xtemp=<dir>			error
  * -xtime			error
  * -xtransition			-Wtransition
- * -xtrigraphs=<yes|no>		-trigraphs -notrigraphs
  * -xunroll=n			error
  * -W0,-xdbggen=no%usedonly	-fno-eliminate-unused-debug-symbols
  *				-fno-eliminate-unused-debug-types
@@ -527,18 +490,6 @@ Xamode(struct aelist __unused *h)
 }
 
 static void
-Xcmode(struct aelist *h)
-{
-	static int xconce;
-
-	if (xconce++)
-		return;
-
-	newae(h, "-ansi");
-	newae(h, "-pedantic-errors");
-}
-
-static void
 Xsmode(struct aelist *h)
 {
 	static int xsonce;
@@ -719,23 +670,6 @@ do_gcc(cw_ictx_t *ctx)
 				newae(ctx->i_ae, "-Werror");
 				continue;
 			}
-			if (strcmp(arg, "-noex") == 0) {
-				/* no exceptions */
-				newae(ctx->i_ae, "-fno-exceptions");
-				/* no run time type descriptor information */
-				newae(ctx->i_ae, "-fno-rtti");
-				continue;
-			}
-			if (strcmp(arg, "-pic") == 0) {
-				newae(ctx->i_ae, "-fpic");
-				pic = 1;
-				continue;
-			}
-			if (strcmp(arg, "-PIC") == 0) {
-				newae(ctx->i_ae, "-fPIC");
-				pic = 1;
-				continue;
-			}
 			if (strcmp(arg, "-norunpath") == 0) {
 				/* gcc has no corresponding option */
 				continue;
@@ -874,20 +808,6 @@ do_gcc(cw_ictx_t *ctx)
 			}
 			error(arg);
 			break;
-		case 'f':
-			if (strcmp(arg, "-flags") == 0) {
-				newae(ctx->i_ae, "--help");
-				break;
-			}
-			if (strncmp(arg, "-features=zla", 13) == 0) {
-				/*
-				 * Accept but ignore this -- gcc allows
-				 * zero length arrays.
-				 */
-				break;
-			}
-			error(arg);
-			break;
 		case 'G':
 			newae(ctx->i_ae, "-shared");
 			nolibc = 1;
@@ -964,15 +884,6 @@ do_gcc(cw_ictx_t *ctx)
 				free(s);
 			}
 			break;
-		case 'n':
-			if (strcmp(arg, "-noqueue") == 0) {
-				/*
-				 * Horrid license server stuff - n/a
-				 */
-				break;
-			}
-			error(arg);
-			break;
 		case 'O':
 			if (arglen == 1) {
 				newae(ctx->i_ae, "-O");
@@ -991,13 +902,6 @@ do_gcc(cw_ictx_t *ctx)
 			newae(ctx->i_ae, "-E");
 			op = CW_O_PREPROCESS;
 			nolibc = 1;
-			break;
-		case 'q':
-			if (strcmp(arg, "-qp") == 0) {
-				newae(ctx->i_ae, "-p");
-				break;
-			}
-			error(arg);
 			break;
 		case 's':
 			if (arglen == 1) {
@@ -1042,18 +946,6 @@ do_gcc(cw_ictx_t *ctx)
 				newae(ctx->i_ae, arg);
 				break;
 			}
-			if (strcmp(arg, "-W0,-xc99=pragma") == 0) {
-				/* (undocumented) enables _Pragma */
-				break;
-			}
-			if (strcmp(arg, "-W0,-xc99=%none") == 0) {
-				/*
-				 * This is a polite way of saying
-				 * "no c99 constructs allowed!"
-				 * For now, just accept and ignore this.
-				 */
-				break;
-			}
 			if (strcmp(arg, "-W0,-noglobal") == 0 ||
 			    strcmp(arg, "-W0,-xglobalstatic") == 0) {
 				/*
@@ -1081,13 +973,6 @@ do_gcc(cw_ictx_t *ctx)
 				 * Use the legacy behaviour (pre-SS11)
 				 * for integer wrapping.
 				 * gcc does not need this.
-				 */
-				break;
-			}
-			if (strcmp(arg, "-W2,-Rcond_elim") == 0) {
-				/*
-				 * Elimination and expansion of conditionals;
-				 * gcc has no direct equivalent.
 				 */
 				break;
 			}
@@ -1120,13 +1005,6 @@ do_gcc(cw_ictx_t *ctx)
 				break;
 			}
 #if defined(__x86)
-			if (strcmp(arg, "-Wu,-xmodel=kernel") == 0) {
-				newae(ctx->i_ae, "-ffreestanding");
-				newae(ctx->i_ae, "-mno-red-zone");
-				model = "-mcmodel=kernel";
-				nolibc = 1;
-				break;
-			}
 			if (strcmp(arg, "-Wu,-save_args") == 0) {
 				newae(ctx->i_ae, "-msave-args");
 				break;
@@ -1140,10 +1018,6 @@ do_gcc(cw_ictx_t *ctx)
 				Xamode(ctx->i_ae);
 				break;
 			}
-			if (strcmp(arg, "-Xc") == 0) {
-				Xcmode(ctx->i_ae);
-				break;
-			}
 			if (strcmp(arg, "-Xs") == 0) {
 				Xsmode(ctx->i_ae);
 				break;
@@ -1154,22 +1028,6 @@ do_gcc(cw_ictx_t *ctx)
 			if (arglen == 1)
 				error(arg);
 			switch (arg[2]) {
-#if defined(__x86)
-			case '3':
-				if (strcmp(arg, "-x386") == 0) {
-					newae(ctx->i_ae, "-march=i386");
-					break;
-				}
-				error(arg);
-				break;
-			case '4':
-				if (strcmp(arg, "-x486") == 0) {
-					newae(ctx->i_ae, "-march=i486");
-					break;
-				}
-				error(arg);
-				break;
-#endif	/* __x86 */
 			case 'a':
 				if (strncmp(arg, "-xarch=", 7) == 0) {
 					mflag |= xlate_xtb(ctx->i_ae, arg + 7);
@@ -1210,15 +1068,11 @@ do_gcc(cw_ictx_t *ctx)
 						pic = 1;
 					break;
 				}
-				if (strncmp(arg, "-xcache=", 8) == 0)
-					break;
 				if (strncmp(arg, "-xcrossfile", 11) == 0)
 					break;
 				error(arg);
 				break;
 			case 'd':
-				if (strcmp(arg, "-xdepend") == 0)
-					break;
 				if (strncmp(arg, "-xdebugformat=", 14) == 0)
 					break;
 				error(arg);
@@ -1255,24 +1109,6 @@ do_gcc(cw_ictx_t *ctx)
 				error(arg);
 				break;
 #endif	/* __x86 */
-			case 'M':
-				if (strcmp(arg, "-xM") == 0) {
-					newae(ctx->i_ae, "-M");
-					break;
-				}
-				if (strcmp(arg, "-xM1") == 0) {
-					newae(ctx->i_ae, "-MM");
-					break;
-				}
-				error(arg);
-				break;
-			case 'n':
-				if (strcmp(arg, "-xnolib") == 0) {
-					nolibc = 1;
-					break;
-				}
-				error(arg);
-				break;
 			case 'O':
 				if (strncmp(arg, "-xO", 3) == 0) {
 					size_t len = strlen(arg);
@@ -1306,17 +1142,6 @@ do_gcc(cw_ictx_t *ctx)
 				}
 				error(arg);
 				break;
-			case 'p':
-				if (strcmp(arg, "-xpentium") == 0) {
-					newae(ctx->i_ae, "-march=pentium");
-					break;
-				}
-				if (strcmp(arg, "-xpg") == 0) {
-					newae(ctx->i_ae, "-pg");
-					break;
-				}
-				error(arg);
-				break;
 			case 'r':
 				if (strncmp(arg, "-xregs=", 7) == 0) {
 					xlate(ctx->i_ae, arg + 7, xregs_tbl);
@@ -1332,18 +1157,6 @@ do_gcc(cw_ictx_t *ctx)
 				error(arg);
 				break;
 			case 't':
-				if (strcmp(arg, "-xtransition") == 0) {
-					newae(ctx->i_ae, "-Wtransition");
-					break;
-				}
-				if (strcmp(arg, "-xtrigraphs=yes") == 0) {
-					newae(ctx->i_ae, "-trigraphs");
-					break;
-				}
-				if (strcmp(arg, "-xtrigraphs=no") == 0) {
-					newae(ctx->i_ae, "-notrigraphs");
-					break;
-				}
 				if (strncmp(arg, "-xtarget=", 9) == 0) {
 					xlate(ctx->i_ae, arg + 9, xtarget_tbl);
 					break;

--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -124,21 +124,21 @@ function normal_build {
 #
 # usage: run_hook HOOKNAME ARGS...
 #
-# If variable "$HOOKNAME" is defined, insert a section header into 
+# If variable "$HOOKNAME" is defined, insert a section header into
 # our logs and then run the command with ARGS
 #
 function run_hook {
 	HOOKNAME=$1
-    	eval HOOKCMD=\$$HOOKNAME
+	eval HOOKCMD=\$$HOOKNAME
 	shift
 
-	if [ -n "$HOOKCMD" ]; then 
-	    	(
+	if [ -n "$HOOKCMD" ]; then
+		(
 			echo "\n==== Running $HOOKNAME command: $HOOKCMD ====\n"
-		    	( $HOOKCMD "$@" 2>&1 )
+			( $HOOKCMD "$@" 2>&1 )
 			if [ "$?" -ne 0 ]; then
-			    	# Let exit status propagate up
-			    	touch $TMPDIR/abort
+				# Let exit status propagate up
+				touch $TMPDIR/abort
 			fi
 		) | tee -a $mail_msg_file >> $LOGFILE
 
@@ -286,9 +286,7 @@ function build {
 			| egrep -v '^Zero Signature length:' \
 			| egrep -v '^Note \(probably harmless\):' \
 			| egrep -v '::' \
-			| egrep -v -- '-xcache' \
 			| egrep -v '^\+' \
-			| egrep -v '^cc1: note: -fwritable-strings' \
 			| egrep -v 'svccfg-native -s svc:/' \
 			| egrep -v '^maximum offset:' \
 			| sort | uniq >$SRC/${NOISE}.out
@@ -406,7 +404,7 @@ function dolint {
 	#
 	rm -f Nothing_to_remove \
 	    `find . \( -name SCCS -o -name .hg -o -name .svn -o -name .git \) \
-	    	-prune -o -type f -name '*.ln' -print `
+		-prune -o -type f -name '*.ln' -print `
 
 	/bin/time $MAKE -ek lint 2>&1 | \
 	    tee -a $LINTOUT >> $LOGFILE
@@ -741,7 +739,7 @@ unset ONBLD_TOOLS
 #
 if [ -f /etc/nightly.conf ]; then
 	. /etc/nightly.conf
-fi    
+fi
 
 if [ -f $1 ]; then
 	if [[ $1 = */* ]]; then
@@ -920,7 +918,7 @@ if [[ -z "$MAKE" ]]; then
 	MAKE=dmake
 elif [[ ! -x "$MAKE" ]]; then
 	echo "\$MAKE is set to garbage in the environment"
-	exit 1	
+	exit 1
 fi
 export PATH
 export MAKE
@@ -1048,9 +1046,9 @@ PKGARCHIVE_ORIG=$PKGARCHIVE
 #
 
 function logshuffle {
-    	LLOG="$ATLOG/log.`date '+%F.%H:%M'`"
+	LLOG="$ATLOG/log.`date '+%F.%H:%M'`"
 	if [ -f $LLOG -o -d $LLOG ]; then
-	    	LLOG=$LLOG.$$
+		LLOG=$LLOG.$$
 	fi
 
 	rm -f "$ATLOG/latest" 2>/dev/null
@@ -1065,7 +1063,7 @@ function logshuffle {
 	        fi
 
 		if [ -f $TMPDIR/wsdiff.results ]; then
-		    	mv $TMPDIR/wsdiff.results $LLOG
+			mv $TMPDIR/wsdiff.results $LLOG
 		fi
 
 		if [ -f $TMPDIR/wsdiff-nd.results ]; then
@@ -1083,7 +1081,7 @@ function logshuffle {
 
 	exec >>$LOGFILE 2>&1
 	if [ -s $build_noise_file ]; then
-	    	echo "\n==== Nightly build noise ====\n" |
+		echo "\n==== Nightly build noise ====\n" |
 		    tee -a $LOGFILE >>$mail_msg_file
 		cat $build_noise_file >>$LOGFILE
 		cat $build_noise_file >>$mail_msg_file
@@ -1099,7 +1097,7 @@ function logshuffle {
 			state=Interrupted
 			;;
 		*)
-	    		state=Failed
+			state=Failed
 			;;
 	esac
 
@@ -1125,13 +1123,13 @@ function logshuffle {
 	cat $build_time_file $build_environ_file $mail_msg_file \
 	    > ${LLOG}/mail_msg
 	if [ "$m_FLAG" = "y" ]; then
-	    	cat ${LLOG}/mail_msg | /usr/bin/mailx ${mailx_r} -s \
+		cat ${LLOG}/mail_msg | /usr/bin/mailx ${mailx_r} -s \
 	"Nightly ${MACH} Build of `basename ${CODEMGR_WS}` ${state}." \
 			${MAILTO}
 	fi
 
 	if [ "$u_FLAG" = "y" -a "$build_ok" = "y" ]; then
-	    	staffer cp ${LLOG}/mail_msg $PARENT_WS/usr/src/mail_msg-${MACH}
+		staffer cp ${LLOG}/mail_msg $PARENT_WS/usr/src/mail_msg-${MACH}
 		staffer cp $LOGFILE $PARENT_WS/usr/src/nightly-${MACH}.log
 	fi
 
@@ -1144,7 +1142,7 @@ function logshuffle {
 #	Remove the locks and temporary files on any exit
 #
 function cleanup {
-    	logshuffle
+	logshuffle
 
 	[ -z "$lockfile" ] || staffer rm -f $lockfile
 	[ -z "$atloglockfile" ] || rm -f $atloglockfile
@@ -1160,7 +1158,7 @@ function cleanup {
 }
 
 function cleanup_signal {
-    	build_ok=i
+	build_ok=i
 	# this will trigger cleanup(), above.
 	exit 1
 }
@@ -1379,7 +1377,7 @@ function parent_wstype {
 		else
 			scm_type="none"
 		fi
-	fi    
+	fi
 
 	# fold both unsupported and unrecognized results into "none"
 	case "$scm_type" in
@@ -1881,7 +1879,7 @@ if [ "$U_FLAG" = "y" -a "$build_ok" = "y" ]; then
 		mkdir -p $NIGHTLY_PARENT_TOOLS_ROOT
 		if [[ "$MULTI_PROTO" = no || "$D_FLAG" = y ]]; then
 			( cd $TOOLS_PROTO; tar cf - . |
-			    ( cd $NIGHTLY_PARENT_TOOLS_ROOT; 
+			    ( cd $NIGHTLY_PARENT_TOOLS_ROOT;
 			    umask 0; tar xpf - ) ) 2>&1 |
 			    tee -a $mail_msg_file >> $LOGFILE
 		fi
@@ -1910,7 +1908,7 @@ if [[ ($build_ok = y) && (($A_FLAG = y) || ($r_FLAG = y)) ]]; then
 	find_elf -fr $checkroot > $elf_ddir/object_list
 
 	if [[ $A_FLAG = y ]]; then
-	       	echo "\n==== Check versioning and ABI information ====\n"  | \
+		echo "\n==== Check versioning and ABI information ====\n"  | \
 		    tee -a $LOGFILE >> $mail_msg_file
 
 		# Produce interface description for the proto. Report errors.
@@ -1931,7 +1929,7 @@ if [[ ($build_ok = y) && (($A_FLAG = y) || ($r_FLAG = y)) ]]; then
 		       	echo "\n==== Compare versioning and ABI information" \
 			    "to baseline ====\n"  | \
 			    tee -a $LOGFILE >> $mail_msg_file
-		       	echo "Baseline:  $base_ifile\n" >> $LOGFILE
+			echo "Baseline:	 $base_ifile\n" >> $LOGFILE
 
 			if [[ -f $base_ifile ]]; then
 				interface_cmp -d -o $base_ifile \
@@ -1944,7 +1942,7 @@ if [[ ($build_ok = y) && (($A_FLAG = y) || ($r_FLAG = y)) ]]; then
 					build_extras_ok=n
 				fi
 			else
-			       	echo "baseline not available. comparison" \
+				echo "baseline not available. comparison" \
                                     "skipped" | \
 				    tee -a $LOGFILE >> $mail_msg_file
 			fi
@@ -1970,7 +1968,7 @@ if [[ ($build_ok = y) && (($A_FLAG = y) || ($r_FLAG = y)) ]]; then
 			build_extras_ok=n
 		fi
 
-		# check_rtime -I output needs to be sorted in order to 
+		# check_rtime -I output needs to be sorted in order to
 		# compare it to that from previous builds.
 		sort $elf_ddir/runtime.attr.raw > $elf_ddir/runtime.attr
 		rm $elf_ddir/runtime.attr.raw
@@ -2011,7 +2009,7 @@ if [[ ($build_ok = y) && (($A_FLAG = y) || ($r_FLAG = y)) ]]; then
 		# These files are used asynchronously by other builds for ABI
 		# verification, as above for the -A option. As such, we require
 		# the file replacement to be atomic. Copy the data to a temp
-		# file in the same filesystem and then rename into place. 
+		# file in the same filesystem and then rename into place.
 		(
 			cd $elf_ddir
 			for elf_dfile in *; do

--- a/usr/src/uts/common/io/qede/579xx/drivers/ecore/ecore_dcbx.c
+++ b/usr/src/uts/common/io/qede/579xx/drivers/ecore/ecore_dcbx.c
@@ -33,6 +33,10 @@
 * limitations under the License.
 */
 
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
 #include "bcm_osal.h"
 #include "ecore.h"
 #include "ecore_sp_commands.h"
@@ -241,7 +245,6 @@ ecore_dcbx_update_app_info(struct ecore_dcbx_results *p_data,
 {
 	enum ecore_pci_personality personality;
 	enum dcbx_protocol_type id;
-	char *name;
 	int i;
 
 	for (i = 0; i < OSAL_ARRAY_SIZE(ecore_dcbx_app_update); i++) {
@@ -251,7 +254,6 @@ ecore_dcbx_update_app_info(struct ecore_dcbx_results *p_data,
 			continue;
 
 		personality = ecore_dcbx_app_update[i].personality;
-		name = ecore_dcbx_app_update[i].name;
 
 		ecore_dcbx_set_params(p_data, p_hwfn, enable,
 				      prio, tc, type, personality);
@@ -999,7 +1001,7 @@ ecore_dcbx_mib_update_event(struct ecore_hwfn *p_hwfn, struct ecore_ptt *p_ptt,
 
 		rc = ecore_dcbx_process_mib_info(p_hwfn);
 		if (!rc) {
-			bool enabled;
+			bool enabled __unused;
 
 			/* reconfigure tcs of QM queues according
 			 * to negotiation results

--- a/usr/src/uts/common/io/qede/579xx/drivers/ecore/ecore_mcp.c
+++ b/usr/src/uts/common/io/qede/579xx/drivers/ecore/ecore_mcp.c
@@ -33,6 +33,10 @@
 * limitations under the License.
 */
 
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
 #include "bcm_osal.h"
 #include "ecore.h"
 #include "ecore_status.h"
@@ -362,7 +366,7 @@ static enum _ecore_status_t ecore_do_mcp_cmd(struct ecore_hwfn *p_hwfn,
 {
 	u32 delay = CHIP_MCP_RESP_ITER_US;
 	u32 max_retries = ECORE_DRV_MB_MAX_RETRIES;
-	u32 seq, cnt = 1, actual_mb_seq;
+	u32 seq, cnt = 1, actual_mb_seq __unused;
 	enum _ecore_status_t rc = ECORE_SUCCESS;
 
 #ifndef ASIC_ONLY
@@ -1433,7 +1437,7 @@ static void ecore_mcp_send_protocol_stats(struct ecore_hwfn *p_hwfn,
 					  struct ecore_ptt *p_ptt,
 					  enum MFW_DRV_MSG_TYPE type)
 {
-	enum ecore_mcp_protocol_type stats_type;
+	enum ecore_mcp_protocol_type stats_type __unused;
 	union ecore_mcp_protocol_stats stats;
 	struct ecore_mcp_mb_params mb_params;
 	u32 hsi_param;
@@ -3128,7 +3132,6 @@ enum _ecore_status_t ecore_mcp_phy_sfp_read(struct ecore_hwfn *p_hwfn,
 					    u32 len, u8 *p_buf)
 {
 	struct ecore_mcp_nvm_params params;
-	enum _ecore_status_t rc;
 	u32 bytes_left, bytes_to_copy, buf_size;
 
 	OSAL_MEMSET(&params, 0, sizeof(struct ecore_mcp_nvm_params));
@@ -3153,7 +3156,7 @@ enum _ecore_status_t ecore_mcp_phy_sfp_read(struct ecore_hwfn *p_hwfn,
 			 DRV_MB_PARAM_TRANSCEIVER_OFFSET_SHIFT);
 		params.nvm_common.offset |=
 			(bytes_to_copy << DRV_MB_PARAM_TRANSCEIVER_SIZE_SHIFT);
-		rc = ecore_mcp_nvm_command(p_hwfn, p_ptt, &params);
+		(void) ecore_mcp_nvm_command(p_hwfn, p_ptt, &params);
 		if ((params.nvm_common.resp & FW_MSG_CODE_MASK) ==
 		    FW_MSG_CODE_TRANSCEIVER_NOT_PRESENT) {
 			return ECORE_NODEV;
@@ -3174,7 +3177,6 @@ enum _ecore_status_t ecore_mcp_phy_sfp_write(struct ecore_hwfn *p_hwfn,
 					     u32 len, u8 *p_buf)
 {
 	struct ecore_mcp_nvm_params params;
-	enum _ecore_status_t rc;
 	u32 buf_idx, buf_size;
 
 	OSAL_MEMSET(&params, 0, sizeof(struct ecore_mcp_nvm_params));
@@ -3197,7 +3199,7 @@ enum _ecore_status_t ecore_mcp_phy_sfp_write(struct ecore_hwfn *p_hwfn,
 			(buf_size << DRV_MB_PARAM_TRANSCEIVER_SIZE_SHIFT);
 		params.nvm_wr.buf_size = buf_size;
 		params.nvm_wr.buf = (u32 *)&p_buf[buf_idx];
-		rc = ecore_mcp_nvm_command(p_hwfn, p_ptt, &params);
+		(void) ecore_mcp_nvm_command(p_hwfn, p_ptt, &params);
 		if ((params.nvm_common.resp & FW_MSG_CODE_MASK) ==
 		    FW_MSG_CODE_TRANSCEIVER_NOT_PRESENT) {
 			return ECORE_NODEV;

--- a/usr/src/uts/common/io/qede/579xx/drivers/ecore/ecore_phy.c
+++ b/usr/src/uts/common/io/qede/579xx/drivers/ecore/ecore_phy.c
@@ -33,6 +33,10 @@
 * limitations under the License.
 */
 
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
 #include "bcm_osal.h"
 #include "ecore.h"
 #include "reg_addr.h"
@@ -626,7 +630,7 @@ static int ecore_ah_e5_phy_mac_stat(struct ecore_hwfn *p_hwfn,
 				    struct ecore_ptt *p_ptt, u32 port,
 				    char *p_phy_result_buf)
 {
-	u32 length, reg_id, addr, data_hi, data_lo;
+	u32 length, reg_id, addr, data_hi __unused, data_lo;
 
 	length = OSAL_SPRINTF(p_phy_result_buf,
 			       "MAC stats for port %d (only non-zero)\n", port);

--- a/usr/src/uts/common/io/vioif/vioif.c
+++ b/usr/src/uts/common/io/vioif/vioif.c
@@ -13,6 +13,7 @@
  * Copyright 2013 Nexenta Inc.  All rights reserved.
  * Copyright 2015 Joyent, Inc.
  * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+ * Copyright 2015 Joyent, Inc.
  */
 
 /* Based on the NetBSD virtio driver by Minoura Makoto. */
@@ -737,7 +738,7 @@ vioif_add_rx(struct vioif_softc *sc, int kmflag)
 	while ((ve = vq_alloc_entry(sc->sc_rx_vq)) != NULL) {
 		struct vioif_rx_buf *buf = sc->sc_rxbufs[ve->qe_index];
 
-		if (!buf) {
+		if (buf == NULL) {
 			/* First run, allocate the buffer. */
 			buf = kmem_cache_alloc(sc->sc_rxbuf_cache, kmflag);
 			sc->sc_rxbufs[ve->qe_index] = buf;
@@ -916,10 +917,9 @@ vioif_reclaim_used_tx(struct vioif_softc *sc)
 		buf->tb_mp = NULL;
 
 		if (mp != NULL) {
-			for (int i = 0; i < buf->tb_external_num; i++) {
+			for (int i = 0; i < buf->tb_external_num; i++)
 				(void) ddi_dma_unbind_handle(
 				    buf->tb_external_mapping[i].vbm_dmah);
-			}
 		}
 
 		virtio_free_chain(ve);

--- a/usr/src/uts/common/sys/smbios.h
+++ b/usr/src/uts/common/sys/smbios.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2015 OmniTI Computer Consulting, Inc. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -178,6 +178,7 @@ typedef union {
  */
 #define	SMB_DEFAULT1	"To Be Filled By O.E.M."
 #define	SMB_DEFAULT2	"Not Available"
+#define	SMB_DEFAULT3	"Default string"
 
 /*
  * SMBIOS Common Information.  These structures do not correspond to anything


### PR DESCRIPTION
Weekly upstream for upstream_merge/2018101101.

Includes the last bits we need to start running a shadow compiler during illumos-omnios builds.

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2018101101-3bfbbf632b i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Oct 11 07:30:13 UTC 2018 ====
==== Nightly distributed build completed: Thu Oct 11 09:21:31 UTC 2018 ====

==== Total build time ====

real    1:51:17

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-3a707f2d8f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.7.0_191-b02"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   151

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018101101-3bfbbf632b

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    37:49.4
user  1:08:40.1
sys     15:06.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    27:24.2
user  1:00:57.5
sys     13:40.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    30:49.8
user    38:02.1
sys      5:12.6

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
