### PR TITLE
9287 : dladm Segmentation Fault (core dumped) on unknown field

### DIFF
--- a/usr/src/cmd/dladm/dladm.c
+++ b/usr/src/cmd/dladm/dladm.c
@@ -651,8 +651,8 @@ static const ofmt_field_t link_s_fields[] = {
 { "IERRORS",	10,		LINK_S_IERRORS,	print_link_stats_cb},
 { "OPACKETS",	12,		LINK_S_OPKTS,	print_link_stats_cb},
 { "OBYTES",	12,		LINK_S_OBYTES,	print_link_stats_cb},
-{ "OERRORS",	8,		LINK_S_OERRORS,	print_link_stats_cb}}
-;
+{ "OERRORS",	8,		LINK_S_OERRORS,	print_link_stats_cb},
+{ NULL,		0,		0,		NULL}};
 
 typedef struct link_args_s {
 	char		*link_s_link;


### PR DESCRIPTION
As described in https://www.illumos.org/issues/9287, the problem was the missing ending in link_s_fields
```bash
cneira@Trixie:...lumos-omnios/usr/src/cmd/dladm$ /build/illumos-omnios/proto/root_i386-nd/usr/sbin/dladm show-link -s -p -o gugus e1000g0
/build/illumos-omnios/proto/root_i386-nd/usr/sbin/dladm: no valid output fields
cneira@Trixie:...lumos-omnios/usr/src/cmd/dladm$ dladm show-link -s -p -o gugus e1000g0
Memory fault(coredump)
cneira@Trixie:...lumos-omnios/usr/src/cmd/dladm$ pstack core
core 'core' of 27096:   dladm show-link -s -p -o gugus e1000g0
 fed82325 ascii_strcasecmp () + 42
```