### PR TITLE
Upstream merge/2018112201

### DIFF
--- a/usr/src/boot/sys/boot/efi/boot1/Makefile.com
+++ b/usr/src/boot/sys/boot/efi/boot1/Makefile.com
@@ -31,6 +31,9 @@ OBJS=	multiboot.o boot1.o self_reloc.o start.o ufs_module.o zfs_module.o \
 
 CFLAGS= -O2
 CPPFLAGS=	-nostdinc -D_STANDALONE
+
+zfs_module.o := CFLAGS += -Wno-unused-function
+
 CPPFLAGS +=	-I.
 CPPFLAGS +=	-I../../include
 CPPFLAGS +=	-I../../include/$(MACHINE)

--- a/usr/src/cmd/mdb/intel/kmdb/kctl/kctl_isadep.c
+++ b/usr/src/cmd/mdb/intel/kmdb/kctl/kctl_isadep.c
@@ -114,14 +114,12 @@ kctl_pcache_create(int *nprops)
 		    ttymode);
 	}
 
-	/*
-	 * console is defined by "console" property, with
-	 * fallback on the old "input-device" property.
-	 */
 	(void) strcpy(inputdev, "text");	/* default to screen */
-	if (!preader("console", inputdev, sizeof ((&pnv[0])->kanv_val)))
+	if (!preader("diag-device", inputdev, sizeof ((&pnv[0])->kanv_val)) &&
+	    !preader("console", inputdev, sizeof ((&pnv[0])->kanv_val))) {
 		(void) preader("input-device", inputdev,
 		    sizeof ((&pnv[0])->kanv_val));
+	}
 
 	if (strncmp(inputdev, "tty", 3) == 0 &&
 	    inputdev[4] == '\0' &&

--- a/usr/src/man/man1m/eeprom.1m
+++ b/usr/src/man/man1m/eeprom.1m
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH EEPROM 1M "Feb 21, 2016"
+.TH EEPROM 1M "Oct 27, 2018"
 .SH NAME
 eeprom \- EEPROM display and load utility
 .SH SYNOPSIS
@@ -109,7 +109,6 @@ the console device falls back to the device specified by \fBinput-device\fR and
 console defaults to the frame buffer and keyboard.
 .RE
 
-.SS "x86 Only"
 .ne 2
 .na
 \fB\fIos_console\fR\fR
@@ -119,6 +118,19 @@ console defaults to the frame buffer and keyboard.
 While \fBconsole\fR controls both boot loader and kernel console, setting
 \fBos_console\fR allows setting console device only for kernel. Values
 are the same as for \fBconsole\fR.
+.RE
+
+.ne 2
+.na
+\fB\fIdiag-device\fR\fR
+.ad
+.sp .6
+.RS 4n
+The \fBdiag-device\fR is currently implemented to support serial port
+as output for system early boot diagnostic messages and input and output
+for \fBkmdb\fR debugger. For early boot, all the console messages are mirrored
+to \fBdiag-device\fR, until the console drivers are loaded.
+After that, only \fBkmdb\fR will continue to use the \fBdiag-device\fR.
 .RE
 
 .SH NVRAM CONFIGURATION PARAMETERS

--- a/usr/src/uts/common/os/space.c
+++ b/usr/src/uts/common/os/space.c
@@ -212,6 +212,7 @@ int ts_dispatch_extended = -1; /* set in ts_getdptbl or set_platform_default */
 dev_t kbddev = NODEV;
 dev_t mousedev = NODEV;
 dev_t stdindev = NODEV;
+dev_t diagdev = NODEV;
 struct vnode *wsconsvp;
 
 dev_t fbdev = NODEV;

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -170,7 +170,7 @@
  *
  *   Ordering requirements:
  *       pool_lock --> cpu_lock --> zonehash_lock --> zone_status_lock -->
- *       	zone_lock --> zsd_key_lock --> pidlock --> p_lock
+ *       zone_lock --> zsd_key_lock --> pidlock --> p_lock
  *
  *   When taking zone_mem_lock or zone_nlwps_lock, the lock ordering is:
  *	zonehash_lock --> a_lock --> pidlock --> p_lock --> zone_mem_lock
@@ -2821,6 +2821,8 @@ zone_free(zone_t *zone)
 	}
 	list_destroy(&zone->zone_dl_list);
 
+	cpu_uarray_free(zone->zone_ustate);
+
 	if (zone->zone_rootvp != NULL)
 		VN_RELE(zone->zone_rootvp);
 	if (zone->zone_rootpath)
