### PR TITLE
Switch /usr/lib/zfs/pyzfs.py to python3

### DIFF
--- a/usr/src/cmd/pyzfs/Makefile
+++ b/usr/src/cmd/pyzfs/Makefile
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
 include ../Makefile.cmd
@@ -28,14 +29,14 @@ ROOTCMDDIR=	$(ROOTLIB)/zfs
 
 PYSRCS=		pyzfs.py
 PYOBJS=		$(PYSRCS:%.py=%.pyc)
-PYFILES=	$(PYSRCS) $(PYOBJS)
+PYFILES=	$(PYSRCS)
 POFILE=		pyzfs.po
 
 ROOTLIBZFSFILES= $(PYFILES:%=$(ROOTLIB)/zfs/%)
 
 .KEEP_STATE:
 
-all: $(PYOBJS)
+all:
 
 install: all $(ROOTLIBZFSFILES)
 

--- a/usr/src/cmd/pyzfs/pyzfs.py
+++ b/usr/src/cmd/pyzfs/pyzfs.py
@@ -1,4 +1,4 @@
-#!@PYTHON@ -S
+#!@PYTHON3@ -S
 #
 # CDDL HEADER START
 #

--- a/usr/src/pkg/manifests/system-file-system-zfs.mf
+++ b/usr/src/pkg/manifests/system-file-system-zfs.mf
@@ -100,7 +100,7 @@ file path=usr/lib/mdb/proc/libzpool.so group=sys mode=0555
 file path=usr/lib/sysevent/modules/zfs_mod.so group=sys
 file path=usr/lib/zfs/availdevs mode=0555
 file path=usr/lib/zfs/pyzfs.py mode=0555
-file path=usr/lib/zfs/pyzfs.pyc mode=0555
+#file path=usr/lib/zfs/pyzfs.pyc mode=0555
 $(i386_ONLY)file path=usr/sbin/$(ARCH32)/zdb mode=0555
 file path=usr/sbin/$(ARCH64)/zdb mode=0555
 file path=usr/sbin/zstreamdump mode=0555


### PR DESCRIPTION
and stop shipping the python compiled version. It will still run without it and if run as root the cache file will be created automatically. This avoids the complication of having to ship both python 2 and python 3 compiled versions and reconciling both versions delivering pyzfs.py.

Following this, dependencies in the zfs package no longer include the python2 modules:

```
% pkg contents -mg . zfs | egrep '^depend.*python'
depend fmri=pkg:/runtime/python-35@3.5.6-151029.0 type=require
depend fmri=pkg:/system/library/python/solaris-35@0.5.11-151029.0 type=require
depend fmri=pkg:/system/library/python/zfs-35@0.5.11-151029.0 type=require
depend fmri=system/library/python/zfs-35 type=require
```