### PR TITLE
Split system/bhyve package

### DIFF
--- a/usr/src/pkg/manifests/system-bhyve.mf
+++ b/usr/src/pkg/manifests/system-bhyve.mf
@@ -14,7 +14,7 @@
 #
 
 #
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -30,12 +30,10 @@ set name=info.classification \
     value=org.opensolaris.category.2008:System/Virtualization
 set name=variant.arch value=i386
 dir path=kernel group=sys
-dir path=lib group=bin
-dir path=lib/$(ARCH64) group=bin
 dir path=usr group=sys
+dir path=usr/bin
 dir path=usr/kernel/drv group=sys
 dir path=usr/kernel/drv/$(ARCH64) group=sys
-dir path=usr/lib group=bin
 dir path=usr/sbin
 dir path=usr/share
 dir path=usr/share/man
@@ -43,31 +41,18 @@ dir path=usr/share/man/man1m
 driver name=ppt
 driver name=viona
 driver name=vmm
-file path=lib/$(ARCH64)/libvmm.so.1
-file path=lib/$(ARCH64)/libvmmapi.so.1
-file path=lib/$(ARCH64)/llib-lvmmapi.ln
 file path=usr/bin/bhhwcompat mode=0555
-file path=usr/include/libppt.h
-file path=usr/include/libvmm.h
 file path=usr/kernel/drv/$(ARCH64)/ppt
 file path=usr/kernel/drv/$(ARCH64)/viona
 file path=usr/kernel/drv/$(ARCH64)/vmm
 file path=usr/kernel/drv/ppt.conf
 file path=usr/kernel/drv/viona.conf
 file path=usr/kernel/drv/vmm.conf
-file path=usr/lib/$(ARCH64)/libppt.so.1
-file path=usr/lib/amd64/llib-lppt.ln
-file path=usr/lib/libppt.so.1
-file path=usr/lib/llib-lppt
-file path=usr/lib/llib-lppt.ln
 file path=usr/sbin/bhyve mode=0555
 file path=usr/sbin/bhyvectl mode=0555
 file path=usr/sbin/pptadm mode=0555
 file path=usr/share/man/man1m/pptadm.1m
 license lic_CDDL license=lic_CDDL
-link path=lib/$(ARCH64)/libvmm.so target=./libvmm.so.1
-link path=lib/$(ARCH64)/libvmmapi.so target=./libvmmapi.so.1
-link path=usr/lib/$(ARCH64)/libppt.so target=libppt.so.1
-link path=usr/lib/libppt.so target=libppt.so.1
 depend fmri=developer/acpi/compiler type=require
 depend fmri=system/bhyve/firmware type=require
+depend fmri=system/library/bhyve type=require

--- a/usr/src/pkg/manifests/system-library-bhyve.mf
+++ b/usr/src/pkg/manifests/system-library-bhyve.mf
@@ -1,0 +1,42 @@
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+#
+
+set name=pkg.fmri value=pkg:/system/library/bhyve@$(PKGVERS)
+set name=pkg.description value="BSD hypervisor (libraries)"
+set name=pkg.summary value="BSD hypervisor (libraries)"
+set name=variant.arch value=i386
+dir path=lib group=bin
+dir path=lib/$(ARCH64) group=bin
+dir path=usr group=sys
+dir path=usr/lib group=bin
+file path=lib/$(ARCH64)/libvmm.so.1
+file path=lib/$(ARCH64)/libvmmapi.so.1
+file path=lib/$(ARCH64)/llib-lvmmapi.ln
+file path=usr/include/libppt.h
+file path=usr/include/libvmm.h
+file path=usr/lib/$(ARCH64)/libppt.so.1
+file path=usr/lib/$(ARCH64)/llib-lppt.ln
+file path=usr/lib/libppt.so.1
+file path=usr/lib/llib-lppt
+file path=usr/lib/llib-lppt.ln
+license lic_CDDL license=lic_CDDL
+link path=lib/$(ARCH64)/libvmm.so target=./libvmm.so.1
+link path=lib/$(ARCH64)/libvmmapi.so target=./libvmmapi.so.1
+link path=usr/lib/$(ARCH64)/libppt.so target=libppt.so.1
+link path=usr/lib/libppt.so target=libppt.so.1


### PR DESCRIPTION
Now that `mdb` is linked against libvmm.so and libvmmapi.so, system/bhyve and its dependencies (system/bhyve/firmware and developer/acpi) have become mandatory packages and we would prefer them to remain optional to minimise reboots for servers which do not run bhyve.

Splitting the bhyve libraries and header files to `system/library/bhyve` makes those required (through the auto-detected dependency in `mdb`) whilst leaving the rest of bhyve optional.

```
developer-debug-mdb.res:depend fmri=pkg:/system/library/bhyve@0.5.11-151029.0 type=require
```

`make check` in `/usr/src/pkg` passes.