@@ -5034,6 +5036,8 @@ zone_create(const char *zone_name, const char *zone_root,
 	zone_pdata[zoneid].zpers_zfsp =
 	    kmem_zalloc(sizeof (zone_zfs_io_t), KM_SLEEP);
 	zone_pdata[zoneid].zpers_zfsp->zpers_zfs_io_pri = 1;
+
+	zone->zone_ustate = cpu_uarray_zalloc(ZONE_USTATE_MAX, KM_SLEEP);
 
 	zone->zone_ustate = cpu_uarray_zalloc(ZONE_USTATE_MAX, KM_SLEEP);
 

--- a/usr/src/uts/common/sys/consconfig_dacf.h
+++ b/usr/src/uts/common/sys/consconfig_dacf.h
@@ -54,6 +54,7 @@ typedef struct cons_state {
 	char	*cons_mouse_path;	/* Mouse path */
 	char	*cons_stdin_path;	/* Standard input path */
 	char	*cons_stdout_path;	/* Standard output path */
+	char	*cons_diag_path;	/* Diag device path */
 
 	char	*cons_fb_path;		/* Frame Buffer path */
 

--- a/usr/src/uts/common/sys/consdev.h
+++ b/usr/src/uts/common/sys/consdev.h
@@ -68,6 +68,7 @@ extern dev_t	stdindev;	/* default standard input device */
 extern dev_t	fbdev;		/* default framebuffer device */
 extern struct vnode *fbvp;	/* pointer to vnode for that device */
 extern dev_info_t *fbdip;	/* pointer to dev_info for fbdev (optional) */
+extern dev_t	diagdev;	/* default diag device (optional) */
 
 extern int	consmode;	/* CONS_FW or CONS_KFB */
 extern int	cons_tem_disable;
@@ -135,7 +136,7 @@ extern struct vnode *rwsconsvp;	/* vnode for underlying workstation console */
  * Set the type simulated by hardwares
  * ioctl(fd, CONSSETKBDTYPE, kbdtype)
  * kbdtype:
- * 	KB_PC or KB_USB
+ *	KB_PC or KB_USB
  */
 #define	CONSSETKBDTYPE		(_CONSIOC|4)
 

--- a/usr/src/uts/common/sys/consplat.h
+++ b/usr/src/uts/common/sys/consplat.h
@@ -40,6 +40,7 @@ extern char *plat_fbpath(void);
 extern char *plat_mousepath(void);
 extern char *plat_stdinpath(void);
 extern char *plat_stdoutpath(void);
+extern char *plat_diagpath(void);
 extern int plat_stdin_is_keyboard(void);
 extern int plat_stdout_is_framebuffer(void);
 extern void plat_tem_get_inverses(int *, int *);

--- a/usr/src/uts/common/sys/cpu_uarray.h
+++ b/usr/src/uts/common/sys/cpu_uarray.h
@@ -60,7 +60,11 @@ extern "C" {
 typedef struct {
 	uint64_t cu_nr_items;
 	char cu_pad[CUA_ALIGN - sizeof (uint64_t)];
-	volatile uint64_t *cu_vals;
+#ifdef	__lint
+	volatile uint64_t cu_vals[1];
+#else
+	volatile uint64_t cu_vals[];
+#endif
 } cpu_uarray_t __aligned(CUA_ALIGN);
 
 extern cpu_uarray_t *cpu_uarray_zalloc(size_t, int);

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015 Joyent, Inc. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  * Copyright 2014 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2014 Igor Kozhukhov <ikozhukhov@gmail.com>.
  * Copyright 2018, Joyent, Inc.

--- a/usr/src/uts/i86pc/boot/boot_console.c
+++ b/usr/src/uts/i86pc/boot/boot_console.c
@@ -59,6 +59,7 @@ extern int bcons_ischar_xen(void);
 
 static int cons_color = CONS_COLOR;
 static int console = CONS_SCREEN_TEXT;
+static int diag = CONS_INVALID;
 static int tty_num = 0;
 static int tty_addr[] = {0x3f8, 0x2f8, 0x3e8, 0x2e8};
 static char *boot_line;
@@ -607,16 +608,57 @@ bcons_init_env(struct xboot_info *xbi)
 	boot_env.be_size = modules[i].bm_size;
 }
 
+/*
+ * Go through the console_devices array trying to match the string
+ * we were given.  The string on the command line must end with
+ * a comma or white space.
+ *
+ * This function does set tty_num as an side effect, this does imply that
+ * only one of the main console and the diag-device can be using serial.
+ */
+static int
+lookup_console_devices(const char *cons_str)
+{
+	int n, cons;
+	size_t len, cons_len;
+	console_value_t *consolep;
+
+	cons = CONS_INVALID;
+	if (cons_str != NULL) {
+
+		cons_len = strlen(cons_str);
+		for (n = 0; console_devices[n].name != NULL; n++) {
+			consolep = &console_devices[n];
+			len = strlen(consolep->name);
+			if ((len <= cons_len) && ((cons_str[len] == '\0') ||
+			    (cons_str[len] == ',') || (cons_str[len] == '\'') ||
+			    (cons_str[len] == '"') || ISSPACE(cons_str[len])) &&
+			    (strncmp(cons_str, consolep->name, len) == 0)) {
+				cons = consolep->value;
+				if (cons == CONS_TTY)
+					tty_num = n;
+				break;
+			}
+		}
+	}
+	return (cons);
+}
+
 void
 bcons_init(struct xboot_info *xbi)
 {
-	console_value_t *consolep;
-	size_t len, cons_len;
 	const char *cons_str;
 #if !defined(_BOOT)
 	static char console_text[] = "text";
 	extern int post_fastreboot;
 #endif
+
+	if (xbi == NULL) {
+		/* This is very early dboot console, set up ttya. */
+		console = CONS_TTY;
+		serial_init();
+		return;
+	}
 
 	/* Set up data to fetch properties from commad line and boot env. */
 	boot_line = (char *)(uintptr_t)xbi->bi_cmdline;
@@ -627,6 +669,13 @@ bcons_init(struct xboot_info *xbi)
 	bcons_init_xen(boot_line);
 #endif /* __xpv */
 
+	/*
+	 * First check for diag-device.
+	 */
+	cons_str = find_boot_prop("diag-device");
+	if (cons_str != NULL)
+		diag = lookup_console_devices(cons_str);
+
 	cons_str = find_boot_prop("console");
 	if (cons_str == NULL)
 		cons_str = find_boot_prop("output-device");
@@ -636,29 +685,8 @@ bcons_init(struct xboot_info *xbi)
 		cons_str = console_text;
 #endif
 
-	/*
-	 * Go through the console_devices array trying to match the string
-	 * we were given.  The string on the command line must end with
-	 * a comma or white space.
-	 */
-	if (cons_str != NULL) {
-		int n;
-
-		cons_len = strlen(cons_str);
-		for (n = 0; console_devices[n].name != NULL; n++) {
-			consolep = &console_devices[n];
-			len = strlen(consolep->name);
-			if ((len <= cons_len) && ((cons_str[len] == '\0') ||
-			    (cons_str[len] == ',') || (cons_str[len] == '\'') ||
-			    (cons_str[len] == '"') || ISSPACE(cons_str[len])) &&
-			    (strncmp(cons_str, consolep->name, len) == 0)) {
-				console = consolep->value;
-				if (console == CONS_TTY)
-					tty_num = n;
-				break;
-			}
-		}
-	}
+	if (cons_str != NULL)
+		console = lookup_console_devices(cons_str);
 
 #if defined(__xpv)
 	/*
@@ -742,6 +770,24 @@ bcons_init(struct xboot_info *xbi)
 		clear_screen();	/* clears the grub or xen screen */
 #endif /* _BOOT */
 		kb_init();
+		break;
+	}
+
+	/*
+	 * Initialize diag device unless already done.
+	 */
+	switch (diag) {
+	case CONS_TTY:
+		if (console != CONS_TTY)
+			serial_init();
+		break;
+	case CONS_SCREEN_GRAPHICS:
+	case CONS_SCREEN_TEXT:
+		if (console != CONS_SCREEN_GRAPHICS &&
+		    console != CONS_SCREEN_TEXT)
+			kb_init();
+		break;
+	default:
 		break;
 	}
 }
@@ -909,9 +955,9 @@ serial_ischar(void)
 }
 
 static void
