### PR TITLE
Exclude weekly release component

### DIFF
--- a/usr/src/tools/env/omnios-illumos-omnios.sh
+++ b/usr/src/tools/env/omnios-illumos-omnios.sh
@@ -293,6 +293,6 @@ _branch=`git -C $CODEMGR_WS rev-parse --abbrev-ref HEAD`
 _hash=`git -C $CODEMGR_WS rev-parse --short HEAD`
 export VERSION=`echo omnios-$_branch-$_hash | tr '/' '-'`
 
-export ONNV_BUILDNUM=`grep '^VERSION=r' /etc/os-release | cut -c10-`
+export ONNV_BUILDNUM=`grep '^VERSION=r' /etc/os-release | cut -c10-15`
 export PKGVERS_BRANCH=$ONNV_BUILDNUM.0
 


### PR DESCRIPTION
We need to exclude the trailing weekly release part of /etc/os-release:VERSION