### PR TITLE
9696 add /etc/system.d support

### DIFF
--- a/usr/src/Targetdirs
+++ b/usr/src/Targetdirs
@@ -28,7 +28,7 @@
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
 # Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2017 Nexenta Systems, Inc.
 # Copyright 2017 RackTop Systems.
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
@@ -182,6 +182,7 @@ DIRS= \
 	/etc/svc/profile \
 	/etc/svc/profile/site \
 	/etc/svc/volatile \
+	/etc/system.d \
 	/etc/tm  \
 	/etc/usb   \
 	/etc/user_attr.d \

--- a/usr/src/cmd/boot/bootadm/bootadm.c
+++ b/usr/src/cmd/boot/bootadm/bootadm.c
@@ -24,7 +24,7 @@
  * Copyright 2012 Milan Jurik. All rights reserved.
  * Copyright (c) 2015 by Delphix. All rights reserved.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
@@ -160,6 +160,9 @@ typedef enum {
 #define	STAGE1			"/boot/grub/stage1"
 #define	STAGE2			"/boot/grub/stage2"
 
+#define	ETC_SYSTEM_DIR		"etc/system.d"
+#define	SELF_ASSEMBLY		"etc/system.d/.self-assembly"
+
 /*
  * Default file attributes
  */
@@ -245,6 +248,7 @@ static int bam_lock_fd = -1;
 static int bam_zfs;
 static int bam_mbr;
 char rootbuf[PATH_MAX] = "/";
+static char self_assembly[PATH_MAX];
 static int bam_update_all;
 static int bam_alt_platform;
 static char *bam_platform;
@@ -283,6 +287,7 @@ static error_t read_list(char *, filelist_t *);
 static error_t set_option(menu_t *, char *, char *);
 static error_t set_kernel(menu_t *, menu_cmd_t, char *, char *, size_t);
 static error_t get_kernel(menu_t *, menu_cmd_t, char *, size_t);
+static error_t build_etc_system_dir(char *);
 static char *expand_path(const char *);
 
 static long s_strtol(char *);
@@ -2420,6 +2425,8 @@ cmpstat(
 	if (is_flag_on(IS_SPARC_TARGET) &&
 	    is_dir_flag_on(NEED_UPDATE) && !bam_nowrite())
 		return (0);
+
+
 	/*
 	 * File exists in old archive. Check if file has changed
 	 */
@@ -2452,6 +2459,19 @@ cmpstat(
 			set_dir_flag(NEED_UPDATE);
 		} else {
 			ret = update_dircache(file, flags);
+			if (ret == BAM_ERROR) {
+				bam_error(_("directory cache update failed "
+				    "for %s\n"), file);
+				return (-1);
+			}
+		}
+
+		/*
+		 * Update self-assembly file if there are changes in
+		 * /etc/system.d directory
+		 */
+		if (strstr(file, ETC_SYSTEM_DIR)) {
+			ret = update_dircache(self_assembly, flags);
 			if (ret == BAM_ERROR) {
 				bam_error(_("directory cache update failed "
 				    "for %s\n"), file);
@@ -3791,6 +3811,129 @@ out_path_err:
 	return (BAM_ERROR);
 }
 
+static int
+assemble_systemfile(char *infilename, char *outfilename)
+{
+	char buf[BUFSIZ];
+	FILE *infile, *outfile;
+	size_t n;
+
+	if ((infile = fopen(infilename, "r")) == NULL) {
+		bam_error(_("failed to open file: %s: %s\n"), infilename,
+		    strerror(errno));
+		return (BAM_ERROR);
+	}
+
+	if ((outfile = fopen(outfilename, "a")) == NULL) {
+		bam_error(_("failed to open file: %s: %s\n"), outfilename,
+		    strerror(errno));
+		(void) fclose(infile);
+		return (BAM_ERROR);
+	}
+
+	while ((n = fread(buf, 1, sizeof (buf), infile)) > 0) {
+		if (fwrite(buf, 1, n, outfile) != n) {
+			bam_error(_("failed to write file: %s: %s\n"),
+			    outfilename, strerror(errno));
+			(void) fclose(infile);
+			(void) fclose(outfile);
+			return (BAM_ERROR);
+		}
+	}
+
+	(void) fclose(infile);
+	(void) fclose(outfile);
+
+	return (BAM_SUCCESS);
+}
+
+/*
+ * Concatenate all files (except those starting with a dot)
+ * from /etc/system.d directory into a single /etc/system.d/.self-assembly
+ * file. The kernel reads it before /etc/system file.
+ */
+static error_t
+build_etc_system_dir(char *root)
+{
+	struct dirent **filelist;
+	char path[PATH_MAX], tmpfile[PATH_MAX];
+	int i, files, sysfiles = 0;
+	int ret = BAM_SUCCESS;
+	struct stat st;
+	timespec_t times[2];
+
+	(void) snprintf(path, sizeof (path), "%s/%s", root, ETC_SYSTEM_DIR);
+	(void) snprintf(self_assembly, sizeof (self_assembly),
+	    "%s%s", root, SELF_ASSEMBLY);
+	(void) snprintf(tmpfile, sizeof (tmpfile), "%s.%ld",
+	    self_assembly, (long)getpid());
+
+	if (stat(self_assembly, &st) >= 0 && (st.st_mode & S_IFMT) == S_IFREG) {
+		times[0] = times[1] = st.st_mtim;
+	} else {
+		times[1].tv_nsec = 0;
+	}
+
+	if ((files = scandir(path, &filelist, NULL, alphasort)) < 0) {
+		/* Don't fail the update if <ROOT>/etc/system.d doesn't exist */
+		if (errno == ENOENT)
+			return (BAM_SUCCESS);
+		bam_error(_("can't read %s: %s\n"), path, strerror(errno));
+		return (BAM_ERROR);
+	}
+
+	for (i = 0; i < files; i++) {
+		char	filepath[PATH_MAX];
+		char	*fname;
+
+		fname = filelist[i]->d_name;
+
+		/* skip anything that starts with a dot */
+		if (strncmp(fname, ".", 1) == 0) {
+			free(filelist[i]);
+			continue;
+		}
+
+		if (bam_verbose)
+			bam_print(_("/etc/system.d adding %s/%s\n"),
+			    path, fname);
+
+		(void) snprintf(filepath, sizeof (filepath), "%s/%s",
+		    path, fname);
+
+		if ((assemble_systemfile(filepath, tmpfile)) < 0) {
+			bam_error(_("failed to append file: %s: %s\n"),
+			    filepath, strerror(errno));
+			ret = BAM_ERROR;
+			break;
+		}
+		sysfiles++;
+	}
+
+	if (sysfiles > 0) {
+		if (rename(tmpfile, self_assembly) < 0) {
+			bam_error(_("failed to rename file: %s: %s\n"), tmpfile,
+			    strerror(errno));
+			return (BAM_ERROR);
+		}
+
+		/*
+		 * Use previous attribute times to avoid
+		 * boot archive recreation.
+		 */
+		if (times[1].tv_nsec != 0 &&
+		    utimensat(AT_FDCWD, self_assembly, times, 0) != 0) {
+			bam_error(_("failed to change times: %s\n"),
+			    strerror(errno));
+			return (BAM_ERROR);
+		}
+	} else {
+		(void) unlink(tmpfile);
+		(void) unlink(self_assembly);
+	}
+	return (ret);
+}
+
 static error_t
 create_ramdisk(char *root)
 {
@@ -4153,6 +4296,12 @@ update_archive(char *root, char *opt)
 		set_flag(RDONLY_FSCHK);
 		bam_check = 1;
 	}
+
+	/*
+	 * Process the /etc/system.d/self-assembly file.
+	 */
+	if (build_etc_system_dir(bam_root) == BAM_ERROR)
+		return (BAM_ERROR);
 
 	/*
 	 * Now check if an update is really needed.

--- a/usr/src/cmd/boot/filelist/i386/filelist.ramdisk
+++ b/usr/src/cmd/boot/filelist/i386/filelist.ramdisk
@@ -16,6 +16,7 @@ etc/name_to_sysnum
 etc/path_to_inst
 etc/rtc_config
 etc/system
+etc/system.d
 etc/hostid
 kernel
 platform/i86hvm/kernel

--- a/usr/src/cmd/nsadmin/system
+++ b/usr/src/cmd/nsadmin/system
@@ -1,4 +1,3 @@
-*ident	"%Z%%M%	%I%	%E% SMI" /* SVR4 1.5 */
 *
 * CDDL HEADER START
 *
@@ -23,6 +22,18 @@
 *
 * SYSTEM SPECIFICATION FILE
 *
+
+* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*
+* It is not recommended to edit this file directly but rather
+* to deliver configuration fragments into files under /etc/system.d;
+* files in /etc/system.d are combined in alphabetical order and read by
+* the kernel before this file (/etc/system) is processed.
+*
+* Refer to the system(4) manual page for more information and
+* recommendations on naming fragment files.
+*
+* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 * moddir:
 *

--- a/usr/src/man/man4/system.4
+++ b/usr/src/man/man4/system.4
@@ -1,11 +1,12 @@
 '\" te
 .\" Copyright (c) 2003 Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+.\" Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 .\" Copyright 1989 AT&T
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SYSTEM 4 "Jan 25, 2016"
+.TH SYSTEM 4 "Jan 29, 2019"
 .SH NAME
 system \- system configuration information file
 .SH DESCRIPTION
@@ -13,6 +14,18 @@ system \- system configuration information file
 The \fBsystem\fR file is used for customizing the operation of the operating
 system kernel. The recommended procedure is to preserve the original
 \fBsystem\fR file before modifying it.
+.sp
+.LP
+It is not recommended to edit the \fB/etc/system\fR file directly but rather
+to deliver configuration fragments into files under \fB/etc/system.d\fR;
+files in this directory are combined in alphabetical order and read by the
+kernel before \fB/etc/system\fR is processed. Directives in \fB/etc/system\fR
+therefore take precedence over any settings delivered in fragment files.
+.sp
+.LP
+The recommended naming schema for the fragment files is to use the name of
+the package which is delivering the file with '\fB/\fR' characters replaced
+by '\fB:\fR'; file names that start with a dot (\fB.\fR) will be ignored.
 .sp
 .LP
 The \fBsystem\fR file contains commands which are read by the kernel during
@@ -360,4 +373,4 @@ file that will work, you may specify \fB/dev/null\fR. This acts as an empty
 settings.
 .SH NOTES
 .LP
-The \fB/etc/system\fR file is read only once, at boot time.
+The \fBsystem\fR files are read only once, at boot time.

--- a/usr/src/pkg/manifests/SUNWcs.mf
+++ b/usr/src/pkg/manifests/SUNWcs.mf
@@ -24,7 +24,7 @@
 # Copyright 2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Copyright (c) 2013 Gary Mills
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
-# Copyright 2015 Nexenta Systems, Inc. All rights reserved.
+# Copyright 2017 Nexenta Systems, Inc.
 # Copyright 2017 Toomas Soome <tsoome@me.com>
 #
 
@@ -90,6 +90,7 @@ dir path=etc/svc/profile/site group=sys
 dir path=etc/svc/volatile group=sys
 dir path=etc/sysevent group=sys
 dir path=etc/sysevent/config group=sys
+dir path=etc/system.d group=sys
 dir path=etc/tm group=sys
 dir path=etc/user_attr.d group=sys
 dir path=export group=sys

--- a/usr/src/uts/common/os/modctl.c
+++ b/usr/src/uts/common/os/modctl.c
@@ -3351,7 +3351,7 @@ mod_askparams()
 	if ((fd = kobj_open(systemfile)) != -1L)
 		kobj_close(fd);
 	else
-		systemfile = NULL;
+		systemfile = self_assembly = NULL;
 
 	/*CONSTANTCONDITION*/
 	while (1) {
@@ -3363,12 +3363,13 @@ mod_askparams()
 		if (s0[0] == '\0')
 			break;
 		else if (strcmp(s0, "/dev/null") == 0) {
-			systemfile = NULL;
+			systemfile = self_assembly = NULL;
 			break;
 		} else {
 			if ((fd = kobj_open(s0)) != -1L) {
 				kobj_close(fd);
 				systemfile = s0;
+				self_assembly = NULL;
 				break;
 			}
 		}

--- a/usr/src/uts/common/os/modsysfile.c
+++ b/usr/src/uts/common/os/modsysfile.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2018 Joyent, Inc.
  */
 
@@ -67,6 +67,7 @@ static char pptfile[] = PPTFILE;
 static char dafile[] = DAFILE;
 static char dacffile[] = DACFFILE;
 
+char *self_assembly = "/etc/system.d/.self-assembly";
 char *systemfile = "/etc/system";	/* name of ascii system file */
 
 static struct sysparam *sysparam_hd;	/* head of parameters list */
@@ -754,67 +755,80 @@ bad:
 	return (NULL);
 }
 
-void
-mod_read_system_file(int ask)
+static void
+read_system_file(char *name)
 {
 	register struct sysparam *sp;
 	register struct _buf *file;
 	register token_t token, last_tok;
 	char tokval[MAXLINESIZE];
 
+	if ((file = kobj_open_file(name)) ==
+	    (struct _buf *)-1) {
+		if (strcmp(name, systemfile) == 0)
+			cmn_err(CE_WARN, "cannot open system file: %s",
+			    name);
+	} else {
+		if (sysparam_tl == NULL)
+			sysparam_tl = (struct sysparam *)&sysparam_hd;
+
+		last_tok = NEWLINE;
+		while ((token = kobj_lex(file, tokval,
+		    sizeof (tokval))) != EOF) {
+			switch (token) {
+			case STAR:
+			case POUND:
+				/*
+				 * Skip comments.
+				 */
+				kobj_find_eol(file);
+				break;
+			case NEWLINE:
+				kobj_newline(file);
+				last_tok = NEWLINE;
+				break;
+			case NAME:
+				if (last_tok != NEWLINE) {
+					kobj_file_err(CE_WARN, file,
+					    extra_err, tokval);
+					kobj_find_eol(file);
+				} else if ((sp = do_sysfile_cmd(file,
+				    tokval)) != NULL) {
+					sp->sys_next = NULL;
+					sysparam_tl->sys_next = sp;
+					sysparam_tl = sp;
+				}
+				last_tok = NAME;
+				break;
+			default:
+				kobj_file_err(CE_WARN,
+				    file, tok_err, tokval);
+				kobj_find_eol(file);
+				break;
+			}
+		}
+		kobj_close_file(file);
+	}
+}
+
+void
+mod_read_system_file(int ask)
+{
 	mod_sysfile_arena = vmem_create("mod_sysfile", NULL, 0, 8,
 	    segkmem_alloc, segkmem_free, heap_arena, 0, VM_SLEEP);
 
 	if (ask)
 		mod_askparams();
 
-	if (systemfile != NULL) {
+	/*
+	 * Read the user self-assembly file first
+	 * to preserve existing system settings.
+	 */
+	if (self_assembly != NULL)
+		read_system_file(self_assembly);
 
-		if ((file = kobj_open_file(systemfile)) ==
-		    (struct _buf *)-1) {
-			cmn_err(CE_WARN, "cannot open system file: %s",
-			    systemfile);
-		} else {
-			sysparam_tl = (struct sysparam *)&sysparam_hd;
-
-			last_tok = NEWLINE;
-			while ((token = kobj_lex(file, tokval,
-			    sizeof (tokval))) != EOF) {
-				switch (token) {
-				case STAR:
-				case POUND:
-					/*
-					 * Skip comments.
-					 */
-					kobj_find_eol(file);
-					break;
-				case NEWLINE:
-					kobj_newline(file);
-					last_tok = NEWLINE;
-					break;
-				case NAME:
-					if (last_tok != NEWLINE) {
-						kobj_file_err(CE_WARN, file,
-						    extra_err, tokval);
-						kobj_find_eol(file);
-					} else if ((sp = do_sysfile_cmd(file,
-					    tokval)) != NULL) {
-						sp->sys_next = NULL;
-						sysparam_tl->sys_next = sp;
-						sysparam_tl = sp;
-					}
-					last_tok = NAME;
-					break;
-				default:
-					kobj_file_err(CE_WARN,
-					    file, tok_err, tokval);
-					kobj_find_eol(file);
-					break;
-				}
-			}
-			kobj_close_file(file);
-		}
-	}
+	if (systemfile != NULL)
+		read_system_file(systemfile);
 
 	/*
 	 * Sanity check of /etc/system.

--- a/usr/src/uts/common/sys/modctl.h
+++ b/usr/src/uts/common/sys/modctl.h
@@ -546,6 +546,7 @@ typedef int modid_t;
 extern kmutex_t mod_lock;
 
 extern char *systemfile;
+extern char *self_assembly;
 extern char **syscallnames;
 extern int moddebug;
 


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Tue Jan 29 13:40:24 UTC 2019 ====
==== Nightly distributed build completed: Tue Jan 29 14:45:16 UTC 2019 ====

==== Total build time ====

real    1:04:52

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-1fd9c3fe3d i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.8.0_192-omnios-151029-20181209"

/usr/bin/openssl
OpenSSL 1.1.1a  20 Nov 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   585

==== Nightly argument issues ====


==== Build version ====

omnios-systemd-432efba439

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    26:56.5
user  2:50:25.3
sys     58:15.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:26.7
user  2:51:18.0
sys   1:09:31.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