-_doputchar(int c)
+_doputchar(int device, int c)
 {
-	switch (console) {
+	switch (device) {
 	case CONS_TTY:
 		serial_putchar(c);
 		return;
@@ -923,6 +969,7 @@ _doputchar(int c)
 	case CONS_USBSER:
 		defcons_putchar(c);
 #endif /* _BOOT */
+	default:
 		return;
 	}
 }
@@ -942,23 +989,33 @@ bcons_putchar(int c)
 
 	if (c == '\t') {
 		do {
-			_doputchar(' ');
+			_doputchar(console, ' ');
+			if (diag != console)
+				_doputchar(diag, ' ');
 		} while (++bhcharpos % 8);
 		return;
 	} else  if (c == '\n' || c == '\r') {
 		bhcharpos = 0;
-		_doputchar('\r');
-		_doputchar(c);
+		_doputchar(console, '\r');
+		_doputchar(console, c);
+		if (diag != console) {
+			_doputchar(diag, '\r');
+			_doputchar(diag, c);
+		}
 		return;
 	} else if (c == '\b') {
 		if (bhcharpos)
 			bhcharpos--;
-		_doputchar(c);
+		_doputchar(console, c);
+		if (diag != console)
+			_doputchar(diag, c);
 		return;
 	}
 
 	bhcharpos++;
-	_doputchar(c);
+	_doputchar(console, c);
+	if (diag != console)
+		_doputchar(diag, c);
 }
 
 /*
@@ -973,11 +1030,15 @@ bcons_getchar(void)
 		return (bcons_getchar_xen());
 #endif /* __xpv */
 
