### PR TITLE
Upstream merge/2018110801

### DIFF
--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -351,12 +351,20 @@ CCNOAUTOINLINE= \
 	-_gcc=-fno-inline-small-functions \
 	-_gcc=-fno-inline-functions-called-once \
 	-_gcc=-fno-ipa-cp \
-	-_gcc6=-fno-ipa-icf \
 	-_gcc7=-fno-ipa-icf \
 	-_gcc8=-fno-ipa-icf \
-	-_gcc6=-fno-clone-functions \
 	-_gcc7=-fno-clone-functions \
 	-_gcc8=-fno-clone-functions
+
+# GCC may put functions in different named sub-sections of .text based on
+# their presumed calling frequency.  At least in the kernel, where we actually
+# deliver relocatable objects, we don't want this to happen.
+#
+# Since at present we don't benefit from this even in userland, we disable it globally,
+# but the application of this may move into usr/src/uts/ in future.
+CCNOREORDER=	\
+	-_gcc7=-fno-reorder-functions \
+	-_gcc8=-fno-reorder-functions
 
 # One optimization the compiler might perform is to turn this:
 #	#pragma weak foo
@@ -576,12 +584,12 @@ $(SRCDBGBLD)CCSOURCEDEBUGFLAGS	= -g -xs
 
 CFLAGS=         $(COPTFLAG) $($(MACH)_CFLAGS) $(SPACEFLAG) $(CCMODE) \
 		$(ILDOFF) $(CERRWARN) $(CSTD) $(CCUNBOUND) $(IROPTFLAG) \
-		$(CGLOBALSTATIC) $(CCNOAUTOINLINE) $(CSOURCEDEBUGFLAGS) \
-		$(CUSERFLAGS)
+		$(CGLOBALSTATIC) $(CCNOAUTOINLINE) $(CCNOREORDER) \
+		$(CSOURCEDEBUGFLAGS) $(CUSERFLAGS)
 CFLAGS64=       $(COPTFLAG64) $($(MACH64)_CFLAGS) $(SPACEFLAG64) $(CCMODE64) \
 		$(ILDOFF) $(CERRWARN) $(CSTD) $(CCUNBOUND) $(IROPTFLAG64) \
-		$(CGLOBALSTATIC) $(CCNOAUTOINLINE) $(CSOURCEDEBUGFLAGS) \
-		$(CUSERFLAGS64)
+		$(CGLOBALSTATIC) $(CCNOAUTOINLINE) $(CCNOREORDER) \
+		$(CSOURCEDEBUGFLAGS) $(CUSERFLAGS64)
 #
 # Flags that are used to build parts of the code that are subsequently
 # run on the build machine (also known as the NATIVE_BUILD).
@@ -589,7 +597,7 @@ CFLAGS64=       $(COPTFLAG64) $($(MACH64)_CFLAGS) $(SPACEFLAG64) $(CCMODE64) \
 NATIVE_CFLAGS=	$(COPTFLAG) $($(NATIVE_MACH)_CFLAGS) $(CCMODE) \
 		$(ILDOFF) $(CERRWARN) $(CSTD) $($(NATIVE_MACH)_CCUNBOUND) \
 		$(IROPTFLAG) $(CGLOBALSTATIC) $(CCNOAUTOINLINE) \
-		$(CSOURCEDEBUGFLAGS) $(CUSERFLAGS)
+		$(CCNOREORDER) $(CSOURCEDEBUGFLAGS) $(CUSERFLAGS)
 
 DTEXTDOM=-DTEXT_DOMAIN=\"$(TEXT_DOMAIN)\"	# For messaging.
 DTS_ERRNO=-D_TS_ERRNO

--- a/usr/src/boot/sys/boot/efi/libefi/delay.c
+++ b/usr/src/boot/sys/boot/efi/libefi/delay.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 2001 Doug Rabson
  * All rights reserved.
  *
@@ -25,7 +25,6 @@
  */
 
 #include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
 #include <efi.h>
 #include <efilib.h>
