### PR TITLE
Fixes for gcc7

### DIFF
--- a/usr/src/lib/krb5/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/usr/src/lib/krb5/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3862,7 +3862,7 @@ pkinit_choose_tokens(krb5_context context,
 	} else {
             char *cp = reply.data;
             /* reply better be digits */
-            while (*cp != NULL) {
+            while (*cp != '\0') {
                 if (!isdigit(*cp++))
                     return (EINVAL);
             }
@@ -4106,7 +4106,7 @@ pkinit_open_session(krb5_context context,
     CK_SLOT_ID_PTR slotlist = NULL, tmpslotlist = NULL;
     CK_TOKEN_INFO tinfo;
     krb5_boolean tokenmatch = FALSE;
-    CK_SESSION_HANDLE tmpsession = NULL;
+    CK_SESSION_HANDLE tmpsession = CK_INVALID_HANDLE;
     struct _token_choices token_choices;
     int choice = 0;
 
@@ -6626,7 +6626,7 @@ pkinit_process_td_trusted_certifiers(
 		pkiDebug("#%d cert = %s is trusted by kdc\n", i, buf);
 	    else
 		pkiDebug("#%d cert = %s is invalid\n", i, buf);
-		sk_X509_NAME_push(sk_xn, xn);
+	    sk_X509_NAME_push(sk_xn, xn);
 	}
 
 	if (krb5_trusted_certifiers[i]->issuerAndSerialNumber.data != NULL) {


### PR DESCRIPTION
These are a few more fixes required to get a clean gcc7 build. I will be upstreaming them but there may be a delay as we don't yet understand why they do not show up when using the gcc7 bundled with OpenIndiana or SmartOS...

(The last change is related to building with openssl 1.1 but the first two are generic)