### PR TITLE
Do not allow to create duplicated vnics

### DIFF
--- a/usr/src/cmd/dlmgmtd/dlmgmt_util.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_util.c
@@ -464,7 +464,9 @@ dlmgmt_create_common(const char *name, datalink_class_t class, uint32_t media,
 	linkp->ll_tomb = B_FALSE;
 
 	if (avl_find(&dlmgmt_name_avl, linkp, &name_where) != NULL ||
-	    avl_find(&dlmgmt_id_avl, linkp, &id_where) != NULL) {
+	    avl_find(&dlmgmt_id_avl, linkp, &id_where) != NULL ||
+	    (zoneid == GLOBAL_ZONEID &&
+	     avl_find(&dlmgmt_loan_avl, linkp, NULL) != NULL)) {
 		err = EEXIST;
 		goto done;
 	}


### PR DESCRIPTION
This change addresses https://www.illumos.org/issues/10001
```bash
cneira@Trixie:~$ pfexec dladm show-vnic
LINK         OVER         SPEED  MACADDRESS        MACADDRTYPE         VID
vnic1        e1000g0      1000   2:8:20:46:d4:ba   random              0
vnic0        e1000g0      1000   2:8:20:29:26:da   random              0

cneira@Trixie:~$ pfexec dladm create-vnic -l e1000g0 vnic2

cneira@Trixie:~$ pfexec dladm show-vnic
LINK         OVER         SPEED  MACADDRESS        MACADDRTYPE         VID
vnic1        e1000g0      1000   2:8:20:46:d4:ba   random              0
vnic0        e1000g0      1000   2:8:20:29:26:da   random              0
vnic2        e1000g0      1000   2:8:20:81:f5:e2   random              0

cneira@Trixie:~$ zcage create --debug --net  "vnic2|192.168.1.226/24|192.168.1.1" --ram 512mb  --with-image 19aa3328-0025-11e7-a19a-c39077bfd4cf --alias vm1 --brand lx
CreateOptions  {
    "brand": "lx",
    "ram": "512mb",
    "debug": true,
    "net": "vnic2|192.168.1.226/24|192.168.1.1",
    "with-image": "19aa3328-0025-11e7-a19a-c39077bfd4cf",
    "alias": "vm1"
}
network is  [ { physical: 'vnic2',
    address: '192.168.1.226',
    netmask: '255.255.255.0',
    gateway: '192.168.1.1' } ]
{
    "brand": "lx",
    "ram": "512mb",
    "debug": true,
    "net": [
        {
            "physical": "vnic2",
            "address": "192.168.1.226",
            "netmask": "255.255.255.0",
            "gateway": "192.168.1.1"
        }
    ],
    "with-image": "19aa3328-0025-11e7-a19a-c39077bfd4cf",
    "zonepath": "/zcage/vms/vm1",
    "alias": "vm1"
}
rctl object {
    "max-physical-memory": "536870912",
    "max-locked-memory": "536870912",
    "max-swap": "1073741824",
    "cpu-shares": "1024",
    "max-lwps": "3000"
}
spec {
    "zonepath": "/zcage/vms/vm1",
    "brand": "lx",
    "ip-type": "exclusive",
    "dns-domain": "",
    "resolvers": [
        "8.8.8.8",
        "8.8.8.4"
    ],
    "autoboot": false,
    "debug": true,
    "net": [
        {
            "physical": "vnic2",
            "address": "192.168.1.226",
            "netmask": "255.255.255.0",
            "gateway": "192.168.1.1"
        }
    ],
    "with-image": "19aa3328-0025-11e7-a19a-c39077bfd4cf",
    "alias": "vm1",
    "rctl": {
        "max-physical-memory": "536870912",
        "max-locked-memory": "536870912",
        "max-swap": "1073741824",
        "cpu-shares": "1024",
        "max-lwps": "3000"
    }
}
spec2script [ 'create',
  'add attr',
  'set name=kernel-version',
  'set type=string',
  'set value=3.16.0',
  'end',
  ' set zonepath=/zcage/vms/vm1',
  ' set brand=lx',
  ' set ip-type=exclusive',
  'add attr',
  'set name=resolvers',
  'set type=string',
  'set value=8.8.8.8,8.8.8.4',
  'end',
  ' set autoboot=false',
  ' add net ',
  'add property (name=gateway,value="192.168.1.1")',
  'add property (name=netmask,value="255.255.255.0")',
  'add property (name=ips,value="192.168.1.226")',
  'add property (name=primary,value="true")',
  ' set physical=vnic2',
  ' end',
  'add rctl',
  'set name=zone.max-physical-memory',
  'add value (priv=privileged,limit=536870912,action=deny)',
  'end',
  ' add rctl',
  'set name=zone.max-locked-memory',
  'add value (priv=privileged,limit=536870912,action=deny)',
  'end',
  ' add rctl',
  'set name=zone.max-swap',
  'add value (priv=privileged,limit=1073741824,action=deny)',
  'end',
  ' add rctl',
  'set name=zone.cpu-shares',
  'add value (priv=privileged, limit=1024,action=none)',
  'end',
  'add rctl',
  'set name=zone.max-lwps',
  'add value (priv=privileged,limit=3000,action=deny)',
  'end',
  ' ',
  'verify',
  ' commit',

cneira@Trixie:~$ zcage start -z vm1
VM vm1 started [OK]
cneira@Trixie:~$ pfexec dladm show-vnic
LINK         OVER         SPEED  MACADDRESS        MACADDRTYPE         VID
vnic1        e1000g0      1000   2:8:20:46:d4:ba   random              0
vnic0        e1000g0      1000   2:8:20:29:26:da   random              0
vnic2        e1000g0      1000   2:8:20:81:f5:e2   random              0
cneira@Trixie:~$ pfexec dladm create-vnic -l e1000g0  vnic2
dladm: vnic creation over e1000g0 failed: object already exists

```