@@ -35,15 +34,5 @@ void delay(int);
 void
 delay(int usecs)
 {
-	static EFI_EVENT ev = 0;
-	UINTN junk;
-
-	if (!ev) {
-		if (BS->CreateEvent(EVT_TIMER, TPL_APPLICATION, 0, 0, &ev)
-		    != EFI_SUCCESS)
-			return;
-	}
-
-	BS->SetTimer(ev, TimerRelative, usecs * 10);
-	BS->WaitForEvent(1, &ev, &junk);
+	BS->Stall(usecs);
 }

--- a/usr/src/boot/sys/boot/i386/libi386/biosdisk.c
+++ b/usr/src/boot/sys/boot/i386/libi386/biosdisk.c
@@ -79,8 +79,10 @@ static struct bdinfo
 #define	BD_MODEINT13	0x0000
 #define	BD_MODEEDD1	0x0001
 #define	BD_MODEEDD3	0x0002
+#define	BD_MODEEDD	(BD_MODEEDD1 | BD_MODEEDD3)
 #define	BD_MODEMASK	0x0003
 #define	BD_FLOPPY	0x0004
+#define	BD_NO_MEDIA	0x0008
 	int		bd_type;	/* BIOS 'drive type' (floppy only) */
 	uint16_t	bd_sectorsize;	/* Sector size */
 	uint64_t	bd_sectors;	/* Disk size */
@@ -188,60 +190,83 @@ bd_init(void)
 }
 
 /*
- * Try to detect a device supported by the legacy int13 BIOS
+ * Return EDD version or 0 if EDD is not supported on this drive.
  */
 static int
-bd_int13probe(struct bdinfo *bd)
+bd_check_extensions(int unit)
 {
-	struct edd_params params;
-	int ret = 1;	/* assume success */
+	/* Determine if we can use EDD with this device. */
+	v86.ctl = V86_FLAGS;
+	v86.addr = 0x13;
+	v86.eax = 0x4100;
+	v86.edx = unit;
+	v86.ebx = 0x55aa;
+	v86int();
 
+	if (V86_CY(v86.efl) ||			/* carry set */
+	    (v86.ebx & 0xffff) != 0xaa55)	/* signature */
+		return (0);
+
+	/* extended disk access functions (AH=42h-44h,47h,48h) supported */
+	if ((v86.ecx & EDD_INTERFACE_FIXED_DISK) == 0)
+		return (0);
+
+	return ((v86.eax >> 8) & 0xff);
+}
+
+static void
+bd_reset_disk(int unit)
+{
+	/* reset disk */
+	v86.ctl = V86_FLAGS;
+	v86.addr = 0x13;
+	v86.eax = 0;
+	v86.edx = unit;
+	v86int();
+}
+
+/*
+ * Read CHS info. Return 0 on success, error otherwise.
+ */
+static int
+bd_get_diskinfo_std(struct bdinfo *bd)
+{
+	bzero(&v86, sizeof (v86));
 	v86.ctl = V86_FLAGS;
 	v86.addr = 0x13;
 	v86.eax = 0x800;
 	v86.edx = bd->bd_unit;
 	v86int();
 
-	/* Don't error out if we get bad sector number, try EDD as well */
-	if (V86_CY(v86.efl) ||	/* carry set */
-	    (v86.edx & 0xff) <= (unsigned)(bd->bd_unit & 0x7f))	/* unit # bad */
-		return (0);	/* skip device */
+	if (V86_CY(v86.efl) && ((v86.eax & 0xff00) != 0))
+		return ((v86.eax & 0xff00) >> 8);
 
-	if ((v86.ecx & 0x3f) == 0)	/* absurd sector number */
-		ret = 0;	/* set error */
+	/* return custom error on absurd sector number */
+	if ((v86.ecx & 0x3f) == 0)
+		return (0x60);
 
-	/* Convert max cyl # -> # of cylinders */
 	bd->bd_cyl = ((v86.ecx & 0xc0) << 2) + ((v86.ecx & 0xff00) >> 8) + 1;
 	/* Convert max head # -> # of heads */
 	bd->bd_hds = ((v86.edx & 0xff00) >> 8) + 1;
 	bd->bd_sec = v86.ecx & 0x3f;
-	bd->bd_type = v86.ebx & 0xff;
-	bd->bd_flags |= BD_MODEINT13;
+	bd->bd_type = v86.ebx;
+	bd->bd_sectors = (uint64_t)bd->bd_cyl * bd->bd_hds * bd->bd_sec;
 
-	/* Calculate sectors count from the geometry */
-	bd->bd_sectors = bd->bd_cyl * bd->bd_hds * bd->bd_sec;
-	bd->bd_sectorsize = BIOSDISK_SECSIZE;
-	DEBUG("unit 0x%x geometry %d/%d/%d", bd->bd_unit, bd->bd_cyl,
-	    bd->bd_hds, bd->bd_sec);
+	return (0);
+}
 
