### PR TITLE
New thread-name APIs should be exposed under ILLUMOS_0.28

### DIFF
--- a/usr/src/lib/libc/port/mapfile-vers
+++ b/usr/src/lib/libc/port/mapfile-vers
@@ -77,6 +77,16 @@ $if _x86 && _ELF64
 $add amd64
 $endif
 
+SYMBOL_VERSION ILLUMOS_0.28 {
+    protected:
+	pthread_attr_getname_np;
+	pthread_attr_setname_np;
+	pthread_getname_np;
+	pthread_setname_np;
+	thr_getname;
+	thr_setname;
+} ILLUMOS_0.27;
+
 SYMBOL_VERSION ILLUMOS_0.27 {	# memset_s(3C) and set_constraint_handler_s(3C)
     protected:
 	abort_handler_s;
@@ -3097,11 +3107,7 @@ $endif
 	pset_bind_lwp;
 	_psignal;
 	pthread_attr_getdaemonstate_np;
-	pthread_attr_getname_np;
 	pthread_attr_setdaemonstate_np;
-	pthread_attr_setname_np;
-	pthread_getname_np;
-	pthread_setname_np;
 	_pthread_setcleanupinit;
 	__putwchar_xpg5;
 	__putwc_xpg5;
@@ -3180,7 +3186,6 @@ $endif
 	_thr_continue_allmutators;
 	thr_continue_mutator;
 	_thr_continue_mutator;
-	thr_getname;
 	thr_getstate;
 	_thr_getstate;
 	thr_mutators_barrier;
@@ -3189,7 +3194,6 @@ $endif
 	_thr_schedctl;
 	thr_setmutator;
 	_thr_setmutator;
-	thr_setname;
 	thr_setstate;
 	_thr_setstate;
 	thr_sighndlrinfo;


### PR DESCRIPTION
So that binaries that require these APIs have the correct libc dependency too.