### PR TITLE
10152 bge debugging always on

### DIFF
--- a/usr/src/uts/common/io/bge/bge_impl.h
+++ b/usr/src/uts/common/io/bge/bge_impl.h
@@ -1097,7 +1097,7 @@ typedef struct bge {
 #ifdef	DEBUG
 #define	BGE_DEBUGGING		1
 #else
-#define	BGE_DEBUGGING		1
+#define	BGE_DEBUGGING		0
 #endif	/* DEBUG */
 
 


### PR DESCRIPTION
from https://www.illumos.org/issues/10152, I checked the code and in fact, it still building with debug enabled. I don't have a bge chip to test this change though.