-	/* Determine if we can use EDD with this device. */
-	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0x4100;
-	v86.edx = bd->bd_unit;
-	v86.ebx = 0x55aa;
-	v86int();
-	if (V86_CY(v86.efl) ||	/* carry set */
-	    (v86.ebx & 0xffff) != 0xaa55 || /* signature */
-	    (v86.ecx & EDD_INTERFACE_FIXED_DISK) == 0)
-		return (ret);	/* return code from int13 AH=08 */
+/*
+ * Read EDD info. Return 0 on success, error otherwise.
+ */
+static int
+bd_get_diskinfo_ext(struct bdinfo *bd)
+{
+	struct edd_params params;
+	uint64_t total;
 
-	/* EDD supported */
-	bd->bd_flags |= BD_MODEEDD1;
-	if ((v86.eax & 0xff00) >= 0x3000)
-		bd->bd_flags |= BD_MODEEDD3;
 	/* Get disk params */
-	params.len = sizeof (struct edd_params);
+	bzero(&params, sizeof (params));
+	params.len = sizeof (params);
 	v86.ctl = V86_FLAGS;
 	v86.addr = 0x13;
 	v86.eax = 0x4800;
@@ -249,36 +274,120 @@ bd_int13probe(struct bdinfo *bd)
 	v86.ds = VTOPSEG(&params);
 	v86.esi = VTOPOFF(&params);
 	v86int();
-	if (!V86_CY(v86.efl)) {
-		uint64_t total;
 
-		/*
-		 * Sector size must be a multiple of 512 bytes.
-		 * An alternate test would be to check power of 2,
-		 * powerof2(params.sector_size).
-		 */
-		if (params.sector_size % BIOSDISK_SECSIZE)
-			bd->bd_sectorsize = BIOSDISK_SECSIZE;
-		else
-			bd->bd_sectorsize = params.sector_size;
+	if (V86_CY(v86.efl) && ((v86.eax & 0xff00) != 0))
+		return ((v86.eax & 0xff00) >> 8);
 
-		total = bd->bd_sectorsize * params.sectors;
-		if (params.sectors != 0) {
-			/* Only update if we did not overflow. */
-			if (total > params.sectors)
-				bd->bd_sectors = params.sectors;
-		}
+	/*
+	 * Sector size must be a multiple of 512 bytes.
+	 * An alternate test would be to check power of 2,
+	 * powerof2(params.sector_size).
+	 * 4K is largest read buffer we can use at this time.
+	 */
+	if (params.sector_size >= 512 &&
+	    params.sector_size <= 4096 &&
+	    (params.sector_size % BIOSDISK_SECSIZE) == 0)
+		bd->bd_sectorsize = params.sector_size;
 
+	bd->bd_cyl = params.cylinders;
+	bd->bd_hds = params.heads;
+	bd->bd_sec = params.sectors_per_track;
+
+	if (params.sectors != 0) {
+		total = params.sectors;
+	} else {
 		total = (uint64_t)params.cylinders *
 		    params.heads * params.sectors_per_track;
-		if (total > 0 && bd->bd_sectors > total)
-			bd->bd_sectors = total;
-
-		ret = 1;
 	}
-	DEBUG("unit 0x%x flags %x, sectors %llu, sectorsize %u",
-	    bd->bd_unit, bd->bd_flags, bd->bd_sectors, bd->bd_sectorsize);
-	return (ret);
+	bd->bd_sectors = total;
+
+	return (0);
+}
+
+/*
+ * Try to detect a device supported by the legacy int13 BIOS
+ */
+static int
+bd_int13probe(struct bdinfo *bd)
+{
+	int edd;
+	int ret;
+
+	bd->bd_flags &= ~BD_NO_MEDIA;
+
+	edd = bd_check_extensions(bd->bd_unit);
+	if (edd == 0)
+		bd->bd_flags |= BD_MODEINT13;
+	else if (edd < 0x30)
+		bd->bd_flags |= BD_MODEEDD1;
+	else
+		bd->bd_flags |= BD_MODEEDD3;
+
+	/* Default sector size */
+	bd->bd_sectorsize = BIOSDISK_SECSIZE;
+
+	/*
+	 * Test if the floppy device is present, so we can avoid receiving
+	 * bogus information from bd_get_diskinfo_std().
+	 */
+	if (bd->bd_unit < 0x80) {
+		/* reset disk */
+		bd_reset_disk(bd->bd_unit);
+
+		/* Get disk type */
+		v86.ctl = V86_FLAGS;
+		v86.addr = 0x13;
+		v86.eax = 0x1500;
+		v86.edx = bd->bd_unit;
+		v86int();
+		if (V86_CY(v86.efl) || (v86.eax & 0x300) == 0)
+			return (0);
+	}
+
+	ret = 1;
+	if (edd != 0)
+		ret = bd_get_diskinfo_ext(bd);
+	if (ret != 0 || bd->bd_sectors == 0)
+		ret = bd_get_diskinfo_std(bd);
+
+	if (ret != 0 && bd->bd_unit < 0x80) {
+		/* Set defaults for 1.44 floppy */
+		bd->bd_cyl = 80;
+		bd->bd_hds = 2;
+		bd->bd_sec = 18;
+		bd->bd_type = 4;
+		bd->bd_sectors = 2880;
+		/* Since we are there, there most likely is no media */
+		bd->bd_flags |= BD_NO_MEDIA;
+		ret = 0;
+	}
+
+	if (ret != 0) {
+		if (bd->bd_sectors != 0 && edd != 0) {
+			bd->bd_sec = 63;
+			bd->bd_hds = 255;
+			bd->bd_cyl =
+			    (bd->bd_sectors + bd->bd_sec * bd->bd_hds - 1) /
+			    bd->bd_sec * bd->bd_hds;
+		} else {
+			printf("Can not get information about %s unit %#x\n",
+			    biosdisk.dv_name, bd->bd_unit);
+			return (0);
+		}
+	}
+
+	if (bd->bd_sec == 0)
+		bd->bd_sec = 63;
+	if (bd->bd_hds == 0)
+		bd->bd_hds = 255;
+
+	if (bd->bd_sectors == 0)
+		bd->bd_sectors = (uint64_t)bd->bd_cyl * bd->bd_hds * bd->bd_sec;
+
+	DEBUG("unit 0x%x geometry %d/%d/%d", bd->bd_unit, bd->bd_cyl,
+	    bd->bd_hds, bd->bd_sec);
+
+	return (1);
 }
 
 /*
@@ -300,13 +409,18 @@ bd_print(int verbose)
 
 	for (i = 0; i < nbdinfo; i++) {
 		snprintf(line, sizeof (line),
-		    "    disk%d:   BIOS drive %c (%ju X %u):\n", i,
+		    "    disk%d:   BIOS drive %c (%s%ju X %u):\n", i,
 		    (bdinfo[i].bd_unit < 0x80) ? ('A' + bdinfo[i].bd_unit):
 		    ('C' + bdinfo[i].bd_unit - 0x80),
+		    (bdinfo[i].bd_flags & BD_NO_MEDIA) == BD_NO_MEDIA ?
+		    "no media, " : "",
 		    (uintmax_t)bdinfo[i].bd_sectors,
 		    bdinfo[i].bd_sectorsize);
 		if ((ret = pager_output(line)) != 0)
 			break;
+
+		if ((bdinfo[i].bd_flags & BD_NO_MEDIA) == BD_NO_MEDIA)
+			continue;
 
 		dev.dd.d_dev = &biosdisk;
 		dev.dd.d_unit = i;
@@ -350,6 +464,13 @@ bd_open(struct open_file *f, ...)
 
 	if (dev->dd.d_unit < 0 || dev->dd.d_unit >= nbdinfo)
 		return (EIO);
+
+	if ((BD(dev).bd_flags & BD_NO_MEDIA) == BD_NO_MEDIA) {
+		if (!bd_int13probe(&BD(dev)))
+			return (EIO);
+		if ((BD(dev).bd_flags & BD_NO_MEDIA) == BD_NO_MEDIA)
+			return (EIO);
+	}
 	BD(dev).bd_open++;
 	if (BD(dev).bd_bcache == NULL)
 	    BD(dev).bd_bcache = bcache_allocate();
@@ -453,6 +574,9 @@ bd_realstrategy(void *devdata, int rw, daddr_t dblk, size_t size,
 	size_t blks, blkoff, bsize, rest;
 	caddr_t bbuf;
 	int rc;
+
+	if ((BD(dev).bd_flags & BD_NO_MEDIA) == BD_NO_MEDIA)
+		return (EIO);
 
 	/*
 	 * First make sure the IO size is a multiple of 512 bytes. While we do
@@ -684,29 +808,33 @@ bd_io(struct disk_devdesc *dev, daddr_t dblk, int blks, caddr_t dest,
 	if (dowrite == BD_RD && dblk >= 0x100000000)
 		bd_io_workaround(dev);
 	for (retry = 0; retry < 3; retry++) {
-		/* if retrying, reset the drive */
-		if (retry > 0) {
-			v86.ctl = V86_FLAGS;
-			v86.addr = 0x13;
-			v86.eax = 0;
-			v86.edx = BD(dev).bd_unit;
-			v86int();
-		}
-
-		if (BD(dev).bd_flags & BD_MODEEDD1)
+		if (BD(dev).bd_flags & BD_MODEEDD)
 			result = bd_edd_io(dev, dblk, blks, dest, dowrite);
 		else
 			result = bd_chs_io(dev, dblk, blks, dest, dowrite);
 
-		if (result == 0)
+		if (result == 0) {
+			if (BD(dev).bd_flags & BD_NO_MEDIA)
+				BD(dev).bd_flags &= ~BD_NO_MEDIA;
 			break;
+		}
+
+		bd_reset_disk(BD(dev).bd_unit);
+
+		/*
+		 * Error codes:
+		 * 20h	controller failure
+		 * 31h	no media in drive (IBM/MS INT 13 extensions)
+		 * 80h	no media in drive, VMWare (Fusion)
+		 * There is no reason to repeat the IO with errors above.
+		 */
+		if (result == 0x20 || result == 0x31 || result == 0x80) {
+			BD(dev).bd_flags |= BD_NO_MEDIA;
+			break;
+		}
 	}
 