-	switch (console) {
-	case CONS_TTY:
-		return (serial_getchar());
-	default:
-		return (kb_getchar());
+	for (;;) {
+		if (console == CONS_TTY || diag == CONS_TTY) {
+			if (serial_ischar())
+				return (serial_getchar());
+		}
+		if (console != CONS_INVALID || diag != CONS_INVALID) {
+			if (kb_ischar())
+				return (kb_getchar());
+		}
 	}
 }
 
@@ -986,6 +1047,7 @@ bcons_getchar(void)
 int
 bcons_ischar(void)
 {
+	int c = 0;
 
 #if defined(__xpv)
 	if (!DOMAIN_IS_INITDOMAIN(xen_info) ||
@@ -995,10 +1057,31 @@ bcons_ischar(void)
 
 	switch (console) {
 	case CONS_TTY:
-		return (serial_ischar());
+		c = serial_ischar();
+		break;
+
+	case CONS_INVALID:
+		break;
+
 	default:
-		return (kb_ischar());
+		c = kb_ischar();
 	}
+	if (c != 0)
+		return (c);
+
+	switch (diag) {
+	case CONS_TTY:
+		c = serial_ischar();
+		break;
+
+	case CONS_INVALID:
+		break;
+
+	default:
+		c = kb_ischar();
+	}
+
+	return (c);
 }
 
 #endif /* _BOOT */

--- a/usr/src/uts/i86pc/dboot/dboot_startkern.c
+++ b/usr/src/uts/i86pc/dboot/dboot_startkern.c
@@ -41,6 +41,13 @@
 #include <util/strtolctype.h>
 #include <sys/efi.h>
 
+/*
+ * Compile time debug knob. We do not have any early mechanism to control it
+ * as the boot is the earliest mechanism we have, and we do not want to have
+ * it being switched on by default.
+ */
+int dboot_debug = 0;
+
 #if defined(__xpv)
 
 #include <sys/hypervisor.h>
@@ -75,7 +82,7 @@ extern int have_cpuid(void);
  *
  * The code executes as:
  *	- 32 bits under GRUB (for 32 or 64 bit Solaris)
- * 	- a 32 bit program for the 32-bit PV hypervisor
+ *	- a 32 bit program for the 32-bit PV hypervisor
  *	- a 64 bit program for the 64-bit PV hypervisor (at least for now)
  *
  * Under the PV hypervisor, we must create mappings for any memory beyond the
@@ -2202,6 +2209,8 @@ startup_kernel(void)
 	physdev_set_iopl_t set_iopl;
 #endif /* __xpv */
 
+	if (dboot_debug == 1)
+		bcons_init(NULL);	/* Set very early console to ttya. */
 	dboot_loader_init();
 	/*
 	 * At this point we are executing in a 32 bit real mode.
@@ -2223,7 +2232,7 @@ startup_kernel(void)
 
 	dboot_init_xboot_consinfo();
 	bi->bi_cmdline = (native_ptr_t)(uintptr_t)cmdline;
-	bcons_init(bi);
+	bcons_init(bi);		/* Now we can set the real console. */
 
 	prom_debug = (find_boot_prop("prom_debug") != NULL);
 	map_debug = (find_boot_prop("map_debug") != NULL);

--- a/usr/src/uts/i86pc/io/consplat.c
+++ b/usr/src/uts/i86pc/io/consplat.c
@@ -532,6 +532,29 @@ plat_stdoutpath(void)
 	return (plat_fbpath());
 }
 
