### PR TITLE
Joyent merge/2018120701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: b118ac96296ecb7740c933bfe013b565a00b56c5
+Last illumos-joyent commit: b3bd764962b86d7c9b6cb4939d04a3bde0ca6519
 

--- a/usr/src/cmd/bhyve/block_if.c
+++ b/usr/src/cmd/bhyve/block_if.c
@@ -46,6 +46,9 @@ __FBSDID("$FreeBSD$");
 #include <sys/disk.h>
 #include <sys/limits.h>
 #include <sys/uio.h>
+#ifndef __FreeBSD__
+#include <sys/dkio.h>
+#endif
 
 #include <assert.h>
 #include <err.h>
@@ -69,11 +72,12 @@ __FBSDID("$FreeBSD$");
 
 #define BLOCKIF_SIG	0xb109b109
 
-#define BLOCKIF_NUMTHR	8
 #ifdef __FreeBSD__
+#define BLOCKIF_NUMTHR	8
 #define BLOCKIF_MAXREQ	(64 + BLOCKIF_NUMTHR)
 #else
 /* Enlarge to keep pace with the virtio-block ring size */
+#define BLOCKIF_NUMTHR	16
 #define BLOCKIF_MAXREQ	(128 + BLOCKIF_NUMTHR)
 #endif
 
@@ -104,12 +108,23 @@ struct blockif_elem {
 	off_t		     be_block;
 };
 
+#ifndef __FreeBSD__
+enum blockif_wce {
+	WCE_NONE = 0,
+	WCE_IOCTL,
+	WCE_FCNTL
+};
+#endif
+
 struct blockif_ctxt {
 	int			bc_magic;
 	int			bc_fd;
 	int			bc_ischr;
 	int			bc_isgeom;
 	int			bc_candelete;
+#ifndef __FreeBSD__
+	enum blockif_wce	bc_wce;
+#endif
 	int			bc_rdonly;
 	off_t			bc_size;
 	int			bc_sectsz;
@@ -230,8 +245,6 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 	struct blockif_req *br;
 #ifdef	__FreeBSD__
 	off_t arg[2];
-#else
-	boolean_t sync = B_FALSE;
 #endif
 	ssize_t clen, len, off, boff, voff;
 	int i, err;
@@ -277,11 +290,6 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 			br->br_resid -= len;
 		}
 		break;
-#ifndef __FreeBSD__
-	case BOP_WRITE_SYNC:
-		sync = B_TRUE;
-#endif
-		/* FALLTHROUGH */
 	case BOP_WRITE:
 		if (bc->bc_rdonly) {
 			err = EROFS;
@@ -330,6 +338,12 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 		} else if (fsync(bc->bc_fd))
 			err = errno;
 #else
+		/*
+		 * This fsync() should be adequate to flush the cache of a file
+		 * or device.  In VFS, the VOP_SYNC operation is converted to
+		 * the appropriate ioctl in both sdev (for real devices) and
+		 * zfs (for zvols).
+		 */
 		if (fsync(bc->bc_fd))
 			err = errno;
 #endif
@@ -356,11 +370,6 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 		err = EINVAL;
 		break;
 	}
-
-#ifndef __FreeBSD__
-	if (sync && err == 0 && fsync(bc->bc_fd) < 0)
-		err = errno;
-#endif
 
 	be->be_status = BST_DONE;
 
@@ -456,6 +465,8 @@ blockif_open(const char *optstr, const char *ident)
 	struct stat sbuf;
 #ifdef	__FreeBSD__
 	struct diocgattr_arg arg;
+#else
+	enum blockif_wce wce = WCE_NONE;
 #endif
 	off_t size, psectsz, psectoff;
 	int extra, fd, i, sectsz;
@@ -555,9 +566,66 @@ blockif_open(const char *optstr, const char *ident)
 			candelete = arg.value.i;
 		if (ioctl(fd, DIOCGPROVIDERNAME, name) == 0)
 			geom = 1;
