### PR TITLE
10052 dladm show-ether should pick one kstat snapshot and stick with it

### DIFF
--- a/usr/src/cmd/flowstat/flowstat.c
+++ b/usr/src/cmd/flowstat/flowstat.c
@@ -426,7 +426,7 @@ query_flow_stats(dladm_handle_t handle, dladm_flow_attr_t *attr, void *arg)
 	prev_stat = flow_node->fc_stat;
 
 	/* Query library for current stats */
-	curr_stat = dladm_flow_stat_query(flowname);
+	curr_stat = dladm_flow_stat_query(flowname, handle);
 	if (curr_stat == NULL)
 		goto done;
 
@@ -491,7 +491,7 @@ dump_one_flow_stats(dladm_handle_t handle, dladm_flow_attr_t *attr, void *arg)
 	char	*flowname = attr->fa_flowname;
 	void	*stat;
 
-	stat = dladm_flow_stat_query_all(flowname);
+	stat = dladm_flow_stat_query_all(flowname, handle);
 	if (stat == NULL)
 		goto done;
 	print_all_stats(stat);

--- a/usr/src/lib/libdladm/common/libdladm.c
+++ b/usr/src/lib/libdladm/common/libdladm.c
@@ -119,6 +119,7 @@ dladm_open(dladm_handle_t *handle)
 		return (DLADM_STATUS_NOMEM);
 	}
 
+	(*handle)->dld_kcp = kstat_open();
 	(*handle)->dld_fd = dld_fd;
 	(*handle)->door_fd = -1;
 
@@ -132,6 +133,8 @@ dladm_close(dladm_handle_t handle)
 		(void) close(handle->dld_fd);
 		if (handle->door_fd != -1)
 			(void) close(handle->door_fd);
+		if (handle->dld_kcp != NULL)
+			(void) kstat_close(handle->dld_kcp);
 		free(handle);
 	}
 }
@@ -140,6 +143,12 @@ int
 dladm_dld_fd(dladm_handle_t handle)
 {
 	return (handle->dld_fd);
+}
+
+kstat_ctl_t*
+dladm_dld_kcp(dladm_handle_t handle)
+{
+	return (handle->dld_kcp);
 }
 
 /*

--- a/usr/src/lib/libdladm/common/libdladm.h
+++ b/usr/src/lib/libdladm/common/libdladm.h
@@ -29,6 +29,7 @@
 #include <sys/dld.h>
 #include <sys/dlpi.h>
 #include <libnvpair.h>
+#include <kstat.h>
 
 /*
  * This file includes structures, macros and common routines shared by all
@@ -208,6 +209,12 @@ extern void		dladm_close(dladm_handle_t);
  * dlmgmtd are given access to the door file descriptor.
  */
 extern int	dladm_dld_fd(dladm_handle_t);
+/*
+ * Retrieve kstat_ctl_t* from handle, at dladm_open kstat_open
+ * is called, so all consumers of kstat could reuse this kcp to avoid
+ * calling kstat_open each time statistics are required.
+ */
+extern kstat_ctl_t	*dladm_dld_kcp(dladm_handle_t);
 
 typedef struct dladm_arg_info {
 	const char	*ai_name;

--- a/usr/src/lib/libdladm/common/libdladm_impl.h
+++ b/usr/src/lib/libdladm/common/libdladm_impl.h
@@ -48,6 +48,7 @@ extern "C" {
 struct dladm_handle {
 	int dld_fd;	/* file descriptor to DLD_CONTROL_DEV */
 	int door_fd;	/* file descriptor to DLMGMT_DOOR */
+	kstat_ctl_t *dld_kcp;	/* for kstat consumers */
 };
 
 /* DLMGMT_DOOR can only be accessed by libdladm and dlmgmtd */

--- a/usr/src/lib/libdladm/common/libdlstat.h
+++ b/usr/src/lib/libdladm/common/libdlstat.h
@@ -279,10 +279,12 @@ extern dladm_stat_chain_t	*dladm_link_stat_diffchain(dladm_stat_chain_t *,
 extern dladm_stat_chain_t	*dladm_link_stat_query_all(dladm_handle_t,
 				    datalink_id_t, dladm_stat_type_t);
 
-extern flow_stat_t		*dladm_flow_stat_query(const char *);
+extern flow_stat_t		*dladm_flow_stat_query(const char *,
+				    dladm_handle_t);
 extern flow_stat_t		*dladm_flow_stat_diff(flow_stat_t *,
 				    flow_stat_t *);
-extern name_value_stat_entry_t	*dladm_flow_stat_query_all(const char *);
+extern name_value_stat_entry_t	*dladm_flow_stat_query_all(const char *,
+				    dladm_handle_t);
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
As explained in https://www.illumos.org/issues/10052 , kstat_ctl_t has been added to dladm_handle_t so kstat_open  is not called each time stats are required, there are the results after the change.

```bash
dtrace: description 'syscall::open:entry ' matched 3 probes
LINK            PTYPE    STATE    AUTO  SPEED-DUPLEX                    PAUSE
e1000g0         current  up       yes   1G-f                            bi
dtrace: pid 102504 has exited

  /dev/dld                                                          1
  /dev/kstat                                                        1
  /etc/svc/volatile/dladm/dlmgmt_door                               1
  /usr/lib/locale//en_US.UTF-8/LC_COLLATE/LCL_DATA                  1
  /usr/lib/locale//en_US.UTF-8/LC_CTYPE/LCL_DATA                    1
  /usr/lib/locale//en_US.UTF-8/LC_MESSAGES/LCL_DATA                 1
  /usr/lib/locale//en_US.UTF-8/LC_MONETARY/LCL_DATA                 1
  /usr/lib/locale//en_US.UTF-8/LC_NUMERIC/LCL_DATA                  1
  /usr/lib/locale//en_US.UTF-8/LC_TIME/LCL_DATA                     1

real        0.5
user        0.6
sys         0.7
```