+char *
+plat_diagpath(void)
+{
+	dev_info_t *root;
+	char *diag;
+	int tty_num = -1;
+
+	root = ddi_root_node();
+
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, root, DDI_PROP_DONTPASS,
+	    "diag-device", &diag) == DDI_SUCCESS) {
+		if (strlen(diag) == 4 && strncmp(diag, "tty", 3) == 0 &&
+		    diag[3] >= 'a' && diag[3] <= 'd') {
+			tty_num = diag[3] - 'a';
+		}
+		ddi_prop_free(diag);
+	}
+
+	if (tty_num != -1)
+		return (plat_ttypath(tty_num));
+	return (NULL);
+}
+
 /*
  * If VIS_PIXEL mode will be implemented on x86, these following
  * functions should be re-considered. Now these functions are


### PR DESCRIPTION
Weekly merge from `illumos-gate`

## Backports

None

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2018112201-ed4add1461 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu Nov 22 18:38:42 CET 2018 ====
==== Nightly distributed build completed: Thu Nov 22 19:55:14 CET 2018 ====

==== Total build time ====

real    1:16:32

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-6ff672c9ac i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.3.0-il-1) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.7.0_201-b00"

/usr/bin/openssl
OpenSSL 1.1.0i  14 Aug 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   80

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2018112201-ed4add1461

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    26:53.9
user  1:45:44.6
sys      7:19.9

==== Build noise differences (non-DEBUG) ====

18a19,22
> In file included from ../sources/ldap/ssldap/clientinit.c:43:
> In file included from ../sources/ldap/ssldap/clientinit.c:43:0:
> In file included from ../sources/ldap/ssldap/ldapsinit.c:55:
> In file included from ../sources/ldap/ssldap/ldapsinit.c:55:0:

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    25:35.9
user  1:38:06.9
sys      7:04.1

==== Build noise differences (DEBUG) ====

16a17,20
> In file included from ../sources/ldap/ssldap/clientinit.c:43:
> In file included from ../sources/ldap/ssldap/clientinit.c:43:0:
> In file included from ../sources/ldap/ssldap/ldapsinit.c:55:
> In file included from ../sources/ldap/ssldap/ldapsinit.c:55:0:

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== 'dmake lint' of src ERRORS ====


==== Elapsed time of 'dmake lint' of src ====

real    14:57.6
user    26:47.6
sys      3:28.6

==== lint warnings src ====


==== lint noise differences src ====

3d2
< "/build/illumos-omnios/proto/root_i386/usr/include/sys/cpu_uarray.h", line 63: error: null dimension: cu_vals (E_NULL_DIMENSION)
9a9
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/intel/vmx.c", line 3437: warning: function returns value which is sometimes ignored: vm_unmap_mmio (E_FUNC_RET_MAYBE_IGNORED2)
13c13
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vatpic.c", line 262: warning: function returns value which is sometimes ignored: lapic_set_local_intr (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/ppt.c", line 887: warning: function returns value which is sometimes ignored: ddi_intr_remove_handler (E_FUNC_RET_MAYBE_IGNORED2)
18,19d17
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vlapic.c", line 481: warning: function returns value which is always ignored: vm_inject_extint (E_FUNC_RET_ALWAYS_IGNOR2)
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/io/vrtc.c", line 1004: warning: function returns value which is sometimes ignored: vrtc_set_reg_b (E_FUNC_RET_MAYBE_IGNORED2)
21c19
< "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 2529: warning: function returns value which is sometimes ignored: vm_restart_instruction (E_FUNC_RET_MAYBE_IGNORED2)
---
> "/build/illumos-omnios/usr/src/uts/i86pc/io/vmm/vmm.c", line 920: warning: function returns value which is sometimes ignored: vm_map_remove (E_FUNC_RET_MAYBE_IGNORED2)
35,45d32
< dmake: Warning: Command failed for target `cmd/mdb'
< dmake: Warning: Command failed for target `kctl_auxv.ln'
< dmake: Warning: Command failed for target `kctl_dmod.ln'
< dmake: Warning: Command failed for target `kctl_err.ln'
< dmake: Warning: Command failed for target `kctl_isadep.ln'
< dmake: Warning: Command failed for target `kctl_main.ln'
< dmake: Warning: Command failed for target `kctl_mod.ln'
< dmake: Warning: Command failed for target `kctl_string.ln'
< dmake: Warning: Command failed for target `kctl_wr.ln'
< dmake: Warning: Command failed for target `kmdb'
< dmake: Warning: Target `lint' not remade because of errors
48,55d34
< lint: errors in kctl_auxv.c; no output created
< lint: errors in kctl_dmod.c; no output created
< lint: errors in kctl_err.c; no output created
< lint: errors in kctl_isadep.c; no output created
< lint: errors in kctl_main.c; no output created
< lint: errors in kctl_mod.c; no output created
< lint: errors in kctl_string.c; no output created
< lint: errors in kctl_wr.c; no output created

==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```