-	} else
-#endif
+	} else {
 		psectsz = sbuf.st_blksize;
+	}
+#else
+	psectsz = sbuf.st_blksize;
+	if (S_ISCHR(sbuf.st_mode)) {
+		struct dk_minfo_ext dkmext;
+		int wce_val;
+
+		/* Look for a more accurate physical blocksize */
+		if (ioctl(fd, DKIOCGMEDIAINFOEXT, &dkmext) == 0) {
+			psectsz = dkmext.dki_pbsize;
+		}
+		/* See if a configurable write cache is present and working */
+		if (ioctl(fd, DKIOCGETWCE, &wce_val) == 0) {
+			/*
+			 * If WCE is already active, disable it until the
+			 * specific device driver calls for its return.  If it
+			 * is not active, toggle it on and off to verify that
+			 * such actions are possible.
+			 */
+			if (wce_val != 0) {
+				wce_val = 0;
+				/*
+				 * Inability to disable the cache is a threat
+				 * to data durability.
+				 */
+				assert(ioctl(fd, DKIOCSETWCE, &wce_val) == 0);
+				wce = WCE_IOCTL;
+			} else {
+				int r1, r2;
+
+				wce_val = 1;
+				r1 = ioctl(fd, DKIOCSETWCE, &wce_val);
+				wce_val = 0;
+				r2 = ioctl(fd, DKIOCSETWCE, &wce_val);
+
+				if (r1 == 0 && r2 == 0) {
+					wce = WCE_IOCTL;
+				} else {
+					/*
+					 * If the cache cache toggle was not
+					 * successful, ensure that the cache
+					 * was not left enabled.
+					 */
+					assert(r1 != 0);
+				}
+			}
+		}
+	} else {
+		int flags;
+
+		if ((flags = fcntl(fd, F_GETFL)) >= 0) {
+			flags |= O_DSYNC;
+			if (fcntl(fd, F_SETFL, flags) != -1) {
+				wce = WCE_FCNTL;
+			}
+		}
+	}
+#endif
 
 #ifndef WITHOUT_CAPSICUM
 	if (cap_ioctls_limit(fd, cmds, nitems(cmds)) == -1 && errno != ENOSYS)
@@ -604,6 +672,9 @@ blockif_open(const char *optstr, const char *ident)
 	bc->bc_ischr = S_ISCHR(sbuf.st_mode);
 	bc->bc_isgeom = geom;
 	bc->bc_candelete = candelete;
+#ifndef __FreeBSD__
+	bc->bc_wce = wce;
+#endif
 	bc->bc_rdonly = ro;
 	bc->bc_size = size;
 	bc->bc_sectsz = sectsz;
@@ -671,19 +742,11 @@ blockif_read(struct blockif_ctxt *bc, struct blockif_req *breq)
 }
 
 int
-#ifdef __FreeBSD__
 blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq)
-#else
-blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq, boolean_t sync)
-#endif
 {
 
 	assert(bc->bc_magic == BLOCKIF_SIG);
-#ifdef __FreeBSD__
 	return (blockif_request(bc, breq, BOP_WRITE));
-#else
-	return (blockif_request(bc, breq, sync ? BOP_WRITE_SYNC : BOP_WRITE));
-#endif
 }
 
 int
@@ -908,3 +971,46 @@ blockif_candelete(struct blockif_ctxt *bc)
 	assert(bc->bc_magic == BLOCKIF_SIG);
 	return (bc->bc_candelete);
 }
+
+#ifndef __FreeBSD__
+int
+blockif_set_wce(struct blockif_ctxt *bc, int wc_enable)
+{
+	int res = 0, flags;
+	int clean_val = (wc_enable != 0) ? 1 : 0;
+
+	(void) pthread_mutex_lock(&bc->bc_mtx);
+	switch (bc->bc_wce) {
+	case WCE_IOCTL:
+		res = ioctl(bc->bc_fd, DKIOCSETWCE, &clean_val);
+		break;
+	case WCE_FCNTL:
+		if ((flags = fcntl(bc->bc_fd, F_GETFL)) >= 0) {
+			if (wc_enable == 0) {
+				flags |= O_DSYNC;
+			} else {
+				flags &= ~O_DSYNC;
+			}
+			if (fcntl(bc->bc_fd, F_SETFL, flags) == -1) {
+				res = -1;
+			}
+		} else {
+			res = -1;
+		}
+		break;
+	default:
+		break;
+	}
+
+	/*
+	 * After a successful disable of the write cache, ensure that any
+	 * lingering data in the cache is synced out.
+	 */
+	if (res == 0 && wc_enable == 0) {
+		res = fsync(bc->bc_fd);
+	}
+	(void) pthread_mutex_unlock(&bc->bc_mtx);
+
+	return (res);
+}
+#endif /* __FreeBSD__ */

