### PR TITLE
sd fixes for misbehaving drives

### DIFF
--- a/usr/src/uts/common/io/scsi/targets/sd.c
+++ b/usr/src/uts/common/io/scsi/targets/sd.c
@@ -6722,7 +6722,7 @@ sdpower(dev_info_t *devi, int component, int level)
 	time_t		intvlp;
 	struct pm_trans_data	sd_pm_tran_data;
 	uchar_t		save_state = SD_STATE_NORMAL;
-	int		sval;
+	int		sval, tursval;
 	uchar_t		state_before_pm;
 	int		got_semaphore_here;
 	sd_ssc_t	*ssc;
@@ -7039,9 +7039,9 @@ sdpower(dev_info_t *devi, int component, int level)
 	 * a deadlock on un_pm_busy_cv will occur.
 	 */
 	if (SD_PM_IS_IO_CAPABLE(un, level)) {
-		sval = sd_send_scsi_TEST_UNIT_READY(ssc,
+		tursval = sd_send_scsi_TEST_UNIT_READY(ssc,
 		    SD_DONT_RETRY_TUR | SD_BYPASS_PM);
-		if (sval != 0)
+		if (tursval != 0)
 			sd_ssc_assessment(ssc, SD_FMT_IGNORE);
 	}
 
@@ -7065,6 +7065,21 @@ sdpower(dev_info_t *devi, int component, int level)
 			sd_ssc_assessment(ssc, SD_FMT_STATUS_CHECK);
 		else
 			sd_ssc_assessment(ssc, SD_FMT_IGNORE);
+
+	}
+
+	/*
+	 * We've encountered certain classes of drives that pass a TUR, but fail
+	 * the START STOP UNIT when using power conditions. Strictly speaking,
+	 * for SPC-4 or greater, no additional actions are required to make the
+	 * drive operational when a TUR passes. If we have something that
+	 * matches this condition, we continue on and presume the drive is
+	 * successfully powered on.
+	 */
+	if (un->un_f_power_condition_supported && sval == ENOTSUP &&
+	    SD_SCSI_VERS_IS_GE_SPC_4(un) && SD_PM_IS_IO_CAPABLE(un, level) &&
+	    level == SD_SPINDLE_ACTIVE && tursval == 0) {
+		sval = 0;
 	}
 
 	/* Command failed, check for media present. */
@@ -31297,7 +31312,7 @@ sd_set_unit_attributes(struct sd_lun *un, dev_info_t *devi)
 		if (SD_PM_CAPABLE_IS_UNDEFINED(pm_cap)) {
 			un->un_f_log_sense_supported = TRUE;
 			if (!un->un_f_power_condition_disabled &&
-			    SD_INQUIRY(un)->inq_ansi == 6) {
+			    SD_SCSI_VERS_IS_GE_SPC_4(un)) {
 				un->un_f_power_condition_supported = TRUE;
 			}
 		} else {
@@ -31315,7 +31330,7 @@ sd_set_unit_attributes(struct sd_lun *un, dev_info_t *devi)
 				/* SD_PM_CAPABLE_IS_TRUE case */
 				un->un_f_pm_supported = TRUE;
 				if (!un->un_f_power_condition_disabled &&
-				    SD_PM_CAPABLE_IS_SPC_4(pm_cap)) {
+				    (SD_PM_CAPABLE_IS_GE_SPC_4(pm_cap))) {
 					un->un_f_power_condition_supported =
 					    TRUE;
 				}

--- a/usr/src/uts/common/io/scsi/targets/sd.c
+++ b/usr/src/uts/common/io/scsi/targets/sd.c
@@ -6722,7 +6722,7 @@ sdpower(dev_info_t *devi, int component, int level)
 	time_t		intvlp;
 	struct pm_trans_data	sd_pm_tran_data;
 	uchar_t		save_state = SD_STATE_NORMAL;
-	int		sval, tursval;
+	int		sval, tursval = 0;
 	uchar_t		state_before_pm;
 	int		got_semaphore_here;
 	sd_ssc_t	*ssc;

--- a/usr/src/uts/common/io/scsi/targets/sd.c
+++ b/usr/src/uts/common/io/scsi/targets/sd.c
@@ -7045,7 +7045,20 @@ sdpower(dev_info_t *devi, int component, int level)
 			sd_ssc_assessment(ssc, SD_FMT_IGNORE);
 	}
 
