### PR TITLE
Upstream merge joyent_merge/2019013101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: c9422bbeaa6b10c8d0b398f4678ccdc8877757ab
+Last illumos-joyent commit: 4bf87f0f9a9dec4e46764fe7c2c7c342fe2f32d9
 


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019013101

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019013101-f719003b01 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Jan 31 10:38:28 UTC 2019 ====
==== Nightly distributed build completed: Thu Jan 31 11:27:32 UTC 2019 ====

==== Total build time ====

real    0:49:04

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-systemd-432efba439 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 3.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.8.0_192-omnios-151029-20181209"

/usr/bin/openssl
OpenSSL 1.1.1a  20 Nov 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)

Build project:  default
Build taskid:   83

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019013101-f719003b01

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:18.3
user  2:27:42.4
sys     19:54.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:06.8
user  2:08:48.0
sys     19:28.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