--- a/usr/src/cmd/bhyve/block_if.h
+++ b/usr/src/cmd/bhyve/block_if.h
@@ -71,13 +71,11 @@ void	blockif_psectsz(struct blockif_ctxt *bc, int *size, int *off);
 int	blockif_queuesz(struct blockif_ctxt *bc);
 int	blockif_is_ro(struct blockif_ctxt *bc);
 int	blockif_candelete(struct blockif_ctxt *bc);
-int	blockif_read(struct blockif_ctxt *bc, struct blockif_req *breq);
-#ifdef __FreeBSD__
-int	blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq);
-#else
-int	blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq,
-    boolean_t sync);
+#ifndef __FreeBSD__
+int	blockif_set_wce(struct blockif_ctxt *bc, int enable);
 #endif
+int	blockif_read(struct blockif_ctxt *bc, struct blockif_req *breq);
+int	blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq);
 int	blockif_flush(struct blockif_ctxt *bc, struct blockif_req *breq);
 int	blockif_delete(struct blockif_ctxt *bc, struct blockif_req *breq);
 int	blockif_cancel(struct blockif_ctxt *bc, struct blockif_req *breq);

--- a/usr/src/cmd/bhyve/fwctl.c
+++ b/usr/src/cmd/bhyve/fwctl.c
@@ -79,8 +79,8 @@ static u_int ident_idx;
 
 struct op_info {
 	int op;
-	int  (*op_start)(int len);
-	void (*op_data)(uint32_t data, int len);
+	int  (*op_start)(uint32_t len);
+	void (*op_data)(uint32_t data, uint32_t len);
 	int  (*op_result)(struct iovec **data);
 	void (*op_done)(struct iovec *data);
 };
@@ -119,7 +119,7 @@ errop_set(int err)
 }
 
 static int
-errop_start(int len)
+errop_start(uint32_t len)
 {
 	errop_code = ENOENT;
 
@@ -128,7 +128,7 @@ errop_start(int len)
 }
 
 static void