-	if (un->un_f_power_condition_supported) {
+	/*
+	 * We've encountered certain classes of drives that pass a TUR, but fail
+	 * the START STOP UNIT when using power conditions, or worse leave the
+	 * drive in an unusable state despite passing SSU. Strictly speaking,
+	 * for SPC-4 or greater, no additional actions are required to make the
+	 * drive operational when a TUR passes. If we have something that
+	 * matches this condition, we continue on and presume the drive is
+	 * successfully powered on.
+	 */
+	if (un->un_f_power_condition_supported &&
+	    SD_SCSI_VERS_IS_GE_SPC_4(un) && SD_PM_IS_IO_CAPABLE(un, level) &&
+	    level == SD_SPINDLE_ACTIVE && tursval == 0) {
+		sval = 0;
+	} else if (un->un_f_power_condition_supported) {
 		char *pm_condition_name[] = {"STOPPED", "STANDBY",
 		    "IDLE", "ACTIVE"};
 		SD_TRACE(SD_LOG_IO_PM, un,
@@ -7066,20 +7079,6 @@ sdpower(dev_info_t *devi, int component, int level)
 		else
 			sd_ssc_assessment(ssc, SD_FMT_IGNORE);
 
-	}
-
-	/*
-	 * We've encountered certain classes of drives that pass a TUR, but fail
-	 * the START STOP UNIT when using power conditions. Strictly speaking,
-	 * for SPC-4 or greater, no additional actions are required to make the
-	 * drive operational when a TUR passes. If we have something that
-	 * matches this condition, we continue on and presume the drive is
-	 * successfully powered on.
-	 */
-	if (un->un_f_power_condition_supported && sval == ENOTSUP &&
-	    SD_SCSI_VERS_IS_GE_SPC_4(un) && SD_PM_IS_IO_CAPABLE(un, level) &&
-	    level == SD_SPINDLE_ACTIVE && tursval == 0) {
-		sval = 0;
 	}
 
 	/* Command failed, check for media present. */

--- a/usr/src/uts/common/sys/scsi/generic/inquiry.h
+++ b/usr/src/uts/common/sys/scsi/generic/inquiry.h
@@ -362,7 +362,8 @@ struct scsi_inquiry {
 #define	DTYPE_NOTPRESENT	(DPQ_NEVER | DTYPE_UNKNOWN)
 
 /*
- * Defined Response Data Formats:
+ * Defined Versions for inquiry data. These represent the base version that a
+ * device supports.
  */
 #define	RDF_LEVEL0		0x00	/* no conformance claim (SCSI-1) */
 #define	RDF_CCS			0x01	/* Obsolete (pseudo-spec) */
@@ -370,7 +371,8 @@ struct scsi_inquiry {
 #define	RDF_SCSI_SPC		0x03	/* ANSI INCITS 301-1997 (SPC) */
 #define	RDF_SCSI_SPC2		0x04	/* ANSI INCITS 351-2001 (SPC-2) */
 #define	RDF_SCSI_SPC3		0x05	/* ANSI INCITS 408-2005 (SPC-3) */
-#define	RDF_SCSI_SPC4		0x06	/* t10 (SPC-4) */
+#define	RDF_SCSI_SPC4		0x06	/* ANSI INCITS 513-2015 (SPC-4) */
+#define	RDF_SCSI_SPC5		0x07	/* t10 (SPC-5) */
 
 /*
  * Defined Target Port Group Select values:
@@ -436,6 +438,7 @@ struct vpd_desc {
 #define	PM_CAPABLE_SPC2		RDF_SCSI_SPC2
 #define	PM_CAPABLE_SPC3		RDF_SCSI_SPC3
 #define	PM_CAPABLE_SPC4		RDF_SCSI_SPC4
+#define	PM_CAPABLE_SPC5		RDF_SCSI_SPC5
 #define	PM_CAPABLE_LOG_MASK	0xffff0000	/* use upper 16 bit to */
 						/* indicate log specifics */
 #define	PM_CAPABLE_LOG_SUPPORTED	0x10000	/* Log page 0xE might be */

--- a/usr/src/uts/common/sys/scsi/targets/sddef.h
+++ b/usr/src/uts/common/sys/scsi/targets/sddef.h
@@ -774,6 +774,12 @@ _NOTE(MUTEX_PROTECTS_DATA(sd_lun::un_fi_mutex,
 #define	SD_FM_LOG(un)		(((struct sd_fm_internal *)\
 				((un)->un_fm_private))->fm_log_level)
 
+/*
+ * Version Related Macros
+ */
+#define	SD_SCSI_VERS_IS_GE_SPC_4(un)	\
+	(SD_INQUIRY(un)->inq_ansi == RDF_SCSI_SPC4 || \
+	SD_INQUIRY(un)->inq_ansi == RDF_SCSI_SPC5)
 
 /*
  * Values for un_ctype
@@ -1860,6 +1866,10 @@ struct sd_fm_internal {
 
 #define	SD_PM_CAPABLE_IS_SPC_4(pm_cap)	\
 	((pm_cap & PM_CAPABLE_PM_MASK) == PM_CAPABLE_SPC4)
+
+#define	SD_PM_CAPABLE_IS_GE_SPC_4(pm_cap)	\
+	(((pm_cap & PM_CAPABLE_PM_MASK) == PM_CAPABLE_SPC4) || \
+	((pm_cap & PM_CAPABLE_PM_MASK) == PM_CAPABLE_SPC5))
 
 #define	SD_PM_CAP_LOG_SUPPORTED(pm_cap)	\
 	((pm_cap & PM_CAPABLE_LOG_SUPPORTED) ? TRUE : FALSE)


### PR DESCRIPTION
Here are a couple of fixes from Joyent to fix problems with some hard drive/HBA combinations that mishandle a START STOP UNIT command when using power conditions.

As usual, great overview and writeup in the Joyent bugs:

https://smartos.org/bugview/OS-5709
https://smartos.org/bugview/OS-7313

I've experienced this on a server with an LSI3108 card and some 15K Seagate drives - lots of errors along the form of:

```
Dec  7 15:43:48 xxx genunix: [ID 353554 kern.warning] WARNING: Device /pci@0,0/pci8086,2f02@1/pci1028,1f49@0/sd@d,1 failed to power up.
```

although the disks show up in `diskinfo` and the HBA says everything is fine and spun up.

Confirmed that this fix resolves the problem there, and the commits have been in SmartOS for a couple of years and a month respectively.

Requires backporting to r151028.