### PR TITLE
 Support on-demand VNICs

### DIFF
--- a/usr/src/cmd/dlmgmtd/dlmgmt_door.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_door.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -1258,8 +1259,7 @@ dlmgmt_setzoneid(void *argp, void *retp, size_t *sz, zoneid_t zoneid,
 	 * Before we remove the link from its current zone, make sure that
 	 * there isn't a link with the same name in the destination zone.
 	 */
-	if (zoneid != GLOBAL_ZONEID &&
-	    link_by_name(linkp->ll_link, newzoneid) != NULL) {
+	if (link_by_name(linkp->ll_link, newzoneid) != NULL) {
 		err = EEXIST;
 		goto done;
 	}

--- a/usr/src/cmd/zoneadm/zoneadm.c
+++ b/usr/src/cmd/zoneadm/zoneadm.c
@@ -2708,11 +2708,6 @@ verify_handle(int cmd_num, zone_dochandle_t handle, char *argv[])
 				dladm_close(dh);
 			}
 			if (status != DLADM_STATUS_OK) {
-				(void) fprintf(stderr,
-				    gettext("WARNING: skipping network "
-				    "interface '%s': %s\n"),
-				    nwiftab.zone_nwif_physical,
-				    dladm_status2str(status, errmsg));
 				break;
 			}
 			dl_owner_zid = ALL_ZONES;

--- a/usr/src/man/man1m/zonecfg.1m
+++ b/usr/src/man/man1m/zonecfg.1m
@@ -5,7 +5,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License"). You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\" See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE. If applicable, add the following below this CDDL HEADER, with the
 .\" fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH ZONECFG 1M "Jul 24, 2017"
+.TH ZONECFG 1M "Feb 13, 2019"
 .SH NAME
 zonecfg \- set up zone configuration
 .SH SYNOPSIS
@@ -369,7 +369,7 @@ The following properties are supported:
 .ad
 .sp .6
 .RS 4n
-\fBaddress\fR, \fBallowed-address\fR, \fBphysical\fR, \fBdefrouter\fR
+\fBaddress\fR, \fBallowed-address\fR, \fBdefrouter\fR, \fBglobal-nic\fR, \fBmac-addr\fR, \fBphysical\fR, \fBvlan-id\fR
 .RE
 
 .sp
@@ -652,7 +652,7 @@ Values needed to determine how, where, and so forth to mount file systems. See
 .sp
 .ne 2
 .na
-\fB\fBnet\fR: address, allowed-address, physical, defrouter\fR
+\fB\fBnet\fR: address, allowed-address, defrouter, global-nic, mac-addr, physical, vlan-id\fR
 .ad
 .sp .6
 .RS 4n
@@ -690,6 +690,8 @@ property must be plumbed in the global zone prior to booting the non-global
 zone. However, if the interface is not used by the global zone, it should be
 configured \fBdown\fR in the global zone, and the default router for the
 interface should be specified here.
+.sp
+The global-nic is used for exclusive stack zones which will use a VNIC on-demand.  When the zone boots, a VNIC named using the physical property will be created on the global NIC.  If provided, the mac-addr and vlan-id will be set on this VNIC.
 .sp
 For an exclusive-IP zone, the physical property must be set and the address and
 default router properties cannot be set.
@@ -990,6 +992,10 @@ fs                dir             simple
                    type            simple
                    options         list of simple
 net               address         simple
+                   allowed-address simple
+                   defrouter       simple
+                   global-nic      simple
+                   mac-addr        simple
                    physical        simple
 device            match           simple
 rctl              name            simple


### PR DESCRIPTION
Most of the work to support on-demand VNICs for zones is already in OmniOS from the lx port. This hooks up the small number of missing bits.

See https://gist.github.com/citrus-it/767a42755825d9dde6d0e8dfb331791f

See associated change in https://github.com/omniosorg/pkg5/pull/114