### PR TITLE
Ship sys/hma.h header

### DIFF
--- a/usr/src/pkg/manifests/system-header.mf
+++ b/usr/src/pkg/manifests/system-header.mf
@@ -1677,6 +1677,7 @@ $(i386_ONLY)file path=usr/platform/i86pc/include/sys/cram.h
 $(i386_ONLY)file path=usr/platform/i86pc/include/sys/ddi_subrdefs.h
 $(i386_ONLY)file path=usr/platform/i86pc/include/sys/debug_info.h
 $(i386_ONLY)file path=usr/platform/i86pc/include/sys/fastboot.h
+$(i386_ONLY)file path=usr/platform/i86pc/include/sys/hma.h
 $(i386_ONLY)file path=usr/platform/i86pc/include/sys/ht.h
 $(i386_ONLY)file path=usr/platform/i86pc/include/sys/mach_mmu.h
 $(i386_ONLY)file path=usr/platform/i86pc/include/sys/machclock.h

--- a/usr/src/uts/i86pc/sys/Makefile
+++ b/usr/src/uts/i86pc/sys/Makefile
@@ -46,6 +46,7 @@ CHKHDRS=  \
 	ddi_subrdefs.h	\
 	debug_info.h	\
 	fastboot.h	\
+	hma.h		\
 	ht.h		\
 	mach_mmu.h	\
 	machclock.h	\


### PR DESCRIPTION
This header is currently not provided under /usr/platform/i86pc/include/sys/ but is needed for integrating Virtualbox with the HMA framework.