### PR TITLE
Honour PKG_INSTALL_ROOT when building hash filename

### DIFF
--- a/usr/src/cmd/svc/common/manifest_hash.c
+++ b/usr/src/cmd/svc/common/manifest_hash.c
@@ -245,6 +245,8 @@ mhash_store_entry(scf_handle_t *hndl, const char *name, const char *fname,
 	scf_transaction_entry_t *fe = NULL;
 	scf_error_t err;
 	int ret, result = 0;
+	char *base;
+	size_t base_sz = 0;
 
 	int i;
 
@@ -366,9 +368,17 @@ mhash_store_entry(scf_handle_t *hndl, const char *name, const char *fname,
 		goto out;
 	}
 
+	/*
+	 * Remove any PKG_INSTALL_ROOT from the manifest filename so that it
+	 * points to the correct location following installation.
+	 */
+	base = getenv("PKG_INSTALL_ROOT");
+	if (base != NULL && strncmp(fname, base, strlen(base)) == 0)
+		base_sz = strlen(base);
+
 	ret = scf_value_set_opaque(val, hash, MHASH_SIZE);
 	assert(ret == SCF_SUCCESS);
-	ret = scf_value_set_astring(fval, fname);
+	ret = scf_value_set_astring(fval, fname + base_sz);
 	assert(ret == SCF_SUCCESS);
 	if (apply_late == APPLY_LATE) {
 		scf_value_set_boolean(aval, 1);


### PR DESCRIPTION
When seeding an SMF database, the paths to the imported manifests end up stored in two places within the repository database:

* The manifestfiles property of the imported service;
* A per-service tree within the `smf/manifest` service.

For example:

```
bloody% cp /lib/svc/seed/global.db /tmp
bloody% export SVCCFG_REPOSITORY=/tmp/global.db
bloody% export SVCCFG_CHECKHASH=1
bloody% svccfg import /kayak_image/r151029/lib/svc/manifest/network/ntp.xml

bloody% svccfg -s ntp listprop manifestfiles
manifestfiles                                                       framework
manifestfiles/kayak_image_r151029_lib_svc_manifest_network_ntp_xml  astring  /kayak_image/r151029/lib/svc/manifest/network/ntp.xml

bloody% svccfg -s manifest listprop | grep ntp
kayak_image_r151029_lib_svc_manifest_network_ntp_xml               framework
kayak_image_r151029_lib_svc_manifest_network_ntp_xml/manifestfile  astring  /kayak_image/r151029/lib/svc/manifest/network/ntp.xml
kayak_image_r151029_lib_svc_manifest_network_ntp_xml/md5sum        opaque   afcd99c29f0dedcf40278f1bf0253f6286787107e11c23bcac675faffed78f41
```

It's possible to set the `PKG_INSTALL_ROOT` environment variable in order to modify these embedded paths, which fixes the keys and the path stored in the service itself, but not the path in `smf/manifest`:

```
bloody% export PKG_INSTALL_ROOT=/kayak_image/r151029
bloody% svccfg import /kayak_image/r151029/lib/svc/manifest/network/ntp.xml

bloody% svccfg -s ntp listprop manifestfiles
manifestfiles                                   framework
manifestfiles/lib_svc_manifest_network_ntp_xml  astring  /lib/svc/manifest/network/ntp.xml

bloody% svccfg -s manifest listprop | grep ntp
lib_svc_manifest_network_ntp_xml               framework
lib_svc_manifest_network_ntp_xml/manifestfile  astring  /kayak_image/r151029/lib/svc/manifest/network/ntp.xml
lib_svc_manifest_network_ntp_xml/md5sum        opaque   afcd99c29f0dedcf40278f1bf0253f6286787107e11c23bcac675faffed78f41
```

This PR changes the hashing code so that this path is updated along with the others.