### PR TITLE
7075 ahci: NULL pointer dereference in ahci_add_doneq()

### DIFF
--- a/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
+++ b/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
@@ -8954,7 +8954,6 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 		}
 
 		satapkt = ahci_portp->ahciport_slot_pkts[tmp_slot];
-		ASSERT(satapkt != NULL);
 
 		AHCIDBG(AHCIDBG_ERRS, ahci_ctlp, "ahci_mop_commands: "
 		    "sending up pkt 0x%p with SATA_PKT_DEV_ERROR",
@@ -8965,9 +8964,11 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 			    tmp_slot);
 		CLEAR_BIT(ahci_portp->ahciport_pending_tags, tmp_slot);
 		CLEAR_BIT(failed_tags, tmp_slot);
-		ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
 
-		ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_DEV_ERROR);
+		if (satapkt != NULL) {
+			ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
+			ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_DEV_ERROR);
+		}
 	}
 
 	/* Send up timeout packets with SATA_PKT_TIMEOUT. */
@@ -9000,7 +9001,6 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 		}
 
 		satapkt = ahci_portp->ahciport_slot_pkts[tmp_slot];
-		ASSERT(satapkt != NULL);
 
 		AHCIDBG(AHCIDBG_ERRS, ahci_ctlp, "ahci_mop_commands: "
 		    "sending up pkt 0x%p with SATA_PKT_TIMEOUT",
@@ -9011,9 +9011,11 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 			    tmp_slot);
 		CLEAR_BIT(ahci_portp->ahciport_pending_tags, tmp_slot);
 		CLEAR_BIT(timeout_tags, tmp_slot);
-		ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
 
-		ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_TIMEOUT);
+		if (satapkt != NULL) {
+			ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
+			ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_TIMEOUT);
+		}
 	}
 
 	/* Send up aborted packets with SATA_PKT_ABORTED */
@@ -9047,7 +9049,6 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 		}
 
 		satapkt = ahci_portp->ahciport_slot_pkts[tmp_slot];
-		ASSERT(satapkt != NULL);
 
 		AHCIDBG(AHCIDBG_ERRS, ahci_ctlp, "ahci_mop_commands: "
 		    "sending up pkt 0x%p with SATA_PKT_ABORTED",
@@ -9058,9 +9059,11 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 			    tmp_slot);
 		CLEAR_BIT(ahci_portp->ahciport_pending_tags, tmp_slot);
 		CLEAR_BIT(aborted_tags, tmp_slot);
-		ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
 
-		ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_ABORTED);
+		if (satapkt != NULL) {
+			ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
+			ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_ABORTED);
+		}
 	}
 
 	/* Send up reset packets with SATA_PKT_RESET. */
@@ -9083,7 +9086,6 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 		}
 
 		satapkt = ahci_portp->ahciport_slot_pkts[tmp_slot];
-		ASSERT(satapkt != NULL);
 
 		AHCIDBG(AHCIDBG_ERRS, ahci_ctlp, "ahci_mop_commands: "
 		    "sending up pkt 0x%p with SATA_PKT_RESET",
@@ -9094,9 +9096,11 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 			    tmp_slot);
 		CLEAR_BIT(ahci_portp->ahciport_pending_tags, tmp_slot);
 		CLEAR_BIT(reset_tags, tmp_slot);
-		ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
 
-		ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_RESET);
+		if (satapkt != NULL) {
+			ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
+			ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_RESET);
+		}
 	}
 
 	/* Send up unfinished packets with SATA_PKT_RESET */
@@ -9107,7 +9111,6 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 		}
 
 		satapkt = ahci_portp->ahciport_slot_pkts[tmp_slot];
-		ASSERT(satapkt != NULL);
 
 		AHCIDBG(AHCIDBG_ERRS, ahci_ctlp, "ahci_mop_commands: "
 		    "sending up pkt 0x%p with SATA_PKT_RESET",
@@ -9118,9 +9121,11 @@ ahci_mop_commands(ahci_ctl_t *ahci_ctlp,
 			    tmp_slot);
 		CLEAR_BIT(ahci_portp->ahciport_pending_tags, tmp_slot);
 		CLEAR_BIT(unfinished_tags, tmp_slot);
-		ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
 
-		ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_RESET);
+		if (satapkt != NULL) {
+			ahci_portp->ahciport_slot_pkts[tmp_slot] = NULL;
+			ahci_add_doneq(ahci_portp, satapkt, SATA_PKT_RESET);
+		}
 	}
 
 	ahci_portp->ahciport_mop_in_progress--;


### PR DESCRIPTION
There are several cases where the ahci driver must handle errors and ends up calling the `ahci_mop_commands()` function to mop up pending commands. However, in error cases, the slot_status returned by the driver has bits set for empty slots resulting in a panic due to unreferenced memory access. The reason for the bad slot status is currently unknown, but this change changes ahci_mop_commands() so that empty slots are just ignored.

Here are two different stack traces showing ahci_mop_commands calling ahci_add_doneq with a NULL packet.

```
ffffff00ac8da9c0 ahci_add_doneq+0x14(ffffff17eb3e5000, 0, 1)
  ffffff00ac8daa60 ahci_mop_commands+0x148(ffffff17eb3dde40, ffffff17eb3e5000, 0, 1, 0, 0, ffffff0000000000)
  ffffff00ac8dab00 ahci_fatal_error_recovery_handler+0x241(ffffff17eb3dde40, ffffff17eb3e5000, ffffff17c3d82830, 8000000)
```

```
fffffe000fcc8820 ahci_add_doneq+0x14(fffffe0bd6812080, 0, 5)
fffffe000fcc8990 ahci_mop_commands+0x6c8(fffffe0be00091c0, fffffe0bd6812080, ffffffff, 0, 0, ffffffff, 0)
fffffe000fcc8a00 ahci_reject_all_abort_pkts+0x8b(fffffe0be00091c0, fffffe0bd6812080, 0)
```