-errop_data(uint32_t data, int len)
+errop_data(uint32_t data, uint32_t len)
 {
 
 	/* ignore */
@@ -188,7 +188,7 @@ static int fget_cnt;
 static size_t fget_size;
 
 static int
-fget_start(int len)
+fget_start(uint32_t len)
 {
 
 	if (len > FGET_STRSZ)
@@ -200,7 +200,7 @@ fget_start(int len)
 }
 
 static void
-fget_data(uint32_t data, int len)
+fget_data(uint32_t data, uint32_t len)
 {
 
 	*((uint32_t *) &fget_str[fget_cnt]) = data;
@@ -285,8 +285,8 @@ static struct req_info {
 	struct op_info *req_op;
 	int	 resp_error;
 	int	 resp_count;
-	int	 resp_size;
-	int	 resp_off;
+	size_t	 resp_size;
+	size_t	 resp_off;
 	struct iovec *resp_biov;
 } rinfo;
 
@@ -346,13 +346,14 @@ fwctl_request_start(void)
 static int
 fwctl_request_data(uint32_t value)
 {
-	int remlen;
 
 	/* Make sure remaining size is >= 0 */
-	rinfo.req_size -= sizeof(uint32_t);
-	remlen = MAX(rinfo.req_size, 0);
+	if (rinfo.req_size <= sizeof(uint32_t))
+		rinfo.req_size = 0;
+	else
+		rinfo.req_size -= sizeof(uint32_t);
 
-	(*rinfo.req_op->op_data)(value, remlen);
+	(*rinfo.req_op->op_data)(value, rinfo.req_size);
 
 	if (rinfo.req_size < sizeof(uint32_t)) {
 		fwctl_request_done();
@@ -401,7 +402,7 @@ static int
 fwctl_response(uint32_t *retval)
 {
 	uint32_t *dp;
-	int remlen;
+	ssize_t remlen;
 
 	switch(rinfo.resp_count) {
 	case 0:
@@ -436,7 +437,7 @@ fwctl_response(uint32_t *retval)
 	}
 
 	if (rinfo.resp_count > 3 &&
-	    rinfo.resp_size - rinfo.resp_off <= 0) {
+	    rinfo.resp_off >= rinfo.resp_size) {
 		fwctl_response_done();
 		return (1);
 	}

--- a/usr/src/cmd/bhyve/gdb.c
+++ b/usr/src/cmd/bhyve/gdb.c
@@ -76,7 +76,11 @@ static cpuset_t vcpus_active, vcpus_suspended, vcpus_waiting;
 static pthread_mutex_t gdb_lock;
 static pthread_cond_t idle_vcpus;
 static bool stop_pending, first_stop;
+#ifdef __FreeBSD__
 static int stepping_vcpu, stopped_vcpu;
+#else
+static int stepping_vcpu = -1, stopped_vcpu = -1;
+#endif
 
 /*
  * An I/O buffer contains 'capacity' bytes of room at 'data'.  For a

--- a/usr/src/cmd/bhyve/pci_nvme.c
+++ b/usr/src/cmd/bhyve/pci_nvme.c
@@ -1013,17 +1013,8 @@ pci_nvme_append_iov_req(struct pci_nvme_softc *sc, struct pci_nvme_ioreq *req,
 					err = blockif_read(sc->nvstore.ctx,
 					                   &req->io_req);
 				else
-#ifdef __FreeBSD__
 					err = blockif_write(sc->nvstore.ctx,
 					                    &req->io_req);
-#else
-					err = blockif_write(sc->nvstore.ctx,
-					    &req->io_req, B_FALSE);
-				/*
-				 * XXX: Is a follow-up needed for proper sync
-				 * detection here or later flush behavior?
-				 */
-#endif
 
 				/* wait until req completes before cont */
 				if (err == 0)
@@ -1368,13 +1359,7 @@ iodone:
 			err = blockif_read(sc->nvstore.ctx, &req->io_req);
 			break;
 		case NVME_OPC_WRITE:
-#ifdef __FreeBSD__
 			err = blockif_write(sc->nvstore.ctx, &req->io_req);
-#else
-			/* XXX: Should this be sync? */
-			err = blockif_write(sc->nvstore.ctx, &req->io_req,
-			    B_FALSE);
-#endif
 			break;
 		default:
 			WPRINTF(("%s unhandled io command 0x%x\r\n",

--- a/usr/src/cmd/bhyve/pci_virtio_block.c
+++ b/usr/src/cmd/bhyve/pci_virtio_block.c
@@ -38,8 +38,8 @@
  * http://www.illumos.org/license/CDDL.
  *
  * Copyright 2014 Pluribus Networks Inc.
- * Copyright 2017 Joyent, Inc.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/cdefs.h>
@@ -158,6 +158,9 @@ struct pci_vtblk_softc {
 	struct vqueue_info vbsc_vq;
 	struct vtblk_config vbsc_cfg;
 	struct blockif_ctxt *bc;
+#ifndef __FreeBSD__
+	int vbsc_wce;
+#endif
 	char vbsc_ident[VTBLK_BLK_ID_BYTES];
 	struct pci_vtblk_ioreq vbsc_ios[VTBLK_RINGSZ];
 };
@@ -166,6 +169,9 @@ static void pci_vtblk_reset(void *);
 static void pci_vtblk_notify(void *, struct vqueue_info *);
 static int pci_vtblk_cfgread(void *, int, int, uint32_t *);
 static int pci_vtblk_cfgwrite(void *, int, int, uint32_t);
+#ifndef __FreeBSD__
+static void pci_vtblk_apply_feats(void *, uint64_t);
+#endif
 
 static struct virtio_consts vtblk_vi_consts = {
 	"vtblk",		/* our name */
@@ -175,7 +181,11 @@ static struct virtio_consts vtblk_vi_consts = {
 	pci_vtblk_notify,	/* device-wide qnotify */
 	pci_vtblk_cfgread,	/* read PCI config */
 	pci_vtblk_cfgwrite,	/* write PCI config */
+#ifndef __FreeBSD__
+	pci_vtblk_apply_feats,	/* apply negotiated features */
+#else
 	NULL,			/* apply negotiated features */
+#endif
 	VTBLK_S_HOSTCAPS,	/* our capabilities */
 };
 
@@ -186,6 +196,11 @@ pci_vtblk_reset(void *vsc)
 
 	DPRINTF(("vtblk: device reset requested !\n"));
 	vi_reset_dev(&sc->vbsc_vs);
+#ifndef __FreeBSD__
+	/* Disable write cache until FLUSH feature is negotiated */
+	(void) blockif_set_wce(sc->bc, 0);
+	sc->vbsc_wce = 0;
+#endif
 }
 
 static void
@@ -285,12 +300,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 		err = blockif_read(sc->bc, &io->io_req);
 		break;
 	case VBH_OP_WRITE:
-#ifdef __FreeBSD__
 		err = blockif_write(sc->bc, &io->io_req);
-#else
-		err = blockif_write(sc->bc, &io->io_req,
-		    (sc->vbsc_vs.vs_negotiated_caps & VTBLK_F_FLUSH) == 0);
-#endif
 		break;
 	case VBH_OP_FLUSH:
 	case VBH_OP_FLUSH_OUT:
@@ -394,6 +404,12 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 		io->io_idx = i;
 	}
 
+#ifndef __FreeBSD__
+	/* Disable write cache until FLUSH feature is negotiated */
+	(void) blockif_set_wce(sc->bc, 0);
+	sc->vbsc_wce = 0;
+#endif
+
 	pthread_mutex_init(&sc->vsc_mtx, NULL);
 
 	/* init virtio softc and virtqueues */
@@ -485,6 +501,20 @@ pci_vtblk_cfgread(void *vsc, int offset, int size, uint32_t *retval)
 	memcpy(retval, ptr, size);
 	return (0);
 }
+
+#ifndef __FreeBSD__
+void
+pci_vtblk_apply_feats(void *vsc, uint64_t caps)
+{
+	struct pci_vtblk_softc *sc = vsc;
+	const int wce_next = ((caps & VTBLK_F_FLUSH) != 0) ? 1 : 0;
+
+	if (sc->vbsc_wce != wce_next) {
+		(void) blockif_set_wce(sc->bc, wce_next);
+		sc->vbsc_wce = wce_next;
+	}
+}
+#endif /* __FreeBSD__ */
 
 struct pci_devemu pci_de_vblk = {
 	.pe_emu =	"virtio-blk",

--- a/usr/src/uts/i86pc/io/vmm/vm/vm_glue.h
+++ b/usr/src/uts/i86pc/io/vmm/vm/vm_glue.h
@@ -44,6 +44,7 @@ struct vmspace {
 
 	/* Implementation private */
 	kmutex_t	vms_lock;
+	boolean_t	vms_map_changing;
 	struct pmap	vms_pmap;
 	uintptr_t	vms_size;	/* fixed after creation */
 
@@ -53,13 +54,16 @@ struct vmspace {
 typedef pfn_t (*vm_pager_fn_t)(vm_object_t, uintptr_t, pfn_t *, uint_t *);
 
 struct vm_object {
-	kmutex_t	vmo_lock;
-	uint_t		vmo_refcnt;
+	uint_t		vmo_refcnt;	/* manipulated with atomic ops */
+
+	/* This group of fields are fixed at creation time */
 	objtype_t	vmo_type;
 	size_t		vmo_size;
-	vm_memattr_t	vmo_attr;
 	vm_pager_fn_t	vmo_pager;
 	void		*vmo_data;
+
+	kmutex_t	vmo_lock;	/* protects fields below */
+	vm_memattr_t	vmo_attr;
 };
 
 struct vm_page {

--- a/usr/src/uts/i86pc/io/vmm/vmm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm.c
@@ -2205,6 +2205,10 @@ restart:
 			break;
 		}
 
+		case VM_EXITCODE_MTRAP:
+			vm_suspend_cpu(vm, vcpuid);
+			retu = true;
+			break;
 #endif
 		default:
 			retu = true;	/* handled in userland */

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
@@ -969,10 +969,30 @@ vmmdev_do_ioctl(vmm_softc_t *sc, int cmd, intptr_t arg, int md,
 	case VM_ACTIVATE_CPU:
 		error = vm_activate_cpu(sc->vmm_vm, vcpu);
 		break;
+
 	case VM_SUSPEND_CPU:
+		if (ddi_copyin(datap, &vcpu, sizeof (vcpu), md)) {
+			error = EFAULT;
+			break;
+		}
+		if (vcpu < -1 || vcpu >= VM_MAXCPU) {
+			error = EINVAL;
+			break;
+		}
+
 		error = vm_suspend_cpu(sc->vmm_vm, vcpu);
 		break;
+
 	case VM_RESUME_CPU:
+		if (ddi_copyin(datap, &vcpu, sizeof (vcpu), md)) {
+			error = EFAULT;
+			break;
+		}
+		if (vcpu < -1 || vcpu >= VM_MAXCPU) {
+			error = EINVAL;
+			break;
+		}
+
 		error = vm_resume_cpu(sc->vmm_vm, vcpu);
 		break;
 

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_vm.c
@@ -136,7 +136,8 @@ static pfn_t eptable_mapin(eptable_map_t *, uintptr_t, pfn_t, uint_t, uint_t,
     vm_memattr_t);
 static void eptable_mapout(eptable_map_t *, uintptr_t);
 static int eptable_find(eptable_map_t *, uintptr_t, pfn_t *, uint_t *);
-static vmspace_mapping_t *vm_mapping_find(struct vmspace *, uintptr_t, size_t);
+static vmspace_mapping_t *vm_mapping_find(struct vmspace *, uintptr_t, size_t,
+    boolean_t);
 static void vm_mapping_remove(struct vmspace *, vmspace_mapping_t *);
 
 static kmutex_t eptable_map_lock;
@@ -230,7 +231,7 @@ vmspace_find_kva(struct vmspace *vms, uintptr_t addr, size_t size)
 	void *result = NULL;
 
 	mutex_enter(&vms->vms_lock);
-	vmsm = vm_mapping_find(vms, addr, size);
+	vmsm = vm_mapping_find(vms, addr, size, B_FALSE);
 	if (vmsm != NULL) {
 		struct vm_object *vmo = vmsm->vmsm_object;
 
@@ -1041,11 +1042,10 @@ vm_object_deallocate(vm_object_t vmo)
 {
 	ASSERT(vmo != NULL);
 
-	mutex_enter(&vmo->vmo_lock);
-	VERIFY(vmo->vmo_refcnt);
-	vmo->vmo_refcnt--;
-	if (vmo->vmo_refcnt != 0) {
-		mutex_exit(&vmo->vmo_lock);
+	uint_t ref = atomic_dec_uint_nv(&vmo->vmo_refcnt);
+	/* underflow would be a deadly serious mistake */
+	VERIFY3U(ref, !=, UINT_MAX);
+	if (ref != 0) {
 		return;
 	}
 
@@ -1064,7 +1064,6 @@ vm_object_deallocate(vm_object_t vmo)
 	vmo->vmo_pager = vm_object_pager_none;
 	vmo->vmo_data = NULL;
 	vmo->vmo_size = 0;
-	mutex_exit(&vmo->vmo_lock);
 	mutex_destroy(&vmo->vmo_lock);
 	kmem_free(vmo, sizeof (*vmo));
 }
@@ -1090,20 +1089,31 @@ vm_object_reference(vm_object_t vmo)
 {
 	ASSERT(vmo != NULL);
 
-	mutex_enter(&vmo->vmo_lock);
-	vmo->vmo_refcnt++;
-	mutex_exit(&vmo->vmo_lock);
+	uint_t ref = atomic_inc_uint_nv(&vmo->vmo_refcnt);
+	/* overflow would be a deadly serious mistake */
+	VERIFY3U(ref, !=, 0);
 }
 
 static vmspace_mapping_t *
-vm_mapping_find(struct vmspace *vms, uintptr_t addr, size_t size)
+vm_mapping_find(struct vmspace *vms, uintptr_t addr, size_t size,
+    boolean_t no_lock)
 {
 	vmspace_mapping_t *vmsm;
 	list_t *ml = &vms->vms_maplist;
 	const uintptr_t range_end = addr + size;
 
-	ASSERT(MUTEX_HELD(&vms->vms_lock));
 	ASSERT(addr <= range_end);
+
+	if (no_lock) {
+		/*
+		 * This check should be superflous with the protections
+		 * promised by the bhyve logic which calls into the VM shim.
+		 * All the same, it is cheap to be paranoid.
+		 */
+		VERIFY(!vms->vms_map_changing);
+	} else {
+		VERIFY(MUTEX_HELD(&vms->vms_lock));
+	}
 
 	if (addr >= vms->vms_size) {
 		return (NULL);
@@ -1148,6 +1158,7 @@ vm_mapping_remove(struct vmspace *vms, vmspace_mapping_t *vmsm)
 	list_t *ml = &vms->vms_maplist;
 
 	ASSERT(MUTEX_HELD(&vms->vms_lock));
+	ASSERT(vms->vms_map_changing);
 
 	list_remove(ml, vmsm);
 	vm_object_deallocate(vmsm->vmsm_object);
@@ -1186,7 +1197,7 @@ vm_fault(vm_map_t map, vm_offset_t off, vm_prot_t type, int flag)
 	}
 
 	/* Try to wire up the address */
-	if ((vmsm = vm_mapping_find(vms, addr, 0)) == NULL) {
+	if ((vmsm = vm_mapping_find(vms, addr, 0, B_FALSE)) == NULL) {
 		mutex_exit(&vms->vms_lock);
 		return (FC_NOMAP);
 	}
@@ -1224,10 +1235,26 @@ vm_fault_quick_hold_pages(vm_map_t map, vm_offset_t addr, vm_size_t len,
 	ASSERT(len == PAGESIZE);
 	ASSERT(max_count == 1);
 
-	mutex_enter(&vms->vms_lock);
-	if ((vmsm = vm_mapping_find(vms, vaddr, PAGESIZE)) == NULL ||
+	/*
+	 * Unlike practically all of the other logic that queries or
+	 * manipulates vmspace objects, vm_fault_quick_hold_pages() does so
+	 * without holding vms_lock.  This is safe because bhyve ensures that
+	 * changes to the vmspace map occur only when all other threads have
+	 * been excluded from running.
+	 *
+	 * Since this task can count on vms_maplist remaining static and does
+	 * not need to modify the pmap (like vm_fault might), it can proceed
+	 * without the lock.  The vm_object has independent refcount and lock
+	 * protection, while the vmo_pager methods do not rely on vms_lock for
+	 * safety.
+	 *
+	 * Performing this work without locks is critical in cases where
+	 * multiple vCPUs require simultaneous instruction emulation, such as
+	 * for frequent guest APIC accesses on a host that lacks hardware
+	 * acceleration for that behavior.
+	 */
+	if ((vmsm = vm_mapping_find(vms, vaddr, PAGESIZE, B_TRUE)) == NULL ||
 	    (prot & ~vmsm->vmsm_prot) != 0) {
-		mutex_exit(&vms->vms_lock);
 		return (-1);
 	}
 
@@ -1239,7 +1266,6 @@ vm_fault_quick_hold_pages(vm_map_t map, vm_offset_t addr, vm_size_t len,
 	vmp->vmp_pfn = vmo->vmo_pager(vmo, VMSM_OFFSET(vmsm, vaddr), NULL,
 	    NULL);
 
-	mutex_exit(&vms->vms_lock);
 	*ma = vmp;
 	return (1);
 }
@@ -1275,6 +1301,7 @@ vm_map_find(vm_map_t map, vm_object_t vmo, vm_ooffset_t off, vm_offset_t *addr,
 	vmsm = kmem_alloc(sizeof (*vmsm), KM_SLEEP);
 
 	mutex_enter(&vms->vms_lock);
+	vms->vms_map_changing = B_TRUE;
 	if (!vm_mapping_gap(vms, base, size)) {
 		res = ENOMEM;
 		goto out;
@@ -1292,6 +1319,7 @@ vm_map_find(vm_map_t map, vm_object_t vmo, vm_ooffset_t off, vm_offset_t *addr,
 		*addr = (vm_offset_t)base;
 	}
 out:
+	vms->vms_map_changing = B_FALSE;
 	mutex_exit(&vms->vms_lock);
 	if (res != 0) {
 		kmem_free(vmsm, sizeof (*vmsm));
@@ -1311,9 +1339,11 @@ vm_map_remove(vm_map_t map, vm_offset_t start, vm_offset_t end)
 	ASSERT(start < end);
 
 	mutex_enter(&vms->vms_lock);
+	vms->vms_map_changing = B_TRUE;
 	/* expect to match existing mapping exactly */
-	if ((vmsm = vm_mapping_find(vms, addr, size)) == NULL ||
+	if ((vmsm = vm_mapping_find(vms, addr, size, B_FALSE)) == NULL ||
 	    vmsm->vmsm_addr != addr || vmsm->vmsm_len != size) {
+		vms->vms_map_changing = B_FALSE;
 		mutex_exit(&vms->vms_lock);
 		return (ENOENT);
 	}
@@ -1331,6 +1361,7 @@ vm_map_remove(vm_map_t map, vm_offset_t start, vm_offset_t end)
 	}
 
 	vm_mapping_remove(vms, vmsm);
+	vms->vms_map_changing = B_FALSE;
 	mutex_exit(&vms->vms_lock);
 	return (0);
 }
@@ -1348,7 +1379,7 @@ vm_map_wire(vm_map_t map, vm_offset_t start, vm_offset_t end, int flags)
 	mutex_enter(&vms->vms_lock);
 
 	/* For the time being, only exact-match mappings are expected */
-	if ((vmsm = vm_mapping_find(vms, addr, size)) == NULL) {
+	if ((vmsm = vm_mapping_find(vms, addr, size, B_FALSE)) == NULL) {
 		mutex_exit(&vms->vms_lock);
 		return (FC_NOMAP);
 	}
@@ -1424,7 +1455,7 @@ vm_segmap_space(struct vmspace *vms, off_t off, struct as *as, caddr_t *addrp,
 	}
 
 	mutex_enter(&vms->vms_lock);
-	if ((vmsm = vm_mapping_find(vms, addr, size)) == NULL) {
+	if ((vmsm = vm_mapping_find(vms, addr, size, B_FALSE)) == NULL) {
 		mutex_exit(&vms->vms_lock);
 		return (ENXIO);
 	}

--- a/usr/src/uts/i86pc/io/vmm/vmm_zsd.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_zsd.c
@@ -105,6 +105,7 @@ static void *
 vmm_zsd_create(zoneid_t zid)
 {
 	vmm_zsd_t *zsd;
+	zone_t *zone;
 
 	zsd = kmem_zalloc(sizeof (*zsd), KM_SLEEP);
 
@@ -114,7 +115,20 @@ vmm_zsd_create(zoneid_t zid)
 	zsd->vz_zoneid = zid;
 
 	mutex_init(&zsd->vz_lock, NULL, MUTEX_DEFAULT, NULL);
-	zsd->vz_active = B_TRUE;
+
+	/*
+	 * If the vmm module is loaded while this zone is in the midst of
+	 * shutting down, vmm_zsd_destroy() may be called without
+	 * vmm_zsd_shutdown() ever being called. If it is shutting down, there
+	 * is no sense in letting any in-flight VM creation succeed so set
+	 * vz_active accordingly.
+	 *
+	 * zone_find_by_id_nolock() is used rather than zone_find_by_id()
+	 * so that the zone is returned regardless of state.
+	 */
+	zone = zone_find_by_id_nolock(zid);
+	VERIFY(zone != NULL);
+	zsd->vz_active = zone_status_get(zone) < ZONE_IS_SHUTTING_DOWN;
 
 	mutex_enter(&vmm_zsd_lock);
 	list_insert_tail(&vmm_zsd_list, zsd);
@@ -134,7 +148,11 @@ vmm_zsd_shutdown(zoneid_t zid, void *data)
 	vmm_softc_t *sc;
 
 	mutex_enter(&zsd->vz_lock);
-	ASSERT(zsd->vz_active);
+
+	/*
+	 * This may already be B_FALSE. See comment in vmm_zsd_create(). If it
+	 * is already B_FALSE we will take a quick trip through the empty list.
+	 */
 	zsd->vz_active = B_FALSE;
 
 	for (sc = list_head(&zsd->vz_vmms); sc != NULL;

--- a/usr/src/uts/i86pc/sys/vmm_impl.h
+++ b/usr/src/uts/i86pc/sys/vmm_impl.h
@@ -49,7 +49,8 @@ enum vmm_softc_state {
 	VMM_HELD	= 1,	/* external driver(s) possess hold on VM */
 	VMM_CLEANUP	= 2,	/* request that holds are released */
 	VMM_PURGED	= 4,	/* all hold have been released */
-	VMM_BLOCK_HOOK	= 8	/* mem hook install temporarily blocked */
+	VMM_BLOCK_HOOK	= 8,	/* mem hook install temporarily blocked */
+	VMM_DESTROY	= 16	/* VM is destroyed, softc still around */
 };
 
 struct vmm_softc {


### PR DESCRIPTION
Weekly upstream for joyent merge/2018120701
## Backports to r28

* BHYVE: OS-7300 bhyve should not sync IO unless necessary
* BHYVE: OS-7397 reduce lock contention in bhyve instr emul 

## Backports to r22/r26

None

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2018120701-12a57e74f2 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Fri Dec  7 19:30:35 CET 2018 ====
==== Nightly distributed build completed: Fri Dec  7 20:31:46 CET 2018 ====

==== Total build time ====

real    1:01:10

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-02fa6a4e60 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.3.0-il-1) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.7.0_201-b00"

/usr/bin/openssl
OpenSSL 1.1.1a  20 Nov 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   82

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2018120701-12a57e74f2

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    26:51.6
user  1:45:58.1
sys      7:15.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    25:31.0
user  1:38:27.3
sys      7:00.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```