### PR TITLE
Add missing dependency to gld

### DIFF
--- a/usr/src/uts/intel/gld/Makefile
+++ b/usr/src/uts/intel/gld/Makefile
@@ -57,6 +57,8 @@ ALL_TARGET	= $(BINARY)
 LINT_TARGET	= $(MODULE).lint
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
+LDFLAGS		+= -dy -N misc/mac
+
 #
 # For now, disable these lint checks; maintainers should endeavor
 # to investigate and remove these for maximum lint coverage.


### PR DESCRIPTION
Followup to 45166ac4ddc51e436ef237c0470cb5bb5fd00fea adding missing dependency to the `gld` module.

Before:

```
# modload /kernel/misc/amd64/gld
can't load module: Invalid argument

Nov 12 11:15:05 bloody genunix: [ID 819705 kern.notice] /kernel/misc/amd64/gld: undefined symbol
Nov 12 11:15:05 bloody genunix: [ID 826211 kern.notice]  'mac_hcksum_set'
Nov 12 11:15:05 bloody genunix: [ID 819705 kern.notice] /kernel/misc/amd64/gld: undefined symbol
Nov 12 11:15:05 bloody genunix: [ID 826211 kern.notice]  'mac_hcksum_get'
Nov 12 11:15:05 bloody genunix: [ID 472681 kern.notice] WARNING: mod_load: cannot load module 'gld'

```

After:
```
# modload /tmp/gld
# modinfo | grep gld
257 fffffffff8054000   c400   -   1  gld (Generic LAN Driver (v2))
```