-	/*
-	 * 0x20 - Controller failure. This is common error when the
-	 * media is not present.
-	 */
-	if (result != 0 && result != 0x20) {
+	if (result != 0 && (BD(dev).bd_flags & BD_NO_MEDIA) == 0) {
 		if (dowrite == BD_WR) {
 			printf("%s%d: Write %d sector(s) from %p (0x%x) "
 			    "to %lld: 0x%x\n", dev->dd.d_dev->dv_name,

--- a/usr/src/boot/sys/boot/i386/loader/main.c
+++ b/usr/src/boot/sys/boot/i386/loader/main.c
@@ -424,6 +424,8 @@ i386_zfs_probe(void)
     for (unit = 0; unit < MAXBDDEV; unit++) {
 	if (bd_unit2bios(unit) == -1)
 	    break;
+	if (bd_unit2bios(unit) < 0x80)
+	    continue;
 	sprintf(devname, "disk%d:", unit);
 	zfs_probe_dev(devname, NULL);
     }

--- a/usr/src/lib/cfgadm_plugins/ib/common/cfga_ib.c
+++ b/usr/src/lib/cfgadm_plugins/ib/common/cfga_ib.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include "cfga_ib.h"
@@ -73,7 +74,7 @@ void			cfga_msg(struct cfga_msg *, const char *);
 cfga_err_t		cfga_help(struct cfga_msg *, const char *,
 			    cfga_flags_t);
 static int		ib_confirm(struct cfga_confirm *, char *);
-static char 		*ib_get_devicepath(const char *);
+static char		*ib_get_devicepath(const char *);
 
 
 /* External function prototypes */
@@ -194,7 +195,7 @@ static char		*ib_service_subopts[] = {
 /* Communication Service name : "port" or "vppa" or "hca-svc" */
 static char		*comm_name = NULL;
 
-char 			*service_name = NULL;	/* service name */
+char			*service_name = NULL;	/* service name */
 ib_service_type_t	service_type = IB_NONE;	/* service type */
 
 
@@ -1654,14 +1655,12 @@ cfga_list_ext(const char *ap_id, cfga_list_data_t **ap_id_list, int *nlistp,
 	cfga_list_data_t	*clp = NULL;
 
 	if ((rv = ib_verify_params(ap_id, options, errstring)) != CFGA_IB_OK) {
-		(void) cfga_help(NULL, options, flags);
 		return (ib_err_msg(errstring, rv, ap_id, errno));
 	}
 
 	/* make sure we have a valid ap_id_list */
 	if (ap_id_list == NULL || nlistp == NULL) {
 		DPRINTF("cfga_list_ext: list = NULL or nlistp = NULL\n");
-		(void) cfga_help(NULL, options, flags);
 		return (ib_err_msg(errstring, CFGA_IB_INVAL_ARG_ERR,
 		    ap_id, errno));
 	}
@@ -1717,7 +1716,7 @@ cfga_list_ext(const char *ap_id, cfga_list_data_t **ap_id_list, int *nlistp,
 	/*
 	 * *nlistp contains to how many APIDs to show w/ cfgadm -l.
 	 * If ap_id is "fabric" then
-	 * 	*nlistp is all Dynamic Apids + One more for "fabric"
+	 *	*nlistp is all Dynamic Apids + One more for "fabric"
 	 * If ap_id is "HCA" ap_id then
 	 *	*nlistp is 1
 	 * Note that each HCA is a static APID, so nlistp will be 1 always

--- a/usr/src/lib/cfgadm_plugins/sata/common/cfga_sata.c
+++ b/usr/src/lib/cfgadm_plugins/sata/common/cfga_sata.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/param.h>
@@ -570,7 +571,7 @@ cfga_change_state(
     cfga_flags_t flags)
 {
 	int		ret;
-	int 		len;
+	int		len;
 	char		*msg;
 	char		*devpath;
 	nvlist_t	*nvl = NULL;
@@ -922,7 +923,7 @@ cfga_private_func(
     cfga_flags_t flags)
 {
 	int			len;
-	char 			*msg;
+	char			*msg;
 	nvlist_t		*list = NULL;
 	ap_ostate_t		ostate;
 	ap_rstate_t		rstate;
@@ -1430,7 +1431,6 @@ cfga_list_ext(
 
 
 	if ((rv = verify_params(ap_id, options, errstring)) != CFGA_SATA_OK) {
-		(void) cfga_help(NULL, options, flags);
 		goto bailout;
 	}
 	/* We do not care here about dynamic AP name component */
@@ -1440,7 +1440,6 @@ cfga_list_ext(
 
 	if (ap_id_list == NULL || nlistp == NULL) {
 		rv = CFGA_SATA_DATA_ERROR;
-		(void) cfga_help(NULL, options, flags);
 		goto bailout;
 	}
 

--- a/usr/src/lib/cfgadm_plugins/usb/common/cfga_usb.c
+++ b/usr/src/lib/cfgadm_plugins/usb/common/cfga_usb.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 
@@ -36,7 +37,7 @@ extern cfga_usb_ret_t	usb_rcm_online(const char *, char **, char *,
 extern cfga_usb_ret_t	usb_rcm_remove(const char *, char **, char *,
 			    cfga_flags_t);
 static int		usb_confirm(struct cfga_confirm *, char *);
-static char 		*usb_get_devicepath(const char *);
+static char		*usb_get_devicepath(const char *);
 
 /*
  * This file contains the entry points to the plugin as defined in the
@@ -621,7 +622,7 @@ device_connected(devctl_hdl_t hdl, nvlist_t *list, ap_ostate_t *ostate)
  */
 cfga_usb_ret_t
 do_control_ioctl(const char *ap_id, uint_t subcommand, uint_t arg,
-	void **descrp, size_t *sizep)
+    void **descrp, size_t *sizep)
 {
 	int			fd = -1;
 	uint_t			port;
@@ -1224,7 +1225,7 @@ cfga_private_func(
 	char			*msg;
 	nvlist_t		*list = NULL;
 	ap_ostate_t		ostate;
-	devctl_hdl_t 		hdl = NULL;
+	devctl_hdl_t		hdl = NULL;
 	cfga_usb_ret_t		rv;
 	usb_dev_descr_t		*dev_descrp = NULL;
 	char			*driver = NULL;
@@ -1474,14 +1475,12 @@ cfga_list_ext(
 	DPRINTF("cfga_list_ext:\n");
 
 	if ((rv = verify_params(ap_id, options, errstring)) != CFGA_USB_OK) {
-		(void) cfga_help(NULL, options, flags);
 		goto bailout;
 	}
 
 	if (ap_id_list == NULL || nlistp == NULL) {
 		DPRINTF("cfga_list_ext: list = NULL or nlistp = NULL\n");
 		rv = CFGA_USB_INTERNAL_ERROR;
-		(void) cfga_help(NULL, options, flags);
 		goto bailout;
 	}
 

--- a/usr/src/uts/Makefile.uts
+++ b/usr/src/uts/Makefile.uts
@@ -43,7 +43,7 @@ include $(SRC)/Makefile.master
 DTEXTDOM =
 
 #
-# 	Keep references to $(SRC)/common relative.
+#	Keep references to $(SRC)/common relative.
 COMMONBASE=	$(UTSBASE)/../common
 
 #
@@ -183,7 +183,7 @@ LINT_MODULE=	$(MODULE)
 #
 #	Build the compile/assemble lines:
 #
-EXTRA_OPTIONS		= 
+EXTRA_OPTIONS		=
 AS_DEFS			= -D_ASM -D__STDC__=0
 
 ALWAYS_DEFS_32		= -D_KERNEL -D_SYSCALL32 -D_DDI_STRICT
@@ -236,6 +236,7 @@ CFLAGS_uts		+= $(XAOPT)
 CFLAGS_uts		+= $(CTF_FLAGS_$(CLASS))
 CFLAGS_uts		+= $(CERRWARN)
 CFLAGS_uts		+= $(CCNOAUTOINLINE)
+CFLAGS_uts		+= $(CCNOREORDER)
 CFLAGS_uts		+= $(CGLOBALSTATIC)
 CFLAGS_uts		+= $(EXTRA_CFLAGS)
 CFLAGS_uts		+= $(CSOURCEDEBUGFLAGS)
@@ -324,7 +325,7 @@ CTFMERGE_GUDIR_sparc	= sun4u
 CTFMERGE_GUDIR_i386	= intel
 CTFMERGE_GUDIR		= $(CTFMERGE_GUDIR_$(MACH))
 
-CTFMERGE_GENUNIX 	= \
+CTFMERGE_GENUNIX	= \
 	$(UTSBASE)/$(CTFMERGE_GUDIR)/genunix/$(OBJS_DIR)/genunix
 
 #

--- a/usr/src/uts/common/io/hook.c
+++ b/usr/src/uts/common/io/hook.c
@@ -754,7 +754,7 @@ hook_stack_notify_unregister(netstackid_t stackid, hook_notify_fn_t callback)
 		}
 	} else {
 		/*
-		 * hook_notify_register() should only fail if the callback has
+		 * hook_notify_unregister() should only fail if the callback has
 		 * already been deleted (ESRCH).
 		 */
 		VERIFY3S(error, ==, ESRCH);

--- a/usr/src/uts/intel/asm/cpu.h
+++ b/usr/src/uts/intel/asm/cpu.h
@@ -63,7 +63,7 @@ prefetch_read_many(void *addr)
 }
 
 extern __GNU_INLINE void
-refetch_read_once(void *addr)
+prefetch_read_once(void *addr)
 {
 #if defined(__amd64)
 	__asm__(


### PR DESCRIPTION
Weekly merge from `illumos-gate`

## Backports to r28

* 9941 Noise from cfgadm plugins

## Backports to r22/r26

None

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2018110801-4ab1a7613b i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu Nov  8 21:09:06 CET 2018 ====
==== Nightly distributed build completed: Thu Nov  8 22:25:47 CET 2018 ====

==== Total build time ====

real    1:16:41

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-a55edc60f2 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.3.0-il-1) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.7.0_191-b02"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   80

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018110801-4ab1a7613b

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:24.9
user  1:48:24.5
sys      7:33.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:09.8
user  1:42:06.2
sys      7:44.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    15:10.0
user    27:22.1
sys      3:37.2

==== lint warnings src ====


==== lint noise differences src ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```