### PR TITLE
cpu_array.h - use pointer in place of null dimension array

### DIFF
--- a/usr/src/uts/common/sys/cpu_uarray.h
+++ b/usr/src/uts/common/sys/cpu_uarray.h
@@ -60,7 +60,7 @@ extern "C" {
 typedef struct {
 	uint64_t cu_nr_items;
 	char cu_pad[CUA_ALIGN - sizeof (uint64_t)];
-	volatile uint64_t cu_vals[];
+	volatile uint64_t *cu_vals;
 } cpu_uarray_t __aligned(CUA_ALIGN);
 
 extern cpu_uarray_t *cpu_uarray_zalloc(size_t, int);


### PR DESCRIPTION
Fixes

`"/usr/include/sys/cpu_uarray.h", line 63: null dimension: cu_vals`

when building g11n and openjdk.

Build is clean with this change.