### PR TITLE
Upstream merge joyent_merge/2018110201

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 169deab52cd857330565aa848f67d4d1538ccb67
+Last illumos-joyent commit: e6151003c8efce19988229b39ba3dbb5551dc6f1
 

--- a/usr/contrib/freebsd/dev/nvme/nvme.h
+++ b/usr/contrib/freebsd/dev/nvme/nvme.h
@@ -1,0 +1,1506 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (C) 2012-2013 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef __NVME_H__
+#define __NVME_H__
+
+#ifdef _KERNEL
+#include <sys/types.h>
+#endif
+
+#include <sys/param.h>
+#include <sys/endian.h>
+
+#define	NVME_PASSTHROUGH_CMD		_IOWR('n', 0, struct nvme_pt_command)
+#define	NVME_RESET_CONTROLLER		_IO('n', 1)
+
+#define	NVME_IO_TEST			_IOWR('n', 100, struct nvme_io_test)
+#define	NVME_BIO_TEST			_IOWR('n', 101, struct nvme_io_test)
+
+/*
+ * Macros to deal with NVME revisions, as defined VS register
+ */
+#define NVME_REV(x, y)			(((x) << 16) | ((y) << 8))
+#define NVME_MAJOR(r)			(((r) >> 16) & 0xffff)
+#define NVME_MINOR(r)			(((r) >> 8) & 0xff)
+
+/*
+ * Use to mark a command to apply to all namespaces, or to retrieve global
+ *  log pages.
+ */
+#define NVME_GLOBAL_NAMESPACE_TAG	((uint32_t)0xFFFFFFFF)
+
+/* Cap nvme to 1MB transfers driver explodes with larger sizes */
+#define NVME_MAX_XFER_SIZE		(MAXPHYS < (1<<20) ? MAXPHYS : (1<<20))
+
+/* Register field definitions */
+#define NVME_CAP_LO_REG_MQES_SHIFT			(0)
+#define NVME_CAP_LO_REG_MQES_MASK			(0xFFFF)
+#define NVME_CAP_LO_REG_CQR_SHIFT			(16)
+#define NVME_CAP_LO_REG_CQR_MASK			(0x1)
+#define NVME_CAP_LO_REG_AMS_SHIFT			(17)
+#define NVME_CAP_LO_REG_AMS_MASK			(0x3)
+#define NVME_CAP_LO_REG_TO_SHIFT			(24)
+#define NVME_CAP_LO_REG_TO_MASK				(0xFF)
+
+#define NVME_CAP_HI_REG_DSTRD_SHIFT			(0)
+#define NVME_CAP_HI_REG_DSTRD_MASK			(0xF)
+#define NVME_CAP_HI_REG_CSS_NVM_SHIFT			(5)
+#define NVME_CAP_HI_REG_CSS_NVM_MASK			(0x1)
+#define NVME_CAP_HI_REG_MPSMIN_SHIFT			(16)
+#define NVME_CAP_HI_REG_MPSMIN_MASK			(0xF)
+#define NVME_CAP_HI_REG_MPSMAX_SHIFT			(20)
+#define NVME_CAP_HI_REG_MPSMAX_MASK			(0xF)
+
+#define NVME_CC_REG_EN_SHIFT				(0)
+#define NVME_CC_REG_EN_MASK				(0x1)
+#define NVME_CC_REG_CSS_SHIFT				(4)
+#define NVME_CC_REG_CSS_MASK				(0x7)
+#define NVME_CC_REG_MPS_SHIFT				(7)
+#define NVME_CC_REG_MPS_MASK				(0xF)
+#define NVME_CC_REG_AMS_SHIFT				(11)
+#define NVME_CC_REG_AMS_MASK				(0x7)
+#define NVME_CC_REG_SHN_SHIFT				(14)
+#define NVME_CC_REG_SHN_MASK				(0x3)
+#define NVME_CC_REG_IOSQES_SHIFT			(16)
+#define NVME_CC_REG_IOSQES_MASK				(0xF)
+#define NVME_CC_REG_IOCQES_SHIFT			(20)
+#define NVME_CC_REG_IOCQES_MASK				(0xF)
+
+#define NVME_CSTS_REG_RDY_SHIFT				(0)
+#define NVME_CSTS_REG_RDY_MASK				(0x1)
+#define NVME_CSTS_REG_CFS_SHIFT				(1)
+#define NVME_CSTS_REG_CFS_MASK				(0x1)
+#define NVME_CSTS_REG_SHST_SHIFT			(2)
+#define NVME_CSTS_REG_SHST_MASK				(0x3)
+
+#define NVME_CSTS_GET_SHST(csts)			(((csts) >> NVME_CSTS_REG_SHST_SHIFT) & NVME_CSTS_REG_SHST_MASK)
+
+#define NVME_AQA_REG_ASQS_SHIFT				(0)
+#define NVME_AQA_REG_ASQS_MASK				(0xFFF)
+#define NVME_AQA_REG_ACQS_SHIFT				(16)
+#define NVME_AQA_REG_ACQS_MASK				(0xFFF)
+
+/* Command field definitions */
+
+#define NVME_CMD_FUSE_SHIFT				(8)
+#define NVME_CMD_FUSE_MASK				(0x3)
+
+#define NVME_STATUS_P_SHIFT				(0)
+#define NVME_STATUS_P_MASK				(0x1)
+#define NVME_STATUS_SC_SHIFT				(1)
+#define NVME_STATUS_SC_MASK				(0xFF)
+#define NVME_STATUS_SCT_SHIFT				(9)
+#define NVME_STATUS_SCT_MASK				(0x7)
+#define NVME_STATUS_M_SHIFT				(14)
+#define NVME_STATUS_M_MASK				(0x1)
+#define NVME_STATUS_DNR_SHIFT				(15)
+#define NVME_STATUS_DNR_MASK				(0x1)
+
+#define NVME_STATUS_GET_P(st)				(((st) >> NVME_STATUS_P_SHIFT) & NVME_STATUS_P_MASK)
+#define NVME_STATUS_GET_SC(st)				(((st) >> NVME_STATUS_SC_SHIFT) & NVME_STATUS_SC_MASK)
+#define NVME_STATUS_GET_SCT(st)				(((st) >> NVME_STATUS_SCT_SHIFT) & NVME_STATUS_SCT_MASK)
+#define NVME_STATUS_GET_M(st)				(((st) >> NVME_STATUS_M_SHIFT) & NVME_STATUS_M_MASK)
+#define NVME_STATUS_GET_DNR(st)				(((st) >> NVME_STATUS_DNR_SHIFT) & NVME_STATUS_DNR_MASK)
+
+#define NVME_PWR_ST_MPS_SHIFT				(0)
+#define NVME_PWR_ST_MPS_MASK				(0x1)
+#define NVME_PWR_ST_NOPS_SHIFT				(1)
+#define NVME_PWR_ST_NOPS_MASK				(0x1)
+#define NVME_PWR_ST_RRT_SHIFT				(0)
+#define NVME_PWR_ST_RRT_MASK				(0x1F)
+#define NVME_PWR_ST_RRL_SHIFT				(0)
+#define NVME_PWR_ST_RRL_MASK				(0x1F)
+#define NVME_PWR_ST_RWT_SHIFT				(0)
+#define NVME_PWR_ST_RWT_MASK				(0x1F)
+#define NVME_PWR_ST_RWL_SHIFT				(0)
+#define NVME_PWR_ST_RWL_MASK				(0x1F)
+#define NVME_PWR_ST_IPS_SHIFT				(6)
+#define NVME_PWR_ST_IPS_MASK				(0x3)
+#define NVME_PWR_ST_APW_SHIFT				(0)
+#define NVME_PWR_ST_APW_MASK				(0x7)
+#define NVME_PWR_ST_APS_SHIFT				(6)
+#define NVME_PWR_ST_APS_MASK				(0x3)
+
+/** Controller Multi-path I/O and Namespace Sharing Capabilities */
+/* More then one port */
+#define NVME_CTRLR_DATA_MIC_MPORTS_SHIFT		(0)
+#define NVME_CTRLR_DATA_MIC_MPORTS_MASK			(0x1)
+/* More then one controller */
+#define NVME_CTRLR_DATA_MIC_MCTRLRS_SHIFT		(1)
+#define NVME_CTRLR_DATA_MIC_MCTRLRS_MASK		(0x1)
+/* SR-IOV Virtual Function */
+#define NVME_CTRLR_DATA_MIC_SRIOVVF_SHIFT		(2)
+#define NVME_CTRLR_DATA_MIC_SRIOVVF_MASK		(0x1)
+
+/** OACS - optional admin command support */
+/* supports security send/receive commands */
+#define NVME_CTRLR_DATA_OACS_SECURITY_SHIFT		(0)
+#define NVME_CTRLR_DATA_OACS_SECURITY_MASK		(0x1)
+/* supports format nvm command */
+#define NVME_CTRLR_DATA_OACS_FORMAT_SHIFT		(1)
+#define NVME_CTRLR_DATA_OACS_FORMAT_MASK		(0x1)
+/* supports firmware activate/download commands */
+#define NVME_CTRLR_DATA_OACS_FIRMWARE_SHIFT		(2)
+#define NVME_CTRLR_DATA_OACS_FIRMWARE_MASK		(0x1)
+/* supports namespace management commands */
+#define NVME_CTRLR_DATA_OACS_NSMGMT_SHIFT		(3)
+#define NVME_CTRLR_DATA_OACS_NSMGMT_MASK		(0x1)
+/* supports Device Self-test command */
+#define NVME_CTRLR_DATA_OACS_SELFTEST_SHIFT		(4)
+#define NVME_CTRLR_DATA_OACS_SELFTEST_MASK		(0x1)
+/* supports Directives */
+#define NVME_CTRLR_DATA_OACS_DIRECTIVES_SHIFT		(5)
+#define NVME_CTRLR_DATA_OACS_DIRECTIVES_MASK		(0x1)
+/* supports NVMe-MI Send/Receive */
+#define NVME_CTRLR_DATA_OACS_NVMEMI_SHIFT		(6)
+#define NVME_CTRLR_DATA_OACS_NVMEMI_MASK		(0x1)
+/* supports Virtualization Management */
+#define NVME_CTRLR_DATA_OACS_VM_SHIFT			(7)
+#define NVME_CTRLR_DATA_OACS_VM_MASK			(0x1)
+/* supports Doorbell Buffer Config */
+#define NVME_CTRLR_DATA_OACS_DBBUFFER_SHIFT		(8)
+#define NVME_CTRLR_DATA_OACS_DBBUFFER_MASK		(0x1)
+
+/** firmware updates */
+/* first slot is read-only */
+#define NVME_CTRLR_DATA_FRMW_SLOT1_RO_SHIFT		(0)
+#define NVME_CTRLR_DATA_FRMW_SLOT1_RO_MASK		(0x1)
+/* number of firmware slots */
+#define NVME_CTRLR_DATA_FRMW_NUM_SLOTS_SHIFT		(1)
+#define NVME_CTRLR_DATA_FRMW_NUM_SLOTS_MASK		(0x7)
+
+/** log page attributes */
+/* per namespace smart/health log page */
+#define NVME_CTRLR_DATA_LPA_NS_SMART_SHIFT		(0)
+#define NVME_CTRLR_DATA_LPA_NS_SMART_MASK		(0x1)
+
+/** AVSCC - admin vendor specific command configuration */
+/* admin vendor specific commands use spec format */
+#define NVME_CTRLR_DATA_AVSCC_SPEC_FORMAT_SHIFT		(0)
+#define NVME_CTRLR_DATA_AVSCC_SPEC_FORMAT_MASK		(0x1)
+
+/** Autonomous Power State Transition Attributes */
+/* Autonomous Power State Transitions supported */
+#define NVME_CTRLR_DATA_APSTA_APST_SUPP_SHIFT		(0)
+#define NVME_CTRLR_DATA_APSTA_APST_SUPP_MASK		(0x1)
+
+/** submission queue entry size */
+#define NVME_CTRLR_DATA_SQES_MIN_SHIFT			(0)
+#define NVME_CTRLR_DATA_SQES_MIN_MASK			(0xF)
+#define NVME_CTRLR_DATA_SQES_MAX_SHIFT			(4)
+#define NVME_CTRLR_DATA_SQES_MAX_MASK			(0xF)
+
+/** completion queue entry size */
+#define NVME_CTRLR_DATA_CQES_MIN_SHIFT			(0)
+#define NVME_CTRLR_DATA_CQES_MIN_MASK			(0xF)
+#define NVME_CTRLR_DATA_CQES_MAX_SHIFT			(4)
+#define NVME_CTRLR_DATA_CQES_MAX_MASK			(0xF)
+
+/** optional nvm command support */
+#define NVME_CTRLR_DATA_ONCS_COMPARE_SHIFT		(0)
+#define NVME_CTRLR_DATA_ONCS_COMPARE_MASK		(0x1)
+#define NVME_CTRLR_DATA_ONCS_WRITE_UNC_SHIFT		(1)
+#define NVME_CTRLR_DATA_ONCS_WRITE_UNC_MASK		(0x1)
+#define NVME_CTRLR_DATA_ONCS_DSM_SHIFT			(2)
+#define NVME_CTRLR_DATA_ONCS_DSM_MASK			(0x1)
+#define NVME_CTRLR_DATA_ONCS_WRZERO_SHIFT		(3)
+#define NVME_CTRLR_DATA_ONCS_WRZERO_MASK		(0x1)
+#define NVME_CTRLR_DATA_ONCS_SAVEFEAT_SHIFT		(4)
+#define NVME_CTRLR_DATA_ONCS_SAVEFEAT_MASK		(0x1)
+#define NVME_CTRLR_DATA_ONCS_RESERV_SHIFT		(5)
+#define NVME_CTRLR_DATA_ONCS_RESERV_MASK		(0x1)
+#define NVME_CTRLR_DATA_ONCS_TIMESTAMP_SHIFT		(6)
+#define NVME_CTRLR_DATA_ONCS_TIMESTAMP_MASK		(0x1)
+
+/** Fused Operation Support */
+#define NVME_CTRLR_DATA_FUSES_CNW_SHIFT		(0)
+#define NVME_CTRLR_DATA_FUSES_CNW_MASK		(0x1)
+
+/** Format NVM Attributes */
+#define NVME_CTRLR_DATA_FNA_FORMAT_ALL_SHIFT		(0)
+#define NVME_CTRLR_DATA_FNA_FORMAT_ALL_MASK		(0x1)
+#define NVME_CTRLR_DATA_FNA_ERASE_ALL_SHIFT		(1)
+#define NVME_CTRLR_DATA_FNA_ERASE_ALL_MASK		(0x1)
+#define NVME_CTRLR_DATA_FNA_CRYPTO_ERASE_SHIFT		(2)
+#define NVME_CTRLR_DATA_FNA_CRYPTO_ERASE_MASK		(0x1)
+
+/** volatile write cache */
+#define NVME_CTRLR_DATA_VWC_PRESENT_SHIFT		(0)
+#define NVME_CTRLR_DATA_VWC_PRESENT_MASK		(0x1)
+
+/** namespace features */
+/* thin provisioning */
+#define NVME_NS_DATA_NSFEAT_THIN_PROV_SHIFT		(0)
+#define NVME_NS_DATA_NSFEAT_THIN_PROV_MASK		(0x1)
+/* NAWUN, NAWUPF, and NACWU fields are valid */
+#define NVME_NS_DATA_NSFEAT_NA_FIELDS_SHIFT		(1)
+#define NVME_NS_DATA_NSFEAT_NA_FIELDS_MASK		(0x1)
+/* Deallocated or Unwritten Logical Block errors supported */
+#define NVME_NS_DATA_NSFEAT_DEALLOC_SHIFT		(2)
+#define NVME_NS_DATA_NSFEAT_DEALLOC_MASK		(0x1)
+/* NGUID and EUI64 fields are not reusable */
+#define NVME_NS_DATA_NSFEAT_NO_ID_REUSE_SHIFT		(3)
+#define NVME_NS_DATA_NSFEAT_NO_ID_REUSE_MASK		(0x1)
+
+/** formatted lba size */
+#define NVME_NS_DATA_FLBAS_FORMAT_SHIFT			(0)
+#define NVME_NS_DATA_FLBAS_FORMAT_MASK			(0xF)
+#define NVME_NS_DATA_FLBAS_EXTENDED_SHIFT		(4)
+#define NVME_NS_DATA_FLBAS_EXTENDED_MASK		(0x1)
+
+/** metadata capabilities */
+/* metadata can be transferred as part of data prp list */
+#define NVME_NS_DATA_MC_EXTENDED_SHIFT			(0)
+#define NVME_NS_DATA_MC_EXTENDED_MASK			(0x1)
+/* metadata can be transferred with separate metadata pointer */
+#define NVME_NS_DATA_MC_POINTER_SHIFT			(1)
+#define NVME_NS_DATA_MC_POINTER_MASK			(0x1)
+
+/** end-to-end data protection capabilities */
+/* protection information type 1 */
+#define NVME_NS_DATA_DPC_PIT1_SHIFT			(0)
+#define NVME_NS_DATA_DPC_PIT1_MASK			(0x1)
+/* protection information type 2 */
+#define NVME_NS_DATA_DPC_PIT2_SHIFT			(1)
+#define NVME_NS_DATA_DPC_PIT2_MASK			(0x1)
+/* protection information type 3 */
+#define NVME_NS_DATA_DPC_PIT3_SHIFT			(2)
+#define NVME_NS_DATA_DPC_PIT3_MASK			(0x1)
+/* first eight bytes of metadata */
+#define NVME_NS_DATA_DPC_MD_START_SHIFT			(3)
+#define NVME_NS_DATA_DPC_MD_START_MASK			(0x1)
+/* last eight bytes of metadata */
+#define NVME_NS_DATA_DPC_MD_END_SHIFT			(4)
+#define NVME_NS_DATA_DPC_MD_END_MASK			(0x1)
+
+/** end-to-end data protection type settings */
+/* protection information type */
+#define NVME_NS_DATA_DPS_PIT_SHIFT			(0)
+#define NVME_NS_DATA_DPS_PIT_MASK			(0x7)
+/* 1 == protection info transferred at start of metadata */
+/* 0 == protection info transferred at end of metadata */
+#define NVME_NS_DATA_DPS_MD_START_SHIFT			(3)
+#define NVME_NS_DATA_DPS_MD_START_MASK			(0x1)
+
+/** Namespace Multi-path I/O and Namespace Sharing Capabilities */
+/* the namespace may be attached to two or more controllers */
+#define NVME_NS_DATA_NMIC_MAY_BE_SHARED_SHIFT		(0)
+#define NVME_NS_DATA_NMIC_MAY_BE_SHARED_MASK		(0x1)
+
+/** Reservation Capabilities */
+/* Persist Through Power Loss */
+#define NVME_NS_DATA_RESCAP_PTPL_SHIFT		(0)
+#define NVME_NS_DATA_RESCAP_PTPL_MASK		(0x1)
+/* supports the Write Exclusive */
+#define NVME_NS_DATA_RESCAP_WR_EX_SHIFT		(1)
+#define NVME_NS_DATA_RESCAP_WR_EX_MASK		(0x1)
+/* supports the Exclusive Access */
+#define NVME_NS_DATA_RESCAP_EX_AC_SHIFT		(2)
+#define NVME_NS_DATA_RESCAP_EX_AC_MASK		(0x1)
+/* supports the Write Exclusive – Registrants Only */
+#define NVME_NS_DATA_RESCAP_WR_EX_RO_SHIFT	(3)
+#define NVME_NS_DATA_RESCAP_WR_EX_RO_MASK	(0x1)
+/* supports the Exclusive Access - Registrants Only */
+#define NVME_NS_DATA_RESCAP_EX_AC_RO_SHIFT	(4)
+#define NVME_NS_DATA_RESCAP_EX_AC_RO_MASK	(0x1)
+/* supports the Write Exclusive – All Registrants */
+#define NVME_NS_DATA_RESCAP_WR_EX_AR_SHIFT	(5)
+#define NVME_NS_DATA_RESCAP_WR_EX_AR_MASK	(0x1)
+/* supports the Exclusive Access - All Registrants */
+#define NVME_NS_DATA_RESCAP_EX_AC_AR_SHIFT	(6)
+#define NVME_NS_DATA_RESCAP_EX_AC_AR_MASK	(0x1)
+/* Ignore Existing Key is used as defined in revision 1.3 or later */
+#define NVME_NS_DATA_RESCAP_IEKEY13_SHIFT	(7)
+#define NVME_NS_DATA_RESCAP_IEKEY13_MASK	(0x1)
+
+/** Format Progress Indicator */
+/* percentage of the Format NVM command that remains to be completed */
+#define NVME_NS_DATA_FPI_PERC_SHIFT		(0)
+#define NVME_NS_DATA_FPI_PERC_MASK		(0x7f)
+/* namespace supports the Format Progress Indicator */
+#define NVME_NS_DATA_FPI_SUPP_SHIFT		(7)
+#define NVME_NS_DATA_FPI_SUPP_MASK		(0x1)
+
+/** lba format support */
+/* metadata size */
+#define NVME_NS_DATA_LBAF_MS_SHIFT			(0)
+#define NVME_NS_DATA_LBAF_MS_MASK			(0xFFFF)
+/* lba data size */
+#define NVME_NS_DATA_LBAF_LBADS_SHIFT			(16)
+#define NVME_NS_DATA_LBAF_LBADS_MASK			(0xFF)
+/* relative performance */
+#define NVME_NS_DATA_LBAF_RP_SHIFT			(24)
+#define NVME_NS_DATA_LBAF_RP_MASK			(0x3)
+
+enum nvme_critical_warning_state {
+	NVME_CRIT_WARN_ST_AVAILABLE_SPARE		= 0x1,
+	NVME_CRIT_WARN_ST_TEMPERATURE			= 0x2,
+	NVME_CRIT_WARN_ST_DEVICE_RELIABILITY		= 0x4,
+	NVME_CRIT_WARN_ST_READ_ONLY			= 0x8,
+	NVME_CRIT_WARN_ST_VOLATILE_MEMORY_BACKUP	= 0x10,
+};
+#define NVME_CRIT_WARN_ST_RESERVED_MASK			(0xE0)
+
+/* slot for current FW */
+#define NVME_FIRMWARE_PAGE_AFI_SLOT_SHIFT		(0)
+#define NVME_FIRMWARE_PAGE_AFI_SLOT_MASK		(0x7)
+
+/* CC register SHN field values */
+enum shn_value {
+	NVME_SHN_NORMAL		= 0x1,
+	NVME_SHN_ABRUPT		= 0x2,
+};
+
+/* CSTS register SHST field values */
+enum shst_value {
+	NVME_SHST_NORMAL	= 0x0,
+	NVME_SHST_OCCURRING	= 0x1,
+	NVME_SHST_COMPLETE	= 0x2,
+};
+
+struct nvme_registers
+{
+	/** controller capabilities */
+	uint32_t		cap_lo;
+	uint32_t		cap_hi;
+
+	uint32_t		vs;	/* version */
+	uint32_t		intms;	/* interrupt mask set */
+	uint32_t		intmc;	/* interrupt mask clear */
+
+	/** controller configuration */
+	uint32_t		cc;
+
+	uint32_t		reserved1;
+
+	/** controller status */
+	uint32_t		csts;
+
+	uint32_t		reserved2;
+
+	/** admin queue attributes */
+	uint32_t		aqa;
+
+	uint64_t		asq;	/* admin submission queue base addr */
+	uint64_t		acq;	/* admin completion queue base addr */
+	uint32_t		reserved3[0x3f2];
+
+	struct {
+	    uint32_t		sq_tdbl; /* submission queue tail doorbell */
+	    uint32_t		cq_hdbl; /* completion queue head doorbell */
+	} doorbell[1] __packed;
+} __packed;
+
+_Static_assert(sizeof(struct nvme_registers) == 0x1008, "bad size for nvme_registers");
+
+struct nvme_command
+{
+	/* dword 0 */
+	uint8_t opc;		/* opcode */
+	uint8_t fuse;		/* fused operation */
+	uint16_t cid;		/* command identifier */
+
+	/* dword 1 */
+	uint32_t nsid;		/* namespace identifier */
+
+	/* dword 2-3 */
+	uint32_t rsvd2;
+	uint32_t rsvd3;
+
+	/* dword 4-5 */
+	uint64_t mptr;		/* metadata pointer */
+
+	/* dword 6-7 */
+	uint64_t prp1;		/* prp entry 1 */
+
+	/* dword 8-9 */
+	uint64_t prp2;		/* prp entry 2 */
+
+	/* dword 10-15 */
+	uint32_t cdw10;		/* command-specific */
+	uint32_t cdw11;		/* command-specific */
+	uint32_t cdw12;		/* command-specific */
+	uint32_t cdw13;		/* command-specific */
+	uint32_t cdw14;		/* command-specific */
+	uint32_t cdw15;		/* command-specific */
+} __packed;
+
+_Static_assert(sizeof(struct nvme_command) == 16 * 4, "bad size for nvme_command");
+
+struct nvme_completion {
+
+	/* dword 0 */
+	uint32_t		cdw0;	/* command-specific */
+
+	/* dword 1 */
+	uint32_t		rsvd1;
+
+	/* dword 2 */
+	uint16_t		sqhd;	/* submission queue head pointer */
+	uint16_t		sqid;	/* submission queue identifier */
+
+	/* dword 3 */
+	uint16_t		cid;	/* command identifier */
+	uint16_t		status;
+} __packed;
+
+_Static_assert(sizeof(struct nvme_completion) == 4 * 4, "bad size for nvme_completion");
+
+struct nvme_dsm_range {
+	uint32_t attributes;
+	uint32_t length;
+	uint64_t starting_lba;
+} __packed;
+
+/* Largest DSM Trim that can be done */
+#define NVME_MAX_DSM_TRIM		4096
+
+_Static_assert(sizeof(struct nvme_dsm_range) == 16, "bad size for nvme_dsm_ranage");
+
+/* status code types */
+enum nvme_status_code_type {
+	NVME_SCT_GENERIC		= 0x0,
+	NVME_SCT_COMMAND_SPECIFIC	= 0x1,
+	NVME_SCT_MEDIA_ERROR		= 0x2,
+	/* 0x3-0x6 - reserved */
+	NVME_SCT_VENDOR_SPECIFIC	= 0x7,
+};
+
+/* generic command status codes */
+enum nvme_generic_command_status_code {
+	NVME_SC_SUCCESS				= 0x00,
+	NVME_SC_INVALID_OPCODE			= 0x01,
+	NVME_SC_INVALID_FIELD			= 0x02,
+	NVME_SC_COMMAND_ID_CONFLICT		= 0x03,
+	NVME_SC_DATA_TRANSFER_ERROR		= 0x04,
+	NVME_SC_ABORTED_POWER_LOSS		= 0x05,
+	NVME_SC_INTERNAL_DEVICE_ERROR		= 0x06,
+	NVME_SC_ABORTED_BY_REQUEST		= 0x07,
+	NVME_SC_ABORTED_SQ_DELETION		= 0x08,
+	NVME_SC_ABORTED_FAILED_FUSED		= 0x09,
+	NVME_SC_ABORTED_MISSING_FUSED		= 0x0a,
+	NVME_SC_INVALID_NAMESPACE_OR_FORMAT	= 0x0b,
+	NVME_SC_COMMAND_SEQUENCE_ERROR		= 0x0c,
+	NVME_SC_INVALID_SGL_SEGMENT_DESCR	= 0x0d,
+	NVME_SC_INVALID_NUMBER_OF_SGL_DESCR	= 0x0e,
+	NVME_SC_DATA_SGL_LENGTH_INVALID		= 0x0f,
+	NVME_SC_METADATA_SGL_LENGTH_INVALID	= 0x10,
+	NVME_SC_SGL_DESCRIPTOR_TYPE_INVALID	= 0x11,
+	NVME_SC_INVALID_USE_OF_CMB		= 0x12,
+	NVME_SC_PRP_OFFET_INVALID		= 0x13,
+	NVME_SC_ATOMIC_WRITE_UNIT_EXCEEDED	= 0x14,
+	NVME_SC_OPERATION_DENIED		= 0x15,
+	NVME_SC_SGL_OFFSET_INVALID		= 0x16,
+	/* 0x17 - reserved */
+	NVME_SC_HOST_ID_INCONSISTENT_FORMAT	= 0x18,
+	NVME_SC_KEEP_ALIVE_TIMEOUT_EXPIRED	= 0x19,
+	NVME_SC_KEEP_ALIVE_TIMEOUT_INVALID	= 0x1a,
+	NVME_SC_ABORTED_DUE_TO_PREEMPT		= 0x1b,
+	NVME_SC_SANITIZE_FAILED			= 0x1c,
+	NVME_SC_SANITIZE_IN_PROGRESS		= 0x1d,
+	NVME_SC_SGL_DATA_BLOCK_GRAN_INVALID	= 0x1e,
+	NVME_SC_NOT_SUPPORTED_IN_CMB		= 0x1f,
+
+	NVME_SC_LBA_OUT_OF_RANGE		= 0x80,
+	NVME_SC_CAPACITY_EXCEEDED		= 0x81,
+	NVME_SC_NAMESPACE_NOT_READY		= 0x82,
+	NVME_SC_RESERVATION_CONFLICT		= 0x83,
+	NVME_SC_FORMAT_IN_PROGRESS		= 0x84,
+};
+
+/* command specific status codes */
+enum nvme_command_specific_status_code {
+	NVME_SC_COMPLETION_QUEUE_INVALID	= 0x00,
+	NVME_SC_INVALID_QUEUE_IDENTIFIER	= 0x01,
+	NVME_SC_MAXIMUM_QUEUE_SIZE_EXCEEDED	= 0x02,
+	NVME_SC_ABORT_COMMAND_LIMIT_EXCEEDED	= 0x03,
+	/* 0x04 - reserved */
+	NVME_SC_ASYNC_EVENT_REQUEST_LIMIT_EXCEEDED = 0x05,
+	NVME_SC_INVALID_FIRMWARE_SLOT		= 0x06,
+	NVME_SC_INVALID_FIRMWARE_IMAGE		= 0x07,
+	NVME_SC_INVALID_INTERRUPT_VECTOR	= 0x08,
+	NVME_SC_INVALID_LOG_PAGE		= 0x09,
+	NVME_SC_INVALID_FORMAT			= 0x0a,
+	NVME_SC_FIRMWARE_REQUIRES_RESET		= 0x0b,
+	NVME_SC_INVALID_QUEUE_DELETION		= 0x0c,
+	NVME_SC_FEATURE_NOT_SAVEABLE		= 0x0d,
+	NVME_SC_FEATURE_NOT_CHANGEABLE		= 0x0e,
+	NVME_SC_FEATURE_NOT_NS_SPECIFIC		= 0x0f,
+	NVME_SC_FW_ACT_REQUIRES_NVMS_RESET	= 0x10,
+	NVME_SC_FW_ACT_REQUIRES_RESET		= 0x11,
+	NVME_SC_FW_ACT_REQUIRES_TIME		= 0x12,
+	NVME_SC_FW_ACT_PROHIBITED		= 0x13,
+	NVME_SC_OVERLAPPING_RANGE		= 0x14,
+	NVME_SC_NS_INSUFFICIENT_CAPACITY	= 0x15,
+	NVME_SC_NS_ID_UNAVAILABLE		= 0x16,
+	/* 0x17 - reserved */
+	NVME_SC_NS_ALREADY_ATTACHED		= 0x18,
+	NVME_SC_NS_IS_PRIVATE			= 0x19,
+	NVME_SC_NS_NOT_ATTACHED			= 0x1a,
+	NVME_SC_THIN_PROV_NOT_SUPPORTED		= 0x1b,
+	NVME_SC_CTRLR_LIST_INVALID		= 0x1c,
+	NVME_SC_SELT_TEST_IN_PROGRESS		= 0x1d,
+	NVME_SC_BOOT_PART_WRITE_PROHIB		= 0x1e,
+	NVME_SC_INVALID_CTRLR_ID		= 0x1f,
+	NVME_SC_INVALID_SEC_CTRLR_STATE		= 0x20,
+	NVME_SC_INVALID_NUM_OF_CTRLR_RESRC	= 0x21,
+	NVME_SC_INVALID_RESOURCE_ID		= 0x22,
+
+	NVME_SC_CONFLICTING_ATTRIBUTES		= 0x80,
+	NVME_SC_INVALID_PROTECTION_INFO		= 0x81,
+	NVME_SC_ATTEMPTED_WRITE_TO_RO_PAGE	= 0x82,
+};
+
+/* media error status codes */
+enum nvme_media_error_status_code {
+	NVME_SC_WRITE_FAULTS			= 0x80,
+	NVME_SC_UNRECOVERED_READ_ERROR		= 0x81,
+	NVME_SC_GUARD_CHECK_ERROR		= 0x82,
+	NVME_SC_APPLICATION_TAG_CHECK_ERROR	= 0x83,
+	NVME_SC_REFERENCE_TAG_CHECK_ERROR	= 0x84,
+	NVME_SC_COMPARE_FAILURE			= 0x85,
+	NVME_SC_ACCESS_DENIED			= 0x86,
+	NVME_SC_DEALLOCATED_OR_UNWRITTEN	= 0x87,
+};
+
+/* admin opcodes */
+enum nvme_admin_opcode {
+	NVME_OPC_DELETE_IO_SQ			= 0x00,
+	NVME_OPC_CREATE_IO_SQ			= 0x01,
+	NVME_OPC_GET_LOG_PAGE			= 0x02,
+	/* 0x03 - reserved */
+	NVME_OPC_DELETE_IO_CQ			= 0x04,
+	NVME_OPC_CREATE_IO_CQ			= 0x05,
+	NVME_OPC_IDENTIFY			= 0x06,
+	/* 0x07 - reserved */
+	NVME_OPC_ABORT				= 0x08,
+	NVME_OPC_SET_FEATURES			= 0x09,
+	NVME_OPC_GET_FEATURES			= 0x0a,
+	/* 0x0b - reserved */
+	NVME_OPC_ASYNC_EVENT_REQUEST		= 0x0c,
+	NVME_OPC_NAMESPACE_MANAGEMENT		= 0x0d,
+	/* 0x0e-0x0f - reserved */
+	NVME_OPC_FIRMWARE_ACTIVATE		= 0x10,
+	NVME_OPC_FIRMWARE_IMAGE_DOWNLOAD	= 0x11,
+	NVME_OPC_DEVICE_SELF_TEST		= 0x14,
+	NVME_OPC_NAMESPACE_ATTACHMENT		= 0x15,
+	NVME_OPC_KEEP_ALIVE			= 0x18,
+	NVME_OPC_DIRECTIVE_SEND			= 0x19,
+	NVME_OPC_DIRECTIVE_RECEIVE		= 0x1a,
+	NVME_OPC_VIRTUALIZATION_MANAGEMENT	= 0x1c,
+	NVME_OPC_NVME_MI_SEND			= 0x1d,
+	NVME_OPC_NVME_MI_RECEIVE		= 0x1e,
+	NVME_OPC_DOORBELL_BUFFER_CONFIG		= 0x7c,
+
+	NVME_OPC_FORMAT_NVM			= 0x80,
+	NVME_OPC_SECURITY_SEND			= 0x81,
+	NVME_OPC_SECURITY_RECEIVE		= 0x82,
+	NVME_OPC_SANITIZE			= 0x84,
+};
+
+/* nvme nvm opcodes */
+enum nvme_nvm_opcode {
+	NVME_OPC_FLUSH				= 0x00,
+	NVME_OPC_WRITE				= 0x01,
+	NVME_OPC_READ				= 0x02,
+	/* 0x03 - reserved */
+	NVME_OPC_WRITE_UNCORRECTABLE		= 0x04,
+	NVME_OPC_COMPARE			= 0x05,
+	/* 0x06 - reserved */
+	NVME_OPC_WRITE_ZEROES			= 0x08,
+	/* 0x07 - reserved */
+	NVME_OPC_DATASET_MANAGEMENT		= 0x09,
+	/* 0x0a-0x0c - reserved */
+	NVME_OPC_RESERVATION_REGISTER		= 0x0d,
+	NVME_OPC_RESERVATION_REPORT		= 0x0e,
+	/* 0x0f-0x10 - reserved */
+	NVME_OPC_RESERVATION_ACQUIRE		= 0x11,
+	/* 0x12-0x14 - reserved */
+	NVME_OPC_RESERVATION_RELEASE		= 0x15,
+};
+
+enum nvme_feature {
+	/* 0x00 - reserved */
+	NVME_FEAT_ARBITRATION			= 0x01,
+	NVME_FEAT_POWER_MANAGEMENT		= 0x02,
+	NVME_FEAT_LBA_RANGE_TYPE		= 0x03,
+	NVME_FEAT_TEMPERATURE_THRESHOLD		= 0x04,
+	NVME_FEAT_ERROR_RECOVERY		= 0x05,
+	NVME_FEAT_VOLATILE_WRITE_CACHE		= 0x06,
+	NVME_FEAT_NUMBER_OF_QUEUES		= 0x07,
+	NVME_FEAT_INTERRUPT_COALESCING		= 0x08,
+	NVME_FEAT_INTERRUPT_VECTOR_CONFIGURATION = 0x09,
+	NVME_FEAT_WRITE_ATOMICITY		= 0x0A,
+	NVME_FEAT_ASYNC_EVENT_CONFIGURATION	= 0x0B,
+	NVME_FEAT_AUTONOMOUS_POWER_STATE_TRANSITION = 0x0C,
+	NVME_FEAT_HOST_MEMORY_BUFFER		= 0x0D,
+	NVME_FEAT_TIMESTAMP			= 0x0E,
+	NVME_FEAT_KEEP_ALIVE_TIMER		= 0x0F,
+	NVME_FEAT_HOST_CONTROLLED_THERMAL_MGMT	= 0x10,
+	NVME_FEAT_NON_OP_POWER_STATE_CONFIG	= 0x11,
+	/* 0x12-0x77 - reserved */
+	/* 0x78-0x7f - NVMe Management Interface */
+	NVME_FEAT_SOFTWARE_PROGRESS_MARKER	= 0x80,
+	/* 0x81-0xBF - command set specific (reserved) */
+	/* 0xC0-0xFF - vendor specific */
+};
+
+enum nvme_dsm_attribute {
+	NVME_DSM_ATTR_INTEGRAL_READ		= 0x1,
+	NVME_DSM_ATTR_INTEGRAL_WRITE		= 0x2,
+	NVME_DSM_ATTR_DEALLOCATE		= 0x4,
+};
+
+enum nvme_activate_action {
+	NVME_AA_REPLACE_NO_ACTIVATE		= 0x0,
+	NVME_AA_REPLACE_ACTIVATE		= 0x1,
+	NVME_AA_ACTIVATE			= 0x2,
+};
+
+struct nvme_power_state {
+	/** Maximum Power */
+	uint16_t	mp;			/* Maximum Power */
+	uint8_t		ps_rsvd1;
+	uint8_t		mps_nops;		/* Max Power Scale, Non-Operational State */
+
+	uint32_t	enlat;			/* Entry Latency */
+	uint32_t	exlat;			/* Exit Latency */
+
+	uint8_t		rrt;			/* Relative Read Throughput */
+	uint8_t		rrl;			/* Relative Read Latency */
+	uint8_t		rwt;			/* Relative Write Throughput */
+	uint8_t		rwl;			/* Relative Write Latency */
+
+	uint16_t	idlp;			/* Idle Power */
+	uint8_t		ips;			/* Idle Power Scale */
+	uint8_t		ps_rsvd8;
+
+	uint16_t	actp;			/* Active Power */
+	uint8_t		apw_aps;		/* Active Power Workload, Active Power Scale */
+	uint8_t		ps_rsvd10[9];
+} __packed;
+
+_Static_assert(sizeof(struct nvme_power_state) == 32, "bad size for nvme_power_state");
+
+#define NVME_SERIAL_NUMBER_LENGTH	20
+#define NVME_MODEL_NUMBER_LENGTH	40
+#define NVME_FIRMWARE_REVISION_LENGTH	8
+
+struct nvme_controller_data {
+
+	/* bytes 0-255: controller capabilities and features */
+
+	/** pci vendor id */
+	uint16_t		vid;
+
+	/** pci subsystem vendor id */
+	uint16_t		ssvid;
+
+	/** serial number */
+	uint8_t			sn[NVME_SERIAL_NUMBER_LENGTH];
+
+	/** model number */
+	uint8_t			mn[NVME_MODEL_NUMBER_LENGTH];
+
+	/** firmware revision */
+	uint8_t			fr[NVME_FIRMWARE_REVISION_LENGTH];
+
+	/** recommended arbitration burst */
+	uint8_t			rab;
+
+	/** ieee oui identifier */
+	uint8_t			ieee[3];
+
+	/** multi-interface capabilities */
+	uint8_t			mic;
+
+	/** maximum data transfer size */
+	uint8_t			mdts;
+
+	/** Controller ID */
+	uint16_t		ctrlr_id;
+
+	/** Version */
+	uint32_t		ver;
+
+	/** RTD3 Resume Latency */
+	uint32_t		rtd3r;
+
+	/** RTD3 Enter Latency */
+	uint32_t		rtd3e;
+
+	/** Optional Asynchronous Events Supported */
+	uint32_t		oaes;	/* bitfield really */
+
+	/** Controller Attributes */
+	uint32_t		ctratt;	/* bitfield really */
+
+	uint8_t			reserved1[12];
+
+	/** FRU Globally Unique Identifier */
+	uint8_t			fguid[16];
+
+	uint8_t			reserved2[128];
+
+	/* bytes 256-511: admin command set attributes */
+
+	/** optional admin command support */
+	uint16_t		oacs;
+
+	/** abort command limit */
+	uint8_t			acl;
+
+	/** asynchronous event request limit */
+	uint8_t			aerl;
+
+	/** firmware updates */
+	uint8_t			frmw;
+
+	/** log page attributes */
+	uint8_t			lpa;
+
+	/** error log page entries */
+	uint8_t			elpe;
+
+	/** number of power states supported */
+	uint8_t			npss;
+
+	/** admin vendor specific command configuration */
+	uint8_t			avscc;
+
+	/** Autonomous Power State Transition Attributes */
+	uint8_t			apsta;
+
+	/** Warning Composite Temperature Threshold */
+	uint16_t		wctemp;
+
+	/** Critical Composite Temperature Threshold */
+	uint16_t		cctemp;
+
+	/** Maximum Time for Firmware Activation */
+	uint16_t		mtfa;
+
+	/** Host Memory Buffer Preferred Size */
+	uint32_t		hmpre;
+
+	/** Host Memory Buffer Minimum Size */
+	uint32_t		hmmin;
+
+	/** Name space capabilities  */
+	struct {
+		/* if nsmgmt, report tnvmcap and unvmcap */
+		uint8_t    tnvmcap[16];
+		uint8_t    unvmcap[16];
+	} __packed untncap;
+
+	/** Replay Protected Memory Block Support */
+	uint32_t		rpmbs; /* Really a bitfield */
+
+	/** Extended Device Self-test Time */
+	uint16_t		edstt;
+
+	/** Device Self-test Options */
+	uint8_t			dsto; /* Really a bitfield */
+
+	/** Firmware Update Granularity */
+	uint8_t			fwug;
+
+	/** Keep Alive Support */
+	uint16_t		kas;
+
+	/** Host Controlled Thermal Management Attributes */
+	uint16_t		hctma; /* Really a bitfield */
+
+	/** Minimum Thermal Management Temperature */
+	uint16_t		mntmt;
+
+	/** Maximum Thermal Management Temperature */
+	uint16_t		mxtmt;
+
+	/** Sanitize Capabilities */
+	uint32_t		sanicap; /* Really a bitfield */
+
+	uint8_t			reserved3[180];
+	/* bytes 512-703: nvm command set attributes */
+
+	/** submission queue entry size */
+	uint8_t			sqes;
+
+	/** completion queue entry size */
+	uint8_t			cqes;
+
+	/** Maximum Outstanding Commands */
+	uint16_t		maxcmd;
+
+	/** number of namespaces */
+	uint32_t		nn;
+
+	/** optional nvm command support */
+	uint16_t		oncs;
+
+	/** fused operation support */
+	uint16_t		fuses;
+
+	/** format nvm attributes */
+	uint8_t			fna;
+
+	/** volatile write cache */
+	uint8_t			vwc;
+
+	/** Atomic Write Unit Normal */
+	uint16_t		awun;
+
+	/** Atomic Write Unit Power Fail */
+	uint16_t		awupf;
+
+	/** NVM Vendor Specific Command Configuration */
+	uint8_t			nvscc;
+	uint8_t			reserved5;
+
+	/** Atomic Compare & Write Unit */
+	uint16_t		acwu;
+	uint16_t		reserved6;
+
+	/** SGL Support */
+	uint32_t		sgls;
+
+	/* bytes 540-767: Reserved */
+	uint8_t			reserved7[228];
+
+	/** NVM Subsystem NVMe Qualified Name */
+	uint8_t			subnqn[256];
+
+	/* bytes 1024-1791: Reserved */
+	uint8_t			reserved8[768];
+
+	/* bytes 1792-2047: NVMe over Fabrics specification */
+	uint8_t			reserved9[256];
+
+	/* bytes 2048-3071: power state descriptors */
+	struct nvme_power_state power_state[32];
+
+	/* bytes 3072-4095: vendor specific */
+	uint8_t			vs[1024];
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct nvme_controller_data) == 4096, "bad size for nvme_controller_data");
+
+struct nvme_namespace_data {
+
+	/** namespace size */
+	uint64_t		nsze;
+
+	/** namespace capacity */
+	uint64_t		ncap;
+
+	/** namespace utilization */
+	uint64_t		nuse;
+
+	/** namespace features */
+	uint8_t			nsfeat;
+
+	/** number of lba formats */
+	uint8_t			nlbaf;
+
+	/** formatted lba size */
+	uint8_t			flbas;
+
+	/** metadata capabilities */
+	uint8_t			mc;
+
+	/** end-to-end data protection capabilities */
+	uint8_t			dpc;
+
+	/** end-to-end data protection type settings */
+	uint8_t			dps;
+
+	/** Namespace Multi-path I/O and Namespace Sharing Capabilities */
+	uint8_t			nmic;
+
+	/** Reservation Capabilities */
+	uint8_t			rescap;
+
+	/** Format Progress Indicator */
+	uint8_t			fpi;
+
+	/** Deallocate Logical Block Features */
+	uint8_t			dlfeat;
+
+	/** Namespace Atomic Write Unit Normal  */
+	uint16_t		nawun;
+
+	/** Namespace Atomic Write Unit Power Fail */
+	uint16_t		nawupf;
+
+	/** Namespace Atomic Compare & Write Unit */
+	uint16_t		nacwu;
+
+	/** Namespace Atomic Boundary Size Normal */
+	uint16_t		nabsn;
+
+	/** Namespace Atomic Boundary Offset */
+	uint16_t		nabo;
+
+	/** Namespace Atomic Boundary Size Power Fail */
+	uint16_t		nabspf;
+
+	/** Namespace Optimal IO Boundary */
+	uint16_t		noiob;
+
+	/** NVM Capacity */
+	uint8_t			nvmcap[16];
+
+	/* bytes 64-103: Reserved */
+	uint8_t			reserved5[40];
+
+	/** Namespace Globally Unique Identifier */
+	uint8_t			nguid[16];
+
+	/** IEEE Extended Unique Identifier */
+	uint8_t			eui64[8];
+
+	/** lba format support */
+	uint32_t		lbaf[16];
+
+	uint8_t			reserved6[192];
+
+	uint8_t			vendor_specific[3712];
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct nvme_namespace_data) == 4096, "bad size for nvme_namepsace_data");
+
+enum nvme_log_page {
+
+	/* 0x00 - reserved */
+	NVME_LOG_ERROR			= 0x01,
+	NVME_LOG_HEALTH_INFORMATION	= 0x02,
+	NVME_LOG_FIRMWARE_SLOT		= 0x03,
+	NVME_LOG_CHANGED_NAMESPACE	= 0x04,
+	NVME_LOG_COMMAND_EFFECT		= 0x05,
+	/* 0x06-0x7F - reserved */
+	/* 0x80-0xBF - I/O command set specific */
+	NVME_LOG_RES_NOTIFICATION	= 0x80,
+	/* 0xC0-0xFF - vendor specific */
+
+	/*
+	 * The following are Intel Specific log pages, but they seem
+	 * to be widely implemented.
+	 */
+	INTEL_LOG_READ_LAT_LOG		= 0xc1,
+	INTEL_LOG_WRITE_LAT_LOG		= 0xc2,
+	INTEL_LOG_TEMP_STATS		= 0xc5,
+	INTEL_LOG_ADD_SMART		= 0xca,
+	INTEL_LOG_DRIVE_MKT_NAME	= 0xdd,
+
+	/*
+	 * HGST log page, with lots ofs sub pages.
+	 */
+	HGST_INFO_LOG			= 0xc1,
+};
+
+struct nvme_error_information_entry {
+
+	uint64_t		error_count;
+	uint16_t		sqid;
+	uint16_t		cid;
+	uint16_t		status;
+	uint16_t		error_location;
+	uint64_t		lba;
+	uint32_t		nsid;
+	uint8_t			vendor_specific;
+	uint8_t			reserved[35];
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct nvme_error_information_entry) == 64, "bad size for nvme_error_information_entry");
+
+struct nvme_health_information_page {
+
+	uint8_t			critical_warning;
+	uint16_t		temperature;
+	uint8_t			available_spare;
+	uint8_t			available_spare_threshold;
+	uint8_t			percentage_used;
+
+	uint8_t			reserved[26];
+
+	/*
+	 * Note that the following are 128-bit values, but are
+	 *  defined as an array of 2 64-bit values.
+	 */
+	/* Data Units Read is always in 512-byte units. */
+	uint64_t		data_units_read[2];
+	/* Data Units Written is always in 512-byte units. */
+	uint64_t		data_units_written[2];
+	/* For NVM command set, this includes Compare commands. */
+	uint64_t		host_read_commands[2];
+	uint64_t		host_write_commands[2];
+	/* Controller Busy Time is reported in minutes. */
+	uint64_t		controller_busy_time[2];
+	uint64_t		power_cycles[2];
+	uint64_t		power_on_hours[2];
+	uint64_t		unsafe_shutdowns[2];
+	uint64_t		media_errors[2];
+	uint64_t		num_error_info_log_entries[2];
+	uint32_t		warning_temp_time;
+	uint32_t		error_temp_time;
+	uint16_t		temp_sensor[8];
+
+	uint8_t			reserved2[296];
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct nvme_health_information_page) == 512, "bad size for nvme_health_information_page");
+
+struct nvme_firmware_page {
+
+	uint8_t			afi;
+	uint8_t			reserved[7];
+	uint64_t		revision[7]; /* revisions for 7 slots */
+	uint8_t			reserved2[448];
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct nvme_firmware_page) == 512, "bad size for nvme_firmware_page");
+
+struct nvme_ns_list {
+	uint32_t		ns[1024];
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct nvme_ns_list) == 4096, "bad size for nvme_ns_list");
+
+struct intel_log_temp_stats
+{
+	uint64_t	current;
+	uint64_t	overtemp_flag_last;
+	uint64_t	overtemp_flag_life;
+	uint64_t	max_temp;
+	uint64_t	min_temp;
+	uint64_t	_rsvd[5];
+	uint64_t	max_oper_temp;
+	uint64_t	min_oper_temp;
+	uint64_t	est_offset;
+} __packed __aligned(4);
+
+_Static_assert(sizeof(struct intel_log_temp_stats) == 13 * 8, "bad size for intel_log_temp_stats");
+
+#define NVME_TEST_MAX_THREADS	128
+
+struct nvme_io_test {
+
+	enum nvme_nvm_opcode	opc;
+	uint32_t		size;
+	uint32_t		time;	/* in seconds */
+	uint32_t		num_threads;
+	uint32_t		flags;
+	uint64_t		io_completed[NVME_TEST_MAX_THREADS];
+};
+
+enum nvme_io_test_flags {
+
+	/*
+	 * Specifies whether dev_refthread/dev_relthread should be
+	 *  called during NVME_BIO_TEST.  Ignored for other test
+	 *  types.
+	 */
+	NVME_TEST_FLAG_REFTHREAD =	0x1,
+};
+
+struct nvme_pt_command {
+
+	/*
+	 * cmd is used to specify a passthrough command to a controller or
+	 *  namespace.
+	 *
+	 * The following fields from cmd may be specified by the caller:
+	 *	* opc  (opcode)
+	 *	* nsid (namespace id) - for admin commands only
+	 *	* cdw10-cdw15
+	 *
+	 * Remaining fields must be set to 0 by the caller.
+	 */
+	struct nvme_command	cmd;
+
+	/*
+	 * cpl returns completion status for the passthrough command
+	 *  specified by cmd.
+	 *
+	 * The following fields will be filled out by the driver, for
+	 *  consumption by the caller:
+	 *	* cdw0
+	 *	* status (except for phase)
+	 *
+	 * Remaining fields will be set to 0 by the driver.
+	 */
+	struct nvme_completion	cpl;
+
+	/* buf is the data buffer associated with this passthrough command. */
+	void *			buf;
+
+	/*
+	 * len is the length of the data buffer associated with this
+	 *  passthrough command.
+	 */
+	uint32_t		len;
+
+	/*
+	 * is_read = 1 if the passthrough command will read data into the
+	 *  supplied buffer from the controller.
+	 *
+	 * is_read = 0 if the passthrough command will write data from the
+	 *  supplied buffer to the controller.
+	 */
+	uint32_t		is_read;
+
+	/*
+	 * driver_lock is used by the driver only.  It must be set to 0
+	 *  by the caller.
+	 */
+	struct mtx *		driver_lock;
+};
+
+#define nvme_completion_is_error(cpl)					\
+	(NVME_STATUS_GET_SC((cpl)->status) != 0 || NVME_STATUS_GET_SCT((cpl)->status) != 0)
+
+void	nvme_strvis(uint8_t *dst, const uint8_t *src, int dstlen, int srclen);
+
+#ifdef _KERNEL
+
+struct bio;
+
+struct nvme_namespace;
+struct nvme_controller;
+struct nvme_consumer;
+
+typedef void (*nvme_cb_fn_t)(void *, const struct nvme_completion *);
+
+typedef void *(*nvme_cons_ns_fn_t)(struct nvme_namespace *, void *);
+typedef void *(*nvme_cons_ctrlr_fn_t)(struct nvme_controller *);
+typedef void (*nvme_cons_async_fn_t)(void *, const struct nvme_completion *,
+				     uint32_t, void *, uint32_t);
+typedef void (*nvme_cons_fail_fn_t)(void *);
+
+enum nvme_namespace_flags {
+	NVME_NS_DEALLOCATE_SUPPORTED	= 0x1,
+	NVME_NS_FLUSH_SUPPORTED		= 0x2,
+};
+
+int	nvme_ctrlr_passthrough_cmd(struct nvme_controller *ctrlr,
+				   struct nvme_pt_command *pt,
+				   uint32_t nsid, int is_user_buffer,
+				   int is_admin_cmd);
+
+/* Admin functions */
+void	nvme_ctrlr_cmd_set_feature(struct nvme_controller *ctrlr,
+				   uint8_t feature, uint32_t cdw11,
+				   void *payload, uint32_t payload_size,
+				   nvme_cb_fn_t cb_fn, void *cb_arg);
+void	nvme_ctrlr_cmd_get_feature(struct nvme_controller *ctrlr,
+				   uint8_t feature, uint32_t cdw11,
+				   void *payload, uint32_t payload_size,
+				   nvme_cb_fn_t cb_fn, void *cb_arg);
+void	nvme_ctrlr_cmd_get_log_page(struct nvme_controller *ctrlr,
+				    uint8_t log_page, uint32_t nsid,
+				    void *payload, uint32_t payload_size,
+				    nvme_cb_fn_t cb_fn, void *cb_arg);
+
+/* NVM I/O functions */
+int	nvme_ns_cmd_write(struct nvme_namespace *ns, void *payload,
+			  uint64_t lba, uint32_t lba_count, nvme_cb_fn_t cb_fn,
+			  void *cb_arg);
+int	nvme_ns_cmd_write_bio(struct nvme_namespace *ns, struct bio *bp,
+			      nvme_cb_fn_t cb_fn, void *cb_arg);
+int	nvme_ns_cmd_read(struct nvme_namespace *ns, void *payload,
+			 uint64_t lba, uint32_t lba_count, nvme_cb_fn_t cb_fn,
+			 void *cb_arg);
+int	nvme_ns_cmd_read_bio(struct nvme_namespace *ns, struct bio *bp,
+			      nvme_cb_fn_t cb_fn, void *cb_arg);
+int	nvme_ns_cmd_deallocate(struct nvme_namespace *ns, void *payload,
+			       uint8_t num_ranges, nvme_cb_fn_t cb_fn,
+			       void *cb_arg);
+int	nvme_ns_cmd_flush(struct nvme_namespace *ns, nvme_cb_fn_t cb_fn,
+			  void *cb_arg);
+int	nvme_ns_dump(struct nvme_namespace *ns, void *virt, off_t offset,
+		     size_t len);
+
+/* Registration functions */
+struct nvme_consumer *	nvme_register_consumer(nvme_cons_ns_fn_t    ns_fn,
+					       nvme_cons_ctrlr_fn_t ctrlr_fn,
+					       nvme_cons_async_fn_t async_fn,
+					       nvme_cons_fail_fn_t  fail_fn);
+void		nvme_unregister_consumer(struct nvme_consumer *consumer);
+
+/* Controller helper functions */
+device_t	nvme_ctrlr_get_device(struct nvme_controller *ctrlr);
+const struct nvme_controller_data *
+		nvme_ctrlr_get_data(struct nvme_controller *ctrlr);
+
+/* Namespace helper functions */
+uint32_t	nvme_ns_get_max_io_xfer_size(struct nvme_namespace *ns);
+uint32_t	nvme_ns_get_sector_size(struct nvme_namespace *ns);
+uint64_t	nvme_ns_get_num_sectors(struct nvme_namespace *ns);
+uint64_t	nvme_ns_get_size(struct nvme_namespace *ns);
+uint32_t	nvme_ns_get_flags(struct nvme_namespace *ns);
+const char *	nvme_ns_get_serial_number(struct nvme_namespace *ns);
+const char *	nvme_ns_get_model_number(struct nvme_namespace *ns);
+const struct nvme_namespace_data *
+		nvme_ns_get_data(struct nvme_namespace *ns);
+uint32_t	nvme_ns_get_stripesize(struct nvme_namespace *ns);
+
+int	nvme_ns_bio_process(struct nvme_namespace *ns, struct bio *bp,
+			    nvme_cb_fn_t cb_fn);
+
+/*
+ * Command building helper functions -- shared with CAM
+ * These functions assume allocator zeros out cmd structure
+ * CAM's xpt_get_ccb and the request allocator for nvme both
+ * do zero'd allocations.
+ */
+static inline
+void	nvme_ns_flush_cmd(struct nvme_command *cmd, uint32_t nsid)
+{
+
+	cmd->opc = NVME_OPC_FLUSH;
+	cmd->nsid = htole32(nsid);
+}
+
+static inline
+void	nvme_ns_rw_cmd(struct nvme_command *cmd, uint32_t rwcmd, uint32_t nsid,
+    uint64_t lba, uint32_t count)
+{
+	cmd->opc = rwcmd;
+	cmd->nsid = htole32(nsid);
+	cmd->cdw10 = htole32(lba & 0xffffffffu);
+	cmd->cdw11 = htole32(lba >> 32);
+	cmd->cdw12 = htole32(count-1);
+}
+
+static inline
+void	nvme_ns_write_cmd(struct nvme_command *cmd, uint32_t nsid,
+    uint64_t lba, uint32_t count)
+{
+	nvme_ns_rw_cmd(cmd, NVME_OPC_WRITE, nsid, lba, count);
+}
+
+static inline
+void	nvme_ns_read_cmd(struct nvme_command *cmd, uint32_t nsid,
+    uint64_t lba, uint32_t count)
+{
+	nvme_ns_rw_cmd(cmd, NVME_OPC_READ, nsid, lba, count);
+}
+
+static inline
+void	nvme_ns_trim_cmd(struct nvme_command *cmd, uint32_t nsid,
+    uint32_t num_ranges)
+{
+	cmd->opc = NVME_OPC_DATASET_MANAGEMENT;
+	cmd->nsid = htole32(nsid);
+	cmd->cdw10 = htole32(num_ranges - 1);
+	cmd->cdw11 = htole32(NVME_DSM_ATTR_DEALLOCATE);
+}
+
+extern int nvme_use_nvd;
+
+#endif /* _KERNEL */
+
+/* Endianess conversion functions for NVMe structs */
+static inline
+void	nvme_completion_swapbytes(struct nvme_completion *s)
+{
+
+	s->cdw0 = le32toh(s->cdw0);
+	/* omit rsvd1 */
+	s->sqhd = le16toh(s->sqhd);
+	s->sqid = le16toh(s->sqid);
+	/* omit cid */
+	s->status = le16toh(s->status);
+}
+
+static inline
+void	nvme_power_state_swapbytes(struct nvme_power_state *s)
+{
+
+	s->mp = le16toh(s->mp);
+	s->enlat = le32toh(s->enlat);
+	s->exlat = le32toh(s->exlat);
+	s->idlp = le16toh(s->idlp);
+	s->actp = le16toh(s->actp);
+}
+
+static inline
+void	nvme_controller_data_swapbytes(struct nvme_controller_data *s)
+{
+	int i;
+
+	s->vid = le16toh(s->vid);
+	s->ssvid = le16toh(s->ssvid);
+	s->ctrlr_id = le16toh(s->ctrlr_id);
+	s->ver = le32toh(s->ver);
+	s->rtd3r = le32toh(s->rtd3r);
+	s->rtd3e = le32toh(s->rtd3e);
+	s->oaes = le32toh(s->oaes);
+	s->ctratt = le32toh(s->ctratt);
+	s->oacs = le16toh(s->oacs);
+	s->wctemp = le16toh(s->wctemp);
+	s->cctemp = le16toh(s->cctemp);
+	s->mtfa = le16toh(s->mtfa);
+	s->hmpre = le32toh(s->hmpre);
+	s->hmmin = le32toh(s->hmmin);
+	s->rpmbs = le32toh(s->rpmbs);
+	s->edstt = le16toh(s->edstt);
+	s->kas = le16toh(s->kas);
+	s->hctma = le16toh(s->hctma);
+	s->mntmt = le16toh(s->mntmt);
+	s->mxtmt = le16toh(s->mxtmt);
+	s->sanicap = le32toh(s->sanicap);
+	s->maxcmd = le16toh(s->maxcmd);
+	s->nn = le32toh(s->nn);
+	s->oncs = le16toh(s->oncs);
+	s->fuses = le16toh(s->fuses);
+	s->awun = le16toh(s->awun);
+	s->awupf = le16toh(s->awupf);
+	s->acwu = le16toh(s->acwu);
+	s->sgls = le32toh(s->sgls);
+	for (i = 0; i < 32; i++)
+		nvme_power_state_swapbytes(&s->power_state[i]);
+}
+
+static inline
+void	nvme_namespace_data_swapbytes(struct nvme_namespace_data *s)
+{
+	int i;
+
+	s->nsze = le64toh(s->nsze);
+	s->ncap = le64toh(s->ncap);
+	s->nuse = le64toh(s->nuse);
+	s->nawun = le16toh(s->nawun);
+	s->nawupf = le16toh(s->nawupf);
+	s->nacwu = le16toh(s->nacwu);
+	s->nabsn = le16toh(s->nabsn);
+	s->nabo = le16toh(s->nabo);
+	s->nabspf = le16toh(s->nabspf);
+	s->noiob = le16toh(s->noiob);
+	for (i = 0; i < 16; i++)
+		s->lbaf[i] = le32toh(s->lbaf[i]);
+}
+
+static inline
+void	nvme_error_information_entry_swapbytes(struct nvme_error_information_entry *s)
+{
+
+	s->error_count = le64toh(s->error_count);
+	s->sqid = le16toh(s->sqid);
+	s->cid = le16toh(s->cid);
+	s->status = le16toh(s->status);
+	s->error_location = le16toh(s->error_location);
+	s->lba = le64toh(s->lba);
+	s->nsid = le32toh(s->nsid);
+}
+
+static inline
+void	nvme_le128toh(void *p)
+{
+	/*
+	 * Upstream, this uses the following comparison:
+	 * #if _BYTE_ORDER != _LITTLE_ENDIAN
+	 *
+	 * Rather than keep this file in compat with only that little bit
+	 * changed, we'll just float a little patch here for now.
+	 */
+#ifndef _LITTLE_ENDIAN
+	/* Swap 16 bytes in place */
+	char *tmp = (char*)p;
+	char b;
+	int i;
+	for (i = 0; i < 8; i++) {
+		b = tmp[i];
+		tmp[i] = tmp[15-i];
+		tmp[15-i] = b;
+	}
+#else
+	(void)p;
+#endif
+}
+
+static inline
+void	nvme_health_information_page_swapbytes(struct nvme_health_information_page *s)
+{
+	int i;
+
+	s->temperature = le16toh(s->temperature);
+	nvme_le128toh((void *)s->data_units_read);
+	nvme_le128toh((void *)s->data_units_written);
+	nvme_le128toh((void *)s->host_read_commands);
+	nvme_le128toh((void *)s->host_write_commands);
+	nvme_le128toh((void *)s->controller_busy_time);
+	nvme_le128toh((void *)s->power_cycles);
+	nvme_le128toh((void *)s->power_on_hours);
+	nvme_le128toh((void *)s->unsafe_shutdowns);
+	nvme_le128toh((void *)s->media_errors);
+	nvme_le128toh((void *)s->num_error_info_log_entries);
+	s->warning_temp_time = le32toh(s->warning_temp_time);
+	s->error_temp_time = le32toh(s->error_temp_time);
+	for (i = 0; i < 8; i++)
+		s->temp_sensor[i] = le16toh(s->temp_sensor[i]);
+}
+
+
+static inline
+void	nvme_firmware_page_swapbytes(struct nvme_firmware_page *s)
+{
+	int i;
+
+	for (i = 0; i < 7; i++)
+		s->revision[i] = le64toh(s->revision[i]);
+}
+
+static inline
+void	nvme_ns_list_swapbytes(struct nvme_ns_list *s)
+{
+	int i;
+
+	for (i = 0; i < 1024; i++)
+		s->ns[i] = le32toh(s->ns[i]);
+}
+
+static inline
+void	intel_log_temp_stats_swapbytes(struct intel_log_temp_stats *s)
+{
+
+	s->current = le64toh(s->current);
+	s->overtemp_flag_last = le64toh(s->overtemp_flag_last);
+	s->overtemp_flag_life = le64toh(s->overtemp_flag_life);
+	s->max_temp = le64toh(s->max_temp);
+	s->min_temp = le64toh(s->min_temp);
+	/* omit _rsvd[] */
+	s->max_oper_temp = le64toh(s->max_oper_temp);
+	s->min_oper_temp = le64toh(s->min_oper_temp);
+	s->est_offset = le64toh(s->est_offset);
+}
+
+#endif /* __NVME_H__ */

--- a/usr/src/cmd/bhyve/Makefile
+++ b/usr/src/cmd/bhyve/Makefile
@@ -50,6 +50,7 @@ SRCS =	acpi.c			\
 	pci_hostbridge.c	\
 	pci_irq.c		\
 	pci_lpc.c		\
+	pci_nvme.c		\
 	pci_passthru.c		\
 	pci_uart.c		\
 	pci_virtio_block.c	\
@@ -75,7 +76,15 @@ SRCS =	acpi.c			\
 	vmm_instruction_emul.c	\
 	xmsr.c			\
 	spinup_ap.c		\
+	iov.c			\
 	bhyve_sol_glue.c
+
+# The virtio-scsi driver appears to include  a slew of materials from FreeBSD's
+# native SCSI implementation.  We will omit that complexity for now.
+	#ctl_util.c		\
+	#ctl_scsi_all.c		\
+	#pci_virtio_scsi.c	\
+
 
 OBJS = $(SRCS:.c=.o)
 
@@ -103,6 +112,13 @@ CPPFLAGS =	-I$(COMPAT)/freebsd -I$(CONTRIB)/freebsd \
 
 # Disable the crypto code until it is wired up
 CPPFLAGS +=	-DNO_OPENSSL
+
+pci_nvme.o := CERRWARN += -_gcc=-Wno-pointer-sign
+
+# Force c99 for everything
+CSTD=		$(CSTD_GNU99)
+C99MODE=	-xc99=%all
+C99LMODE=	-Xc99=%all
 
 $(PROG) := LDLIBS += -lsocket -lnsl -ldlpi -ldladm -lmd -luuid -lvmmapi -lz
 $(MEVENT_TEST_PROG) := LDLIBS += -lsocket

--- a/usr/src/cmd/bhyve/acpi.c
+++ b/usr/src/cmd/bhyve/acpi.c
@@ -118,18 +118,14 @@ struct basl_fio {
 };
 
 #define EFPRINTF(...) \
-	err = fprintf(__VA_ARGS__); if (err < 0) goto err_exit;
+	if (fprintf(__VA_ARGS__) < 0) goto err_exit;
 
 #define EFFLUSH(x) \
-	err = fflush(x); if (err != 0) goto err_exit;
+	if (fflush(x) != 0) goto err_exit;
 
 static int
 basl_fwrite_rsdp(FILE *fp)
 {
-	int err;
-
-	err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve RSDP template\n");
 	EFPRINTF(fp, " */\n");
@@ -156,10 +152,6 @@ err_exit:
 static int
 basl_fwrite_rsdt(FILE *fp)
 {
-	int err;
-
-	err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve RSDT template\n");
 	EFPRINTF(fp, " */\n");
@@ -196,10 +188,6 @@ err_exit:
 static int
 basl_fwrite_xsdt(FILE *fp)
 {
-	int err;
-
-	err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve XSDT template\n");
 	EFPRINTF(fp, " */\n");
@@ -236,10 +224,7 @@ err_exit:
 static int
 basl_fwrite_madt(FILE *fp)
 {
-	int err;
 	int i;
-
-	err = 0;
 
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve MADT template\n");
@@ -326,10 +311,6 @@ err_exit:
 static int
 basl_fwrite_fadt(FILE *fp)
 {
-	int err;
-
-	err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve FADT template\n");
 	EFPRINTF(fp, " */\n");
@@ -547,10 +528,6 @@ err_exit:
 static int
 basl_fwrite_hpet(FILE *fp)
 {
-	int err;
-
-	err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve HPET template\n");
 	EFPRINTF(fp, " */\n");
@@ -596,8 +573,6 @@ err_exit:
 static int
 basl_fwrite_mcfg(FILE *fp)
 {
-	int err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve MCFG template\n");
 	EFPRINTF(fp, " */\n");
@@ -629,10 +604,6 @@ err_exit:
 static int
 basl_fwrite_facs(FILE *fp)
 {
-	int err;
-
-	err = 0;
-
 	EFPRINTF(fp, "/*\n");
 	EFPRINTF(fp, " * bhyve FACS template\n");
 	EFPRINTF(fp, " */\n");
@@ -666,7 +637,6 @@ void
 dsdt_line(const char *fmt, ...)
 {
 	va_list ap;
-	int err = 0;
 
 	if (dsdt_error != 0)
 		return;
@@ -675,8 +645,10 @@ dsdt_line(const char *fmt, ...)
 		if (dsdt_indent_level != 0)
 			EFPRINTF(dsdt_fp, "%*c", dsdt_indent_level * 2, ' ');
 		va_start(ap, fmt);
-		if (vfprintf(dsdt_fp, fmt, ap) < 0)
+		if (vfprintf(dsdt_fp, fmt, ap) < 0) {
+			va_end(ap);
 			goto err_exit;
+		}
 		va_end(ap);
 	}
 	EFPRINTF(dsdt_fp, "\n");
@@ -735,9 +707,6 @@ dsdt_fixed_mem32(uint32_t base, uint32_t length)
 static int
 basl_fwrite_dsdt(FILE *fp)
 {
-	int err;
-
-	err = 0;
 	dsdt_fp = fp;
 	dsdt_error = 0;
 	dsdt_indent_level = 0;
@@ -916,7 +885,7 @@ basl_make_templates(void)
 	int len;
 
 	err = 0;
-	
+
 	/*
 	 * 
 	 */

--- a/usr/src/cmd/bhyve/ahci.h
+++ b/usr/src/cmd/bhyve/ahci.h
@@ -33,292 +33,292 @@
 #define	_AHCI_H_
 
 /* ATA register defines */
-#define ATA_DATA                        0       /* (RW) data */
+#define	ATA_DATA		0	/* (RW) data */
 
-#define ATA_FEATURE                     1       /* (W) feature */
-#define         ATA_F_DMA               0x01    /* enable DMA */
-#define         ATA_F_OVL               0x02    /* enable overlap */
+#define	ATA_FEATURE		1	/* (W) feature */
+#define	ATA_F_DMA		0x01	/* enable DMA */
+#define	ATA_F_OVL		0x02	/* enable overlap */
 
-#define ATA_COUNT                       2       /* (W) sector count */
+#define	ATA_COUNT		2	/* (W) sector count */
 
-#define ATA_SECTOR                      3       /* (RW) sector # */
-#define ATA_CYL_LSB                     4       /* (RW) cylinder# LSB */
-#define ATA_CYL_MSB                     5       /* (RW) cylinder# MSB */
-#define ATA_DRIVE                       6       /* (W) Sector/Drive/Head */
-#define         ATA_D_LBA               0x40    /* use LBA addressing */
-#define         ATA_D_IBM               0xa0    /* 512 byte sectors, ECC */
+#define	ATA_SECTOR		3	/* (RW) sector # */
+#define	ATA_CYL_LSB		4	/* (RW) cylinder# LSB */
+#define	ATA_CYL_MSB		5	/* (RW) cylinder# MSB */
+#define	ATA_DRIVE		6	/* (W) Sector/Drive/Head */
+#define	ATA_D_LBA		0x40	/* use LBA addressing */
+#define	ATA_D_IBM		0xa0	/* 512 byte sectors, ECC */
 
-#define ATA_COMMAND                     7       /* (W) command */
+#define	ATA_COMMAND		7	/* (W) command */
 
-#define ATA_ERROR                       8       /* (R) error */
-#define         ATA_E_ILI               0x01    /* illegal length */
-#define         ATA_E_NM                0x02    /* no media */
-#define         ATA_E_ABORT             0x04    /* command aborted */
-#define         ATA_E_MCR               0x08    /* media change request */
-#define         ATA_E_IDNF              0x10    /* ID not found */
-#define         ATA_E_MC                0x20    /* media changed */
-#define         ATA_E_UNC               0x40    /* uncorrectable data */
-#define         ATA_E_ICRC              0x80    /* UDMA crc error */
-#define		ATA_E_ATAPI_SENSE_MASK	0xf0	/* ATAPI sense key mask */
+#define	ATA_ERROR		8	/* (R) error */
+#define	ATA_E_ILI		0x01	/* illegal length */
+#define	ATA_E_NM		0x02	/* no media */
+#define	ATA_E_ABORT		0x04	/* command aborted */
+#define	ATA_E_MCR		0x08	/* media change request */
+#define	ATA_E_IDNF		0x10	/* ID not found */
+#define	ATA_E_MC		0x20	/* media changed */
+#define	ATA_E_UNC		0x40	/* uncorrectable data */
+#define	ATA_E_ICRC		0x80	/* UDMA crc error */
+#define	ATA_E_ATAPI_SENSE_MASK	0xf0	/* ATAPI sense key mask */
 
-#define ATA_IREASON                     9       /* (R) interrupt reason */
-#define         ATA_I_CMD               0x01    /* cmd (1) | data (0) */
-#define         ATA_I_IN                0x02    /* read (1) | write (0) */
-#define         ATA_I_RELEASE           0x04    /* released bus (1) */
-#define         ATA_I_TAGMASK           0xf8    /* tag mask */
+#define	ATA_IREASON		9	/* (R) interrupt reason */
+#define	ATA_I_CMD		0x01	/* cmd (1) | data (0) */
+#define	ATA_I_IN		0x02	/* read (1) | write (0) */
+#define	ATA_I_RELEASE		0x04	/* released bus (1) */
+#define	ATA_I_TAGMASK		0xf8	/* tag mask */
 
-#define ATA_STATUS                      10      /* (R) status */
-#define ATA_ALTSTAT                     11      /* (R) alternate status */
-#define         ATA_S_ERROR             0x01    /* error */
-#define         ATA_S_INDEX             0x02    /* index */
-#define         ATA_S_CORR              0x04    /* data corrected */
-#define         ATA_S_DRQ               0x08    /* data request */
-#define         ATA_S_DSC               0x10    /* drive seek completed */
-#define         ATA_S_SERVICE           0x10    /* drive needs service */
-#define         ATA_S_DWF               0x20    /* drive write fault */
-#define         ATA_S_DMA               0x20    /* DMA ready */
-#define         ATA_S_READY             0x40    /* drive ready */
-#define         ATA_S_BUSY              0x80    /* busy */
+#define	ATA_STATUS		10	/* (R) status */
+#define	ATA_ALTSTAT		11	/* (R) alternate status */
+#define	ATA_S_ERROR		0x01	/* error */
+#define	ATA_S_INDEX		0x02	/* index */
+#define	ATA_S_CORR		0x04	/* data corrected */
+#define	ATA_S_DRQ		0x08	/* data request */
+#define	ATA_S_DSC		0x10	/* drive seek completed */
+#define	ATA_S_SERVICE		0x10	/* drive needs service */
+#define	ATA_S_DWF		0x20	/* drive write fault */
+#define	ATA_S_DMA		0x20	/* DMA ready */
+#define	ATA_S_READY		0x40	/* drive ready */
+#define	ATA_S_BUSY		0x80	/* busy */
 
-#define ATA_CONTROL                     12      /* (W) control */
-#define         ATA_A_IDS               0x02    /* disable interrupts */
-#define         ATA_A_RESET             0x04    /* RESET controller */
-#define         ATA_A_4BIT              0x08    /* 4 head bits */
-#define         ATA_A_HOB               0x80    /* High Order Byte enable */
+#define	ATA_CONTROL		12	/* (W) control */
+#define	ATA_A_IDS		0x02	/* disable interrupts */
+#define	ATA_A_RESET		0x04	/* RESET controller */
+#define	ATA_A_4BIT		0x08	/* 4 head bits */
+#define	ATA_A_HOB		0x80	/* High Order Byte enable */
 
 /* SATA register defines */
-#define ATA_SSTATUS                     13
-#define         ATA_SS_DET_MASK         0x0000000f
-#define         ATA_SS_DET_NO_DEVICE    0x00000000
-#define         ATA_SS_DET_DEV_PRESENT  0x00000001
-#define         ATA_SS_DET_PHY_ONLINE   0x00000003
-#define         ATA_SS_DET_PHY_OFFLINE  0x00000004
+#define	ATA_SSTATUS		13
+#define	ATA_SS_DET_MASK		0x0000000f
+#define	ATA_SS_DET_NO_DEVICE	0x00000000
+#define	ATA_SS_DET_DEV_PRESENT	0x00000001
+#define	ATA_SS_DET_PHY_ONLINE	0x00000003
+#define	ATA_SS_DET_PHY_OFFLINE	0x00000004
 
-#define         ATA_SS_SPD_MASK         0x000000f0
-#define         ATA_SS_SPD_NO_SPEED     0x00000000
-#define         ATA_SS_SPD_GEN1         0x00000010
-#define         ATA_SS_SPD_GEN2         0x00000020
-#define         ATA_SS_SPD_GEN3         0x00000030
+#define	ATA_SS_SPD_MASK		0x000000f0
+#define	ATA_SS_SPD_NO_SPEED	0x00000000
+#define	ATA_SS_SPD_GEN1		0x00000010
+#define	ATA_SS_SPD_GEN2		0x00000020
+#define	ATA_SS_SPD_GEN3		0x00000030
 
-#define         ATA_SS_IPM_MASK         0x00000f00
-#define         ATA_SS_IPM_NO_DEVICE    0x00000000
-#define         ATA_SS_IPM_ACTIVE       0x00000100
-#define         ATA_SS_IPM_PARTIAL      0x00000200
-#define         ATA_SS_IPM_SLUMBER      0x00000600
-#define         ATA_SS_IPM_DEVSLEEP     0x00000800
+#define	ATA_SS_IPM_MASK		0x00000f00
+#define	ATA_SS_IPM_NO_DEVICE	0x00000000
+#define	ATA_SS_IPM_ACTIVE	0x00000100
+#define	ATA_SS_IPM_PARTIAL	0x00000200
+#define	ATA_SS_IPM_SLUMBER	0x00000600
+#define	ATA_SS_IPM_DEVSLEEP	0x00000800
 
-#define ATA_SERROR                      14
-#define         ATA_SE_DATA_CORRECTED   0x00000001
-#define         ATA_SE_COMM_CORRECTED   0x00000002
-#define         ATA_SE_DATA_ERR         0x00000100
-#define         ATA_SE_COMM_ERR         0x00000200
-#define         ATA_SE_PROT_ERR         0x00000400
-#define         ATA_SE_HOST_ERR         0x00000800
-#define         ATA_SE_PHY_CHANGED      0x00010000
-#define         ATA_SE_PHY_IERROR       0x00020000
-#define         ATA_SE_COMM_WAKE        0x00040000
-#define         ATA_SE_DECODE_ERR       0x00080000
-#define         ATA_SE_PARITY_ERR       0x00100000
-#define         ATA_SE_CRC_ERR          0x00200000
-#define         ATA_SE_HANDSHAKE_ERR    0x00400000
-#define         ATA_SE_LINKSEQ_ERR      0x00800000
-#define         ATA_SE_TRANSPORT_ERR    0x01000000
-#define         ATA_SE_UNKNOWN_FIS      0x02000000
-#define         ATA_SE_EXCHANGED        0x04000000
+#define	ATA_SERROR		14
+#define	ATA_SE_DATA_CORRECTED	0x00000001
+#define	ATA_SE_COMM_CORRECTED	0x00000002
+#define	ATA_SE_DATA_ERR		0x00000100
+#define	ATA_SE_COMM_ERR		0x00000200
+#define	ATA_SE_PROT_ERR		0x00000400
+#define	ATA_SE_HOST_ERR		0x00000800
+#define	ATA_SE_PHY_CHANGED	0x00010000
+#define	ATA_SE_PHY_IERROR	0x00020000
+#define	ATA_SE_COMM_WAKE	0x00040000
+#define	ATA_SE_DECODE_ERR	0x00080000
+#define	ATA_SE_PARITY_ERR	0x00100000
+#define	ATA_SE_CRC_ERR		0x00200000
+#define	ATA_SE_HANDSHAKE_ERR	0x00400000
+#define	ATA_SE_LINKSEQ_ERR	0x00800000
+#define	ATA_SE_TRANSPORT_ERR	0x01000000
+#define	ATA_SE_UNKNOWN_FIS	0x02000000
+#define	ATA_SE_EXCHANGED	0x04000000
 
-#define ATA_SCONTROL                    15
-#define         ATA_SC_DET_MASK         0x0000000f
-#define         ATA_SC_DET_IDLE         0x00000000
-#define         ATA_SC_DET_RESET        0x00000001
-#define         ATA_SC_DET_DISABLE      0x00000004
+#define	ATA_SCONTROL		15
+#define	ATA_SC_DET_MASK		0x0000000f
+#define	ATA_SC_DET_IDLE		0x00000000
+#define	ATA_SC_DET_RESET	0x00000001
+#define	ATA_SC_DET_DISABLE	0x00000004
 
-#define         ATA_SC_SPD_MASK         0x000000f0
-#define         ATA_SC_SPD_NO_SPEED     0x00000000
-#define         ATA_SC_SPD_SPEED_GEN1   0x00000010
-#define         ATA_SC_SPD_SPEED_GEN2   0x00000020
-#define         ATA_SC_SPD_SPEED_GEN3   0x00000030
+#define	ATA_SC_SPD_MASK		0x000000f0
+#define	ATA_SC_SPD_NO_SPEED	0x00000000
+#define	ATA_SC_SPD_SPEED_GEN1	0x00000010
+#define	ATA_SC_SPD_SPEED_GEN2	0x00000020
+#define	ATA_SC_SPD_SPEED_GEN3	0x00000030
 
-#define         ATA_SC_IPM_MASK         0x00000f00
-#define         ATA_SC_IPM_NONE         0x00000000
-#define         ATA_SC_IPM_DIS_PARTIAL  0x00000100
-#define         ATA_SC_IPM_DIS_SLUMBER  0x00000200
-#define         ATA_SC_IPM_DIS_DEVSLEEP 0x00000400
+#define	ATA_SC_IPM_MASK		0x00000f00
+#define	ATA_SC_IPM_NONE		0x00000000
+#define	ATA_SC_IPM_DIS_PARTIAL	0x00000100
+#define	ATA_SC_IPM_DIS_SLUMBER	0x00000200
+#define	ATA_SC_IPM_DIS_DEVSLEEP	0x00000400
 
-#define ATA_SACTIVE                     16
+#define	ATA_SACTIVE		16
 
-#define AHCI_MAX_PORTS			32
-#define AHCI_MAX_SLOTS			32
-#define AHCI_MAX_IRQS			16
+#define	AHCI_MAX_PORTS		32
+#define	AHCI_MAX_SLOTS		32
+#define	AHCI_MAX_IRQS		16
 
 /* SATA AHCI v1.0 register defines */
-#define AHCI_CAP                    0x00
-#define		AHCI_CAP_NPMASK	0x0000001f
-#define		AHCI_CAP_SXS	0x00000020
-#define		AHCI_CAP_EMS	0x00000040
-#define		AHCI_CAP_CCCS	0x00000080
-#define		AHCI_CAP_NCS	0x00001F00
-#define		AHCI_CAP_NCS_SHIFT	8
-#define		AHCI_CAP_PSC	0x00002000
-#define		AHCI_CAP_SSC	0x00004000
-#define		AHCI_CAP_PMD	0x00008000
-#define		AHCI_CAP_FBSS	0x00010000
-#define		AHCI_CAP_SPM	0x00020000
-#define		AHCI_CAP_SAM	0x00080000
-#define		AHCI_CAP_ISS	0x00F00000
-#define		AHCI_CAP_ISS_SHIFT	20
-#define		AHCI_CAP_SCLO	0x01000000
-#define		AHCI_CAP_SAL	0x02000000
-#define		AHCI_CAP_SALP	0x04000000
-#define		AHCI_CAP_SSS	0x08000000
-#define		AHCI_CAP_SMPS	0x10000000
-#define		AHCI_CAP_SSNTF	0x20000000
-#define		AHCI_CAP_SNCQ	0x40000000
-#define		AHCI_CAP_64BIT	0x80000000
+#define	AHCI_CAP		0x00
+#define	AHCI_CAP_NPMASK		0x0000001f
+#define	AHCI_CAP_SXS		0x00000020
+#define	AHCI_CAP_EMS		0x00000040
+#define	AHCI_CAP_CCCS		0x00000080
+#define	AHCI_CAP_NCS		0x00001F00
+#define	AHCI_CAP_NCS_SHIFT	8
+#define	AHCI_CAP_PSC		0x00002000
+#define	AHCI_CAP_SSC		0x00004000
+#define	AHCI_CAP_PMD		0x00008000
+#define	AHCI_CAP_FBSS		0x00010000
+#define	AHCI_CAP_SPM		0x00020000
+#define	AHCI_CAP_SAM		0x00080000
+#define	AHCI_CAP_ISS		0x00F00000
+#define	AHCI_CAP_ISS_SHIFT	20
+#define	AHCI_CAP_SCLO		0x01000000
+#define	AHCI_CAP_SAL		0x02000000
+#define	AHCI_CAP_SALP		0x04000000
+#define	AHCI_CAP_SSS		0x08000000
+#define	AHCI_CAP_SMPS		0x10000000
+#define	AHCI_CAP_SSNTF		0x20000000
+#define	AHCI_CAP_SNCQ		0x40000000
+#define	AHCI_CAP_64BIT		0x80000000
 
-#define AHCI_GHC                    0x04
-#define         AHCI_GHC_AE         0x80000000
-#define         AHCI_GHC_MRSM       0x00000004
-#define         AHCI_GHC_IE         0x00000002
-#define         AHCI_GHC_HR         0x00000001
+#define	AHCI_GHC		0x04
+#define	AHCI_GHC_AE		0x80000000
+#define	AHCI_GHC_MRSM		0x00000004
+#define	AHCI_GHC_IE		0x00000002
+#define	AHCI_GHC_HR		0x00000001
 
-#define AHCI_IS                     0x08
-#define AHCI_PI                     0x0c
-#define AHCI_VS                     0x10
+#define	AHCI_IS			0x08
+#define	AHCI_PI			0x0c
+#define	AHCI_VS			0x10
 
-#define AHCI_CCCC                   0x14
-#define		AHCI_CCCC_TV_MASK	0xffff0000
-#define		AHCI_CCCC_TV_SHIFT	16
-#define		AHCI_CCCC_CC_MASK	0x0000ff00
-#define		AHCI_CCCC_CC_SHIFT	8
-#define		AHCI_CCCC_INT_MASK	0x000000f8
-#define		AHCI_CCCC_INT_SHIFT	3
-#define		AHCI_CCCC_EN		0x00000001
-#define AHCI_CCCP                   0x18
+#define	AHCI_CCCC		0x14
+#define	AHCI_CCCC_TV_MASK	0xffff0000
+#define	AHCI_CCCC_TV_SHIFT	16
+#define	AHCI_CCCC_CC_MASK	0x0000ff00
+#define	AHCI_CCCC_CC_SHIFT	8
+#define	AHCI_CCCC_INT_MASK	0x000000f8
+#define	AHCI_CCCC_INT_SHIFT	3
+#define	AHCI_CCCC_EN		0x00000001
+#define	AHCI_CCCP		0x18
 
-#define AHCI_EM_LOC                 0x1C
-#define AHCI_EM_CTL                 0x20
-#define 	AHCI_EM_MR              0x00000001
-#define 	AHCI_EM_TM              0x00000100
-#define 	AHCI_EM_RST             0x00000200
-#define 	AHCI_EM_LED             0x00010000
-#define 	AHCI_EM_SAFTE           0x00020000
-#define 	AHCI_EM_SES2            0x00040000
-#define 	AHCI_EM_SGPIO           0x00080000
-#define 	AHCI_EM_SMB             0x01000000
-#define 	AHCI_EM_XMT             0x02000000
-#define 	AHCI_EM_ALHD            0x04000000
-#define 	AHCI_EM_PM              0x08000000
+#define	AHCI_EM_LOC		0x1C
+#define	AHCI_EM_CTL		0x20
+#define	AHCI_EM_MR		0x00000001
+#define	AHCI_EM_TM		0x00000100
+#define	AHCI_EM_RST		0x00000200
+#define	AHCI_EM_LED		0x00010000
+#define	AHCI_EM_SAFTE		0x00020000
+#define	AHCI_EM_SES2		0x00040000
+#define	AHCI_EM_SGPIO		0x00080000
+#define	AHCI_EM_SMB		0x01000000
+#define	AHCI_EM_XMT		0x02000000
+#define	AHCI_EM_ALHD		0x04000000
+#define	AHCI_EM_PM		0x08000000
 
-#define AHCI_CAP2                   0x24
-#define		AHCI_CAP2_BOH	0x00000001
-#define		AHCI_CAP2_NVMP	0x00000002
-#define		AHCI_CAP2_APST	0x00000004
-#define		AHCI_CAP2_SDS	0x00000008
-#define		AHCI_CAP2_SADM	0x00000010
-#define		AHCI_CAP2_DESO	0x00000020
+#define	AHCI_CAP2		0x24
+#define	AHCI_CAP2_BOH		0x00000001
+#define	AHCI_CAP2_NVMP		0x00000002
+#define	AHCI_CAP2_APST		0x00000004
+#define	AHCI_CAP2_SDS		0x00000008
+#define	AHCI_CAP2_SADM		0x00000010
+#define	AHCI_CAP2_DESO		0x00000020
 
-#define AHCI_OFFSET                 0x100
-#define AHCI_STEP                   0x80
+#define	AHCI_OFFSET		0x100
+#define	AHCI_STEP		0x80
 
-#define AHCI_P_CLB                  0x00
-#define AHCI_P_CLBU                 0x04
-#define AHCI_P_FB                   0x08
-#define AHCI_P_FBU                  0x0c
-#define AHCI_P_IS                   0x10
-#define AHCI_P_IE                   0x14
-#define         AHCI_P_IX_DHR       0x00000001
-#define         AHCI_P_IX_PS        0x00000002
-#define         AHCI_P_IX_DS        0x00000004
-#define         AHCI_P_IX_SDB       0x00000008
-#define         AHCI_P_IX_UF        0x00000010
-#define         AHCI_P_IX_DP        0x00000020
-#define         AHCI_P_IX_PC        0x00000040
-#define         AHCI_P_IX_MP        0x00000080
+#define	AHCI_P_CLB		0x00
+#define	AHCI_P_CLBU		0x04
+#define	AHCI_P_FB		0x08
+#define	AHCI_P_FBU		0x0c
+#define	AHCI_P_IS		0x10
+#define	AHCI_P_IE		0x14
+#define	AHCI_P_IX_DHR		0x00000001
+#define	AHCI_P_IX_PS		0x00000002
+#define	AHCI_P_IX_DS		0x00000004
+#define	AHCI_P_IX_SDB		0x00000008
+#define	AHCI_P_IX_UF		0x00000010
+#define	AHCI_P_IX_DP		0x00000020
+#define	AHCI_P_IX_PC		0x00000040
+#define	AHCI_P_IX_MP		0x00000080
 
-#define         AHCI_P_IX_PRC       0x00400000
-#define         AHCI_P_IX_IPM       0x00800000
-#define         AHCI_P_IX_OF        0x01000000
-#define         AHCI_P_IX_INF       0x04000000
-#define         AHCI_P_IX_IF        0x08000000
-#define         AHCI_P_IX_HBD       0x10000000
-#define         AHCI_P_IX_HBF       0x20000000
-#define         AHCI_P_IX_TFE       0x40000000
-#define         AHCI_P_IX_CPD       0x80000000
+#define	AHCI_P_IX_PRC		0x00400000
+#define	AHCI_P_IX_IPM		0x00800000
+#define	AHCI_P_IX_OF		0x01000000
+#define	AHCI_P_IX_INF		0x04000000
+#define	AHCI_P_IX_IF		0x08000000
+#define	AHCI_P_IX_HBD		0x10000000
+#define	AHCI_P_IX_HBF		0x20000000
+#define	AHCI_P_IX_TFE		0x40000000
+#define	AHCI_P_IX_CPD		0x80000000
 
-#define AHCI_P_CMD                  0x18
-#define         AHCI_P_CMD_ST       0x00000001
-#define         AHCI_P_CMD_SUD      0x00000002
-#define         AHCI_P_CMD_POD      0x00000004
-#define         AHCI_P_CMD_CLO      0x00000008
-#define         AHCI_P_CMD_FRE      0x00000010
-#define         AHCI_P_CMD_CCS_MASK 0x00001f00
-#define         AHCI_P_CMD_CCS_SHIFT 8
-#define         AHCI_P_CMD_ISS      0x00002000
-#define         AHCI_P_CMD_FR       0x00004000
-#define         AHCI_P_CMD_CR       0x00008000
-#define         AHCI_P_CMD_CPS      0x00010000
-#define         AHCI_P_CMD_PMA      0x00020000
-#define         AHCI_P_CMD_HPCP     0x00040000
-#define         AHCI_P_CMD_MPSP     0x00080000
-#define         AHCI_P_CMD_CPD      0x00100000
-#define         AHCI_P_CMD_ESP      0x00200000
-#define         AHCI_P_CMD_FBSCP    0x00400000
-#define         AHCI_P_CMD_APSTE    0x00800000
-#define         AHCI_P_CMD_ATAPI    0x01000000
-#define         AHCI_P_CMD_DLAE     0x02000000
-#define         AHCI_P_CMD_ALPE     0x04000000
-#define         AHCI_P_CMD_ASP      0x08000000
-#define         AHCI_P_CMD_ICC_MASK 0xf0000000
-#define         AHCI_P_CMD_NOOP     0x00000000
-#define         AHCI_P_CMD_ACTIVE   0x10000000
-#define         AHCI_P_CMD_PARTIAL  0x20000000
-#define         AHCI_P_CMD_SLUMBER  0x60000000
-#define         AHCI_P_CMD_DEVSLEEP 0x80000000
+#define	AHCI_P_CMD		0x18
+#define	AHCI_P_CMD_ST		0x00000001
+#define	AHCI_P_CMD_SUD		0x00000002
+#define	AHCI_P_CMD_POD		0x00000004
+#define	AHCI_P_CMD_CLO		0x00000008
+#define	AHCI_P_CMD_FRE		0x00000010
+#define	AHCI_P_CMD_CCS_MASK	0x00001f00
+#define	AHCI_P_CMD_CCS_SHIFT	8
+#define	AHCI_P_CMD_ISS		0x00002000
+#define	AHCI_P_CMD_FR		0x00004000
+#define	AHCI_P_CMD_CR		0x00008000
+#define	AHCI_P_CMD_CPS		0x00010000
+#define	AHCI_P_CMD_PMA		0x00020000
+#define	AHCI_P_CMD_HPCP		0x00040000
+#define	AHCI_P_CMD_MPSP		0x00080000
+#define	AHCI_P_CMD_CPD		0x00100000
+#define	AHCI_P_CMD_ESP		0x00200000
+#define	AHCI_P_CMD_FBSCP	0x00400000
+#define	AHCI_P_CMD_APSTE	0x00800000
+#define	AHCI_P_CMD_ATAPI	0x01000000
+#define	AHCI_P_CMD_DLAE		0x02000000
+#define	AHCI_P_CMD_ALPE		0x04000000
+#define	AHCI_P_CMD_ASP		0x08000000
+#define	AHCI_P_CMD_ICC_MASK	0xf0000000
+#define	AHCI_P_CMD_NOOP		0x00000000
+#define	AHCI_P_CMD_ACTIVE	0x10000000
+#define	AHCI_P_CMD_PARTIAL	0x20000000
+#define	AHCI_P_CMD_SLUMBER	0x60000000
+#define	AHCI_P_CMD_DEVSLEEP	0x80000000
 
-#define AHCI_P_TFD                  0x20
-#define AHCI_P_SIG                  0x24
-#define AHCI_P_SSTS                 0x28
-#define AHCI_P_SCTL                 0x2c
-#define AHCI_P_SERR                 0x30
-#define AHCI_P_SACT                 0x34
-#define AHCI_P_CI                   0x38
-#define AHCI_P_SNTF                 0x3C
-#define AHCI_P_FBS                  0x40
-#define 	AHCI_P_FBS_EN       0x00000001
-#define 	AHCI_P_FBS_DEC      0x00000002
-#define 	AHCI_P_FBS_SDE      0x00000004
-#define 	AHCI_P_FBS_DEV      0x00000f00
-#define 	AHCI_P_FBS_DEV_SHIFT 8
-#define 	AHCI_P_FBS_ADO      0x0000f000
-#define 	AHCI_P_FBS_ADO_SHIFT 12
-#define 	AHCI_P_FBS_DWE      0x000f0000
-#define 	AHCI_P_FBS_DWE_SHIFT 16
-#define AHCI_P_DEVSLP               0x44
-#define 	AHCI_P_DEVSLP_ADSE  0x00000001
-#define 	AHCI_P_DEVSLP_DSP   0x00000002
-#define 	AHCI_P_DEVSLP_DETO  0x000003fc
-#define 	AHCI_P_DEVSLP_DETO_SHIFT 2
-#define 	AHCI_P_DEVSLP_MDAT  0x00007c00
-#define 	AHCI_P_DEVSLP_MDAT_SHIFT 10
-#define 	AHCI_P_DEVSLP_DITO  0x01ff8000
-#define 	AHCI_P_DEVSLP_DITO_SHIFT 15
-#define 	AHCI_P_DEVSLP_DM    0x0e000000
-#define 	AHCI_P_DEVSLP_DM_SHIFT 25
+#define	AHCI_P_TFD			0x20
+#define	AHCI_P_SIG			0x24
+#define	AHCI_P_SSTS			0x28
+#define	AHCI_P_SCTL			0x2c
+#define	AHCI_P_SERR			0x30
+#define	AHCI_P_SACT			0x34
+#define	AHCI_P_CI			0x38
+#define	AHCI_P_SNTF			0x3C
+#define	AHCI_P_FBS			0x40
+#define	AHCI_P_FBS_EN			0x00000001
+#define	AHCI_P_FBS_DEC			0x00000002
+#define	AHCI_P_FBS_SDE			0x00000004
+#define	AHCI_P_FBS_DEV			0x00000f00
+#define	AHCI_P_FBS_DEV_SHIFT		8
+#define	AHCI_P_FBS_ADO			0x0000f000
+#define	AHCI_P_FBS_ADO_SHIFT		12
+#define	AHCI_P_FBS_DWE			0x000f0000
+#define	AHCI_P_FBS_DWE_SHIFT		16
+#define	AHCI_P_DEVSLP			0x44
+#define	AHCI_P_DEVSLP_ADSE		0x00000001
+#define	AHCI_P_DEVSLP_DSP		0x00000002
+#define	AHCI_P_DEVSLP_DETO		0x000003fc
+#define	AHCI_P_DEVSLP_DETO_SHIFT	2
+#define	AHCI_P_DEVSLP_MDAT		0x00007c00
+#define	AHCI_P_DEVSLP_MDAT_SHIFT	10
+#define	AHCI_P_DEVSLP_DITO		0x01ff8000
+#define	AHCI_P_DEVSLP_DITO_SHIFT	15
+#define	AHCI_P_DEVSLP_DM		0x0e000000
+#define	AHCI_P_DEVSLP_DM_SHIFT		25
 
 /* Just to be sure, if building as module. */
 #if MAXPHYS < 512 * 1024
 #undef MAXPHYS
-#define MAXPHYS				512 * 1024
+#define	MAXPHYS			512 * 1024
 #endif
 /* Pessimistic prognosis on number of required S/G entries */
-#define AHCI_SG_ENTRIES	(roundup(btoc(MAXPHYS) + 1, 8))
+#define	AHCI_SG_ENTRIES	(roundup(btoc(MAXPHYS) + 1, 8))
 /* Command list. 32 commands. First, 1Kbyte aligned. */
-#define AHCI_CL_OFFSET              0
-#define AHCI_CL_SIZE                32
+#define	AHCI_CL_OFFSET		0
+#define	AHCI_CL_SIZE		32
 /* Command tables. Up to 32 commands, Each, 128byte aligned. */
-#define AHCI_CT_OFFSET              (AHCI_CL_OFFSET + AHCI_CL_SIZE * AHCI_MAX_SLOTS)
-#define AHCI_CT_SIZE                (128 + AHCI_SG_ENTRIES * 16)
+#define	AHCI_CT_OFFSET		(AHCI_CL_OFFSET + AHCI_CL_SIZE * AHCI_MAX_SLOTS)
+#define	AHCI_CT_SIZE		(128 + AHCI_SG_ENTRIES * 16)
 /* Total main work area. */
-#define AHCI_WORK_SIZE              (AHCI_CT_OFFSET + AHCI_CT_SIZE * ch->numslots)
+#define	AHCI_WORK_SIZE		(AHCI_CT_OFFSET + AHCI_CT_SIZE * ch->numslots)
 
 #endif /* _AHCI_H_ */

--- a/usr/src/cmd/bhyve/atkbdc.c
+++ b/usr/src/cmd/bhyve/atkbdc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2015 Nahanni Systems Inc.
  * All rights reserved.
@@ -45,6 +47,7 @@ __FBSDID("$FreeBSD$");
 #include <pthread_np.h>
 
 #include "acpi.h"
+#include "atkbdc.h"
 #include "inout.h"
 #include "pci_emul.h"
 #include "pci_irq.h"

--- a/usr/src/cmd/bhyve/bhyvegc.c
+++ b/usr/src/cmd/bhyve/bhyvegc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/bhyvegc.h
+++ b/usr/src/cmd/bhyve/bhyvegc.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/bhyverun.c
+++ b/usr/src/cmd/bhyve/bhyverun.c
@@ -141,14 +141,14 @@ static void vm_loop(struct vmctx *ctx, int vcpu, uint64_t rip);
 static struct vm_exit vmexit[VM_MAXCPU];
 
 struct bhyvestats {
-        uint64_t        vmexit_bogus;
+	uint64_t	vmexit_bogus;
 	uint64_t	vmexit_reqidle;
-        uint64_t        vmexit_hlt;
-        uint64_t        vmexit_pause;
-        uint64_t        vmexit_mtrap;
-        uint64_t        vmexit_inst_emul;
-        uint64_t        cpu_switch_rotate;
-        uint64_t        cpu_switch_direct;
+	uint64_t	vmexit_hlt;
+	uint64_t	vmexit_pause;
+	uint64_t	vmexit_mtrap;
+	uint64_t	vmexit_inst_emul;
+	uint64_t	cpu_switch_rotate;
+	uint64_t	cpu_switch_direct;
 } stats;
 
 struct mt_vmm_info {
@@ -176,7 +176,7 @@ usage(int code)
 #endif
 		"       -a: local apic is in xAPIC mode (deprecated)\n"
 		"       -A: create ACPI tables\n"
-		"       -c: number of cpus and/or topology specification"
+		"       -c: number of cpus and/or topology specification\n"
 		"       -C: include guest memory in core file\n"
 		"       -e: exit on unhandled I/O access\n"
 		"       -g: gdb port\n"
@@ -224,6 +224,8 @@ topology_parse(const char *opt)
 	c = 1, n = 1, s = 1, t = 1;
 	ns = false, scts = false;
 	str = strdup(opt);
+	if (str == NULL)
+		goto out;
 
 	while ((cp = strsep(&str, ",")) != NULL) {
 		if (sscanf(cp, "%i%n", &tmp, &chk) == 1) {
@@ -249,11 +251,14 @@ topology_parse(const char *opt)
 		} else if (cp[0] == '\0')
 			continue;
 		else
-			return (-1);
+			goto out;
 		/* Any trailing garbage causes an error */
 		if (cp[chk] != '\0')
-			return (-1);
+			goto out;
 	}
+	free(str);
+	str = NULL;
+
 	/*
 	 * Range check 1 <= n <= UINT16_MAX all values
 	 */
@@ -279,6 +284,10 @@ topology_parse(const char *opt)
 	cores = c;
 	threads = t;
 	return(0);
+
+out:
+	free(str);
+	return (-1);
 }
 
 #ifndef WITHOUT_CAPSICUM
@@ -458,7 +467,7 @@ fbsdrun_deletecpu(struct vmctx *ctx, int vcpu)
 
 	if (!CPU_ISSET(vcpu, &cpumask)) {
 		fprintf(stderr, "Attempting to delete unknown cpu %d\n", vcpu);
-		exit(1);
+		exit(4);
 	}
 
 	CPU_CLR_ATOMIC(vcpu, &cpumask);
@@ -474,7 +483,7 @@ vmexit_handle_notify(struct vmctx *ctx, struct vm_exit *vme, int *pvcpu,
 	 * put guest-driven debug here
 	 */
 #endif
-        return (VMEXIT_CONTINUE);
+	return (VMEXIT_CONTINUE);
 }
 
 static int
@@ -804,7 +813,7 @@ vm_loop(struct vmctx *ctx, int vcpu, uint64_t startrip)
 		if (exitcode >= VM_EXITCODE_MAX || handler[exitcode] == NULL) {
 			fprintf(stderr, "vm_loop: unexpected exitcode 0x%x\n",
 			    exitcode);
-			exit(1);
+			exit(4);
 		}
 
 		rc = (*handler[exitcode])(ctx, &vmexit[vcpu], &vcpu);
@@ -815,7 +824,7 @@ vm_loop(struct vmctx *ctx, int vcpu, uint64_t startrip)
 		case VMEXIT_ABORT:
 			abort();
 		default:
-			exit(1);
+			exit(4);
 		}
 	}
 	fprintf(stderr, "vm_run error %d, errno %d\n", error, errno);
@@ -847,7 +856,7 @@ fbsdrun_set_capabilities(struct vmctx *ctx, int cpu)
 		err = vm_get_capability(ctx, cpu, VM_CAP_HALT_EXIT, &tmp);
 		if (err < 0) {
 			fprintf(stderr, "VM exit on HLT not supported\n");
-			exit(1);
+			exit(4);
 		}
 		vm_set_capability(ctx, cpu, VM_CAP_HALT_EXIT, 1);
 		if (cpu == BSP)
@@ -862,7 +871,7 @@ fbsdrun_set_capabilities(struct vmctx *ctx, int cpu)
 		if (err < 0) {
 			fprintf(stderr,
 			    "SMP mux requested, no pause support\n");
-			exit(1);
+			exit(4);
 		}
 		vm_set_capability(ctx, cpu, VM_CAP_PAUSE_EXIT, 1);
 		if (cpu == BSP)
@@ -876,7 +885,7 @@ fbsdrun_set_capabilities(struct vmctx *ctx, int cpu)
 
 	if (err) {
 		fprintf(stderr, "Unable to set x2apic state (%d)\n", err);
-		exit(1);
+		exit(4);
 	}
 
 #ifdef	__FreeBSD__
@@ -914,7 +923,7 @@ do_open(const char *vmname)
 			}
 		} else {
 			perror("vm_create");
-			exit(1);
+			exit(4);
 		}
 	} else {
 		if (!romboot) {
@@ -923,14 +932,14 @@ do_open(const char *vmname)
 			 * bootrom must be configured to boot it.
 			 */
 			fprintf(stderr, "virtual machine cannot be booted\n");
-			exit(1);
+			exit(4);
 		}
 	}
 
 	ctx = vm_open(vmname);
 	if (ctx == NULL) {
 		perror("vm_open");
-		exit(1);
+		exit(4);
 	}
 
 #ifndef WITHOUT_CAPSICUM
@@ -952,7 +961,7 @@ do_open(const char *vmname)
 		error = vm_reinit(ctx);
 		if (error) {
 			perror("vm_reinit");
-			exit(1);
+			exit(4);
 		}
 	}
 	error = vm_set_topology(ctx, sockets, cores, threads, maxcpus);
@@ -1036,14 +1045,20 @@ main(int argc, char *argv[])
 			gdb_port = atoi(optarg);
 			break;
 		case 'l':
-			if (lpc_device_parse(optarg) != 0) {
+			if (strncmp(optarg, "help", strlen(optarg)) == 0) {
+				lpc_print_supported_devices();
+				exit(0);
+			} else if (lpc_device_parse(optarg) != 0) {
 				errx(EX_USAGE, "invalid lpc device "
 				    "configuration '%s'", optarg);
 			}
 			break;
 		case 's':
-			if (pci_parse_slot(optarg) != 0)
-				exit(1);
+			if (strncmp(optarg, "help", strlen(optarg)) == 0) {
+				pci_print_supported_devices();
+				exit(0);
+			} else if (pci_parse_slot(optarg) != 0)
+				exit(4);
 			else
 				break;
 		case 'S':
@@ -1109,7 +1124,7 @@ main(int argc, char *argv[])
 	if (guest_ncpus > max_vcpus) {
 		fprintf(stderr, "%d vCPUs requested but only %d available\n",
 			guest_ncpus, max_vcpus);
-		exit(1);
+		exit(4);
 	}
 
 	fbsdrun_set_capabilities(ctx, BSP);
@@ -1131,13 +1146,13 @@ main(int argc, char *argv[])
 #endif
 	if (err) {
 		fprintf(stderr, "Unable to setup memory (%d)\n", errno);
-		exit(1);
+		exit(4);
 	}
 
 	error = init_msr();
 	if (error) {
 		fprintf(stderr, "init_msr error %d", error);
-		exit(1);
+		exit(4);
 	}
 
 	init_mem();
@@ -1152,8 +1167,10 @@ main(int argc, char *argv[])
 	/*
 	 * Exit if a device emulation finds an error in its initilization
 	 */
-	if (init_pci(ctx) != 0)
-		exit(1);
+	if (init_pci(ctx) != 0) {
+		perror("device emulation initialization error");
+		exit(4);
+	}
 
 	if (dbg_port != 0)
 		init_dbgport(dbg_port);
@@ -1170,7 +1187,7 @@ main(int argc, char *argv[])
 		if (vm_set_capability(ctx, BSP, VM_CAP_UNRESTRICTED_GUEST, 1)) {
 			fprintf(stderr, "ROM boot failed: unrestricted guest "
 			    "capability not available\n");
-			exit(1);
+			exit(4);
 		}
 		error = vcpu_reset(ctx, BSP);
 		assert(error == 0);
@@ -1184,8 +1201,10 @@ main(int argc, char *argv[])
 	 */
 	if (mptgen) {
 		error = mptable_build(ctx, guest_ncpus);
-		if (error)
-			exit(1);
+		if (error) {
+			perror("error to build the guest tables");
+			exit(4);
+		}
 	}
 
 	error = smbios_build(ctx);
@@ -1199,20 +1218,20 @@ main(int argc, char *argv[])
 	if (lpc_bootrom())
 		fwctl_init();
 
+	/*
+	 * Change the proc title to include the VM name.
+	 */
+	setproctitle("%s", vmname);
+
 #ifndef WITHOUT_CAPSICUM
 	caph_cache_catpages();
 
 	if (caph_limit_stdout() == -1 || caph_limit_stderr() == -1)
 		errx(EX_OSERR, "Unable to apply rights for sandbox");
 
-	if (cap_enter() == -1 && errno != ENOSYS)
+	if (caph_enter() == -1)
 		errx(EX_OSERR, "cap_enter() failed");
 #endif
-
-	/*
-	 * Change the proc title to include the VM name.
-	 */
-	setproctitle("%s", vmname); 
 
 #ifndef	__FreeBSD__
 	/*
@@ -1239,5 +1258,5 @@ main(int argc, char *argv[])
 	 */
 	mevent_dispatch();
 
-	exit(1);
+	exit(4);
 }

--- a/usr/src/cmd/bhyve/block_if.c
+++ b/usr/src/cmd/bhyve/block_if.c
@@ -117,8 +117,8 @@ struct blockif_ctxt {
 	int			bc_psectoff;
 	int			bc_closing;
 	pthread_t		bc_btid[BLOCKIF_NUMTHR];
-        pthread_mutex_t		bc_mtx;
-        pthread_cond_t		bc_cond;
+	pthread_mutex_t		bc_mtx;
+	pthread_cond_t		bc_cond;
 
 	/* Request elements and free/pending/busy queues */
 	TAILQ_HEAD(, blockif_elem) bc_freeq;       

--- a/usr/src/cmd/bhyve/block_if.h
+++ b/usr/src/cmd/bhyve/block_if.h
@@ -53,12 +53,12 @@
 #endif
 
 struct blockif_req {
-	struct iovec	br_iov[BLOCKIF_IOV_MAX];
 	int		br_iovcnt;
 	off_t		br_offset;
 	ssize_t		br_resid;
 	void		(*br_callback)(struct blockif_req *req, int err);
 	void		*br_param;
+	struct iovec	br_iov[BLOCKIF_IOV_MAX];
 };
 
 struct blockif_ctxt;

--- a/usr/src/cmd/bhyve/bootrom.c
+++ b/usr/src/cmd/bhyve/bootrom.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Neel Natu <neel@freebsd.org>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/bootrom.h
+++ b/usr/src/cmd/bhyve/bootrom.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Neel Natu <neel@freebsd.org>
  * All rights reserved.
  *
@@ -33,6 +35,6 @@
 
 struct vmctx;
 
-int	bootrom_init(struct vmctx *ctx, const char *romfile);
+int bootrom_init(struct vmctx *ctx, const char *romfile);
 
 #endif

--- a/usr/src/cmd/bhyve/console.c
+++ b/usr/src/cmd/bhyve/console.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/consport.c
+++ b/usr/src/cmd/bhyve/consport.c
@@ -78,14 +78,14 @@ ttyopen(void)
 static bool
 tty_char_available(void)
 {
-        fd_set rfds;
-        struct timeval tv;
+	fd_set rfds;
+	struct timeval tv;
 
-        FD_ZERO(&rfds);
-        FD_SET(STDIN_FILENO, &rfds);
-        tv.tv_sec = 0;
-        tv.tv_usec = 0;
-        if (select(STDIN_FILENO + 1, &rfds, NULL, NULL, &tv) > 0) {
+	FD_ZERO(&rfds);
+	FD_SET(STDIN_FILENO, &rfds);
+	tv.tv_sec = 0;
+	tv.tv_usec = 0;
+	if (select(STDIN_FILENO + 1, &rfds, NULL, NULL, &tv) > 0) {
 		return (true);
 	} else {
 		return (false);

--- a/usr/src/cmd/bhyve/dbgport.c
+++ b/usr/src/cmd/bhyve/dbgport.c
@@ -139,8 +139,8 @@ init_dbgport(int sport)
 	conn_fd = -1;
 
 	if ((listen_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		perror("socket");
-		exit(1);
+		perror("cannot create socket");
+		exit(4);
 	}
 
 #ifdef	__FreeBSD__
@@ -153,18 +153,18 @@ init_dbgport(int sport)
 	reuse = 1;
 	if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse,
 	    sizeof(reuse)) < 0) {
-		perror("setsockopt");
-		exit(1);
+		perror("cannot set socket options");
+		exit(4);
 	}
 
 	if (bind(listen_fd, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
-		perror("bind");
-		exit(1);
+		perror("cannot bind socket");
+		exit(4);
 	}
 
 	if (listen(listen_fd, 1) < 0) {
-		perror("listen");
-		exit(1);
+		perror("cannot listen socket");
+		exit(4);
 	}
 
 #ifndef WITHOUT_CAPSICUM

--- a/usr/src/cmd/bhyve/fwctl.c
+++ b/usr/src/cmd/bhyve/fwctl.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015  Peter Grehan <grehan@freebsd.org>
  * All rights reserved.
  *
@@ -373,7 +375,7 @@ fwctl_request(uint32_t value)
 		/* Verify size */
 		if (value < 12) {
 			printf("msg size error");
-			exit(1);
+			exit(4);
 		}
 		rinfo.req_size = value;
 		rinfo.req_count = 1;

--- a/usr/src/cmd/bhyve/fwctl.h
+++ b/usr/src/cmd/bhyve/fwctl.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015  Peter Grehan <grehan@freebsd.org>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/inout.c
+++ b/usr/src/cmd/bhyve/inout.c
@@ -68,21 +68,21 @@ static int
 default_inout(struct vmctx *ctx, int vcpu, int in, int port, int bytes,
               uint32_t *eax, void *arg)
 {
-        if (in) {
-                switch (bytes) {
-                case 4:
-                        *eax = 0xffffffff;
-                        break;
-                case 2:
-                        *eax = 0xffff;
-                        break;
-                case 1:
-                        *eax = 0xff;
-                        break;
-                }
-        }
-        
-        return (0);
+	if (in) {
+		switch (bytes) {
+		case 4:
+			*eax = 0xffffffff;
+			break;
+		case 2:
+			*eax = 0xffff;
+			break;
+		case 1:
+			*eax = 0xff;
+			break;
+		}
+	}
+
+	return (0);
 }
 
 static void 

--- a/usr/src/cmd/bhyve/iov.c
+++ b/usr/src/cmd/bhyve/iov.c
@@ -1,0 +1,141 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2016 Jakub Klama <jceel@FreeBSD.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include "iov.h"
+
+void
+seek_iov(struct iovec *iov1, size_t niov1, struct iovec *iov2, size_t *niov2,
+    size_t seek)
+{
+	size_t remainder = 0;
+	size_t left = seek;
+	size_t i, j;
+
+	for (i = 0; i < niov1; i++) {
+		size_t toseek = MIN(left, iov1[i].iov_len);
+		left -= toseek;
+
+		if (toseek == iov1[i].iov_len)
+			continue;
+
+		if (left == 0) {
+			remainder = toseek;
+			break;
+		}
+	}
+
+	for (j = i; j < niov1; j++) {
+		iov2[j - i].iov_base = (char *)iov1[j].iov_base + remainder;
+		iov2[j - i].iov_len = iov1[j].iov_len - remainder;
+		remainder = 0;
+	}
+
+	*niov2 = j - i;
+}
+
+size_t
+count_iov(struct iovec *iov, size_t niov)
+{
+	size_t i, total = 0;
+
+	for (i = 0; i < niov; i++)
+		total += iov[i].iov_len;
+
+	return (total);
+}
+
+size_t
+truncate_iov(struct iovec *iov, size_t niov, size_t length)
+{
+	size_t i, done = 0;
+
+	for (i = 0; i < niov; i++) {
+		size_t toseek = MIN(length - done, iov[i].iov_len);
+		done += toseek;
+
+		if (toseek < iov[i].iov_len) {
+			iov[i].iov_len = toseek;
+			return (i + 1);
+		}
+	}
+
+	return (niov);
+}
+
+ssize_t
+iov_to_buf(struct iovec *iov, size_t niov, void **buf)
+{
+	size_t i, ptr = 0, total = 0;
+
+	for (i = 0; i < niov; i++) {
+		total += iov[i].iov_len;
+		*buf = realloc(*buf, total);
+		if (*buf == NULL)
+			return (-1);
+
+		memcpy(*buf + ptr, iov[i].iov_base, iov[i].iov_len);
+		ptr += iov[i].iov_len;
+	}
+
+	return (total);
+}
+
+ssize_t
+buf_to_iov(void *buf, size_t buflen, struct iovec *iov, size_t niov,
+    size_t seek)
+{
+	struct iovec *diov;
+	size_t ndiov, i;
+	uintptr_t off = 0;
+
+	if (seek > 0) {
+		diov = malloc(sizeof(struct iovec) * niov);
+		seek_iov(iov, niov, diov, &ndiov, seek);
+	} else {
+		diov = iov;
+		ndiov = niov;
+	}
+
+	for (i = 0; i < ndiov; i++) {
+		memcpy(diov[i].iov_base, buf + off, diov[i].iov_len);
+		off += diov[i].iov_len;
+	}
+
+	return ((ssize_t)off);
+}
+

--- a/usr/src/cmd/bhyve/iov.h
+++ b/usr/src/cmd/bhyve/iov.h
@@ -1,19 +1,20 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
  *
- * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
+ * Copyright (c) 2016 Jakub Klama <jceel@FreeBSD.org>.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
@@ -28,28 +29,15 @@
  * $FreeBSD$
  */
 
-#ifndef _CONSOLE_H_
-#define	_CONSOLE_H_
+#ifndef _IOV_H_
+#define	_IOV_H_
 
-struct bhyvegc;
+void seek_iov(struct iovec *iov1, size_t niov1, struct iovec *iov2,
+    size_t *niov2, size_t seek);
+size_t truncate_iov(struct iovec *iov, size_t niov, size_t length);
+size_t count_iov(struct iovec *iov, size_t niov);
+ssize_t iov_to_buf(struct iovec *iov, size_t niov, void **buf);
+ssize_t buf_to_iov(void *buf, size_t buflen, struct iovec *iov, size_t niov,
+    size_t seek);
 
-typedef void (*fb_render_func_t)(struct bhyvegc *gc, void *arg);
-typedef void (*kbd_event_func_t)(int down, uint32_t keysym, void *arg);
-typedef void (*ptr_event_func_t)(uint8_t mask, int x, int y, void *arg);
-
-void console_init(int w, int h, void *fbaddr);
-
-void console_set_fbaddr(void *fbaddr);
-
-struct bhyvegc_image *console_get_image(void);
-
-void console_fb_register(fb_render_func_t render_cb, void *arg);
-void console_refresh(void);
-
-void console_kbd_register(kbd_event_func_t event_cb, void *arg, int pri);
-void console_key_event(int down, uint32_t keysym);
-
-void console_ptr_register(ptr_event_func_t event_cb, void *arg, int pri);
-void console_ptr_event(uint8_t button, int x, int y);
-
-#endif /* _CONSOLE_H_ */
+#endif	/* _IOV_H_ */

--- a/usr/src/cmd/bhyve/mem.c
+++ b/usr/src/cmd/bhyve/mem.c
@@ -38,15 +38,16 @@
 __FBSDID("$FreeBSD$");
 
 #include <sys/types.h>
-#include <sys/tree.h>
 #include <sys/errno.h>
+#include <sys/tree.h>
 #include <machine/vmm.h>
 #include <machine/vmm_instruction_emul.h>
 
+#include <assert.h>
+#include <err.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <pthread.h>
 
 #include "mem.h"
 
@@ -123,6 +124,7 @@ mmio_rb_add(struct mmio_rb_tree *rbt, struct mmio_rb_range *new)
 static void
 mmio_rb_dump(struct mmio_rb_tree *rbt)
 {
+	int perror;
 	struct mmio_rb_range *np;
 
 	pthread_rwlock_rdlock(&mmio_rwlock);
@@ -130,7 +132,8 @@ mmio_rb_dump(struct mmio_rb_tree *rbt)
 		printf(" %lx:%lx, %s\n", np->mr_base, np->mr_end,
 		       np->mr_param.name);
 	}
-	pthread_rwlock_unlock(&mmio_rwlock);
+	perror = pthread_rwlock_unlock(&mmio_rwlock);
+	assert(perror == 0);
 }
 #endif
 
@@ -166,7 +169,7 @@ access_memory(struct vmctx *ctx, int vcpu, uint64_t paddr, mem_cb_t *cb,
     void *arg)
 {
 	struct mmio_rb_range *entry;
-	int err, immutable;
+	int err, perror, immutable;
 	
 	pthread_rwlock_rdlock(&mmio_rwlock);
 	/*
@@ -184,7 +187,8 @@ access_memory(struct vmctx *ctx, int vcpu, uint64_t paddr, mem_cb_t *cb,
 			/* Update the per-vCPU cache */
 			mmio_hint[vcpu] = entry;			
 		} else if (mmio_rb_lookup(&mmio_rb_fallback, paddr, &entry)) {
-			pthread_rwlock_unlock(&mmio_rwlock);
+			perror = pthread_rwlock_unlock(&mmio_rwlock);
+			assert(perror == 0);
 			return (ESRCH);
 		}
 	}
@@ -203,13 +207,18 @@ access_memory(struct vmctx *ctx, int vcpu, uint64_t paddr, mem_cb_t *cb,
 	 * config space window as 'immutable' the deadlock can be avoided.
 	 */
 	immutable = (entry->mr_param.flags & MEM_F_IMMUTABLE);
-	if (immutable)
-		pthread_rwlock_unlock(&mmio_rwlock);
+	if (immutable) {
+		perror = pthread_rwlock_unlock(&mmio_rwlock);
+		assert(perror == 0);
+	}
 
 	err = cb(ctx, vcpu, paddr, &entry->mr_param, arg);
 
-	if (!immutable)
-		pthread_rwlock_unlock(&mmio_rwlock);
+	if (!immutable) {
+		perror = pthread_rwlock_unlock(&mmio_rwlock);
+		assert(perror == 0);
+	}
+
 
 	return (err);
 }
@@ -272,24 +281,27 @@ static int
 register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 {
 	struct mmio_rb_range *entry, *mrp;
-	int		err;
+	int err, perror;
 
 	err = 0;
 
 	mrp = malloc(sizeof(struct mmio_rb_range));
-	
-	if (mrp != NULL) {
+	if (mrp == NULL) {
+		warn("%s: couldn't allocate memory for mrp\n",
+		     __func__);
+		err = ENOMEM;
+	} else {
 		mrp->mr_param = *memp;
 		mrp->mr_base = memp->base;
 		mrp->mr_end = memp->base + memp->size - 1;
 		pthread_rwlock_wrlock(&mmio_rwlock);
 		if (mmio_rb_lookup(rbt, memp->base, &entry) != 0)
 			err = mmio_rb_add(rbt, mrp);
-		pthread_rwlock_unlock(&mmio_rwlock);
+		perror = pthread_rwlock_unlock(&mmio_rwlock);
+		assert(perror == 0);
 		if (err)
 			free(mrp);
-	} else
-		err = ENOMEM;
+	}
 
 	return (err);
 }
@@ -313,7 +325,7 @@ unregister_mem(struct mem_range *memp)
 {
 	struct mem_range *mr;
 	struct mmio_rb_range *entry = NULL;
-	int err, i;
+	int err, perror, i;
 	
 	pthread_rwlock_wrlock(&mmio_rwlock);
 	err = mmio_rb_lookup(&mmio_rb_root, memp->base, &entry);
@@ -330,7 +342,8 @@ unregister_mem(struct mem_range *memp)
 				mmio_hint[i] = NULL;
 		}
 	}
-	pthread_rwlock_unlock(&mmio_rwlock);
+	perror = pthread_rwlock_unlock(&mmio_rwlock);
+	assert(perror == 0);
 
 	if (entry)
 		free(entry);

--- a/usr/src/cmd/bhyve/mem.h
+++ b/usr/src/cmd/bhyve/mem.h
@@ -55,7 +55,7 @@ struct mem_range {
 void	init_mem(void);
 int     emulate_mem(struct vmctx *, int vcpu, uint64_t paddr, struct vie *vie,
 		    struct vm_guest_paging *paging);
-		    
+
 int	read_mem(struct vmctx *ctx, int vcpu, uint64_t gpa, uint64_t *rval,
 		 int size);
 int	register_mem(struct mem_range *memp);

--- a/usr/src/cmd/bhyve/mevent.c
+++ b/usr/src/cmd/bhyve/mevent.c
@@ -82,7 +82,7 @@ static int mevent_timid = 43;
 static int mevent_pipefd[2];
 static pthread_mutex_t mevent_lmutex = PTHREAD_MUTEX_INITIALIZER;
 
-struct mevent {	
+struct mevent {
 	void	(*me_func)(int, enum ev_type, void *);
 #define me_msecs me_fd
 	int	me_fd;
@@ -101,7 +101,7 @@ struct mevent {
 	struct sigevent	me_sigev;
 	boolean_t	me_auto_requeue;
 #endif
-	LIST_ENTRY(mevent) me_list;			   
+	LIST_ENTRY(mevent) me_list;
 };
 
 static LIST_HEAD(listhead, mevent) global_head, change_head;

--- a/usr/src/cmd/bhyve/mevent_test.c
+++ b/usr/src/cmd/bhyve/mevent_test.c
@@ -164,7 +164,7 @@ echoer(void *param)
 	mev = mevent_add(fd, EVF_READ, echoer_callback, &sync);
 	if (mev == NULL) {
 		printf("Could not allocate echoer event\n");
-		exit(1);
+		exit(4);
 	}
 
 	while (!pthread_cond_wait(&sync.e_cond, &sync.e_mt)) {
@@ -219,27 +219,27 @@ acceptor(void *param)
 	int news;
 	int s;
 
-        if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-                perror("socket");
-                exit(1);
-        }
+	if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		perror("cannot create socket");
+		exit(4);
+	}
 
 #ifdef __FreeBSD__
-        sin.sin_len = sizeof(sin);
+	sin.sin_len = sizeof(sin);
 #endif
-        sin.sin_family = AF_INET;
-        sin.sin_addr.s_addr = htonl(INADDR_ANY);
-        sin.sin_port = htons(TEST_PORT);
+	sin.sin_family = AF_INET;
+	sin.sin_addr.s_addr = htonl(INADDR_ANY);
+	sin.sin_port = htons(TEST_PORT);
 
-        if (bind(s, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
-                perror("bind");
-                exit(1);
-        }
+	if (bind(s, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
+		perror("cannot bind socket");
+		exit(4);
+	}
 
-        if (listen(s, 1) < 0) {
-                perror("listen");
-                exit(1);
-        }
+	if (listen(s, 1) < 0) {
+		perror("cannot listen socket");
+		exit(4);
+	}
 
 	(void) mevent_add(s, EVF_READ, acceptor_callback, NULL);
 

--- a/usr/src/cmd/bhyve/pci_e82545.c
+++ b/usr/src/cmd/bhyve/pci_e82545.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2016 Alexander Motin <mav@FreeBSD.org>
  * Copyright (c) 2015 Peter Grehan <grehan@freebsd.org>
  * Copyright (c) 2013 Jeremiah Lott, Avere Systems
@@ -345,8 +347,8 @@ struct e82545_softc {
 #define E82545_NVM_MODE_OPADDR  0x0
 #define E82545_NVM_MODE_DATAIN  0x1
 #define E82545_NVM_MODE_DATAOUT 0x2
-        /* EEPROM data */
-        uint16_t eeprom_data[E82545_NVM_EEPROM_SIZE];
+	/* EEPROM data */
+	uint16_t eeprom_data[E82545_NVM_EEPROM_SIZE];
 };
 
 static void e82545_reset(struct e82545_softc *sc, int dev);
@@ -1495,7 +1497,7 @@ e82545_rx_disable(struct e82545_softc *sc)
 static void
 e82545_write_ra(struct e82545_softc *sc, int reg, uint32_t wval)
 {
-        struct eth_uni *eu;
+	struct eth_uni *eu;
 	int idx;
 
 	idx = reg >> 1;
@@ -1521,7 +1523,7 @@ e82545_write_ra(struct e82545_softc *sc, int reg, uint32_t wval)
 static uint32_t
 e82545_read_ra(struct e82545_softc *sc, int reg)
 {
-        struct eth_uni *eu;
+	struct eth_uni *eu;
 	uint32_t retval;
 	int idx;
 
@@ -1765,12 +1767,12 @@ e82545_read_register(struct e82545_softc *sc, uint32_t offset)
 {
 	uint32_t retval;
 	int ridx;
-	
+
 	if (offset & 0x3) {
 		DPRINTF("Unaligned register read offset:0x%x\r\n", offset);
 		return 0;
 	}
-		
+
 	DPRINTF("Register read: 0x%x\r\n", offset);
 
 	switch (offset) {
@@ -2247,7 +2249,7 @@ e82545_open_tap(struct e82545_softc *sc, char *opts)
 	sc->esc_tapfd = open(tbuf, O_RDWR);
 	if (sc->esc_tapfd == -1) {
 		DPRINTF("unable to open tap device %s\n", opts);
-		exit(1);
+		exit(4);
 	}
 
 	/*

--- a/usr/src/cmd/bhyve/pci_emul.c
+++ b/usr/src/cmd/bhyve/pci_emul.c
@@ -250,6 +250,17 @@ done:
 	return (error);
 }
 
+void
+pci_print_supported_devices()
+{
+	struct pci_devemu **pdpp, *pdp;
+
+	SET_FOREACH(pdpp, pci_devemu_set) {
+		pdp = *pdpp;
+		printf("%s\n", pdp->pe_emu);
+	}
+}
+
 static int
 pci_valid_pba_offset(struct pci_devinst *pi, uint64_t offset)
 {
@@ -882,7 +893,7 @@ msixcap_cfgwrite(struct pci_devinst *pi, int capoff, int offset,
 {
 	uint16_t msgctrl, rwmask;
 	int off;
-	
+
 	off = offset - capoff;
 	/* Message Control Register */
 	if (off == 2 && bytes == 2) {
@@ -895,8 +906,8 @@ msixcap_cfgwrite(struct pci_devinst *pi, int capoff, int offset,
 		pi->pi_msix.enabled = val & PCIM_MSIXCTRL_MSIX_ENABLE;
 		pi->pi_msix.function_mask = val & PCIM_MSIXCTRL_FUNCTION_MASK;
 		pci_lintr_update(pi);
-	} 
-	
+	}
+
 	CFGWRITE(pi, offset, val, bytes);
 }
 
@@ -1355,11 +1366,11 @@ pci_bus_write_dsdt(int bus)
 		dsdt_line("Name (PPRT, Package ()");
 		dsdt_line("{");
 		pci_walk_lintr(bus, pci_pirq_prt_entry, NULL);
- 		dsdt_line("})");
+		dsdt_line("})");
 		dsdt_line("Name (APRT, Package ()");
 		dsdt_line("{");
 		pci_walk_lintr(bus, pci_apic_prt_entry, NULL);
- 		dsdt_line("})");
+		dsdt_line("})");
 		dsdt_line("Method (_PRT, 0, NotSerialized)");
 		dsdt_line("{");
 		dsdt_line("  If (PICM)");
@@ -1750,7 +1761,7 @@ pci_emul_cmdsts_write(struct pci_devinst *pi, int coff, uint32_t new, int bytes)
 	 * interrupt.
 	 */
 	pci_lintr_update(pi);
-}	
+}
 
 static void
 pci_cfgrw(struct vmctx *ctx, int vcpu, int in, int bus, int slot, int func,

--- a/usr/src/cmd/bhyve/pci_emul.h
+++ b/usr/src/cmd/bhyve/pci_emul.h
@@ -241,6 +241,7 @@ int	pci_msix_table_bar(struct pci_devinst *pi);
 int	pci_msix_pba_bar(struct pci_devinst *pi);
 int	pci_msi_maxmsgnum(struct pci_devinst *pi);
 int	pci_parse_slot(char *opt);
+void    pci_print_supported_devices();
 void	pci_populate_msicap(struct msicap *cap, int msgs, int nextptr);
 int	pci_emul_add_msixcap(struct pci_devinst *pi, int msgnum, int barnum);
 int	pci_emul_msix_twrite(struct pci_devinst *pi, uint64_t offset, int size,

--- a/usr/src/cmd/bhyve/pci_fbuf.c
+++ b/usr/src/cmd/bhyve/pci_fbuf.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Nahanni Systems, Inc.
  * Copyright 2018 Joyent, Inc.
  * All rights reserved.

--- a/usr/src/cmd/bhyve/pci_irq.c
+++ b/usr/src/cmd/bhyve/pci_irq.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Hudson River Trading LLC
  * Written by: John H. Baldwin <jhb@FreeBSD.org>
  * All rights reserved.

--- a/usr/src/cmd/bhyve/pci_irq.h
+++ b/usr/src/cmd/bhyve/pci_irq.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Hudson River Trading LLC
  * Written by: John H. Baldwin <jhb@FreeBSD.org>
  * All rights reserved.

--- a/usr/src/cmd/bhyve/pci_lpc.c
+++ b/usr/src/cmd/bhyve/pci_lpc.c
@@ -118,6 +118,16 @@ done:
 	return (error);
 }
 
+void
+lpc_print_supported_devices()
+{
+	size_t i;
+
+	printf("bootrom\n");
+	for (i = 0; i < LPC_UART_NUM; i++)
+		printf("%s\n", lpc_uart_names[i]);
+}
+
 const char *
 lpc_bootrom(void)
 {

--- a/usr/src/cmd/bhyve/pci_lpc.h
+++ b/usr/src/cmd/bhyve/pci_lpc.h
@@ -68,6 +68,7 @@ struct lpc_sysres {
 #define	SYSRES_MEM(base, length)	LPC_SYSRES(LPC_SYSRES_MEM, base, length)
 
 int	lpc_device_parse(const char *opt);
+void    lpc_print_supported_devices();
 char	*lpc_pirq_name(int pin);
 void	lpc_pirq_routed(void);
 const char *lpc_bootrom(void);

--- a/usr/src/cmd/bhyve/pci_nvme.c
+++ b/usr/src/cmd/bhyve/pci_nvme.c
@@ -1,0 +1,1873 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2017 Shunsuke Mie
+ * Copyright (c) 2018 Leon Dang
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * bhyve PCIe-NVMe device emulation.
+ *
+ * options:
+ *  -s <n>,nvme,devpath,maxq=#,qsz=#,ioslots=#,sectsz=#,ser=A-Z
+ *
+ *  accepted devpath:
+ *    /dev/blockdev
+ *    /path/to/image
+ *    ram=size_in_MiB
+ *
+ *  maxq    = max number of queues
+ *  qsz     = max elements in each queue
+ *  ioslots = max number of concurrent io requests
+ *  sectsz  = sector size (defaults to blockif sector size)
+ *  ser     = serial number (20-chars max)
+ *
+ */
+
+/* TODO:
+    - create async event for smart and log
+    - intr coalesce
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+
+#include <assert.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <machine/atomic.h>
+#include <machine/vmm.h>
+#include <vmmapi.h>
+
+#include <dev/nvme/nvme.h>
+
+#include "bhyverun.h"
+#include "block_if.h"
+#include "pci_emul.h"
+
+
+static int nvme_debug = 0;
+#define	DPRINTF(params) if (nvme_debug) printf params
+#define	WPRINTF(params) printf params
+
+/* defaults; can be overridden */
+#define	NVME_MSIX_BAR		4
+
+#define	NVME_IOSLOTS		8
+
+#define	NVME_QUEUES		16
+#define	NVME_MAX_QENTRIES	2048
+
+#define	NVME_PRP2_ITEMS		(PAGE_SIZE/sizeof(uint64_t))
+#define	NVME_MAX_BLOCKIOVS	512
+
+/* helpers */
+
+#define	NVME_DOORBELL_OFFSET	offsetof(struct nvme_registers, doorbell)
+
+enum nvme_controller_register_offsets {
+	NVME_CR_CAP_LOW = 0x00,
+	NVME_CR_CAP_HI  = 0x04,
+	NVME_CR_VS      = 0x08,
+	NVME_CR_INTMS   = 0x0c,
+	NVME_CR_INTMC   = 0x10,
+	NVME_CR_CC      = 0x14,
+	NVME_CR_CSTS    = 0x1c,
+	NVME_CR_NSSR    = 0x20,
+	NVME_CR_AQA     = 0x24,
+	NVME_CR_ASQ_LOW = 0x28,
+	NVME_CR_ASQ_HI  = 0x2c,
+	NVME_CR_ACQ_LOW = 0x30,
+	NVME_CR_ACQ_HI  = 0x34,
+};
+
+enum nvme_cmd_cdw11 {
+	NVME_CMD_CDW11_PC  = 0x0001,
+	NVME_CMD_CDW11_IEN = 0x0002,
+	NVME_CMD_CDW11_IV  = 0xFFFF0000,
+};
+
+#define	NVME_CQ_INTEN	0x01
+#define	NVME_CQ_INTCOAL	0x02
+
+struct nvme_completion_queue {
+	struct nvme_completion *qbase;
+	uint32_t	size;
+	uint16_t	tail; /* nvme progress */
+	uint16_t	head; /* guest progress */
+	uint16_t	intr_vec;
+	uint32_t	intr_en;
+	pthread_mutex_t	mtx;
+};
+
+struct nvme_submission_queue {
+	struct nvme_command *qbase;
+	uint32_t	size;
+	uint16_t	head; /* nvme progress */
+	uint16_t	tail; /* guest progress */
+	uint16_t	cqid; /* completion queue id */
+	int		busy; /* queue is being processed */
+	int		qpriority;
+};
+
+enum nvme_storage_type {
+	NVME_STOR_BLOCKIF = 0,
+	NVME_STOR_RAM = 1,
+};
+
+struct pci_nvme_blockstore {
+	enum nvme_storage_type type;
+	void		*ctx;
+	uint64_t	size;
+	uint32_t	sectsz;
+	uint32_t	sectsz_bits;
+};
+
+struct pci_nvme_ioreq {
+	struct pci_nvme_softc *sc;
+	struct pci_nvme_ioreq *next;
+	struct nvme_submission_queue *nvme_sq;
+	uint16_t	sqid;
+
+	/* command information */
+	uint16_t	opc;
+	uint16_t	cid;
+	uint32_t	nsid;
+
+	uint64_t	prev_gpaddr;
+	size_t		prev_size;
+
+	/*
+	 * lock if all iovs consumed (big IO);
+	 * complete transaction before continuing
+	 */
+	pthread_mutex_t	mtx;
+	pthread_cond_t	cv;
+
+	struct blockif_req io_req;
+
+	/* pad to fit up to 512 page descriptors from guest IO request */
+	struct iovec	iovpadding[NVME_MAX_BLOCKIOVS-BLOCKIF_IOV_MAX];
+};
+
+struct pci_nvme_softc {
+	struct pci_devinst *nsc_pi;
+
+	pthread_mutex_t	mtx;
+
+	struct nvme_registers regs;
+
+	struct nvme_namespace_data  nsdata;
+	struct nvme_controller_data ctrldata;
+
+	struct pci_nvme_blockstore nvstore;
+
+	uint16_t	max_qentries; /* max entries per queue */
+	uint32_t	max_queues;
+	uint32_t	num_cqueues;
+	uint32_t	num_squeues;
+
+	struct pci_nvme_ioreq *ioreqs;
+	struct pci_nvme_ioreq *ioreqs_free; /* free list of ioreqs */
+	uint32_t	pending_ios;
+	uint32_t	ioslots;
+	sem_t		iosemlock;
+
+	/* status and guest memory mapped queues */
+	struct nvme_completion_queue *compl_queues;
+	struct nvme_submission_queue *submit_queues;
+
+	/* controller features */
+	uint32_t	intr_coales_aggr_time;   /* 0x08: uS to delay intr */
+	uint32_t	intr_coales_aggr_thresh; /* 0x08: compl-Q entries */
+	uint32_t	async_ev_config;         /* 0x0B: async event config */
+};
+
+
+static void pci_nvme_io_partial(struct blockif_req *br, int err);
+
+/* Controller Configuration utils */
+#define	NVME_CC_GET_EN(cc) \
+	((cc) >> NVME_CC_REG_EN_SHIFT & NVME_CC_REG_EN_MASK)
+#define	NVME_CC_GET_CSS(cc) \
+	((cc) >> NVME_CC_REG_CSS_SHIFT & NVME_CC_REG_CSS_MASK)
+#define	NVME_CC_GET_SHN(cc) \
+	((cc) >> NVME_CC_REG_SHN_SHIFT & NVME_CC_REG_SHN_MASK)
+#define	NVME_CC_GET_IOSQES(cc) \
+	((cc) >> NVME_CC_REG_IOSQES_SHIFT & NVME_CC_REG_IOSQES_MASK)
+#define	NVME_CC_GET_IOCQES(cc) \
+	((cc) >> NVME_CC_REG_IOCQES_SHIFT & NVME_CC_REG_IOCQES_MASK)
+
+#define	NVME_CC_WRITE_MASK \
+	((NVME_CC_REG_EN_MASK << NVME_CC_REG_EN_SHIFT) | \
+	 (NVME_CC_REG_IOSQES_MASK << NVME_CC_REG_IOSQES_SHIFT) | \
+	 (NVME_CC_REG_IOCQES_MASK << NVME_CC_REG_IOCQES_SHIFT))
+
+#define	NVME_CC_NEN_WRITE_MASK \
+	((NVME_CC_REG_CSS_MASK << NVME_CC_REG_CSS_SHIFT) | \
+	 (NVME_CC_REG_MPS_MASK << NVME_CC_REG_MPS_SHIFT) | \
+	 (NVME_CC_REG_AMS_MASK << NVME_CC_REG_AMS_SHIFT))
+
+/* Controller Status utils */
+#define	NVME_CSTS_GET_RDY(sts) \
+	((sts) >> NVME_CSTS_REG_RDY_SHIFT & NVME_CSTS_REG_RDY_MASK)
+
+#define	NVME_CSTS_RDY	(1 << NVME_CSTS_REG_RDY_SHIFT)
+
+/* Completion Queue status word utils */
+#define	NVME_STATUS_P	(1 << NVME_STATUS_P_SHIFT)
+#define	NVME_STATUS_MASK \
+	((NVME_STATUS_SCT_MASK << NVME_STATUS_SCT_SHIFT) |\
+	 (NVME_STATUS_SC_MASK << NVME_STATUS_SC_SHIFT))
+
+static __inline void
+cpywithpad(char *dst, int dst_size, const char *src, char pad)
+{
+	int len = strnlen(src, dst_size);
+	memcpy(dst, src, len);
+	memset(dst + len, pad, dst_size - len);
+}
+
+static __inline void
+pci_nvme_status_tc(uint16_t *status, uint16_t type, uint16_t code)
+{
+
+	*status &= ~NVME_STATUS_MASK;
+	*status |= (type & NVME_STATUS_SCT_MASK) << NVME_STATUS_SCT_SHIFT |
+		(code & NVME_STATUS_SC_MASK) << NVME_STATUS_SC_SHIFT;
+}
+
+static __inline void
+pci_nvme_status_genc(uint16_t *status, uint16_t code)
+{
+
+	pci_nvme_status_tc(status, NVME_SCT_GENERIC, code);
+}
+
+static __inline void
+pci_nvme_toggle_phase(uint16_t *status, int prev)
+{
+
+	if (prev)
+		*status &= ~NVME_STATUS_P;
+	else
+		*status |= NVME_STATUS_P;
+}
+
+static void
+pci_nvme_init_ctrldata(struct pci_nvme_softc *sc)
+{
+	struct nvme_controller_data *cd = &sc->ctrldata;
+
+	cd->vid = 0xFB5D;
+	cd->ssvid = 0x0000;
+
+	cpywithpad((char *)cd->mn, sizeof(cd->mn), "bhyve-NVMe", ' ');
+	cpywithpad((char *)cd->fr, sizeof(cd->fr), "1.0", ' ');
+
+	/* Num of submission commands that we can handle at a time (2^rab) */
+	cd->rab   = 4;
+
+	/* FreeBSD OUI */
+	cd->ieee[0] = 0x58;
+	cd->ieee[1] = 0x9c;
+	cd->ieee[2] = 0xfc;
+
+	cd->mic = 0;
+
+	cd->mdts = 9;	/* max data transfer size (2^mdts * CAP.MPSMIN) */
+
+	cd->ver = 0x00010300;
+
+	cd->oacs = 1 << NVME_CTRLR_DATA_OACS_FORMAT_SHIFT;
+	cd->acl = 2;
+	cd->aerl = 4;
+
+	cd->lpa = 0;	/* TODO: support some simple things like SMART */
+	cd->elpe = 0;	/* max error log page entries */
+	cd->npss = 1;	/* number of power states support */
+
+	/* Warning Composite Temperature Threshold */
+	cd->wctemp = 0x0157;
+
+	cd->sqes = (6 << NVME_CTRLR_DATA_SQES_MAX_SHIFT) |
+	    (6 << NVME_CTRLR_DATA_SQES_MIN_SHIFT);
+	cd->cqes = (4 << NVME_CTRLR_DATA_CQES_MAX_SHIFT) |
+	    (4 << NVME_CTRLR_DATA_CQES_MIN_SHIFT);
+	cd->nn = 1;	/* number of namespaces */
+
+	cd->fna = 0x03;
+
+	cd->power_state[0].mp = 10;
+}
+
+static void
+pci_nvme_init_nsdata(struct pci_nvme_softc *sc)
+{
+	struct nvme_namespace_data *nd;
+
+	nd = &sc->nsdata;
+
+	nd->nsze = sc->nvstore.size / sc->nvstore.sectsz;
+	nd->ncap = nd->nsze;
+	nd->nuse = nd->nsze;
+
+	/* Get LBA and backstore information from backing store */
+	nd->nlbaf = 1;
+	/* LBA data-sz = 2^lbads */
+	nd->lbaf[0] = sc->nvstore.sectsz_bits << NVME_NS_DATA_LBAF_LBADS_SHIFT;
+
+	nd->flbas = 0;
+}
+
+static void
+pci_nvme_reset_locked(struct pci_nvme_softc *sc)
+{
+	DPRINTF(("%s\r\n", __func__));
+
+	sc->regs.cap_lo = (sc->max_qentries & NVME_CAP_LO_REG_MQES_MASK) |
+	    (1 << NVME_CAP_LO_REG_CQR_SHIFT) |
+	    (60 << NVME_CAP_LO_REG_TO_SHIFT);
+
+	sc->regs.cap_hi = 1 << NVME_CAP_HI_REG_CSS_NVM_SHIFT;
+
+	sc->regs.vs = 0x00010300;	/* NVMe v1.3 */
+
+	sc->regs.cc = 0;
+	sc->regs.csts = 0;
+
+	sc->num_cqueues = sc->num_squeues = sc->max_queues;
+	if (sc->submit_queues != NULL) {
+		for (int i = 0; i <= sc->max_queues; i++) {
+			/*
+			 * The Admin Submission Queue is at index 0.
+			 * It must not be changed at reset otherwise the
+			 * emulation will be out of sync with the guest.
+			 */
+			if (i != 0) {
+				sc->submit_queues[i].qbase = NULL;
+				sc->submit_queues[i].size = 0;
+				sc->submit_queues[i].cqid = 0;
+
+				sc->compl_queues[i].qbase = NULL;
+				sc->compl_queues[i].size = 0;
+			}
+			sc->submit_queues[i].tail = 0;
+			sc->submit_queues[i].head = 0;
+			sc->submit_queues[i].busy = 0;
+
+			sc->compl_queues[i].tail = 0;
+			sc->compl_queues[i].head = 0;
+		}
+	} else
+		sc->submit_queues = calloc(sc->max_queues + 1,
+		                        sizeof(struct nvme_submission_queue));
+
+	if (sc->compl_queues == NULL) {
+		sc->compl_queues = calloc(sc->max_queues + 1,
+		                        sizeof(struct nvme_completion_queue));
+
+		for (int i = 0; i <= sc->num_cqueues; i++)
+			pthread_mutex_init(&sc->compl_queues[i].mtx, NULL);
+	}
+}
+
+static void
+pci_nvme_reset(struct pci_nvme_softc *sc)
+{
+	pthread_mutex_lock(&sc->mtx);
+	pci_nvme_reset_locked(sc);
+	pthread_mutex_unlock(&sc->mtx);
+}
+
+static void
+pci_nvme_init_controller(struct vmctx *ctx, struct pci_nvme_softc *sc)
+{
+	uint16_t acqs, asqs;
+
+	DPRINTF(("%s\r\n", __func__));
+
+	asqs = (sc->regs.aqa & NVME_AQA_REG_ASQS_MASK) + 1;
+	sc->submit_queues[0].size = asqs;
+	sc->submit_queues[0].qbase = vm_map_gpa(ctx, sc->regs.asq,
+	            sizeof(struct nvme_command) * asqs);
+
+	DPRINTF(("%s mapping Admin-SQ guest 0x%lx, host: %p\r\n",
+	        __func__, sc->regs.asq, sc->submit_queues[0].qbase));
+
+	acqs = ((sc->regs.aqa >> NVME_AQA_REG_ACQS_SHIFT) & 
+	    NVME_AQA_REG_ACQS_MASK) + 1;
+	sc->compl_queues[0].size = acqs;
+	sc->compl_queues[0].qbase = vm_map_gpa(ctx, sc->regs.acq,
+	         sizeof(struct nvme_completion) * acqs);
+	DPRINTF(("%s mapping Admin-CQ guest 0x%lx, host: %p\r\n",
+	        __func__, sc->regs.acq, sc->compl_queues[0].qbase));
+}
+
+static int
+nvme_opc_delete_io_sq(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	uint16_t qid = command->cdw10 & 0xffff;
+
+	DPRINTF(("%s DELETE_IO_SQ %u\r\n", __func__, qid));
+	if (qid == 0 || qid > sc->num_cqueues) {
+		WPRINTF(("%s NOT PERMITTED queue id %u / num_squeues %u\r\n",
+		        __func__, qid, sc->num_squeues));
+		pci_nvme_status_tc(&compl->status, NVME_SCT_COMMAND_SPECIFIC,
+		    NVME_SC_INVALID_QUEUE_IDENTIFIER);
+		return (1);
+	}
+
+	sc->submit_queues[qid].qbase = NULL;
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	return (1);
+}
+
+static int
+nvme_opc_create_io_sq(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	if (command->cdw11 & NVME_CMD_CDW11_PC) {
+		uint16_t qid = command->cdw10 & 0xffff;
+		struct nvme_submission_queue *nsq;
+
+		if (qid > sc->num_squeues) {
+			WPRINTF(("%s queue index %u > num_squeues %u\r\n",
+			        __func__, qid, sc->num_squeues));
+			pci_nvme_status_tc(&compl->status,
+			    NVME_SCT_COMMAND_SPECIFIC,
+			    NVME_SC_INVALID_QUEUE_IDENTIFIER);
+			return (1);
+		}
+
+		nsq = &sc->submit_queues[qid];
+		nsq->size = ((command->cdw10 >> 16) & 0xffff) + 1;
+
+		nsq->qbase = vm_map_gpa(sc->nsc_pi->pi_vmctx, command->prp1,
+		              sizeof(struct nvme_command) * (size_t)nsq->size);
+		nsq->cqid = (command->cdw11 >> 16) & 0xffff;
+		nsq->qpriority = (command->cdw11 >> 1) & 0x03;
+
+		DPRINTF(("%s sq %u size %u gaddr %p cqid %u\r\n", __func__,
+		        qid, nsq->size, nsq->qbase, nsq->cqid));
+
+		pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+
+		DPRINTF(("%s completed creating IOSQ qid %u\r\n",
+		         __func__, qid));
+	} else {
+		/* 
+		 * Guest sent non-cont submission queue request.
+		 * This setting is unsupported by this emulation.
+		 */
+		WPRINTF(("%s unsupported non-contig (list-based) "
+		         "create i/o submission queue\r\n", __func__));
+
+		pci_nvme_status_genc(&compl->status, NVME_SC_INVALID_FIELD);
+	}
+	return (1);
+}
+
+static int
+nvme_opc_delete_io_cq(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	uint16_t qid = command->cdw10 & 0xffff;
+
+	DPRINTF(("%s DELETE_IO_CQ %u\r\n", __func__, qid));
+	if (qid == 0 || qid > sc->num_cqueues) {
+		WPRINTF(("%s queue index %u / num_cqueues %u\r\n",
+		        __func__, qid, sc->num_cqueues));
+		pci_nvme_status_tc(&compl->status, NVME_SCT_COMMAND_SPECIFIC,
+		    NVME_SC_INVALID_QUEUE_IDENTIFIER);
+		return (1);
+	}
+
+	sc->compl_queues[qid].qbase = NULL;
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	return (1);
+}
+
+static int
+nvme_opc_create_io_cq(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	if (command->cdw11 & NVME_CMD_CDW11_PC) {
+		uint16_t qid = command->cdw10 & 0xffff;
+		struct nvme_completion_queue *ncq;
+
+		if (qid > sc->num_cqueues) {
+			WPRINTF(("%s queue index %u > num_cqueues %u\r\n",
+			        __func__, qid, sc->num_cqueues));
+			pci_nvme_status_tc(&compl->status,
+			    NVME_SCT_COMMAND_SPECIFIC,
+			    NVME_SC_INVALID_QUEUE_IDENTIFIER);
+			return (1);
+		}
+
+		ncq = &sc->compl_queues[qid];
+		ncq->intr_en = (command->cdw11 & NVME_CMD_CDW11_IEN) >> 1;
+		ncq->intr_vec = (command->cdw11 >> 16) & 0xffff;
+		ncq->size = ((command->cdw10 >> 16) & 0xffff) + 1;
+
+		ncq->qbase = vm_map_gpa(sc->nsc_pi->pi_vmctx,
+		             command->prp1,
+		             sizeof(struct nvme_command) * (size_t)ncq->size);
+
+		pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	} else {
+		/* 
+		 * Non-contig completion queue unsupported.
+		 */
+		WPRINTF(("%s unsupported non-contig (list-based) "
+		         "create i/o completion queue\r\n",
+		         __func__));
+
+		/* 0x12 = Invalid Use of Controller Memory Buffer */
+		pci_nvme_status_genc(&compl->status, 0x12);
+	}
+
+	return (1);
+}
+
+static int
+nvme_opc_get_log_page(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	uint32_t logsize = (1 + ((command->cdw10 >> 16) & 0xFFF)) * 2;
+	uint8_t logpage = command->cdw10 & 0xFF;
+#ifdef __FreeBSD__
+	void *data;
+#else
+	/* Our compiler grumbles about this, despite it being OK */
+	void *data = NULL;
+#endif
+
+	DPRINTF(("%s log page %u len %u\r\n", __func__, logpage, logsize));
+
+	if (logpage >= 1 && logpage <= 3)
+		data = vm_map_gpa(sc->nsc_pi->pi_vmctx, command->prp1,
+		                  PAGE_SIZE);
+
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+
+	switch (logpage) {
+	case 0x01: /* Error information */
+		memset(data, 0, logsize > PAGE_SIZE ? PAGE_SIZE : logsize);
+		break;
+	case 0x02: /* SMART/Health information */
+		/* TODO: present some smart info */
+		memset(data, 0, logsize > PAGE_SIZE ? PAGE_SIZE : logsize);
+		break;
+	case 0x03: /* Firmware slot information */
+		memset(data, 0, logsize > PAGE_SIZE ? PAGE_SIZE : logsize);
+		break;
+	default:
+		WPRINTF(("%s get log page %x command not supported\r\n",
+		        __func__, logpage));
+
+		pci_nvme_status_tc(&compl->status, NVME_SCT_COMMAND_SPECIFIC,
+		    NVME_SC_INVALID_LOG_PAGE);
+	}
+
+	return (1);
+}
+
+static int
+nvme_opc_identify(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	void *dest;
+
+	DPRINTF(("%s identify 0x%x nsid 0x%x\r\n", __func__,
+	        command->cdw10 & 0xFF, command->nsid));
+
+	switch (command->cdw10 & 0xFF) {
+	case 0x00: /* return Identify Namespace data structure */
+		dest = vm_map_gpa(sc->nsc_pi->pi_vmctx, command->prp1,
+		                  sizeof(sc->nsdata));
+		memcpy(dest, &sc->nsdata, sizeof(sc->nsdata));
+		break;
+	case 0x01: /* return Identify Controller data structure */
+		dest = vm_map_gpa(sc->nsc_pi->pi_vmctx, command->prp1,
+		                  sizeof(sc->ctrldata));
+		memcpy(dest, &sc->ctrldata, sizeof(sc->ctrldata));
+		break;
+	case 0x02: /* list of 1024 active NSIDs > CDW1.NSID */
+		dest = vm_map_gpa(sc->nsc_pi->pi_vmctx, command->prp1,
+		                  sizeof(uint32_t) * 1024);
+		((uint32_t *)dest)[0] = 1;
+		((uint32_t *)dest)[1] = 0;
+		break;
+	case 0x11:
+		pci_nvme_status_genc(&compl->status,
+		    NVME_SC_INVALID_NAMESPACE_OR_FORMAT);
+		return (1);
+	case 0x03: /* list of NSID structures in CDW1.NSID, 4096 bytes */
+	case 0x10:
+	case 0x12:
+	case 0x13:
+	case 0x14:
+	case 0x15:
+	default:
+		DPRINTF(("%s unsupported identify command requested 0x%x\r\n",
+		         __func__, command->cdw10 & 0xFF));
+		pci_nvme_status_genc(&compl->status, NVME_SC_INVALID_FIELD);
+		return (1);
+	}
+
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	return (1);
+}
+
+static int
+nvme_opc_set_features(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	int feature = command->cdw10 & 0xFF;
+	uint32_t iv;
+
+	DPRINTF(("%s feature 0x%x\r\n", __func__, feature));
+	compl->cdw0 = 0;
+
+	switch (feature) {
+	case NVME_FEAT_ARBITRATION:
+		DPRINTF(("  arbitration 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_POWER_MANAGEMENT:
+		DPRINTF(("  power management 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_LBA_RANGE_TYPE:
+		DPRINTF(("  lba range 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_TEMPERATURE_THRESHOLD:
+		DPRINTF(("  temperature threshold 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_ERROR_RECOVERY:
+		DPRINTF(("  error recovery 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_VOLATILE_WRITE_CACHE:
+		DPRINTF(("  volatile write cache 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_NUMBER_OF_QUEUES:
+		sc->num_squeues = command->cdw11 & 0xFFFF;
+		sc->num_cqueues = (command->cdw11 >> 16) & 0xFFFF;
+		DPRINTF(("  number of queues (submit %u, completion %u)\r\n",
+		        sc->num_squeues, sc->num_cqueues));
+
+		if (sc->num_squeues == 0 || sc->num_squeues > sc->max_queues)
+			sc->num_squeues = sc->max_queues;
+		if (sc->num_cqueues == 0 || sc->num_cqueues > sc->max_queues)
+			sc->num_cqueues = sc->max_queues;
+
+		compl->cdw0 = (sc->num_squeues & 0xFFFF) |
+		              ((sc->num_cqueues & 0xFFFF) << 16);
+
+		break;
+	case NVME_FEAT_INTERRUPT_COALESCING:
+		DPRINTF(("  interrupt coalescing 0x%x\r\n", command->cdw11));
+
+		/* in uS */
+		sc->intr_coales_aggr_time = ((command->cdw11 >> 8) & 0xFF)*100;
+
+		sc->intr_coales_aggr_thresh = command->cdw11 & 0xFF;
+		break;
+	case NVME_FEAT_INTERRUPT_VECTOR_CONFIGURATION:
+		iv = command->cdw11 & 0xFFFF;
+
+		DPRINTF(("  interrupt vector configuration 0x%x\r\n",
+		        command->cdw11));
+
+		for (uint32_t i = 0; i <= sc->num_cqueues; i++) {
+			if (sc->compl_queues[i].intr_vec == iv) {
+				if (command->cdw11 & (1 << 16))
+					sc->compl_queues[i].intr_en |=
+					                      NVME_CQ_INTCOAL;  
+				else
+					sc->compl_queues[i].intr_en &=
+					                     ~NVME_CQ_INTCOAL;  
+			}
+		}
+		break;
+	case NVME_FEAT_WRITE_ATOMICITY:
+		DPRINTF(("  write atomicity 0x%x\r\n", command->cdw11));
+		break;
+	case NVME_FEAT_ASYNC_EVENT_CONFIGURATION:
+		DPRINTF(("  async event configuration 0x%x\r\n",
+		        command->cdw11));
+		sc->async_ev_config = command->cdw11;
+		break;
+	case NVME_FEAT_SOFTWARE_PROGRESS_MARKER:
+		DPRINTF(("  software progress marker 0x%x\r\n",
+		        command->cdw11));
+		break;
+	case 0x0C:
+		DPRINTF(("  autonomous power state transition 0x%x\r\n",
+		        command->cdw11));
+		break;
+	default:
+		WPRINTF(("%s invalid feature\r\n", __func__));
+		pci_nvme_status_genc(&compl->status, NVME_SC_INVALID_FIELD);
+		return (1);
+	}
+
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	return (1);
+}
+
+static int
+nvme_opc_get_features(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	int feature = command->cdw10 & 0xFF;
+
+	DPRINTF(("%s feature 0x%x\r\n", __func__, feature));
+
+	compl->cdw0 = 0;
+
+	switch (feature) {
+	case NVME_FEAT_ARBITRATION:
+		DPRINTF(("  arbitration\r\n"));
+		break;
+	case NVME_FEAT_POWER_MANAGEMENT:
+		DPRINTF(("  power management\r\n"));
+		break;
+	case NVME_FEAT_LBA_RANGE_TYPE:
+		DPRINTF(("  lba range\r\n"));
+		break;
+	case NVME_FEAT_TEMPERATURE_THRESHOLD:
+		DPRINTF(("  temperature threshold\r\n"));
+		switch ((command->cdw11 >> 20) & 0x3) {
+		case 0:
+			/* Over temp threshold */
+			compl->cdw0 = 0xFFFF;
+			break;
+		case 1:
+			/* Under temp threshold */
+			compl->cdw0 = 0;
+			break;
+		default:
+			WPRINTF(("  invalid threshold type select\r\n"));
+			pci_nvme_status_genc(&compl->status,
+			    NVME_SC_INVALID_FIELD);
+			return (1);
+		}
+		break;
+	case NVME_FEAT_ERROR_RECOVERY:
+		DPRINTF(("  error recovery\r\n"));
+		break;
+	case NVME_FEAT_VOLATILE_WRITE_CACHE:
+		DPRINTF(("  volatile write cache\r\n"));
+		break;
+	case NVME_FEAT_NUMBER_OF_QUEUES:
+		compl->cdw0 = 0;
+		if (sc->num_squeues == 0)
+			compl->cdw0 |= sc->max_queues & 0xFFFF;
+		else
+			compl->cdw0 |= sc->num_squeues & 0xFFFF;
+
+		if (sc->num_cqueues == 0)
+			compl->cdw0 |= (sc->max_queues & 0xFFFF) << 16;
+		else
+			compl->cdw0 |= (sc->num_cqueues & 0xFFFF) << 16;
+
+		DPRINTF(("  number of queues (submit %u, completion %u)\r\n",
+		        compl->cdw0 & 0xFFFF,
+		        (compl->cdw0 >> 16) & 0xFFFF));
+
+		break;
+	case NVME_FEAT_INTERRUPT_COALESCING:
+		DPRINTF(("  interrupt coalescing\r\n"));
+		break;
+	case NVME_FEAT_INTERRUPT_VECTOR_CONFIGURATION:
+		DPRINTF(("  interrupt vector configuration\r\n"));
+		break;
+	case NVME_FEAT_WRITE_ATOMICITY:
+		DPRINTF(("  write atomicity\r\n"));
+		break;
+	case NVME_FEAT_ASYNC_EVENT_CONFIGURATION:
+		DPRINTF(("  async event configuration\r\n"));
+		sc->async_ev_config = command->cdw11;
+		break;
+	case NVME_FEAT_SOFTWARE_PROGRESS_MARKER:
+		DPRINTF(("  software progress marker\r\n"));
+		break;
+	case 0x0C:
+		DPRINTF(("  autonomous power state transition\r\n"));
+		break;
+	default:
+		WPRINTF(("%s invalid feature 0x%x\r\n", __func__, feature));
+		pci_nvme_status_genc(&compl->status, NVME_SC_INVALID_FIELD);
+		return (1);
+	}
+
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	return (1);
+}
+
+static int
+nvme_opc_abort(struct pci_nvme_softc* sc, struct nvme_command* command,
+	struct nvme_completion* compl)
+{
+	DPRINTF(("%s submission queue %u, command ID 0x%x\r\n", __func__,
+	        command->cdw10 & 0xFFFF, (command->cdw10 >> 16) & 0xFFFF));
+
+	/* TODO: search for the command ID and abort it */
+
+	compl->cdw0 = 1;
+	pci_nvme_status_genc(&compl->status, NVME_SC_SUCCESS);
+	return (1);
+}
+
+#ifdef __FreeBSD__
+static int
+nvme_opc_async_event_req(struct pci_nvme_softc* sc,
+	struct nvme_command* command, struct nvme_completion* compl)
+{
+	DPRINTF(("%s async event request 0x%x\r\n", __func__, command->cdw11));
+
+	/*
+	 * TODO: raise events when they happen based on the Set Features cmd.
+	 * These events happen async, so only set completion successful if
+	 * there is an event reflective of the request to get event.
+	 */
+	pci_nvme_status_tc(&compl->status, NVME_SCT_COMMAND_SPECIFIC,
+	    NVME_SC_ASYNC_EVENT_REQUEST_LIMIT_EXCEEDED);
+	return (0);
+}
+#else
+/* This is kept behind an ifdef while it's unused to appease the compiler. */
+#endif /* __FreeBSD__ */
+
+static void
+pci_nvme_handle_admin_cmd(struct pci_nvme_softc* sc, uint64_t value)
+{
+	struct nvme_completion compl;
+	struct nvme_command *cmd;
+	struct nvme_submission_queue *sq;
+	struct nvme_completion_queue *cq;
+	int do_intr = 0;
+	uint16_t sqhead;
+
+	DPRINTF(("%s index %u\r\n", __func__, (uint32_t)value));
+
+	sq = &sc->submit_queues[0];
+
+	sqhead = atomic_load_acq_short(&sq->head);
+
+	if (atomic_testandset_int(&sq->busy, 1)) {
+		DPRINTF(("%s SQ busy, head %u, tail %u\r\n",
+		        __func__, sqhead, sq->tail));
+		return;
+	}
+
+	DPRINTF(("sqhead %u, tail %u\r\n", sqhead, sq->tail));
+	
+	while (sqhead != atomic_load_acq_short(&sq->tail)) {
+		cmd = &(sq->qbase)[sqhead];
+		compl.status = 0;
+
+		switch (cmd->opc) {
+		case NVME_OPC_DELETE_IO_SQ:
+			DPRINTF(("%s command DELETE_IO_SQ\r\n", __func__));
+			do_intr |= nvme_opc_delete_io_sq(sc, cmd, &compl);
+			break;
+		case NVME_OPC_CREATE_IO_SQ:
+			DPRINTF(("%s command CREATE_IO_SQ\r\n", __func__));
+			do_intr |= nvme_opc_create_io_sq(sc, cmd, &compl);
+			break;
+		case NVME_OPC_DELETE_IO_CQ:
+			DPRINTF(("%s command DELETE_IO_CQ\r\n", __func__));
+			do_intr |= nvme_opc_delete_io_cq(sc, cmd, &compl);
+			break;
+		case NVME_OPC_CREATE_IO_CQ:
+			DPRINTF(("%s command CREATE_IO_CQ\r\n", __func__));
+			do_intr |= nvme_opc_create_io_cq(sc, cmd, &compl);
+			break;
+		case NVME_OPC_GET_LOG_PAGE:
+			DPRINTF(("%s command GET_LOG_PAGE\r\n", __func__));
+			do_intr |= nvme_opc_get_log_page(sc, cmd, &compl);
+			break;
+		case NVME_OPC_IDENTIFY:
+			DPRINTF(("%s command IDENTIFY\r\n", __func__));
+			do_intr |= nvme_opc_identify(sc, cmd, &compl);
+			break;
+		case NVME_OPC_ABORT:
+			DPRINTF(("%s command ABORT\r\n", __func__));
+			do_intr |= nvme_opc_abort(sc, cmd, &compl);
+			break;
+		case NVME_OPC_SET_FEATURES:
+			DPRINTF(("%s command SET_FEATURES\r\n", __func__));
+			do_intr |= nvme_opc_set_features(sc, cmd, &compl);
+			break;
+		case NVME_OPC_GET_FEATURES:
+			DPRINTF(("%s command GET_FEATURES\r\n", __func__));
+			do_intr |= nvme_opc_get_features(sc, cmd, &compl);
+			break;
+		case NVME_OPC_ASYNC_EVENT_REQUEST:
+			DPRINTF(("%s command ASYNC_EVENT_REQ\r\n", __func__));
+			/* XXX dont care, unhandled for now
+			do_intr |= nvme_opc_async_event_req(sc, cmd, &compl);
+			*/
+			break;
+		default:
+			WPRINTF(("0x%x command is not implemented\r\n",
+			    cmd->opc));
+		}
+	
+		/* for now skip async event generation */
+		if (cmd->opc != NVME_OPC_ASYNC_EVENT_REQUEST) {
+			struct nvme_completion *cp;
+			int phase;
+
+			cq = &sc->compl_queues[0];
+
+			cp = &(cq->qbase)[cq->tail];
+			cp->sqid = 0;
+			cp->sqhd = sqhead;
+			cp->cid = cmd->cid;
+
+			phase = NVME_STATUS_GET_P(cp->status);
+			cp->status = compl.status;
+			pci_nvme_toggle_phase(&cp->status, phase);
+
+			cq->tail = (cq->tail + 1) % cq->size;
+		}
+		sqhead = (sqhead + 1) % sq->size;
+	}
+
+	DPRINTF(("setting sqhead %u\r\n", sqhead));
+	atomic_store_short(&sq->head, sqhead);
+	atomic_store_int(&sq->busy, 0);
+
+	if (do_intr)
+		pci_generate_msix(sc->nsc_pi, 0);
+
+}
+
+static int
+pci_nvme_append_iov_req(struct pci_nvme_softc *sc, struct pci_nvme_ioreq *req,
+	uint64_t gpaddr, size_t size, int do_write, uint64_t lba)
+{
+	int iovidx;
+
+	if (req != NULL) {
+		/* concatenate contig block-iovs to minimize number of iovs */
+		if ((req->prev_gpaddr + req->prev_size) == gpaddr) {
+			iovidx = req->io_req.br_iovcnt - 1;
+
+			req->io_req.br_iov[iovidx].iov_base =
+			    paddr_guest2host(req->sc->nsc_pi->pi_vmctx,
+			                     req->prev_gpaddr, size);
+
+			req->prev_size += size;
+			req->io_req.br_resid += size;
+
+			req->io_req.br_iov[iovidx].iov_len = req->prev_size;
+		} else {
+			pthread_mutex_lock(&req->mtx);
+
+			iovidx = req->io_req.br_iovcnt;
+			if (iovidx == NVME_MAX_BLOCKIOVS) {
+				int err = 0;
+
+				DPRINTF(("large I/O, doing partial req\r\n"));
+
+				iovidx = 0;
+				req->io_req.br_iovcnt = 0;
+
+				req->io_req.br_callback = pci_nvme_io_partial;
+
+				if (!do_write)
+					err = blockif_read(sc->nvstore.ctx,
+					                   &req->io_req);
+				else
+#ifdef __FreeBSD__
+					err = blockif_write(sc->nvstore.ctx,
+					                    &req->io_req);
+#else
+					err = blockif_write(sc->nvstore.ctx,
+					    &req->io_req, B_FALSE);
+				/*
+				 * XXX: Is a follow-up needed for proper sync
+				 * detection here or later flush behavior?
+				 */
+#endif
+
+				/* wait until req completes before cont */
+				if (err == 0)
+					pthread_cond_wait(&req->cv, &req->mtx);
+			}
+			if (iovidx == 0) {
+				req->io_req.br_offset = lba;
+				req->io_req.br_resid = 0;
+				req->io_req.br_param = req;
+			}
+
+			req->io_req.br_iov[iovidx].iov_base =
+			    paddr_guest2host(req->sc->nsc_pi->pi_vmctx,
+			                     gpaddr, size);
+
+			req->io_req.br_iov[iovidx].iov_len = size;
+
+			req->prev_gpaddr = gpaddr;
+			req->prev_size = size;
+			req->io_req.br_resid += size;
+
+			req->io_req.br_iovcnt++;
+
+			pthread_mutex_unlock(&req->mtx);
+		}
+	} else {
+		/* RAM buffer: read/write directly */
+		void *p = sc->nvstore.ctx;
+		void *gptr;
+
+		if ((lba + size) > sc->nvstore.size) {
+			WPRINTF(("%s write would overflow RAM\r\n", __func__));
+			return (-1);
+		}
+
+		p = (void *)((uintptr_t)p + (uintptr_t)lba);
+		gptr = paddr_guest2host(sc->nsc_pi->pi_vmctx, gpaddr, size);
+		if (do_write) 
+			memcpy(p, gptr, size);
+		else
+			memcpy(gptr, p, size);
+	}
+	return (0);
+}
+
+static void
+pci_nvme_set_completion(struct pci_nvme_softc *sc,
+	struct nvme_submission_queue *sq, int sqid, uint16_t cid,
+	uint32_t cdw0, uint16_t status, int ignore_busy)
+{
+	struct nvme_completion_queue *cq = &sc->compl_queues[sq->cqid];
+	struct nvme_completion *compl;
+	int do_intr = 0;
+	int phase;
+
+	DPRINTF(("%s sqid %d cqid %u cid %u status: 0x%x 0x%x\r\n",
+		 __func__, sqid, sq->cqid, cid, NVME_STATUS_GET_SCT(status),
+		 NVME_STATUS_GET_SC(status)));
+
+	pthread_mutex_lock(&cq->mtx);
+
+	assert(cq->qbase != NULL);
+
+	compl = &cq->qbase[cq->tail];
+
+	compl->sqhd = atomic_load_acq_short(&sq->head);
+	compl->sqid = sqid;
+	compl->cid = cid;
+
+	// toggle phase
+	phase = NVME_STATUS_GET_P(compl->status);
+	compl->status = status;
+	pci_nvme_toggle_phase(&compl->status, phase);
+
+	cq->tail = (cq->tail + 1) % cq->size;
+
+	if (cq->intr_en & NVME_CQ_INTEN)
+		do_intr = 1;
+
+	pthread_mutex_unlock(&cq->mtx);
+
+	if (ignore_busy || !atomic_load_acq_int(&sq->busy))
+		if (do_intr)
+			pci_generate_msix(sc->nsc_pi, cq->intr_vec);
+}
+
+static void
+pci_nvme_release_ioreq(struct pci_nvme_softc *sc, struct pci_nvme_ioreq *req)
+{
+	req->sc = NULL;
+	req->nvme_sq = NULL;
+	req->sqid = 0;
+
+	pthread_mutex_lock(&sc->mtx);
+
+	req->next = sc->ioreqs_free;
+	sc->ioreqs_free = req;
+	sc->pending_ios--;
+
+	/* when no more IO pending, can set to ready if device reset/enabled */
+	if (sc->pending_ios == 0 &&
+	    NVME_CC_GET_EN(sc->regs.cc) && !(NVME_CSTS_GET_RDY(sc->regs.csts)))
+		sc->regs.csts |= NVME_CSTS_RDY;
+
+	pthread_mutex_unlock(&sc->mtx);
+
+	sem_post(&sc->iosemlock);
+}
+
+static struct pci_nvme_ioreq *
+pci_nvme_get_ioreq(struct pci_nvme_softc *sc)
+{
+	struct pci_nvme_ioreq *req = NULL;;
+
+	sem_wait(&sc->iosemlock);
+	pthread_mutex_lock(&sc->mtx);
+
+	req = sc->ioreqs_free;
+	assert(req != NULL);
+
+	sc->ioreqs_free = req->next;
+
+	req->next = NULL;
+	req->sc = sc;
+
+	sc->pending_ios++;
+
+	pthread_mutex_unlock(&sc->mtx);
+
+	req->io_req.br_iovcnt = 0;
+	req->io_req.br_offset = 0;
+	req->io_req.br_resid = 0;
+	req->io_req.br_param = req;
+	req->prev_gpaddr = 0;
+	req->prev_size = 0;
+
+	return req;
+}
+
+static void
+pci_nvme_io_done(struct blockif_req *br, int err)
+{
+	struct pci_nvme_ioreq *req = br->br_param;
+	struct nvme_submission_queue *sq = req->nvme_sq;
+	uint16_t code, status = 0;
+
+	DPRINTF(("%s error %d %s\r\n", __func__, err, strerror(err)));
+	
+	/* TODO return correct error */
+	code = err ? NVME_SC_DATA_TRANSFER_ERROR : NVME_SC_SUCCESS;
+	pci_nvme_status_genc(&status, code);
+
+	pci_nvme_set_completion(req->sc, sq, req->sqid, req->cid, 0, status, 0);
+	pci_nvme_release_ioreq(req->sc, req);
+}
+
+static void
+pci_nvme_io_partial(struct blockif_req *br, int err)
+{
+	struct pci_nvme_ioreq *req = br->br_param;
+
+	DPRINTF(("%s error %d %s\r\n", __func__, err, strerror(err)));
+
+	pthread_cond_signal(&req->cv);
+}
+
+
+static void
+pci_nvme_handle_io_cmd(struct pci_nvme_softc* sc, uint16_t idx)
+{
+	struct nvme_submission_queue *sq;
+	uint16_t status = 0;
+	uint16_t sqhead;
+	int err;
+
+	/* handle all submissions up to sq->tail index */
+	sq = &sc->submit_queues[idx];
+
+	if (atomic_testandset_int(&sq->busy, 1)) {
+		DPRINTF(("%s sqid %u busy\r\n", __func__, idx));
+		return;
+	}
+
+	sqhead = atomic_load_acq_short(&sq->head);
+
+	DPRINTF(("nvme_handle_io qid %u head %u tail %u cmdlist %p\r\n",
+	         idx, sqhead, sq->tail, sq->qbase));
+
+	while (sqhead != atomic_load_acq_short(&sq->tail)) {
+		struct nvme_command *cmd;
+		struct pci_nvme_ioreq *req = NULL;
+		uint64_t lba;
+		uint64_t nblocks, bytes, size, cpsz;
+
+		/* TODO: support scatter gather list handling */
+
+		cmd = &sq->qbase[sqhead];
+		sqhead = (sqhead + 1) % sq->size;
+
+		lba = ((uint64_t)cmd->cdw11 << 32) | cmd->cdw10;
+
+		if (cmd->opc == NVME_OPC_FLUSH) {
+			pci_nvme_status_genc(&status, NVME_SC_SUCCESS);
+			pci_nvme_set_completion(sc, sq, idx, cmd->cid, 0,
+			                        status, 1);
+
+			continue;
+		} else if (cmd->opc == 0x08) {
+			/* TODO: write zeroes */
+			WPRINTF(("%s write zeroes lba 0x%lx blocks %u\r\n",
+			        __func__, lba, cmd->cdw12 & 0xFFFF));
+			pci_nvme_status_genc(&status, NVME_SC_SUCCESS);
+			pci_nvme_set_completion(sc, sq, idx, cmd->cid, 0,
+			                        status, 1);
+
+			continue;
+		}
+
+		nblocks = (cmd->cdw12 & 0xFFFF) + 1;
+
+		bytes = nblocks * sc->nvstore.sectsz;
+
+		if (sc->nvstore.type == NVME_STOR_BLOCKIF) {
+			req = pci_nvme_get_ioreq(sc);
+			req->nvme_sq = sq;
+			req->sqid = idx;
+		}
+
+		/*
+		 * If data starts mid-page and flows into the next page, then
+		 * increase page count
+		 */
+
+		DPRINTF(("[h%u:t%u:n%u] %s starting LBA 0x%lx blocks %lu "
+		         "(%lu-bytes)\r\n",
+		         sqhead==0 ? sq->size-1 : sqhead-1, sq->tail, sq->size,
+		         cmd->opc == NVME_OPC_WRITE ?
+			     "WRITE" : "READ",
+		         lba, nblocks, bytes));
+
+		cmd->prp1 &= ~(0x03UL);
+		cmd->prp2 &= ~(0x03UL);
+
+		DPRINTF((" prp1 0x%lx prp2 0x%lx\r\n", cmd->prp1, cmd->prp2));
+
+		size = bytes;
+		lba *= sc->nvstore.sectsz;
+
+		cpsz = PAGE_SIZE - (cmd->prp1 % PAGE_SIZE);
+
+		if (cpsz > bytes)
+			cpsz = bytes;
+
+		if (req != NULL) {
+			req->io_req.br_offset = ((uint64_t)cmd->cdw11 << 32) |
+			                        cmd->cdw10;
+			req->opc = cmd->opc;
+			req->cid = cmd->cid;
+			req->nsid = cmd->nsid;
+		}
+
+		err = pci_nvme_append_iov_req(sc, req, cmd->prp1, cpsz,
+		    cmd->opc == NVME_OPC_WRITE, lba);
+		lba += cpsz;
+		size -= cpsz;
+
+		if (size == 0)
+			goto iodone;
+
+		if (size <= PAGE_SIZE) {
+			/* prp2 is second (and final) page in transfer */
+
+			err = pci_nvme_append_iov_req(sc, req, cmd->prp2,
+			    size,
+			    cmd->opc == NVME_OPC_WRITE,
+			    lba);
+		} else {
+			uint64_t *prp_list;
+			int i;
+
+			/* prp2 is pointer to a physical region page list */
+			prp_list = paddr_guest2host(sc->nsc_pi->pi_vmctx,
+			                            cmd->prp2, PAGE_SIZE);
+
+			i = 0;
+			while (size != 0) {
+				cpsz = MIN(size, PAGE_SIZE);
+
+				/*
+				 * Move to linked physical region page list
+				 * in last item.
+				 */ 
+				if (i == (NVME_PRP2_ITEMS-1) &&
+				    size > PAGE_SIZE) {
+					assert((prp_list[i] & (PAGE_SIZE-1)) == 0);
+					prp_list = paddr_guest2host(
+					              sc->nsc_pi->pi_vmctx,
+					              prp_list[i], PAGE_SIZE);
+					i = 0;
+				}
+				if (prp_list[i] == 0) {
+					WPRINTF(("PRP2[%d] = 0 !!!\r\n", i));
+					err = 1;
+					break;
+				}
+
+				err = pci_nvme_append_iov_req(sc, req,
+				    prp_list[i], cpsz,
+				    cmd->opc == NVME_OPC_WRITE, lba);
+				if (err)
+					break;
+
+				lba += cpsz;
+				size -= cpsz;
+				i++;
+			}
+		}
+
+iodone:
+		if (sc->nvstore.type == NVME_STOR_RAM) {
+			uint16_t code, status = 0;
+
+			code = err ? NVME_SC_LBA_OUT_OF_RANGE :
+			    NVME_SC_SUCCESS;
+			pci_nvme_status_genc(&status, code);
+
+			pci_nvme_set_completion(sc, sq, idx, cmd->cid, 0,
+			                        status, 1);
+
+			continue;
+		}
+
+
+		if (err)
+			goto do_error;
+
+		req->io_req.br_callback = pci_nvme_io_done;
+
+		err = 0;
+		switch (cmd->opc) {
+		case NVME_OPC_READ:
+			err = blockif_read(sc->nvstore.ctx, &req->io_req);
+			break;
+		case NVME_OPC_WRITE:
+#ifdef __FreeBSD__
+			err = blockif_write(sc->nvstore.ctx, &req->io_req);
+#else
+			/* XXX: Should this be sync? */
+			err = blockif_write(sc->nvstore.ctx, &req->io_req,
+			    B_FALSE);
+#endif
+			break;
+		default:
+			WPRINTF(("%s unhandled io command 0x%x\r\n",
+				 __func__, cmd->opc));
+			err = 1;
+		}
+
+do_error:
+		if (err) {
+			uint16_t status = 0;
+
+			pci_nvme_status_genc(&status,
+			    NVME_SC_DATA_TRANSFER_ERROR);
+
+			pci_nvme_set_completion(sc, sq, idx, cmd->cid, 0,
+			                        status, 1);
+			pci_nvme_release_ioreq(sc, req);
+		}
+	}
+
+	atomic_store_short(&sq->head, sqhead);
+	atomic_store_int(&sq->busy, 0);
+}
+
+static void
+pci_nvme_handle_doorbell(struct vmctx *ctx, struct pci_nvme_softc* sc,
+	uint64_t idx, int is_sq, uint64_t value)
+{
+	DPRINTF(("nvme doorbell %lu, %s, val 0x%lx\r\n",
+	        idx, is_sq ? "SQ" : "CQ", value & 0xFFFF));
+
+	if (is_sq) {
+		atomic_store_short(&sc->submit_queues[idx].tail,
+		                   (uint16_t)value);
+
+		if (idx == 0) {
+			pci_nvme_handle_admin_cmd(sc, value);
+		} else {
+			/* submission queue; handle new entries in SQ */
+			if (idx > sc->num_squeues) {
+				WPRINTF(("%s SQ index %lu overflow from "
+				         "guest (max %u)\r\n",
+				         __func__, idx, sc->num_squeues));
+				return;
+			}
+			pci_nvme_handle_io_cmd(sc, (uint16_t)idx);
+		}
+	} else {
+		if (idx > sc->num_cqueues) {
+			WPRINTF(("%s queue index %lu overflow from "
+			         "guest (max %u)\r\n",
+			         __func__, idx, sc->num_cqueues));
+			return;
+		}
+
+		sc->compl_queues[idx].head = (uint16_t)value;
+	}
+}
+
+static void
+pci_nvme_bar0_reg_dumps(const char *func, uint64_t offset, int iswrite)
+{
+	const char *s = iswrite ? "WRITE" : "READ";
+
+	switch (offset) {
+	case NVME_CR_CAP_LOW:
+		DPRINTF(("%s %s NVME_CR_CAP_LOW\r\n", func, s));
+		break;
+	case NVME_CR_CAP_HI:
+		DPRINTF(("%s %s NVME_CR_CAP_HI\r\n", func, s));
+		break;
+	case NVME_CR_VS:
+		DPRINTF(("%s %s NVME_CR_VS\r\n", func, s));
+		break;
+	case NVME_CR_INTMS:
+		DPRINTF(("%s %s NVME_CR_INTMS\r\n", func, s));
+		break;
+	case NVME_CR_INTMC:
+		DPRINTF(("%s %s NVME_CR_INTMC\r\n", func, s));
+		break;
+	case NVME_CR_CC:
+		DPRINTF(("%s %s NVME_CR_CC\r\n", func, s));
+		break;
+	case NVME_CR_CSTS:
+		DPRINTF(("%s %s NVME_CR_CSTS\r\n", func, s));
+		break;
+	case NVME_CR_NSSR:
+		DPRINTF(("%s %s NVME_CR_NSSR\r\n", func, s));
+		break;
+	case NVME_CR_AQA:
+		DPRINTF(("%s %s NVME_CR_AQA\r\n", func, s));
+		break;
+	case NVME_CR_ASQ_LOW:
+		DPRINTF(("%s %s NVME_CR_ASQ_LOW\r\n", func, s));
+		break;
+	case NVME_CR_ASQ_HI:
+		DPRINTF(("%s %s NVME_CR_ASQ_HI\r\n", func, s));
+		break;
+	case NVME_CR_ACQ_LOW:
+		DPRINTF(("%s %s NVME_CR_ACQ_LOW\r\n", func, s));
+		break;
+	case NVME_CR_ACQ_HI:
+		DPRINTF(("%s %s NVME_CR_ACQ_HI\r\n", func, s));
+		break;
+	default:
+		DPRINTF(("unknown nvme bar-0 offset 0x%lx\r\n", offset));
+	}
+
+}
+
+static void
+pci_nvme_write_bar_0(struct vmctx *ctx, struct pci_nvme_softc* sc,
+	uint64_t offset, int size, uint64_t value)
+{
+	uint32_t ccreg;
+
+	if (offset >= NVME_DOORBELL_OFFSET) {
+		uint64_t belloffset = offset - NVME_DOORBELL_OFFSET;
+		uint64_t idx = belloffset / 8; /* door bell size = 2*int */
+		int is_sq = (belloffset % 8) < 4;
+
+		if (belloffset > ((sc->max_queues+1) * 8 - 4)) {
+			WPRINTF(("guest attempted an overflow write offset "
+			         "0x%lx, val 0x%lx in %s",
+			         offset, value, __func__));
+			return;
+		}
+
+		pci_nvme_handle_doorbell(ctx, sc, idx, is_sq, value);
+		return;
+	}
+
+	DPRINTF(("nvme-write offset 0x%lx, size %d, value 0x%lx\r\n",
+	        offset, size, value));
+
+	if (size != 4) {
+		WPRINTF(("guest wrote invalid size %d (offset 0x%lx, "
+		         "val 0x%lx) to bar0 in %s",
+		         size, offset, value, __func__));
+		/* TODO: shutdown device */
+		return;
+	}
+
+	pci_nvme_bar0_reg_dumps(__func__, offset, 1);
+
+	pthread_mutex_lock(&sc->mtx);
+
+	switch (offset) {
+	case NVME_CR_CAP_LOW:
+	case NVME_CR_CAP_HI:
+		/* readonly */
+		break;
+	case NVME_CR_VS:
+		/* readonly */
+		break;
+	case NVME_CR_INTMS:
+		/* MSI-X, so ignore */
+		break;
+	case NVME_CR_INTMC:
+		/* MSI-X, so ignore */
+		break;
+	case NVME_CR_CC:
+		ccreg = (uint32_t)value;
+
+		DPRINTF(("%s NVME_CR_CC en %x css %x shn %x iosqes %u "
+		         "iocqes %u\r\n",
+		        __func__,
+			 NVME_CC_GET_EN(ccreg), NVME_CC_GET_CSS(ccreg),
+			 NVME_CC_GET_SHN(ccreg), NVME_CC_GET_IOSQES(ccreg),
+			 NVME_CC_GET_IOCQES(ccreg)));
+
+		if (NVME_CC_GET_SHN(ccreg)) {
+			/* perform shutdown - flush out data to backend */
+			sc->regs.csts &= ~(NVME_CSTS_REG_SHST_MASK <<
+			    NVME_CSTS_REG_SHST_SHIFT);
+			sc->regs.csts |= NVME_SHST_COMPLETE <<
+			    NVME_CSTS_REG_SHST_SHIFT;
+		}
+		if (NVME_CC_GET_EN(ccreg) != NVME_CC_GET_EN(sc->regs.cc)) {
+			if (NVME_CC_GET_EN(ccreg) == 0)
+				/* transition 1-> causes controller reset */
+				pci_nvme_reset_locked(sc);
+			else
+				pci_nvme_init_controller(ctx, sc);
+		}
+
+		/* Insert the iocqes, iosqes and en bits from the write */
+		sc->regs.cc &= ~NVME_CC_WRITE_MASK;
+		sc->regs.cc |= ccreg & NVME_CC_WRITE_MASK;
+		if (NVME_CC_GET_EN(ccreg) == 0) {
+			/* Insert the ams, mps and css bit fields */
+			sc->regs.cc &= ~NVME_CC_NEN_WRITE_MASK;
+			sc->regs.cc |= ccreg & NVME_CC_NEN_WRITE_MASK;
+			sc->regs.csts &= ~NVME_CSTS_RDY;
+		} else if (sc->pending_ios == 0) {
+			sc->regs.csts |= NVME_CSTS_RDY;
+		}
+		break;
+	case NVME_CR_CSTS:
+		break;
+	case NVME_CR_NSSR:
+		/* ignore writes; don't support subsystem reset */
+		break;
+	case NVME_CR_AQA:
+		sc->regs.aqa = (uint32_t)value;
+		break;
+	case NVME_CR_ASQ_LOW:
+		sc->regs.asq = (sc->regs.asq & (0xFFFFFFFF00000000)) |
+		               (0xFFFFF000 & value);
+		break;
+	case NVME_CR_ASQ_HI:
+		sc->regs.asq = (sc->regs.asq & (0x00000000FFFFFFFF)) |
+		               (value << 32);
+		break;
+	case NVME_CR_ACQ_LOW:
+		sc->regs.acq = (sc->regs.acq & (0xFFFFFFFF00000000)) |
+		               (0xFFFFF000 & value);
+		break;
+	case NVME_CR_ACQ_HI:
+		sc->regs.acq = (sc->regs.acq & (0x00000000FFFFFFFF)) |
+		               (value << 32);
+		break;
+	default:
+		DPRINTF(("%s unknown offset 0x%lx, value 0x%lx size %d\r\n",
+		         __func__, offset, value, size));
+	}
+	pthread_mutex_unlock(&sc->mtx);
+}
+
+static void
+pci_nvme_write(struct vmctx *ctx, int vcpu, struct pci_devinst *pi,
+                int baridx, uint64_t offset, int size, uint64_t value)
+{
+	struct pci_nvme_softc* sc = pi->pi_arg;
+
+	if (baridx == pci_msix_table_bar(pi) ||
+	    baridx == pci_msix_pba_bar(pi)) {
+		DPRINTF(("nvme-write baridx %d, msix: off 0x%lx, size %d, "
+		         " value 0x%lx\r\n", baridx, offset, size, value));
+
+		pci_emul_msix_twrite(pi, offset, size, value);
+		return;
+	}
+
+	switch (baridx) {
+	case 0:
+		pci_nvme_write_bar_0(ctx, sc, offset, size, value);
+		break;
+
+	default:
+		DPRINTF(("%s unknown baridx %d, val 0x%lx\r\n",
+		         __func__, baridx, value));
+	}
+}
+
+static uint64_t pci_nvme_read_bar_0(struct pci_nvme_softc* sc,
+	uint64_t offset, int size)
+{
+	uint64_t value;
+
+	pci_nvme_bar0_reg_dumps(__func__, offset, 0);
+
+	if (offset < NVME_DOORBELL_OFFSET) {
+		void *p = &(sc->regs);
+		pthread_mutex_lock(&sc->mtx);
+		memcpy(&value, (void *)((uintptr_t)p + offset), size);
+		pthread_mutex_unlock(&sc->mtx);
+	} else {
+		value = 0;
+                WPRINTF(("pci_nvme: read invalid offset %ld\r\n", offset));
+	}
+
+	switch (size) {
+	case 1:
+		value &= 0xFF;
+		break;
+	case 2:
+		value &= 0xFFFF;
+		break;
+	case 4:
+		value &= 0xFFFFFFFF;
+		break;
+	}
+
+	DPRINTF(("   nvme-read offset 0x%lx, size %d -> value 0x%x\r\n",
+	         offset, size, (uint32_t)value));
+
+	return (value);
+}
+
+
+
+static uint64_t
+pci_nvme_read(struct vmctx *ctx, int vcpu, struct pci_devinst *pi, int baridx,
+    uint64_t offset, int size)
+{
+	struct pci_nvme_softc* sc = pi->pi_arg;
+
+	if (baridx == pci_msix_table_bar(pi) ||
+	    baridx == pci_msix_pba_bar(pi)) {
+		DPRINTF(("nvme-read bar: %d, msix: regoff 0x%lx, size %d\r\n",
+		        baridx, offset, size));
+
+		return pci_emul_msix_tread(pi, offset, size);
+	}
+
+	switch (baridx) {
+	case 0:
+       		return pci_nvme_read_bar_0(sc, offset, size);
+
+	default:
+		DPRINTF(("unknown bar %d, 0x%lx\r\n", baridx, offset));
+	}
+
+	return (0);
+}
+
+
+static int
+pci_nvme_parse_opts(struct pci_nvme_softc *sc, char *opts)
+{
+	char bident[sizeof("XX:X:X")];
+	char	*uopt, *xopts, *config;
+	uint32_t sectsz;
+	int optidx;
+
+	sc->max_queues = NVME_QUEUES;
+	sc->max_qentries = NVME_MAX_QENTRIES;
+	sc->ioslots = NVME_IOSLOTS;
+	sc->num_squeues = sc->max_queues;
+	sc->num_cqueues = sc->max_queues;
+	sectsz = 0;
+
+	uopt = strdup(opts);
+	optidx = 0;
+	snprintf(sc->ctrldata.sn, sizeof(sc->ctrldata.sn),
+	         "NVME-%d-%d", sc->nsc_pi->pi_slot, sc->nsc_pi->pi_func);
+	for (xopts = strtok(uopt, ",");
+	     xopts != NULL;
+	     xopts = strtok(NULL, ",")) {
+
+		if ((config = strchr(xopts, '=')) != NULL)
+			*config++ = '\0';
+
+		if (!strcmp("maxq", xopts)) {
+			sc->max_queues = atoi(config);
+		} else if (!strcmp("qsz", xopts)) {
+			sc->max_qentries = atoi(config);
+		} else if (!strcmp("ioslots", xopts)) {
+			sc->ioslots = atoi(config);
+		} else if (!strcmp("sectsz", xopts)) {
+			sectsz = atoi(config);
+		} else if (!strcmp("ser", xopts)) {
+			/*
+			 * This field indicates the Product Serial Number in
+			 * 7-bit ASCII, unused bytes should be space characters.
+			 * Ref: NVMe v1.3c.
+			 */
+			cpywithpad((char *)sc->ctrldata.sn,
+			           sizeof(sc->ctrldata.sn), config, ' ');
+		} else if (!strcmp("ram", xopts)) {
+			uint64_t sz = strtoull(&xopts[4], NULL, 10);
+
+			sc->nvstore.type = NVME_STOR_RAM;
+			sc->nvstore.size = sz * 1024 * 1024;
+			sc->nvstore.ctx = calloc(1, sc->nvstore.size);
+			sc->nvstore.sectsz = 4096;
+			sc->nvstore.sectsz_bits = 12;
+			if (sc->nvstore.ctx == NULL) {
+				perror("Unable to allocate RAM");
+				free(uopt);
+				return (-1);
+			}
+		} else if (optidx == 0) {
+			snprintf(bident, sizeof(bident), "%d:%d",
+			         sc->nsc_pi->pi_slot, sc->nsc_pi->pi_func);
+			sc->nvstore.ctx = blockif_open(xopts, bident);
+			if (sc->nvstore.ctx == NULL) {
+				perror("Could not open backing file");
+				free(uopt);
+				return (-1);
+			}
+			sc->nvstore.type = NVME_STOR_BLOCKIF;
+			sc->nvstore.size = blockif_size(sc->nvstore.ctx);
+		} else {
+			fprintf(stderr, "Invalid option %s\n", xopts);
+			free(uopt);
+			return (-1);
+		}
+
+		optidx++;
+	}
+	free(uopt);
+
+	if (sc->nvstore.ctx == NULL || sc->nvstore.size == 0) {
+		fprintf(stderr, "backing store not specified\n");
+		return (-1);
+	}
+	if (sectsz == 512 || sectsz == 4096 || sectsz == 8192)
+		sc->nvstore.sectsz = sectsz;
+	else if (sc->nvstore.type != NVME_STOR_RAM)
+		sc->nvstore.sectsz = blockif_sectsz(sc->nvstore.ctx);
+	for (sc->nvstore.sectsz_bits = 9;
+	     (1 << sc->nvstore.sectsz_bits) < sc->nvstore.sectsz;
+	     sc->nvstore.sectsz_bits++);
+
+	if (sc->max_queues <= 0 || sc->max_queues > NVME_QUEUES)
+		sc->max_queues = NVME_QUEUES;
+
+	if (sc->max_qentries <= 0) {
+		fprintf(stderr, "Invalid qsz option\n");
+		return (-1);
+	}
+	if (sc->ioslots <= 0) {
+		fprintf(stderr, "Invalid ioslots option\n");
+		return (-1);
+	}
+
+	return (0);
+}
+
+static int
+pci_nvme_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
+{
+	struct pci_nvme_softc *sc;
+	uint32_t pci_membar_sz;
+	int	error;
+
+	error = 0;
+
+	sc = calloc(1, sizeof(struct pci_nvme_softc));
+	pi->pi_arg = sc;
+	sc->nsc_pi = pi;
+
+	error = pci_nvme_parse_opts(sc, opts);
+	if (error < 0)
+		goto done;
+	else
+		error = 0;
+
+	sc->ioreqs = calloc(sc->ioslots, sizeof(struct pci_nvme_ioreq));
+	for (int i = 0; i < sc->ioslots; i++) {
+		if (i < (sc->ioslots-1))
+			sc->ioreqs[i].next = &sc->ioreqs[i+1];
+		pthread_mutex_init(&sc->ioreqs[i].mtx, NULL);
+		pthread_cond_init(&sc->ioreqs[i].cv, NULL);
+	}
+	sc->ioreqs_free = sc->ioreqs;
+	sc->intr_coales_aggr_thresh = 1;
+
+	pci_set_cfgdata16(pi, PCIR_DEVICE, 0x0A0A);
+	pci_set_cfgdata16(pi, PCIR_VENDOR, 0xFB5D);
+	pci_set_cfgdata8(pi, PCIR_CLASS, PCIC_STORAGE);
+	pci_set_cfgdata8(pi, PCIR_SUBCLASS, PCIS_STORAGE_NVM);
+	pci_set_cfgdata8(pi, PCIR_PROGIF,
+	                 PCIP_STORAGE_NVM_ENTERPRISE_NVMHCI_1_0);
+
+	/* allocate size of nvme registers + doorbell space for all queues */
+	pci_membar_sz = sizeof(struct nvme_registers) +
+	                2*sizeof(uint32_t)*(sc->max_queues);
+
+	DPRINTF(("nvme membar size: %u\r\n", pci_membar_sz));
+
+	error = pci_emul_alloc_bar(pi, 0, PCIBAR_MEM64, pci_membar_sz);
+	if (error) {
+		WPRINTF(("%s pci alloc mem bar failed\r\n", __func__));
+		goto done;
+	}
+
+	error = pci_emul_add_msixcap(pi, sc->max_queues, NVME_MSIX_BAR);
+	if (error) {
+		WPRINTF(("%s pci add msixcap failed\r\n", __func__));
+		goto done;
+	}
+
+	pthread_mutex_init(&sc->mtx, NULL);
+	sem_init(&sc->iosemlock, 0, sc->ioslots);
+
+	pci_nvme_reset(sc);
+	pci_nvme_init_ctrldata(sc);
+	pci_nvme_init_nsdata(sc);
+
+	pci_lintr_request(pi);
+
+done:
+	return (error);
+}
+
+
+struct pci_devemu pci_de_nvme = {
+	.pe_emu =	"nvme",
+	.pe_init =	pci_nvme_init,
+	.pe_barwrite =	pci_nvme_write,
+	.pe_barread =	pci_nvme_read
+};
+PCI_EMUL_SET(pci_de_nvme);

--- a/usr/src/cmd/bhyve/pci_virtio_block.c
+++ b/usr/src/cmd/bhyve/pci_virtio_block.c
@@ -128,9 +128,9 @@ struct virtio_blk_hdr {
 #define	VBH_OP_WRITE		1
 #define	VBH_OP_FLUSH		4
 #define	VBH_OP_FLUSH_OUT	5
-#define	VBH_OP_IDENT		8		
+#define	VBH_OP_IDENT		8
 #define	VBH_FLAG_BARRIER	0x80000000	/* OR'ed into vbh_type */
-	uint32_t       	vbh_type;
+	uint32_t	vbh_type;
 	uint32_t	vbh_ioprio;
 	uint64_t	vbh_sector;
 } __packed;
@@ -144,8 +144,8 @@ static int pci_vtblk_debug;
 
 struct pci_vtblk_ioreq {
 	struct blockif_req		io_req;
-	struct pci_vtblk_softc	       *io_sc;
-	uint8_t			       *io_status;
+	struct pci_vtblk_softc		*io_sc;
+	uint8_t				*io_status;
 	uint16_t			io_idx;
 };
 
@@ -170,7 +170,7 @@ static int pci_vtblk_cfgwrite(void *, int, int, uint32_t);
 static struct virtio_consts vtblk_vi_consts = {
 	"vtblk",		/* our name */
 	1,			/* we support 1 virtqueue */
-	sizeof(struct vtblk_config), /* config reg size */
+	sizeof(struct vtblk_config),	/* config reg size */
 	pci_vtblk_reset,	/* reset */
 	pci_vtblk_notify,	/* device-wide qnotify */
 	pci_vtblk_cfgread,	/* read PCI config */
@@ -276,7 +276,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	}
 	io->io_req.br_resid = iolen;
 
-	DPRINTF(("virtio-block: %s op, %zd bytes, %d segs, offset %ld\n\r", 
+	DPRINTF(("virtio-block: %s op, %zd bytes, %d segs, offset %ld\n\r",
 		 writeop ? "write" : "read/ident", iolen, i - 1,
 		 io->io_req.br_offset));
 
@@ -375,7 +375,7 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 #else
 	bctxt = blockif_open(opts, bident);
 #endif
-	if (bctxt == NULL) {       	
+	if (bctxt == NULL) {
 		perror("Could not open backing file");
 		return (1);
 	}
@@ -409,7 +409,7 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	 */
 	MD5Init(&mdctx);
 	MD5Update(&mdctx, opts, strlen(opts));
-	MD5Final(digest, &mdctx);	
+	MD5Final(digest, &mdctx);
 	sprintf(sc->vbsc_ident, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
 #if !defined(__FreeBSD__) && !defined(__JOYENT__)

--- a/usr/src/cmd/bhyve/pci_virtio_net.c
+++ b/usr/src/cmd/bhyve/pci_virtio_net.c
@@ -822,24 +822,24 @@ pci_vtnet_ping_ctlq(void *vsc, struct vqueue_info *vq)
 static int
 pci_vtnet_parsemac(char *mac_str, uint8_t *mac_addr)
 {
-        struct ether_addr *ea;
-        char *tmpstr;
-        char zero_addr[ETHER_ADDR_LEN] = { 0, 0, 0, 0, 0, 0 };
+	struct ether_addr *ea;
+	char *tmpstr;
+	char zero_addr[ETHER_ADDR_LEN] = { 0, 0, 0, 0, 0, 0 };
 
-        tmpstr = strsep(&mac_str,"=");
-       
-        if ((mac_str != NULL) && (!strcmp(tmpstr,"mac"))) {
-                ea = ether_aton(mac_str);
+	tmpstr = strsep(&mac_str,"=");
 
-                if (ea == NULL || ETHER_IS_MULTICAST(ea->octet) ||
-                    memcmp(ea->octet, zero_addr, ETHER_ADDR_LEN) == 0) {
+	if ((mac_str != NULL) && (!strcmp(tmpstr,"mac"))) {
+		ea = ether_aton(mac_str);
+
+		if (ea == NULL || ETHER_IS_MULTICAST(ea->octet) ||
+		    memcmp(ea->octet, zero_addr, ETHER_ADDR_LEN) == 0) {
 			fprintf(stderr, "Invalid MAC %s\n", mac_str);
-                        return (EINVAL);
-                } else
-                        memcpy(mac_addr, ea->octet, ETHER_ADDR_LEN);
-        }
+			return (EINVAL);
+		} else
+			memcpy(mac_addr, ea->octet, ETHER_ADDR_LEN);
+	}
 
-        return (0);
+	return (0);
 }
 #endif /* __FreeBSD__ */
 
@@ -1104,8 +1104,9 @@ pci_vtnet_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	pthread_mutex_init(&sc->tx_mtx, NULL);
 	pthread_cond_init(&sc->tx_cond, NULL);
 	pthread_create(&sc->tx_tid, NULL, pci_vtnet_tx_thread, (void *)sc);
-        snprintf(tname, sizeof(tname), "%s vtnet%d tx", vmname, pi->pi_slot);
-        pthread_set_name_np(sc->tx_tid, tname);
+	snprintf(tname, sizeof(tname), "vtnet-%d:%d tx", pi->pi_slot,
+	    pi->pi_func);
+	pthread_set_name_np(sc->tx_tid, tname);
 
 	return (0);
 }

--- a/usr/src/cmd/bhyve/pci_virtio_rnd.c
+++ b/usr/src/cmd/bhyve/pci_virtio_rnd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Nahanni Systems Inc.
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/pci_virtio_scsi.c
+++ b/usr/src/cmd/bhyve/pci_virtio_scsi.c
@@ -1,0 +1,718 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2016 Jakub Klama <jceel@FreeBSD.org>.
+ * Copyright (c) 2018 Marcelo Araujo <araujo@FreeBSD.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/linker_set.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/queue.h>
+#include <sys/sbuf.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <pthread.h>
+#include <pthread_np.h>
+
+#include <cam/scsi/scsi_all.h>
+#include <cam/scsi/scsi_message.h>
+#include <cam/ctl/ctl.h>
+#include <cam/ctl/ctl_io.h>
+#include <cam/ctl/ctl_backend.h>
+#include <cam/ctl/ctl_ioctl.h>
+#include <cam/ctl/ctl_util.h>
+#include <cam/ctl/ctl_scsi_all.h>
+#include <camlib.h>
+
+#include "bhyverun.h"
+#include "pci_emul.h"
+#include "virtio.h"
+#include "iov.h"
+
+#define VTSCSI_RINGSZ		64
+#define	VTSCSI_REQUESTQ		1
+#define	VTSCSI_THR_PER_Q	16
+#define	VTSCSI_MAXQ		(VTSCSI_REQUESTQ + 2)
+#define	VTSCSI_MAXSEG		64
+
+#define	VTSCSI_IN_HEADER_LEN(_sc)	\
+	(sizeof(struct pci_vtscsi_req_cmd_rd) + _sc->vss_config.cdb_size)
+
+#define	VTSCSI_OUT_HEADER_LEN(_sc) 	\
+	(sizeof(struct pci_vtscsi_req_cmd_wr) + _sc->vss_config.sense_size)
+
+#define	VIRTIO_SCSI_MAX_CHANNEL	0
+#define	VIRTIO_SCSI_MAX_TARGET	0
+#define	VIRTIO_SCSI_MAX_LUN	16383
+
+#define	VIRTIO_SCSI_F_INOUT	(1 << 0)
+#define	VIRTIO_SCSI_F_HOTPLUG	(1 << 1)
+#define	VIRTIO_SCSI_F_CHANGE	(1 << 2)
+
+static int pci_vtscsi_debug = 0;
+#define	DPRINTF(params) if (pci_vtscsi_debug) printf params
+#define	WPRINTF(params) printf params
+
+struct pci_vtscsi_config {
+	uint32_t num_queues;
+	uint32_t seg_max;
+	uint32_t max_sectors;
+	uint32_t cmd_per_lun;
+	uint32_t event_info_size;
+	uint32_t sense_size;
+	uint32_t cdb_size;
+	uint16_t max_channel;
+	uint16_t max_target;
+	uint32_t max_lun;
+} __attribute__((packed));
+
+struct pci_vtscsi_queue {
+	struct pci_vtscsi_softc *         vsq_sc;
+	struct vqueue_info *              vsq_vq;
+	int                               vsq_ctl_fd;
+	pthread_mutex_t                   vsq_mtx;
+	pthread_mutex_t                   vsq_qmtx;
+	pthread_cond_t                    vsq_cv;
+	STAILQ_HEAD(, pci_vtscsi_request) vsq_requests;
+	LIST_HEAD(, pci_vtscsi_worker)    vsq_workers;
+};
+
+struct pci_vtscsi_worker {
+	struct pci_vtscsi_queue *     vsw_queue;
+	pthread_t                     vsw_thread;
+	bool                          vsw_exiting;
+	LIST_ENTRY(pci_vtscsi_worker) vsw_link;
+};
+
+struct pci_vtscsi_request {
+	struct pci_vtscsi_queue * vsr_queue;
+	struct iovec              vsr_iov_in[VTSCSI_MAXSEG];
+	int                       vsr_niov_in;
+	struct iovec              vsr_iov_out[VTSCSI_MAXSEG];
+	int                       vsr_niov_out;
+	uint32_t                  vsr_idx;
+	STAILQ_ENTRY(pci_vtscsi_request) vsr_link;
+};
+
+/*
+ * Per-device softc
+ */
+struct pci_vtscsi_softc {
+	struct virtio_softc      vss_vs;
+	struct vqueue_info       vss_vq[VTSCSI_MAXQ];
+	struct pci_vtscsi_queue  vss_queues[VTSCSI_REQUESTQ];
+	pthread_mutex_t          vss_mtx;
+	int                      vss_iid;
+	int                      vss_ctl_fd;
+	uint32_t                 vss_features;
+	struct pci_vtscsi_config vss_config;
+};
+
+#define	VIRTIO_SCSI_T_TMF			0
+#define	VIRTIO_SCSI_T_TMF_ABORT_TASK		0
+#define	VIRTIO_SCSI_T_TMF_ABORT_TASK_SET	1
+#define	VIRTIO_SCSI_T_TMF_CLEAR_ACA		2
+#define	VIRTIO_SCSI_T_TMF_CLEAR_TASK_SET	3
+#define	VIRTIO_SCSI_T_TMF_I_T_NEXUS_RESET	4
+#define	VIRTIO_SCSI_T_TMF_LOGICAL_UNIT_RESET	5
+#define	VIRTIO_SCSI_T_TMF_QUERY_TASK		6
+#define	VIRTIO_SCSI_T_TMF_QUERY_TASK_SET 	7
+
+/* command-specific response values */
+#define	VIRTIO_SCSI_S_FUNCTION_COMPLETE		0
+#define	VIRTIO_SCSI_S_FUNCTION_SUCCEEDED	10
+#define	VIRTIO_SCSI_S_FUNCTION_REJECTED		11
+
+struct pci_vtscsi_ctrl_tmf {
+	uint32_t type;
+	uint32_t subtype;
+	uint8_t lun[8];
+	uint64_t id;
+	uint8_t response;
+} __attribute__((packed));
+
+#define	VIRTIO_SCSI_T_AN_QUERY			1
+#define	VIRTIO_SCSI_EVT_ASYNC_OPERATIONAL_CHANGE 2
+#define	VIRTIO_SCSI_EVT_ASYNC_POWER_MGMT	4
+#define	VIRTIO_SCSI_EVT_ASYNC_EXTERNAL_REQUEST	8
+#define	VIRTIO_SCSI_EVT_ASYNC_MEDIA_CHANGE	16
+#define	VIRTIO_SCSI_EVT_ASYNC_MULTI_HOST	32
+#define	VIRTIO_SCSI_EVT_ASYNC_DEVICE_BUSY	64
+
+struct pci_vtscsi_ctrl_an {
+	uint32_t type;
+	uint8_t lun[8];
+	uint32_t event_requested;
+	uint32_t event_actual;
+	uint8_t response;
+} __attribute__((packed));
+
+/* command-specific response values */
+#define	VIRTIO_SCSI_S_OK 			0
+#define	VIRTIO_SCSI_S_OVERRUN			1
+#define	VIRTIO_SCSI_S_ABORTED			2
+#define	VIRTIO_SCSI_S_BAD_TARGET		3
+#define	VIRTIO_SCSI_S_RESET			4
+#define	VIRTIO_SCSI_S_BUSY			5
+#define	VIRTIO_SCSI_S_TRANSPORT_FAILURE		6
+#define	VIRTIO_SCSI_S_TARGET_FAILURE		7
+#define	VIRTIO_SCSI_S_NEXUS_FAILURE		8
+#define	VIRTIO_SCSI_S_FAILURE			9
+#define	VIRTIO_SCSI_S_INCORRECT_LUN		12
+
+/* task_attr */
+#define	VIRTIO_SCSI_S_SIMPLE			0
+#define	VIRTIO_SCSI_S_ORDERED			1
+#define	VIRTIO_SCSI_S_HEAD			2
+#define	VIRTIO_SCSI_S_ACA			3
+
+struct pci_vtscsi_event {
+	uint32_t event;
+	uint8_t lun[8];
+	uint32_t reason;
+} __attribute__((packed));
+
+struct pci_vtscsi_req_cmd_rd {
+	uint8_t lun[8];
+	uint64_t id;
+	uint8_t task_attr;
+	uint8_t prio;
+	uint8_t crn;
+	uint8_t cdb[];
+} __attribute__((packed));
+
+struct pci_vtscsi_req_cmd_wr {
+	uint32_t sense_len;
+	uint32_t residual;
+	uint16_t status_qualifier;
+	uint8_t status;
+	uint8_t response;
+	uint8_t sense[];
+} __attribute__((packed));
+
+static void *pci_vtscsi_proc(void *);
+static void pci_vtscsi_reset(void *);
+static void pci_vtscsi_neg_features(void *, uint64_t);
+static int pci_vtscsi_cfgread(void *, int, int, uint32_t *);
+static int pci_vtscsi_cfgwrite(void *, int, int, uint32_t);
+static inline int pci_vtscsi_get_lun(uint8_t *);
+static int pci_vtscsi_control_handle(struct pci_vtscsi_softc *, void *, size_t);
+static int pci_vtscsi_tmf_handle(struct pci_vtscsi_softc *,
+    struct pci_vtscsi_ctrl_tmf *);
+static int pci_vtscsi_an_handle(struct pci_vtscsi_softc *,
+    struct pci_vtscsi_ctrl_an *);
+static int pci_vtscsi_request_handle(struct pci_vtscsi_queue *, struct iovec *,
+    int, struct iovec *, int);
+static void pci_vtscsi_controlq_notify(void *, struct vqueue_info *);
+static void pci_vtscsi_eventq_notify(void *, struct vqueue_info *);
+static void pci_vtscsi_requestq_notify(void *, struct vqueue_info *);
+static int  pci_vtscsi_init_queue(struct pci_vtscsi_softc *,
+    struct pci_vtscsi_queue *, int);
+static int pci_vtscsi_init(struct vmctx *, struct pci_devinst *, char *);
+
+static struct virtio_consts vtscsi_vi_consts = {
+	"vtscsi",				/* our name */
+	VTSCSI_MAXQ,				/* we support 2+n virtqueues */
+	sizeof(struct pci_vtscsi_config),	/* config reg size */
+	pci_vtscsi_reset,			/* reset */
+	NULL,					/* device-wide qnotify */
+	pci_vtscsi_cfgread,			/* read virtio config */
+	pci_vtscsi_cfgwrite,			/* write virtio config */
+	pci_vtscsi_neg_features,		/* apply negotiated features */
+	0,					/* our capabilities */
+};
+
+static void *
+pci_vtscsi_proc(void *arg)
+{
+	struct pci_vtscsi_worker *worker = (struct pci_vtscsi_worker *)arg;
+	struct pci_vtscsi_queue *q = worker->vsw_queue;
+	struct pci_vtscsi_request *req;
+	int iolen;
+
+	for (;;) {
+		pthread_mutex_lock(&q->vsq_mtx);
+
+		while (STAILQ_EMPTY(&q->vsq_requests)
+		    && !worker->vsw_exiting)
+			pthread_cond_wait(&q->vsq_cv, &q->vsq_mtx);
+
+		if (worker->vsw_exiting)
+			break;
+
+		req = STAILQ_FIRST(&q->vsq_requests);
+		STAILQ_REMOVE_HEAD(&q->vsq_requests, vsr_link);
+
+		pthread_mutex_unlock(&q->vsq_mtx);
+		iolen = pci_vtscsi_request_handle(q, req->vsr_iov_in,
+		    req->vsr_niov_in, req->vsr_iov_out, req->vsr_niov_out);
+
+		pthread_mutex_lock(&q->vsq_qmtx);
+		vq_relchain(q->vsq_vq, req->vsr_idx, iolen);
+		vq_endchains(q->vsq_vq, 0);
+		pthread_mutex_unlock(&q->vsq_qmtx);
+
+		DPRINTF(("virtio-scsi: request <idx=%d> completed\n",
+		    req->vsr_idx));
+		free(req);
+	}
+
+	pthread_mutex_unlock(&q->vsq_mtx);
+	return (NULL);
+}
+
+static void
+pci_vtscsi_reset(void *vsc)
+{
+	struct pci_vtscsi_softc *sc;
+
+	sc = vsc;
+
+	DPRINTF(("vtscsi: device reset requested\n"));
+	vi_reset_dev(&sc->vss_vs);
+
+	/* initialize config structure */
+	sc->vss_config = (struct pci_vtscsi_config){
+		.num_queues = VTSCSI_REQUESTQ,
+		.seg_max = VTSCSI_MAXSEG,
+		.max_sectors = 2,
+		.cmd_per_lun = 1,
+		.event_info_size = sizeof(struct pci_vtscsi_event),
+		.sense_size = 96,
+		.cdb_size = 32,
+		.max_channel = VIRTIO_SCSI_MAX_CHANNEL,
+		.max_target = VIRTIO_SCSI_MAX_TARGET,
+		.max_lun = VIRTIO_SCSI_MAX_LUN
+	};
+}
+
+static void
+pci_vtscsi_neg_features(void *vsc, uint64_t negotiated_features)
+{
+	struct pci_vtscsi_softc *sc = vsc;
+
+	sc->vss_features = negotiated_features;
+}
+
+static int
+pci_vtscsi_cfgread(void *vsc, int offset, int size, uint32_t *retval)
+{
+	struct pci_vtscsi_softc *sc = vsc;
+	void *ptr;
+
+	ptr = (uint8_t *)&sc->vss_config + offset;
+	memcpy(retval, ptr, size);
+	return (0);
+}
+
+static int
+pci_vtscsi_cfgwrite(void *vsc, int offset, int size, uint32_t val)
+{
+
+	return (0);
+}
+
+static inline int
+pci_vtscsi_get_lun(uint8_t *lun)
+{
+
+	return (((lun[2] << 8) | lun[3]) & 0x3fff);
+}
+
+static int
+pci_vtscsi_control_handle(struct pci_vtscsi_softc *sc, void *buf,
+    size_t bufsize)
+{
+	struct pci_vtscsi_ctrl_tmf *tmf;
+	struct pci_vtscsi_ctrl_an *an;
+	uint32_t type;
+
+	type = *(uint32_t *)buf;
+
+	if (type == VIRTIO_SCSI_T_TMF) {
+		tmf = (struct pci_vtscsi_ctrl_tmf *)buf;
+		return (pci_vtscsi_tmf_handle(sc, tmf));
+	}
+
+	if (type == VIRTIO_SCSI_T_AN_QUERY) {
+		an = (struct pci_vtscsi_ctrl_an *)buf;
+		return (pci_vtscsi_an_handle(sc, an));
+	}
+
+	return (0);
+}
+
+static int
+pci_vtscsi_tmf_handle(struct pci_vtscsi_softc *sc,
+    struct pci_vtscsi_ctrl_tmf *tmf)
+{
+	union ctl_io *io;
+	int err;
+
+	io = ctl_scsi_alloc_io(sc->vss_iid);
+	ctl_scsi_zero_io(io);
+
+	io->io_hdr.io_type = CTL_IO_TASK;
+	io->io_hdr.nexus.targ_port = tmf->lun[1];
+	io->io_hdr.nexus.targ_lun = pci_vtscsi_get_lun(tmf->lun);
+	io->taskio.tag_type = CTL_TAG_SIMPLE;
+	io->taskio.tag_num = (uint32_t)tmf->id;
+
+	switch (tmf->subtype) {
+	case VIRTIO_SCSI_T_TMF_ABORT_TASK:
+		io->taskio.task_action = CTL_TASK_ABORT_TASK;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_ABORT_TASK_SET:
+		io->taskio.task_action = CTL_TASK_ABORT_TASK_SET;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_CLEAR_ACA:
+		io->taskio.task_action = CTL_TASK_CLEAR_ACA;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_CLEAR_TASK_SET:
+		io->taskio.task_action = CTL_TASK_CLEAR_TASK_SET;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_I_T_NEXUS_RESET:
+		io->taskio.task_action = CTL_TASK_I_T_NEXUS_RESET;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_LOGICAL_UNIT_RESET:
+		io->taskio.task_action = CTL_TASK_LUN_RESET;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_QUERY_TASK:
+		io->taskio.task_action = CTL_TASK_QUERY_TASK;
+		break;
+
+	case VIRTIO_SCSI_T_TMF_QUERY_TASK_SET:
+		io->taskio.task_action = CTL_TASK_QUERY_TASK_SET;
+		break;
+	}
+
+	if (pci_vtscsi_debug) {
+		struct sbuf *sb = sbuf_new_auto();
+		ctl_io_sbuf(io, sb);
+		sbuf_finish(sb);
+		DPRINTF(("pci_virtio_scsi: %s", sbuf_data(sb)));
+		sbuf_delete(sb);
+	}
+
+	err = ioctl(sc->vss_ctl_fd, CTL_IO, io);
+	if (err != 0)
+		WPRINTF(("CTL_IO: err=%d (%s)\n", errno, strerror(errno)));
+
+	tmf->response = io->taskio.task_status;
+	ctl_scsi_free_io(io);
+	return (1);
+}
+
+static int
+pci_vtscsi_an_handle(struct pci_vtscsi_softc *sc,
+    struct pci_vtscsi_ctrl_an *an)
+{
+
+	return (0);
+}
+
+static int
+pci_vtscsi_request_handle(struct pci_vtscsi_queue *q, struct iovec *iov_in,
+    int niov_in, struct iovec *iov_out, int niov_out)
+{
+	struct pci_vtscsi_softc *sc = q->vsq_sc;
+	struct pci_vtscsi_req_cmd_rd *cmd_rd = NULL;
+	struct pci_vtscsi_req_cmd_wr *cmd_wr;
+	struct iovec data_iov_in[VTSCSI_MAXSEG], data_iov_out[VTSCSI_MAXSEG];
+	union ctl_io *io;
+	size_t data_niov_in, data_niov_out;
+	void *ext_data_ptr = NULL;
+	uint32_t ext_data_len = 0, ext_sg_entries = 0;
+	int err;
+
+	seek_iov(iov_in, niov_in, data_iov_in, &data_niov_in,
+	    VTSCSI_IN_HEADER_LEN(sc));
+	seek_iov(iov_out, niov_out, data_iov_out, &data_niov_out,
+	    VTSCSI_OUT_HEADER_LEN(sc));
+
+	truncate_iov(iov_in, niov_in, VTSCSI_IN_HEADER_LEN(sc));
+	truncate_iov(iov_out, niov_out, VTSCSI_OUT_HEADER_LEN(sc));
+	iov_to_buf(iov_in, niov_in, (void **)&cmd_rd);
+
+	cmd_wr = malloc(VTSCSI_OUT_HEADER_LEN(sc));
+	io = ctl_scsi_alloc_io(sc->vss_iid);
+	ctl_scsi_zero_io(io);
+
+	io->io_hdr.nexus.targ_port = cmd_rd->lun[1];
+	io->io_hdr.nexus.targ_lun = pci_vtscsi_get_lun(cmd_rd->lun);
+
+	io->io_hdr.io_type = CTL_IO_SCSI;
+
+	if (data_niov_in > 0) {
+		ext_data_ptr = (void *)data_iov_in;
+		ext_sg_entries = data_niov_in;
+		ext_data_len = count_iov(data_iov_in, data_niov_in);
+		io->io_hdr.flags |= CTL_FLAG_DATA_OUT;
+	} else if (data_niov_out > 0) {
+		ext_data_ptr = (void *)data_iov_out;
+		ext_sg_entries = data_niov_out;
+		ext_data_len = count_iov(data_iov_out, data_niov_out);
+		io->io_hdr.flags |= CTL_FLAG_DATA_IN;
+	}
+
+	io->scsiio.sense_len = sc->vss_config.sense_size;
+	io->scsiio.tag_num = (uint32_t)cmd_rd->id;
+	io->scsiio.tag_type = CTL_TAG_SIMPLE;
+	io->scsiio.ext_sg_entries = ext_sg_entries;
+	io->scsiio.ext_data_ptr = ext_data_ptr;
+	io->scsiio.ext_data_len = ext_data_len;
+	io->scsiio.ext_data_filled = 0;
+	io->scsiio.cdb_len = sc->vss_config.cdb_size;
+	memcpy(io->scsiio.cdb, cmd_rd->cdb, sc->vss_config.cdb_size);
+
+	if (pci_vtscsi_debug) {
+		struct sbuf *sb = sbuf_new_auto();
+		ctl_io_sbuf(io, sb);
+		sbuf_finish(sb);
+		DPRINTF(("pci_virtio_scsi: %s", sbuf_data(sb)));
+		sbuf_delete(sb);
+	}
+
+	err = ioctl(q->vsq_ctl_fd, CTL_IO, io);
+	if (err != 0) {
+		WPRINTF(("CTL_IO: err=%d (%s)\n", errno, strerror(errno)));
+		cmd_wr->response = VIRTIO_SCSI_S_FAILURE;
+	} else {
+		cmd_wr->sense_len = MIN(io->scsiio.sense_len,
+		    sc->vss_config.sense_size);
+		cmd_wr->residual = io->scsiio.residual;
+		cmd_wr->status = io->scsiio.scsi_status;
+		cmd_wr->response = VIRTIO_SCSI_S_OK;
+		memcpy(&cmd_wr->sense, &io->scsiio.sense_data,
+		    cmd_wr->sense_len);
+	}
+
+	buf_to_iov(cmd_wr, VTSCSI_OUT_HEADER_LEN(sc), iov_out, niov_out, 0);
+	free(cmd_rd);
+	free(cmd_wr);
+	ctl_scsi_free_io(io);
+	return (VTSCSI_OUT_HEADER_LEN(sc) + io->scsiio.ext_data_filled);
+}
+
+static void
+pci_vtscsi_controlq_notify(void *vsc, struct vqueue_info *vq)
+{
+	struct pci_vtscsi_softc *sc;
+	struct iovec iov[VTSCSI_MAXSEG];
+	uint16_t idx, n;
+	void *buf = NULL;
+	size_t bufsize;
+	int iolen;
+
+	sc = vsc;
+
+	while (vq_has_descs(vq)) {
+		n = vq_getchain(vq, &idx, iov, VTSCSI_MAXSEG, NULL);
+		bufsize = iov_to_buf(iov, n, &buf);
+		iolen = pci_vtscsi_control_handle(sc, buf, bufsize);
+		buf_to_iov(buf + bufsize - iolen, iolen, iov, n, iolen);
+
+		/*
+		 * Release this chain and handle more
+		 */
+		vq_relchain(vq, idx, iolen);
+	}
+	vq_endchains(vq, 1);	/* Generate interrupt if appropriate. */
+}
+
+static void
+pci_vtscsi_eventq_notify(void *vsc, struct vqueue_info *vq)
+{
+
+	vq->vq_used->vu_flags |= VRING_USED_F_NO_NOTIFY;
+}
+
+static void
+pci_vtscsi_requestq_notify(void *vsc, struct vqueue_info *vq)
+{
+	struct pci_vtscsi_softc *sc;
+	struct pci_vtscsi_queue *q;
+	struct pci_vtscsi_request *req;
+	struct iovec iov[VTSCSI_MAXSEG];
+	uint16_t flags[VTSCSI_MAXSEG];
+	uint16_t idx, n, i;
+	int readable;
+
+	sc = vsc;
+	q = &sc->vss_queues[vq->vq_num - 2];
+
+	while (vq_has_descs(vq)) {
+		readable = 0;
+		n = vq_getchain(vq, &idx, iov, VTSCSI_MAXSEG, flags);
+
+		/* Count readable descriptors */
+		for (i = 0; i < n; i++) {
+			if (flags[i] & VRING_DESC_F_WRITE)
+				break;
+
+			readable++;
+		}
+
+		req = calloc(1, sizeof(struct pci_vtscsi_request));
+		req->vsr_idx = idx;
+		req->vsr_queue = q;
+		req->vsr_niov_in = readable;
+		req->vsr_niov_out = n - readable;
+		memcpy(req->vsr_iov_in, iov,
+		    req->vsr_niov_in * sizeof(struct iovec));
+		memcpy(req->vsr_iov_out, iov + readable,
+		    req->vsr_niov_out * sizeof(struct iovec));
+
+		pthread_mutex_lock(&q->vsq_mtx);
+		STAILQ_INSERT_TAIL(&q->vsq_requests, req, vsr_link);
+		pthread_cond_signal(&q->vsq_cv);
+		pthread_mutex_unlock(&q->vsq_mtx);
+
+		DPRINTF(("virtio-scsi: request <idx=%d> enqueued\n", idx));
+	}
+}
+
+static int
+pci_vtscsi_init_queue(struct pci_vtscsi_softc *sc, 
+    struct pci_vtscsi_queue *queue, int num)
+{
+	struct pci_vtscsi_worker *worker;
+	char threadname[16];
+	int i;
+
+	queue->vsq_sc = sc;
+	queue->vsq_ctl_fd = open("/dev/cam/ctl", O_RDWR);
+	queue->vsq_vq = &sc->vss_vq[num + 2];
+
+	if (queue->vsq_ctl_fd < 0) {
+		WPRINTF(("cannot open /dev/cam/ctl: %s\n", strerror(errno)));
+		return (-1);
+	}
+
+	pthread_mutex_init(&queue->vsq_mtx, NULL);
+	pthread_mutex_init(&queue->vsq_qmtx, NULL);
+	pthread_cond_init(&queue->vsq_cv, NULL);
+	STAILQ_INIT(&queue->vsq_requests);
+	LIST_INIT(&queue->vsq_workers);
+
+	for (i = 0; i < VTSCSI_THR_PER_Q; i++) {
+		worker = calloc(1, sizeof(struct pci_vtscsi_worker));
+		worker->vsw_queue = queue;
+
+		pthread_create(&worker->vsw_thread, NULL, &pci_vtscsi_proc,
+		    (void *)worker);
+
+		sprintf(threadname, "virtio-scsi:%d-%d", num, i);
+		pthread_set_name_np(worker->vsw_thread, threadname);
+		LIST_INSERT_HEAD(&queue->vsq_workers, worker, vsw_link);
+	}
+
+	return (0);
+}
+
+static int
+pci_vtscsi_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
+{
+	struct pci_vtscsi_softc *sc;
+	char *optname = NULL;
+	char *opt;
+	int i;
+
+	sc = calloc(1, sizeof(struct pci_vtscsi_softc));
+	sc->vss_ctl_fd = open("/dev/cam/ctl", O_RDWR);
+
+	if (sc->vss_ctl_fd < 0) {
+		WPRINTF(("cannot open /dev/cam/ctl: %s\n", strerror(errno)));
+		return (1);
+	}
+
+	while ((opt = strsep(&opts, ",")) != NULL) {
+		if ((optname = strsep(&opt, "=")) != NULL) {
+			if (strcmp(optname, "iid") == 0) {
+				sc->vss_iid = strtoul(opt, NULL, 10);
+			}
+		}
+	}
+
+	vi_softc_linkup(&sc->vss_vs, &vtscsi_vi_consts, sc, pi, sc->vss_vq);
+	sc->vss_vs.vs_mtx = &sc->vss_mtx;
+
+	/* controlq */
+	sc->vss_vq[0].vq_qsize = VTSCSI_RINGSZ;
+	sc->vss_vq[0].vq_notify = pci_vtscsi_controlq_notify;
+
+	/* eventq */
+	sc->vss_vq[1].vq_qsize = VTSCSI_RINGSZ;
+	sc->vss_vq[1].vq_notify = pci_vtscsi_eventq_notify;
+
+	/* request queues */
+	for (i = 2; i < VTSCSI_MAXQ; i++) {
+		sc->vss_vq[i].vq_qsize = VTSCSI_RINGSZ;
+		sc->vss_vq[i].vq_notify = pci_vtscsi_requestq_notify;
+		pci_vtscsi_init_queue(sc, &sc->vss_queues[i - 2], i - 2);
+	}
+
+	/* initialize config space */
+	pci_set_cfgdata16(pi, PCIR_DEVICE, VIRTIO_DEV_SCSI);
+	pci_set_cfgdata16(pi, PCIR_VENDOR, VIRTIO_VENDOR);
+	pci_set_cfgdata8(pi, PCIR_CLASS, PCIC_STORAGE);
+	pci_set_cfgdata16(pi, PCIR_SUBDEV_0, VIRTIO_TYPE_SCSI);
+	pci_set_cfgdata16(pi, PCIR_SUBVEND_0, VIRTIO_VENDOR);
+
+	if (vi_intr_init(&sc->vss_vs, 1, fbsdrun_virtio_msix()))
+		return (1);
+	vi_set_io_bar(&sc->vss_vs, 0);
+
+	return (0);
+}
+
+
+struct pci_devemu pci_de_vscsi = {
+	.pe_emu =	"virtio-scsi",
+	.pe_init =	pci_vtscsi_init,
+	.pe_barwrite =	vi_pci_write,
+	.pe_barread =	vi_pci_read
+};
+PCI_EMUL_SET(pci_de_vscsi);

--- a/usr/src/cmd/bhyve/pci_xhci.c
+++ b/usr/src/cmd/bhyve/pci_xhci.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Leon Dang <ldang@nahannisys.com>
  * Copyright 2018 Joyent, Inc.
  * All rights reserved.
@@ -2227,12 +2229,12 @@ pci_xhci_write(struct vmctx *ctx, int vcpu, struct pci_devinst *pi,
 
 	sc = pi->pi_arg;
 
-        assert(baridx == 0);
+	assert(baridx == 0);
 
 
-        pthread_mutex_lock(&sc->mtx);
+	pthread_mutex_lock(&sc->mtx);
 	if (offset < XHCI_CAPLEN)	/* read only registers */
-                WPRINTF(("pci_xhci: write RO-CAPs offset %ld\r\n", offset));
+		WPRINTF(("pci_xhci: write RO-CAPs offset %ld\r\n", offset));
 	else if (offset < sc->dboff)
 		pci_xhci_hostop_write(sc, offset, value);
 	else if (offset < sc->rtsoff)
@@ -2240,9 +2242,9 @@ pci_xhci_write(struct vmctx *ctx, int vcpu, struct pci_devinst *pi,
 	else if (offset < sc->regsend)
 		pci_xhci_rtsregs_write(sc, offset, value);
 	else
-                WPRINTF(("pci_xhci: write invalid offset %ld\r\n", offset));
+		WPRINTF(("pci_xhci: write invalid offset %ld\r\n", offset));
 
-        pthread_mutex_unlock(&sc->mtx);
+	pthread_mutex_unlock(&sc->mtx);
 }
 
 static uint64_t
@@ -2450,9 +2452,9 @@ pci_xhci_read(struct vmctx *ctx, int vcpu, struct pci_devinst *pi, int baridx,
 
 	sc = pi->pi_arg;
 
-        assert(baridx == 0);
+	assert(baridx == 0);
 
-        pthread_mutex_lock(&sc->mtx);
+	pthread_mutex_lock(&sc->mtx);
 	if (offset < XHCI_CAPLEN)
 		value = pci_xhci_hostcap_read(sc, offset);
 	else if (offset < sc->dboff)
@@ -2465,10 +2467,10 @@ pci_xhci_read(struct vmctx *ctx, int vcpu, struct pci_devinst *pi, int baridx,
 		value = pci_xhci_xecp_read(sc, offset);
 	else {
 		value = 0;
-                WPRINTF(("pci_xhci: read invalid offset %ld\r\n", offset));
+		WPRINTF(("pci_xhci: read invalid offset %ld\r\n", offset));
 	}
 
-        pthread_mutex_unlock(&sc->mtx);
+	pthread_mutex_unlock(&sc->mtx);
 
 	switch (size) {
 	case 1:

--- a/usr/src/cmd/bhyve/pci_xhci.h
+++ b/usr/src/cmd/bhyve/pci_xhci.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Leon Dang <ldang@nahannisys.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/ps2kbd.c
+++ b/usr/src/cmd/bhyve/ps2kbd.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2015 Nahanni Systems Inc.
  * All rights reserved.

--- a/usr/src/cmd/bhyve/ps2kbd.h
+++ b/usr/src/cmd/bhyve/ps2kbd.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/ps2mouse.c
+++ b/usr/src/cmd/bhyve/ps2mouse.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2015 Nahanni Systems Inc.
  * All rights reserved.

--- a/usr/src/cmd/bhyve/ps2mouse.h
+++ b/usr/src/cmd/bhyve/ps2mouse.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/rfb.c
+++ b/usr/src/cmd/bhyve/rfb.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2015 Leon Dang
  * Copyright 2018 Joyent, Inc.
@@ -77,11 +79,11 @@ static int rfb_debug = 0;
 #define AUTH_LENGTH	16
 #define PASSWD_LENGTH	8
 
-#define SECURITY_TYPE_NONE 1
-#define SECURITY_TYPE_VNC_AUTH 2
+#define SECURITY_TYPE_NONE	1
+#define SECURITY_TYPE_VNC_AUTH	2
 
-#define AUTH_FAILED_UNAUTH 1
-#define AUTH_FAILED_ERROR 2
+#define AUTH_FAILED_UNAUTH	1
+#define AUTH_FAILED_ERROR	2
 
 struct rfb_softc {
 	int		sfd;
@@ -143,12 +145,12 @@ struct rfb_pixfmt_msg {
 #define	RFB_ENCODING_ZLIB		6
 #define	RFB_ENCODING_RESIZE		-223
 
-#define RFB_MAX_WIDTH			2000
-#define RFB_MAX_HEIGHT			1200
+#define	RFB_MAX_WIDTH			2000
+#define	RFB_MAX_HEIGHT			1200
 #define	RFB_ZLIB_BUFSZ			RFB_MAX_WIDTH*RFB_MAX_HEIGHT*4
 
 /* percentage changes to screen before sending the entire screen */
-#define RFB_SEND_ALL_THRESH             25
+#define	RFB_SEND_ALL_THRESH		25
 
 struct rfb_enc_msg {
 	uint8_t		type;
@@ -309,7 +311,7 @@ rfb_send_rect(struct rfb_softc *rc, int cfd, struct bhyvegc_image *gc,
               int x, int y, int w, int h)
 {
 	struct rfb_srvr_updt_msg supdt_msg;
-        struct rfb_srvr_rect_hdr srect_hdr;
+	struct rfb_srvr_rect_hdr srect_hdr;
 	unsigned long zlen;
 	ssize_t nwrite, total;
 	int err;
@@ -469,9 +471,9 @@ doraw:
 	return (nwrite);
 }
 
-#define PIX_PER_CELL	32
+#define	PIX_PER_CELL	32
 #define	PIXCELL_SHIFT	5
-#define PIXCELL_MASK	0x1F
+#define	PIXCELL_MASK	0x1F
 
 static int
 rfb_send_screen(struct rfb_softc *rc, int cfd, int all)
@@ -717,7 +719,7 @@ rfb_wr_thr(void *arg)
 		tv.tv_usec = 10000;
 
 		err = select(cfd+1, &rfds, NULL, NULL, &tv);
-                if (err < 0)
+		if (err < 0)
 			return (NULL);
 
 		/* Determine if its time to push screen; ~24hz */

--- a/usr/src/cmd/bhyve/rfb.h
+++ b/usr/src/cmd/bhyve/rfb.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright 2018 Joyent, Inc.
  * All rights reserved.

--- a/usr/src/cmd/bhyve/rtc.c
+++ b/usr/src/cmd/bhyve/rtc.c
@@ -51,7 +51,7 @@ __FBSDID("$FreeBSD$");
 #define	RTC_HMEM_SB	0x5c
 #define	RTC_HMEM_MSB	0x5d
 
-#define m_64KB		(64*1024)
+#define	m_64KB		(64*1024)
 #define	m_16MB		(16*1024*1024)
 #define	m_4GB		(4ULL*1024*1024*1024)
 

--- a/usr/src/cmd/bhyve/sockstream.c
+++ b/usr/src/cmd/bhyve/sockstream.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Nahanni Systems, Inc.
  * All rights reserved.
  *
@@ -82,5 +84,3 @@ stream_write(int fd, const void *buf, ssize_t nbytes)
 	}
 	return (len);
 }
-
-

--- a/usr/src/cmd/bhyve/sockstream.h
+++ b/usr/src/cmd/bhyve/sockstream.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Nahanni Systems, Inc.
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/task_switch.c
+++ b/usr/src/cmd/bhyve/task_switch.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Neel Natu <neel@freebsd.org>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/uart_emul.c
+++ b/usr/src/cmd/bhyve/uart_emul.c
@@ -85,7 +85,7 @@ __FBSDID("$FreeBSD$");
 #define	COM1_BASE	0x3F8
 #define	COM1_IRQ	4
 #define	COM2_BASE	0x2F8
-#define COM2_IRQ	3
+#define	COM2_IRQ	3
 
 #define	DEFAULT_RCLK	1843200
 #define	DEFAULT_BAUD	9600
@@ -98,7 +98,7 @@ __FBSDID("$FreeBSD$");
 #define	MSR_DELTA_MASK	0x0f
 
 #ifndef REG_SCR
-#define REG_SCR		com_scr
+#define	REG_SCR		com_scr
 #endif
 
 #define	FIFOSZ	16

--- a/usr/src/cmd/bhyve/usb_emul.c
+++ b/usr/src/cmd/bhyve/usb_emul.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Nahanni Systems Inc.
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/usb_emul.h
+++ b/usr/src/cmd/bhyve/usb_emul.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Leon Dang <ldang@nahannisys.com>
  * Copyright 2018 Joyent, Inc.
  * All rights reserved.

--- a/usr/src/cmd/bhyve/usb_mouse.c
+++ b/usr/src/cmd/bhyve/usb_mouse.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Leon Dang <ldang@nahannisys.com>
  * All rights reserved.
  *
@@ -220,16 +222,16 @@ struct umouse_bos_desc umouse_bosd = {
 		HSETW(.wTotalLength, sizeof(umouse_bosd)),
 		.bNumDeviceCaps = 1,
 	},
-        .usbssd = {
-                .bLength = sizeof(umouse_bosd.usbssd),
-                .bDescriptorType = UDESC_DEVICE_CAPABILITY,
-                .bDevCapabilityType = 3,
-                .bmAttributes = 0,
-                HSETW(.wSpeedsSupported, 0x08),
-                .bFunctionalitySupport = 3,
-                .bU1DevExitLat = 0xa,   /* dummy - not used */
-                .wU2DevExitLat = { 0x20, 0x00 },
-        }
+	.usbssd = {
+		.bLength = sizeof(umouse_bosd.usbssd),
+		.bDescriptorType = UDESC_DEVICE_CAPABILITY,
+		.bDevCapabilityType = 3,
+		.bmAttributes = 0,
+		HSETW(.wSpeedsSupported, 0x08),
+		.bFunctionalitySupport = 3,
+		.bU1DevExitLat = 0xa,   /* dummy - not used */
+		.wU2DevExitLat = { 0x20, 0x00 },
+	}
 };
 
 

--- a/usr/src/cmd/bhyve/vga.c
+++ b/usr/src/cmd/bhyve/vga.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/cmd/bhyve/vga.h
+++ b/usr/src/cmd/bhyve/vga.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2015 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *
@@ -38,8 +40,8 @@
 #define	GEN_MISC_OUTPUT_PORT		0x3cc
 #define	GEN_INPUT_STS1_MONO_PORT	0x3ba
 #define	GEN_INPUT_STS1_COLOR_PORT	0x3da
-#define	 GEN_IS1_VR			0x08	/* Vertical retrace */
-#define	 GEN_IS1_DE			0x01	/* Display enable not */
+#define	GEN_IS1_VR			0x08	/* Vertical retrace */
+#define	GEN_IS1_DE			0x01	/* Display enable not */
 
 /* Attribute controller registers. */
 #define	ATC_IDX_PORT			0x3c0
@@ -49,14 +51,14 @@
 #define	ATC_PALETTE0			0
 #define	ATC_PALETTE15			15
 #define	ATC_MODE_CONTROL		16
-#define	 ATC_MC_IPS			0x80	/* Internal palette size */
-#define	 ATC_MC_GA			0x01	/* Graphics/alphanumeric */
+#define	ATC_MC_IPS			0x80	/* Internal palette size */
+#define	ATC_MC_GA			0x01	/* Graphics/alphanumeric */
 #define	ATC_OVERSCAN_COLOR		17
 #define	ATC_COLOR_PLANE_ENABLE		18
 #define	ATC_HORIZ_PIXEL_PANNING		19
 #define	ATC_COLOR_SELECT		20
-#define	 ATC_CS_C67			0x0c	/* Color select bits 6+7 */
-#define	 ATC_CS_C45			0x03	/* Color select bits 4+5 */
+#define	ATC_CS_C67			0x0c	/* Color select bits 6+7 */
+#define	ATC_CS_C45			0x03	/* Color select bits 4+5 */
 
 /* Sequencer registers. */
 #define	SEQ_IDX_PORT			0x3c4
@@ -66,22 +68,22 @@
 #define	SEQ_RESET_ASYNC			0x1
 #define	SEQ_RESET_SYNC			0x2
 #define	SEQ_CLOCKING_MODE		1
-#define	 SEQ_CM_SO			0x20	/* Screen off */
-#define	 SEQ_CM_89			0x01	/* 8/9 dot clock */
+#define	SEQ_CM_SO			0x20	/* Screen off */
+#define	SEQ_CM_89			0x01	/* 8/9 dot clock */
 #define	SEQ_MAP_MASK			2
 #define	SEQ_CHAR_MAP_SELECT		3
-#define	 SEQ_CMS_SAH			0x20	/* Char map A bit 2 */
-#define	 SEQ_CMS_SAH_SHIFT		5
-#define	 SEQ_CMS_SA			0x0c	/* Char map A bits 0+1 */
-#define	 SEQ_CMS_SA_SHIFT		2
-#define	 SEQ_CMS_SBH			0x10	/* Char map B bit 2 */
-#define	 SEQ_CMS_SBH_SHIFT		4
-#define	 SEQ_CMS_SB			0x03	/* Char map B bits 0+1 */
-#define	 SEQ_CMS_SB_SHIFT		0
+#define	SEQ_CMS_SAH			0x20	/* Char map A bit 2 */
+#define	SEQ_CMS_SAH_SHIFT		5
+#define	SEQ_CMS_SA			0x0c	/* Char map A bits 0+1 */
+#define	SEQ_CMS_SA_SHIFT		2
+#define	SEQ_CMS_SBH			0x10	/* Char map B bit 2 */
+#define	SEQ_CMS_SBH_SHIFT		4
+#define	SEQ_CMS_SB			0x03	/* Char map B bits 0+1 */
+#define	SEQ_CMS_SB_SHIFT		0
 #define	SEQ_MEMORY_MODE			4
-#define	 SEQ_MM_C4			0x08	/* Chain 4 */
-#define	 SEQ_MM_OE			0x04	/* Odd/even */
-#define	 SEQ_MM_EM			0x02	/* Extended memory */
+#define	SEQ_MM_C4			0x08	/* Chain 4 */
+#define	SEQ_MM_OE			0x04	/* Odd/even */
+#define	SEQ_MM_EM			0x02	/* Extended memory */
 
 /* Graphics controller registers. */
 #define	GC_IDX_PORT			0x3ce
@@ -93,13 +95,13 @@
 #define	GC_DATA_ROTATE			3
 #define	GC_READ_MAP_SELECT		4
 #define	GC_MODE				5
-#define	 GC_MODE_OE			0x10	/* Odd/even */
-#define	 GC_MODE_C4			0x04	/* Chain 4 */
+#define	GC_MODE_OE			0x10	/* Odd/even */
+#define	GC_MODE_C4			0x04	/* Chain 4 */
 
 #define	GC_MISCELLANEOUS		6
-#define	 GC_MISC_GM			0x01	/* Graphics/alphanumeric */
-#define	 GC_MISC_MM			0x0c	/* memory map */
-#define	 GC_MISC_MM_SHIFT	2
+#define	GC_MISC_GM			0x01	/* Graphics/alphanumeric */
+#define	GC_MISC_MM			0x0c	/* memory map */
+#define	GC_MISC_MM_SHIFT		2
 #define	GC_COLOR_DONT_CARE		7
 #define	GC_BIT_MASK			8
 
@@ -117,36 +119,36 @@
 #define	CRTC_END_HORIZ_RETRACE		5
 #define	CRTC_VERT_TOTAL			6
 #define	CRTC_OVERFLOW			7
-#define	 CRTC_OF_VRS9			0x80	/* VRS bit 9 */
-#define	 CRTC_OF_VRS9_SHIFT		7
-#define	 CRTC_OF_VDE9			0x40	/* VDE bit 9 */
-#define	 CRTC_OF_VDE9_SHIFT		6
-#define	 CRTC_OF_VRS8			0x04	/* VRS bit 8 */
-#define	 CRTC_OF_VRS8_SHIFT		2
-#define	 CRTC_OF_VDE8			0x02	/* VDE bit 8 */
-#define	 CRTC_OF_VDE8_SHIFT		1
+#define	CRTC_OF_VRS9			0x80	/* VRS bit 9 */
+#define	CRTC_OF_VRS9_SHIFT		7
+#define	CRTC_OF_VDE9			0x40	/* VDE bit 9 */
+#define	CRTC_OF_VDE9_SHIFT		6
+#define	CRTC_OF_VRS8			0x04	/* VRS bit 8 */
+#define	CRTC_OF_VRS8_SHIFT		2
+#define	CRTC_OF_VDE8			0x02	/* VDE bit 8 */
+#define	CRTC_OF_VDE8_SHIFT		1
 #define	CRTC_PRESET_ROW_SCAN		8
 #define	CRTC_MAX_SCAN_LINE		9
-#define	 CRTC_MSL_MSL			0x1f
+#define	CRTC_MSL_MSL			0x1f
 #define	CRTC_CURSOR_START		10
-#define	 CRTC_CS_CO			0x20	/* Cursor off */
-#define	 CRTC_CS_CS			0x1f	/* Cursor start */
+#define	CRTC_CS_CO			0x20	/* Cursor off */
+#define	CRTC_CS_CS			0x1f	/* Cursor start */
 #define	CRTC_CURSOR_END			11
-#define	 CRTC_CE_CE			0x1f	/* Cursor end */
+#define	CRTC_CE_CE			0x1f	/* Cursor end */
 #define	CRTC_START_ADDR_HIGH		12
 #define	CRTC_START_ADDR_LOW		13
 #define	CRTC_CURSOR_LOC_HIGH		14
 #define	CRTC_CURSOR_LOC_LOW		15
 #define	CRTC_VERT_RETRACE_START		16
 #define	CRTC_VERT_RETRACE_END		17
-#define	 CRTC_VRE_MASK			0xf
+#define	CRTC_VRE_MASK			0xf
 #define	CRTC_VERT_DISP_END		18
 #define	CRTC_OFFSET			19
 #define	CRTC_UNDERLINE_LOC		20
 #define	CRTC_START_VERT_BLANK		21
 #define	CRTC_END_VERT_BLANK		22
 #define	CRTC_MODE_CONTROL		23
-#define	 CRTC_MC_TE			0x80	/* Timing enable */
+#define	CRTC_MC_TE			0x80	/* Timing enable */
 #define	CRTC_LINE_COMPARE		24
 
 /* DAC registers */

--- a/usr/src/cmd/bhyve/virtio.c
+++ b/usr/src/cmd/bhyve/virtio.c
@@ -51,7 +51,7 @@ __FBSDID("$FreeBSD$");
  * front of virtio-based device softc" constraint, let's use
  * this to convert.
  */
-#define DEV_SOFTC(vs) ((void *)(vs))
+#define	DEV_SOFTC(vs) ((void *)(vs))
 
 /*
  * Link a virtio_softc to its constants, the device softc, and

--- a/usr/src/cmd/bhyve/virtio.h
+++ b/usr/src/cmd/bhyve/virtio.h
@@ -188,7 +188,7 @@ struct vring_used {
 /*
  * PFN register shift amount
  */
-#define VRING_PFN               12
+#define	VRING_PFN		12
 
 /*
  * Virtio device types
@@ -215,6 +215,7 @@ struct vring_used {
 #define	VIRTIO_DEV_BLOCK	0x1001
 #define	VIRTIO_DEV_CONSOLE	0x1003
 #define	VIRTIO_DEV_RANDOM	0x1005
+#define	VIRTIO_DEV_SCSI		0x1008
 
 /*
  * PCI config space constants.
@@ -225,19 +226,19 @@ struct vring_used {
  * If MSI-X is not enabled, those two registers disappear and
  * the remaining configuration registers start at offset 20.
  */
-#define VTCFG_R_HOSTCAP		0
-#define VTCFG_R_GUESTCAP	4
-#define VTCFG_R_PFN		8
-#define VTCFG_R_QNUM		12
-#define VTCFG_R_QSEL		14
-#define VTCFG_R_QNOTIFY		16
-#define VTCFG_R_STATUS		18
-#define VTCFG_R_ISR		19
-#define VTCFG_R_CFGVEC		20
-#define VTCFG_R_QVEC		22
-#define VTCFG_R_CFG0		20	/* No MSI-X */
-#define VTCFG_R_CFG1		24	/* With MSI-X */
-#define VTCFG_R_MSIX		20
+#define	VTCFG_R_HOSTCAP		0
+#define	VTCFG_R_GUESTCAP	4
+#define	VTCFG_R_PFN		8
+#define	VTCFG_R_QNUM		12
+#define	VTCFG_R_QSEL		14
+#define	VTCFG_R_QNOTIFY		16
+#define	VTCFG_R_STATUS		18
+#define	VTCFG_R_ISR		19
+#define	VTCFG_R_CFGVEC		20
+#define	VTCFG_R_QVEC		22
+#define	VTCFG_R_CFG0		20	/* No MSI-X */
+#define	VTCFG_R_CFG1		24	/* With MSI-X */
+#define	VTCFG_R_MSIX		20
 
 /*
  * Bits in VTCFG_R_STATUS.  Guests need not actually set any of these,
@@ -256,7 +257,7 @@ struct vring_used {
 #define	VTCFG_ISR_QUEUES	0x01	/* re-scan queues */
 #define	VTCFG_ISR_CONF_CHANGED	0x80	/* configuration changed */
 
-#define VIRTIO_MSI_NO_VECTOR	0xFFFF
+#define	VIRTIO_MSI_NO_VECTOR	0xFFFF
 
 /*
  * Feature flags.

--- a/usr/src/cmd/bhyvectl/bhyvectl.c
+++ b/usr/src/cmd/bhyvectl/bhyvectl.c
@@ -868,7 +868,7 @@ get_all_registers(struct vmctx *ctx, int vcpu)
 		if (error == 0)
 			printf("rflags[%d]\t0x%016lx\n", vcpu, rflags);
 	}
-	
+
 	return (error);
 }
 
@@ -1135,7 +1135,7 @@ get_misc_vmcs(struct vmctx *ctx, int vcpu)
 				vcpu, u64);
 		}
 	}
-	
+
 	if (!error && (get_tpr_threshold || get_all)) {
 		uint64_t threshold;
 		error = vm_get_vmcs_field(ctx, vcpu, VMCS_TPR_THRESHOLD,
@@ -1153,7 +1153,7 @@ get_misc_vmcs(struct vmctx *ctx, int vcpu)
 				vcpu, insterr);
 		}
 	}
-	
+
 	if (!error && (get_exit_ctls || get_all)) {
 		error = vm_get_vmcs_field(ctx, vcpu, VMCS_EXIT_CTLS, &ctl);
 		if (error == 0)
@@ -1201,7 +1201,7 @@ get_misc_vmcs(struct vmctx *ctx, int vcpu)
 		if (error == 0)
 			printf("host_rsp[%d]\t\t0x%016lx\n", vcpu, rsp);
 	}
-	
+
 	if (!error && (get_vmcs_link || get_all)) {
 		error = vm_get_vmcs_field(ctx, vcpu, VMCS_LINK_POINTER, &addr);
 		if (error == 0)

--- a/usr/src/compat/freebsd/amd64/machine/atomic.h
+++ b/usr/src/compat/freebsd/amd64/machine/atomic.h
@@ -18,6 +18,17 @@
 #define	_COMPAT_FREEBSD_AMD64_MACHINE_ATOMIC_H_
 
 static __inline u_int
+atomic_load_acq_short(volatile u_short *p)
+{
+	u_short res;
+
+	res = *p;
+	__asm volatile("" : : : "memory");
+
+	return (res);
+}
+
+static __inline u_int
 atomic_load_acq_int(volatile u_int *p)
 {
 	u_int res;
@@ -93,6 +104,23 @@ atomic_cmpset_long(volatile u_long *dst, u_long expect, u_long src)
 	  "+a" (expect)			/* 2 */
 	: "r" (src)			/* 3 */
 	: "memory", "cc");
+	return (res);
+}
+
+static __inline int
+atomic_testandset_int(volatile u_int *p, u_int v)
+{
+	u_char res;
+
+	__asm __volatile(
+	"	lock ;			"
+	"	btsl	%2,%1 ;		"
+	"	setc	%0 ;		"
+	"# atomic_testandset_int"
+	: "=q" (res),		/* 0 */
+	"+m" (*p)		/* 1 */
+	: "Ir" (v & 0x1f)	/* 2 */
+	: "cc");
 	return (res);
 }
 
@@ -187,6 +215,13 @@ atomic_swap_long(volatile u_long *p, u_long v)
 	  "+m" (*p));			/* 1 */
 	return (v);
 }
+
+
+#define	atomic_store_short(p, v)	\
+	    (*(volatile u_short *)(p) = (u_short)(v))
+#define	atomic_store_int(p, v)		\
+	    (*(volatile u_int *)(p) = (u_int)(v))
+
 
 #define	atomic_readandclear_int(p)	atomic_swap_int(p, 0)
 #define	atomic_readandclear_long(p)	atomic_swap_long(p, 0)

--- a/usr/src/compat/freebsd/amd64/machine/reg.h
+++ b/usr/src/compat/freebsd/amd64/machine/reg.h
@@ -1,0 +1,23 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#ifndef _COMPAT_FREEBSD_AMD64_MACHINE_REG_H_
+#define	_COMPAT_FREEBSD_AMD64_MACHINE_REG_H_
+
+#define	DBREG_DR6_RESERVED1	0xffff0ff0
+#define	DBREG_DR7_RESERVED1	0x0400
+
+
+#endif	/* _COMPAT_FREEBSD_AMD64_MACHINE_REG_H_ */

--- a/usr/src/compat/freebsd/sys/endian.h
+++ b/usr/src/compat/freebsd/sys/endian.h
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2014 Pluribus Networks Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _COMPAT_FREEBSD_SYS_ENDIAN_H_
@@ -121,5 +122,15 @@ le64enc(void *pp, uint64_t u)
 	le32enc(p, (uint32_t)(u & 0xffffffffU));
 	le32enc(p + 4, (uint32_t)(u >> 32));
 }
+
+#ifdef _LITTLE_ENDIAN
+#define	htole16(x)	((uint16_t)(x))
+#define	htole32(x)	((uint32_t)(x))
+#define	htole64(x)	((uint64_t)(x))
+
+#define	le16toh(x)	((uint16_t)(x))
+#define	le32toh(x)	((uint32_t)(x))
+#define	le64toh(x)	((uint64_t)(x))
+#endif
 
 #endif	/* _COMPAT_FREEBSD_SYS_ENDIAN_H_ */

--- a/usr/src/man/man9f/mac_hcksum_get.9f
+++ b/usr/src/man/man9f/mac_hcksum_get.9f
@@ -9,9 +9,9 @@
 .\" http://www.illumos.org/license/CDDL.
 .\"
 .\"
-.\" Copyright 2016 Joyent, Inc.
+.\" Copyright 2018 Joyent, Inc.
 .\"
-.Dd June 01, 2016
+.Dd March 15, 2018
 .Dt MAC_HCKSUM_GET 9F
 .Os
 .Sh NAME
@@ -22,7 +22,7 @@
 .In sys/mac_provider.h
 .Ft void
 .Fo mac_hcksum_get
-.Fa "mblk_t *mp"
+.Fa "const mblk_t *mp"
 .Fa "uint32_t *start"
 .Fa "uint32_t *stuff"
 .Fa "uint32_t *end"

--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -1009,7 +1009,7 @@ stol_cmsgs_copyout(void *input, socklen_t inlen, void *addr,
 		goto finish;
 	}
 
-	VERIFY(inlen > sizeof (struct cmsghdr));
+	VERIFY(inlen >= sizeof (struct cmsghdr));
 
 	/*
 	 * First determine how much space we need for the conversion and

--- a/usr/src/uts/common/inet/ip/ip_input.c
+++ b/usr/src/uts/common/inet/ip/ip_input.c
@@ -56,6 +56,7 @@
 #include <sys/vtrace.h>
 #include <sys/isa_defs.h>
 #include <sys/mac.h>
+#include <sys/mac_client.h>
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <net/route.h>
@@ -660,11 +661,13 @@ ill_input_short_v4(mblk_t *mp, void *iph_arg, void *nexthop_arg,
 	}
 
 	/*
-	 * If there is a good HW IP header checksum we clear the need
+	 * If the packet originated from a same-machine sender or
+	 * there is a good HW IP header checksum, we clear the need
 	 * look at the IP header checksum.
 	 */
-	if ((DB_CKSUMFLAGS(mp) & HCK_IPV4_HDRCKSUM) &&
-	    ILL_HCKSUM_CAPABLE(ill) && dohwcksum) {
+	if ((DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) ||
+	    ((DB_CKSUMFLAGS(mp) & HCK_IPV4_HDRCKSUM) &&
+	    ILL_HCKSUM_CAPABLE(ill) && dohwcksum)) {
 		/* Header checksum was ok. Clear the flag */
 		DB_CKSUMFLAGS(mp) &= ~HCK_IPV4_HDRCKSUM;
 		ira->ira_flags &= ~IRAF_VERIFY_IP_CKSUM;
@@ -2257,12 +2260,13 @@ ip_input_cksum_v4(iaflags_t iraflags, mblk_t *mp, ipha_t *ipha,
 	 * We apply this for all ULP protocols. Does the HW know to
 	 * not set the flags for SCTP and other protocols.
 	 */
-
 	hck_flags = DB_CKSUMFLAGS(mp);
 
-	if (hck_flags & HCK_FULLCKSUM_OK) {
+	if ((hck_flags & HCK_FULLCKSUM_OK) || (hck_flags & HW_LOCAL_MAC)) {
 		/*
-		 * Hardware has already verified the checksum.
+		 * Either the hardware already verified the checksum
+		 * or the packet is from a same-machine sender in
+		 * which case we assume data integrity.
 		 */
 		return (B_TRUE);
 	}

--- a/usr/src/uts/common/inet/ip_impl.h
+++ b/usr/src/uts/common/inet/ip_impl.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_INET_IP_IMPL_H
@@ -159,9 +160,27 @@ extern "C" {
 #define	ILL_DIRECT_CAPABLE(ill)						\
 	(((ill)->ill_capabilities & ILL_CAPAB_DLD_DIRECT) != 0)
 
-/* This macro is used by the mac layer */
+/*
+ * Determine if a mblk needs to take the "slow path", aka OTH
+ * softring. There are multiple reasons why a mblk might take the slow
+ * path.
+ *
+ * o The mblk is not a data message.
+ *
+ * o There is more than one outstanding reference to the mblk and it
+ *   does not originate from a local MAC client. If the mblk does
+ *   originate from a local MAC then allow it to pass through with
+ *   more than one reference and leave the copying up to the consumer.
+ *
+ * o The IP header is not aligned (we assume alignment in the checksum
+ *   routine).
+ *
+ * o The mblk doesn't contain enough data to populate a simple IP header.
+ */
 #define	MBLK_RX_FANOUT_SLOWPATH(mp, ipha)				\
-	(DB_TYPE(mp) != M_DATA || DB_REF(mp) != 1 || !OK_32PTR(ipha) || \
+	(DB_TYPE(mp) != M_DATA ||					\
+	(DB_REF(mp) != 1 && ((DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) == 0)) || \
+	!OK_32PTR(ipha) ||						\
 	(((uchar_t *)ipha + IP_SIMPLE_HDR_LENGTH) >= (mp)->b_wptr))
 
 /*

--- a/usr/src/uts/common/inet/ipf/ip_fil_solaris.c
+++ b/usr/src/uts/common/inet/ipf/ip_fil_solaris.c
@@ -22,11 +22,13 @@ static const char rcsid[] = "@(#)$Id: ip_fil_solaris.c,v 2.62.2.19 2005/07/13 21
 #include <sys/filio.h>
 #include <sys/systm.h>
 #include <sys/strsubr.h>
+#include <sys/strsun.h>
 #include <sys/cred.h>
 #include <sys/ddi.h>
 #include <sys/sunddi.h>
 #include <sys/ksynch.h>
 #include <sys/kmem.h>
+#include <sys/mac_provider.h>
 #include <sys/mkdev.h>
 #include <sys/protosw.h>
 #include <sys/socket.h>
@@ -83,8 +85,18 @@ static	int	ipf_hook6_loop_out __P((hook_event_token_t, hook_data_t,
 static	int	ipf_hook6_loop_in __P((hook_event_token_t, hook_data_t,
     void *));
 static	int     ipf_hook6 __P((hook_data_t, int, int, void *));
+
+static	int	ipf_hookviona_in __P((hook_event_token_t, hook_data_t, void *));
+static	int	ipf_hookviona_out __P((hook_event_token_t, hook_data_t,
+    void *));
+
 extern	int	ipf_geniter __P((ipftoken_t *, ipfgeniter_t *, ipf_stack_t *));
 extern	int	ipf_frruleiter __P((void *, int, void *, ipf_stack_t *));
+
+static int	ipf_hook_protocol_notify __P((hook_notify_cmd_t, void *,
+    const char *, const char *, const char *));
+static int	ipf_hook_instance_notify __P((hook_notify_cmd_t, void *,
+    const char *, const char *, const char *));
 
 #if SOLARIS2 < 10
 #if SOLARIS2 >= 7
@@ -151,6 +163,12 @@ char *hook6_loop_in = 		"ipfilter_hook6_loop_in";
 char *hook6_loop_in_gz = 	"ipfilter_hook6_loop_in_gz";
 char *hook6_loop_out = 		"ipfilter_hook6_loop_out";
 char *hook6_loop_out_gz = 	"ipfilter_hook6_loop_out_gz";
+
+/* viona hook names */
+char *hook_viona_in =		"ipfilter_hookviona_in";
+char *hook_viona_in_gz =	"ipfilter_hookviona_in_gz";
+char *hook_viona_out =		"ipfilter_hookviona_out";
+char *hook_viona_out_gz =	"ipfilter_hookviona_out_gz";
 
 /* ------------------------------------------------------------------------ */
 /* Function:    ipldetach                                                   */
@@ -248,7 +266,39 @@ ipf_stack_t *ifs;
 		ifs->ifs_ipf_ipv4 = NULL;
 	}
 
+	/*
+	 * Remove notification of viona hooks
+	 */
+	(void) net_instance_notify_unregister(ifs->ifs_netid,
+	    ipf_hook_instance_notify);
+
 #undef UNDO_HOOK
+
+	/*
+	 * Normally, viona will unregister itself before ipldetach() is called,
+	 * so these will be no-ops, but out of caution, we try to make sure
+	 * we've removed any of our references.
+	 */
+	(void) ipf_hook_protocol_notify(HN_UNREGISTER, ifs, Hn_VIONA, NULL,
+	    NH_PHYSICAL_IN);
+	(void) ipf_hook_protocol_notify(HN_UNREGISTER, ifs, Hn_VIONA, NULL,
+	    NH_PHYSICAL_OUT);
+
+	{
+		char netidstr[12]; /* Large enough for INT_MAX + NUL */
+		(void) snprintf(netidstr, sizeof (netidstr), "%d",
+		    ifs->ifs_netid);
+
+		/*
+		 * The notify callbacks expect the netid value passed as a
+		 * string in the third argument.  To prevent confusion if
+		 * traced, we pass the same value the nethook framework would
+		 * pass, even though the callback does not currently use the
+		 * value.
+		 */
+		(void) ipf_hook_instance_notify(HN_UNREGISTER, ifs, netidstr,
+		    NULL, Hn_VIONA);
+	}
 
 #ifdef	IPFDEBUG
 	cmn_err(CE_CONT, "ipldetach()\n");
@@ -445,6 +495,21 @@ ipf_stack_t *ifs;
 	}
 
 	/*
+	 * VIONA INET hooks.  While the nethook framework allows us to register
+	 * hooks for events that haven't been registered yet, we instead
+	 * register and unregister our hooks in response to notifications
+	 * about the viona hooks from the nethook framework.  This prevents
+	 * problems when the viona module gets unloaded while the ipf module
+	 * does not.  If we do not unregister our hooks after the viona module
+	 * is unloaded, the viona module cannot later re-register them if it
+	 * gets reloaded.  As the ip, vnd, and ipf modules are rarely unloaded
+	 * even on DEBUG kernels, they do not experience this issue.
+	 */
+	if (net_instance_notify_register(id, ipf_hook_instance_notify,
+	    ifs) != 0)
+		goto hookup_failed;
+
+	/*
 	 * Reacquire ipf_global, now it is safe.
 	 */
 	WRITE_ENTER(&ifs->ifs_ipf_global);
@@ -505,6 +570,157 @@ ipf_stack_t *ifs;
 hookup_failed:
 	WRITE_ENTER(&ifs->ifs_ipf_global);
 	return -1;
+}
+
+/* ------------------------------------------------------------------------ */
+/*
+ * Called whenever a nethook protocol is registered or unregistered.  Currently
+ * only used to add or remove the hooks for viona.
+ *
+ * While the function signature requires returning int, nothing
+ * in usr/src/uts/common/io/hook.c that invokes the callbacks
+ * captures the return value (nor is there currently any documentation
+ * on what return values should be).  For now at least, we'll return 0
+ * on success (or 'not applicable') or an error value.  Even if the
+ * nethook framework doesn't use the return address, it can be observed via
+ * dtrace if needed.
+ */
+/* ARGSUSED */
+static int
+ipf_hook_protocol_notify(hook_notify_cmd_t command, void *arg,
+    const char *name, const char *dummy __unused, const char *he_name)
+{
+	ipf_stack_t *ifs = arg;
+	hook_t **hookpp;
+	char *hint_name;
+	hook_func_t hookfn;
+	boolean_t *hookedp;
+	hook_hint_t hint;
+	boolean_t out;
+	int ret = 0;
+
+	const boolean_t gz = ifs->ifs_gz_controlled;
+
+	/* We currently only care about viona hooks notifications */
+	if (strcmp(name, Hn_VIONA) != 0)
+		return (0);
+
+	if (strcmp(he_name, NH_PHYSICAL_IN) == 0) {
+		out = B_FALSE;
+	} else if (strcmp(he_name, NH_PHYSICAL_OUT) == 0) {
+		out = B_TRUE;
+	} else {
+		/*
+		 * If we've added more hook events to viona, we must add
+		 * the corresponding handling here (even if it's just to
+		 * ignore it) to prevent the firewall from not working as
+		 * intended.
+		 */
+		cmn_err(CE_PANIC, "%s: unhandled hook event %s", __func__,
+		    he_name);
+
+		return (0);
+	}
+
+	if (out) {
+		hookpp = &ifs->ifs_ipfhookviona_out;
+		hookfn = ipf_hookviona_out;
+		hookedp = &ifs->ifs_hookviona_physical_out;
+		name = gz ? hook_viona_out_gz : hook_viona_out;
+		hint = gz ? HH_AFTER : HH_BEFORE;
+		hint_name = gz ? hook_viona_out : hook_viona_out_gz;
+	} else {
+		hookpp = &ifs->ifs_ipfhookviona_in;
+		hookfn = ipf_hookviona_in;
+		hookedp = &ifs->ifs_hookviona_physical_in;
+		name = gz ? hook_viona_in_gz : hook_viona_in;
+		hint = gz ? HH_BEFORE : HH_AFTER;
+		hint_name = gz ? hook_viona_in : hook_viona_in_gz;
+	}
+
+	switch (command) {
+	default:
+	case HN_NONE:
+		break;
+	case HN_REGISTER:
+		HOOK_INIT(*hookpp, hookfn, (char *)name, ifs);
+		(*hookpp)->h_hint = hint;
+		(*hookpp)->h_hintvalue = (uintptr_t)hint_name;
+		ret = net_hook_register(ifs->ifs_ipf_viona,
+		    (char *)he_name, *hookpp);
+		if (ret != 0) {
+			cmn_err(CE_NOTE, "%s: could not register hook "
+			    "(hook family=%s hook=%s) err=%d", __func__,
+			    name, he_name, ret);
+			*hookedp = B_FALSE;
+			return (ret);
+		}
+		*hookedp = B_TRUE;
+		break;
+	case HN_UNREGISTER:
+		if (ifs->ifs_ipf_viona == NULL)
+			break;
+
+		ret = *hookedp ? net_hook_unregister(ifs->ifs_ipf_viona,
+		    (char *)he_name, *hookpp) : 0;
+		if ((ret == 0 || ret == ENXIO)) {
+			if (*hookpp != NULL) {
+				hook_free(*hookpp);
+				*hookpp = NULL;
+			}
+			*hookedp = B_FALSE;
+		}
+		break;
+	}
+
+	return (ret);
+}
+
+/*
+ * Called whenever a new nethook instance is created.  Currently only used
+ * with the Hn_VIONA nethooks.  Similar to ipf_hook_protocol_notify, the out
+ * function signature must return an int, though the result is never used.
+ * We elect to return 0 on success (or not applicable) or a non-zero value
+ * on error.
+ */
+/* ARGSUSED */
+static int
+ipf_hook_instance_notify(hook_notify_cmd_t command, void *arg,
+    const char *netid, const char *dummy __unused, const char *instance)
+{
+	ipf_stack_t *ifs = arg;
+	int ret = 0;
+
+	/* We currently only care about viona hooks */
+	if (strcmp(instance, Hn_VIONA) != 0)
+		return (0);
+
+	switch (command) {
+	case HN_NONE:
+	default:
+		return (0);
+	case HN_REGISTER:
+		ifs->ifs_ipf_viona = net_protocol_lookup(ifs->ifs_netid,
+		    NHF_VIONA);
+
+		if (ifs->ifs_ipf_viona == NULL)
+			return (EPROTONOSUPPORT);
+
+		ret = net_protocol_notify_register(ifs->ifs_ipf_viona,
+		    ipf_hook_protocol_notify, ifs);
+		VERIFY(ret == 0 || ret == ESHUTDOWN);
+		break;
+	case HN_UNREGISTER:
+		if (ifs->ifs_ipf_viona == NULL)
+			break;
+		VERIFY0(net_protocol_notify_unregister(ifs->ifs_ipf_viona,
+		    ipf_hook_protocol_notify));
+		VERIFY0(net_protocol_release(ifs->ifs_ipf_viona));
+		ifs->ifs_ipf_viona = NULL;
+		break;
+	}
+
+	return (ret);
 }
 
 static	int	fr_setipfloopback(set, ifs)
@@ -2044,6 +2260,125 @@ int ipf_hook6_loop_out(hook_event_token_t token, hook_data_t info, void *arg)
 	return ipf_hook6(info, 1, FI_NOCKSUM, arg);
 }
 
+/* Static constants used by ipf_hook_ether */
+static uint8_t ipf_eth_bcast_addr[ETHERADDRL] = {
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+static uint8_t ipf_eth_ipv4_mcast[3] = { 0x01, 0x00, 0x5E };
+static uint8_t ipf_eth_ipv6_mcast[2] = { 0x33, 0x33 };
+
+/* ------------------------------------------------------------------------ */
+/* Function:	ipf_hook_ether                                              */
+/* Returns:	int - 0 == packet ok, else problem, free packet if not done */
+/* Parameters:	token(I)     - pointer to event                             */
+/*              info(I)      - pointer to hook information for firewalling  */
+/*                                                                          */
+/* The ipf_hook_ether hook is currently private to illumos.  It represents  */
+/* a layer 2 datapath generally used by virtual machines.  Currently the    */
+/* hook is only used by the viona driver to pass along L2 frames for        */
+/* inspection.  It requires that the L2 ethernet header is contained within */
+/* a single dblk_t (however layers above the L2 header have no restrctions  */
+/* in ipf).  ipf does not currently support filtering on L2 fields (e.g.    */
+/* filtering on a MAC address or ethertype), however virtual machines do    */
+/* not have native IP stack instances where ipf traditionally hooks in.     */
+/* Instead this entry point is used to determine if the packet is unicast,  */
+/* broadcast, or multicast. The IPv4 or IPv6 packet is then passed to the   */
+/* traditional ip hooks for filtering.  Non IPv4 or non IPv6 packets are    */
+/* not subject to examination.                                              */
+/* ------------------------------------------------------------------------ */
+/* ARGSUSED */
+int ipf_hook_ether(hook_event_token_t token, hook_data_t info, void *arg,
+    boolean_t out)
+{
+	struct ether_header *ethp;
+	hook_pkt_event_t *hpe = (hook_pkt_event_t *)info;
+	mblk_t *mp;
+	size_t offset, len;
+	uint16_t etype;
+	boolean_t v6;
+
+	/*
+	 * viona will only pass us mblks with the L2 header contained in a
+	 * single data block.
+	 */
+	mp = *hpe->hpe_mp;
+	len = MBLKL(mp);
+
+	VERIFY3S(len, >=, sizeof (struct ether_header));
+
+	ethp = (struct ether_header *)mp->b_rptr;
+	if ((etype = ntohs(ethp->ether_type)) == ETHERTYPE_VLAN) {
+		struct ether_vlan_header *evh =
+		    (struct ether_vlan_header *)ethp;
+
+		VERIFY3S(len, >=, sizeof (struct ether_vlan_header));
+
+		etype = ntohs(evh->ether_type);
+		offset = sizeof (*evh);
+	} else {
+		offset = sizeof (*ethp);
+	}
+
+	/*
+	 * ipf only support filtering IPv4 and IPv6.  Ignore other types.
+	 */
+	if (etype == ETHERTYPE_IP)
+		v6 = B_FALSE;
+	else if (etype == ETHERTYPE_IPV6)
+		v6 = B_TRUE;
+	else
+		return (0);
+
+	if (bcmp(ipf_eth_bcast_addr, ethp, ETHERADDRL) == 0)
+		hpe->hpe_flags |= HPE_BROADCAST;
+	else if (bcmp(ipf_eth_ipv4_mcast, ethp,
+	    sizeof (ipf_eth_ipv4_mcast)) == 0)
+		hpe->hpe_flags |= HPE_MULTICAST;
+	else if (bcmp(ipf_eth_ipv6_mcast, ethp,
+	    sizeof (ipf_eth_ipv6_mcast)) == 0)
+		hpe->hpe_flags |= HPE_MULTICAST;
+
+	/* Find the start of the IPv4 or IPv6 header */
+	for (; offset >= len; len = MBLKL(mp)) {
+		offset -= len;
+		mp = mp->b_cont;
+		if (mp == NULL) {
+			freemsg(*hpe->hpe_mp);
+			*hpe->hpe_mp = NULL;
+			return (-1);
+		}
+	}
+	hpe->hpe_mb = mp;
+	hpe->hpe_hdr = mp->b_rptr + offset;
+
+	return (v6 ? ipf_hook6(info, out, 0, arg) :
+	    ipf_hook(info, out, 0, arg));
+}
+
+/* ------------------------------------------------------------------------ */
+/* Function:    ipf_hookviona_{in,out}                                      */
+/* Returns:     int - 0 == packet ok, else problem, free packet if not done */
+/* Parameters:  event(I)     - pointer to event                             */
+/*              info(I)      - pointer to hook information for firewalling  */
+/*                                                                          */
+/* The viona hooks are private hooks to illumos. They represents a layer 2  */
+/* datapath generally used to implement virtual machines.                   */
+/* along L2 packets.                                                        */
+/*                                                                          */
+/* They end up calling the appropriate traditional ip hooks.                */
+/* ------------------------------------------------------------------------ */
+int
+ipf_hookviona_in(hook_event_token_t token, hook_data_t info, void *arg)
+{
+	return (ipf_hook_ether(token, info, arg, B_FALSE));
+}
+
+int
+ipf_hookviona_out(hook_event_token_t token, hook_data_t info, void *arg)
+{
+	return (ipf_hook_ether(token, info, arg, B_TRUE));
+}
+
 /* ------------------------------------------------------------------------ */
 /* Function:    ipf_hook4_loop_in                                           */
 /* Returns:     int - 0 == packet ok, else problem, free packet if not done */
@@ -2387,7 +2722,7 @@ fr_info_t *fin;
 #ifdef USE_INET6
 	struct in6_addr	tmp_src6;
 #endif
-	
+
 	ASSERT(fin->fin_p == IPPROTO_TCP);
 
 	/*
@@ -2429,7 +2764,7 @@ fr_info_t *fin;
 #endif
 
 	if (tcp != NULL) {
-		/* 
+		/*
 		 * Adjust TCP header:
 		 *	swap ports,
 		 *	set flags,

--- a/usr/src/uts/common/inet/ipf/ip_fil_solaris.c
+++ b/usr/src/uts/common/inet/ipf/ip_fil_solaris.c
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  *
- * Copyright (c) 2015, Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #if !defined(lint)
@@ -1931,8 +1931,7 @@ int len;
 		 * Need to preserve checksum information by copying them
 		 * to newmp which heads the pulluped message.
 		 */
-		hcksum_retrieve(m, NULL, NULL, &start, &stuff, &end,
-		    &value, &flags);
+		mac_hcksum_get(m, &start, &stuff, &end, &value, &flags);
 
 		if (pullupmsg(m, len + ipoff + inc) == 0) {
 			ATOMIC_INCL(ifs->ifs_frstats[out].fr_pull[1]);
@@ -1945,8 +1944,7 @@ int len;
 			return NULL;
 		}
 
-		(void) hcksum_assoc(m, NULL, NULL, start, stuff, end,
-		    value, flags, 0);
+		mac_hcksum_set(m, start, stuff, end, value, flags);
 
 		m->b_prev = m2;
 		m->b_rptr += inc;

--- a/usr/src/uts/common/inet/ipf/netinet/ipf_stack.h
+++ b/usr/src/uts/common/inet/ipf/netinet/ipf_stack.h
@@ -6,7 +6,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
- * Copyright 2014 Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.  All rights reserved.
  */
 
 #ifndef	__IPF_STACK_H__
@@ -87,8 +87,8 @@ struct ipf_stack {
 #endif
 	int			ifs_ipf_locks_done;
 
-	ipftoken_t 		*ifs_ipftokenhead;
-	ipftoken_t 		**ifs_ipftokentail;
+	ipftoken_t		*ifs_ipftokenhead;
+	ipftoken_t		**ifs_ipftokentail;
 
 	ipfmutex_t	ifs_ipl_mutex;
 	ipfmutex_t	ifs_ipf_authmx;
@@ -126,6 +126,9 @@ struct ipf_stack {
 	hook_t		*ifs_ipfhook6_loop_out;
 	hook_t		*ifs_ipfhook6_nicevents;
 
+	hook_t		*ifs_ipfhookviona_in;
+	hook_t		*ifs_ipfhookviona_out;
+
 	/* flags to indicate whether hooks are registered. */
 	boolean_t	ifs_hook4_physical_in;
 	boolean_t	ifs_hook4_physical_out;
@@ -137,10 +140,13 @@ struct ipf_stack {
 	boolean_t	ifs_hook6_nic_events;
 	boolean_t	ifs_hook6_loopback_in;
 	boolean_t	ifs_hook6_loopback_out;
+	boolean_t	ifs_hookviona_physical_in;
+	boolean_t	ifs_hookviona_physical_out;
 
 	int		ifs_ipf_loopback;
 	net_handle_t	ifs_ipf_ipv4;
 	net_handle_t	ifs_ipf_ipv6;
+	net_handle_t	ifs_ipf_viona;
 
 	/* ip_auth.c */
 	int			ifs_fr_authsize;
@@ -167,8 +173,8 @@ struct ipf_stack {
 	ipfr_t			**ifs_ipfr_nattail;
 	ipfr_t			**ifs_ipfr_nattab;
 
-	ipfr_t  		*ifs_ipfr_ipidlist;
-	ipfr_t  		**ifs_ipfr_ipidtail;
+	ipfr_t			*ifs_ipfr_ipidlist;
+	ipfr_t			**ifs_ipfr_ipidtail;
 	ipfr_t			**ifs_ipfr_ipidtab;
 
 	ipfrstat_t		ifs_ipfr_stats;

--- a/usr/src/uts/common/io/bridge.c
+++ b/usr/src/uts/common/io/bridge.c
@@ -23,6 +23,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -41,6 +42,7 @@
 #include <sys/modctl.h>
 #include <sys/note.h>
 #include <sys/param.h>
+#include <sys/pattr.h>
 #include <sys/policy.h>
 #include <sys/sdt.h>
 #include <sys/stat.h>
@@ -1692,7 +1694,8 @@ bridge_learn(bridge_link_t *blp, const uint8_t *saddr, uint16_t ingress_nick,
  * The passed-in tci is the "impossible" value 0xFFFF when no tag is present.
  */
 static mblk_t *
-reform_vlan_header(mblk_t *mp, uint16_t vlanid, uint16_t tci, uint16_t pvid)
+reform_vlan_header(mblk_t *mp, uint16_t vlanid, uint16_t tci, uint16_t pvid,
+    boolean_t keep_flags)
 {
 	boolean_t source_has_tag = (tci != 0xFFFF);
 	mblk_t *mpcopy;
@@ -1704,8 +1707,13 @@ reform_vlan_header(mblk_t *mp, uint16_t vlanid, uint16_t tci, uint16_t pvid)
 	if (mp == NULL)
 		return (mp);
 
-	/* No forwarded packet can have hardware checksum enabled */
-	DB_CKSUMFLAGS(mp) = 0;
+	/*
+	 * A forwarded packet cannot have HW offloads enabled unless
+	 * the destination is known to be local to the host and HW
+	 * offloads haven't been emulated.
+	 */
+	if (!keep_flags)
+		DB_CKSUMFLAGS(mp) = 0;
 
 	/* Get the no-modification cases out of the way first */
 	if (!source_has_tag && vlanid == pvid)		/* 1a */
@@ -1906,17 +1914,46 @@ bridge_forward(bridge_link_t *blp, mac_header_info_t *hdr_info, mblk_t *mp,
 				blp->bl_trillthreads++;
 				mutex_exit(&blp->bl_trilllock);
 				update_header(mp, hdr_info, B_FALSE);
-				if (is_xmit)
-					mp = mac_fix_cksum(mp);
-				/* all trill data frames have Inner.VLAN */
-				mp = reform_vlan_header(mp, vlanid, tci, 0);
-				if (mp == NULL) {
-					KIINCR(bki_drops);
-					fwd_unref(bfp);
-					return (NULL);
+
+				if (is_xmit) {
+					mac_hw_emul(&mp, NULL, NULL,
+					    MAC_HWCKSUM_EMUL | MAC_LSO_EMUL);
+
+					if (mp == NULL) {
+						KIINCR(bki_drops);
+						goto done;
+					}
 				}
-				trill_encap_fn(tdp, blp, hdr_info, mp,
-				    bfp->bf_trill_nick);
+
+				while (mp != NULL) {
+					mblk_t *next = mp->b_next;
+
+					mp->b_next = NULL;
+
+					/*
+					 * All trill data frames have
+					 * Inner.VLAN.
+					 */
+					mp = reform_vlan_header(mp, vlanid, tci,
+					    0, B_FALSE);
+
+					if (mp == NULL) {
+						/*
+						 * Make sure to free
+						 * any remaining
+						 * segments.
+						 */
+						freemsgchain(next);
+						KIINCR(bki_drops);
+						goto done;
+					}
+
+					trill_encap_fn(tdp, blp, hdr_info, mp,
+					    bfp->bf_trill_nick);
+					mp = next;
+				}
+
+done:
 				mutex_enter(&blp->bl_trilllock);
 				if (--blp->bl_trillthreads == 0 &&
 				    blp->bl_trilldata == NULL)
@@ -1958,31 +1995,68 @@ bridge_forward(bridge_link_t *blp, mac_header_info_t *hdr_info, mblk_t *mp,
 				mpsend = copymsg(mp);
 			}
 
-			if (!from_trill && is_xmit)
-				mpsend = mac_fix_cksum(mpsend);
+			/*
+			 * If the destination is not local to the host
+			 * then we need to emulate HW offloads because
+			 * we can't guarantee the forwarding
+			 * destination provides them.
+			 */
+			if (!from_trill && is_xmit &&
+			    !(bfp->bf_flags & BFF_LOCALADDR)) {
+				mac_hw_emul(&mpsend, NULL, NULL,
+				    MAC_HWCKSUM_EMUL | MAC_LSO_EMUL);
 
-			mpsend = reform_vlan_header(mpsend, vlanid, tci,
-			    blpsend->bl_pvid);
-			if (mpsend == NULL) {
-				KIINCR(bki_drops);
-				continue;
+				if (mpsend == NULL) {
+					KIINCR(bki_drops);
+					continue;
+				}
 			}
 
-			KIINCR(bki_forwards);
+			/*
+			 * The HW emulation above may have segmented
+			 * an LSO mblk.
+			 */
+			while ((mpsend != NULL) &&
+			    !(bfp->bf_flags & BFF_LOCALADDR)) {
+				mblk_t *next = mpsend->b_next;
+
+				mpsend->b_next = NULL;
+				mpsend = reform_vlan_header(mpsend, vlanid, tci,
+				    blpsend->bl_pvid, B_FALSE);
+
+				if (mpsend == NULL) {
+					KIINCR(bki_drops);
+					mpsend = next;
+					continue;
+				}
+
+				KIINCR(bki_forwards);
+				KLPINCR(blpsend, bkl_xmit);
+				MAC_RING_TX(blpsend->bl_mh, NULL, mpsend,
+				    mpsend);
+				freemsg(mpsend);
+				mpsend = next;
+			}
+
 			/*
 			 * No need to bump up the link reference count, as
 			 * the forwarding entry itself holds a reference to
 			 * the link.
 			 */
 			if (bfp->bf_flags & BFF_LOCALADDR) {
+				mpsend = reform_vlan_header(mpsend, vlanid, tci,
+				    blpsend->bl_pvid, B_TRUE);
+
+				if (mpsend == NULL) {
+					KIINCR(bki_drops);
+					continue;
+				}
+
+				KIINCR(bki_forwards);
 				mac_rx_common(blpsend->bl_mh, NULL, mpsend);
-			} else {
-				KLPINCR(blpsend, bkl_xmit);
-				MAC_RING_TX(blpsend->bl_mh, NULL, mpsend,
-				    mpsend);
-				freemsg(mpsend);
 			}
 		}
+
 		/*
 		 * Handle a special case: if we're transmitting to the original
 		 * link, then check whether the localaddr flag is set.  If it
@@ -2018,7 +2092,7 @@ bridge_forward(bridge_link_t *blp, mac_header_info_t *hdr_info, mblk_t *mp,
 					 * Inner.VLAN
 					 */
 					mpsend = reform_vlan_header(mpsend,
-					    vlanid, tci, 0);
+					    vlanid, tci, 0, B_FALSE);
 					if (mpsend == NULL) {
 						KIINCR(bki_drops);
 					} else {
@@ -2069,25 +2143,57 @@ bridge_forward(bridge_link_t *blp, mac_header_info_t *hdr_info, mblk_t *mp,
 				mpsend = copymsg(mp);
 			}
 
-			if (!from_trill && is_xmit)
-				mpsend = mac_fix_cksum(mpsend);
+			/*
+			 * In this case, send to all links connected
+			 * to the bridge. Some of these destinations
+			 * may not provide HW offload -- so just
+			 * emulate it here.
+			 */
+			if (!from_trill && is_xmit) {
+				mac_hw_emul(&mpsend, NULL, NULL,
+				    MAC_HWCKSUM_EMUL | MAC_LSO_EMUL);
 
-			mpsend = reform_vlan_header(mpsend, vlanid, tci,
-			    blpsend->bl_pvid);
-			if (mpsend == NULL) {
-				KIINCR(bki_drops);
-				continue;
+				if (mpsend == NULL) {
+					KIINCR(bki_drops);
+					continue;
+				}
 			}
 
-			if (hdr_info->mhi_dsttype == MAC_ADDRTYPE_UNICAST)
-				KIINCR(bki_unknown);
-			else
-				KIINCR(bki_mbcast);
-			KLPINCR(blpsend, bkl_xmit);
-			if ((mpcopy = copymsg(mpsend)) != NULL)
-				mac_rx_common(blpsend->bl_mh, NULL, mpcopy);
-			MAC_RING_TX(blpsend->bl_mh, NULL, mpsend, mpsend);
-			freemsg(mpsend);
+			/*
+			 * The HW emulation above may have segmented
+			 * an LSO mblk.
+			 */
+			while (mpsend != NULL) {
+				mblk_t *next = mpsend->b_next;
+
+				mpsend->b_next = NULL;
+				mpsend = reform_vlan_header(mpsend, vlanid, tci,
+				    blpsend->bl_pvid, B_FALSE);
+
+				if (mpsend == NULL) {
+					KIINCR(bki_drops);
+					mpsend = next;
+					continue;
+				}
+
+				if (hdr_info->mhi_dsttype ==
+				    MAC_ADDRTYPE_UNICAST)
+					KIINCR(bki_unknown);
+				else
+					KIINCR(bki_mbcast);
+
+				KLPINCR(blpsend, bkl_xmit);
+				if ((mpcopy = copymsg(mpsend)) != NULL) {
+					mac_rx_common(blpsend->bl_mh, NULL,
+					    mpcopy);
+				}
+
+				MAC_RING_TX(blpsend->bl_mh, NULL, mpsend,
+				    mpsend);
+				freemsg(mpsend);
+				mpsend = next;
+			}
+
 			link_unref(blpsend);
 		}
 	}

--- a/usr/src/uts/common/io/chxge/ch.c
+++ b/usr/src/uts/common/io/chxge/ch.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -59,6 +60,7 @@
 #include <sys/sunddi.h>
 #include <sys/dlpi.h>
 #include <sys/ethernet.h>
+#include <sys/mac_provider.h>
 #include <sys/strsun.h>
 #include <sys/strsubr.h>
 #include <inet/common.h>
@@ -1377,8 +1379,7 @@ ch_send_up(ch_t *chp, mblk_t *mp, uint32_t cksum, int flg)
 		 * set in /etc/system (see sge.c).
 		 */
 		if (flg)
-			(void) hcksum_assoc(mp, NULL, NULL, 0, 0, 0, cksum,
-			    HCK_FULLCKSUM, 0);
+			mac_hcksum_set(mp, 0, 0, 0, cksum, HCK_FULLCKSUM);
 		gld_recv(chp->ch_macp, mp);
 	} else {
 		freemsg(mp);
@@ -1693,8 +1694,7 @@ ch_send(gld_mac_info_t *macinfo, mblk_t *mp)
 	msg_flg = 0;
 	if (chp->ch_config.cksum_enabled) {
 		if (is_T2(chp)) {
-			hcksum_retrieve(mp, NULL, NULL, NULL, NULL, NULL,
-			    NULL, &msg_flg);
+			mac_hcksum_get(mp, NULL, NULL, NULL, NULL, &msg_flg);
 			flg = (msg_flg & HCK_FULLCKSUM)?
 			    CH_NO_CPL: CH_NO_HWCKSUM|CH_NO_CPL;
 		} else

--- a/usr/src/uts/common/io/dld/dld_proto.c
+++ b/usr/src/uts/common/io/dld/dld_proto.c
@@ -606,6 +606,14 @@ proto_promiscon_req(dld_str_t *dsp, mblk_t *mp)
 		new_flags |= DLS_PROMISC_PHYS;
 		break;
 
+	case DL_PROMISC_RX_ONLY:
+		new_flags |= DLS_PROMISC_RX_ONLY;
+		break;
+
+	case DL_PROMISC_FIXUPS:
+		new_flags |= DLS_PROMISC_FIXUPS;
+		break;
+
 	default:
 		dl_err = DL_NOTSUPPORTED;
 		goto failed2;
@@ -691,6 +699,22 @@ proto_promiscoff_req(dld_str_t *dsp, mblk_t *mp)
 			goto failed2;
 		}
 		new_flags &= ~DLS_PROMISC_PHYS;
+		break;
+
+	case DL_PROMISC_RX_ONLY:
+		if (!(dsp->ds_promisc & DLS_PROMISC_RX_ONLY)) {
+			dl_err = DL_NOTENAB;
+			goto failed;
+		}
+		new_flags &= ~DLS_PROMISC_RX_ONLY;
+		break;
+
+	case DL_PROMISC_FIXUPS:
+		if (!(dsp->ds_promisc & DLS_PROMISC_FIXUPS)) {
+			dl_err = DL_NOTENAB;
+			goto failed;
+		}
+		new_flags &= ~DLS_PROMISC_FIXUPS;
 		break;
 
 	default:

--- a/usr/src/uts/common/io/dld/dld_proto.c
+++ b/usr/src/uts/common/io/dld/dld_proto.c
@@ -1208,7 +1208,6 @@ proto_unitdata_req(dld_str_t *dsp, mblk_t *mp)
 	uint16_t		sap;
 	uint_t			addr_length;
 	mblk_t			*bp, *payload;
-	uint32_t		start, stuff, end, value, flags;
 	t_uscalar_t		dl_err;
 	uint_t			max_sdu;
 
@@ -1277,9 +1276,7 @@ proto_unitdata_req(dld_str_t *dsp, mblk_t *mp)
 	/*
 	 * Transfer the checksum offload information if it is present.
 	 */
-	hcksum_retrieve(payload, NULL, NULL, &start, &stuff, &end, &value,
-	    &flags);
-	(void) hcksum_assoc(bp, NULL, NULL, start, stuff, end, value, flags, 0);
+	mac_hcksum_clone(payload, bp);
 
 	/*
 	 * Link the payload onto the new header.

--- a/usr/src/uts/common/io/dls/dls.c
+++ b/usr/src/uts/common/io/dls/dls.c
@@ -251,6 +251,7 @@ dls_promisc(dld_str_t *dsp, uint32_t new_flags)
 	uint32_t new_type = new_flags &
 	    ~(DLS_PROMISC_RX_ONLY | DLS_PROMISC_FIXUPS);
 	mac_client_promisc_type_t mptype = MAC_CLIENT_PROMISC_ALL;
+	uint16_t mac_flags = 0;
 
 	ASSERT(MAC_PERIM_HELD(dsp->ds_mh));
 	ASSERT(!(new_flags & ~(DLS_PROMISC_SAP | DLS_PROMISC_MULTI |
@@ -297,9 +298,7 @@ dls_promisc(dld_str_t *dsp, uint32_t new_flags)
 		 */
 		dsp->ds_promisc = new_flags;
 		err = mac_promisc_add(dsp->ds_mch, mptype,
-		    dls_rx_promisc, dsp, &dsp->ds_mph,
-		    (new_flags != DLS_PROMISC_SAP) ? 0 :
-		    MAC_PROMISC_FLAGS_NO_PHYS);
+		    dls_rx_promisc, dsp, &dsp->ds_mph, mac_flags);
 		if (err != 0) {
 			dsp->ds_promisc = old_flags;
 			return (err);
@@ -337,7 +336,7 @@ dls_promisc(dld_str_t *dsp, uint32_t new_flags)
 		/* Honors both after-remove and before-add semantics! */
 		dsp->ds_promisc = new_flags;
 		err = mac_promisc_add(dsp->ds_mch, mptype,
-		    dls_rx_promisc, dsp, &dsp->ds_mph, 0);
+		    dls_rx_promisc, dsp, &dsp->ds_mph, mac_flags);
 		if (err != 0)
 			dsp->ds_promisc = old_flags;
 	} else {

--- a/usr/src/uts/common/io/dls/dls.c
+++ b/usr/src/uts/common/io/dls/dls.c
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright (c) 2013 Joyent, Inc.  All rights reserved.
+ * Copyright 2015 Joyent, Inc.
  */
 
 /*
@@ -248,11 +248,21 @@ dls_promisc(dld_str_t *dsp, uint32_t new_flags)
 {
 	int err = 0;
 	uint32_t old_flags = dsp->ds_promisc;
+	uint32_t new_type = new_flags &
+	    ~(DLS_PROMISC_RX_ONLY | DLS_PROMISC_FIXUPS);
 	mac_client_promisc_type_t mptype = MAC_CLIENT_PROMISC_ALL;
 
 	ASSERT(MAC_PERIM_HELD(dsp->ds_mh));
 	ASSERT(!(new_flags & ~(DLS_PROMISC_SAP | DLS_PROMISC_MULTI |
-	    DLS_PROMISC_PHYS)));
+	    DLS_PROMISC_PHYS | DLS_PROMISC_RX_ONLY | DLS_PROMISC_FIXUPS)));
+
+	/*
+	 * Asking us just to turn on DLS_PROMISC_RX_ONLY and DLS_PROMISC_FIXUPS
+	 * is not valid.
+	 */
+	if ((new_flags & ~(DLS_PROMISC_RX_ONLY | DLS_PROMISC_FIXUPS)) == 0 &&
+	    new_flags != 0)
+		return (EINVAL);
 
 	/*
 	 * If the user has only requested DLS_PROMISC_MULTI then we need to make
@@ -261,6 +271,25 @@ dls_promisc(dld_str_t *dsp, uint32_t new_flags)
 	if (new_flags == DLS_PROMISC_MULTI)
 		mptype = MAC_CLIENT_PROMISC_MULTI;
 
+	/*
+	 * Look at new flags and figure out the correct mac promisc flags.
+	 * If we've only requested DLS_PROMISC_SAP and not _MULTI or _PHYS,
+	 * don't turn on physical promisc mode.
+	 */
+	if (new_flags & DLS_PROMISC_RX_ONLY)
+		mac_flags |= MAC_PROMISC_FLAGS_NO_TX_LOOP;
+	if (new_flags & DLS_PROMISC_FIXUPS)
+		mac_flags |= MAC_PROMISC_FLAGS_DO_FIXUPS;
+	if (new_type == DLS_PROMISC_SAP)
+		mac_flags |= MAC_PROMISC_FLAGS_NO_PHYS;
+
+	/*
+	 * There are three cases we care about here with respect to MAC. Going
+	 * from nothing to something, something to nothing, something to
+	 * something where we need to change how we're getting stuff from mac.
+	 * In the last case, as long as they're not equal, we need to assume
+	 * something has changed and do something about it.
+	 */
 	if (dsp->ds_promisc == 0 && new_flags != 0) {
 		/*
 		 * If only DLS_PROMISC_SAP, we don't turn on the

--- a/usr/src/uts/common/io/dls/dls_link.c
+++ b/usr/src/uts/common/io/dls/dls_link.c
@@ -30,6 +30,7 @@
 
 #include	<sys/sysmacros.h>
 #include	<sys/strsubr.h>
+#include	<sys/pattr.h>
 #include	<sys/strsun.h>
 #include	<sys/vlan.h>
 #include	<sys/dld_impl.h>
@@ -158,6 +159,18 @@ i_dls_link_subchain(dls_link_t *dlp, mblk_t *mp, const mac_header_info_t *mhip,
 		mac_header_info_t cmhi;
 		uint16_t cvid, cpri;
 		int err;
+
+		/*
+		 * If this message is from a same-machine sender, then
+		 * there may be HW checksum offloads to emulate.
+		 */
+		if (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) {
+			mblk_t *tmpnext = mp->b_next;
+
+			mp->b_next = NULL;
+			mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
+			mp->b_next = tmpnext;
+		}
 
 		DLS_PREPARE_PKT(dlp->dl_mh, mp, &cmhi, err);
 		if (err != 0)
@@ -353,6 +366,22 @@ i_dls_link_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 	int				err, rval;
 
 	/*
+	 * The mac_hw_emul() function, by design, doesn't predicate on
+	 * HW_LOCAL_MAC. But since we are in Rx context we know that
+	 * any LSO packet must also be from a same-machine sender. We
+	 * take advantage of that and forgoe writing a manual loop to
+	 * predicate on HW_LOCAL_MAC.
+	 *
+	 * But for checksum emulation we need to predicate on
+	 * HW_LOCAL_MAC to avoid calling mac_hw_emul() on packets that
+	 * don't need it (thanks to the fact that HCK_IPV4_HDRCKSUM
+	 * and HCK_IPV4_HDRCKSUM_OK use the same value). Therefore we
+	 * do the checksum emulation in the second loop and in
+	 * subchain matching.
+	 */
+	mac_hw_emul(&mp, NULL, NULL, MAC_LSO_EMUL);
+
+	/*
 	 * Walk the packet chain.
 	 */
 	for (; mp != NULL; mp = nextp) {
@@ -360,6 +389,18 @@ i_dls_link_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 		 * Wipe the accepted state.
 		 */
 		accepted = B_FALSE;
+
+		/*
+		 * If this message is from a same-machine sender, then
+		 * there may be HW checksum offloads to emulate.
+		 */
+		if (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) {
+			mblk_t *tmpnext = mp->b_next;
+
+			mp->b_next = NULL;
+			mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
+			mp->b_next = tmpnext;
+		}
 
 		DLS_PREPARE_PKT(dlp->dl_mh, mp, &mhi, err);
 		if (err != 0) {
@@ -554,7 +595,13 @@ dls_rx_promisc(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 	dls_head_t			*dhp;
 	mod_hash_key_t			key;
 
+	/*
+	 * We expect to deal with only a single packet.
+	 */
+	ASSERT3P(mp->b_next, ==, NULL);
+
 	DLS_PREPARE_PKT(dlp->dl_mh, mp, &mhi, err);
+
 	if (err != 0)
 		goto drop;
 

--- a/usr/src/uts/common/io/elxl/elxl.c
+++ b/usr/src/uts/common/io/elxl/elxl.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -1163,8 +1164,7 @@ elxl_m_tx(void *arg, mblk_t *mp)
 		cflags = 0;
 		if ((sc->ex_conf & CONF_90XB) != 0) {
 			uint32_t	pflags;
-			hcksum_retrieve(mp, NULL, NULL, NULL, NULL, NULL, NULL,
-			    &pflags);
+			mac_hcksum_get(mp, NULL, NULL, NULL, NULL, &pflags);
 			if (pflags & HCK_IPV4_HDRCKSUM) {
 				cflags |= EX_DPD_IPCKSUM;
 			}
@@ -1327,7 +1327,7 @@ elxl_recv(elxl_t *sc, ex_desc_t *rxd, uint32_t stat)
 		if (stat & (EX_UPD_TCPCHECKED | EX_UPD_UDPCHECKED)) {
 			pflags |= (HCK_FULLCKSUM | HCK_FULLCKSUM_OK);
 		}
-		(void) hcksum_assoc(mp, NULL, NULL, 0, 0, 0, 0, pflags, 0);
+		mac_hcksum_set(mp, 0, 0, 0, 0, pflags);
 	}
 
 	return (mp);

--- a/usr/src/uts/common/io/gld.c
+++ b/usr/src/uts/common/io/gld.c
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -4550,8 +4551,7 @@ gld_unitdata(queue_t *q, mblk_t *mp)
 	ifp = ((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->interfacep;
 
 	/* grab any checksum information that may be present */
-	hcksum_retrieve(mp->b_cont, NULL, NULL, &start, &stuff, &end,
-	    &value, &flags);
+	mac_hcksum_get(mp->b_cont, &start, &stuff, &end, &value, &flags);
 
 	/*
 	 * Prepend a valid header for transmission
@@ -4567,8 +4567,7 @@ gld_unitdata(queue_t *q, mblk_t *mp)
 	}
 
 	/* apply any checksum information to the first block in the chain */
-	(void) hcksum_assoc(nmp, NULL, NULL, start, stuff, end, value,
-	    flags, 0);
+	mac_hcksum_set(nmp, start, stuff, end, value, flags);
 
 	GLD_CLEAR_MBLK_VTAG(nmp);
 	if (gld_start(q, nmp, GLD_WSRV, upri) == GLD_NORESOURCES) {

--- a/usr/src/uts/common/io/hook.c
+++ b/usr/src/uts/common/io/hook.c
@@ -22,7 +22,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  *
- * Copyright 2013 Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.  All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 #include <sys/param.h>
@@ -1035,7 +1035,7 @@ hook_family_free(hook_family_int_t *hfi, hook_stack_t *hks)
 	/* Free container */
 	kmem_free(hfi, sizeof (*hfi));
 
-	if (hks->hks_shutdown == 2)
+	if (hks != NULL && hks->hks_shutdown == 2)
 		hook_stack_remove(hks);
 
 	mutex_exit(&hook_stack_lock);
@@ -1126,7 +1126,7 @@ hook_family_copy(hook_family_t *src)
  * Parameters:	family(I) - family name string
  *
  * Search family list with family name
- * 	A lock on hfi_lock must be held when called.
+ *	A lock on hfi_lock must be held when called.
  */
 static hook_family_int_t *
 hook_family_find(char *family, hook_stack_t *hks)
@@ -1651,7 +1651,7 @@ hook_event_copy(hook_event_t *src)
  *		event(I) - event name string
  *
  * Search event list with event name
- * 	A lock on hfi->hfi_lock must be held when called.
+ *	A lock on hfi->hfi_lock must be held when called.
  */
 static hook_event_int_t *
 hook_event_find(hook_family_int_t *hfi, char *event)

--- a/usr/src/uts/common/io/ib/clients/ibd/ibd_cm.c
+++ b/usr/src/uts/common/io/ib/clients/ibd/ibd_cm.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 /* Copyright (c) 1990 Mentat Inc. */
 
@@ -272,8 +273,7 @@ ibd_async_rc_process_too_big(ibd_state_t *state, ibd_req_t *req)
 	icmph->icmph_checksum = IP_CSUM(pmtu_mp,
 	    (int32_t)sizeof (ib_header_info_t) + (int32_t)sizeof (ipha_t), 0);
 
-	(void) hcksum_assoc(pmtu_mp, NULL, NULL, 0, 0, 0, 0,
-	    HCK_FULLCKSUM | HCK_FULLCKSUM_OK, 0);
+	mac_hcksum_set(pmtu_mp, 0, 0, 0, 0, HCK_FULLCKSUM | HCK_FULLCKSUM_OK);
 
 	DPRINT(30, "ibd_async_rc_process_too_big: sap=0x%x, ip_src=0x%x, "
 	    "ip_dst=0x%x, ttl=%d, len_needed=%d, msg_len=%d",
@@ -1560,8 +1560,7 @@ ibd_rc_process_rx(ibd_rc_chan_t *chan, ibd_rwqe_t *rwqe, ibt_wc_t *wc)
 	/*
 	 * Can RC mode in IB guarantee its checksum correctness?
 	 *
-	 *	(void) hcksum_assoc(mp, NULL, NULL, 0, 0, 0, 0,
-	 *	    HCK_FULLCKSUM | HCK_FULLCKSUM_OK, 0);
+	 * mac_hcksum_set(mp, 0, 0, 0, 0, HCK_FULLCKSUM | HCK_FULLCKSUM_OK);
 	 */
 
 	/*

--- a/usr/src/uts/common/io/mac/mac_bcast.c
+++ b/usr/src/uts/common/io/mac/mac_bcast.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -146,7 +147,7 @@ mac_bcast_send(void *arg1, void *arg2, mblk_t *mp_chain, boolean_t is_loopback)
 	uint64_t gen;
 	uint_t i;
 	mblk_t *mp_chain1;
-	flow_entry_t	*flent;
+	flow_entry_t *flent;
 	int err;
 
 	rw_enter(&mip->mi_rw_lock, RW_READER);
@@ -181,13 +182,6 @@ mac_bcast_send(void *arg1, void *arg2, mblk_t *mp_chain, boolean_t is_loopback)
 		 * flow_ent here.
 		 */
 		if ((mp_chain1 = mac_copymsgchain_cksum(mp_chain)) == NULL)
-			break;
-		/*
-		 * Fix the checksum for packets originating
-		 * from the local machine.
-		 */
-		if ((src_mcip != NULL) &&
-		    (mp_chain1 = mac_fix_cksum(mp_chain1)) == NULL)
 			break;
 
 		FLOW_TRY_REFHOLD(flent, err);

--- a/usr/src/uts/common/io/mac/mac_client.c
+++ b/usr/src/uts/common/io/mac/mac_client.c
@@ -3264,6 +3264,11 @@ mac_promisc_add(mac_client_handle_t mch, mac_client_promisc_type_t type,
 	mac_cb_info_t	*mcbi;
 	int rc;
 
+	if ((flags & MAC_PROMISC_FLAGS_NO_COPY) &&
+	    (flags & MAC_PROMISC_FLAGS_DO_FIXUPS)) {
+		return (EINVAL);
+	}
+
 	i_mac_perim_enter(mip);
 
 	if ((rc = mac_start((mac_handle_t)mip)) != 0) {
@@ -3310,6 +3315,7 @@ mac_promisc_add(mac_client_handle_t mch, mac_client_promisc_type_t type,
 	mpip->mpi_strip_vlan_tag =
 	    ((flags & MAC_PROMISC_FLAGS_VLAN_TAG_STRIP) != 0);
 	mpip->mpi_no_copy = ((flags & MAC_PROMISC_FLAGS_NO_COPY) != 0);
+	mpip->mpi_do_fixups = ((flags & MAC_PROMISC_FLAGS_DO_FIXUPS) != 0);
 
 	mcbi = &mip->mi_promisc_cb_info;
 	mutex_enter(mcbi->mcbi_lockp);
@@ -3946,14 +3952,21 @@ mac_client_get_effective_resources(mac_client_handle_t mch,
 
 static void
 mac_promisc_dispatch_one(mac_promisc_impl_t *mpip, mblk_t *mp,
-    boolean_t loopback)
+    boolean_t loopback, boolean_t local)
 {
 	mblk_t *mp_copy, *mp_next;
 
-	if (!mpip->mpi_no_copy || mpip->mpi_strip_vlan_tag) {
+	if (!mpip->mpi_no_copy || mpip->mpi_strip_vlan_tag ||
+	    (mpip->mpi_do_fixups && local)) {
 		mp_copy = copymsg(mp);
 		if (mp_copy == NULL)
 			return;
+
+		if (mpip->mpi_do_fixups && local) {
+			mp_copy = mac_fix_cksum(mp_copy);
+			if (mp_copy == NULL)
+				return;
+		}
 
 		if (mpip->mpi_strip_vlan_tag) {
 			mp_copy = mac_strip_vlan_tag_chain(mp_copy);
@@ -4011,7 +4024,7 @@ mac_is_mcast(mac_impl_t *mip, mblk_t *mp)
  */
 void
 mac_promisc_dispatch(mac_impl_t *mip, mblk_t *mp_chain,
-    mac_client_impl_t *sender)
+    mac_client_impl_t *sender, boolean_t local)
 {
 	mac_promisc_impl_t *mpip;
 	mac_cb_t *mcb;
@@ -4051,8 +4064,10 @@ mac_promisc_dispatch(mac_impl_t *mip, mblk_t *mp_chain,
 
 			if (is_sender ||
 			    mpip->mpi_type == MAC_CLIENT_PROMISC_ALL ||
-			    is_mcast)
-				mac_promisc_dispatch_one(mpip, mp, is_sender);
+			    is_mcast) {
+				mac_promisc_dispatch_one(mpip, mp, is_sender,
+				    local);
+			}
 		}
 	}
 	MAC_PROMISC_WALKER_DCR(mip);
@@ -4081,7 +4096,8 @@ mac_promisc_client_dispatch(mac_client_impl_t *mcip, mblk_t *mp_chain)
 			mpip = (mac_promisc_impl_t *)mcb->mcb_objp;
 			if (mpip->mpi_type == MAC_CLIENT_PROMISC_FILTERED &&
 			    !is_mcast) {
-				mac_promisc_dispatch_one(mpip, mp, B_FALSE);
+				mac_promisc_dispatch_one(mpip, mp, B_FALSE,
+				    B_FALSE);
 			}
 		}
 	}

--- a/usr/src/uts/common/io/mac/mac_client.c
+++ b/usr/src/uts/common/io/mac/mac_client.c
@@ -114,6 +114,7 @@
 #include <sys/stream.h>
 #include <sys/strsun.h>
 #include <sys/strsubr.h>
+#include <sys/pattr.h>
 #include <sys/dlpi.h>
 #include <sys/modhash.h>
 #include <sys/mac_impl.h>
@@ -1353,7 +1354,7 @@ mac_client_open(mac_handle_t mh, mac_client_handle_t *mchp, char *name,
 
 	mcip->mci_mip = mip;
 	mcip->mci_upper_mip = NULL;
-	mcip->mci_rx_fn = mac_pkt_drop;
+	mcip->mci_rx_fn = mac_rx_def;
 	mcip->mci_rx_arg = NULL;
 	mcip->mci_rx_p_fn = NULL;
 	mcip->mci_rx_p_arg = NULL;
@@ -1623,7 +1624,7 @@ mac_rx_set(mac_client_handle_t mch, mac_rx_t rx_fn, void *arg)
 void
 mac_rx_clear(mac_client_handle_t mch)
 {
-	mac_rx_set(mch, mac_pkt_drop, NULL);
+	mac_rx_set(mch, mac_rx_def, NULL);
 }
 
 void
@@ -2918,7 +2919,7 @@ mac_client_datapath_teardown(mac_client_handle_t mch, mac_unicast_impl_t *muip,
 	mac_misc_stat_delete(flent);
 
 	/* Initialize the receiver function to a safe routine */
-	flent->fe_cb_fn = (flow_fn_t)mac_pkt_drop;
+	flent->fe_cb_fn = (flow_fn_t)mac_rx_def;
 	flent->fe_cb_arg1 = NULL;
 	flent->fe_cb_arg2 = NULL;
 
@@ -3536,6 +3537,13 @@ mac_tx(mac_client_handle_t mch, mblk_t *mp_chain, uintptr_t hint,
 		obytes = (mp_chain->b_cont == NULL ? MBLKL(mp_chain) :
 		    msgdsize(mp_chain));
 
+		/*
+		 * There's a chance this primary client might be part
+		 * of a bridge and the packet forwarded to a local
+		 * receiver -- mark the packet accordingly.
+		 */
+		DB_CKSUMFLAGS(mp_chain) |= HW_LOCAL_MAC;
+
 		MAC_TX(mip, srs_tx->st_arg2, mp_chain, mcip);
 		if (mp_chain == NULL) {
 			cookie = NULL;
@@ -3949,21 +3957,36 @@ mac_client_get_effective_resources(mac_client_handle_t mch,
  * The unicast packets of MAC_CLIENT_PROMISC_FILTER callbacks are dispatched
  * after classification by mac_rx_deliver().
  */
-
 static void
 mac_promisc_dispatch_one(mac_promisc_impl_t *mpip, mblk_t *mp,
-    boolean_t loopback, boolean_t local)
+    boolean_t loopback)
 {
-	mblk_t *mp_copy, *mp_next;
+	mblk_t *mp_next;
+	boolean_t local = (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) != 0;
 
 	if (!mpip->mpi_no_copy || mpip->mpi_strip_vlan_tag ||
 	    (mpip->mpi_do_fixups && local)) {
+		mblk_t *mp_copy;
+
 		mp_copy = copymsg(mp);
 		if (mp_copy == NULL)
 			return;
 
+		/*
+		 * The consumer has requested we emulate HW offloads
+		 * for host-local packets.
+		 */
 		if (mpip->mpi_do_fixups && local) {
-			mp_copy = mac_fix_cksum(mp_copy);
+			/*
+			 * Remember that copymsg() doesn't copy
+			 * b_next, so we are only passing a single
+			 * packet to mac_hw_emul(). Also keep in mind
+			 * that mp_copy will become an mblk chain if
+			 * the argument is an LSO message.
+			 */
+			mac_hw_emul(&mp_copy, NULL, NULL,
+			    MAC_HWCKSUM_EMUL | MAC_LSO_EMUL);
+
 			if (mp_copy == NULL)
 				return;
 		}
@@ -3973,16 +3996,24 @@ mac_promisc_dispatch_one(mac_promisc_impl_t *mpip, mblk_t *mp,
 			if (mp_copy == NULL)
 				return;
 		}
-		mp_next = NULL;
-	} else {
-		mp_copy = mp;
-		mp_next = mp->b_next;
-	}
-	mp_copy->b_next = NULL;
 
-	mpip->mpi_fn(mpip->mpi_arg, NULL, mp_copy, loopback);
-	if (mp_copy == mp)
-		mp->b_next = mp_next;
+		/*
+		 * There is code upstack that can't deal with message
+		 * chains.
+		 */
+		for (mblk_t *tmp = mp_copy; tmp != NULL; tmp = mp_next) {
+			mp_next = tmp->b_next;
+			tmp->b_next = NULL;
+			mpip->mpi_fn(mpip->mpi_arg, NULL, tmp, loopback);
+		}
+
+		return;
+	}
+
+	mp_next = mp->b_next;
+	mp->b_next = NULL;
+	mpip->mpi_fn(mpip->mpi_arg, NULL, mp, loopback);
+	mp->b_next = mp_next;
 }
 
 /*
@@ -4024,7 +4055,7 @@ mac_is_mcast(mac_impl_t *mip, mblk_t *mp)
  */
 void
 mac_promisc_dispatch(mac_impl_t *mip, mblk_t *mp_chain,
-    mac_client_impl_t *sender, boolean_t local)
+    mac_client_impl_t *sender)
 {
 	mac_promisc_impl_t *mpip;
 	mac_cb_t *mcb;
@@ -4065,8 +4096,7 @@ mac_promisc_dispatch(mac_impl_t *mip, mblk_t *mp_chain,
 			if (is_sender ||
 			    mpip->mpi_type == MAC_CLIENT_PROMISC_ALL ||
 			    is_mcast) {
-				mac_promisc_dispatch_one(mpip, mp, is_sender,
-				    local);
+				mac_promisc_dispatch_one(mpip, mp, is_sender);
 			}
 		}
 	}
@@ -4096,8 +4126,7 @@ mac_promisc_client_dispatch(mac_client_impl_t *mcip, mblk_t *mp_chain)
 			mpip = (mac_promisc_impl_t *)mcb->mcb_objp;
 			if (mpip->mpi_type == MAC_CLIENT_PROMISC_FILTERED &&
 			    !is_mcast) {
-				mac_promisc_dispatch_one(mpip, mp, B_FALSE,
-				    B_FALSE);
+				mac_promisc_dispatch_one(mpip, mp, B_FALSE);
 			}
 		}
 	}
@@ -4196,8 +4225,9 @@ mac_capab_get(mac_handle_t mh, mac_capab_t cap, void *cap_data)
 	mac_impl_t *mip = (mac_impl_t *)mh;
 
 	/*
-	 * if mi_nactiveclients > 1, only MAC_CAPAB_LEGACY, MAC_CAPAB_HCKSUM,
-	 * MAC_CAPAB_NO_NATIVEVLAN and MAC_CAPAB_NO_ZCOPY can be advertised.
+	 * Some capabilities are restricted when there are more than one active
+	 * clients on the MAC resource.  The ones noted below are safe,
+	 * independent of that count.
 	 */
 	if (mip->mi_nactiveclients > 1) {
 		switch (cap) {
@@ -4205,6 +4235,7 @@ mac_capab_get(mac_handle_t mh, mac_capab_t cap, void *cap_data)
 			return (B_TRUE);
 		case MAC_CAPAB_LEGACY:
 		case MAC_CAPAB_HCKSUM:
+		case MAC_CAPAB_LSO:
 		case MAC_CAPAB_NO_NATIVEVLAN:
 			break;
 		default:

--- a/usr/src/uts/common/io/mac/mac_datapath_setup.c
+++ b/usr/src/uts/common/io/mac/mac_datapath_setup.c
@@ -3385,7 +3385,7 @@ mac_srs_free(mac_soft_ring_set_t *mac_srs)
 	ASSERT((mac_srs->srs_state & (SRS_CONDEMNED | SRS_CONDEMNED_DONE |
 	    SRS_PROC | SRS_PROC_FAST)) == (SRS_CONDEMNED | SRS_CONDEMNED_DONE));
 
-	mac_pkt_drop(NULL, NULL, mac_srs->srs_first, B_FALSE);
+	mac_drop_chain(mac_srs->srs_first, "SRS free");
 	mac_srs_ring_free(mac_srs);
 	mac_srs_soft_rings_free(mac_srs);
 	mac_srs_fanout_list_free(mac_srs);

--- a/usr/src/uts/common/io/mac/mac_flow.c
+++ b/usr/src/uts/common/io/mac/mac_flow.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/strsun.h>
@@ -229,7 +230,7 @@ mac_flow_create(flow_desc_t *fd, mac_resource_props_t *mrp, char *name,
 		cv_init(&flent->fe_cv, NULL, CV_DEFAULT, NULL);
 
 		/* Initialize the receiver function to a safe routine */
-		flent->fe_cb_fn = (flow_fn_t)mac_pkt_drop;
+		flent->fe_cb_fn = (flow_fn_t)mac_rx_def;
 		flent->fe_index = -1;
 	}
 	(void) strlcpy(flent->fe_flow_name, name, MAXFLOWNAMELEN);

--- a/usr/src/uts/common/io/mac/mac_provider.c
+++ b/usr/src/uts/common/io/mac/mac_provider.c
@@ -683,7 +683,7 @@ mac_trill_snoop(mac_handle_t mh, mblk_t *mp)
 	mac_impl_t *mip = (mac_impl_t *)mh;
 
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp, NULL, B_FALSE);
+		mac_promisc_dispatch(mip, mp, NULL);
 }
 
 /*
@@ -704,7 +704,7 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 	 * this MAC, pass them a copy if appropriate.
 	 */
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp_chain, NULL, B_FALSE);
+		mac_promisc_dispatch(mip, mp_chain, NULL);
 
 	if (mr != NULL) {
 		/*
@@ -1518,15 +1518,22 @@ mac_hcksum_clone(const mblk_t *src, mblk_t *dst)
 	ASSERT3U(DB_TYPE(dst), ==, M_DATA);
 
 	/*
-	 * Do these assignments unconditionally, rather than only when flags is
-	 * non-zero.  This protects a situation where zeroed hcksum data does
-	 * not make the jump onto an mblk_t with stale data in those fields.
+	 * Do these assignments unconditionally, rather than only when
+	 * flags is non-zero. This protects a situation where zeroed
+	 * hcksum data does not make the jump onto an mblk_t with
+	 * stale data in those fields. It's important to copy all
+	 * possible flags (HCK_* as well as HW_*) and not just the
+	 * checksum specific flags. Dropping flags during a clone
+	 * could result in dropped packets. If the caller has good
+	 * reason to drop those flags then it should do it manually,
+	 * after the clone.
 	 */
-	DB_CKSUMFLAGS(dst) = (DB_CKSUMFLAGS(src) & HCK_FLAGS);
+	DB_CKSUMFLAGS(dst) = DB_CKSUMFLAGS(src);
 	DB_CKSUMSTART(dst) = DB_CKSUMSTART(src);
 	DB_CKSUMSTUFF(dst) = DB_CKSUMSTUFF(src);
 	DB_CKSUMEND(dst) = DB_CKSUMEND(src);
 	DB_CKSUM16(dst) = DB_CKSUM16(src);
+	DB_LSOMSS(dst) = DB_LSOMSS(src);
 }
 
 void

--- a/usr/src/uts/common/io/mac/mac_provider.c
+++ b/usr/src/uts/common/io/mac/mac_provider.c
@@ -683,7 +683,7 @@ mac_trill_snoop(mac_handle_t mh, mblk_t *mp)
 	mac_impl_t *mip = (mac_impl_t *)mh;
 
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp, NULL);
+		mac_promisc_dispatch(mip, mp, NULL, B_FALSE);
 }
 
 /*
@@ -704,7 +704,7 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 	 * this MAC, pass them a copy if appropriate.
 	 */
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp_chain, NULL);
+		mac_promisc_dispatch(mip, mp_chain, NULL, B_FALSE);
 
 	if (mr != NULL) {
 		/*

--- a/usr/src/uts/common/io/mac/mac_provider.c
+++ b/usr/src/uts/common/io/mac/mac_provider.c
@@ -1472,7 +1472,8 @@ mac_prop_info_set_perm(mac_prop_info_handle_t ph, uint8_t perm)
 	pr->pr_flags |= MAC_PROP_INFO_PERM;
 }
 
-void mac_hcksum_get(mblk_t *mp, uint32_t *start, uint32_t *stuff,
+void
+mac_hcksum_get(const mblk_t *mp, uint32_t *start, uint32_t *stuff,
     uint32_t *end, uint32_t *value, uint32_t *flags_ptr)
 {
 	uint32_t flags;
@@ -1497,8 +1498,9 @@ void mac_hcksum_get(mblk_t *mp, uint32_t *start, uint32_t *stuff,
 		*flags_ptr = flags;
 }
 
-void mac_hcksum_set(mblk_t *mp, uint32_t start, uint32_t stuff,
-    uint32_t end, uint32_t value, uint32_t flags)
+void
+mac_hcksum_set(mblk_t *mp, uint32_t start, uint32_t stuff, uint32_t end,
+    uint32_t value, uint32_t flags)
 {
 	ASSERT(DB_TYPE(mp) == M_DATA);
 
@@ -1507,6 +1509,24 @@ void mac_hcksum_set(mblk_t *mp, uint32_t start, uint32_t stuff,
 	DB_CKSUMEND(mp) = (intptr_t)end;
 	DB_CKSUMFLAGS(mp) = (uint16_t)flags;
 	DB_CKSUM16(mp) = (uint16_t)value;
+}
+
+void
+mac_hcksum_clone(const mblk_t *src, mblk_t *dst)
+{
+	ASSERT3U(DB_TYPE(src), ==, M_DATA);
+	ASSERT3U(DB_TYPE(dst), ==, M_DATA);
+
+	/*
+	 * Do these assignments unconditionally, rather than only when flags is
+	 * non-zero.  This protects a situation where zeroed hcksum data does
+	 * not make the jump onto an mblk_t with stale data in those fields.
+	 */
+	DB_CKSUMFLAGS(dst) = (DB_CKSUMFLAGS(src) & HCK_FLAGS);
+	DB_CKSUMSTART(dst) = DB_CKSUMSTART(src);
+	DB_CKSUMSTUFF(dst) = DB_CKSUMSTUFF(src);
+	DB_CKSUMEND(dst) = DB_CKSUMEND(src);
+	DB_CKSUM16(dst) = DB_CKSUM16(src);
 }
 
 void

--- a/usr/src/uts/common/io/mac/mac_sched.c
+++ b/usr/src/uts/common/io/mac/mac_sched.c
@@ -2313,7 +2313,7 @@ check_again:
 				if (smcip->mci_mip->mi_promisc_list != NULL) {
 					mutex_exit(lock);
 					mac_promisc_dispatch(smcip->mci_mip,
-					    head, NULL);
+					    head, NULL, B_FALSE);
 					mutex_enter(lock);
 				}
 			}
@@ -4453,8 +4453,10 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 				 * check is done inside the MAC_TX()
 				 * macro.
 				 */
-				if (mip->mi_promisc_list != NULL)
-					mac_promisc_dispatch(mip, mp, src_mcip);
+				if (mip->mi_promisc_list != NULL) {
+					mac_promisc_dispatch(mip, mp, src_mcip,
+					    B_TRUE);
+				}
 
 				do_switch = ((src_mcip->mci_state_flags &
 				    dst_mcip->mci_state_flags &

--- a/usr/src/uts/common/io/mac/mac_sched.c
+++ b/usr/src/uts/common/io/mac/mac_sched.c
@@ -969,6 +969,7 @@
 
 #include <sys/types.h>
 #include <sys/callb.h>
+#include <sys/pattr.h>
 #include <sys/sdt.h>
 #include <sys/strsubr.h>
 #include <sys/strsun.h>
@@ -1328,7 +1329,7 @@ int mac_srs_worker_wakeup_ticks = 0;
 			 * b_prev may be set to the fanout hint		\
 			 * hence can't use freemsg directly		\
 			 */						\
-			mac_pkt_drop(NULL, NULL, mp_chain, B_FALSE);	\
+			mac_drop_chain(mp_chain, "SRS Tx max queue");	\
 			DTRACE_PROBE1(tx_queued_hiwat,			\
 			    mac_soft_ring_set_t *, srs);		\
 			enqueue = 0;					\
@@ -1347,11 +1348,11 @@ int mac_srs_worker_wakeup_ticks = 0;
 	if (!(srs->srs_type & SRST_TX))					\
 		mutex_exit(&srs->srs_bw->mac_bw_lock);
 
-#define	MAC_TX_SRS_DROP_MESSAGE(srs, mp, cookie) {		\
-	mac_pkt_drop(NULL, NULL, mp, B_FALSE);			\
+#define	MAC_TX_SRS_DROP_MESSAGE(srs, chain, cookie, s) {	\
+	mac_drop_pkt((chain), (s));				\
 	/* increment freed stats */				\
-	mac_srs->srs_tx.st_stat.mts_sdrops++;			\
-	cookie = (mac_tx_cookie_t)srs;				\
+	(srs)->srs_tx.st_stat.mts_sdrops++;			\
+	(cookie) = (mac_tx_cookie_t)(srs);			\
 }
 
 #define	MAC_TX_SET_NO_ENQUEUE(srs, mp_chain, ret_mp, cookie) {		\
@@ -2313,7 +2314,7 @@ check_again:
 				if (smcip->mci_mip->mi_promisc_list != NULL) {
 					mutex_exit(lock);
 					mac_promisc_dispatch(smcip->mci_mip,
-					    head, NULL, B_FALSE);
+					    head, NULL);
 					mutex_enter(lock);
 				}
 			}
@@ -2888,7 +2889,7 @@ again:
 		mac_srs->srs_bw->mac_bw_sz -= sz;
 		mac_srs->srs_bw->mac_bw_drop_bytes += sz;
 		mutex_exit(&mac_srs->srs_bw->mac_bw_lock);
-		mac_pkt_drop(NULL, NULL, head, B_FALSE);
+		mac_drop_chain(head, "Rx no bandwidth");
 		goto leave_poll;
 	} else {
 		mutex_exit(&mac_srs->srs_bw->mac_bw_lock);
@@ -3270,9 +3271,10 @@ mac_rx_srs_subflow_process(void *arg, mac_resource_handle_t srs,
 }
 
 /*
- * mac_rx_srs_process
- *
- * Receive side routine called from the interrupt path.
+ * MAC SRS receive side routine. If the data is coming from the
+ * network (i.e. from a NIC) then this is called in interrupt context.
+ * If the data is coming from a local sender (e.g. mac_tx_send() or
+ * bridge_forward()) then this is not called in interrupt context.
  *
  * loopback is set to force a context switch on the loopback
  * path between MAC clients.
@@ -3332,7 +3334,7 @@ mac_rx_srs_process(void *arg, mac_resource_handle_t srs, mblk_t *mp_chain,
 			mac_bw->mac_bw_drop_bytes += sz;
 			mutex_exit(&mac_bw->mac_bw_lock);
 			mutex_exit(&mac_srs->srs_lock);
-			mac_pkt_drop(NULL, NULL, mp_chain, B_FALSE);
+			mac_drop_chain(mp_chain, "Rx no bandwidth");
 			return;
 		} else {
 			if ((mac_bw->mac_bw_sz + sz) <=
@@ -3454,7 +3456,8 @@ mac_tx_srs_no_desc(mac_soft_ring_set_t *mac_srs, mblk_t *mp_chain,
 
 	ASSERT(tx_mode == SRS_TX_DEFAULT || tx_mode == SRS_TX_BW);
 	if (flag & MAC_DROP_ON_NO_DESC) {
-		MAC_TX_SRS_DROP_MESSAGE(mac_srs, mp_chain, cookie);
+		MAC_TX_SRS_DROP_MESSAGE(mac_srs, mp_chain, cookie,
+		    "Tx no desc");
 	} else {
 		if (mac_srs->srs_first != NULL)
 			wakeup_worker = B_FALSE;
@@ -3517,7 +3520,8 @@ mac_tx_srs_enqueue(mac_soft_ring_set_t *mac_srs, mblk_t *mp_chain,
 	MAC_COUNT_CHAIN(mac_srs, mp_chain, tail, cnt, sz);
 	if (flag & MAC_DROP_ON_NO_DESC) {
 		if (mac_srs->srs_count > mac_srs->srs_tx.st_hiwat) {
-			MAC_TX_SRS_DROP_MESSAGE(mac_srs, mp_chain, cookie);
+			MAC_TX_SRS_DROP_MESSAGE(mac_srs, mp_chain, cookie,
+			    "Tx SRS hiwat");
 		} else {
 			MAC_TX_SRS_ENQUEUE_CHAIN(mac_srs,
 			    mp_chain, tail, cnt, sz);
@@ -3890,7 +3894,8 @@ mac_tx_bw_mode(mac_soft_ring_set_t *mac_srs, mblk_t *mp_chain,
 			cookie = (mac_tx_cookie_t)mac_srs;
 			*ret_mp = mp_chain;
 		} else {
-			MAC_TX_SRS_DROP_MESSAGE(mac_srs, mp_chain, cookie);
+			MAC_TX_SRS_DROP_MESSAGE(mac_srs, mp_chain, cookie,
+			    "Tx no bandwidth");
 		}
 		mutex_exit(&mac_srs->srs_lock);
 		return (cookie);
@@ -4336,6 +4341,14 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 			obytes += (mp->b_cont == NULL ? MBLKL(mp) :
 			    msgdsize(mp));
 
+			/*
+			 * Mark all packets as local so that a
+			 * receiver can determine if a packet arrived
+			 * from a local source or from the network.
+			 * This allows some consumers to avoid
+			 * unecessary work like checksum computation.
+			 */
+			DB_CKSUMFLAGS(mp) |= HW_LOCAL_MAC;
 			CHECK_VID_AND_ADD_TAG(mp);
 			MAC_TX(mip, ring, mp, src_mcip);
 
@@ -4368,7 +4381,6 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 		flow_entry_t *dst_flow_ent;
 		void *flow_cookie;
 		size_t	pkt_size;
-		mblk_t *mp1;
 
 		next = mp->b_next;
 		mp->b_next = NULL;
@@ -4378,49 +4390,25 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 		CHECK_VID_AND_ADD_TAG(mp);
 
 		/*
+		 * Mark all packets as local so that a receiver can
+		 * determine if a packet arrived from a local source
+		 * or from the network. This allows some consumers to
+		 * avoid unecessary work like checksum computation.
+		 */
+		DB_CKSUMFLAGS(mp) |= HW_LOCAL_MAC;
+
+		/*
 		 * Find the destination.
 		 */
 		dst_flow_ent = mac_tx_classify(mip, mp);
 
 		if (dst_flow_ent != NULL) {
-			size_t	hdrsize;
-			int	err = 0;
-
-			if (mip->mi_info.mi_nativemedia == DL_ETHER) {
-				struct ether_vlan_header *evhp =
-				    (struct ether_vlan_header *)mp->b_rptr;
-
-				if (ntohs(evhp->ether_tpid) == ETHERTYPE_VLAN)
-					hdrsize = sizeof (*evhp);
-				else
-					hdrsize = sizeof (struct ether_header);
-			} else {
-				mac_header_info_t	mhi;
-
-				err = mac_header_info((mac_handle_t)mip,
-				    mp, &mhi);
-				if (err == 0)
-					hdrsize = mhi.mhi_hdrsize;
-			}
-
 			/*
 			 * Got a matching flow. It's either another
 			 * MAC client, or a broadcast/multicast flow.
-			 * Make sure the packet size is within the
-			 * allowed size. If not drop the packet and
-			 * move to next packet.
 			 */
-			if (err != 0 ||
-			    (pkt_size - hdrsize) > mip->mi_sdu_max) {
-				oerrors++;
-				DTRACE_PROBE2(loopback__drop, size_t, pkt_size,
-				    mblk_t *, mp);
-				freemsg(mp);
-				mp = next;
-				FLOW_REFRELE(dst_flow_ent);
-				continue;
-			}
 			flow_cookie = mac_flow_get_client_cookie(dst_flow_ent);
+
 			if (flow_cookie != NULL) {
 				/*
 				 * The vnic_bcast_send function expects
@@ -4438,6 +4426,7 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 				 * bypass is set.
 				 */
 				boolean_t do_switch;
+
 				mac_client_impl_t *dst_mcip =
 				    dst_flow_ent->fe_mcip;
 
@@ -4454,20 +4443,18 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 				 * macro.
 				 */
 				if (mip->mi_promisc_list != NULL) {
-					mac_promisc_dispatch(mip, mp, src_mcip,
-					    B_TRUE);
+					mac_promisc_dispatch(mip, mp, src_mcip);
 				}
 
 				do_switch = ((src_mcip->mci_state_flags &
 				    dst_mcip->mci_state_flags &
 				    MCIS_CLIENT_POLL_CAPABLE) != 0);
 
-				if ((mp1 = mac_fix_cksum(mp)) != NULL) {
-					(dst_flow_ent->fe_cb_fn)(
-					    dst_flow_ent->fe_cb_arg1,
-					    dst_flow_ent->fe_cb_arg2,
-					    mp1, do_switch);
-				}
+				(dst_flow_ent->fe_cb_fn)(
+				    dst_flow_ent->fe_cb_arg1,
+				    dst_flow_ent->fe_cb_arg2,
+				    mp, do_switch);
+
 			}
 			FLOW_REFRELE(dst_flow_ent);
 		} else {
@@ -4823,7 +4810,7 @@ mac_tx_sring_enqueue(mac_soft_ring_t *ringp, mblk_t *mp_chain, uint16_t flag,
 	ASSERT(MUTEX_HELD(&ringp->s_ring_lock));
 	MAC_COUNT_CHAIN(mac_srs, mp_chain, tail, cnt, sz);
 	if (flag & MAC_DROP_ON_NO_DESC) {
-		mac_pkt_drop(NULL, NULL, mp_chain, B_FALSE);
+		mac_drop_chain(mp_chain, "Tx softring no desc");
 		/* increment freed stats */
 		ringp->s_ring_drops += cnt;
 		cookie = (mac_tx_cookie_t)ringp;
@@ -4867,8 +4854,8 @@ mac_tx_sring_enqueue(mac_soft_ring_t *ringp, mblk_t *mp_chain, uint16_t flag,
 					 * b_prev may be set to the fanout hint
 					 * hence can't use freemsg directly
 					 */
-					mac_pkt_drop(NULL, NULL,
-					    mp_chain, B_FALSE);
+					mac_drop_chain(mp_chain,
+					    "Tx softring max queue");
 					DTRACE_PROBE1(tx_queued_hiwat,
 					    mac_soft_ring_t *, ringp);
 					enqueue = B_FALSE;

--- a/usr/src/uts/common/io/mac/mac_soft_ring.c
+++ b/usr/src/uts/common/io/mac/mac_soft_ring.c
@@ -242,7 +242,7 @@ mac_soft_ring_free(mac_soft_ring_t *softring)
 	ASSERT((softring->s_ring_state &
 	    (S_RING_CONDEMNED | S_RING_CONDEMNED_DONE | S_RING_PROC)) ==
 	    (S_RING_CONDEMNED | S_RING_CONDEMNED_DONE));
-	mac_pkt_drop(NULL, NULL, softring->s_ring_first, B_FALSE);
+	mac_drop_chain(softring->s_ring_first, "softring free");
 	softring->s_ring_tx_arg2 = NULL;
 	mac_soft_ring_stat_delete(softring);
 	mac_callback_free(softring->s_ring_notify_cb_list);

--- a/usr/src/uts/common/io/mac/mac_util.c
+++ b/usr/src/uts/common/io/mac/mac_util.c
@@ -48,6 +48,74 @@
 #include <inet/sadb.h>
 #include <inet/ipsecesp.h>
 #include <inet/ipsecah.h>
+#include <inet/tcp.h>
+#include <inet/udp_impl.h>
+
+/*
+ * The next two functions are used for dropping packets or chains of
+ * packets, respectively. We could use one function for both but
+ * separating the use cases allows us to specify intent and prevent
+ * dropping more data than intended.
+ *
+ * The purpose of these functions is to aid the debugging effort,
+ * especially in production. Rather than use freemsg()/freemsgchain(),
+ * it's preferable to use these functions when dropping a packet in
+ * the MAC layer. These functions should only be used during
+ * unexpected conditions. That is, any time a packet is dropped
+ * outside of the regular, successful datapath. Consolidating all
+ * drops on these functions allows the user to trace one location and
+ * determine why the packet was dropped based on the msg. It also
+ * allows the user to inspect the packet before it is freed. Finally,
+ * it allows the user to avoid tracing freemsg()/freemsgchain() thus
+ * keeping the hot path running as efficiently as possible.
+ *
+ * NOTE: At this time not all MAC drops are aggregated on these
+ * functions; but that is the plan. This comment should be erased once
+ * completed.
+ */
+
+/*PRINTFLIKE2*/
+void
+mac_drop_pkt(mblk_t *mp, const char *fmt, ...)
+{
+	va_list adx;
+	char msg[128];
+	char *msgp = msg;
+
+	ASSERT3P(mp->b_next, ==, NULL);
+
+	va_start(adx, fmt);
+	(void) vsnprintf(msgp, sizeof (msg), fmt, adx);
+	va_end(adx);
+
+	DTRACE_PROBE2(mac__drop, mblk_t *, mp, char *, msgp);
+	freemsg(mp);
+}
+
+/*PRINTFLIKE2*/
+void
+mac_drop_chain(mblk_t *chain, const char *fmt, ...)
+{
+	va_list adx;
+	char msg[128];
+	char *msgp = msg;
+
+	va_start(adx, fmt);
+	(void) vsnprintf(msgp, sizeof (msg), fmt, adx);
+	va_end(adx);
+
+	/*
+	 * We could use freemsgchain() for the actual freeing but
+	 * since we are already walking the chain to fire the dtrace
+	 * probe we might as well free the msg here too.
+	 */
+	for (mblk_t *mp = chain, *next; mp != NULL; ) {
+		next = mp->b_next;
+		DTRACE_PROBE2(mac__drop, mblk_t *, mp, char *, msgp);
+		freemsg(mp);
+		mp = next;
+	}
+}
 
 /*
  * Copy an mblk, preserving its hardware checksum flags.
@@ -89,222 +157,1125 @@ mac_copymsgchain_cksum(mblk_t *mp)
 }
 
 /*
- * Process the specified mblk chain for proper handling of hardware
- * checksum offload. This routine is invoked for loopback traffic
- * between MAC clients.
- * The function handles a NULL mblk chain passed as argument.
+ * Perform software checksum on a single message, if needed. The
+ * emulation performed is determined by an intersection of the mblk's
+ * flags and the emul flags requested. The emul flags are documented
+ * in mac.h.
  */
-mblk_t *
-mac_fix_cksum(mblk_t *mp_chain)
+static mblk_t *
+mac_sw_cksum(mblk_t *mp, mac_emul_t emul)
 {
-	mblk_t *mp, *prev = NULL, *new_chain = mp_chain, *mp1;
+	mblk_t *skipped_hdr = NULL;
 	uint32_t flags, start, stuff, end, value;
+	uint16_t len;
+	uint32_t offset;
+	uint16_t etype;
+	struct ether_header *ehp;
+	ipha_t *ipha;
+	uint8_t proto;
+	const char *err = "";
 
-	for (mp = mp_chain; mp != NULL; prev = mp, mp = mp->b_next) {
-		uint16_t len;
-		uint32_t offset;
-		struct ether_header *ehp;
-		uint16_t sap;
+	/*
+	 * This function should only be called from mac_hw_emul()
+	 * which handles mblk chains and the shared ref case.
+	 */
+	ASSERT3P(mp->b_next, ==, NULL);
 
-		mac_hcksum_get(mp, &start, &stuff, &end, &value, &flags);
-		if (flags == 0)
-			continue;
+	mac_hcksum_get(mp, &start, &stuff, &end, &value, NULL);
 
-		/*
-		 * Since the processing of checksum offload for loopback
-		 * traffic requires modification of the packet contents,
-		 * ensure sure that we are always modifying our own copy.
-		 */
-		if (DB_REF(mp) > 1) {
-			mp1 = copymsg(mp);
-			if (mp1 == NULL)
-				continue;
-			mp1->b_next = mp->b_next;
-			mp->b_next = NULL;
-			freemsg(mp);
-			if (prev != NULL)
-				prev->b_next = mp1;
-			else
-				new_chain = mp1;
-			mp = mp1;
+	/*
+	 * We use DB_CKSUMFLAGS (instead of mac_hcksum_get()) because
+	 * we don't want to mask-out the HW_LOCAL_MAC flag.
+	 */
+	flags = DB_CKSUMFLAGS(mp);
+
+	/* Why call this if checksum emulation isn't needed? */
+	ASSERT3U(flags & (HCK_FLAGS), !=, 0);
+
+	/*
+	 * Ethernet, and optionally VLAN header. mac_hw_emul() has
+	 * already verified we have enough data to read the L2 header.
+	 */
+	ehp = (struct ether_header *)mp->b_rptr;
+	if (ntohs(ehp->ether_type) == VLAN_TPID) {
+		struct ether_vlan_header *evhp;
+
+		evhp = (struct ether_vlan_header *)mp->b_rptr;
+		etype = ntohs(evhp->ether_type);
+		offset = sizeof (struct ether_vlan_header);
+	} else {
+		etype = ntohs(ehp->ether_type);
+		offset = sizeof (struct ether_header);
+	}
+
+	/*
+	 * If this packet isn't IPv4, then leave it alone. We still
+	 * need to add IPv6 support and we don't want to affect non-IP
+	 * traffic like ARP.
+	 */
+	if (etype != ETHERTYPE_IP)
+		return (mp);
+
+	ASSERT3U(MBLKL(mp), >=, offset);
+
+	/*
+	 * If the first mblk of this packet contains only the ethernet
+	 * header, skip past it for now. Packets with their data
+	 * contained in only a single mblk can then use the fastpaths
+	 * tuned to that possibility.
+	 */
+	if (MBLKL(mp) == offset) {
+		offset -= MBLKL(mp);
+		/* This is guaranteed by mac_hw_emul(). */
+		ASSERT3P(mp->b_cont, !=, NULL);
+		skipped_hdr = mp;
+		mp = mp->b_cont;
+	}
+
+	/*
+	 * Both full and partial checksum rely on finding the IP
+	 * header in the current mblk. Our native TCP stack honors
+	 * this assumption but it's prudent to guard our future
+	 * clients that might not honor this contract.
+	 */
+	ASSERT3U(MBLKL(mp), >=, offset + sizeof (ipha_t));
+	if (MBLKL(mp) < (offset + sizeof (ipha_t))) {
+		err = "mblk doesn't contain IP header";
+		goto bail;
+	}
+
+	/*
+	 * We are about to modify the header mblk; make sure we are
+	 * modifying our own copy. The code that follows assumes that
+	 * the IP/ULP headers exist in this mblk (and drops the
+	 * message if they don't).
+	 */
+	if (DB_REF(mp) > 1) {
+		mblk_t *tmp = copyb(mp);
+
+		if (tmp == NULL) {
+			err = "copyb failed";
+			goto bail;
 		}
 
-		/*
-		 * Ethernet, and optionally VLAN header.
-		 */
-		/* LINTED: improper alignment cast */
-		ehp = (struct ether_header *)mp->b_rptr;
-		if (ntohs(ehp->ether_type) == VLAN_TPID) {
-			struct ether_vlan_header *evhp;
-
-			ASSERT(MBLKL(mp) >= sizeof (struct ether_vlan_header));
-			/* LINTED: improper alignment cast */
-			evhp = (struct ether_vlan_header *)mp->b_rptr;
-			sap = ntohs(evhp->ether_type);
-			offset = sizeof (struct ether_vlan_header);
-		} else {
-			sap = ntohs(ehp->ether_type);
-			offset = sizeof (struct ether_header);
+		if (skipped_hdr != NULL) {
+			ASSERT3P(skipped_hdr->b_cont, ==, mp);
+			skipped_hdr->b_cont = tmp;
 		}
 
-		if (MBLKL(mp) <= offset) {
-			offset -= MBLKL(mp);
-			if (mp->b_cont == NULL) {
-				/* corrupted packet, skip it */
-				if (prev != NULL)
-					prev->b_next = mp->b_next;
-				else
-					new_chain = mp->b_next;
-				mp1 = mp->b_next;
-				mp->b_next = NULL;
-				freemsg(mp);
-				mp = mp1;
-				continue;
+		tmp->b_cont = mp->b_cont;
+		freeb(mp);
+		mp = tmp;
+	}
+
+	ipha = (ipha_t *)(mp->b_rptr + offset);
+
+	/*
+	 * This code assumes a "simple" IP header (20 bytes, no
+	 * options). IPv4 options are mostly a historic artifact. The
+	 * one slight exception is Router Alert, but we don't expect
+	 * such a packet to land here.
+	 */
+	proto = ipha->ipha_protocol;
+	ASSERT(ipha->ipha_version_and_hdr_length == IP_SIMPLE_HDR_VERSION);
+	if (ipha->ipha_version_and_hdr_length != IP_SIMPLE_HDR_VERSION) {
+		err = "not simple IP header";
+		goto bail;
+	}
+
+	switch (proto) {
+	case IPPROTO_TCP:
+		ASSERT3U(MBLKL(mp), >=,
+		    (offset + sizeof (ipha_t) + sizeof (tcph_t)));
+		if (MBLKL(mp) < (offset + sizeof (ipha_t) + sizeof (tcph_t))) {
+			err = "mblk doesn't contain TCP header";
+			goto bail;
+		}
+		break;
+
+	case IPPROTO_UDP:
+		ASSERT3U(MBLKL(mp), >=,
+		    (offset + sizeof (ipha_t) + sizeof (udpha_t)));
+		if (MBLKL(mp) < (offset + sizeof (ipha_t) + sizeof (udpha_t))) {
+			err = "mblk doesn't contain UDP header";
+			goto bail;
+		}
+		break;
+
+	default:
+		err = "unexpected protocol";
+		goto bail;
+	}
+
+	if (flags & (HCK_FULLCKSUM | HCK_IPV4_HDRCKSUM)) {
+		if ((flags & HCK_FULLCKSUM) && (emul & MAC_HWCKSUM_EMUL)) {
+			ipaddr_t src, dst;
+			uint32_t cksum;
+			uint16_t *up;
+
+			/* Get a pointer to the ULP checksum. */
+			switch (proto) {
+			case IPPROTO_TCP:
+				/* LINTED: improper alignment cast */
+				up = IPH_TCPH_CHECKSUMP(ipha,
+				    IP_SIMPLE_HDR_LENGTH);
+				break;
+
+			case IPPROTO_UDP:
+				/* LINTED: improper alignment cast */
+				up = IPH_UDPH_CHECKSUMP(ipha,
+				    IP_SIMPLE_HDR_LENGTH);
+				break;
 			}
-			mp = mp->b_cont;
-		}
 
-		if (flags & (HCK_FULLCKSUM | HCK_IPV4_HDRCKSUM)) {
-			ipha_t *ipha = NULL;
+			/* Pseudo-header checksum. */
+			src = ipha->ipha_src;
+			dst = ipha->ipha_dst;
+			len = ntohs(ipha->ipha_length) - IP_SIMPLE_HDR_LENGTH;
+
+			cksum = (dst >> 16) + (dst & 0xFFFF) +
+			    (src >> 16) + (src & 0xFFFF);
+			cksum += htons(len);
 
 			/*
-			 * In order to compute the full and header
-			 * checksums, we need to find and parse
-			 * the IP and/or ULP headers.
+			 * The checksum value stored in the packet
+			 * needs to be correct. Compute it here.
 			 */
-
-			sap = (sap < ETHERTYPE_802_MIN) ? 0 : sap;
-
-			/*
-			 * IP header.
-			 */
-			if (sap != ETHERTYPE_IP)
-				continue;
-
-			ASSERT(MBLKL(mp) >= offset + sizeof (ipha_t));
-			/* LINTED: improper alignment cast */
-			ipha = (ipha_t *)(mp->b_rptr + offset);
-
-			if (flags & HCK_FULLCKSUM) {
-				ipaddr_t src, dst;
-				uint32_t cksum;
-				uint16_t *up;
-				uint8_t proto;
-
-				/*
-				 * Pointer to checksum field in ULP header.
-				 */
-				proto = ipha->ipha_protocol;
-				ASSERT(ipha->ipha_version_and_hdr_length ==
-				    IP_SIMPLE_HDR_VERSION);
-
-				switch (proto) {
-				case IPPROTO_TCP:
-					/* LINTED: improper alignment cast */
-					up = IPH_TCPH_CHECKSUMP(ipha,
-					    IP_SIMPLE_HDR_LENGTH);
-					break;
-
-				case IPPROTO_UDP:
-					/* LINTED: improper alignment cast */
-					up = IPH_UDPH_CHECKSUMP(ipha,
-					    IP_SIMPLE_HDR_LENGTH);
-					break;
-
-				default:
-					cmn_err(CE_WARN, "mac_fix_cksum: "
-					    "unexpected protocol: %d", proto);
-					continue;
-				}
-
-				/*
-				 * Pseudo-header checksum.
-				 */
-				src = ipha->ipha_src;
-				dst = ipha->ipha_dst;
-				len = ntohs(ipha->ipha_length) -
-				    IP_SIMPLE_HDR_LENGTH;
-
-				cksum = (dst >> 16) + (dst & 0xFFFF) +
-				    (src >> 16) + (src & 0xFFFF);
-				cksum += htons(len);
-
-				/*
-				 * The checksum value stored in the packet needs
-				 * to be correct. Compute it here.
-				 */
-				*up = 0;
-				cksum += (((proto) == IPPROTO_UDP) ?
-				    IP_UDP_CSUM_COMP : IP_TCP_CSUM_COMP);
-				cksum = IP_CSUM(mp, IP_SIMPLE_HDR_LENGTH +
-				    offset, cksum);
-				*(up) = (uint16_t)(cksum ? cksum : ~cksum);
-
-				/*
-				 * Flag the packet so that it appears
-				 * that the checksum has already been
-				 * verified by the hardware.
-				 */
-				flags &= ~HCK_FULLCKSUM;
-				flags |= HCK_FULLCKSUM_OK;
-				value = 0;
-			}
-
-			if (flags & HCK_IPV4_HDRCKSUM) {
-				ASSERT(ipha != NULL);
-				ipha->ipha_hdr_checksum =
-				    (uint16_t)ip_csum_hdr(ipha);
-				flags &= ~HCK_IPV4_HDRCKSUM;
-				flags |= HCK_IPV4_HDRCKSUM_OK;
-
-			}
-		}
-
-		if (flags & HCK_PARTIALCKSUM) {
-			uint16_t *up, partial, cksum;
-			uchar_t *ipp; /* ptr to beginning of IP header */
-
-			if (mp->b_cont != NULL) {
-				mblk_t *mp1;
-
-				mp1 = msgpullup(mp, offset + end);
-				if (mp1 == NULL)
-					continue;
-				mp1->b_next = mp->b_next;
-				mp->b_next = NULL;
-				freemsg(mp);
-				if (prev != NULL)
-					prev->b_next = mp1;
-				else
-					new_chain = mp1;
-				mp = mp1;
-			}
-
-			ipp = mp->b_rptr + offset;
-			/* LINTED: cast may result in improper alignment */
-			up = (uint16_t *)((uchar_t *)ipp + stuff);
-			partial = *up;
 			*up = 0;
+			cksum += (((proto) == IPPROTO_UDP) ?
+			    IP_UDP_CSUM_COMP : IP_TCP_CSUM_COMP);
+			cksum = IP_CSUM(mp, IP_SIMPLE_HDR_LENGTH +
+			    offset, cksum);
+			*(up) = (uint16_t)(cksum ? cksum : ~cksum);
 
-			cksum = IP_BCSUM_PARTIAL(mp->b_rptr + offset + start,
-			    end - start, partial);
-			cksum = ~cksum;
-			*up = cksum ? cksum : ~cksum;
+		}
 
-			/*
-			 * Since we already computed the whole checksum,
-			 * indicate to the stack that it has already
-			 * been verified by the hardware.
-			 */
-			flags &= ~HCK_PARTIALCKSUM;
+		/* We always update the ULP checksum flags. */
+		if ((flags & HCK_FULLCKSUM) && (emul & MAC_HWCKSUM_EMULS)) {
+			flags &= ~HCK_FULLCKSUM;
 			flags |= HCK_FULLCKSUM_OK;
 			value = 0;
 		}
 
-		mac_hcksum_set(mp, start, stuff, end, value, flags);
+		/*
+		 * Out of paranoia, and for the sake of correctness,
+		 * we won't calulate the IP header checksum if it's
+		 * already populated. While unlikely, it's possible to
+		 * write code that might end up calling mac_sw_cksum()
+		 * twice on the same mblk (performing both LSO and
+		 * checksum emualtion in a single mblk chain loop --
+		 * the LSO emulation inserts a new chain into the
+		 * existing chain and then the loop iterates back over
+		 * the new segments and emulates the checksum a second
+		 * time). Normally this wouldn't be a problem, because
+		 * the HCK_*_OK flags are supposed to indicate that we
+		 * don't need to do peform the work. But
+		 * HCK_IPV4_HDRCKSUM and HCK_IPV4_HDRCKSUM_OK have the
+		 * same value; so we cannot use these flags to
+		 * determine if the IP header checksum has already
+		 * been calculated or not. Luckily, if IP requests
+		 * HCK_IPV4_HDRCKSUM, then the IP header checksum will
+		 * be zero. So this test works just as well as
+		 * checking the flag. However, in the future, we
+		 * should fix the HCK_* flags.
+		 */
+		if ((flags & HCK_IPV4_HDRCKSUM) && (emul & MAC_HWCKSUM_EMULS) &&
+		    ipha->ipha_hdr_checksum == 0) {
+			ipha->ipha_hdr_checksum = (uint16_t)ip_csum_hdr(ipha);
+			flags &= ~HCK_IPV4_HDRCKSUM;
+			flags |= HCK_IPV4_HDRCKSUM_OK;
+		}
 	}
 
-	return (new_chain);
+	if ((flags & HCK_PARTIALCKSUM) && (emul & MAC_HWCKSUM_EMUL)) {
+		uint16_t *up, partial, cksum;
+		uchar_t *ipp; /* ptr to beginning of IP header */
+
+		ipp = mp->b_rptr + offset;
+		/* LINTED: cast may result in improper alignment */
+		up = (uint16_t *)((uchar_t *)ipp + stuff);
+		partial = *up;
+		*up = 0;
+
+		ASSERT3S(end, >, start);
+		cksum = ~IP_CSUM_PARTIAL(mp, offset + start, partial);
+		*up = cksum != 0 ? cksum : ~cksum;
+	}
+
+	/* We always update the ULP checksum flags. */
+	if ((flags & HCK_PARTIALCKSUM) && (emul & MAC_HWCKSUM_EMULS)) {
+		flags &= ~HCK_PARTIALCKSUM;
+		flags |= HCK_FULLCKSUM_OK;
+		value = 0;
+	}
+
+	mac_hcksum_set(mp, start, stuff, end, value, flags);
+
+	/* Don't forget to reattach the header. */
+	if (skipped_hdr != NULL) {
+		ASSERT3P(skipped_hdr->b_cont, ==, mp);
+
+		/*
+		 * Duplicate the HCKSUM data into the header mblk.
+		 * This mimics mac_add_vlan_tag which ensures that
+		 * both the first mblk _and_ the first data bearing
+		 * mblk possess the HCKSUM information. Consumers like
+		 * IP will end up discarding the ether_header mblk, so
+		 * for now, it is important that the data be available
+		 * in both places.
+		 */
+		mac_hcksum_clone(mp, skipped_hdr);
+		mp = skipped_hdr;
+	}
+
+	return (mp);
+
+bail:
+	if (skipped_hdr != NULL) {
+		ASSERT3P(skipped_hdr->b_cont, ==, mp);
+		mp = skipped_hdr;
+	}
+
+	mac_drop_pkt(mp, err);
+	return (NULL);
+}
+
+/*
+ * Build a single data segment from an LSO packet. The mblk chain
+ * returned, seg_head, represents the data segment and is always
+ * exactly seg_len bytes long. The lso_mp and offset input/output
+ * parameters track our position in the LSO packet. This function
+ * exists solely as a helper to mac_sw_lso().
+ *
+ * Case A
+ *
+ *     The current lso_mp is larger than the requested seg_len. The
+ *     beginning of seg_head may start at the beginning of lso_mp or
+ *     offset into it. In either case, a single mblk is returned, and
+ *     *offset is updated to reflect our new position in the current
+ *     lso_mp.
+ *
+ *          +----------------------------+
+ *          |  in *lso_mp / out *lso_mp  |
+ *          +----------------------------+
+ *          ^                        ^
+ *          |                        |
+ *          |                        |
+ *          |                        |
+ *          +------------------------+
+ *          |        seg_head        |
+ *          +------------------------+
+ *          ^                        ^
+ *          |                        |
+ *   in *offset = 0        out *offset = seg_len
+ *
+ *          |------   seg_len    ----|
+ *
+ *
+ *       +------------------------------+
+ *       |   in *lso_mp / out *lso_mp   |
+ *       +------------------------------+
+ *          ^                        ^
+ *          |                        |
+ *          |                        |
+ *          |                        |
+ *          +------------------------+
+ *          |        seg_head        |
+ *          +------------------------+
+ *          ^                        ^
+ *          |                        |
+ *   in *offset = N        out *offset = N + seg_len
+ *
+ *          |------   seg_len    ----|
+ *
+ *
+ *
+ * Case B
+ *
+ *    The requested seg_len consumes exactly the rest of the lso_mp.
+ *    I.e., the seg_head's b_wptr is equivalent to lso_mp's b_wptr.
+ *    The seg_head may start at the beginning of the lso_mp or at some
+ *    offset into it. In either case we return a single mblk, reset
+ *    *offset to zero, and walk to the next lso_mp.
+ *
+ *          +------------------------+           +------------------------+
+ *          |       in *lso_mp       |---------->|      out *lso_mp       |
+ *          +------------------------+           +------------------------+
+ *          ^                        ^           ^
+ *          |                        |           |
+ *          |                        |    out *offset = 0
+ *          |                        |
+ *          +------------------------+
+ *          |        seg_head        |
+ *          +------------------------+
+ *          ^
+ *          |
+ *   in *offset = 0
+ *
+ *          |------   seg_len    ----|
+ *
+ *
+ *
+ *      +----------------------------+           +------------------------+
+ *      |         in *lso_mp         |---------->|      out *lso_mp       |
+ *      +----------------------------+           +------------------------+
+ *          ^                        ^           ^
+ *          |                        |           |
+ *          |                        |    out *offset = 0
+ *          |                        |
+ *          +------------------------+
+ *          |        seg_head        |
+ *          +------------------------+
+ *          ^
+ *          |
+ *   in *offset = N
+ *
+ *          |------   seg_len    ----|
+ *
+ *
+ * Case C
+ *
+ *    The requested seg_len is greater than the current lso_mp. In
+ *    this case we must consume LSO mblks until we have enough data to
+ *    satisfy either case (A) or (B) above. We will return multiple
+ *    mblks linked via b_cont, offset will be set based on the cases
+ *    above, and lso_mp will walk forward at least one mblk, but maybe
+ *    more.
+ *
+ *    N.B. This digram is not exhaustive. The seg_head may start on
+ *    the beginning of an lso_mp. The seg_tail may end exactly on the
+ *    boundary of an lso_mp. And there may be two (in this case the
+ *    middle block wouldn't exist), three, or more mblks in the
+ *    seg_head chain. This is meant as one example of what might
+ *    happen. The main thing to remember is that the seg_tail mblk
+ *    must be one of case (A) or (B) above.
+ *
+ *  +------------------+    +----------------+    +------------------+
+ *  |    in *lso_mp    |--->|    *lso_mp     |--->|   out *lso_mp    |
+ *  +------------------+    +----------------+    +------------------+
+ *        ^            ^    ^                ^    ^            ^
+ *        |            |    |                |    |            |
+ *        |            |    |                |    |            |
+ *        |            |    |                |    |            |
+ *        |            |    |                |    |            |
+ *        +------------+    +----------------+    +------------+
+ *        |  seg_head  |--->|                |--->|  seg_tail  |
+ *        +------------+    +----------------+    +------------+
+ *        ^                                                    ^
+ *        |                                                    |
+ *  in *offset = N                          out *offset = MBLKL(seg_tail)
+ *
+ *        |-------------------   seg_len    -------------------|
+ *
+ */
+static mblk_t *
+build_data_seg(mblk_t **lso_mp, uint32_t *offset, uint32_t seg_len)
+{
+	mblk_t *seg_head, *seg_tail, *seg_mp;
+
+	ASSERT3P(*lso_mp, !=, NULL);
+	ASSERT3U((*lso_mp)->b_rptr + *offset, <, (*lso_mp)->b_wptr);
+
+	seg_mp = dupb(*lso_mp);
+	if (seg_mp == NULL)
+		return (NULL);
+
+	seg_head = seg_mp;
+	seg_tail = seg_mp;
+
+	/* Continue where we left off from in the lso_mp. */
+	seg_mp->b_rptr += *offset;
+
+last_mblk:
+	/* Case (A) */
+	if ((seg_mp->b_rptr + seg_len) < seg_mp->b_wptr) {
+		*offset += seg_len;
+		seg_mp->b_wptr = seg_mp->b_rptr + seg_len;
+		return (seg_head);
+	}
+
+	/* Case (B) */
+	if ((seg_mp->b_rptr + seg_len) == seg_mp->b_wptr) {
+		*offset = 0;
+		*lso_mp = (*lso_mp)->b_cont;
+		return (seg_head);
+	}
+
+	/* Case (C) */
+	ASSERT3U(seg_mp->b_rptr + seg_len, >, seg_mp->b_wptr);
+
+	/*
+	 * The current LSO mblk doesn't have enough data to satisfy
+	 * seg_len -- continue peeling off LSO mblks to build the new
+	 * segment message. If allocation fails we free the previously
+	 * allocated segment mblks and return NULL.
+	 */
+	while ((seg_mp->b_rptr + seg_len) > seg_mp->b_wptr) {
+		ASSERT3U(MBLKL(seg_mp), <=, seg_len);
+		seg_len -= MBLKL(seg_mp);
+		*offset = 0;
+		*lso_mp = (*lso_mp)->b_cont;
+		seg_mp = dupb(*lso_mp);
+
+		if (seg_mp == NULL) {
+			freemsgchain(seg_head);
+			return (NULL);
+		}
+
+		seg_tail->b_cont = seg_mp;
+		seg_tail = seg_mp;
+	}
+
+	/*
+	 * We've walked enough LSO mblks that we can now satisfy the
+	 * remaining seg_len. At this point we need to jump back to
+	 * determine if we have arrived at case (A) or (B).
+	 */
+
+	/* Just to be paranoid that we didn't underflow. */
+	ASSERT3U(seg_len, <, IP_MAXPACKET);
+	ASSERT3U(seg_len, >, 0);
+	goto last_mblk;
+}
+
+/*
+ * Perform software segmentation of a single LSO message. Take an LSO
+ * message as input and return head/tail pointers as output. This
+ * function should not be invoked directly but instead through
+ * mac_hw_emul().
+ *
+ * The resulting chain is comprised of multiple (nsegs) MSS sized
+ * segments. Each segment will consist of two or more mblks joined by
+ * b_cont: a header and one or more data mblks. The header mblk is
+ * allocated anew for each message. The first segment's header is used
+ * as a template for the rest with adjustments made for things such as
+ * ID, sequence, length, TCP flags, etc. The data mblks reference into
+ * the existing LSO mblk (passed in as omp) by way of dupb(). Their
+ * b_rptr/b_wptr values are adjusted to reference only the fraction of
+ * the LSO message they are responsible for. At the successful
+ * completion of this function the original mblk (omp) is freed,
+ * leaving the newely created segment chain as the only remaining
+ * reference to the data.
+ */
+static void
+mac_sw_lso(mblk_t *omp, mac_emul_t emul, mblk_t **head, mblk_t **tail,
+    uint_t *count)
+{
+	uint32_t ocsum_flags, ocsum_start, ocsum_stuff;
+	uint32_t mss;
+	uint32_t oehlen, oiphlen, otcphlen, ohdrslen, opktlen, odatalen;
+	uint32_t oleft;
+	uint_t nsegs, seg;
+	int len;
+
+	struct ether_vlan_header *oevh;
+	const ipha_t *oiph;
+	const tcph_t *otcph;
+	ipha_t *niph;
+	tcph_t *ntcph;
+	uint16_t ip_id;
+	uint32_t tcp_seq, tcp_sum, otcp_sum;
+
+	uint32_t offset;
+	mblk_t *odatamp;
+	mblk_t *seg_chain, *prev_nhdrmp, *next_nhdrmp, *nhdrmp, *ndatamp;
+	mblk_t *tmptail;
+
+	ASSERT3P(head, !=, NULL);
+	ASSERT3P(tail, !=, NULL);
+	ASSERT3P(count, !=, NULL);
+	ASSERT3U((DB_CKSUMFLAGS(omp) & HW_LSO), !=, 0);
+
+	/* Assume we are dealing with a single LSO message. */
+	ASSERT3P(omp->b_next, ==, NULL);
+
+	/*
+	 * XXX: This is a hack to deal with mac_add_vlan_tag().
+	 *
+	 * When VLANs are in play, mac_add_vlan_tag() creates a new
+	 * mblk with just the ether_vlan_header and tacks it onto the
+	 * front of 'omp'. This breaks the assumptions made below;
+	 * namely that the TCP/IP headers are in the first mblk. In
+	 * this case, since we already have to pay the cost of LSO
+	 * emulation, we simply pull up everything. While this might
+	 * seem irksome, keep in mind this will only apply in a couple
+	 * of scenarios: a) an LSO-capable VLAN client sending to a
+	 * non-LSO-capable client over the "MAC/bridge loopback"
+	 * datapath or b) an LSO-capable VLAN client is sending to a
+	 * client that, for whatever reason, doesn't have DLS-bypass
+	 * enabled. Finally, we have to check for both a tagged and
+	 * untagged sized mblk depending on if the mblk came via
+	 * mac_promisc_dispatch() or mac_rx_deliver().
+	 *
+	 * In the future, two things should be done:
+	 *
+	 * 1. This function should make use of some yet to be
+	 *    implemented "mblk helpers". These helper functions would
+	 *    perform all the b_cont walking for us and guarantee safe
+	 *    access to the mblk data.
+	 *
+	 * 2. We should add some slop to the mblks so that
+	 *    mac_add_vlan_tag() can just edit the first mblk instead
+	 *    of allocating on the hot path.
+	 */
+	if (MBLKL(omp) == sizeof (struct ether_vlan_header) ||
+	    MBLKL(omp) == sizeof (struct ether_header)) {
+		mblk_t *tmp = msgpullup(omp, -1);
+
+		if (tmp == NULL) {
+			mac_drop_pkt(omp, "failed to pull up");
+			goto fail;
+		}
+
+		mac_hcksum_clone(omp, tmp);
+		freemsg(omp);
+		omp = tmp;
+	}
+
+	mss = DB_LSOMSS(omp);
+	ASSERT3U(msgsize(omp), <=, IP_MAXPACKET +
+	    sizeof (struct ether_vlan_header));
+	opktlen = msgsize(omp);
+
+	/*
+	 * First, get references to the IP and TCP headers and
+	 * determine the total TCP length (header + data).
+	 *
+	 * Thanks to mac_hw_emul() we know that the first mblk must
+	 * contain (at minimum) the full L2 header. However, this
+	 * function assumes more than that. It assumes the L2/L3/L4
+	 * headers are all contained in the first mblk of a message
+	 * (i.e., no b_cont walking for headers). While this is a
+	 * current reality (our native TCP stack and viona both
+	 * enforce this) things may become more nuanced in the future
+	 * (e.g. when introducing encap support or adding new
+	 * clients). For now we guard against this case by dropping
+	 * the packet.
+	 */
+	oevh = (struct ether_vlan_header *)omp->b_rptr;
+	if (oevh->ether_tpid == htons(ETHERTYPE_VLAN))
+		oehlen = sizeof (struct ether_vlan_header);
+	else
+		oehlen = sizeof (struct ether_header);
+
+	ASSERT3U(MBLKL(omp), >=, (oehlen + sizeof (ipha_t) + sizeof (tcph_t)));
+	if (MBLKL(omp) < (oehlen + sizeof (ipha_t) + sizeof (tcph_t))) {
+		mac_drop_pkt(omp, "mblk doesn't contain TCP/IP headers");
+		goto fail;
+	}
+
+	oiph = (ipha_t *)(omp->b_rptr + oehlen);
+	oiphlen = IPH_HDR_LENGTH(oiph);
+	otcph = (tcph_t *)(omp->b_rptr + oehlen + oiphlen);
+	otcphlen = TCP_HDR_LENGTH(otcph);
+
+	/*
+	 * Currently we only support LSO for TCP/IPv4.
+	 */
+	if (IPH_HDR_VERSION(oiph) != IPV4_VERSION) {
+		mac_drop_pkt(omp, "LSO unsupported IP version: %uhh",
+		    IPH_HDR_VERSION(oiph));
+		goto fail;
+	}
+
+	if (oiph->ipha_protocol != IPPROTO_TCP) {
+		mac_drop_pkt(omp, "LSO unsupported protocol: %uhh",
+		    oiph->ipha_protocol);
+		goto fail;
+	}
+
+	if (otcph->th_flags[0] & (TH_SYN | TH_RST | TH_URG)) {
+		mac_drop_pkt(omp, "LSO packet has SYN|RST|URG set");
+		goto fail;
+	}
+
+	ohdrslen = oehlen + oiphlen + otcphlen;
+	if ((len = MBLKL(omp)) < ohdrslen) {
+		mac_drop_pkt(omp, "LSO packet too short: %d < %u", len,
+		    ohdrslen);
+		goto fail;
+	}
+
+	/*
+	 * Either we have data in the first mblk or it's just the
+	 * header. In either case, we need to set rptr to the start of
+	 * the TCP data.
+	 */
+	if (len > ohdrslen) {
+		odatamp = omp;
+		offset = ohdrslen;
+	} else {
+		ASSERT3U(len, ==, ohdrslen);
+		odatamp = omp->b_cont;
+		offset = 0;
+	}
+
+	/* Make sure we still have enough data. */
+	ASSERT3U(msgsize(odatamp), >=, opktlen - ohdrslen);
+
+	/*
+	 * If a MAC negotiated LSO then it must negotioate both
+	 * HCKSUM_IPHDRCKSUM and either HCKSUM_INET_FULL_V4 or
+	 * HCKSUM_INET_PARTIAL; because both the IP and TCP headers
+	 * change during LSO segmentation (only the 3 fields of the
+	 * pseudo header checksum don't change: src, dst, proto). Thus
+	 * we would expect these flags (HCK_IPV4_HDRCKSUM |
+	 * HCK_PARTIALCKSUM | HCK_FULLCKSUM) to be set and for this
+	 * function to emulate those checksums in software. However,
+	 * that assumes a world where we only expose LSO if the
+	 * underlying hardware exposes LSO. Moving forward the plan is
+	 * to assume LSO in the upper layers and have MAC perform
+	 * software LSO when the underlying provider doesn't support
+	 * it. In such a world, if the provider doesn't support LSO
+	 * but does support hardware checksum offload, then we could
+	 * simply perform the segmentation and allow the hardware to
+	 * calculate the checksums. To the hardware it's just another
+	 * chain of non-LSO packets.
+	 */
+	ASSERT3S(DB_TYPE(omp), ==, M_DATA);
+	ocsum_flags = DB_CKSUMFLAGS(omp);
+	ASSERT3U(ocsum_flags & HCK_IPV4_HDRCKSUM, !=, 0);
+	ASSERT3U(ocsum_flags & (HCK_PARTIALCKSUM | HCK_FULLCKSUM), !=, 0);
+
+	/*
+	 * If hardware only provides partial checksum then software
+	 * must supply the pseudo-header checksum. In the case of LSO
+	 * we leave the TCP length at zero to be filled in by
+	 * hardware. This function must handle two scenarios.
+	 *
+	 * 1. Being called by a MAC client on the Rx path to segment
+	 *    an LSO packet and calculate the checksum.
+	 *
+	 * 2. Being called by a MAC provider to segment an LSO packet.
+	 *    In this case the LSO segmentation is performed in
+	 *    software (by this routine) but the MAC provider should
+	 *    still calculate the TCP/IP checksums in hardware.
+	 *
+	 *  To elaborate on the second case: we cannot have the
+	 *  scenario where IP sends LSO packets but the underlying HW
+	 *  doesn't support checksum offload -- because in that case
+	 *  TCP/IP would calculate the checksum in software (for the
+	 *  LSO packet) but then MAC would segment the packet and have
+	 *  to redo all the checksum work. So IP should never do LSO
+	 *  if HW doesn't support both IP and TCP checksum.
+	 */
+	if (ocsum_flags & HCK_PARTIALCKSUM) {
+		ocsum_start = (uint32_t)DB_CKSUMSTART(omp);
+		ocsum_stuff = (uint32_t)DB_CKSUMSTUFF(omp);
+	}
+
+	odatalen = opktlen - ohdrslen;
+
+	/*
+	 * Subtract one to account for the case where the data length
+	 * is evenly divisble by the MSS. Add one to account for the
+	 * fact that the division will always result in one less
+	 * segment than needed.
+	 */
+	nsegs = ((odatalen - 1) / mss) + 1;
+	if (nsegs < 2) {
+		mac_drop_pkt(omp, "LSO not enough segs: %u", nsegs);
+		goto fail;
+	}
+
+	DTRACE_PROBE6(sw__lso__start, mblk_t *, omp, void_ip_t *, oiph,
+	    __dtrace_tcp_tcph_t *, otcph, uint_t, odatalen, uint_t, mss, uint_t,
+	    nsegs);
+
+	seg_chain = NULL;
+	tmptail = seg_chain;
+	oleft = odatalen;
+
+	for (uint_t i = 0; i < nsegs; i++) {
+		boolean_t last_seg = ((i + 1) == nsegs);
+		uint32_t seg_len;
+
+		/*
+		 * If we fail to allocate, then drop the partially
+		 * allocated chain as well as the LSO packet. Let the
+		 * sender deal with the fallout.
+		 */
+		if ((nhdrmp = allocb(ohdrslen, 0)) == NULL) {
+			freemsgchain(seg_chain);
+			mac_drop_pkt(omp, "failed to alloc segment header");
+			goto fail;
+		}
+		ASSERT3P(nhdrmp->b_cont, ==, NULL);
+
+		if (seg_chain == NULL) {
+			seg_chain = nhdrmp;
+		} else {
+			ASSERT3P(tmptail, !=, NULL);
+			tmptail->b_next = nhdrmp;
+		}
+
+		tmptail = nhdrmp;
+
+		/*
+		 * Calculate this segment's lengh. It's either the MSS
+		 * or whatever remains for the last segment.
+		 */
+		seg_len = last_seg ? oleft : mss;
+		ASSERT3U(seg_len, <=, mss);
+		ndatamp = build_data_seg(&odatamp, &offset, seg_len);
+
+		if (ndatamp == NULL) {
+			freemsgchain(seg_chain);
+			mac_drop_pkt(omp, "LSO failed to segment data");
+			goto fail;
+		}
+
+		/* Attach data mblk to header mblk. */
+		nhdrmp->b_cont = ndatamp;
+		DB_CKSUMFLAGS(ndatamp) &= ~HW_LSO;
+		ASSERT3U(seg_len, <=, oleft);
+		oleft -= seg_len;
+	}
+
+	/* We should have consumed entire LSO msg. */
+	ASSERT3S(oleft, ==, 0);
+	ASSERT3P(odatamp, ==, NULL);
+
+	/*
+	 * All seg data mblks are referenced by the header mblks, null
+	 * out this pointer to catch any bad derefs.
+	 */
+	ndatamp = NULL;
+
+	/*
+	 * Set headers and checksum for first segment.
+	 */
+	nhdrmp = seg_chain;
+	bcopy(omp->b_rptr, nhdrmp->b_rptr, ohdrslen);
+	nhdrmp->b_wptr = nhdrmp->b_rptr + ohdrslen;
+	niph = (ipha_t *)(nhdrmp->b_rptr + oehlen);
+	ASSERT3U(msgsize(nhdrmp->b_cont), ==, mss);
+	niph->ipha_length = htons(oiphlen + otcphlen + mss);
+	niph->ipha_hdr_checksum = 0;
+	ip_id = ntohs(niph->ipha_ident);
+	ntcph = (tcph_t *)(nhdrmp->b_rptr + oehlen + oiphlen);
+	tcp_seq = BE32_TO_U32(ntcph->th_seq);
+	tcp_seq += mss;
+
+	/*
+	 * The first segment shouldn't:
+	 *
+	 *	o indicate end of data transmission (FIN),
+	 *	o indicate immediate handling of the data (PUSH).
+	 */
+	ntcph->th_flags[0] &= ~(TH_FIN | TH_PUSH);
+	DB_CKSUMFLAGS(nhdrmp) = (uint16_t)(ocsum_flags & ~HW_LSO);
+
+	/*
+	 * If the underlying HW provides partial checksum, then make
+	 * sure to correct the pseudo header checksum before calling
+	 * mac_sw_cksum(). The native TCP stack doesn't include the
+	 * length field in the pseudo header when LSO is in play -- so
+	 * we need to calculate it here.
+	 */
+	if (ocsum_flags & HCK_PARTIALCKSUM) {
+		DB_CKSUMSTART(nhdrmp) = ocsum_start;
+		DB_CKSUMEND(nhdrmp) = ntohs(niph->ipha_length);
+		DB_CKSUMSTUFF(nhdrmp) = ocsum_stuff;
+		tcp_sum = BE16_TO_U16(ntcph->th_sum);
+		otcp_sum = tcp_sum;
+		tcp_sum += mss + otcphlen;
+		tcp_sum = (tcp_sum >> 16) + (tcp_sum & 0xFFFF);
+		U16_TO_BE16(tcp_sum, ntcph->th_sum);
+	}
+
+	if ((ocsum_flags & (HCK_PARTIALCKSUM | HCK_FULLCKSUM)) &&
+	    (emul & MAC_HWCKSUM_EMULS)) {
+		next_nhdrmp = nhdrmp->b_next;
+		nhdrmp->b_next = NULL;
+		nhdrmp = mac_sw_cksum(nhdrmp, emul);
+		nhdrmp->b_next = next_nhdrmp;
+		next_nhdrmp = NULL;
+
+		/*
+		 * We may have freed the nhdrmp argument during
+		 * checksum emulation, make sure that seg_chain
+		 * references a valid mblk.
+		 */
+		seg_chain = nhdrmp;
+	}
+
+	ASSERT3P(nhdrmp, !=, NULL);
+
+	seg = 1;
+	DTRACE_PROBE5(sw__lso__seg, mblk_t *, nhdrmp, void_ip_t *,
+	    (ipha_t *)(nhdrmp->b_rptr + oehlen), __dtrace_tcp_tcph_t *,
+	    (tcph_t *)(nhdrmp->b_rptr + oehlen + oiphlen), uint_t, mss,
+	    uint_t, seg);
+	seg++;
+
+	/* There better be at least 2 segs. */
+	ASSERT3P(nhdrmp->b_next, !=, NULL);
+	prev_nhdrmp = nhdrmp;
+	nhdrmp = nhdrmp->b_next;
+
+	/*
+	 * Now adjust the headers of the middle segments. For each
+	 * header we need to adjust the following.
+	 *
+	 *	o IP ID
+	 *	o IP length
+	 *	o TCP sequence
+	 *	o TCP flags
+	 *	o cksum flags
+	 *	o cksum values (if MAC_HWCKSUM_EMUL is set)
+	 */
+	for (; seg < nsegs; seg++) {
+		/*
+		 * We use seg_chain as a reference to the first seg
+		 * header mblk -- this first header is a template for
+		 * the rest of the segments. This copy will include
+		 * the now updated checksum values from the first
+		 * header. We must reset these checksum values to
+		 * their original to make sure we produce the correct
+		 * value.
+		 */
+		bcopy(seg_chain->b_rptr, nhdrmp->b_rptr, ohdrslen);
+		nhdrmp->b_wptr = nhdrmp->b_rptr + ohdrslen;
+		niph = (ipha_t *)(nhdrmp->b_rptr + oehlen);
+		niph->ipha_ident = htons(++ip_id);
+		ASSERT3P(msgsize(nhdrmp->b_cont), ==, mss);
+		niph->ipha_length = htons(oiphlen + otcphlen + mss);
+		niph->ipha_hdr_checksum = 0;
+		ntcph = (tcph_t *)(nhdrmp->b_rptr + oehlen + oiphlen);
+		U32_TO_BE32(tcp_seq, ntcph->th_seq);
+		tcp_seq += mss;
+		/*
+		 * Just like the first segment, the middle segments
+		 * shouldn't have these flags set.
+		 */
+		ntcph->th_flags[0] &= ~(TH_FIN | TH_PUSH);
+		DB_CKSUMFLAGS(nhdrmp) = (uint16_t)(ocsum_flags & ~HW_LSO);
+
+		if (ocsum_flags & HCK_PARTIALCKSUM) {
+			/*
+			 * First and middle segs have same
+			 * pseudo-header checksum.
+			 */
+			U16_TO_BE16(tcp_sum, ntcph->th_sum);
+			DB_CKSUMSTART(nhdrmp) = ocsum_start;
+			DB_CKSUMEND(nhdrmp) = ntohs(niph->ipha_length);
+			DB_CKSUMSTUFF(nhdrmp) = ocsum_stuff;
+		}
+
+		if ((ocsum_flags & (HCK_PARTIALCKSUM | HCK_FULLCKSUM)) &&
+		    (emul & MAC_HWCKSUM_EMULS)) {
+			next_nhdrmp = nhdrmp->b_next;
+			nhdrmp->b_next = NULL;
+			nhdrmp = mac_sw_cksum(nhdrmp, emul);
+			nhdrmp->b_next = next_nhdrmp;
+			next_nhdrmp = NULL;
+			/* We may have freed the original nhdrmp. */
+			prev_nhdrmp->b_next = nhdrmp;
+		}
+
+		DTRACE_PROBE5(sw__lso__seg, mblk_t *, nhdrmp, void_ip_t *,
+		    (ipha_t *)(nhdrmp->b_rptr + oehlen), __dtrace_tcp_tcph_t *,
+		    (tcph_t *)(nhdrmp->b_rptr + oehlen + oiphlen),
+		    uint_t, mss, uint_t, seg);
+
+		ASSERT3P(nhdrmp->b_next, !=, NULL);
+		prev_nhdrmp = nhdrmp;
+		nhdrmp = nhdrmp->b_next;
+	}
+
+	/* Make sure we are on the last segment. */
+	ASSERT3U(seg, ==, nsegs);
+	ASSERT3P(nhdrmp->b_next, ==, NULL);
+
+	/*
+	 * Now we set the last segment header. The difference being
+	 * that FIN/PSH/RST flags are allowed.
+	 */
+	bcopy(seg_chain->b_rptr, nhdrmp->b_rptr, ohdrslen);
+	nhdrmp->b_wptr = nhdrmp->b_rptr + ohdrslen;
+	niph = (ipha_t *)(nhdrmp->b_rptr + oehlen);
+	niph->ipha_ident = htons(++ip_id);
+	len = msgsize(nhdrmp->b_cont);
+	ASSERT3S(len, >, 0);
+	niph->ipha_length = htons(oiphlen + otcphlen + len);
+	niph->ipha_hdr_checksum = 0;
+	ntcph = (tcph_t *)(nhdrmp->b_rptr + oehlen + oiphlen);
+	U32_TO_BE32(tcp_seq, ntcph->th_seq);
+
+	DB_CKSUMFLAGS(nhdrmp) = (uint16_t)(ocsum_flags & ~HW_LSO);
+	if (ocsum_flags & HCK_PARTIALCKSUM) {
+		DB_CKSUMSTART(nhdrmp) = ocsum_start;
+		DB_CKSUMEND(nhdrmp) = ntohs(niph->ipha_length);
+		DB_CKSUMSTUFF(nhdrmp) = ocsum_stuff;
+		tcp_sum = otcp_sum;
+		tcp_sum += len + otcphlen;
+		tcp_sum = (tcp_sum >> 16) + (tcp_sum & 0xFFFF);
+		U16_TO_BE16(tcp_sum, ntcph->th_sum);
+	}
+
+	if ((ocsum_flags & (HCK_PARTIALCKSUM | HCK_FULLCKSUM)) &&
+	    (emul & MAC_HWCKSUM_EMULS)) {
+		/* This should be the last mblk. */
+		ASSERT3P(nhdrmp->b_next, ==, NULL);
+		nhdrmp = mac_sw_cksum(nhdrmp, emul);
+		prev_nhdrmp->b_next = nhdrmp;
+	}
+
+	DTRACE_PROBE5(sw__lso__seg, mblk_t *, nhdrmp, void_ip_t *,
+	    (ipha_t *)(nhdrmp->b_rptr + oehlen), __dtrace_tcp_tcph_t *,
+	    (tcph_t *)(nhdrmp->b_rptr + oehlen + oiphlen), uint_t, len,
+	    uint_t, seg);
+
+	/*
+	 * Free the reference to the original LSO message as it is
+	 * being replaced by seg_cahin.
+	 */
+	freemsg(omp);
+	*head = seg_chain;
+	*tail = nhdrmp;
+	*count = nsegs;
+	return;
+
+fail:
+	*head = NULL;
+	*tail = NULL;
+	*count = 0;
+}
+
+#define	HCK_NEEDED	(HCK_IPV4_HDRCKSUM | HCK_PARTIALCKSUM | HCK_FULLCKSUM)
+
+/*
+ * Emulate various hardware offload features in software. Take a chain
+ * of packets as input and emulate the hardware features specified in
+ * 'emul'. The resulting chain's head pointer replaces the 'mp_chain'
+ * pointer given as input, and its tail pointer is written to
+ * '*otail'. The number of packets in the new chain is written to
+ * '*ocount'. The 'otail' and 'ocount' arguments are optional and thus
+ * may be NULL. The 'mp_chain' argument may point to a NULL chain; in
+ * which case 'mp_chain' will simply stay a NULL chain.
+ *
+ * While unlikely, it is technically possible that this function could
+ * receive a non-NULL chain as input and return a NULL chain as output
+ * ('*mp_chain' and '*otail' would be NULL and '*ocount' would be
+ * zero). This could happen if all the packets in the chain are
+ * dropped or if we fail to allocate new mblks. In this case, there is
+ * nothing for the caller to free. In any event, the caller shouldn't
+ * assume that '*mp_chain' is non-NULL on return.
+ *
+ * This function was written with two main use cases in mind.
+ *
+ * 1. A way for MAC clients to emulate hardware offloads when they
+ *    can't directly handle LSO packets or packets without fully
+ *    calculated checksums.
+ *
+ * 2. A way for MAC providers (drivers) to offer LSO even when the
+ *    underlying HW can't or won't supply LSO offload.
+ *
+ * At the time of this writing no provider is making use of this
+ * function. However, the plan for the future is to always assume LSO
+ * is available and then add SW LSO emulation to all providers that
+ * don't support it in HW.
+ */
+void
+mac_hw_emul(mblk_t **mp_chain, mblk_t **otail, uint_t *ocount, mac_emul_t emul)
+{
+	mblk_t *head = NULL, *tail = NULL;
+	uint_t count = 0;
+
+	ASSERT3S(~(MAC_HWCKSUM_EMULS | MAC_LSO_EMUL) & emul, ==, 0);
+	ASSERT3P(mp_chain, !=, NULL);
+
+	for (mblk_t *mp = *mp_chain; mp != NULL; ) {
+		mblk_t *tmp, *next, *tmphead, *tmptail;
+		struct ether_header *ehp;
+		uint32_t flags;
+		uint_t len = MBLKL(mp), l2len;
+
+		/* Perform LSO/cksum one message at a time. */
+		next = mp->b_next;
+		mp->b_next = NULL;
+
+		/*
+		 * For our sanity the first mblk should contain at
+		 * least the full L2 header.
+		 */
+		if (len < sizeof (struct ether_header)) {
+			mac_drop_pkt(mp, "packet too short (A): %u", len);
+			mp = next;
+			continue;
+		}
+
+		ehp = (struct ether_header *)mp->b_rptr;
+		if (ntohs(ehp->ether_type) == VLAN_TPID)
+			l2len = sizeof (struct ether_vlan_header);
+		else
+			l2len = sizeof (struct ether_header);
+
+		/*
+		 * If the first mblk is solely the L2 header, then
+		 * there better be more data.
+		 */
+		if (len < l2len || (len == l2len && mp->b_cont == NULL)) {
+			mac_drop_pkt(mp, "packet too short (C): %u", len);
+			mp = next;
+			continue;
+		}
+
+		DTRACE_PROBE2(mac__emul, mblk_t *, mp, mac_emul_t, emul);
+
+		/*
+		 * We use DB_CKSUMFLAGS (instead of mac_hcksum_get())
+		 * because we don't want to mask-out the LSO flag.
+		 */
+		flags = DB_CKSUMFLAGS(mp);
+
+		if ((flags & HW_LSO) && (emul & MAC_LSO_EMUL)) {
+			uint_t tmpcount = 0;
+
+			/*
+			 * LSO fix-up handles checksum emulation
+			 * inline (if requested). It also frees mp.
+			 */
+			mac_sw_lso(mp, emul, &tmphead, &tmptail,
+			    &tmpcount);
+			count += tmpcount;
+		} else if ((flags & HCK_NEEDED) && (emul & MAC_HWCKSUM_EMULS)) {
+			tmp = mac_sw_cksum(mp, emul);
+			tmphead = tmp;
+			tmptail = tmp;
+			count++;
+		} else {
+			/* There is nothing to emulate. */
+			tmp = mp;
+			tmphead = tmp;
+			tmptail = tmp;
+			count++;
+		}
+
+		/*
+		 * The tmp mblk chain is either the start of the new
+		 * chain or added to the tail of the new chain.
+		 */
+		if (head == NULL) {
+			head = tmphead;
+			tail = tmptail;
+		} else {
+			/* Attach the new mblk to the end of the new chain. */
+			tail->b_next = tmphead;
+			tail = tmptail;
+		}
+
+		mp = next;
+	}
+
+	*mp_chain = head;
+
+	if (otail != NULL)
+		*otail = tail;
+
+	if (ocount != NULL)
+		*ocount = count;
 }
 
 /*
@@ -449,16 +1420,9 @@ mac_strip_vlan_tag_chain(mblk_t *mp_chain)
  */
 /* ARGSUSED */
 void
-mac_pkt_drop(void *arg, mac_resource_handle_t resource, mblk_t *mp,
+mac_rx_def(void *arg, mac_resource_handle_t resource, mblk_t *mp,
     boolean_t loopback)
 {
-	mblk_t	*mp1 = mp;
-
-	while (mp1 != NULL) {
-		mp1->b_prev = NULL;
-		mp1->b_queue = NULL;
-		mp1 = mp1->b_next;
-	}
 	freemsgchain(mp);
 }
 

--- a/usr/src/uts/common/io/simnet/simnet.c
+++ b/usr/src/uts/common/io/simnet/simnet.c
@@ -21,6 +21,8 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -792,12 +794,6 @@ simnet_m_tx(void *arg, mblk_t *mp_chain)
 		if (!pullupmsg(mp, -1)) {
 			sdev->sd_stats.xmit_errors++;
 			freemsg(mp);
-			continue;
-		}
-
-		/* Fix mblk checksum as the pkt dest is local */
-		if ((mp = mac_fix_cksum(mp)) == NULL) {
-			sdev->sd_stats.xmit_errors++;
 			continue;
 		}
 

--- a/usr/src/uts/common/io/stream.c
+++ b/usr/src/uts/common/io/stream.c
@@ -1451,6 +1451,16 @@ copyb(mblk_t *bp)
 	ndp = nbp->b_datap;
 
 	/*
+	 * Copy the various checksum information that came in
+	 * originally.
+	 */
+	ndp->db_cksumstart = dp->db_cksumstart;
+	ndp->db_cksumend = dp->db_cksumend;
+	ndp->db_cksumstuff = dp->db_cksumstuff;
+	bcopy(dp->db_struioun.data, ndp->db_struioun.data,
+	    sizeof (dp->db_struioun.data));
+
+	/*
 	 * Well, here is a potential issue.  If we are trying to
 	 * trace a flow, and we copy the message, we might lose
 	 * information about where this message might have been.

--- a/usr/src/uts/common/io/vnic/vnic_dev.c
+++ b/usr/src/uts/common/io/vnic/vnic_dev.c
@@ -455,6 +455,20 @@ vnic_dev_create(datalink_id_t vnic_id, datalink_id_t linkid,
 		} else {
 			vnic->vn_hcksum_txflags = 0;
 		}
+
+		/*
+		 * Check for LSO capabilities. LSO implementations
+		 * depend on hardware checksumming, so the same
+		 * requirement is enforced here.
+		 */
+		if (vnic->vn_hcksum_txflags != 0) {
+			if (!mac_capab_get(vnic->vn_lower_mh, MAC_CAPAB_LSO,
+			    &vnic->vn_cap_lso)) {
+				vnic->vn_cap_lso.lso_flags = 0;
+			}
+		} else {
+			vnic->vn_cap_lso.lso_flags = 0;
+		}
 	}
 
 	/* register with the MAC module */
@@ -822,6 +836,15 @@ vnic_m_capab_get(void *arg, mac_capab_t cap, void *cap_data)
 		*hcksum_txflags = vnic->vn_hcksum_txflags &
 		    (HCKSUM_INET_FULL_V4 | HCKSUM_IPHDRCKSUM |
 		    HCKSUM_INET_PARTIAL);
+		break;
+	}
+	case MAC_CAPAB_LSO: {
+		mac_capab_lso_t *cap_lso = cap_data;
+
+		if (vnic->vn_cap_lso.lso_flags == 0) {
+			return (B_FALSE);
+		}
+		*cap_lso = vnic->vn_cap_lso;
 		break;
 	}
 	case MAC_CAPAB_VNIC: {

--- a/usr/src/uts/common/os/strsubr.c
+++ b/usr/src/uts/common/os/strsubr.c
@@ -27,6 +27,7 @@
  * Use is subject to license terms.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -8461,6 +8462,12 @@ mblk_copycred(mblk_t *mp, const mblk_t *src)
 		dbp->db_cpid = cpid;
 }
 
+
+/*
+ * Now that NIC drivers are expected to deal only with M_DATA mblks, the
+ * hcksum_assoc and hcksum_retrieve functions are deprecated in favor of their
+ * respective mac_hcksum_set and mac_hcksum_get counterparts.
+ */
 int
 hcksum_assoc(mblk_t *mp,  multidata_t *mmd, pdesc_t *pd,
     uint32_t start, uint32_t stuff, uint32_t end, uint32_t value,

--- a/usr/src/uts/common/sys/dlpi.h
+++ b/usr/src/uts/common/sys/dlpi.h
@@ -388,6 +388,8 @@ typedef struct dl_ipnetinfo {
 #define	DL_PROMISC_PHYS		0x01	/* promiscuous mode at phys level */
 #define	DL_PROMISC_SAP		0x02	/* promiscuous mode at sap level */
 #define	DL_PROMISC_MULTI	0x03	/* promiscuous mode for multicast */
+#define	DL_PROMISC_RX_ONLY	0x04	/* above only enabled for rx */
+#define	DL_PROMISC_FIXUPS	0x05	/* above will be fixed up */
 
 /*
  * DLPI notification codes for DL_NOTIFY_REQ primitives.

--- a/usr/src/uts/common/sys/dls.h
+++ b/usr/src/uts/common/sys/dls.h
@@ -85,6 +85,8 @@ typedef struct dls_link_s	dls_link_t;
 #define	DLS_PROMISC_SAP		0x00000001
 #define	DLS_PROMISC_MULTI	0x00000002
 #define	DLS_PROMISC_PHYS	0x00000004
+#define	DLS_PROMISC_RX_ONLY	0x00000008
+#define	DLS_PROMISC_FIXUPS	0x00000010
 
 extern int	dls_open(dls_link_t *, dls_dl_handle_t, dld_str_t *);
 extern void	dls_close(dld_str_t *);

--- a/usr/src/uts/common/sys/hook_impl.h
+++ b/usr/src/uts/common/sys/hook_impl.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018, Joyent, Inc.
  */
 
 /*
@@ -171,7 +172,7 @@ typedef struct hook_family_int {
 	cvwaitlock_t			hfi_lock;
 	SLIST_ENTRY(hook_family_int)	hfi_entry;
 	hook_event_int_head_t		hfi_head;
-	hook_family_t 			hfi_family;
+	hook_family_t			hfi_family;
 	kstat_t				*hfi_kstat;
 	struct hook_stack		*hfi_stack;
 	hook_notify_head_t		hfi_nhead;
@@ -209,6 +210,7 @@ typedef struct hook_stack_head hook_stack_head_t;
 #define	Hn_ARP	"arp"
 #define	Hn_IPV4	"inet"
 #define	Hn_IPV6	"inet6"
+#define	Hn_VIONA "viona_inet"
 
 extern int hook_run(hook_family_int_t *, hook_event_token_t, hook_data_t);
 extern int hook_register(hook_family_int_t *, char *, hook_t *);

--- a/usr/src/uts/common/sys/mac.h
+++ b/usr/src/uts/common/sys/mac.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  * Copyright (c) 2015 Garrett D'Amore <garrett@damore.org>
  */
 
@@ -612,6 +612,36 @@ typedef struct mactype_register_s {
 	mac_ndd_mapping_t *mtr_mapping;
 	size_t		mtr_mappingcount;
 } mactype_register_t;
+
+/*
+ * Flags to describe the hardware emulation desired from a client when
+ * calling mac_hw_emul().
+ *
+ * MAC_HWCKSUM_EMUL
+ *
+ *	If an mblk is marked with HCK_* flags, then calculate those
+ *	checksums and update the checksum flags.
+ *
+ * MAC_IPCKSUM_EMUL
+ *
+ *	Like MAC_HWCKSUM_EMUL, except only calculate the IPv4 header
+ *	checksum. We still update both the IPv4 and ULP checksum
+ *	flags.
+ *
+ * MAC_LSO_EMUL
+ *
+ *	If an mblk is marked with HW_LSO, then segment the LSO mblk
+ *	into a new chain of mblks which reference the original data
+ *	block. This flag DOES NOT imply MAC_HWCKSUM_EMUL. If the
+ *	caller needs both then it must set both.
+ */
+typedef enum mac_emul {
+	MAC_HWCKSUM_EMUL = (1 << 0),
+	MAC_IPCKSUM_EMUL = (1 << 1),
+	MAC_LSO_EMUL = (1 << 2)
+} mac_emul_t;
+
+#define	MAC_HWCKSUM_EMULS	(MAC_HWCKSUM_EMUL | MAC_IPCKSUM_EMUL)
 
 /*
  * Driver interface functions.

--- a/usr/src/uts/common/sys/mac_client.h
+++ b/usr/src/uts/common/sys/mac_client.h
@@ -199,6 +199,8 @@ extern int mac_set_mtu(mac_handle_t, uint_t, uint_t *);
 
 extern void mac_client_set_rings(mac_client_handle_t, int, int);
 
+extern void mac_hw_emul(mblk_t **, mblk_t **, uint_t *, mac_emul_t);
+
 #endif	/* _KERNEL */
 
 #ifdef	__cplusplus

--- a/usr/src/uts/common/sys/mac_client.h
+++ b/usr/src/uts/common/sys/mac_client.h
@@ -22,7 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2013 Joyent, Inc.  All rights reserved.
+ * Copyright 2015 Joyent, Inc.  All rights reserved.
  */
 
 /*
@@ -115,6 +115,7 @@ typedef enum {
 #define	MAC_PROMISC_FLAGS_NO_PHYS		0x0002
 #define	MAC_PROMISC_FLAGS_VLAN_TAG_STRIP	0x0004
 #define	MAC_PROMISC_FLAGS_NO_COPY		0x0008
+#define	MAC_PROMISC_FLAGS_DO_FIXUPS		0x0010
 
 /* flags passed to mac_tx() */
 #define	MAC_DROP_ON_NO_DESC	0x01 /* freemsg() if no tx descs */

--- a/usr/src/uts/common/sys/mac_client_impl.h
+++ b/usr/src/uts/common/sys/mac_client_impl.h
@@ -338,8 +338,7 @@ extern	int	mac_tx_percpu_cnt;
 extern void mac_promisc_client_dispatch(mac_client_impl_t *, mblk_t *);
 extern void mac_client_init(void);
 extern void mac_client_fini(void);
-extern void mac_promisc_dispatch(mac_impl_t *, mblk_t *,
-    mac_client_impl_t *, boolean_t);
+extern void mac_promisc_dispatch(mac_impl_t *, mblk_t *, mac_client_impl_t *);
 
 extern int mac_validate_props(mac_impl_t *, mac_resource_props_t *);
 

--- a/usr/src/uts/common/sys/mac_client_impl.h
+++ b/usr/src/uts/common/sys/mac_client_impl.h
@@ -24,7 +24,7 @@
  * Copyright (c) 2012, Joyent, Inc.  All rights reserved.
  */
 /*
- * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright 2015 Joyent, Inc.
  */
 
 #ifndef	_SYS_MAC_CLIENT_IMPL_H
@@ -83,6 +83,7 @@ typedef struct mac_promisc_impl_s {			/* Protected by */
 	boolean_t			mpi_no_phys;	/* WO */
 	boolean_t			mpi_strip_vlan_tag;	/* WO */
 	boolean_t			mpi_no_copy;	/* WO */
+	boolean_t			mpi_do_fixups;	/* WO */
 } mac_promisc_impl_t;
 
 typedef union mac_tx_percpu_s {
@@ -338,7 +339,7 @@ extern void mac_promisc_client_dispatch(mac_client_impl_t *, mblk_t *);
 extern void mac_client_init(void);
 extern void mac_client_fini(void);
 extern void mac_promisc_dispatch(mac_impl_t *, mblk_t *,
-    mac_client_impl_t *);
+    mac_client_impl_t *, boolean_t);
 
 extern int mac_validate_props(mac_impl_t *, mac_resource_props_t *);
 

--- a/usr/src/uts/common/sys/mac_impl.h
+++ b/usr/src/uts/common/sys/mac_impl.h
@@ -331,7 +331,7 @@ struct mac_group_s {
 	if ((src_mcip)->mci_state_flags & MCIS_SHARE_BOUND)		\
 		rhandle = (mip)->mi_default_tx_ring;			\
 	if (mip->mi_promisc_list != NULL)				\
-		mac_promisc_dispatch(mip, mp, src_mcip, B_TRUE);	\
+		mac_promisc_dispatch(mip, mp, src_mcip);		\
 	/*								\
 	 * Grab the proper transmit pointer and handle. Special 	\
 	 * optimization: we can test mi_bridge_link itself atomically,	\
@@ -722,12 +722,23 @@ typedef struct mac_client_impl_s mac_client_impl_t;
 extern void	mac_init(void);
 extern int	mac_fini(void);
 
+/*
+ * MAC packet/chain drop functions to aggregate all dropped-packet
+ * debugging to a single surface.
+ */
+/*PRINTFLIKE2*/
+extern void	mac_drop_pkt(mblk_t *, const char *, ...)
+    __KPRINTFLIKE(2);
+
+/*PRINTFLIKE2*/
+extern void	mac_drop_chain(mblk_t *, const char *, ...)
+    __KPRINTFLIKE(2);
+
 extern void	mac_ndd_ioctl(mac_impl_t *, queue_t *, mblk_t *);
 extern boolean_t mac_ip_hdr_length_v6(ip6_t *, uint8_t *, uint16_t *,
     uint8_t *, ip6_frag_t **);
 
 extern mblk_t *mac_copymsgchain_cksum(mblk_t *);
-extern mblk_t *mac_fix_cksum(mblk_t *);
 extern void mac_packet_print(mac_handle_t, mblk_t *);
 extern void mac_rx_deliver(void *, mac_resource_handle_t, mblk_t *,
     mac_header_info_t *);
@@ -829,7 +840,7 @@ extern void mac_flow_set_name(flow_entry_t *, const char *);
 extern mblk_t *mac_add_vlan_tag(mblk_t *, uint_t, uint16_t);
 extern mblk_t *mac_add_vlan_tag_chain(mblk_t *, uint_t, uint16_t);
 extern mblk_t *mac_strip_vlan_tag_chain(mblk_t *);
-extern void mac_pkt_drop(void *, mac_resource_handle_t, mblk_t *, boolean_t);
+extern void mac_rx_def(void *, mac_resource_handle_t, mblk_t *, boolean_t);
 extern mblk_t *mac_rx_flow(mac_handle_t, mac_resource_handle_t, mblk_t *);
 
 extern void i_mac_share_alloc(mac_client_impl_t *);

--- a/usr/src/uts/common/sys/mac_impl.h
+++ b/usr/src/uts/common/sys/mac_impl.h
@@ -331,7 +331,7 @@ struct mac_group_s {
 	if ((src_mcip)->mci_state_flags & MCIS_SHARE_BOUND)		\
 		rhandle = (mip)->mi_default_tx_ring;			\
 	if (mip->mi_promisc_list != NULL)				\
-		mac_promisc_dispatch(mip, mp, src_mcip);		\
+		mac_promisc_dispatch(mip, mp, src_mcip, B_TRUE);	\
 	/*								\
 	 * Grab the proper transmit pointer and handle. Special 	\
 	 * optimization: we can test mi_bridge_link itself atomically,	\

--- a/usr/src/uts/common/sys/mac_provider.h
+++ b/usr/src/uts/common/sys/mac_provider.h
@@ -558,11 +558,12 @@ extern void			mac_prop_info_set_range_uint32(
 extern void			mac_prop_info_set_perm(mac_prop_info_handle_t,
 				    uint8_t);
 
-extern void			mac_hcksum_get(mblk_t *, uint32_t *,
+extern void			mac_hcksum_get(const mblk_t *, uint32_t *,
 				    uint32_t *, uint32_t *, uint32_t *,
 				    uint32_t *);
 extern void			mac_hcksum_set(mblk_t *, uint32_t, uint32_t,
 				    uint32_t, uint32_t, uint32_t);
+extern void			mac_hcksum_clone(const mblk_t *, mblk_t *);
 
 extern void			mac_lso_get(mblk_t *, uint32_t *, uint32_t *);
 

--- a/usr/src/uts/common/sys/neti.h
+++ b/usr/src/uts/common/sys/neti.h
@@ -21,6 +21,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2018, Joyent, Inc.
  */
 
 #ifndef _SYS_NETI_H
@@ -46,6 +48,7 @@ struct msgb;	/* avoiding sys/stream.h here */
 #define	NHF_INET	"NHF_INET"
 #define	NHF_INET6	"NHF_INET6"
 #define	NHF_ARP		"NHF_ARP"
+#define	NHF_VIONA	"NHF_VIONA"
 
 /*
  * Event identification
@@ -61,7 +64,7 @@ struct msgb;	/* avoiding sys/stream.h here */
 /*
  * Network NIC hardware checksum capability
  */
-#define	NET_HCK_NONE   	0x00
+#define	NET_HCK_NONE	0x00
 #define	NET_HCK_L3_FULL	0x01
 #define	NET_HCK_L3_PART	0x02
 #define	NET_HCK_L4_FULL	0x10

--- a/usr/src/uts/common/sys/pattr.h
+++ b/usr/src/uts/common/sys/pattr.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _SYS_PATTR_H
@@ -104,6 +105,25 @@ typedef struct pattr_hcksum_s {
 					/* On Receive: N/A */
 
 #define	HW_LSO_FLAGS		HW_LSO	/* All LSO flags, currently only one */
+
+/*
+ * The packet originates from a MAC on the same machine as the
+ * receiving MAC. There are two ways this can happen.
+ *
+ * 1. MAC loopback: When a packet is destined for a MAC client on the
+ *                  same MAC as the sender. This datapath is taken in
+ *                  max_tx_send().
+ *
+ * 2. Bridge Fwd: When a packet is destined for a MAC client on the
+ *                same bridge as the sender. This datapath is taken in
+ *                bridge_forward().
+ *
+ * Presented with this flag, a receiver can then decide whether or not
+ * it needs to emulate some or all of the HW offloads that the NIC
+ * would have performed otherwise -- or whether it should accept the
+ * packet as-is.
+ */
+#define	HW_LOCAL_MAC		0x100
 
 /*
  * Structure used for zerocopy attribute.

--- a/usr/src/uts/common/sys/strsubr.h
+++ b/usr/src/uts/common/sys/strsubr.h
@@ -25,6 +25,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef _SYS_STRSUBR_H
@@ -1238,10 +1239,17 @@ extern void strsignal_nolock(stdata_t *, int, uchar_t);
 
 struct multidata_s;
 struct pdesc_s;
+
+/*
+ * Now that NIC drivers are expected to deal only with M_DATA mblks, the
+ * hcksum_assoc and hcksum_retrieve functions are deprecated in favor of their
+ * respective mac_hcksum_set and mac_hcksum_get counterparts.
+ */
 extern int hcksum_assoc(mblk_t *, struct multidata_s *, struct pdesc_s  *,
     uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, int);
 extern void hcksum_retrieve(mblk_t *, struct multidata_s *, struct pdesc_s *,
     uint32_t *, uint32_t *, uint32_t *, uint32_t *, uint32_t *);
+
 extern void lso_info_set(mblk_t *, uint32_t, uint32_t);
 extern void lso_info_cleanup(mblk_t *);
 extern unsigned int bcksum(uchar_t *, int, unsigned int);

--- a/usr/src/uts/common/sys/vnic_impl.h
+++ b/usr/src/uts/common/sys/vnic_impl.h
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2014 Joyent, Inc.  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_SYS_VNIC_IMPL_H
@@ -64,6 +64,7 @@ typedef struct vnic_s {
 	mac_notify_handle_t	vn_mnh;
 
 	uint32_t		vn_hcksum_txflags;
+	mac_capab_lso_t		vn_cap_lso;
 	uint32_t		vn_mtu;
 } vnic_t;
 

--- a/usr/src/uts/common/xen/io/xnb.c
+++ b/usr/src/uts/common/xen/io/xnb.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifdef DEBUG
@@ -251,8 +252,8 @@ xnb_software_csum(xnb_t *xnbp, mblk_t *mp)
 	 * because it doesn't cover all of the interesting cases :-(
 	 */
 	mac_hcksum_set(mp, 0, 0, 0, 0, HCK_FULLCKSUM);
-
-	return (mac_fix_cksum(mp));
+	mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
+	return (mp);
 }
 
 mblk_t *

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -207,6 +207,23 @@
  * slow path for interrupts.  It will poll(2) the viona handle, receiving
  * notification when ring events necessitate the assertion of an interrupt.
  *
+ *
+ * ---------------
+ * Nethook Support
+ * ---------------
+ *
+ * Viona provides four nethook events that consumers (e.g. ipf) can hook into
+ * to intercept packets as they go up or down the stack.  Unfortunately,
+ * the nethook framework does not understand raw packets, so we can only
+ * generate events (in, out) for IPv4 and IPv6 packets.  At driver attach,
+ * we register callbacks with the neti (netinfo) module that will be invoked
+ * for each netstack already present, as well as for any additional netstack
+ * instances created as the system operates.  These callbacks will
+ * register/unregister the hooks with the nethook framework for each
+ * netstack instance.  This registration occurs prior to creating any
+ * viona instances for a given netstack, and the unregistration for a netstack
+ * instance occurs after all viona instances of the netstack instance have
+ * been deleted.
  */
 
 #include <sys/conf.h>
@@ -225,9 +242,13 @@
 #include <sys/pattr.h>
 #include <sys/dls.h>
 #include <sys/dlpi.h>
+#include <sys/hook.h>
+#include <sys/hook_event.h>
+#include <sys/list.h>
 #include <sys/mac_client.h>
 #include <sys/mac_provider.h>
 #include <sys/mac_client_priv.h>
+#include <sys/neti.h>
 #include <sys/vlan.h>
 #include <inet/ip.h>
 #include <inet/ip_impl.h>
@@ -348,6 +369,8 @@ struct viona_link;
 typedef struct viona_link viona_link_t;
 struct viona_desb;
 typedef struct viona_desb viona_desb_t;
+struct viona_net;
+typedef struct viona_neti viona_neti_t;
 
 enum viona_ring_state {
 	VRS_RESET	= 0x0,	/* just allocated or reset */
@@ -363,6 +386,11 @@ enum viona_ring_state_flags {
 #define	VRING_NEED_BAIL(ring, proc)					\
 		(((ring)->vr_state_flags & VRSF_REQ_STOP) != 0 ||	\
 		((proc)->p_flag & SEXITING) != 0)
+
+#define	VNETHOOK_INTERESTED_IN(neti) \
+	(neti)->vni_nethook.vnh_event_in.he_interested
+#define	VNETHOOK_INTERESTED_OUT(neti) \
+	(neti)->vni_nethook.vnh_event_out.he_interested
 
 typedef struct viona_vring {
 	viona_link_t	*vr_link;
@@ -422,6 +450,9 @@ typedef struct viona_vring {
 		uint64_t	rs_rx_pad_short;
 		uint64_t	rs_too_short;
 		uint64_t	rs_tx_absent;
+
+		uint64_t	rs_rx_hookdrop;
+		uint64_t	rs_tx_hookdrop;
 	} vr_stats;
 } viona_vring_t;
 
@@ -443,6 +474,32 @@ struct viona_link {
 	mac_client_handle_t	l_mch;
 
 	pollhead_t		l_pollhead;
+
+	viona_neti_t		*l_neti;
+};
+
+typedef struct viona_nethook {
+	net_handle_t		vnh_neti;
+	hook_family_t		vnh_family;
+	hook_event_t		vnh_event_in;
+	hook_event_t		vnh_event_out;
+	hook_event_token_t	vnh_token_in;
+	hook_event_token_t	vnh_token_out;
+	boolean_t		vnh_hooked;
+} viona_nethook_t;
+
+struct viona_neti {
+	list_node_t		vni_node;
+
+	netid_t			vni_netid;
+	zoneid_t		vni_zid;
+
+	viona_nethook_t		vni_nethook;
+
+	kmutex_t		vni_lock;	/* Protects remaining members */
+	kcondvar_t		vni_ref_change; /* Protected by vni_lock */
+	uint_t			vni_ref;	/* Protected by vni_lock */
+	list_t			vni_dev_list;	/* Protected by vni_lock */
 };
 
 struct viona_desb {
@@ -457,6 +514,7 @@ struct viona_desb {
 typedef struct viona_soft_state {
 	kmutex_t		ss_lock;
 	viona_link_t		*ss_link;
+	list_node_t		ss_node;
 } viona_soft_state_t;
 
 typedef struct used_elem {
@@ -468,6 +526,18 @@ static void			*viona_state;
 static dev_info_t		*viona_dip;
 static id_space_t		*viona_minors;
 static mblk_t			*viona_vlan_pad_mp;
+
+/*
+ * Global linked list of viona_neti_ts.  Access is protected by viona_neti_lock
+ */
+static kmutex_t			viona_neti_lock;
+static list_t			viona_neti_list;
+
+/*
+ * viona_neti is allocated and initialized during attach, and read-only
+ * until detach (where it's also freed)
+ */
+static net_instance_t		*viona_neti;
 
 /*
  * copy tx mbufs from virtio ring to avoid necessitating a wait for packet
@@ -509,6 +579,15 @@ static void viona_intr_ring(viona_vring_t *);
 static void viona_desb_release(viona_desb_t *);
 static void viona_rx(void *, mac_resource_handle_t, mblk_t *, boolean_t);
 static void viona_tx(viona_link_t *, viona_vring_t *);
+
+static viona_neti_t *viona_neti_lookup_by_zid(zoneid_t);
+static void viona_neti_rele(viona_neti_t *);
+
+static void *viona_neti_create(const netid_t);
+static void viona_neti_shutdown(const netid_t, void *);
+static void viona_neti_destroy(const netid_t, void *);
+
+static int viona_hook(viona_link_t *, viona_vring_t *, mblk_t **, boolean_t);
 
 static struct cb_ops viona_cb_ops = {
 	viona_open,
@@ -658,6 +737,21 @@ viona_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	viona_dip = dip;
 	ddi_report_dev(viona_dip);
 
+	mutex_init(&viona_neti_lock, NULL, MUTEX_DRIVER, NULL);
+	list_create(&viona_neti_list, sizeof (viona_neti_t),
+	    offsetof(viona_neti_t, vni_node));
+
+	/* This can only fail if NETINFO_VERSION is wrong */
+	viona_neti = net_instance_alloc(NETINFO_VERSION);
+	VERIFY(viona_neti != NULL);
+
+	viona_neti->nin_name = "viona";
+	viona_neti->nin_create = viona_neti_create;
+	viona_neti->nin_shutdown = viona_neti_shutdown;
+	viona_neti->nin_destroy = viona_neti_destroy;
+	/* This can only fail if we've registered ourselves multiple times */
+	VERIFY3S(net_instance_register(viona_neti), ==, DDI_SUCCESS);
+
 	return (DDI_SUCCESS);
 }
 
@@ -679,6 +773,14 @@ viona_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
 	id_space_destroy(viona_minors);
 	ddi_remove_minor_node(viona_dip, NULL);
 	viona_dip = NULL;
+
+	/* This can only fail if we've not registered previously */
+	VERIFY3S(net_instance_unregister(viona_neti), ==, DDI_SUCCESS);
+	net_instance_free(viona_neti);
+	viona_neti = NULL;
+
+	list_destroy(&viona_neti_list);
+	mutex_destroy(&viona_neti_lock);
 
 	return (DDI_SUCCESS);
 }
@@ -740,6 +842,7 @@ viona_close(dev_t dev, int flag, int otype, cred_t *credp)
 	}
 
 	VERIFY0(viona_ioc_delete(ss, B_TRUE));
+	VERIFY(!list_link_active(&ss->ss_node));
 	ddi_soft_state_free(viona_state, minor);
 	id_free(viona_minors, minor);
 
@@ -883,6 +986,8 @@ viona_ioc_create(viona_soft_state_t *ss, void *dptr, int md, cred_t *cr)
 	int		err = 0;
 	file_t		*fp;
 	vmm_hold_t	*hold = NULL;
+	viona_neti_t	*nip = NULL;
+	zoneid_t	zid;
 
 	ASSERT(MUTEX_NOT_HELD(&ss->ss_lock));
 
@@ -890,9 +995,21 @@ viona_ioc_create(viona_soft_state_t *ss, void *dptr, int md, cred_t *cr)
 		return (EFAULT);
 	}
 
+	zid = crgetzoneid(cr);
+	nip = viona_neti_lookup_by_zid(zid);
+	if (nip == NULL) {
+		return (EIO);
+	}
+
+	if (!nip->vni_nethook.vnh_hooked) {
+		viona_neti_rele(nip);
+		return (EIO);
+	}
+
 	mutex_enter(&ss->ss_lock);
 	if (ss->ss_link != NULL) {
 		mutex_exit(&ss->ss_lock);
+		viona_neti_rele(nip);
 		return (EEXIST);
 	}
 
@@ -924,11 +1041,18 @@ viona_ioc_create(viona_soft_state_t *ss, void *dptr, int md, cred_t *cr)
 		goto bail;
 	}
 
+	link->l_neti = nip;
+
 	viona_ring_alloc(link, &link->l_vrings[VIONA_VQ_RX]);
 	viona_ring_alloc(link, &link->l_vrings[VIONA_VQ_TX]);
 	ss->ss_link = link;
 
 	mutex_exit(&ss->ss_lock);
+
+	mutex_enter(&nip->vni_lock);
+	list_insert_tail(&nip->vni_dev_list, ss);
+	mutex_exit(&nip->vni_lock);
+
 	return (0);
 
 bail:
@@ -944,6 +1068,7 @@ bail:
 	if (hold != NULL) {
 		vmm_drv_rele(hold);
 	}
+	viona_neti_rele(nip);
 
 	mutex_exit(&ss->ss_lock);
 	return (err);
@@ -953,6 +1078,7 @@ static int
 viona_ioc_delete(viona_soft_state_t *ss, boolean_t on_close)
 {
 	viona_link_t *link;
+	viona_neti_t *nip = NULL;
 
 	mutex_enter(&ss->ss_lock);
 	if ((link = ss->ss_link) == NULL) {
@@ -1003,11 +1129,20 @@ viona_ioc_delete(viona_soft_state_t *ss, boolean_t on_close)
 		link->l_vm_hold = NULL;
 	}
 
+	nip = link->l_neti;
+	link->l_neti = NULL;
+
 	viona_ring_free(&link->l_vrings[VIONA_VQ_RX]);
 	viona_ring_free(&link->l_vrings[VIONA_VQ_TX]);
 	pollhead_clean(&link->l_pollhead);
 	ss->ss_link = NULL;
 	mutex_exit(&ss->ss_lock);
+
+	mutex_enter(&nip->vni_lock);
+	list_remove(&nip->vni_dev_list, ss);
+	mutex_exit(&nip->vni_lock);
+
+	viona_neti_rele(nip);
 
 	kmem_free(link, sizeof (viona_link_t));
 	return (0);
@@ -2098,6 +2233,30 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 		size = msgsize(mp);
 
 		/*
+		 * We treat both a 'drop' response and errors the same here
+		 * and put the packet on the drop chain.  As packets may be
+		 * subject to different actions in ipf (which do not all
+		 * return the same set of error values), an error processing
+		 * one packet doesn't mean the next packet will also generate
+		 * an error.
+		 */
+		if (VNETHOOK_INTERESTED_IN(link->l_neti) &&
+		    viona_hook(link, ring, &mp, B_FALSE) != 0) {
+			if (mp != NULL) {
+				*mpdrop_prevp = mp;
+				mpdrop_prevp = &mp->b_next;
+			} else {
+				/*
+				 * If the hook consumer (e.g. ipf) already
+				 * freed the mblk_t, update the drop count now.
+				 */
+				ndrop++;
+			}
+			mp = next;
+			continue;
+		}
+
+		/*
 		 * Ethernet frames are expected to be padded out in order to
 		 * meet the minimum size.
 		 *
@@ -2155,6 +2314,14 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 		}
 
 pad_drop:
+		/*
+		 * While an error during rx processing
+		 * (viona_recv_{merged,plain}) does not free mp on error,
+		 * hook processing might or might not free mp.  Handle either
+		 * scenario -- if mp is not yet free, it is queued up and
+		 * freed after the guest has been notified.  If mp is
+		 * already NULL, just proceed on.
+		 */
 		if (err != 0) {
 			*mpdrop_prevp = mp;
 			mpdrop_prevp = &mp->b_next;
@@ -2446,7 +2613,44 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 		mp_tail = mp;
 	}
 
-	/* Request hardware checksumming, if necessary */
+	if (VNETHOOK_INTERESTED_OUT(link->l_neti)) {
+		/*
+		 * The hook consumer may elect to free the mblk_t and set
+		 * our mblk_t ** to NULL.  When using a viona_desb_t
+		 * (dp != NULL), we do not want the corresponding cleanup to
+		 * occur during the viona_hook() call. We instead want to
+		 * reset and recycle dp for future use.  To prevent cleanup
+		 * during the viona_hook() call, we take a ref on dp (if being
+		 * used), and release it on success.  On failure, the
+		 * freemsgchain() call will release all the refs taken earlier
+		 * in viona_tx() (aside from the initial ref and the one we
+		 * take), and drop_hook will reset dp for reuse.
+		 */
+		if (dp != NULL)
+			dp->d_ref++;
+
+		/*
+		 * Pass &mp instead of &mp_head so we don't lose track of
+		 * mp_head if the hook consumer (i.e. ipf) elects to free mp
+		 * and set mp to NULL.
+		 */
+		mp = mp_head;
+		if (viona_hook(link, ring, &mp, B_TRUE) != 0) {
+			if (mp != NULL)
+				freemsgchain(mp);
+			goto drop_hook;
+		}
+
+		if (dp != NULL)
+			dp->d_ref--;
+	}
+
+	/*
+	 * Request hardware checksumming, if necessary. If the guest
+	 * sent an LSO packet then it must have also negotiated and
+	 * requested partial checksum; therefore the LSO logic is
+	 * contained within viona_tx_csum().
+	 */
 	if ((link->l_features & VIRTIO_NET_F_CSUM) != 0 &&
 	    (hdr->vrh_flags & VIRTIO_NET_HDR_F_NEEDS_CSUM) != 0) {
 		if (!viona_tx_csum(ring, hdr, mp_head, len - iov[0].iov_len)) {
@@ -2499,6 +2703,8 @@ drop_fail:
 	 * dropped data to be released to the used ring.
 	 */
 	freemsgchain(mp_head);
+
+drop_hook:
 	len = 0;
 	for (uint_t i = 0; i < n; i++) {
 		len += iov[i].iov_len;
@@ -2516,4 +2722,380 @@ drop_fail:
 	VIONA_PROBE3(tx_drop, viona_vring_t *, ring, uint32_t, len,
 	    uint16_t, cookie);
 	viona_tx_done(ring, len, cookie);
+}
+
+/*
+ * Generate a hook event for the packet in *mpp headed in the direction
+ * indicated by 'out'.  If the packet is accepted, 0 is returned.  If the
+ * packet is rejected, an error is returned.  The hook function may or may not
+ * alter or even free *mpp.  The caller is expected to deal with either
+ * situation.
+ */
+static int
+viona_hook(viona_link_t *link, viona_vring_t *ring, mblk_t **mpp, boolean_t out)
+{
+	viona_neti_t *nip = link->l_neti;
+	viona_nethook_t *vnh = &nip->vni_nethook;
+	hook_pkt_event_t info;
+	hook_event_t he;
+	hook_event_token_t het;
+	int ret;
+
+	he = out ? vnh->vnh_event_out : vnh->vnh_event_in;
+	het = out ? vnh->vnh_token_out : vnh->vnh_token_in;
+
+	if (!he.he_interested)
+		return (0);
+
+	info.hpe_protocol = vnh->vnh_neti;
+	info.hpe_ifp = (phy_if_t)link;
+	info.hpe_ofp = (phy_if_t)link;
+	info.hpe_mp = mpp;
+	info.hpe_flags = 0;
+
+	ret = hook_run(vnh->vnh_neti->netd_hooks, het, (hook_data_t)&info);
+	if (ret == 0)
+		return (0);
+
+	if (out) {
+		VIONA_PROBE3(tx_hook_drop, viona_vring_t *, ring,
+		    mblk_t *, *mpp, int, ret);
+		VIONA_RING_STAT_INCR(ring, tx_hookdrop);
+	} else {
+		VIONA_PROBE3(rx_hook_drop, viona_vring_t *, ring,
+		    mblk_t *, *mpp, int, ret);
+		VIONA_RING_STAT_INCR(ring, rx_hookdrop);
+	}
+	return (ret);
+}
+
+/*
+ * netinfo stubs - required by the nethook framework, but otherwise unused
+ *
+ * Currently, all ipf rules are applied against all interfaces in a given
+ * netstack (e.g. all interfaces in a zone).  In the future if we want to
+ * support being able to apply different rules to different interfaces, I
+ * believe we would need to implement some of these stubs to map an interface
+ * name in a rule (e.g. 'net0', back to an index or viona_link_t);
+ */
+static int
+viona_neti_getifname(net_handle_t neti __unused, phy_if_t phy __unused,
+    char *buf __unused, const size_t len __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_getmtu(net_handle_t neti __unused, phy_if_t phy __unused,
+    lif_if_t ifdata __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_getptmue(net_handle_t neti __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_getlifaddr(net_handle_t neti __unused, phy_if_t phy __unused,
+    lif_if_t ifdata __unused, size_t nelem __unused,
+    net_ifaddr_t type[] __unused, void *storage __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_getlifzone(net_handle_t neti __unused, phy_if_t phy __unused,
+    lif_if_t ifdata __unused, zoneid_t *zid __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_getlifflags(net_handle_t neti __unused, phy_if_t phy __unused,
+    lif_if_t ifdata __unused, uint64_t *flags __unused)
+{
+	return (-1);
+}
+
+static phy_if_t
+viona_neti_phygetnext(net_handle_t neti __unused, phy_if_t phy __unused)
+{
+	return ((phy_if_t)-1);
+}
+
+static phy_if_t
+viona_neti_phylookup(net_handle_t neti __unused, const char *name __unused)
+{
+	return ((phy_if_t)-1);
+}
+
+static lif_if_t
+viona_neti_lifgetnext(net_handle_t neti __unused, phy_if_t phy __unused,
+    lif_if_t ifdata __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_inject(net_handle_t neti __unused, inject_t style __unused,
+    net_inject_t *packet __unused)
+{
+	return (-1);
+}
+
+static phy_if_t
+viona_neti_route(net_handle_t neti __unused, struct sockaddr *address __unused,
+    struct sockaddr *next __unused)
+{
+	return ((phy_if_t)-1);
+}
+
+static int
+viona_neti_ispchksum(net_handle_t neti __unused, mblk_t *mp __unused)
+{
+	return (-1);
+}
+
+static int
+viona_neti_isvchksum(net_handle_t neti __unused, mblk_t *mp __unused)
+{
+	return (-1);
+}
+
+static net_protocol_t viona_netinfo = {
+	NETINFO_VERSION,
+	NHF_VIONA,
+	viona_neti_getifname,
+	viona_neti_getmtu,
+	viona_neti_getptmue,
+	viona_neti_getlifaddr,
+	viona_neti_getlifzone,
+	viona_neti_getlifflags,
+	viona_neti_phygetnext,
+	viona_neti_phylookup,
+	viona_neti_lifgetnext,
+	viona_neti_inject,
+	viona_neti_route,
+	viona_neti_ispchksum,
+	viona_neti_isvchksum
+};
+
+/*
+ * Create/register our nethooks
+ */
+static int
+viona_nethook_init(netid_t nid, viona_nethook_t *vnh, char *nh_name,
+    net_protocol_t *netip)
+{
+	int ret;
+
+	if ((vnh->vnh_neti = net_protocol_register(nid, netip)) == NULL) {
+		cmn_err(CE_NOTE, "%s: net_protocol_register failed "
+		    "(netid=%d name=%s)", __func__, nid, nh_name);
+		goto fail_init_proto;
+	}
+
+	HOOK_FAMILY_INIT(&vnh->vnh_family, nh_name);
+	if ((ret = net_family_register(vnh->vnh_neti, &vnh->vnh_family)) != 0) {
+		cmn_err(CE_NOTE, "%s: net_family_register failed "
+		    "(netid=%d name=%s err=%d)", __func__,
+		    nid, nh_name, ret);
+		goto fail_init_family;
+	}
+
+	HOOK_EVENT_INIT(&vnh->vnh_event_in, NH_PHYSICAL_IN);
+	if ((vnh->vnh_token_in = net_event_register(vnh->vnh_neti,
+	    &vnh->vnh_event_in)) == NULL) {
+		cmn_err(CE_NOTE, "%s: net_event_register %s failed "
+		    "(netid=%d name=%s)", __func__, NH_PHYSICAL_IN, nid,
+		    nh_name);
+		goto fail_init_event_in;
+	}
+
+	HOOK_EVENT_INIT(&vnh->vnh_event_out, NH_PHYSICAL_OUT);
+	if ((vnh->vnh_token_out = net_event_register(vnh->vnh_neti,
+	    &vnh->vnh_event_out)) == NULL) {
+		cmn_err(CE_NOTE, "%s: net_event_register %s failed "
+		    "(netid=%d name=%s)", __func__, NH_PHYSICAL_OUT, nid,
+		    nh_name);
+		goto fail_init_event_out;
+	}
+	return (0);
+
+	/*
+	 * On failure, we undo all the steps that succeeded in the
+	 * reverse order of initialization, starting at the last
+	 * successful step (the labels denoting the failing step).
+	 */
+fail_init_event_out:
+	VERIFY0(net_event_shutdown(vnh->vnh_neti, &vnh->vnh_event_in));
+	VERIFY0(net_event_unregister(vnh->vnh_neti, &vnh->vnh_event_in));
+	vnh->vnh_token_in = NULL;
+
+fail_init_event_in:
+	VERIFY0(net_family_shutdown(vnh->vnh_neti, &vnh->vnh_family));
+	VERIFY0(net_family_unregister(vnh->vnh_neti, &vnh->vnh_family));
+
+fail_init_family:
+	VERIFY0(net_protocol_unregister(vnh->vnh_neti));
+	vnh->vnh_neti = NULL;
+
+fail_init_proto:
+	return (1);
+}
+
+/*
+ * Shutdown the nethooks for a protocol family.  This triggers notification
+ * callbacks to anything that has registered interest to allow hook consumers
+ * to unhook prior to the removal of the hooks as well as makes them unavailable
+ * to any future consumers as the first step of removal.
+ */
+static void
+viona_nethook_shutdown(viona_nethook_t *vnh)
+{
+	VERIFY0(net_event_shutdown(vnh->vnh_neti, &vnh->vnh_event_out));
+	VERIFY0(net_event_shutdown(vnh->vnh_neti, &vnh->vnh_event_in));
+	VERIFY0(net_family_shutdown(vnh->vnh_neti, &vnh->vnh_family));
+}
+
+/*
+ * Remove the nethooks for a protocol family.
+ */
+static void
+viona_nethook_fini(viona_nethook_t *vnh)
+{
+	VERIFY0(net_event_unregister(vnh->vnh_neti, &vnh->vnh_event_out));
+	VERIFY0(net_event_unregister(vnh->vnh_neti, &vnh->vnh_event_in));
+	VERIFY0(net_family_unregister(vnh->vnh_neti, &vnh->vnh_family));
+	VERIFY0(net_protocol_unregister(vnh->vnh_neti));
+	vnh->vnh_neti = NULL;
+}
+
+/*
+ * Callback invoked by the neti module.  This creates/registers our hooks
+ * {IPv4,IPv6}{in,out} with the nethook framework so they are available to
+ * interested consumers (e.g. ipf).
+ *
+ * During attach, viona_neti_create is called once for every netstack
+ * present on the system at the time of attach.  Thereafter, it is called
+ * during the creation of additional netstack instances (i.e. zone boot).  As a
+ * result, the viona_neti_t that is created during this call always occurs
+ * prior to any viona instances that will use it to send hook events.
+ *
+ * It should never return NULL.  If we cannot register our hooks, we do not
+ * set vnh_hooked of the respective protocol family, which will prevent the
+ * creation of any viona instances on this netstack (see viona_ioc_create).
+ * This can only occur if after a shutdown event (which means destruction is
+ * imminent) we are trying to create a new instance.
+ */
+static void *
+viona_neti_create(const netid_t netid)
+{
+	viona_neti_t *nip;
+
+	VERIFY(netid != -1);
+
+	nip = kmem_zalloc(sizeof (*nip), KM_SLEEP);
+	nip->vni_netid = netid;
+	nip->vni_zid = net_getzoneidbynetid(netid);
+	mutex_init(&nip->vni_lock, NULL, MUTEX_DRIVER, NULL);
+	list_create(&nip->vni_dev_list, sizeof (viona_soft_state_t),
+	    offsetof(viona_soft_state_t, ss_node));
+
+	if (viona_nethook_init(netid, &nip->vni_nethook, Hn_VIONA,
+	    &viona_netinfo) == 0)
+		nip->vni_nethook.vnh_hooked = B_TRUE;
+
+	mutex_enter(&viona_neti_lock);
+	list_insert_tail(&viona_neti_list, nip);
+	mutex_exit(&viona_neti_lock);
+
+	return (nip);
+}
+
+/*
+ * Called during netstack teardown by the neti module.  During teardown, all
+ * the shutdown callbacks are invoked, allowing consumers to release any holds
+ * and otherwise quiesce themselves prior to destruction, followed by the
+ * actual destruction callbacks.
+ */
+static void
+viona_neti_shutdown(netid_t nid, void *arg)
+{
+	viona_neti_t *nip = arg;
+
+	ASSERT(nip != NULL);
+	VERIFY(nid == nip->vni_netid);
+
+	mutex_enter(&viona_neti_lock);
+	list_remove(&viona_neti_list, nip);
+	mutex_exit(&viona_neti_lock);
+
+	if (nip->vni_nethook.vnh_hooked)
+		viona_nethook_shutdown(&nip->vni_nethook);
+}
+
+/*
+ * Called during netstack teardown by the neti module.  Destroys the viona
+ * netinst data.  This is invoked after all the netstack and neti shutdown
+ * callbacks have been invoked.
+ */
+static void
+viona_neti_destroy(netid_t nid, void *arg)
+{
+	viona_neti_t *nip = arg;
+
+	ASSERT(nip != NULL);
+	VERIFY(nid == nip->vni_netid);
+
+	mutex_enter(&nip->vni_lock);
+	while (nip->vni_ref != 0)
+		cv_wait(&nip->vni_ref_change, &nip->vni_lock);
+	mutex_exit(&nip->vni_lock);
+
+	VERIFY(!list_link_active(&nip->vni_node));
+
+	if (nip->vni_nethook.vnh_hooked)
+		viona_nethook_fini(&nip->vni_nethook);
+
+	mutex_destroy(&nip->vni_lock);
+	list_destroy(&nip->vni_dev_list);
+	kmem_free(nip, sizeof (*nip));
+}
+
+/*
+ * Find the viona netinst data by zone id.  This is only used during
+ * viona instance creation (and thus is only called by a zone that is running).
+ */
+static viona_neti_t *
+viona_neti_lookup_by_zid(zoneid_t zid)
+{
+	viona_neti_t *nip;
+
+	mutex_enter(&viona_neti_lock);
+	for (nip = list_head(&viona_neti_list); nip != NULL;
+	    nip = list_next(&viona_neti_list, nip)) {
+		if (nip->vni_zid == zid) {
+			mutex_enter(&nip->vni_lock);
+			nip->vni_ref++;
+			mutex_exit(&nip->vni_lock);
+			mutex_exit(&viona_neti_lock);
+			return (nip);
+		}
+	}
+	mutex_exit(&viona_neti_lock);
+	return (NULL);
+}
+
+static void
+viona_neti_rele(viona_neti_t *nip)
+{
+	mutex_enter(&nip->vni_lock);
+	VERIFY3S(nip->vni_ref, >, 0);
+	nip->vni_ref--;
+	mutex_exit(&nip->vni_lock);
+	cv_broadcast(&nip->vni_ref_change);
 }

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -279,27 +279,36 @@
 #define	VIRTIO_NET_HDR_F_NEEDS_CSUM	(1 << 0)
 #define	VIRTIO_NET_HDR_F_DATA_VALID	(1 << 1)
 
+#define	VIRTIO_NET_HDR_GSO_NONE		0
+#define	VIRTIO_NET_HDR_GSO_TCPV4	1
 
 #define	VRING_AVAIL_F_NO_INTERRUPT	1
 
 #define	VRING_USED_F_NO_NOTIFY		1
 
 #define	BCM_NIC_DRIVER		"bnxe"
+
 /*
- * Host capabilities
+ * Feature bits. See section 5.1.3 of the VIRTIO 1.0 spec.
  */
-#define	VIRTIO_NET_F_CSUM	(1 <<  0)
-#define	VIRTIO_NET_F_GUEST_CSUM	(1 <<  1)
-#define	VIRTIO_NET_F_MAC	(1 <<  5) /* host supplies MAC */
+#define	VIRTIO_NET_F_CSUM	(1 << 0)
+#define	VIRTIO_NET_F_GUEST_CSUM	(1 << 1)
+#define	VIRTIO_NET_F_MAC	(1 << 5) /* host supplies MAC */
+#define	VIRTIO_NET_F_GUEST_TSO4	(1 << 7) /* guest can accept TSO */
+#define	VIRTIO_NET_F_HOST_TSO4	(1 << 11) /* host can accept TSO */
 #define	VIRTIO_NET_F_MRG_RXBUF	(1 << 15) /* host can merge RX buffers */
 #define	VIRTIO_NET_F_STATUS	(1 << 16) /* config status field available */
 #define	VIRTIO_F_RING_NOTIFY_ON_EMPTY	(1 << 24)
 #define	VIRTIO_F_RING_INDIRECT_DESC	(1 << 28)
 #define	VIRTIO_F_RING_EVENT_IDX		(1 << 29)
 
+/*
+ * Host capabilities.
+ */
 #define	VIONA_S_HOSTCAPS	(	\
 	VIRTIO_NET_F_GUEST_CSUM |	\
 	VIRTIO_NET_F_MAC |		\
+	VIRTIO_NET_F_GUEST_TSO4 |	\
 	VIRTIO_NET_F_MRG_RXBUF |	\
 	VIRTIO_NET_F_STATUS |		\
 	VIRTIO_F_RING_NOTIFY_ON_EMPTY |	\
@@ -891,6 +900,13 @@ viona_ioctl(dev_t dev, int cmd, intptr_t data, int md, cred_t *cr, int *rv)
 			break;
 		}
 		val &= (VIONA_S_HOSTCAPS | link->l_features_hw);
+
+		if ((val & VIRTIO_NET_F_CSUM) == 0)
+			val &= ~VIRTIO_NET_F_HOST_TSO4;
+
+		if ((val & VIRTIO_NET_F_GUEST_CSUM) == 0)
+			val &= ~VIRTIO_NET_F_GUEST_TSO4;
+
 		link->l_features = val;
 		break;
 	case VNA_IOC_RING_INIT:
@@ -963,6 +979,7 @@ viona_get_mac_capab(viona_link_t *link)
 {
 	mac_handle_t mh = link->l_mh;
 	uint32_t cap = 0;
+	mac_capab_lso_t lso_cap;
 
 	link->l_features_hw = 0;
 	if (mac_capab_get(mh, MAC_CAPAB_HCKSUM, &cap)) {
@@ -974,6 +991,19 @@ viona_get_mac_capab(viona_link_t *link)
 			link->l_features_hw |= VIRTIO_NET_F_CSUM;
 		}
 		link->l_cap_csum = cap;
+	}
+
+	if ((link->l_features_hw & VIRTIO_NET_F_CSUM) &&
+	    mac_capab_get(mh, MAC_CAPAB_LSO, &lso_cap)) {
+		/*
+		 * Virtio doesn't allow for negotiating a maximum LSO
+		 * packet size. We have to assume that the guest may
+		 * send a maximum length IP packet. Make sure the
+		 * underlying MAC can handle an LSO of this size.
+		 */
+		if ((lso_cap.lso_flags & LSO_TX_BASIC_TCP_IPV4) &&
+		    lso_cap.lso_basic_tcp_ipv4.lso_max >= IP_MAXPACKET)
+			link->l_features_hw |= VIRTIO_NET_F_HOST_TSO4;
 	}
 }
 
@@ -1981,6 +2011,7 @@ viona_recv_plain(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	size_t len, copied = 0;
 	caddr_t buf = NULL;
 	boolean_t end = B_FALSE;
+	const uint32_t features = ring->vr_link->l_features;
 
 	ASSERT(msz >= MIN_BUF_SIZE);
 
@@ -2035,8 +2066,14 @@ viona_recv_plain(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	copied += hdr_sz;
 
 	/* Add chksum bits, if needed */
-	if ((ring->vr_link->l_features & VIRTIO_NET_F_GUEST_CSUM) != 0) {
+	if ((features & VIRTIO_NET_F_GUEST_CSUM) != 0) {
 		uint32_t cksum_flags;
+
+		if (((features & VIRTIO_NET_F_GUEST_TSO4) != 0) &&
+		    ((DB_CKSUMFLAGS(mp) & HW_LSO) != 0)) {
+			hdr->vrh_gso_type |= VIRTIO_NET_HDR_GSO_TCPV4;
+			hdr->vrh_gso_size = DB_LSOMSS(mp);
+		}
 
 		mac_hcksum_get((mblk_t *)mp, NULL, NULL, NULL, NULL,
 		    &cksum_flags);
@@ -2070,6 +2107,7 @@ viona_recv_merged(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	struct virtio_net_mrgrxhdr *hdr = NULL;
 	const size_t hdr_sz = sizeof (struct virtio_net_mrgrxhdr);
 	boolean_t end = B_FALSE;
+	const uint32_t features = ring->vr_link->l_features;
 
 	ASSERT(msz >= MIN_BUF_SIZE);
 
@@ -2175,8 +2213,14 @@ viona_recv_merged(viona_vring_t *ring, const mblk_t *mp, size_t msz)
 	}
 
 	/* Add chksum bits, if needed */
-	if ((ring->vr_link->l_features & VIRTIO_NET_F_GUEST_CSUM) != 0) {
+	if ((features & VIRTIO_NET_F_GUEST_CSUM) != 0) {
 		uint32_t cksum_flags;
+
+		if (((features & VIRTIO_NET_F_GUEST_TSO4) != 0) &&
+		    ((DB_CKSUMFLAGS(mp) & HW_LSO) != 0)) {
+			hdr->vrh_gso_type |= VIRTIO_NET_HDR_GSO_TCPV4;
+			hdr->vrh_gso_size = DB_LSOMSS(mp);
+		}
 
 		mac_hcksum_get((mblk_t *)mp, NULL, NULL, NULL, NULL,
 		    &cksum_flags);
@@ -2221,7 +2265,28 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 	mblk_t *mpdrop = NULL, **mpdrop_prevp = &mpdrop;
 	const boolean_t do_merge =
 	    ((link->l_features & VIRTIO_NET_F_MRG_RXBUF) != 0);
+	const boolean_t guest_csum =
+	    ((link->l_features & VIRTIO_NET_F_GUEST_CSUM) != 0);
+	const boolean_t guest_tso4 =
+	    ((link->l_features & VIRTIO_NET_F_GUEST_TSO4) != 0);
+
 	size_t nrx = 0, ndrop = 0;
+
+	/*
+	 * The mac_hw_emul() function, by design, doesn't predicate on
+	 * HW_LOCAL_MAC. Since we are in Rx context we know that any
+	 * LSO packet must also be from a same-machine sender. We take
+	 * advantage of that and forgoe writing a manual loop to
+	 * predicate on HW_LOCAL_MAC.
+	 *
+	 * For checksum emulation we need to predicate on HW_LOCAL_MAC
+	 * to avoid calling mac_hw_emul() on packets that don't need
+	 * it (thanks to the fact that HCK_IPV4_HDRCKSUM and
+	 * HCK_IPV4_HDRCKSUM_OK use the same value). Therefore, we do
+	 * the checksum emulation in the second loop.
+	 */
+	if (!guest_tso4)
+		mac_hw_emul(&mp, NULL, NULL, MAC_LSO_EMUL);
 
 	while (mp != NULL) {
 		mblk_t *next, *pad = NULL;
@@ -2230,6 +2295,25 @@ viona_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp, boolean_t loopback)
 
 		next = mp->b_next;
 		mp->b_next = NULL;
+
+		if (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) {
+			/*
+			 * The VIRTIO_NET_HDR_F_DATA_VALID flag only
+			 * covers the ULP checksum -- so we still have
+			 * to populate the IP header checksum.
+			 */
+			if (guest_csum) {
+				mac_hw_emul(&mp, NULL, NULL, MAC_IPCKSUM_EMUL);
+			} else {
+				mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
+			}
+
+			if (mp == NULL) {
+				mp = next;
+				continue;
+			}
+		}
+
 		size = msgsize(mp);
 
 		/*
@@ -2416,14 +2500,22 @@ viona_tx_csum(viona_vring_t *ring, const struct virtio_net_hdr *hdr,
 	const struct ether_header *eth;
 	uint_t eth_len = sizeof (struct ether_header);
 	ushort_t ftype;
+	ipha_t *ipha = NULL;
+	uint8_t ipproto = IPPROTO_NONE; /* NONE is not exactly right, but ok */
+	uint16_t flags = 0;
 
-	eth = (const struct ether_header *)mp->b_rptr;
 	if (MBLKL(mp) < sizeof (*eth)) {
 		/* Buffers shorter than an ethernet header are hopeless */
 		return (B_FALSE);
 	}
 
+	/*
+	 * This is guaranteed to be safe thanks to the header copying
+	 * done in viona_tx().
+	 */
+	eth = (const struct ether_header *)mp->b_rptr;
 	ftype = ntohs(eth->ether_type);
+
 	if (ftype == ETHERTYPE_VLAN) {
 		const struct ether_vlan_header *veth;
 
@@ -2433,22 +2525,97 @@ viona_tx_csum(viona_vring_t *ring, const struct virtio_net_hdr *hdr,
 		ftype = ntohs(veth->ether_type);
 	}
 
+	if (ftype == ETHERTYPE_IP) {
+		ipha = (ipha_t *)(mp->b_rptr + eth_len);
+
+		ipproto = ipha->ipha_protocol;
+	} else if (ftype == ETHERTYPE_IPV6) {
+		ip6_t *ip6h = (ip6_t *)(mp->b_rptr + eth_len);
+
+		ipproto = ip6h->ip6_nxt;
+	}
+
+	/*
+	 * We ignore hdr_len because the spec says it can't be
+	 * trusted. Besides, our own stack will determine the header
+	 * boundary.
+	 */
+	if ((link->l_cap_csum & HCKSUM_INET_PARTIAL) != 0 &&
+	    (hdr->vrh_gso_type & VIRTIO_NET_HDR_GSO_TCPV4) != 0 &&
+	    ftype == ETHERTYPE_IP) {
+		uint16_t	*cksump;
+		uint32_t	cksum;
+		ipaddr_t	src = ipha->ipha_src;
+		ipaddr_t	dst = ipha->ipha_dst;
+
+		/*
+		 * Our native IP stack doesn't set the L4 length field
+		 * of the pseudo header when LSO is in play. Other IP
+		 * stacks, e.g. Linux, do include the length field.
+		 * This is a problem because the hardware expects that
+		 * the length field is not set. When it is set it will
+		 * cause an incorrect TCP checksum to be generated.
+		 * The reason this works in Linux is because Linux
+		 * corrects the pseudo-header checksum in the driver
+		 * code. In order to get the correct HW checksum we
+		 * need to assume the guest's IP stack gave us a bogus
+		 * TCP partial checksum and calculate it ourselves.
+		 */
+		cksump = IPH_TCPH_CHECKSUMP(ipha, IPH_HDR_LENGTH(ipha));
+		cksum = IP_TCP_CSUM_COMP;
+		cksum += (dst >> 16) + (dst & 0xFFFF) +
+		    (src >> 16) + (src & 0xFFFF);
+		cksum = (cksum & 0xFFFF) + (cksum >> 16);
+		*(cksump) = (cksum & 0xFFFF) + (cksum >> 16);
+
+		/*
+		 * Since viona is a "legacy device", the data stored
+		 * by the driver will be in the guest's native endian
+		 * format (see sections 2.4.3 and 5.1.6.1 of the
+		 * VIRTIO 1.0 spec for more info). At this time the
+		 * only guests using viona are x86 and we can assume
+		 * little-endian.
+		 */
+		lso_info_set(mp, LE_16(hdr->vrh_gso_size), HW_LSO);
+
+		/*
+		 * Hardware, like ixgbe, expects the client to request
+		 * IP header checksum offload if it's sending LSO (see
+		 * ixgbe_get_context()). Unfortunately, virtio makes
+		 * no allowances for negotiating IP header checksum
+		 * and HW offload, only TCP checksum. We add the flag
+		 * and zero-out the checksum field. This mirrors the
+		 * behavior of our native IP stack (which does this in
+		 * the interest of HW that expects the field to be
+		 * zero).
+		 */
+		flags |= HCK_IPV4_HDRCKSUM;
+		ipha->ipha_hdr_checksum = 0;
+	}
+
+	/*
+	 * Use DB_CKSUMFLAGS instead of mac_hcksum_get() to make sure
+	 * HW_LSO, if present, is not lost.
+	 */
+	flags |= DB_CKSUMFLAGS(mp);
+
 	/*
 	 * Partial checksum support from the NIC is ideal, since it most
 	 * closely maps to the interface defined by virtio.
 	 */
-	if ((link->l_cap_csum & HCKSUM_INET_PARTIAL) != 0) {
+	if ((link->l_cap_csum & HCKSUM_INET_PARTIAL) != 0 &&
+	    (ipproto == IPPROTO_TCP || ipproto == IPPROTO_UDP)) {
 		uint_t start, stuff, end;
 
 		/*
-		 * The lower-level driver is expecting these offsets to be
-		 * relative to the start of the L3 header rather than the
-		 * ethernet frame.
+		 * MAC expects these offsets to be relative to the
+		 * start of the L3 header rather than the L2 frame.
 		 */
 		start = hdr->vrh_csum_start - eth_len;
 		stuff = start + hdr->vrh_csum_offset;
 		end = len - eth_len;
-		mac_hcksum_set(mp, start, stuff, end, 0, HCK_PARTIALCKSUM);
+		flags |= HCK_PARTIALCKSUM;
+		mac_hcksum_set(mp, start, stuff, end, 0, flags);
 		return (B_TRUE);
 	}
 
@@ -2458,8 +2625,10 @@ viona_tx_csum(viona_vring_t *ring, const struct virtio_net_hdr *hdr,
 	 * checksum will need to calculated inline.
 	 */
 	if (ftype == ETHERTYPE_IP) {
-		if ((link->l_cap_csum & HCKSUM_INET_FULL_V4) != 0) {
-			mac_hcksum_set(mp, 0, 0, 0, 0, HCK_FULLCKSUM);
+		if ((link->l_cap_csum & HCKSUM_INET_FULL_V4) != 0 &&
+		    (ipproto == IPPROTO_TCP || ipproto == IPPROTO_UDP)) {
+			flags |= HCK_FULLCKSUM;
+			mac_hcksum_set(mp, 0, 0, 0, 0, flags);
 			return (B_TRUE);
 		}
 
@@ -2468,8 +2637,10 @@ viona_tx_csum(viona_vring_t *ring, const struct virtio_net_hdr *hdr,
 		VIONA_RING_STAT_INCR(ring, fail_hcksum);
 		return (B_FALSE);
 	} else if (ftype == ETHERTYPE_IPV6) {
-		if ((link->l_cap_csum & HCKSUM_INET_FULL_V6) != 0) {
-			mac_hcksum_set(mp, 0, 0, 0, 0, HCK_FULLCKSUM);
+		if ((link->l_cap_csum & HCKSUM_INET_FULL_V6) != 0 &&
+		    (ipproto == IPPROTO_TCP || ipproto == IPPROTO_UDP)) {
+			flags |= HCK_FULLCKSUM;
+			mac_hcksum_set(mp, 0, 0, 0, 0, flags);
 			return (B_TRUE);
 		}
 

--- a/usr/src/uts/i86pc/io/vmm/README.sync
+++ b/usr/src/uts/i86pc/io/vmm/README.sync
@@ -1,22 +1,18 @@
 The bhyve kernel module and its associated userland consumers have been updated
 to the latest upstream FreeBSD sources as of:
 
-commit 0fac2150fc0f1befa5803ca010ed63a6335847ad
-Author: grehan <grehan@FreeBSD.org>
-Date:   Fri May 4 01:36:49 2018 +0000
+commit f81459bd8363602ed5e436f10288320419e80ccf
+Author: andrew <andrew@FreeBSD.org>
+Date:   Thu Sep 27 11:16:19 2018 +0000
 
-    Allow arbitrary numbers of columns for VNC server screen resolution.
+    Handle a guest executing a vm instruction by trapping and raising an
+    undefined instruction exception. Previously we would exit the guest,
+    however an unprivileged user could execute these.
 
-    The prior code only allowed multiples of 32 for the
-    numbers of columns. Remove this restriction to allow
-    a forthcoming UEFI firmware update to allow arbitrary
-    x,y resolutions.
+    Found with:     syzkaller
+    Reviewed by:    araujo, tychon (previous version)
+    Approved by:    re (kib)
+    MFC after:      1 week
+    Differential Revision:  https://reviews.freebsd.org/D17192
 
-    (the code for handling rows already supported non mult-32 values)
-
-    Reviewed by:    Leon Dang (original author)
-    MFC after:      3 weeks
-    Differential Revision:  https://reviews.freebsd.org/D15274
-
-
-Which corresponds to SVN revision: 333235
+Which corresponds to SVN revision: 338957

--- a/usr/src/uts/i86pc/io/vmm/amd/amdvi_hw.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/amdvi_hw.c
@@ -1,0 +1,1461 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2016, Anish Gupta (anish@freebsd.org)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/malloc.h>
+#include <sys/pcpu.h>
+#include <sys/rman.h>
+#include <sys/smp.h>
+#include <sys/sysctl.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
+
+#include <dev/pci/pcivar.h>
+#include <dev/pci/pcireg.h>
+
+#include <machine/resource.h>
+#include <machine/vmm.h>
+#include <machine/pmap.h>
+#include <machine/vmparam.h>
+#include <machine/pci_cfgreg.h>
+
+#include "pcib_if.h"
+
+#include "io/iommu.h"
+#include "amdvi_priv.h"
+
+SYSCTL_DECL(_hw_vmm);
+SYSCTL_NODE(_hw_vmm, OID_AUTO, amdvi, CTLFLAG_RW, NULL, NULL);
+
+#define MOD_INC(a, s, m) (((a) + (s)) % ((m) * (s)))
+#define MOD_DEC(a, s, m) (((a) - (s)) % ((m) * (s)))
+
+/* Print RID or device ID in PCI string format. */
+#define RID2PCI_STR(d) PCI_RID2BUS(d), PCI_RID2SLOT(d), PCI_RID2FUNC(d)
+
+static void amdvi_dump_cmds(struct amdvi_softc *softc);
+static void amdvi_print_dev_cap(struct amdvi_softc *softc);
+
+MALLOC_DEFINE(M_AMDVI, "amdvi", "amdvi");
+
+extern device_t *ivhd_devs;
+
+extern int ivhd_count;
+SYSCTL_INT(_hw_vmm_amdvi, OID_AUTO, count, CTLFLAG_RDTUN, &ivhd_count,
+    0, NULL);
+
+static int amdvi_enable_user = 0;
+SYSCTL_INT(_hw_vmm_amdvi, OID_AUTO, enable, CTLFLAG_RDTUN,
+    &amdvi_enable_user, 0, NULL);
+TUNABLE_INT("hw.vmm.amdvi_enable", &amdvi_enable_user);
+
+#ifdef AMDVI_ATS_ENABLE
+/* XXX: ATS is not tested. */
+static int amdvi_enable_iotlb = 1;
+SYSCTL_INT(_hw_vmm_amdvi, OID_AUTO, iotlb_enabled, CTLFLAG_RDTUN,
+    &amdvi_enable_iotlb, 0, NULL);
+TUNABLE_INT("hw.vmm.enable_iotlb", &amdvi_enable_iotlb);
+#endif
+
+static int amdvi_host_ptp = 1;	/* Use page tables for host. */
+SYSCTL_INT(_hw_vmm_amdvi, OID_AUTO, host_ptp, CTLFLAG_RDTUN,
+    &amdvi_host_ptp, 0, NULL);
+TUNABLE_INT("hw.vmm.amdvi.host_ptp", &amdvi_host_ptp);
+
+/* Page table level used <= supported by h/w[v1=7]. */
+static int amdvi_ptp_level = 4;
+SYSCTL_INT(_hw_vmm_amdvi, OID_AUTO, ptp_level, CTLFLAG_RDTUN,
+    &amdvi_ptp_level, 0, NULL);
+TUNABLE_INT("hw.vmm.amdvi.ptp_level", &amdvi_ptp_level);
+
+/* Disable fault event reporting. */
+static int amdvi_disable_io_fault = 0;
+SYSCTL_INT(_hw_vmm_amdvi, OID_AUTO, disable_io_fault, CTLFLAG_RDTUN,
+    &amdvi_disable_io_fault, 0, NULL);
+TUNABLE_INT("hw.vmm.amdvi.disable_io_fault", &amdvi_disable_io_fault);
+
+static uint32_t amdvi_dom_id = 0;	/* 0 is reserved for host. */
+SYSCTL_UINT(_hw_vmm_amdvi, OID_AUTO, domain_id, CTLFLAG_RD,
+    &amdvi_dom_id, 0, NULL);
+/*
+ * Device table entry.
+ * Bus(256) x Dev(32) x Fun(8) x DTE(256 bits or 32 bytes).
+ *	= 256 * 2 * PAGE_SIZE.
+ */
+static struct amdvi_dte amdvi_dte[PCI_NUM_DEV_MAX] __aligned(PAGE_SIZE);
+CTASSERT(PCI_NUM_DEV_MAX == 0x10000);
+CTASSERT(sizeof(amdvi_dte) == 0x200000);
+
+static SLIST_HEAD (, amdvi_domain) dom_head;
+
+static inline uint32_t
+amdvi_pci_read(struct amdvi_softc *softc, int off)
+{
+
+	return (pci_cfgregread(PCI_RID2BUS(softc->pci_rid),
+	    PCI_RID2SLOT(softc->pci_rid), PCI_RID2FUNC(softc->pci_rid),
+	    off, 4));
+}
+
+#ifdef AMDVI_ATS_ENABLE
+/* XXX: Should be in pci.c */
+/*
+ * Check if device has ATS capability and its enabled.
+ * If ATS is absent or disabled, return (-1), otherwise ATS
+ * queue length.
+ */
+static int
+amdvi_find_ats_qlen(uint16_t devid)
+{
+	device_t dev;
+	uint32_t off, cap;
+	int qlen = -1;
+
+	dev = pci_find_bsf(PCI_RID2BUS(devid), PCI_RID2SLOT(devid),
+			   PCI_RID2FUNC(devid));
+
+	if (!dev) {
+		return (-1);
+	}
+#define PCIM_ATS_EN	BIT(31)
+
+	if (pci_find_extcap(dev, PCIZ_ATS, &off) == 0) {
+		cap = pci_read_config(dev, off + 4, 4);
+		qlen = (cap & 0x1F);
+		qlen = qlen ? qlen : 32;
+		printf("AMD-Vi: PCI device %d.%d.%d ATS %s qlen=%d\n",
+		       RID2PCI_STR(devid),
+		       (cap & PCIM_ATS_EN) ? "enabled" : "Disabled",
+		       qlen);
+		qlen = (cap & PCIM_ATS_EN) ? qlen : -1;
+	}
+
+	return (qlen);
+}
+
+/*
+ * Check if an endpoint device support device IOTLB or ATS.
+ */
+static inline bool
+amdvi_dev_support_iotlb(struct amdvi_softc *softc, uint16_t devid)
+{
+	struct ivhd_dev_cfg *cfg;
+	int qlen, i;
+	bool pci_ats, ivhd_ats;
+
+	qlen = amdvi_find_ats_qlen(devid);
+	if (qlen < 0)
+		return (false);
+
+	KASSERT(softc, ("softc is NULL"));
+	cfg = softc->dev_cfg;
+
+	ivhd_ats = false;
+	for (i = 0; i < softc->dev_cfg_cnt; i++) {
+		if ((cfg->start_id <= devid) && (cfg->end_id >= devid)) {
+			ivhd_ats = cfg->enable_ats;
+			break;
+		}
+		cfg++;
+	}
+
+	pci_ats = (qlen < 0) ? false : true;
+	if (pci_ats != ivhd_ats)
+		device_printf(softc->dev,
+		    "BIOS bug: mismatch in ATS setting for %d.%d.%d,"
+		    "ATS inv qlen = %d\n", RID2PCI_STR(devid), qlen);
+
+	/* Ignore IVRS setting and respect PCI setting. */
+	return (pci_ats);
+}
+#endif
+
+/* Enable IOTLB support for IOMMU if its supported. */
+static inline void
+amdvi_hw_enable_iotlb(struct amdvi_softc *softc)
+{
+#ifndef AMDVI_ATS_ENABLE
+	softc->iotlb = false;
+#else
+	bool supported;
+
+	supported = (softc->ivhd_flag & IVHD_FLAG_IOTLB) ? true : false;
+
+	if (softc->pci_cap & AMDVI_PCI_CAP_IOTLB) {
+		if (!supported)
+			device_printf(softc->dev, "IOTLB disabled by BIOS.\n");
+
+		if (supported && !amdvi_enable_iotlb) {
+			device_printf(softc->dev, "IOTLB disabled by user.\n");
+			supported = false;
+		}
+	} else
+		supported = false;
+
+	softc->iotlb = supported;
+
+#endif
+}
+
+static int
+amdvi_init_cmd(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl = softc->ctrl;
+
+	ctrl->cmd.len = 8;	/* Use 256 command buffer entries. */
+	softc->cmd_max = 1 << ctrl->cmd.len;
+
+	softc->cmd = malloc(sizeof(struct amdvi_cmd) *
+	    softc->cmd_max, M_AMDVI, M_WAITOK | M_ZERO);
+
+	if ((uintptr_t)softc->cmd & PAGE_MASK)
+		panic("AMDVi: Command buffer not aligned on page boundary.");
+
+	ctrl->cmd.base = vtophys(softc->cmd) / PAGE_SIZE;
+	/*
+	 * XXX: Reset the h/w pointers in case IOMMU is restarting,
+	 * h/w doesn't clear these pointers based on empirical data.
+	 */
+	ctrl->cmd_tail = 0;
+	ctrl->cmd_head = 0;
+
+	return (0);
+}
+
+/*
+ * Note: Update tail pointer after we have written the command since tail
+ * pointer update cause h/w to execute new commands, see section 3.3
+ * of AMD IOMMU spec ver 2.0.
+ */
+/* Get the command tail pointer w/o updating it. */
+static struct amdvi_cmd *
+amdvi_get_cmd_tail(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	struct amdvi_cmd *tail;
+
+	KASSERT(softc, ("softc is NULL"));
+	KASSERT(softc->cmd != NULL, ("cmd is NULL"));
+
+	ctrl = softc->ctrl;
+	KASSERT(ctrl != NULL, ("ctrl is NULL"));
+
+	tail = (struct amdvi_cmd *)((uint8_t *)softc->cmd +
+	    ctrl->cmd_tail);
+
+	return (tail);
+}
+
+/*
+ * Update the command tail pointer which will start command execution.
+ */
+static void
+amdvi_update_cmd_tail(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	int size;
+
+	size = sizeof(struct amdvi_cmd);
+	KASSERT(softc->cmd != NULL, ("cmd is NULL"));
+
+	ctrl = softc->ctrl;
+	KASSERT(ctrl != NULL, ("ctrl is NULL"));
+
+	ctrl->cmd_tail = MOD_INC(ctrl->cmd_tail, size, softc->cmd_max);
+	softc->total_cmd++;
+
+#ifdef AMDVI_DEBUG_CMD
+	device_printf(softc->dev, "cmd_tail: %s Tail:0x%x, Head:0x%x.\n",
+	    ctrl->cmd_tail,
+	    ctrl->cmd_head);
+#endif
+
+}
+
+/*
+ * Various commands supported by IOMMU.
+ */
+
+/* Completion wait command. */
+static void
+amdvi_cmd_cmp(struct amdvi_softc *softc, const uint64_t data)
+{
+	struct amdvi_cmd *cmd;
+	uint64_t pa;
+
+	cmd = amdvi_get_cmd_tail(softc);
+	KASSERT(cmd != NULL, ("Cmd is NULL"));
+
+	pa = vtophys(&softc->cmp_data);
+	cmd->opcode = AMDVI_CMP_WAIT_OPCODE;
+	cmd->word0 = (pa & 0xFFFFFFF8) |
+	    (AMDVI_CMP_WAIT_STORE);
+	//(AMDVI_CMP_WAIT_FLUSH | AMDVI_CMP_WAIT_STORE);
+	cmd->word1 = (pa >> 32) & 0xFFFFF;
+	cmd->addr = data;
+
+	amdvi_update_cmd_tail(softc);
+}
+
+/* Invalidate device table entry. */
+static void
+amdvi_cmd_inv_dte(struct amdvi_softc *softc, uint16_t devid)
+{
+	struct amdvi_cmd *cmd;
+
+	cmd = amdvi_get_cmd_tail(softc);
+	KASSERT(cmd != NULL, ("Cmd is NULL"));
+	cmd->opcode = AMDVI_INVD_DTE_OPCODE;
+	cmd->word0 = devid;
+	amdvi_update_cmd_tail(softc);
+#ifdef AMDVI_DEBUG_CMD
+	device_printf(softc->dev, "Invalidated DTE:0x%x\n", devid);
+#endif
+}
+
+/* Invalidate IOMMU page, use for invalidation of domain. */
+static void
+amdvi_cmd_inv_iommu_pages(struct amdvi_softc *softc, uint16_t domain_id,
+			  uint64_t addr, bool guest_nested,
+			  bool pde, bool page)
+{
+	struct amdvi_cmd *cmd;
+
+	cmd = amdvi_get_cmd_tail(softc);
+	KASSERT(cmd != NULL, ("Cmd is NULL"));
+
+
+	cmd->opcode = AMDVI_INVD_PAGE_OPCODE;
+	cmd->word1 = domain_id;
+	/*
+	 * Invalidate all addresses for this domain.
+	 */
+	cmd->addr = addr;
+	cmd->addr |= pde ? AMDVI_INVD_PAGE_PDE : 0;
+	cmd->addr |= page ? AMDVI_INVD_PAGE_S : 0;
+
+	amdvi_update_cmd_tail(softc);
+}
+
+#ifdef AMDVI_ATS_ENABLE
+/* Invalidate device IOTLB. */
+static void
+amdvi_cmd_inv_iotlb(struct amdvi_softc *softc, uint16_t devid)
+{
+	struct amdvi_cmd *cmd;
+	int qlen;
+
+	if (!softc->iotlb)
+		return;
+
+	qlen = amdvi_find_ats_qlen(devid);
+	if (qlen < 0) {
+		panic("AMDVI: Invalid ATS qlen(%d) for device %d.%d.%d\n",
+		      qlen, RID2PCI_STR(devid));
+	}
+	cmd = amdvi_get_cmd_tail(softc);
+	KASSERT(cmd != NULL, ("Cmd is NULL"));
+
+#ifdef AMDVI_DEBUG_CMD
+	device_printf(softc->dev, "Invalidate IOTLB devID 0x%x"
+		      " Qlen:%d\n", devid, qlen);
+#endif
+	cmd->opcode = AMDVI_INVD_IOTLB_OPCODE;
+	cmd->word0 = devid;
+	cmd->word1 = qlen;
+	cmd->addr = AMDVI_INVD_IOTLB_ALL_ADDR |
+		AMDVI_INVD_IOTLB_S;
+	amdvi_update_cmd_tail(softc);
+}
+#endif
+
+#ifdef notyet				/* For Interrupt Remap. */
+static void
+amdvi_cmd_inv_intr_map(struct amdvi_softc *softc,
+		       uint16_t devid)
+{
+	struct amdvi_cmd *cmd;
+
+	cmd = amdvi_get_cmd_tail(softc);
+	KASSERT(cmd != NULL, ("Cmd is NULL"));
+	cmd->opcode = AMDVI_INVD_INTR_OPCODE;
+	cmd->word0 = devid;
+	amdvi_update_cmd_tail(softc);
+#ifdef AMDVI_DEBUG_CMD
+	device_printf(softc->dev, "Invalidate INTR map of devID 0x%x\n", devid);
+#endif
+}
+#endif
+
+/* Invalidate domain using INVALIDATE_IOMMU_PAGES command. */
+static void
+amdvi_inv_domain(struct amdvi_softc *softc, uint16_t domain_id)
+{
+	struct amdvi_cmd *cmd;
+
+	cmd = amdvi_get_cmd_tail(softc);
+	KASSERT(cmd != NULL, ("Cmd is NULL"));
+
+	/*
+	 * See section 3.3.3 of IOMMU spec rev 2.0, software note
+	 * for invalidating domain.
+	 */
+	amdvi_cmd_inv_iommu_pages(softc, domain_id, AMDVI_INVD_PAGE_ALL_ADDR,
+				false, true, true);
+
+#ifdef AMDVI_DEBUG_CMD
+	device_printf(softc->dev, "Invalidate domain:0x%x\n", domain_id);
+
+#endif
+}
+
+static	bool
+amdvi_cmp_wait(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	const uint64_t VERIFY = 0xA5A5;
+	volatile uint64_t *read;
+	int i;
+	bool status;
+
+	ctrl = softc->ctrl;
+	read = &softc->cmp_data;
+	*read = 0;
+	amdvi_cmd_cmp(softc, VERIFY);
+	/* Wait for h/w to update completion data. */
+	for (i = 0; i < 100 && (*read != VERIFY); i++) {
+		DELAY(1000);		/* 1 ms */
+	}
+	status = (VERIFY == softc->cmp_data) ? true : false;
+
+#ifdef AMDVI_DEBUG_CMD
+	if (status)
+		device_printf(softc->dev, "CMD completion DONE Tail:0x%x, "
+			      "Head:0x%x, loop:%d.\n", ctrl->cmd_tail,
+			      ctrl->cmd_head, loop);
+#endif
+	return (status);
+}
+
+static void
+amdvi_wait(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	int i;
+
+	KASSERT(softc, ("softc is NULL"));
+
+	ctrl = softc->ctrl;
+	KASSERT(ctrl != NULL, ("ctrl is NULL"));
+	/* Don't wait if h/w is not enabled. */
+	if ((ctrl->control & AMDVI_CTRL_EN) == 0)
+		return;
+
+	for (i = 0; i < 10; i++) {
+		if (amdvi_cmp_wait(softc))
+			return;
+	}
+
+	device_printf(softc->dev, "Error: completion failed"
+		      " tail:0x%x, head:0x%x.\n",
+		      ctrl->cmd_tail, ctrl->cmd_head);
+	amdvi_dump_cmds(softc);
+}
+
+static void
+amdvi_dump_cmds(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	struct amdvi_cmd *cmd;
+	int off, i;
+
+	ctrl = softc->ctrl;
+	device_printf(softc->dev, "Dump all the commands:\n");
+	/*
+	 * If h/w is stuck in completion, it is the previous command,
+	 * start dumping from previous command onward.
+	 */
+	off = MOD_DEC(ctrl->cmd_head, sizeof(struct amdvi_cmd),
+	    softc->cmd_max);
+	for (i = 0; off != ctrl->cmd_tail &&
+	    i < softc->cmd_max; i++) {
+		cmd = (struct amdvi_cmd *)((uint8_t *)softc->cmd + off);
+		printf("  [CMD%d, off:0x%x] opcode= 0x%x 0x%x"
+		    " 0x%x 0x%lx\n", i, off, cmd->opcode,
+		    cmd->word0, cmd->word1, cmd->addr);
+		off = (off + sizeof(struct amdvi_cmd)) %
+		    (softc->cmd_max * sizeof(struct amdvi_cmd));
+	}
+}
+
+static int
+amdvi_init_event(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+
+	ctrl = softc->ctrl;
+	ctrl->event.len = 8;
+	softc->event_max = 1 << ctrl->event.len;
+	softc->event = malloc(sizeof(struct amdvi_event) *
+	    softc->event_max, M_AMDVI, M_WAITOK | M_ZERO);
+	if ((uintptr_t)softc->event & PAGE_MASK) {
+		device_printf(softc->dev, "Event buffer not aligned on page.");
+		return (false);
+	}
+	ctrl->event.base = vtophys(softc->event) / PAGE_SIZE;
+
+	/* Reset the pointers. */
+	ctrl->evt_head = 0;
+	ctrl->evt_tail = 0;
+
+	return (0);
+}
+
+static inline void
+amdvi_decode_evt_flag(uint16_t flag)
+{
+
+	flag &= AMDVI_EVENT_FLAG_MASK;
+	printf(" 0x%b]\n", flag,
+		"\020"
+		"\001GN"
+		"\002NX"
+		"\003US"
+		"\004I"
+		"\005PR"
+		"\006RW"
+		"\007PE"
+		"\010RZ"
+		"\011TR"
+		);
+}
+
+/* See section 2.5.4 of AMD IOMMU spec ver 2.62.*/
+static inline void
+amdvi_decode_evt_flag_type(uint8_t type)
+{
+
+	switch (AMDVI_EVENT_FLAG_TYPE(type)) {
+	case 0:
+		printf("RSVD\n");
+		break;
+	case 1:
+		printf("Master Abort\n");
+		break;
+	case 2:
+		printf("Target Abort\n");
+		break;
+	case 3:
+		printf("Data Err\n");
+		break;
+	default:
+		break;
+	}
+}
+
+static void
+amdvi_decode_inv_dte_evt(uint16_t devid, uint16_t domid, uint64_t addr,
+    uint16_t flag)
+{
+
+	printf("\t[IO_PAGE_FAULT EVT: devId:0x%x DomId:0x%x"
+	    " Addr:0x%lx",
+	    devid, domid, addr);
+	amdvi_decode_evt_flag(flag);
+}
+
+static void
+amdvi_decode_pf_evt(uint16_t devid, uint16_t domid, uint64_t addr,
+    uint16_t flag)
+{
+
+	printf("\t[IO_PAGE_FAULT EVT: devId:0x%x DomId:0x%x"
+	    " Addr:0x%lx",
+	    devid, domid, addr);
+	amdvi_decode_evt_flag(flag);
+}
+
+static void
+amdvi_decode_dte_hwerr_evt(uint16_t devid, uint16_t domid,
+    uint64_t addr, uint16_t flag)
+{
+
+	printf("\t[DEV_TAB_HW_ERR EVT: devId:0x%x DomId:0x%x"
+	    " Addr:0x%lx", devid, domid, addr);
+	amdvi_decode_evt_flag(flag);
+	amdvi_decode_evt_flag_type(flag);
+}
+
+static void
+amdvi_decode_page_hwerr_evt(uint16_t devid, uint16_t domid, uint64_t addr,
+    uint16_t flag)
+{
+
+	printf("\t[PAGE_TAB_HW_ERR EVT: devId:0x%x DomId:0x%x"
+	    " Addr:0x%lx", devid, domid, addr);
+	amdvi_decode_evt_flag(flag);
+	amdvi_decode_evt_flag_type(AMDVI_EVENT_FLAG_TYPE(flag));
+}
+
+static void
+amdvi_decode_evt(struct amdvi_event *evt)
+{
+	struct amdvi_cmd *cmd;
+
+	switch (evt->opcode) {
+	case AMDVI_EVENT_INVALID_DTE:
+		amdvi_decode_inv_dte_evt(evt->devid, evt->pasid_domid,
+		    evt->addr, evt->flag);
+		break;
+
+	case AMDVI_EVENT_PFAULT:
+		amdvi_decode_pf_evt(evt->devid, evt->pasid_domid,
+		    evt->addr, evt->flag);
+		break;
+
+	case AMDVI_EVENT_DTE_HW_ERROR:
+		amdvi_decode_dte_hwerr_evt(evt->devid, evt->pasid_domid,
+		    evt->addr, evt->flag);
+		break;
+
+	case AMDVI_EVENT_PAGE_HW_ERROR:
+		amdvi_decode_page_hwerr_evt(evt->devid, evt->pasid_domid,
+		    evt->addr, evt->flag);
+		break;
+
+	case AMDVI_EVENT_ILLEGAL_CMD:
+		/* FALL THROUGH */
+	case AMDVI_EVENT_CMD_HW_ERROR:
+		printf("\t[%s EVT]\n", (evt->opcode == AMDVI_EVENT_ILLEGAL_CMD) ?
+		    "ILLEGAL CMD" : "CMD HW ERR");
+		cmd = (struct amdvi_cmd *)PHYS_TO_DMAP(evt->addr);
+		printf("\tCMD opcode= 0x%x 0x%x 0x%x 0x%lx\n",
+		    cmd->opcode, cmd->word0, cmd->word1, cmd->addr);
+		break;
+
+	case AMDVI_EVENT_IOTLB_TIMEOUT:
+		printf("\t[IOTLB_INV_TIMEOUT devid:0x%x addr:0x%lx]\n",
+		    evt->devid, evt->addr);
+		break;
+
+	case AMDVI_EVENT_INVALID_DTE_REQ:
+		printf("\t[INV_DTE devid:0x%x addr:0x%lx type:0x%x tr:%d]\n",
+		    evt->devid, evt->addr, evt->flag >> 9,
+		    (evt->flag >> 8) & 1);
+		break;
+
+	case AMDVI_EVENT_INVALID_PPR_REQ:
+	case AMDVI_EVENT_COUNTER_ZERO:
+		printf("AMD-Vi: v2 events.\n");
+		break;
+
+	default:
+		printf("Unsupported AMD-Vi event:%d\n", evt->opcode);
+	}
+}
+
+static void
+amdvi_print_events(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	struct amdvi_event *event;
+	int i, size;
+
+	ctrl = softc->ctrl;
+	size = sizeof(struct amdvi_event);
+	for (i = 0; i < softc->event_max; i++) {
+		event = &softc->event[ctrl->evt_head / size];
+		if (!event->opcode)
+			break;
+		device_printf(softc->dev, "\t[Event%d: Head:0x%x Tail:0x%x]\n",
+		    i, ctrl->evt_head, ctrl->evt_tail);
+		amdvi_decode_evt(event);
+		ctrl->evt_head = MOD_INC(ctrl->evt_head, size,
+		    softc->event_max);
+	}
+}
+
+static int
+amdvi_init_dte(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+
+	ctrl = softc->ctrl;
+	ctrl->dte.base = vtophys(amdvi_dte) / PAGE_SIZE;
+	ctrl->dte.size = 0x1FF;		/* 2MB device table. */
+
+	return (0);
+}
+
+/*
+ * Not all capabilities of IOMMU are available in ACPI IVHD flag
+ * or EFR entry, read directly from device.
+ */
+static int
+amdvi_print_pci_cap(device_t dev)
+{
+	struct amdvi_softc *softc;
+	uint32_t off, cap;
+
+
+	softc = device_get_softc(dev);
+	off = softc->cap_off;
+
+	/*
+	 * Section 3.7.1 of IOMMU sepc rev 2.0.
+	 * Read capability from device.
+	 */
+	cap = amdvi_pci_read(softc, off);
+
+	/* Make sure capability type[18:16] is 3. */
+	KASSERT((((cap >> 16) & 0x7) == 0x3),
+	    ("Not a IOMMU capability 0x%x@0x%x", cap, off));
+
+	softc->pci_cap = cap >> 24;
+	device_printf(softc->dev, "PCI cap 0x%x@0x%x feature:%b\n",
+	    cap, off, softc->pci_cap,
+	    "\20\1IOTLB\2HT\3NPCache\4EFR\5CapExt");
+
+	return (0);
+}
+
+static void
+amdvi_event_intr(void *arg)
+{
+	struct amdvi_softc *softc;
+	struct amdvi_ctrl *ctrl;
+
+	softc = (struct amdvi_softc *)arg;
+	ctrl = softc->ctrl;
+	device_printf(softc->dev, "EVT INTR %ld Status:0x%x"
+	    " EVT Head:0x%x Tail:0x%x]\n", softc->event_intr_cnt++,
+	    ctrl->status, ctrl->evt_head, ctrl->evt_tail);
+	printf("  [CMD Total 0x%lx] Tail:0x%x, Head:0x%x.\n",
+	    softc->total_cmd, ctrl->cmd_tail, ctrl->cmd_head);
+
+	amdvi_print_events(softc);
+	ctrl->status &= AMDVI_STATUS_EV_OF | AMDVI_STATUS_EV_INTR;
+}
+
+static void
+amdvi_free_evt_intr_res(device_t dev)
+{
+
+	struct amdvi_softc *softc;
+
+	softc = device_get_softc(dev);
+	if (softc->event_tag != NULL) {
+		bus_teardown_intr(dev, softc->event_res, softc->event_tag);
+	}
+	if (softc->event_res != NULL) {
+		bus_release_resource(dev, SYS_RES_IRQ, softc->event_rid,
+		    softc->event_res);
+	}
+	bus_delete_resource(dev, SYS_RES_IRQ, softc->event_rid);
+	PCIB_RELEASE_MSI(device_get_parent(device_get_parent(dev)),
+	    dev, 1, &softc->event_irq);
+}
+
+static bool
+amdvi_alloc_intr_resources(struct amdvi_softc *softc)
+{
+	struct amdvi_ctrl *ctrl;
+	device_t dev, pcib;
+	device_t mmio_dev;
+	uint64_t msi_addr;
+	uint32_t msi_data;
+	int err;
+
+	dev = softc->dev;
+	pcib = device_get_parent(device_get_parent(dev));
+	mmio_dev = pci_find_bsf(PCI_RID2BUS(softc->pci_rid),
+            PCI_RID2SLOT(softc->pci_rid), PCI_RID2FUNC(softc->pci_rid));
+	if (device_is_attached(mmio_dev)) {
+		device_printf(dev,
+		    "warning: IOMMU device is claimed by another driver %s\n",
+		    device_get_driver(mmio_dev)->name);
+	}
+
+	softc->event_irq = -1;
+	softc->event_rid = 0;
+
+	/*
+	 * Section 3.7.1 of IOMMU rev 2.0. With MSI, there is only one
+	 * interrupt. XXX: Enable MSI/X support.
+	 */
+	err = PCIB_ALLOC_MSI(pcib, dev, 1, 1, &softc->event_irq);
+	if (err) {
+		device_printf(dev,
+		    "Couldn't find event MSI IRQ resource.\n");
+		return (ENOENT);
+	}
+
+	err = bus_set_resource(dev, SYS_RES_IRQ, softc->event_rid,
+	    softc->event_irq, 1);
+	if (err) {
+		device_printf(dev, "Couldn't set event MSI resource.\n");
+		return (ENXIO);
+	}
+
+	softc->event_res = bus_alloc_resource_any(dev, SYS_RES_IRQ,
+	    &softc->event_rid, RF_ACTIVE);
+	if (!softc->event_res) {
+		device_printf(dev,
+		    "Unable to allocate event INTR resource.\n");
+		return (ENOMEM);
+	}
+
+	if (bus_setup_intr(dev, softc->event_res,
+	    INTR_TYPE_MISC | INTR_MPSAFE, NULL, amdvi_event_intr,
+	    softc, &softc->event_tag)) {
+		device_printf(dev, "Fail to setup event intr\n");
+		bus_release_resource(softc->dev, SYS_RES_IRQ,
+		    softc->event_rid, softc->event_res);
+		softc->event_res = NULL;
+		return (ENXIO);
+	}
+
+	bus_describe_intr(dev, softc->event_res, softc->event_tag,
+	    "fault");
+
+	err = PCIB_MAP_MSI(pcib, dev, softc->event_irq, &msi_addr,
+	    &msi_data);
+	if (err) {
+		device_printf(dev,
+		    "Event interrupt config failed, err=%d.\n",
+		    err);
+		amdvi_free_evt_intr_res(softc->dev);
+		return (err);
+	}
+
+	/* Clear interrupt status bits. */
+	ctrl = softc->ctrl;
+	ctrl->status &= AMDVI_STATUS_EV_OF | AMDVI_STATUS_EV_INTR;
+
+	/* Now enable MSI interrupt. */
+	pci_enable_msi(mmio_dev, msi_addr, msi_data);
+	return (0);
+}
+
+
+static void
+amdvi_print_dev_cap(struct amdvi_softc *softc)
+{
+	struct ivhd_dev_cfg *cfg;
+	int i;
+
+	cfg = softc->dev_cfg;
+	for (i = 0; i < softc->dev_cfg_cnt; i++) {
+		device_printf(softc->dev, "device [0x%x - 0x%x]"
+		    "config:%b%s\n", cfg->start_id, cfg->end_id,
+		    cfg->data,
+		    "\020\001INIT\002ExtInt\003NMI"
+		    "\007LINT0\008LINT1",
+		    cfg->enable_ats ? "ATS enabled" : "");
+		cfg++;
+	}
+}
+
+static int
+amdvi_handle_sysctl(SYSCTL_HANDLER_ARGS)
+{
+	struct amdvi_softc *softc;
+	int result, type, error = 0;
+
+	softc = (struct amdvi_softc *)arg1;
+	type = arg2;
+
+	switch (type) {
+	case 0:
+		result = softc->ctrl->cmd_head;
+		error = sysctl_handle_int(oidp, &result, 0,
+		    req);
+		break;
+	case 1:
+		result = softc->ctrl->cmd_tail;
+		error = sysctl_handle_int(oidp, &result, 0,
+		    req);
+		break;
+	case 2:
+		result = softc->ctrl->evt_head;
+		error = sysctl_handle_int(oidp, &result, 0,
+		    req);
+		break;
+	case 3:
+		result = softc->ctrl->evt_tail;
+		error = sysctl_handle_int(oidp, &result, 0,
+		    req);
+		break;
+
+	default:
+		device_printf(softc->dev, "Unknown sysctl:%d\n", type);
+	}
+
+	return (error);
+}
+
+static void
+amdvi_add_sysctl(struct amdvi_softc *softc)
+{
+	struct sysctl_oid_list *child;
+	struct sysctl_ctx_list *ctx;
+	device_t dev;
+
+	dev = softc->dev;
+	ctx = device_get_sysctl_ctx(dev);
+	child = SYSCTL_CHILDREN(device_get_sysctl_tree(dev));
+
+	SYSCTL_ADD_ULONG(ctx, child, OID_AUTO, "event_intr_count", CTLFLAG_RD,
+	    &softc->event_intr_cnt, "Event interrupt count");
+	SYSCTL_ADD_ULONG(ctx, child, OID_AUTO, "command_count", CTLFLAG_RD,
+	    &softc->total_cmd, "Command submitted count");
+	SYSCTL_ADD_U16(ctx, child, OID_AUTO, "pci_rid", CTLFLAG_RD,
+	    &softc->pci_rid, 0, "IOMMU RID");
+	SYSCTL_ADD_U16(ctx, child, OID_AUTO, "start_dev_rid", CTLFLAG_RD,
+	    &softc->start_dev_rid, 0, "Start of device under this IOMMU");
+	SYSCTL_ADD_U16(ctx, child, OID_AUTO, "end_dev_rid", CTLFLAG_RD,
+	    &softc->end_dev_rid, 0, "End of device under this IOMMU");
+	SYSCTL_ADD_PROC(ctx, child, OID_AUTO, "command_head",
+	    CTLTYPE_UINT | CTLFLAG_RD, softc, 0,
+	    amdvi_handle_sysctl, "IU", "Command head");
+	SYSCTL_ADD_PROC(ctx, child, OID_AUTO, "command_tail",
+	    CTLTYPE_UINT | CTLFLAG_RD, softc, 1,
+	    amdvi_handle_sysctl, "IU", "Command tail");
+	SYSCTL_ADD_PROC(ctx, child, OID_AUTO, "event_head",
+	    CTLTYPE_UINT | CTLFLAG_RD, softc, 2,
+	    amdvi_handle_sysctl, "IU", "Command head");
+	SYSCTL_ADD_PROC(ctx, child, OID_AUTO, "event_tail",
+	    CTLTYPE_UINT | CTLFLAG_RD, softc, 3,
+	    amdvi_handle_sysctl, "IU", "Command tail");
+}
+
+int
+amdvi_setup_hw(struct amdvi_softc *softc)
+{
+	device_t dev;
+	int status;
+
+	dev = softc->dev;
+
+	amdvi_hw_enable_iotlb(softc);
+
+	amdvi_print_dev_cap(softc);
+
+	if ((status = amdvi_print_pci_cap(dev)) != 0) {
+		device_printf(dev, "PCI capability.\n");
+		return (status);
+	}
+	if ((status = amdvi_init_cmd(softc)) != 0) {
+		device_printf(dev, "Couldn't configure command buffer.\n");
+		return (status);
+	}
+	if ((status = amdvi_init_event(softc)) != 0) {
+		device_printf(dev, "Couldn't configure event buffer.\n");
+		return (status);
+	}
+	if ((status = amdvi_init_dte(softc)) != 0) {
+		device_printf(dev, "Couldn't configure device table.\n");
+		return (status);
+	}
+	if ((status = amdvi_alloc_intr_resources(softc)) != 0) {
+		return (status);
+	}
+	amdvi_add_sysctl(softc);
+	return (0);
+}
+
+int
+amdvi_teardown_hw(struct amdvi_softc *softc)
+{
+	device_t dev;
+
+	dev = softc->dev;
+
+	/* 
+	 * Called after disable, h/w is stopped by now, free all the resources. 
+	 */
+	amdvi_free_evt_intr_res(dev);
+
+	if (softc->cmd)
+		free(softc->cmd, M_AMDVI);
+
+	if (softc->event)
+		free(softc->event, M_AMDVI);
+
+	return (0);
+}
+
+/*********** bhyve interfaces *********************/
+static int
+amdvi_init(void)
+{
+	if (!ivhd_count) {
+		return (EIO);
+	}
+	if (!amdvi_enable_user && ivhd_count) {
+		printf("bhyve: Found %d AMD-Vi/IOMMU device(s), "
+		    	"use hw.vmm.amdvi.enable=1 to enable pass-through.\n",
+		    ivhd_count);
+		return (EINVAL);
+	}
+	return (0);
+}
+
+static void
+amdvi_cleanup(void)
+{
+	/* Nothing. */
+}
+
+static uint16_t
+amdvi_domainId(void)
+{
+
+	/*
+	 * If we hit maximum domain limit, rollover leaving host
+	 * domain(0).
+	 * XXX: make sure that this domain is not used.
+	 */
+	if (amdvi_dom_id == AMDVI_MAX_DOMAIN)
+		amdvi_dom_id = 1;
+
+	return ((uint16_t)amdvi_dom_id++);
+}
+
+static void
+amdvi_do_inv_domain(uint16_t domain_id, bool create)
+{
+	struct amdvi_softc *softc;
+	int i;
+
+	for (i = 0; i < ivhd_count; i++) {
+		softc = device_get_softc(ivhd_devs[i]);
+		KASSERT(softc, ("softc is NULL"));
+		/*
+		 * If not present pages are cached, invalidate page after
+		 * creating domain.
+		 */
+#if 0
+		if (create && ((softc->pci_cap & AMDVI_PCI_CAP_NPCACHE) == 0))
+			continue;
+#endif
+		amdvi_inv_domain(softc, domain_id);
+		amdvi_wait(softc);
+	}
+}
+
+static void *
+amdvi_create_domain(vm_paddr_t maxaddr)
+{
+	struct amdvi_domain *dom;
+
+	dom = malloc(sizeof(struct amdvi_domain), M_AMDVI, M_ZERO | M_WAITOK);
+	dom->id = amdvi_domainId();
+	//dom->maxaddr = maxaddr;
+#ifdef AMDVI_DEBUG_CMD
+	printf("Created domain #%d\n", dom->id);
+#endif
+	/*
+	 * Host domain(#0) don't create translation table.
+	 */
+	if (dom->id || amdvi_host_ptp)
+		dom->ptp = malloc(PAGE_SIZE, M_AMDVI, M_WAITOK | M_ZERO);
+
+	dom->ptp_level = amdvi_ptp_level;
+
+	amdvi_do_inv_domain(dom->id, true);
+	SLIST_INSERT_HEAD(&dom_head, dom, next);
+
+	return (dom);
+}
+
+static void
+amdvi_free_ptp(uint64_t *ptp, int level)
+{
+	int i;
+
+	if (level < 1)
+		return;
+
+	for (i = 0; i < NPTEPG ; i++) {
+		if ((ptp[i] & AMDVI_PT_PRESENT) == 0)
+			continue;
+		/* XXX: Add super-page or PTE mapping > 4KB. */
+#ifdef notyet
+		/* Super-page mapping. */
+		if (AMDVI_PD_SUPER(ptp[i]))
+			continue;
+#endif
+
+		amdvi_free_ptp((uint64_t *)PHYS_TO_DMAP(ptp[i]
+		    & AMDVI_PT_MASK), level - 1);
+
+	}
+
+	free(ptp, M_AMDVI);
+}
+
+static void
+amdvi_destroy_domain(void *arg)
+{
+	struct amdvi_domain *domain;
+
+	domain = (struct amdvi_domain *)arg;
+	KASSERT(domain, ("domain is NULL"));
+#ifdef AMDVI_DEBUG_CMD
+	printf("Destroying domain %d\n", domain->id);
+#endif
+	if (domain->ptp)
+		amdvi_free_ptp(domain->ptp, domain->ptp_level);
+
+	amdvi_do_inv_domain(domain->id, false);
+	SLIST_REMOVE(&dom_head, domain, amdvi_domain, next);
+	free(domain, M_AMDVI);
+}
+
+static uint64_t
+amdvi_set_pt(uint64_t *pt, int level, vm_paddr_t gpa,
+    vm_paddr_t hpa, uint64_t pg_size, bool create)
+{
+	uint64_t *page, pa;
+	int shift, index;
+	const int PT_SHIFT = 9;
+	const int PT_INDEX_MASK = (1 << PT_SHIFT) - 1;	/* Based on PT_SHIFT */
+
+	if (!pg_size)
+		return (0);
+
+	if (hpa & (pg_size - 1)) {
+		printf("HPA is not size aligned.\n");
+		return (0);
+	}
+	if (gpa & (pg_size - 1)) {
+		printf("HPA is not size aligned.\n");
+		return (0);
+	}
+	shift = PML4SHIFT;
+	while ((shift > PAGE_SHIFT) && (pg_size < (1UL << shift))) {
+		index = (gpa >> shift) & PT_INDEX_MASK;
+
+		if ((pt[index] == 0) && create) {
+			page = malloc(PAGE_SIZE, M_AMDVI, M_WAITOK | M_ZERO);
+			pa = vtophys(page);
+			pt[index] = pa | AMDVI_PT_PRESENT | AMDVI_PT_RW |
+			    ((level - 1) << AMDVI_PD_LEVEL_SHIFT);
+		}
+#ifdef AMDVI_DEBUG_PTE
+		if ((gpa % 0x1000000) == 0)
+			printf("[level%d, shift = %d]PTE:0x%lx\n",
+			    level, shift, pt[index]);
+#endif
+#define PTE2PA(x)	((uint64_t)(x) & AMDVI_PT_MASK)
+		pa = PTE2PA(pt[index]);
+		pt = (uint64_t *)PHYS_TO_DMAP(pa);
+		shift -= PT_SHIFT;
+		level--;
+	}
+
+	/* Leaf entry. */
+	index = (gpa >> shift) & PT_INDEX_MASK;
+
+	if (create) {
+		pt[index] = hpa | AMDVI_PT_RW | AMDVI_PT_PRESENT;
+	} else
+		pt[index] = 0;
+
+#ifdef AMDVI_DEBUG_PTE
+	if ((gpa % 0x1000000) == 0)
+		printf("[Last level%d, shift = %d]PTE:0x%lx\n",
+		    level, shift, pt[index]);
+#endif
+	return (1ULL << shift);
+}
+
+static uint64_t
+amdvi_update_mapping(struct amdvi_domain *domain, vm_paddr_t gpa,
+    vm_paddr_t hpa, uint64_t size, bool create)
+{
+	uint64_t mapped, *ptp, len;
+	int level;
+
+	KASSERT(domain, ("domain is NULL"));
+	level = domain->ptp_level;
+	KASSERT(level, ("Page table level is 0"));
+
+	ptp = domain->ptp;
+	KASSERT(ptp, ("PTP is NULL"));
+	mapped = 0;
+	while (mapped < size) {
+		len = amdvi_set_pt(ptp, level, gpa + mapped, hpa + mapped,
+		    PAGE_SIZE, create);
+		if (!len) {
+			printf("Error: Couldn't map HPA:0x%lx GPA:0x%lx\n",
+			    hpa, gpa);
+			return (0);
+		}
+		mapped += len;
+	}
+
+	return (mapped);
+}
+
+static uint64_t
+amdvi_create_mapping(void *arg, vm_paddr_t gpa, vm_paddr_t hpa,
+    uint64_t len)
+{
+	struct amdvi_domain *domain;
+
+	domain = (struct amdvi_domain *)arg;
+
+	if (domain->id && !domain->ptp) {
+		printf("ptp is NULL");
+		return (-1);
+	}
+
+	/*
+	 * If host domain is created w/o page table, skip IOMMU page
+	 * table set-up.
+	 */
+	if (domain->ptp)
+		return (amdvi_update_mapping(domain, gpa, hpa, len, true));
+	else
+		return (len);
+}
+
+static uint64_t
+amdvi_destroy_mapping(void *arg, vm_paddr_t gpa, uint64_t len)
+{
+	struct amdvi_domain *domain;
+
+	domain = (struct amdvi_domain *)arg;
+	/*
+	 * If host domain is created w/o page table, skip IOMMU page
+	 * table set-up.
+	 */
+	if (domain->ptp)
+		return (amdvi_update_mapping(domain, gpa, 0, len, false));
+	return
+	    (len);
+}
+
+static struct amdvi_softc *
+amdvi_find_iommu(uint16_t devid)
+{
+	struct amdvi_softc *softc;
+	int i;
+
+	for (i = 0; i < ivhd_count; i++) {
+		softc = device_get_softc(ivhd_devs[i]);
+		if ((devid >= softc->start_dev_rid) &&
+		    (devid <= softc->end_dev_rid))
+			return (softc);
+	}
+
+	/*
+	 * XXX: BIOS bug, device not in IVRS table, assume its from first IOMMU.
+	 */
+	printf("BIOS bug device(%d.%d.%d) doesn't have IVHD entry.\n",
+	    RID2PCI_STR(devid));
+
+	return (device_get_softc(ivhd_devs[0]));
+}
+
+/*
+ * Set-up device table entry.
+ * IOMMU spec Rev 2.0, section 3.2.2.2, some of the fields must
+ * be set concurrently, e.g. read and write bits.
+ */
+static void
+amdvi_set_dte(struct amdvi_domain *domain, uint16_t devid, bool enable)
+{
+	struct amdvi_softc *softc;
+	struct amdvi_dte* temp;
+
+	KASSERT(domain, ("domain is NULL for pci_rid:0x%x\n", devid));
+	
+	softc = amdvi_find_iommu(devid);
+	KASSERT(softc, ("softc is NULL for pci_rid:0x%x\n", devid));
+
+	temp = &amdvi_dte[devid];
+
+#ifdef AMDVI_ATS_ENABLE
+	/* If IOMMU and device support IOTLB, enable it. */
+	if (amdvi_dev_support_iotlb(softc, devid) && softc->iotlb)
+		temp->iotlb_enable = 1;
+#endif
+
+	/* Avoid duplicate I/O faults. */
+	temp->sup_second_io_fault = 1;
+	temp->sup_all_io_fault = amdvi_disable_io_fault;
+
+	temp->dt_valid = 1;
+	temp->domain_id = domain->id;
+
+	if (enable) {
+		if (domain->ptp) {
+			temp->pt_base = vtophys(domain->ptp) >> 12;
+			temp->pt_level = amdvi_ptp_level;
+		}
+		/*
+		 * XXX: Page table valid[TV] bit must be set even if host domain
+		 * page tables are not enabled.
+		 */
+		temp->pt_valid = 1;
+		temp->read_allow = 1;
+		temp->write_allow = 1;
+	}
+}
+
+static void
+amdvi_inv_device(uint16_t devid)
+{
+	struct amdvi_softc *softc;
+
+	softc = amdvi_find_iommu(devid);
+	KASSERT(softc, ("softc is NULL"));
+
+	amdvi_cmd_inv_dte(softc, devid);
+#ifdef AMDVI_ATS_ENABLE
+	if (amdvi_dev_support_iotlb(softc, devid))
+		amdvi_cmd_inv_iotlb(softc, devid);
+#endif
+	amdvi_wait(softc);
+}
+
+static void
+amdvi_add_device(void *arg, uint16_t devid)
+{
+	struct amdvi_domain *domain;
+
+	domain = (struct amdvi_domain *)arg;
+	KASSERT(domain != NULL, ("domain is NULL"));
+#ifdef AMDVI_DEBUG_CMD
+	printf("Assigning device(%d.%d.%d) to domain:%d\n",
+	    RID2PCI_STR(devid), domain->id);
+#endif
+	amdvi_set_dte(domain, devid, true);
+	amdvi_inv_device(devid);
+}
+
+static void
+amdvi_remove_device(void *arg, uint16_t devid)
+{
+	struct amdvi_domain *domain;
+
+	domain = (struct amdvi_domain *)arg;
+#ifdef AMDVI_DEBUG_CMD
+	printf("Remove device(0x%x) from domain:%d\n",
+	       devid, domain->id);
+#endif
+	amdvi_set_dte(domain, devid, false);
+	amdvi_inv_device(devid);
+}
+
+static void
+amdvi_enable(void)
+{
+	struct amdvi_ctrl *ctrl;
+	struct amdvi_softc *softc;
+	uint64_t val;
+	int i;
+
+	for (i = 0; i < ivhd_count; i++) {
+		softc = device_get_softc(ivhd_devs[i]);
+		KASSERT(softc, ("softc is NULL\n"));
+		ctrl = softc->ctrl;
+		KASSERT(ctrl, ("ctrl is NULL\n"));
+
+		val = (	AMDVI_CTRL_EN 		|
+			AMDVI_CTRL_CMD 		|
+		    	AMDVI_CTRL_ELOG 	|
+		    	AMDVI_CTRL_ELOGINT 	|
+		    	AMDVI_CTRL_INV_TO_1S);
+
+		if (softc->ivhd_flag & IVHD_FLAG_COH)
+			val |= AMDVI_CTRL_COH;
+		if (softc->ivhd_flag & IVHD_FLAG_HTT)
+			val |= AMDVI_CTRL_HTT;
+		if (softc->ivhd_flag & IVHD_FLAG_RPPW)
+			val |= AMDVI_CTRL_RPPW;
+		if (softc->ivhd_flag & IVHD_FLAG_PPW)
+			val |= AMDVI_CTRL_PPW;
+		if (softc->ivhd_flag & IVHD_FLAG_ISOC)
+			val |= AMDVI_CTRL_ISOC;
+
+		ctrl->control = val;
+	}
+}
+
+static void
+amdvi_disable(void)
+{
+	struct amdvi_ctrl *ctrl;
+	struct amdvi_softc *softc;
+	int i;
+
+	for (i = 0; i < ivhd_count; i++) {
+		softc = device_get_softc(ivhd_devs[i]);
+		KASSERT(softc, ("softc is NULL\n"));
+		ctrl = softc->ctrl;
+		KASSERT(ctrl, ("ctrl is NULL\n"));
+
+		ctrl->control = 0;
+	}
+}
+
+static void
+amdvi_inv_tlb(void *arg)
+{
+	struct amdvi_domain *domain;
+
+	domain = (struct amdvi_domain *)arg;
+	KASSERT(domain, ("domain is NULL"));
+	amdvi_do_inv_domain(domain->id, false);
+}
+
+struct iommu_ops iommu_ops_amd = {
+	amdvi_init,
+	amdvi_cleanup,
+	amdvi_enable,
+	amdvi_disable,
+	amdvi_create_domain,
+	amdvi_destroy_domain,
+	amdvi_create_mapping,
+	amdvi_destroy_mapping,
+	amdvi_add_device,
+	amdvi_remove_device,
+	amdvi_inv_tlb
+};

--- a/usr/src/uts/i86pc/io/vmm/amd/amdvi_priv.h
+++ b/usr/src/uts/i86pc/io/vmm/amd/amdvi_priv.h
@@ -1,0 +1,431 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2016 Anish Gupta (anish@freebsd.org)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _AMDVI_PRIV_H_
+#define _AMDVI_PRIV_H_
+
+#include <contrib/dev/acpica/include/acpi.h>
+
+#define	BIT(n)			(1ULL << (n))
+/* Return value of bits[n:m] where n and (n >= ) m are bit positions. */
+#define REG_BITS(x, n, m)	(((x) >> (m)) & 		\
+				((1 << (((n) - (m)) + 1)) - 1))
+
+/*
+ * IOMMU PCI capability.
+ */
+#define AMDVI_PCI_CAP_IOTLB	BIT(0)	/* IOTLB is supported. */
+#define AMDVI_PCI_CAP_HT	BIT(1)	/* HyperTransport tunnel support. */
+#define AMDVI_PCI_CAP_NPCACHE	BIT(2)	/* Not present page cached. */
+#define AMDVI_PCI_CAP_EFR	BIT(3)	/* Extended features. */
+#define AMDVI_PCI_CAP_EXT	BIT(4)	/* Miscellaneous information reg. */
+
+/*
+ * IOMMU extended features.
+ */
+#define AMDVI_EX_FEA_PREFSUP	BIT(0)	/* Prefetch command support. */
+#define AMDVI_EX_FEA_PPRSUP	BIT(1)	/* PPR support */
+#define AMDVI_EX_FEA_XTSUP	BIT(2)	/* Reserved */
+#define AMDVI_EX_FEA_NXSUP	BIT(3)	/* No-execute. */
+#define AMDVI_EX_FEA_GTSUP	BIT(4)	/* Guest translation support. */
+#define AMDVI_EX_FEA_EFRW	BIT(5)	/* Reserved */
+#define AMDVI_EX_FEA_IASUP	BIT(6)	/* Invalidate all command supp. */
+#define AMDVI_EX_FEA_GASUP	BIT(7)	/* Guest APIC or AVIC support. */
+#define AMDVI_EX_FEA_HESUP	BIT(8)	/* Hardware Error. */
+#define AMDVI_EX_FEA_PCSUP	BIT(9)	/* Performance counters support. */
+/* XXX: add more EFER bits. */
+
+/*
+ * Device table entry or DTE
+ * NOTE: Must be 256-bits/32 bytes aligned.
+ */
+struct amdvi_dte {
+	uint32_t dt_valid:1;		/* Device Table valid. */
+	uint32_t pt_valid:1;		/* Page translation valid. */
+	uint16_t :7;			/* Reserved[8:2] */
+	uint8_t	 pt_level:3;		/* Paging level, 0 to disable. */
+	uint64_t pt_base:40;		/* Page table root pointer. */
+	uint8_t  :3;			/* Reserved[54:52] */
+	uint8_t	 gv_valid:1;		/* Revision 2, GVA to SPA. */
+	uint8_t	 gv_level:2;		/* Revision 2, GLX level. */
+	uint8_t	 gv_cr3_lsb:3;		/* Revision 2, GCR3[14:12] */
+	uint8_t	 read_allow:1;		/* I/O read enabled. */
+	uint8_t	 write_allow:1;		/* I/O write enabled. */
+	uint8_t  :1;			/* Reserved[63] */
+	uint16_t domain_id:16;		/* Domain ID */
+	uint16_t gv_cr3_lsb2:16;	/* Revision 2, GCR3[30:15] */
+	uint8_t	 iotlb_enable:1;	/* Device support IOTLB */
+	uint8_t	 sup_second_io_fault:1;	/* Suppress subsequent I/O faults. */
+	uint8_t	 sup_all_io_fault:1;	/* Suppress all I/O page faults. */
+	uint8_t	 IOctl:2;		/* Port I/O control. */
+	uint8_t	 iotlb_cache_disable:1;	/* IOTLB cache hints. */
+	uint8_t	 snoop_disable:1;	/* Snoop disable. */
+	uint8_t	 allow_ex:1;		/* Allow exclusion. */
+	uint8_t	 sysmgmt:2;		/* System management message.*/
+	uint8_t  :1;			/* Reserved[106] */
+	uint32_t gv_cr3_msb:21;		/* Revision 2, GCR3[51:31] */
+	uint8_t	 intmap_valid:1;	/* Interrupt map valid. */
+	uint8_t	 intmap_len:4;		/* Interrupt map table length. */
+	uint8_t	 intmap_ign:1;		/* Ignore unmapped interrupts. */
+	uint64_t intmap_base:46;	/* IntMap base. */
+	uint8_t  :4;			/* Reserved[183:180] */
+	uint8_t	 init_pass:1;		/* INIT pass through or PT */
+	uint8_t	 extintr_pass:1;	/* External Interrupt PT */
+	uint8_t	 nmi_pass:1;		/* NMI PT */
+	uint8_t  :1;			/* Reserved[187] */
+	uint8_t	 intr_ctrl:2;		/* Interrupt control */
+	uint8_t	 lint0_pass:1;		/* LINT0 PT */
+	uint8_t	 lint1_pass:1;		/* LINT1 PT */
+	uint64_t :64;			/* Reserved[255:192] */
+} __attribute__((__packed__));
+CTASSERT(sizeof(struct amdvi_dte) == 32);
+
+/*
+ * IOMMU command entry.
+ */
+struct amdvi_cmd {
+	uint32_t 	word0;
+	uint32_t 	word1:28;
+	uint8_t		opcode:4;
+	uint64_t 	addr;
+} __attribute__((__packed__));
+
+/* Command opcodes. */
+#define AMDVI_CMP_WAIT_OPCODE	0x1	/* Completion wait. */
+#define AMDVI_INVD_DTE_OPCODE	0x2	/* Invalidate device table entry. */
+#define AMDVI_INVD_PAGE_OPCODE	0x3	/* Invalidate pages. */
+#define AMDVI_INVD_IOTLB_OPCODE	0x4	/* Invalidate IOTLB pages. */
+#define AMDVI_INVD_INTR_OPCODE	0x5	/* Invalidate Interrupt table. */
+#define AMDVI_PREFETCH_PAGES_OPCODE	0x6	/* Prefetch IOMMU pages. */
+#define AMDVI_COMP_PPR_OPCODE	0x7	/* Complete PPR request. */
+#define AMDVI_INV_ALL_OPCODE	0x8	/* Invalidate all. */
+
+/* Completion wait attributes. */
+#define AMDVI_CMP_WAIT_STORE	BIT(0)	/* Write back data. */
+#define AMDVI_CMP_WAIT_INTR	BIT(1)	/* Completion wait interrupt. */
+#define AMDVI_CMP_WAIT_FLUSH	BIT(2)	/* Flush queue. */
+
+/* Invalidate page. */
+#define AMDVI_INVD_PAGE_S	BIT(0)	/* Invalidation size. */
+#define AMDVI_INVD_PAGE_PDE	BIT(1)	/* Invalidate PDE. */
+#define AMDVI_INVD_PAGE_GN_GVA	BIT(2)	/* GPA or GVA. */
+
+#define AMDVI_INVD_PAGE_ALL_ADDR	(0x7FFFFFFFFFFFFULL << 12)
+
+/* Invalidate IOTLB. */
+#define AMDVI_INVD_IOTLB_S	BIT(0)	/* Invalidation size 4k or addr */
+#define AMDVI_INVD_IOTLB_GN_GVA	BIT(2)	/* GPA or GVA. */
+
+#define AMDVI_INVD_IOTLB_ALL_ADDR	(0x7FFFFFFFFFFFFULL << 12)
+/* XXX: add more command entries. */
+
+/*
+ * IOMMU event entry.
+ */
+struct amdvi_event {
+	uint16_t 	devid;
+	uint16_t 	pasid_hi;
+	uint16_t 	pasid_domid;	/* PASID low or DomainID */
+	uint16_t 	flag:12;
+	uint8_t		opcode:4;
+	uint64_t 	addr;
+} __attribute__((__packed__));
+CTASSERT(sizeof(struct amdvi_event) == 16);
+
+/* Various event types. */
+#define AMDVI_EVENT_INVALID_DTE		0x1
+#define AMDVI_EVENT_PFAULT		0x2
+#define AMDVI_EVENT_DTE_HW_ERROR	0x3
+#define AMDVI_EVENT_PAGE_HW_ERROR	0x4
+#define AMDVI_EVENT_ILLEGAL_CMD		0x5
+#define AMDVI_EVENT_CMD_HW_ERROR	0x6
+#define AMDVI_EVENT_IOTLB_TIMEOUT	0x7
+#define AMDVI_EVENT_INVALID_DTE_REQ	0x8
+#define AMDVI_EVENT_INVALID_PPR_REQ	0x9
+#define AMDVI_EVENT_COUNTER_ZERO	0xA
+
+#define AMDVI_EVENT_FLAG_MASK           0x1FF	/* Mask for event flags. */
+#define AMDVI_EVENT_FLAG_TYPE(x)        (((x) >> 9) & 0x3)
+
+/*
+ * IOMMU control block.
+ */
+struct amdvi_ctrl {
+	struct {
+		uint16_t size:9;
+		uint16_t :3;
+		uint64_t base:40;	/* Devtable register base. */
+		uint16_t :12;
+	} dte;
+	struct {
+		uint16_t :12;
+		uint64_t base:40;
+		uint8_t  :4;
+		uint8_t	 len:4;
+		uint8_t  :4;
+	} cmd;
+	struct {
+		uint16_t :12;
+		uint64_t base:40;
+		uint8_t  :4;
+		uint8_t	 len:4;
+		uint8_t  :4;
+	} event;
+	uint16_t control :13;
+	uint64_t	 :51;
+	struct {
+		uint8_t	 enable:1;
+		uint8_t	 allow:1;
+		uint16_t :10;
+		uint64_t base:40;
+		uint16_t :12;
+		uint16_t :12;
+		uint64_t limit:40;
+		uint16_t :12;
+	} excl;
+	/* 
+	 * Revision 2 only. 
+	 */
+	uint64_t ex_feature;
+	struct {
+		uint16_t :12;
+		uint64_t base:40;
+		uint8_t  :4;
+		uint8_t	 len:4;
+		uint8_t  :4;
+	} ppr;
+	uint64_t first_event;
+	uint64_t second_event;
+	uint64_t event_status;
+	/* Revision 2 only, end. */
+	uint8_t	 pad1[0x1FA8];		/* Padding. */
+	uint32_t cmd_head:19;
+	uint64_t :45;
+	uint32_t cmd_tail:19;
+	uint64_t :45;
+	uint32_t evt_head:19;
+	uint64_t :45;
+	uint32_t evt_tail:19;
+	uint64_t :45;
+	uint32_t status:19;
+	uint64_t :45;
+	uint64_t pad2;
+	uint8_t  :4;
+	uint16_t ppr_head:15;
+	uint64_t :45;
+	uint8_t  :4;
+	uint16_t ppr_tail:15;
+	uint64_t :45;
+	uint8_t	 pad3[0x1FC0];		/* Padding. */
+
+	/* XXX: More for rev2. */
+} __attribute__((__packed__));
+CTASSERT(offsetof(struct amdvi_ctrl, pad1)== 0x58);
+CTASSERT(offsetof(struct amdvi_ctrl, pad2)== 0x2028);
+CTASSERT(offsetof(struct amdvi_ctrl, pad3)== 0x2040);
+
+#define AMDVI_MMIO_V1_SIZE	(4 * PAGE_SIZE)	/* v1 size */
+/* 
+ * AMF IOMMU v2 size including event counters 
+ */
+#define AMDVI_MMIO_V2_SIZE	(8 * PAGE_SIZE)
+
+CTASSERT(sizeof(struct amdvi_ctrl) == 0x4000);
+CTASSERT(sizeof(struct amdvi_ctrl) == AMDVI_MMIO_V1_SIZE);
+
+/* IVHD flag */
+#define IVHD_FLAG_HTT		BIT(0)	/* Hypertransport Tunnel. */
+#define IVHD_FLAG_PPW		BIT(1)	/* Pass posted write. */
+#define IVHD_FLAG_RPPW		BIT(2)	/* Response pass posted write. */
+#define IVHD_FLAG_ISOC		BIT(3)	/* Isoc support. */
+#define IVHD_FLAG_IOTLB		BIT(4)	/* IOTLB support. */
+#define IVHD_FLAG_COH		BIT(5)	/* Coherent control, default 1 */
+#define IVHD_FLAG_PFS		BIT(6)	/* Prefetch IOMMU pages. */
+#define IVHD_FLAG_PPRS		BIT(7)	/* Peripheral page support. */
+
+/* IVHD device entry data setting. */
+#define IVHD_DEV_LINT0_PASS	BIT(6)	/* LINT0 interrupts. */
+#define IVHD_DEV_LINT1_PASS	BIT(7)	/* LINT1 interrupts. */
+
+/* Bit[5:4] for System Mgmt. Bit3 is reserved. */
+#define IVHD_DEV_INIT_PASS	BIT(0)	/* INIT */
+#define IVHD_DEV_EXTINTR_PASS	BIT(1)	/* ExtInt */
+#define IVHD_DEV_NMI_PASS	BIT(2)	/* NMI */
+
+/* IVHD 8-byte extended data settings. */
+#define IVHD_DEV_EXT_ATS_DISABLE	BIT(31)	/* Disable ATS */
+
+/* IOMMU control register. */
+#define AMDVI_CTRL_EN		BIT(0)	/* IOMMU enable. */
+#define AMDVI_CTRL_HTT		BIT(1)	/* Hypertransport tunnel enable. */
+#define AMDVI_CTRL_ELOG		BIT(2)	/* Event log enable. */
+#define AMDVI_CTRL_ELOGINT	BIT(3)	/* Event log interrupt. */
+#define AMDVI_CTRL_COMINT	BIT(4)	/* Completion wait interrupt. */
+#define AMDVI_CTRL_PPW		BIT(8)
+#define AMDVI_CTRL_RPPW		BIT(9)
+#define AMDVI_CTRL_COH		BIT(10)
+#define AMDVI_CTRL_ISOC		BIT(11)
+#define AMDVI_CTRL_CMD		BIT(12)	/* Command buffer enable. */
+#define AMDVI_CTRL_PPRLOG	BIT(13)
+#define AMDVI_CTRL_PPRINT	BIT(14)
+#define AMDVI_CTRL_PPREN	BIT(15)
+#define AMDVI_CTRL_GTE		BIT(16)	/* Guest translation enable. */
+#define AMDVI_CTRL_GAE		BIT(17)	/* Guest APIC enable. */
+
+/* Invalidation timeout. */
+#define AMDVI_CTRL_INV_NO_TO	0	/* No timeout. */
+#define AMDVI_CTRL_INV_TO_1ms	1	/* 1 ms */
+#define AMDVI_CTRL_INV_TO_10ms	2	/* 10 ms */
+#define AMDVI_CTRL_INV_TO_100ms	3	/* 100 ms */
+#define AMDVI_CTRL_INV_TO_1S	4	/* 1 second */
+#define AMDVI_CTRL_INV_TO_10S	5	/* 10 second */
+#define AMDVI_CTRL_INV_TO_100S	6	/* 100 second */
+
+/*
+ * Max number of PCI devices.
+ * 256 bus x 32 slot/devices x 8 functions.
+ */
+#define PCI_NUM_DEV_MAX		0x10000
+
+/* Maximum number of domains supported by IOMMU. */
+#define AMDVI_MAX_DOMAIN	(BIT(16) - 1)
+
+/*
+ * IOMMU Page Table attributes.
+ */
+#define AMDVI_PT_PRESENT	BIT(0)
+#define AMDVI_PT_COHERENT	BIT(60)
+#define AMDVI_PT_READ		BIT(61)
+#define AMDVI_PT_WRITE		BIT(62)
+
+#define AMDVI_PT_RW		(AMDVI_PT_READ | AMDVI_PT_WRITE)
+#define AMDVI_PT_MASK		0xFFFFFFFFFF000UL /* Only [51:12] for PA */
+
+#define AMDVI_PD_LEVEL_SHIFT	9
+#define AMDVI_PD_SUPER(x)	(((x) >> AMDVI_PD_LEVEL_SHIFT) == 7)
+/*
+ * IOMMU Status, offset 0x2020
+ */
+#define AMDVI_STATUS_EV_OF		BIT(0)	/* Event overflow. */
+#define AMDVI_STATUS_EV_INTR		BIT(1)	/* Event interrupt. */
+/* Completion wait command completed. */
+#define AMDVI_STATUS_CMP		BIT(2)
+
+#define	IVRS_CTRL_RID			1	/* MMIO RID */
+
+/* ACPI IVHD */
+struct ivhd_dev_cfg {
+	uint32_t start_id;
+	uint32_t end_id;
+	uint8_t	 data;			/* Device configuration. */
+	bool	 enable_ats;		/* ATS enabled for the device. */
+	int	 ats_qlen;		/* ATS invalidation queue depth. */
+};
+
+struct amdvi_domain {
+	uint64_t *ptp;			/* Highest level page table */
+	int	ptp_level;		/* Level of page tables */
+	u_int	id;			/* Domain id */
+	SLIST_ENTRY (amdvi_domain) next;
+};
+
+/*
+ * I/O Virtualization Hardware Definition Block (IVHD) type 0x10 (legacy)
+ * uses ACPI_IVRS_HARDWARE define in contrib/dev/acpica/include/actbl2.h
+ * New IVHD types 0x11 and 0x40 as defined in AMD IOMMU spec[48882] are missing in
+ * ACPI code. These new types add extra field EFR(Extended Feature Register).
+ * XXX : Use definition from ACPI when it is available.
+ */
+typedef struct acpi_ivrs_hardware_efr_sup
+{
+	ACPI_IVRS_HEADER Header;
+	UINT16 CapabilityOffset;   /* Offset for IOMMU control fields */
+	UINT64 BaseAddress;        /* IOMMU control registers */
+	UINT16 PciSegmentGroup;
+	UINT16 Info;               /* MSI number and unit ID */
+	UINT32 Attr;               /* IOMMU Feature */
+	UINT64 ExtFR;              /* IOMMU Extended Feature */
+	UINT64 Reserved;           /* v1 feature or v2 attribute */
+} __attribute__ ((__packed__)) ACPI_IVRS_HARDWARE_EFRSUP;
+CTASSERT(sizeof(ACPI_IVRS_HARDWARE_EFRSUP) == 40);
+
+/*
+ * Different type of IVHD.
+ * XXX: Use AcpiIvrsType once new IVHD types are available.
+*/
+enum IvrsType
+{
+	IVRS_TYPE_HARDWARE_LEGACY = 0x10, /* Legacy without EFRi support. */
+	IVRS_TYPE_HARDWARE_EFR 	  = 0x11, /* With EFR support. */
+	IVRS_TYPE_HARDWARE_MIXED  = 0x40, /* Mixed with EFR support. */
+};
+
+/*
+ * AMD IOMMU softc.
+ */
+struct amdvi_softc {
+	struct amdvi_ctrl *ctrl;	/* Control area. */
+	device_t 	dev;		/* IOMMU device. */
+	enum IvrsType   ivhd_type;	/* IOMMU IVHD type. */
+	bool		iotlb;		/* IOTLB supported by IOMMU */
+	struct amdvi_cmd *cmd;		/* Command descriptor area. */
+	int 		cmd_max;	/* Max number of commands. */
+	uint64_t	cmp_data;	/* Command completion write back. */
+	struct amdvi_event *event;	/* Event descriptor area. */
+	struct resource *event_res;	/* Event interrupt resource. */
+	void   		*event_tag;	/* Event interrupt tag. */
+	int		event_max;	/* Max number of events. */
+	int		event_irq;
+	int		event_rid;
+	/* ACPI various flags. */
+	uint32_t 	ivhd_flag;	/* ACPI IVHD flag. */
+	uint32_t 	ivhd_feature;	/* ACPI v1 Reserved or v2 attribute. */
+	uint64_t 	ext_feature;	/* IVHD EFR */
+	/* PCI related. */
+	uint16_t 	cap_off;	/* PCI Capability offset. */
+	uint8_t		pci_cap;	/* PCI capability. */
+	uint16_t 	pci_seg;	/* IOMMU PCI domain/segment. */
+	uint16_t 	pci_rid;	/* PCI BDF of IOMMU */
+	/* Device range under this IOMMU. */
+	uint16_t 	start_dev_rid;	/* First device under this IOMMU. */
+	uint16_t 	end_dev_rid;	/* Last device under this IOMMU. */
+
+	/* BIOS provided device configuration for end points. */
+	struct 		ivhd_dev_cfg dev_cfg[10];
+	int		dev_cfg_cnt;
+
+	/* Software statistics. */
+	uint64_t 	event_intr_cnt;	/* Total event INTR count. */
+	uint64_t 	total_cmd;	/* Total number of commands. */
+};
+
+int	amdvi_setup_hw(struct amdvi_softc *softc);
+int	amdvi_teardown_hw(struct amdvi_softc *softc);
+#endif /* _AMDVI_PRIV_H_ */

--- a/usr/src/uts/i86pc/io/vmm/amd/ivrs_drv.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/ivrs_drv.c
@@ -1,0 +1,735 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2016, Anish Gupta (anish@freebsd.org)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include "opt_acpi.h"
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/malloc.h>
+
+#include <machine/vmparam.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
+
+#include <contrib/dev/acpica/include/acpi.h>
+#include <contrib/dev/acpica/include/accommon.h>
+#include <dev/acpica/acpivar.h>
+
+#include "io/iommu.h"
+#include "amdvi_priv.h"
+
+device_t *ivhd_devs;			/* IVHD or AMD-Vi device list. */
+int	ivhd_count;			/* Number of IVHD header. */
+/* 
+ * Cached IVHD header list.
+ * Single entry for each IVHD, filtered the legacy one.
+ */
+ACPI_IVRS_HARDWARE *ivhd_hdrs[10];	
+
+extern int amdvi_ptp_level;		/* Page table levels. */
+
+typedef int (*ivhd_iter_t)(ACPI_IVRS_HEADER *ptr, void *arg);
+/*
+ * Iterate IVRS table for IVHD and IVMD device type.
+ */
+static void
+ivrs_hdr_iterate_tbl(ivhd_iter_t iter, void *arg)
+{
+	ACPI_TABLE_IVRS *ivrs;
+	ACPI_IVRS_HEADER *ivrs_hdr, *end;
+	ACPI_STATUS status;
+
+	status = AcpiGetTable(ACPI_SIG_IVRS, 1, (ACPI_TABLE_HEADER **)&ivrs);
+	if (ACPI_FAILURE(status))
+		return;
+
+	if (ivrs->Header.Length == 0) {
+		return;
+	}
+
+	ivrs_hdr = (ACPI_IVRS_HEADER *)(ivrs + 1);
+	end = (ACPI_IVRS_HEADER *)((char *)ivrs + ivrs->Header.Length);
+
+	while (ivrs_hdr < end) {
+		if ((uint8_t *)ivrs_hdr + ivrs_hdr->Length > (uint8_t *)end) {
+			printf("AMD-Vi:IVHD/IVMD is corrupted, length : %d\n",
+			    ivrs_hdr->Length);
+			break;
+		}
+
+		switch (ivrs_hdr->Type) {
+		case IVRS_TYPE_HARDWARE_LEGACY:	/* Legacy */
+		case IVRS_TYPE_HARDWARE_EFR:
+		case IVRS_TYPE_HARDWARE_MIXED:
+			if (!iter(ivrs_hdr, arg))
+				return;
+			break;
+
+		case ACPI_IVRS_TYPE_MEMORY1:
+		case ACPI_IVRS_TYPE_MEMORY2:
+		case ACPI_IVRS_TYPE_MEMORY3:
+			if (!iter(ivrs_hdr, arg))
+				return;
+
+			break;
+
+		default:
+			printf("AMD-Vi:Not IVHD/IVMD type(%d)", ivrs_hdr->Type);
+
+		}
+
+		ivrs_hdr = (ACPI_IVRS_HEADER *)((uint8_t *)ivrs_hdr +
+			ivrs_hdr->Length);
+	}
+}
+
+static bool
+ivrs_is_ivhd(UINT8 type)
+{
+
+	switch(type) {
+	case IVRS_TYPE_HARDWARE_LEGACY:
+	case IVRS_TYPE_HARDWARE_EFR:
+	case IVRS_TYPE_HARDWARE_MIXED:
+		return (true);
+
+	default:
+		return (false);
+	}
+}
+
+/* Count the number of AMD-Vi devices in the system. */
+static int
+ivhd_count_iter(ACPI_IVRS_HEADER * ivrs_he, void *arg)
+{
+
+	if (ivrs_is_ivhd(ivrs_he->Type))
+		ivhd_count++;
+
+	return (1);
+}
+
+struct find_ivrs_hdr_args {
+	int	i;
+	ACPI_IVRS_HEADER *ptr;
+};
+
+static int
+ivrs_hdr_find_iter(ACPI_IVRS_HEADER * ivrs_hdr, void *args)
+{
+	struct find_ivrs_hdr_args *fi;
+
+	fi = (struct find_ivrs_hdr_args *)args;
+	if (ivrs_is_ivhd(ivrs_hdr->Type)) {
+		if (fi->i == 0) {
+			fi->ptr = ivrs_hdr;
+			return (0);
+		}
+		fi->i--;
+	}
+
+	return (1);
+}
+
+static ACPI_IVRS_HARDWARE *
+ivhd_find_by_index(int idx)
+{
+	struct find_ivrs_hdr_args fi;
+
+	fi.i = idx;
+	fi.ptr = NULL;
+
+	ivrs_hdr_iterate_tbl(ivrs_hdr_find_iter, &fi);
+
+	return ((ACPI_IVRS_HARDWARE *)fi.ptr);
+}
+
+static void
+ivhd_dev_add_entry(struct amdvi_softc *softc, uint32_t start_id,
+    uint32_t end_id, uint8_t cfg, bool ats)
+{
+	struct ivhd_dev_cfg *dev_cfg;
+
+	/* If device doesn't have special data, don't add it. */
+	if (!cfg)
+		return;
+
+	dev_cfg = &softc->dev_cfg[softc->dev_cfg_cnt++];
+	dev_cfg->start_id = start_id;
+	dev_cfg->end_id = end_id;
+	dev_cfg->data = cfg;
+	dev_cfg->enable_ats = ats;
+}
+
+/*
+ * Record device attributes as suggested by BIOS.
+ */
+static int
+ivhd_dev_parse(ACPI_IVRS_HARDWARE* ivhd, struct amdvi_softc *softc)
+{
+	ACPI_IVRS_DE_HEADER *de;
+	uint8_t *p, *end;
+	int range_start_id = 0, range_end_id = 0;
+	uint32_t *extended;
+	uint8_t all_data = 0, range_data = 0;
+	bool range_enable_ats = false, enable_ats;
+
+	softc->start_dev_rid = ~0;
+	softc->end_dev_rid = 0;
+
+	switch (ivhd->Header.Type) {
+		case IVRS_TYPE_HARDWARE_LEGACY:
+			p = (uint8_t *)ivhd + sizeof(ACPI_IVRS_HARDWARE);
+			break;
+
+		case IVRS_TYPE_HARDWARE_EFR:
+		case IVRS_TYPE_HARDWARE_MIXED:
+			p = (uint8_t *)ivhd + sizeof(ACPI_IVRS_HARDWARE_EFRSUP);
+			break;
+
+		default:
+			device_printf(softc->dev, 
+				"unknown type: 0x%x\n", ivhd->Header.Type);
+			return (-1);
+	}
+
+	end = (uint8_t *)ivhd + ivhd->Header.Length;
+
+	while (p < end) {
+		de = (ACPI_IVRS_DE_HEADER *)p;
+		softc->start_dev_rid = MIN(softc->start_dev_rid, de->Id);
+		softc->end_dev_rid = MAX(softc->end_dev_rid, de->Id);
+		switch (de->Type) {
+		case ACPI_IVRS_TYPE_ALL:
+			all_data = de->DataSetting;
+			break;
+
+		case ACPI_IVRS_TYPE_SELECT:
+		case ACPI_IVRS_TYPE_ALIAS_SELECT:
+		case ACPI_IVRS_TYPE_EXT_SELECT:
+			enable_ats = false;
+			if (de->Type == ACPI_IVRS_TYPE_EXT_SELECT) {
+				extended = (uint32_t *)(de + 1);
+				enable_ats =
+				    (*extended & IVHD_DEV_EXT_ATS_DISABLE) ?
+					false : true;
+			}
+			ivhd_dev_add_entry(softc, de->Id, de->Id,
+			    de->DataSetting | all_data, enable_ats);
+			break;
+
+		case ACPI_IVRS_TYPE_START:
+		case ACPI_IVRS_TYPE_ALIAS_START:
+		case ACPI_IVRS_TYPE_EXT_START:
+			range_start_id = de->Id;
+			range_data = de->DataSetting;
+			if (de->Type == ACPI_IVRS_TYPE_EXT_START) {
+				extended = (uint32_t *)(de + 1);
+				range_enable_ats =
+				    (*extended & IVHD_DEV_EXT_ATS_DISABLE) ?
+					false : true;
+			}
+			break;
+
+		case ACPI_IVRS_TYPE_END:
+			range_end_id = de->Id;
+			ivhd_dev_add_entry(softc, range_start_id, range_end_id,
+				range_data | all_data, range_enable_ats);
+			range_start_id = range_end_id = 0;
+			range_data = 0;
+			all_data = 0;
+			break;
+
+		case ACPI_IVRS_TYPE_PAD4:
+			break;
+
+		case ACPI_IVRS_TYPE_SPECIAL:
+			/* HPET or IOAPIC */
+			break;
+		default:
+			if ((de->Type < 5) ||
+			    (de->Type >= ACPI_IVRS_TYPE_PAD8))
+				device_printf(softc->dev,
+				    "Unknown dev entry:0x%x\n", de->Type);
+		}
+
+		if (softc->dev_cfg_cnt >
+			(sizeof(softc->dev_cfg) / sizeof(softc->dev_cfg[0]))) {
+			device_printf(softc->dev,
+			    "WARN Too many device entries.\n");
+			return (EINVAL);
+		}
+		if (de->Type < 0x40)
+			p += sizeof(ACPI_IVRS_DEVICE4);
+		else if (de->Type < 0x80)
+			p += sizeof(ACPI_IVRS_DEVICE8A);
+		else {
+			printf("Variable size IVHD type 0x%x not supported\n",
+			    de->Type);
+			break;
+		}
+	}
+
+	KASSERT((softc->end_dev_rid >= softc->start_dev_rid),
+	    ("Device end[0x%x] < start[0x%x.\n",
+	    softc->end_dev_rid, softc->start_dev_rid));
+
+	return (0);
+}
+
+static bool
+ivhd_is_newer(ACPI_IVRS_HEADER *old, ACPI_IVRS_HEADER  *new)
+{
+	/*
+	 * Newer IVRS header type take precedence.
+	 */
+	if ((old->DeviceId == new->DeviceId) &&
+		(old->Type == IVRS_TYPE_HARDWARE_LEGACY) &&
+		((new->Type == IVRS_TYPE_HARDWARE_EFR) ||
+		(new->Type == IVRS_TYPE_HARDWARE_MIXED))) {
+		return (true);
+	}
+
+	return (false);
+}
+
+static void
+ivhd_identify(driver_t *driver, device_t parent)
+{
+	ACPI_TABLE_IVRS *ivrs;
+	ACPI_IVRS_HARDWARE *ivhd;
+	ACPI_STATUS status;
+	int i, count = 0;
+	uint32_t ivrs_ivinfo;
+
+	if (acpi_disabled("ivhd"))
+		return;
+
+	status = AcpiGetTable(ACPI_SIG_IVRS, 1, (ACPI_TABLE_HEADER **)&ivrs);
+	if (ACPI_FAILURE(status))
+		return;
+
+	if (ivrs->Header.Length == 0) {
+		return;
+	}
+
+	ivrs_ivinfo = ivrs->Info;
+	printf("AMD-Vi: IVRS Info VAsize = %d PAsize = %d GVAsize = %d"
+	       " flags:%b\n",
+		REG_BITS(ivrs_ivinfo, 21, 15), REG_BITS(ivrs_ivinfo, 14, 8), 
+		REG_BITS(ivrs_ivinfo, 7, 5), REG_BITS(ivrs_ivinfo, 22, 22),
+		"\020\001EFRSup");
+
+	ivrs_hdr_iterate_tbl(ivhd_count_iter, NULL);
+	if (!ivhd_count)
+		return;
+
+	for (i = 0; i < ivhd_count; i++) {
+		ivhd = ivhd_find_by_index(i);
+		KASSERT(ivhd, ("ivhd%d is NULL\n", i));
+		ivhd_hdrs[i] = ivhd;
+	}
+
+        /* 
+	 * Scan for presence of legacy and non-legacy device type
+	 * for same AMD-Vi device and override the old one.
+	 */
+	for (i = ivhd_count - 1 ; i > 0 ; i--){
+       		if (ivhd_is_newer(&ivhd_hdrs[i-1]->Header, 
+			&ivhd_hdrs[i]->Header)) {
+			ivhd_hdrs[i-1] = ivhd_hdrs[i];
+			ivhd_count--;
+		}
+       }	       
+
+	ivhd_devs = malloc(sizeof(device_t) * ivhd_count, M_DEVBUF,
+		M_WAITOK | M_ZERO);
+	for (i = 0; i < ivhd_count; i++) {
+		ivhd = ivhd_hdrs[i];
+		KASSERT(ivhd, ("ivhd%d is NULL\n", i));
+
+		/*
+		 * Use a high order to ensure that this driver is probed after
+		 * the Host-PCI bridge and the root PCI bus.
+		 */
+		ivhd_devs[i] = BUS_ADD_CHILD(parent,
+		    ACPI_DEV_BASE_ORDER + 10 * 10, "ivhd", i);
+
+		/*
+		 * XXX: In case device was not destroyed before, add will fail.
+		 * locate the old device instance.
+		 */
+		if (ivhd_devs[i] == NULL) {
+			ivhd_devs[i] = device_find_child(parent, "ivhd", i);
+			if (ivhd_devs[i] == NULL) {
+				printf("AMD-Vi: cant find ivhd%d\n", i);
+				break;
+			}
+		}
+		count++;
+	}
+
+	/*
+	 * Update device count in case failed to attach.
+	 */
+	ivhd_count = count;
+}
+
+static int
+ivhd_probe(device_t dev)
+{
+	ACPI_IVRS_HARDWARE *ivhd;
+	int unit;
+
+	if (acpi_get_handle(dev) != NULL)
+		return (ENXIO);
+
+	unit = device_get_unit(dev);
+	KASSERT((unit < ivhd_count), 
+		("ivhd unit %d > count %d", unit, ivhd_count));
+	ivhd = ivhd_hdrs[unit];
+	KASSERT(ivhd, ("ivhd is NULL"));
+
+	switch (ivhd->Header.Type) {
+	case IVRS_TYPE_HARDWARE_EFR:
+		device_set_desc(dev, "AMD-Vi/IOMMU ivhd with EFR");
+		break;
+	
+	case IVRS_TYPE_HARDWARE_MIXED:
+		device_set_desc(dev, "AMD-Vi/IOMMU ivhd in mixed format");
+		break;
+
+	case IVRS_TYPE_HARDWARE_LEGACY:
+        default:
+		device_set_desc(dev, "AMD-Vi/IOMMU ivhd");
+		break;
+	}
+
+	return (BUS_PROBE_NOWILDCARD);
+}
+
+static void
+ivhd_print_flag(device_t dev, enum IvrsType ivhd_type, uint8_t flag)
+{
+	/*
+	 * IVHD lgeacy type has two extra high bits in flag which has
+	 * been moved to EFR for non-legacy device.
+	 */
+	switch (ivhd_type) {
+	case IVRS_TYPE_HARDWARE_LEGACY:
+		device_printf(dev, "Flag:%b\n", flag,
+			"\020"
+			"\001HtTunEn"
+			"\002PassPW"
+			"\003ResPassPW"
+			"\004Isoc"
+			"\005IotlbSup"
+			"\006Coherent"
+			"\007PreFSup"
+			"\008PPRSup");
+		break;
+
+	case IVRS_TYPE_HARDWARE_EFR:
+	case IVRS_TYPE_HARDWARE_MIXED:
+		device_printf(dev, "Flag:%b\n", flag,
+			"\020"
+			"\001HtTunEn"
+			"\002PassPW"
+			"\003ResPassPW"
+			"\004Isoc"
+			"\005IotlbSup"
+			"\006Coherent");
+		break;
+
+	default:
+		device_printf(dev, "Can't decode flag of ivhd type :0x%x\n",
+			ivhd_type);
+		break;
+	}
+}
+
+/*
+ * Feature in legacy IVHD type(0x10) and attribute in newer type(0x11 and 0x40).
+ */
+static void
+ivhd_print_feature(device_t dev, enum IvrsType ivhd_type, uint32_t feature) 
+{
+	switch (ivhd_type) {
+	case IVRS_TYPE_HARDWARE_LEGACY:
+		device_printf(dev, "Features(type:0x%x) HATS = %d GATS = %d"
+			" MsiNumPPR = %d PNBanks= %d PNCounters= %d\n",
+			ivhd_type,
+			REG_BITS(feature, 31, 30),
+			REG_BITS(feature, 29, 28),
+			REG_BITS(feature, 27, 23),
+			REG_BITS(feature, 22, 17),
+			REG_BITS(feature, 16, 13));
+		device_printf(dev, "max PASID = %d GLXSup = %d Feature:%b\n",
+			REG_BITS(feature, 12, 8),
+			REG_BITS(feature, 4, 3),
+			feature,
+			"\020"
+			"\002NXSup"
+			"\003GTSup"
+			"\004<b4>"
+			"\005IASup"
+			"\006GASup"
+			"\007HESup");
+		break;
+
+	/* Fewer features or attributes are reported in non-legacy type. */
+	case IVRS_TYPE_HARDWARE_EFR:
+	case IVRS_TYPE_HARDWARE_MIXED:
+		device_printf(dev, "Features(type:0x%x) MsiNumPPR = %d"
+			" PNBanks= %d PNCounters= %d\n",
+			ivhd_type,
+			REG_BITS(feature, 27, 23),
+			REG_BITS(feature, 22, 17),
+			REG_BITS(feature, 16, 13));
+		break;
+
+	default: /* Other ivhd type features are not decoded. */
+		device_printf(dev, "Can't decode ivhd type :0x%x\n", ivhd_type);
+	}
+}
+
+/* Print extended features of IOMMU. */
+static void
+ivhd_print_ext_feature(device_t dev, uint64_t ext_feature)
+{
+	uint32_t ext_low, ext_high;
+
+	if (!ext_feature)
+		return;
+
+	ext_low = ext_feature;
+	device_printf(dev, "Extended features[31:0]:%b "
+		"HATS = 0x%x GATS = 0x%x "
+		"GLXSup = 0x%x SmiFSup = 0x%x SmiFRC = 0x%x "
+		"GAMSup = 0x%x DualPortLogSup = 0x%x DualEventLogSup = 0x%x\n",
+		(int)ext_low,
+		"\020"
+		"\001PreFSup"
+		"\002PPRSup"
+		"\003<b2>"
+		"\004NXSup"
+		"\005GTSup"
+		"\006<b5>"
+		"\007IASup"
+		"\008GASup"
+		"\009HESup"
+		"\010PCSup",
+		REG_BITS(ext_low, 11, 10),
+		REG_BITS(ext_low, 13, 12),
+		REG_BITS(ext_low, 15, 14),
+		REG_BITS(ext_low, 17, 16),
+		REG_BITS(ext_low, 20, 18),
+		REG_BITS(ext_low, 23, 21),
+		REG_BITS(ext_low, 25, 24),
+		REG_BITS(ext_low, 29, 28));
+
+	ext_high = ext_feature >> 32;
+	device_printf(dev, "Extended features[62:32]:%b "
+		"Max PASID: 0x%x DevTblSegSup = 0x%x "
+		"MarcSup = 0x%x\n",
+		(int)(ext_high),
+		"\020"
+		"\006USSup"
+		"\009PprOvrflwEarlySup"
+		"\010PPRAutoRspSup"
+		"\013BlKStopMrkSup"
+		"\014PerfOptSup"
+		"\015MsiCapMmioSup"
+		"\017GIOSup"
+		"\018HASup"
+		"\019EPHSup"
+		"\020AttrFWSup"
+		"\021HDSup"
+		"\023InvIotlbSup",
+	    	REG_BITS(ext_high, 5, 0),
+	    	REG_BITS(ext_high, 8, 7),
+	    	REG_BITS(ext_high, 11, 10));
+}
+
+static int
+ivhd_print_cap(struct amdvi_softc *softc, ACPI_IVRS_HARDWARE * ivhd)
+{
+	device_t dev;
+	int max_ptp_level;
+
+	dev = softc->dev;
+	
+	ivhd_print_flag(dev, softc->ivhd_type, softc->ivhd_flag);
+	ivhd_print_feature(dev, softc->ivhd_type, softc->ivhd_feature);
+	ivhd_print_ext_feature(dev, softc->ext_feature);
+	max_ptp_level = 7;
+	/* Make sure device support minimum page level as requested by user. */
+	if (max_ptp_level < amdvi_ptp_level) {
+		device_printf(dev, "insufficient PTP level:%d\n",
+			max_ptp_level);
+		return (EINVAL);
+	} else {
+		device_printf(softc->dev, "supported paging level:%d, will use only: %d\n",
+	    		max_ptp_level, amdvi_ptp_level);
+	}
+
+	device_printf(softc->dev, "device range: 0x%x - 0x%x\n",
+			softc->start_dev_rid, softc->end_dev_rid);
+
+	return (0);
+}
+
+static int
+ivhd_attach(device_t dev)
+{
+	ACPI_IVRS_HARDWARE *ivhd;
+	ACPI_IVRS_HARDWARE_EFRSUP *ivhd_efr;
+	struct amdvi_softc *softc;
+	int status, unit;
+
+	unit = device_get_unit(dev);
+	KASSERT((unit < ivhd_count), 
+		("ivhd unit %d > count %d", unit, ivhd_count));
+	/* Make sure its same device for which attach is called. */
+	KASSERT((ivhd_devs[unit] == dev),
+		("Not same device old %p new %p", ivhd_devs[unit], dev));
+
+	softc = device_get_softc(dev);
+	softc->dev = dev;
+	ivhd = ivhd_hdrs[unit];
+	KASSERT(ivhd, ("ivhd is NULL"));
+
+	softc->ivhd_type = ivhd->Header.Type;
+	softc->pci_seg = ivhd->PciSegmentGroup;
+	softc->pci_rid = ivhd->Header.DeviceId;
+	softc->ivhd_flag = ivhd->Header.Flags;
+	/* 
+	 * On lgeacy IVHD type(0x10), it is documented as feature
+	 * but in newer type it is attribute.
+	 */
+	softc->ivhd_feature = ivhd->Reserved;
+	/* 
+	 * PCI capability has more capabilities that are not part of IVRS.
+	 */
+	softc->cap_off = ivhd->CapabilityOffset;
+
+#ifdef notyet
+	/* IVHD Info bit[4:0] is event MSI/X number. */
+	softc->event_msix = ivhd->Info & 0x1F;
+#endif
+	switch (ivhd->Header.Type) {
+		case IVRS_TYPE_HARDWARE_EFR:
+		case IVRS_TYPE_HARDWARE_MIXED:
+			ivhd_efr = (ACPI_IVRS_HARDWARE_EFRSUP *)ivhd;
+			softc->ext_feature = ivhd_efr->ExtFR;
+			break;
+
+	}
+
+	softc->ctrl = (struct amdvi_ctrl *) PHYS_TO_DMAP(ivhd->BaseAddress);
+	status = ivhd_dev_parse(ivhd, softc);
+	if (status != 0) {
+		device_printf(dev,
+		    "endpoint device parsing error=%d\n", status);
+	}
+
+	status = ivhd_print_cap(softc, ivhd);
+	if (status != 0) {
+		return (status);
+	}
+
+	status = amdvi_setup_hw(softc);
+	if (status != 0) {
+		device_printf(dev, "couldn't be initialised, error=%d\n", 
+		    status);
+		return (status);
+	}
+
+	return (0);
+}
+
+static int
+ivhd_detach(device_t dev)
+{
+	struct amdvi_softc *softc;
+
+	softc = device_get_softc(dev);
+
+	amdvi_teardown_hw(softc);
+
+	/*
+	 * XXX: delete the device.
+	 * don't allow detach, return EBUSY.
+	 */
+	return (0);
+}
+
+static int
+ivhd_suspend(device_t dev)
+{
+
+	return (0);
+}
+
+static int
+ivhd_resume(device_t dev)
+{
+
+	return (0);
+}
+
+static device_method_t ivhd_methods[] = {
+	DEVMETHOD(device_identify, ivhd_identify),
+	DEVMETHOD(device_probe, ivhd_probe),
+	DEVMETHOD(device_attach, ivhd_attach),
+	DEVMETHOD(device_detach, ivhd_detach),
+	DEVMETHOD(device_suspend, ivhd_suspend),
+	DEVMETHOD(device_resume, ivhd_resume),
+	DEVMETHOD_END
+};
+
+static driver_t ivhd_driver = {
+	"ivhd",
+	ivhd_methods,
+	sizeof(struct amdvi_softc),
+};
+
+static devclass_t ivhd_devclass;
+
+/*
+ * Load this module at the end after PCI re-probing to configure interrupt.
+ */
+DRIVER_MODULE_ORDERED(ivhd, acpi, ivhd_driver, ivhd_devclass, 0, 0,
+		      SI_ORDER_ANY);
+MODULE_DEPEND(ivhd, acpi, 1, 1, 1);
+MODULE_DEPEND(ivhd, pci, 1, 1, 1);

--- a/usr/src/uts/i86pc/io/vmm/amd/npt.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/npt.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013 Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/npt.h
+++ b/usr/src/uts/i86pc/io/vmm/amd/npt.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013 Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/svm.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013, Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *
@@ -50,6 +52,7 @@ __FBSDID("$FreeBSD$");
 #include <machine/cpufunc.h>
 #include <machine/psl.h>
 #include <machine/md_var.h>
+#include <machine/reg.h>
 #include <machine/specialreg.h>
 #include <machine/smp.h>
 #include <machine/vmm.h>
@@ -528,8 +531,8 @@ vmcb_init(struct svm_softc *sc, int vcpu, uint64_t iopm_base_pa,
 	    PAT_VALUE(7, PAT_UNCACHEABLE);
 
 	/* Set up DR6/7 to power-on state */
-	state->dr6 = 0xffff0ff0;
-	state->dr7 = 0x400;
+	state->dr6 = DBREG_DR6_RESERVED1;
+	state->dr7 = DBREG_DR7_RESERVED1;
 }
 
 /*

--- a/usr/src/uts/i86pc/io/vmm/amd/svm.h
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013 Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/svm_msr.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm_msr.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014, Neel Natu (neel@freebsd.org)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/svm_msr.h
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm_msr.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Neel Natu (neel@freebsd.org)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/svm_softc.h
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm_softc.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013 Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/vmcb.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/vmcb.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013 Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/amd/vmcb.h
+++ b/usr/src/uts/i86pc/io/vmm/amd/vmcb.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2013 Anish Gupta (akgupt3@gmail.com)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/io/vatpic.c
+++ b/usr/src/uts/i86pc/io/vmm/io/vatpic.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/io/vatpit.h
+++ b/usr/src/uts/i86pc/io/vmm/io/vatpit.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * Copyright (c) 2011 NetApp, Inc.
  * All rights reserved.

--- a/usr/src/uts/i86pc/io/vmm/io/vpmtmr.c
+++ b/usr/src/uts/i86pc/io/vmm/io/vpmtmr.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014, Neel Natu (neel@freebsd.org)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/io/vpmtmr.h
+++ b/usr/src/uts/i86pc/io/vmm/io/vpmtmr.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Neel Natu (neel@freebsd.org)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/io/vrtc.c
+++ b/usr/src/uts/i86pc/io/vmm/io/vrtc.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014, Neel Natu (neel@freebsd.org)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/io/vrtc.h
+++ b/usr/src/uts/i86pc/io/vmm/io/vrtc.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Neel Natu (neel@freebsd.org)
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -991,8 +991,8 @@ sysmem_mapping(struct vm *vm, struct mem_map *mm)
 		return (false);
 }
 
-static vm_paddr_t
-sysmem_maxaddr(struct vm *vm)
+vm_paddr_t
+vmm_sysmem_maxaddr(struct vm *vm)
 {
 	struct mem_map *mm;
 	vm_paddr_t maxaddr;
@@ -1127,7 +1127,7 @@ vm_assign_pptdev(struct vm *vm, int pptfd)
 	if (ppt_assigned_devices(vm) == 0) {
 		KASSERT(vm->iommu == NULL,
 		    ("vm_assign_pptdev: iommu must be NULL"));
-		maxaddr = sysmem_maxaddr(vm);
+		maxaddr = vmm_sysmem_maxaddr(vm);
 		vm->iommu = iommu_create_domain(maxaddr);
 		if (vm->iommu == NULL)
 			return (ENXIO);
@@ -2190,6 +2190,7 @@ restart:
 			break;
 		case VM_EXITCODE_MONITOR:
 		case VM_EXITCODE_MWAIT:
+		case VM_EXITCODE_VMINSN:
 			vm_inject_ud(vm, vcpuid);
 			break;
 #ifndef __FreeBSD__

--- a/usr/src/uts/i86pc/io/vmm/vmm_ioport.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_ioport.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/io/vmm/vmm_ioport.h
+++ b/usr/src/uts/i86pc/io/vmm/vmm_ioport.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2014 Tycho Nightingale <tycho.nightingale@pluribusnetworks.com>
  * All rights reserved.
  *

--- a/usr/src/uts/i86pc/sys/vmm.h
+++ b/usr/src/uts/i86pc/sys/vmm.h
@@ -240,6 +240,7 @@ int vm_mmap_getnext(struct vm *vm, vm_paddr_t *gpa, int *segid,
     vm_ooffset_t *segoff, size_t *len, int *prot, int *flags);
 int vm_get_memseg(struct vm *vm, int ident, size_t *len, bool *sysmem,
     struct vm_object **objptr);
+vm_paddr_t vmm_sysmem_maxaddr(struct vm *vm);
 void *vm_gpa_hold(struct vm *, int vcpuid, vm_paddr_t gpa, size_t len,
     int prot, void **cookie);
 void vm_gpa_release(void *cookie);
@@ -587,6 +588,7 @@ enum vm_exitcode {
 	VM_EXITCODE_SVM,
 	VM_EXITCODE_REQIDLE,
 	VM_EXITCODE_DEBUG,
+	VM_EXITCODE_VMINSN,
 #ifndef	__FreeBSD__
 	VM_EXITCODE_HT,
 #endif

--- a/usr/src/uts/i86pc/viona/Makefile
+++ b/usr/src/uts/i86pc/viona/Makefile
@@ -53,7 +53,8 @@ ALL_BUILDS	= $(ALL_BUILDSONLY64)
 DEF_BUILDS	= $(DEF_BUILDSONLY64)
 
 CFLAGS		+= $(CCVERBOSE)
-LDFLAGS		+= -dy -Ndrv/dld -Nmisc/mac -Nmisc/dls -Ndrv/vmm
+LDFLAGS		+= -dy -Ndrv/dld -Nmisc/mac -Nmisc/dls -Ndrv/vmm -Nmisc/neti
+LDFLAGS		+= -Nmisc/hook
 
 #
 #	Default build targets.

--- a/usr/src/uts/intel/chxge/Makefile
+++ b/usr/src/uts/intel/chxge/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2018 Joyent, Inc.
 #
 
 #
@@ -69,9 +70,9 @@ CFLAGS		+= -DSUN_KSTATS -DHOST_PAUSE -DTX_CKSUM_FIX -DTX_THREAD_RECLAIM
 # CFLAGS		+= -DCH_DEBUG=1 -DPE_DBGOUT_ENABLED=1
 
 #
-#	Driver depends on GLD & IP
+#	Driver depends on GLD, IP, and MAC
 #
-LDFLAGS		+= -dy -N misc/gld -N drv/ip
+LDFLAGS		+= -dy -N misc/gld -N drv/ip -N misc/mac
 
 #	Lint flag
 #

--- a/usr/src/uts/intel/io/vmxnet3s/vmxnet3_rx.c
+++ b/usr/src/uts/intel/io/vmxnet3s/vmxnet3_rx.c
@@ -14,6 +14,7 @@
  */
 /*
  * Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <vmxnet3.h>
@@ -322,7 +323,7 @@ vmxnet3_rx_hwcksum(vmxnet3_softc_t *dp, mblk_t *mp,
 
 		VMXNET3_DEBUG(dp, 3, "rx cksum flags = 0x%x\n", flags);
 
-		(void) hcksum_assoc(mp, NULL, NULL, 0, 0, 0, 0, flags, 0);
+		mac_hcksum_set(mp, 0, 0, 0, 0, flags);
 	}
 }
 

--- a/usr/src/uts/intel/io/vmxnet3s/vmxnet3_tx.c
+++ b/usr/src/uts/intel/io/vmxnet3s/vmxnet3_tx.c
@@ -15,6 +15,7 @@
 
 /*
  * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <vmxnet3.h>
@@ -79,7 +80,7 @@ vmxnet3_tx_prepare_offload(vmxnet3_softc_t *dp, vmxnet3_offload_t *ol,
 	ol->hlen = 0;
 	ol->msscof = 0;
 
-	hcksum_retrieve(mp, NULL, NULL, &start, &stuff, NULL, &value, &flags);
+	mac_hcksum_get(mp, &start, &stuff, NULL, &value, &flags);
 
 	mac_lso_get(mp, &mss, &lso_flag);
 

--- a/usr/src/uts/intel/ipf/Makefile
+++ b/usr/src/uts/intel/ipf/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2018 Joyent, Inc.
 #
 # uts/intel/ipf/Makefile
 #
@@ -59,6 +60,7 @@ INSTALL_TARGET	= $(BINARY) $(ROOTMODULE) $(ROOT_CONFFILE)
 CPPFLAGS += -DIPFILTER_LKM -DIPFILTER_LOG -DIPFILTER_LOOKUP -DUSE_INET6
 CPPFLAGS += -DSUNDDI -DSOLARIS2=$(RELEASE_MINOR) -DIRE_ILL_CN
 LDFLAGS += -dy -Ndrv/ip -Nmisc/md5 -Nmisc/neti -Nmisc/hook -Nmisc/kcf
+LDFLAGS += -Nmisc/mac
 
 INC_PATH += -I$(UTSBASE)/common/inet/ipf
 

--- a/usr/src/uts/intel/ipf/ipf.global-objs.debug64
+++ b/usr/src/uts/intel/ipf/ipf.global-objs.debug64
@@ -22,13 +22,17 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Copyright 2013 Joyent, Inc. All rights reserved
+# Copyright 2018 Joyent, Inc. All rights reserved
 #
 
 fr_availfuncs
 fr_features
 fr_objbytes
 hdrsizes
+hook_viona_in
+hook_viona_in_gz
+hook_viona_out
+hook_viona_out_gz
 hook4_in
 hook4_in_gz
 hook4_loop_in
@@ -58,6 +62,9 @@ ip6exthdr
 ipf_cb_ops
 ipf_dev_info
 ipf_devfiles
+ipf_eth_bcast_addr
+ipf_eth_ipv4_mcast
+ipf_eth_ipv6_mcast
 ipf_kstat_tmp
 ipf_minor
 ipf_ops

--- a/usr/src/uts/sparc/chxge/Makefile
+++ b/usr/src/uts/sparc/chxge/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2018 Joyent, Inc.
 #
 
 #
@@ -69,9 +70,9 @@ CFLAGS		+= -DSUN_KSTATS -DHOST_PAUSE -DTX_CKSUM_FIX -DTX_THREAD_RECLAIM
 # CFLAGS		+= -DCH_DEBUG=1 -DPE_DBGOUT_ENABLED=1
 
 #
-#	Driver depends on GLD & IP
+#	Driver depends on GLD, IP, and MAC
 #
-LDFLAGS		+= -dy -N misc/gld -N drv/ip
+LDFLAGS		+= -dy -N misc/gld -N drv/ip -N misc/mac
 
 #	Lint flag
 #

--- a/usr/src/uts/sparc/ipf/Makefile
+++ b/usr/src/uts/sparc/ipf/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+# Copyright 2018 Joyent, Inc.
 #
 # uts/sparc/ipf/Makefile
 #
@@ -64,6 +65,7 @@ CFLAGS += $(CCVERBOSE)
 CPPFLAGS += -DIPFILTER_LKM -DIPFILTER_LOG -DIPFILTER_LOOKUP 
 CPPFLAGS += -DSUNDDI -DSOLARIS2=$(RELEASE_MINOR) -DIRE_ILL_CN -DUSE_INET6
 LDFLAGS += -dy -Ndrv/ip -Nmisc/md5 -Nmisc/neti -Nmisc/hook -Nmisc/kcf
+LDFLAGS += -Nmisc/mac
 
 INC_PATH += -I$(UTSBASE)/common/inet/ipf
 


### PR DESCRIPTION
Weekly upstream for joyent_merge/2018110201

## Backports

None.

## onu

Tested on physical box including network communication between native, lx and bhyve zones.

## mail_msg

```

==== Nightly distributed build started:   Sat Nov  3 00:35:40 UTC 2018 ====
==== Nightly distributed build completed: Sat Nov  3 02:50:04 UTC 2018 ====

==== Total build time ====

real    2:14:24

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-joyent_merge-2018110201-ab0fd652a5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151027/7.3.0-il-1) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.7.0_191-b02"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   74

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018110201-25fa26129e

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:30.9
user  2:15:44.5
sys     30:21.1

==== Build noise differences (non-DEBUG) ====

12,17d11
< ../../common/io/dls/dls.c: In function 'dls_promisc':
< ../../common/io/dls/dls.c:280: error: 'mac_flags' undeclared (first use in this function)
< ../../common/io/dls/dls.c:280: error: (Each undeclared identifier is reported only once
< ../../common/io/dls/dls.c:280: error: for each function it appears in.)
< ../../common/io/dls/dls.c:280:3: error: 'mac_flags' undeclared (first use in this function); did you mean 'old_flags'?
< ../../common/io/dls/dls.c:280:3: note: each undeclared identifier is reported only once for each function it appears in
55,61d48
< The following command caused the error:
< dmake: Warning: Command failed for target `dls'
< dmake: Warning: Command failed for target `intel'
< dmake: Warning: Command failed for target `obj64/dls.o'
< dmake: Warning: Command failed for target `uts'
< dmake: Warning: Target `install' not remade because of errors
< dmake: Warning: Target `install.targ' not remade because of errors

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    36:54.5
user  2:08:06.7
sys     23:27.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    47:26.4
user    44:12.6
sys     12:43.5

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
