### PR TITLE
Upstream merge joyent_merge/2019021401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 7a899a42e86d8d3e6d7d3eaf31bcacc6411fbb74
+Last illumos-joyent commit: c8b89b2e0ef5e796d5ea1ee45802f7ebc39545f4
 

--- a/exception_lists/packaging
+++ b/exception_lists/packaging
@@ -809,6 +809,21 @@ usr/lib/sparcv9/libsff.so		sparc
 usr/lib/libsff.so
 
 #
+# private bhyve files
+#
+lib/amd64/libvmm.so			i386
+lib/amd64/libvmmapi.so			i386
+usr/include/bhyve.h			i386
+usr/include/libppt.h			i386
+usr/include/libvmm.h			i386
+usr/include/vmmapi.h			i386
+usr/lib/amd64/libppt.so			i386
+usr/lib/libppt.so			i386
+usr/platform/i86pc/include/sys/vmm.h	i386
+usr/platform/i86pc/include/sys/vmm_impl.h	i386
+usr/platform/i86pc/include/sys/vmm_instruction_emul.h	i386
+
+#
 # libcustr is private
 #
 usr/include/libcustr.h
@@ -838,15 +853,6 @@ usr/lib/libdwarf.so
 #
 usr/bin/ctfconvert
 usr/bin/ctfmerge
-
-#
-# private bhyve header files
-#
-usr/include/bhyve.h
-usr/include/vmmapi.h
-usr/platform/i86pc/include/sys/vmm.h
-usr/platform/i86pc/include/sys/vmm_impl.h
-usr/platform/i86pc/include/sys/vmm_instruction_emul.h
 
 #
 # foreign loader brands not shipped

--- a/usr/src/cmd/mdb/i86pc/modules/unix/amd64/Makefile
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/amd64/Makefile
@@ -22,7 +22,7 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Copyright 2016 Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 
 MODULE = unix.so
 MDBTGT = kvm
@@ -38,6 +38,7 @@ include ../../../../Makefile.module
 
 CPPFLAGS += -DMP -D_MACHDEP
 CPPFLAGS += -I../../../../common
+CPPFLAGS += -I../../../../intel
 CPPFLAGS += -I$(SRC)/uts/i86pc
 CPPFLAGS += -I$(SRC)/uts/intel
 

--- a/usr/src/cmd/mdb/i86pc/modules/unix/unix.c
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/unix.c
@@ -21,11 +21,12 @@
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <mdb/mdb_modapi.h>
 #include <mdb/mdb_ctf.h>
+#include <mdb/mdb_x86util.h>
 #include <sys/cpuvar.h>
 #include <sys/systm.h>
 #include <sys/traptrace.h>
@@ -908,73 +909,24 @@ x86_featureset_cmd(uintptr_t addr, uint_t flags, int argc,
 static int
 sysregs_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	ulong_t cr0, cr2, cr3, cr4;
+	struct sysregs sregs = { 0 };
 	desctbr_t gdtr;
+	boolean_t longmode = B_FALSE;
 
-	static const mdb_bitmask_t cr0_flag_bits[] = {
-		{ "PE",		CR0_PE,		CR0_PE },
-		{ "MP",		CR0_MP,		CR0_MP },
-		{ "EM",		CR0_EM,		CR0_EM },
-		{ "TS",		CR0_TS,		CR0_TS },
-		{ "ET",		CR0_ET,		CR0_ET },
-		{ "NE",		CR0_NE,		CR0_NE },
-		{ "WP",		CR0_WP,		CR0_WP },
-		{ "AM",		CR0_AM,		CR0_AM },
-		{ "NW",		CR0_NW,		CR0_NW },
-		{ "CD",		CR0_CD,		CR0_CD },
-		{ "PG",		CR0_PG,		CR0_PG },
-		{ NULL,		0,		0 }
-	};
+#ifdef __amd64
+	longmode = B_TRUE;
+#endif
 
-	static const mdb_bitmask_t cr3_flag_bits[] = {
-		{ "PCD",	CR3_PCD,	CR3_PCD },
-		{ "PWT",	CR3_PWT,	CR3_PWT },
-		{ NULL,		0,		0, }
-	};
-
-	static const mdb_bitmask_t cr4_flag_bits[] = {
-		{ "VME",	CR4_VME,	CR4_VME },
-		{ "PVI",	CR4_PVI,	CR4_PVI },
-		{ "TSD",	CR4_TSD,	CR4_TSD },
-		{ "DE",		CR4_DE,		CR4_DE },
-		{ "PSE",	CR4_PSE,	CR4_PSE },
-		{ "PAE",	CR4_PAE,	CR4_PAE },
-		{ "MCE",	CR4_MCE,	CR4_MCE },
-		{ "PGE",	CR4_PGE,	CR4_PGE },
-		{ "PCE",	CR4_PCE,	CR4_PCE },
-		{ "OSFXSR",	CR4_OSFXSR,	CR4_OSFXSR },
-		{ "OSXMMEXCPT",	CR4_OSXMMEXCPT,	CR4_OSXMMEXCPT },
-		{ "VMXE",	CR4_VMXE,	CR4_VMXE },
-		{ "SMXE",	CR4_SMXE,	CR4_SMXE },
-		{ "PCIDE",	CR4_PCIDE,	CR4_PCIDE },
-		{ "OSXSAVE",	CR4_OSXSAVE,	CR4_OSXSAVE },
-		{ "SMEP",	CR4_SMEP,	CR4_SMEP },
-		{ "SMAP",	CR4_SMAP,	CR4_SMAP },
-		{ NULL,		0,		0 }
-	};
-
-	cr0 = kmdb_unix_getcr0();
-	cr2 = kmdb_unix_getcr2();
-	cr3 = kmdb_unix_getcr3();
-	cr4 = kmdb_unix_getcr4();
+	sregs.sr_cr0 = kmdb_unix_getcr0();
+	sregs.sr_cr2 = kmdb_unix_getcr2();
+	sregs.sr_cr3 = kmdb_unix_getcr3();
+	sregs.sr_cr4 = kmdb_unix_getcr4();
 
 	kmdb_unix_getgdtr(&gdtr);
+	sregs.sr_gdtr.d_base = gdtr.dtr_base;
+	sregs.sr_gdtr.d_lim = gdtr.dtr_limit;
 
-	mdb_printf("%%cr0 = 0x%lx <%b>\n", cr0, cr0, cr0_flag_bits);
-	mdb_printf("%%cr2 = 0x%lx <%a>\n", cr2, cr2);
-
-	if ((cr4 & CR4_PCIDE)) {
-		mdb_printf("%%cr3 = 0x%lx <pfn:0x%lx pcid:%lu>\n", cr3,
-		    cr3 >> MMU_PAGESHIFT, cr3 & MMU_PAGEOFFSET);
-	} else {
-		mdb_printf("%%cr3 = 0x%lx <pfn:0x%lx flags:%b>\n", cr3,
-		    cr3 >> MMU_PAGESHIFT, cr3, cr3_flag_bits);
-	}
-
-	mdb_printf("%%cr4 = 0x%lx <%b>\n", cr4, cr4, cr4_flag_bits);
-
-	mdb_printf("%%gdtr.base = 0x%lx, %%gdtr.limit = 0x%hx\n",
-	    gdtr.dtr_base, gdtr.dtr_limit);
+	mdb_x86_print_sysregs(&sregs, longmode);
 
 	return (DCMD_OK);
 }

--- a/usr/src/cmd/mdb/i86xpv/modules/unix/amd64/Makefile
+++ b/usr/src/cmd/mdb/i86xpv/modules/unix/amd64/Makefile
@@ -22,7 +22,7 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Copyright 2016 Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 
 MODULE = unix.so
 MDBTGT = kvm
@@ -40,6 +40,7 @@ MODSRCS_DIR = ../../../../i86pc/modules/unix/
 
 CPPFLAGS += -DMP -D_MACHDEP -D__xpv
 CPPFLAGS += -I../../../../common
+CPPFLAGS += -I../../../../intel
 CPPFLAGS += -I$(SRC)/uts/common
 CPPFLAGS += -I$(SRC)/uts/i86xpv
 CPPFLAGS += -I$(SRC)/uts/i86pc

--- a/usr/src/cmd/mdb/intel/Makefile.kmdb
+++ b/usr/src/cmd/mdb/intel/Makefile.kmdb
@@ -22,7 +22,7 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Copyright 2018 Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 
 PROMSRCS += \
@@ -66,6 +66,7 @@ KMDBLIBS = $(STANDLIBS) ../mdb_ks/kmod/mdb_ks
 MAPFILE_SOURCES = \
 	$(MAPFILE_SOURCES_COMMON) \
 	../../kmdb/kmdb_dpi_isadep.h \
+	../../mdb/mdb_x86util.h \
 	$(MAPFILE_SOURCES_$(MACH))
 
 %.o: ../../../../../uts/intel/promif/%.c

--- a/usr/src/cmd/mdb/intel/amd64/Makefile.kmdb
+++ b/usr/src/cmd/mdb/intel/amd64/Makefile.kmdb
@@ -22,6 +22,8 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2019 Joyent, Inc.
+#
 
 KMDBML += \
 	kaif_invoke.s \
@@ -29,6 +31,7 @@ KMDBML += \
 
 KMDBSRCS += \
 	kmdb_makecontext.c \
-	mdb_amd64util.c
+	mdb_amd64util.c \
+	mdb_x86util.c
 
 SACPPFLAGS = -D__$(MACH64) -U__$(MACH)

--- a/usr/src/cmd/mdb/intel/amd64/mdb/Makefile
+++ b/usr/src/cmd/mdb/intel/amd64/mdb/Makefile
@@ -22,13 +22,14 @@
 # Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Copyright 2018 Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 
 SRCS =	kvm_amd64dep.c \
 	kvm_isadep.c \
 	mdb_amd64util.c \
 	mdb_ia32util.c \
+	mdb_x86util.c \
 	mdb_bhyve.c \
 	proc_amd64dep.c
 

--- a/usr/src/cmd/mdb/intel/mdb/mdb_x86util.c
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_x86util.c
@@ -1,0 +1,215 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+/*
+ * ISA-independent utility functions for the x86 architecture
+ */
+
+#include <mdb/mdb_modapi.h>
+#include <mdb/mdb_x86util.h>
+
+#include <sys/controlregs.h>
+#include <inttypes.h>
+
+#define	MMU_PAGESHIFT	12
+#define	MMU_PAGESIZE	(1 << MMU_PAGESHIFT)
+#define	MMU_PAGEOFFSET	(MMU_PAGESIZE - 1)
+#define	MMU_PAGEMASK	(~MMU_PAGEOFFSET)
+
+#ifndef _KMDB
+static void
+mdb_x86_print_desc(const char *name, const mdb_x86_desc_t *desc, uint_t width)
+{
+	const char *type;
+	const mdb_bitmask_t *bits;
+
+	static const mdb_bitmask_t mem_desc_flag_bits[] = {
+		{ "P",		0x80,	0x80 },
+		{ "16b",	0x6000, 0x0 },
+		{ "32b",	0x6000, 0x4000 },
+		{ "64b",	0x6000,	0x2000 },
+		{ "G",		0x8000,	0x8000 },
+		{ "A",		0x1,	0x1 },
+		{ NULL,		0,	0 },
+	};
+
+	static const char *mem_desc_types[] = {
+		"data, up, read-only",
+		"data, up, read-write",
+		"data, down, read-only",
+		"data, down, read-write",
+		"code, non-conforming, execute-only",
+		"code, non-conforming, execute-read",
+		"code, conforming, execute-only",
+		"code, conforming, execute-read"
+	};
+
+	static const mdb_bitmask_t sys_desc_flag_bits[] = {
+		{ "P",		0x80,	0x80 },
+		{ "16b",	0x6000, 0x0 },
+		{ "32b",	0x6000, 0x4000 },
+		{ "64b",	0x6000,	0x2000 },
+		{ "G",		0x8000,	0x8000 },
+		{ NULL,		0,	0 },
+	};
+
+	static const char *sys_desc_types[] = {
+		"reserved",
+		"16b TSS, available",
+		"LDT",
+		"16b TSS, busy",
+		"16b call gate",
+		"task gate",
+		"16b interrupt gate",
+		"16b trap gate",
+		"reserved",
+		"32b/64b TSS, available",
+		"reserved",
+		"32b/64b TSS, busy",
+		"32b/64b call gate",
+		"reserved",
+		"32b/64b interrupt gate"
+		"32b/64b trap gate",
+	};
+
+	if (desc->d_acc & 0x10) {
+		type = mem_desc_types[(desc->d_acc >> 1) & 7];
+		bits = mem_desc_flag_bits;
+	} else {
+		type = sys_desc_types[desc->d_acc & 0xf];
+		bits = sys_desc_flag_bits;
+	}
+
+	mdb_printf("%%%s = 0x%0*lx/0x%0*x 0x%05x "
+	    "<%susable, %s, dpl %d, flags: %b>\n",
+	    name, width, desc->d_base, width / 2, desc->d_lim, desc->d_acc,
+	    (desc->d_acc >> 16) & 1 ? "un" : "", type,
+	    (desc->d_acc >> 5) & 3, desc->d_acc, bits);
+}
+#endif
+
+void
+mdb_x86_print_sysregs(struct sysregs *sregs, boolean_t long_mode)
+{
+	const uint_t width =
+	    2 * (long_mode ? sizeof (uint64_t) : sizeof (uint32_t));
+
+
+#ifndef _KMDB
+	static const mdb_bitmask_t efer_flag_bits[] = {
+		{ "SCE",	AMD_EFER_SCE,	AMD_EFER_SCE },
+		{ "LME",	AMD_EFER_LME,	AMD_EFER_LME },
+		{ "LMA",	AMD_EFER_LMA,	AMD_EFER_LMA },
+		{ "NXE",	AMD_EFER_NXE,	AMD_EFER_NXE },
+		{ "SVME",	AMD_EFER_SVME,	AMD_EFER_SVME },
+		{ "LMSLE",	AMD_EFER_LMSLE,	AMD_EFER_LMSLE },
+		{ "FFXSR",	AMD_EFER_FFXSR,	AMD_EFER_FFXSR },
+		{ "TCE",	AMD_EFER_TCE,	AMD_EFER_TCE },
+		{ NULL,		0,		0 }
+	};
+#endif
+
+	static const mdb_bitmask_t cr0_flag_bits[] = {
+		{ "PE",		CR0_PE,		CR0_PE },
+		{ "MP",		CR0_MP,		CR0_MP },
+		{ "EM",		CR0_EM,		CR0_EM },
+		{ "TS",		CR0_TS,		CR0_TS },
+		{ "ET",		CR0_ET,		CR0_ET },
+		{ "NE",		CR0_NE,		CR0_NE },
+		{ "WP",		CR0_WP,		CR0_WP },
+		{ "AM",		CR0_AM,		CR0_AM },
+		{ "NW",		CR0_NW,		CR0_NW },
+		{ "CD",		CR0_CD,		CR0_CD },
+		{ "PG",		CR0_PG,		CR0_PG },
+		{ NULL,		0,		0 }
+	};
+
+	static const mdb_bitmask_t cr3_flag_bits[] = {
+		{ "PCD",	CR3_PCD,	CR3_PCD },
+		{ "PWT",	CR3_PWT,	CR3_PWT },
+		{ NULL,		0,		0, }
+	};
+
+	static const mdb_bitmask_t cr4_flag_bits[] = {
+		{ "VME",	CR4_VME,	CR4_VME },
+		{ "PVI",	CR4_PVI,	CR4_PVI },
+		{ "TSD",	CR4_TSD,	CR4_TSD },
+		{ "DE",		CR4_DE,		CR4_DE },
+		{ "PSE",	CR4_PSE,	CR4_PSE },
+		{ "PAE",	CR4_PAE,	CR4_PAE },
+		{ "MCE",	CR4_MCE,	CR4_MCE },
+		{ "PGE",	CR4_PGE,	CR4_PGE },
+		{ "PCE",	CR4_PCE,	CR4_PCE },
+		{ "OSFXSR",	CR4_OSFXSR,	CR4_OSFXSR },
+		{ "OSXMMEXCPT",	CR4_OSXMMEXCPT,	CR4_OSXMMEXCPT },
+		{ "UMIP",	CR4_UMIP,	CR4_UMIP },
+		{ "VMXE",	CR4_VMXE,	CR4_VMXE },
+		{ "SMXE",	CR4_SMXE,	CR4_SMXE },
+		{ "FSGSBASE",	CR4_FSGSBASE,	CR4_FSGSBASE },
+		{ "PCIDE",	CR4_PCIDE,	CR4_PCIDE },
+		{ "OSXSAVE",	CR4_OSXSAVE,	CR4_OSXSAVE },
+		{ "SMEP",	CR4_SMEP,	CR4_SMEP },
+		{ "SMAP",	CR4_SMAP,	CR4_SMAP },
+		{ "PKE",	CR4_PKE,	CR4_PKE },
+		{ NULL,		0,		0 }
+	};
+
+#ifndef _KMDB
+	mdb_printf("%%efer = 0x%0lx <%b>\n",
+	    sregs->sr_efer, sregs->sr_efer, efer_flag_bits);
+#endif
+	mdb_printf("%%cr0 = 0x%0lx <%b>\n",
+	    sregs->sr_cr0, sregs->sr_cr0, cr0_flag_bits);
+	mdb_printf("%%cr2 = 0x%0*x <%a>\n", width,
+	    sregs->sr_cr2, sregs->sr_cr2);
+	mdb_printf("%%cr3 = 0x%0lx <pfn:0x%lx ",
+	    sregs->sr_cr3, sregs->sr_cr3 >> MMU_PAGESHIFT);
+	if (sregs->sr_cr4 & CR4_PCIDE)
+		mdb_printf("pcid:%lu>\n", sregs->sr_cr3 & MMU_PAGEOFFSET);
+	else
+		mdb_printf("flags:%b>\n", sregs->sr_cr3, cr3_flag_bits);
+	mdb_printf("%%cr4 = 0x%0lx <%b>\n",
+	    sregs->sr_cr4, sregs->sr_cr4, cr4_flag_bits);
+
+#ifndef _KMDB
+	mdb_printf("\n");
+	mdb_printf("%%pdpte0 = 0x%0?lx\t%%pdpte2 = 0x%0?lx\n",
+	    sregs->sr_pdpte0, sregs->sr_pdpte2);
+	mdb_printf("%%pdpte1 = 0x%0?lx\t%%pdpte3 = 0x%0?lx\n",
+	    sregs->sr_pdpte1, sregs->sr_pdpte3);
+	mdb_printf("\n");
+
+	mdb_printf("%%gdtr = 0x%0*lx/0x%hx\n",
+	    width, sregs->sr_gdtr.d_base, sregs->sr_gdtr.d_lim);
+#else
+	mdb_printf("%%gdtr.base = 0x%0*lx, %%gdtr.limit = 0x%hx\n",
+	    width, sregs->sr_gdtr.d_base, sregs->sr_gdtr.d_lim);
+#endif
+#ifndef _KMDB
+	mdb_printf("%%idtr = 0x%0*lx/0x%hx\n",
+	    width, sregs->sr_idtr.d_base, sregs->sr_idtr.d_lim);
+	mdb_x86_print_desc("ldtr", &sregs->sr_ldtr, width);
+	mdb_x86_print_desc("tr  ", &sregs->sr_tr, width);
+	mdb_x86_print_desc("cs  ", &sregs->sr_cs, width);
+	mdb_x86_print_desc("ss  ", &sregs->sr_ss, width);
+	mdb_x86_print_desc("ds  ", &sregs->sr_ds, width);
+	mdb_x86_print_desc("es  ", &sregs->sr_es, width);
+	mdb_x86_print_desc("fs  ", &sregs->sr_fs, width);
+	mdb_x86_print_desc("gs  ", &sregs->sr_gs, width);
+
+	mdb_printf("%%intr_shadow = 0x%lx\n",
+	    sregs->sr_intr_shadow);
+#endif
+}

--- a/usr/src/cmd/mdb/intel/mdb/mdb_x86util.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_x86util.h
@@ -1,0 +1,68 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#ifndef _MDB_X86UTIL_H
+#define	_MDB_X86UTIL_H
+
+#include <sys/types.h>
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mdb_x86_desc {
+	uint64_t d_base;
+	uint32_t d_lim;
+	uint32_t d_acc;
+} mdb_x86_desc_t;
+
+struct sysregs {
+	uint64_t sr_cr0;
+	uint64_t sr_cr2;
+	uint64_t sr_cr3;
+	uint64_t sr_cr4;
+	uint64_t sr_dr0;
+	uint64_t sr_dr1;
+	uint64_t sr_dr2;
+	uint64_t sr_dr3;
+	uint64_t sr_dr6;
+	uint64_t sr_dr7;
+	uint64_t sr_efer;
+	uint64_t sr_pdpte0;
+	uint64_t sr_pdpte1;
+	uint64_t sr_pdpte2;
+	uint64_t sr_pdpte3;
+	uint64_t sr_intr_shadow;
+	mdb_x86_desc_t sr_gdtr;
+	mdb_x86_desc_t sr_idtr;
+	mdb_x86_desc_t sr_ldtr;
+	mdb_x86_desc_t sr_tr;
+	mdb_x86_desc_t sr_cs;
+	mdb_x86_desc_t sr_ss;
+	mdb_x86_desc_t sr_ds;
+	mdb_x86_desc_t sr_es;
+	mdb_x86_desc_t sr_fs;
+	mdb_x86_desc_t sr_gs;
+};
+
+extern void mdb_x86_print_sysregs(struct sysregs *, boolean_t);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MDB_X86UTIL_H */

--- a/usr/src/lib/libvmm/libvmm.h
+++ b/usr/src/lib/libvmm/libvmm.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _LIBVMM_H
@@ -98,9 +98,9 @@ ssize_t vmm_vwrite(vmm_t *, int, int, const void *, size_t, uintptr_t);
 size_t vmm_ncpu(vmm_t *);
 size_t vmm_memsize(vmm_t *);
 
-void vmm_cont(vmm_t *);
+int vmm_cont(vmm_t *);
 int vmm_step(vmm_t *, int);
-void vmm_stop(vmm_t *);
+int vmm_stop(vmm_t *);
 
 int vmm_getreg(vmm_t *, int, int, uint64_t *);
 int vmm_setreg(vmm_t *, int, int, uint64_t);

--- a/usr/src/pkg/manifests/system-bhyve-tests.mf
+++ b/usr/src/pkg/manifests/system-bhyve-tests.mf
@@ -22,7 +22,7 @@ set name=pkg.description value="BSD hypervisor tests"
 set name=pkg.summary value="BSD hypervisor tests"
 set name=info.classification \
     value=org.opensolaris.category.2008:System/Virtualization
-set name=variant.arch value=$(ARCH)
+set name=variant.arch value=i386
 dir path=opt/bhyvetest
 dir path=opt/bhyvetest/bin
 dir path=opt/bhyvetest/tst

--- a/usr/src/pkg/manifests/system-bhyve.mf
+++ b/usr/src/pkg/manifests/system-bhyve.mf
@@ -14,6 +14,7 @@
 #
 
 #
+# Copyright 2018 Joyent, Inc.
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 

--- a/usr/src/pkg/manifests/system-library-bhyve.mf
+++ b/usr/src/pkg/manifests/system-library-bhyve.mf
@@ -25,14 +25,9 @@ dir path=lib group=bin
 dir path=lib/$(ARCH64) group=bin
 dir path=usr group=sys
 dir path=usr/lib group=bin
+dir path=usr/lib/$(ARCH64) group=bin
 file path=lib/$(ARCH64)/libvmm.so.1
 file path=lib/$(ARCH64)/libvmmapi.so.1
-file path=usr/include/libppt.h
-file path=usr/include/libvmm.h
 file path=usr/lib/$(ARCH64)/libppt.so.1
 file path=usr/lib/libppt.so.1
 license lic_CDDL license=lic_CDDL
-link path=lib/$(ARCH64)/libvmm.so target=./libvmm.so.1
-link path=lib/$(ARCH64)/libvmmapi.so target=./libvmmapi.so.1
-link path=usr/lib/$(ARCH64)/libppt.so target=libppt.so.1
-link path=usr/lib/libppt.so target=libppt.so.1

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -23,7 +23,7 @@
 # Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
 #
 # Copyright (c) 2010, Intel Corporation.
-# Copyright 2018 Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 #	This Makefile defines file modules in the directory uts/i86pc
 #	and its children. These are the source files which are i86pc
@@ -275,8 +275,10 @@ VMM_OBJS += vmm.o \
 	vmcb.o \
 	svm_support.o \
 	amdv.o \
+	gipt.o \
 	vmm_sol_vm.o \
 	vmm_sol_glue.o \
+	vmm_sol_ept.o \
 	vmm_zsd.o
 
 VIONA_OBJS += viona.o

--- a/usr/src/uts/i86pc/io/vmm/vm/vm_glue.h
+++ b/usr/src/uts/i86pc/io/vmm/vm/vm_glue.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef	_VM_GLUE_
@@ -24,6 +24,7 @@ struct vmspace;
 struct vm_map;
 struct pmap;
 struct vm_object;
+struct vmm_pt_ops;
 
 struct vm_map {
 	struct vmspace *vmm_space;
@@ -36,7 +37,8 @@ struct pmap {
 
 	/* Implementation private */
 	enum pmap_type	pm_type;
-	void		*pm_map;
+	struct vmm_pt_ops *pm_ops;
+	void		*pm_impl;
 };
 
 struct vmspace {
@@ -80,5 +82,17 @@ int vm_segmap_space(struct vmspace *, off_t, struct as *, caddr_t *, off_t,
 void *vmspace_find_kva(struct vmspace *, uintptr_t, size_t);
 void vmm_arena_init(void);
 void vmm_arena_fini(void);
+
+struct vmm_pt_ops {
+	void * (*vpo_init)(uint64_t *);
+	void (*vpo_free)(void *);
+	uint64_t (*vpo_wired_cnt)(void *);
+	int (*vpo_is_wired)(void *, uint64_t, uint_t *);
+	int (*vpo_map)(void *, uint64_t, pfn_t, uint_t, uint_t, uint8_t);
+	uint64_t (*vpo_unmap)(void *, uint64_t, uint64_t);
+};
+
+extern struct vmm_pt_ops ept_ops;
+
 
 #endif /* _VM_GLUE_ */

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_ept.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_ept.c
@@ -1,0 +1,268 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/kmem.h>
+#include <sys/machsystm.h>
+
+#include <sys/gipt.h>
+#include <vm/vm_glue.h>
+
+
+struct ept_map {
+	gipt_map_t	em_gipt;
+	uint64_t	em_wired_page_count;
+};
+typedef struct ept_map ept_map_t;
+
+#define	EPT_LOCK(m)	(&(m)->em_gipt.giptm_lock)
+
+#define	EPT_MAX_LEVELS	4
+
+CTASSERT(EPT_MAX_LEVELS <= GIPT_MAX_LEVELS);
+
+#define	EPT_R		(0x1 << 0)
+#define	EPT_W		(0x1 << 1)
+#define	EPT_X		(0x1 << 2)
+#define	EPT_RWX		(EPT_R | EPT_W | EPT_X)
+#define	EPT_LGPG	(0x1 << 7)
+
+#define	EPT_PA_MASK	(0x000ffffffffff000ull)
+
+CTASSERT(EPT_R == PROT_READ);
+CTASSERT(EPT_W == PROT_WRITE);
+CTASSERT(EPT_X == PROT_EXEC);
+
+
+#define	EPT_PAT(attr)	(((attr) & 0x7) << 3)
+#define	EPT_PADDR(addr)	((addr) & EPT_PA_MASK)
+
+#define	EPT_IS_ABSENT(pte)	(((pte) & EPT_RWX) == 0)
+#define	EPT_PTE_PFN(pte)	mmu_btop(EPT_PADDR(pte))
+#define	EPT_PTE_PROT(pte)	((pte) & EPT_RWX)
+#define	EPT_MAPS_PAGE(pte, lvl)	\
+	(EPT_PTE_PROT(pte) != 0 && (((pte) & EPT_LGPG) != 0 || (lvl) == 0))
+
+/*
+ * Only assign EPT_LGPG for levels higher than 0.  Although this bit is defined
+ * as being ignored at level 0, some versions of VMWare fail to honor this and
+ * report such a PTE as an EPT mis-configuration.
+ */
+#define	EPT_PTE_ASSIGN_PAGE(lvl, pfn, prot, attr)	\
+	(EPT_PADDR(pfn_to_pa(pfn)) |			\
+	(((lvl) != 0) ? EPT_LGPG : 0) |			\
+	EPT_PAT(attr) | ((prot) & EPT_RWX))
+#define	EPT_PTE_ASSIGN_TABLE(pfn)	(EPT_PADDR(pfn_to_pa(pfn)) | EPT_RWX)
+
+
+static gipt_pte_type_t
+ept_pte_type(uint64_t pte, uint_t level)
+{
+	if (EPT_IS_ABSENT(pte)) {
+		return (PTET_EMPTY);
+	} else if (EPT_MAPS_PAGE(pte, level)) {
+		return (PTET_PAGE);
+	} else {
+		return (PTET_LINK);
+	}
+}
+
+static uint64_t
+ept_pte_map(uint64_t pfn)
+{
+	return (EPT_PTE_ASSIGN_TABLE(pfn));
+}
+
+static void *
+ept_create(uintptr_t *pml4_kaddr)
+{
+	ept_map_t *emap;
+	gipt_map_t *map;
+	gipt_t *root;
+	struct gipt_cbs cbs = {
+		.giptc_pte_type = ept_pte_type,
+		.giptc_pte_map = ept_pte_map,
+	};
+
+	emap = kmem_zalloc(sizeof (*emap), KM_SLEEP);
+	map = &emap->em_gipt;
+	root = gipt_alloc();
+	root->gipt_level = EPT_MAX_LEVELS - 1;
+	gipt_map_init(map, EPT_MAX_LEVELS, GIPT_HASH_SIZE_DEFAULT, &cbs, root);
+
+	*pml4_kaddr = (uintptr_t)root->gipt_kva;
+	return (emap);
+}
+
+static void
+ept_destroy(void *arg)
+{
+	ept_map_t *emap = arg;
+
+	if (emap != NULL) {
+		gipt_map_t *map = &emap->em_gipt;
+
+		gipt_map_fini(map);
+		kmem_free(emap, sizeof (*emap));
+	}
+}
+
+static uint64_t
+ept_wired_count(void *arg)
+{
+	ept_map_t *emap = arg;
+	uint64_t res;
+
+	mutex_enter(EPT_LOCK(emap));
+	res = emap->em_wired_page_count;
+	mutex_exit(EPT_LOCK(emap));
+
+	return (res);
+}
+
+static int
+ept_is_wired(void *arg, uint64_t va, uint_t *protp)
+{
+	ept_map_t *emap = arg;
+	gipt_t *pt;
+	int rv = -1;
+
+	mutex_enter(EPT_LOCK(emap));
+	pt = gipt_map_lookup_deepest(&emap->em_gipt, va);
+	if (pt != NULL) {
+		const uint64_t pte = GIPT_VA2PTE(pt, va);
+
+		if (EPT_MAPS_PAGE(pte, pt->gipt_level)) {
+			*protp = EPT_PTE_PROT(pte);
+			rv = 0;
+		}
+	}
+	mutex_exit(EPT_LOCK(emap));
+
+	return (rv);
+}
+
+static int
+ept_map(void *arg, uint64_t va, pfn_t pfn, uint_t lvl, uint_t prot,
+    uint8_t attr)
+{
+	ept_map_t *emap = arg;
+	gipt_map_t *map = &emap->em_gipt;
+	gipt_t *pt;
+	uint64_t *ptep, pte;
+
+	ASSERT((prot & EPT_RWX) != 0 && (prot & ~EPT_RWX) == 0);
+	ASSERT3U(lvl, <, EPT_MAX_LEVELS);
+
+	mutex_enter(EPT_LOCK(emap));
+	pt = gipt_map_lookup(map, va, lvl);
+	if (pt == NULL) {
+		/*
+		 * A table at the appropriate VA/level that would house this
+		 * mapping does not currently exist.  Try to walk down to that
+		 * point, creating any necessary parent(s).
+		 */
+		pt = gipt_map_create_parents(map, va, lvl);
+
+		/*
+		 * There was a large page mapping in the way of creating the
+		 * necessary parent table(s).
+		 */
+		if (pt == NULL) {
+			panic("unexpected large page @ %08lx", va);
+		}
+	}
+	ptep = GIPT_VA2PTEP(pt, va);
+
+	pte = *ptep;
+	if (!EPT_IS_ABSENT(pte)) {
+		if (!EPT_MAPS_PAGE(pte, lvl)) {
+			panic("unexpected PT link @ %08lx in %p", va, pt);
+		} else {
+			panic("unexpected page mapped @ %08lx in %p", va, pt);
+		}
+	}
+
+	pte = EPT_PTE_ASSIGN_PAGE(lvl, pfn, prot, attr);
+	*ptep = pte;
+	pt->gipt_valid_cnt++;
+	emap->em_wired_page_count += gipt_level_count[lvl];
+
+	mutex_exit(EPT_LOCK(emap));
+	return (0);
+}
+
+static uint64_t
+ept_unmap(void *arg, uint64_t va, uint64_t end_va)
+{
+	ept_map_t *emap = arg;
+	gipt_map_t *map = &emap->em_gipt;
+	gipt_t *pt;
+	uint64_t cur_va = va;
+	uint64_t unmapped = 0;
+
+	mutex_enter(EPT_LOCK(emap));
+
+	pt = gipt_map_lookup_deepest(map, cur_va);
+	if (pt == NULL) {
+		mutex_exit(EPT_LOCK(emap));
+		return (0);
+	}
+	if (!EPT_MAPS_PAGE(GIPT_VA2PTE(pt, cur_va), pt->gipt_level)) {
+		cur_va = gipt_map_next_page(map, cur_va, end_va, &pt);
+		if (cur_va == 0) {
+			mutex_exit(EPT_LOCK(emap));
+			return (0);
+		}
+	}
+
+	while (cur_va < end_va) {
+		uint64_t *ptep = GIPT_VA2PTEP(pt, cur_va);
+		const uint_t lvl = pt->gipt_level;
+
+		ASSERT(EPT_MAPS_PAGE(*ptep, lvl));
+		*ptep = 0;
+		pt->gipt_valid_cnt--;
+		unmapped += gipt_level_count[pt->gipt_level];
+
+		gipt_t *next_pt = pt;
+		uint64_t next_va;
+		next_va = gipt_map_next_page(map, cur_va, end_va, &next_pt);
+
+		if (pt->gipt_valid_cnt == 0) {
+			gipt_map_clean_parents(map, pt);
+		}
+		if (next_va == 0) {
+			break;
+		}
+		pt = next_pt;
+		cur_va = next_va;
+	}
+	emap->em_wired_page_count -= unmapped;
+
+	mutex_exit(EPT_LOCK(emap));
+
+	return (unmapped);
+}
+
+struct vmm_pt_ops ept_ops = {
+	.vpo_init	= ept_create,
+	.vpo_free	= ept_destroy,
+	.vpo_wired_cnt	= ept_wired_count,
+	.vpo_is_wired	= ept_is_wired,
+	.vpo_map	= ept_map,
+	.vpo_unmap	= ept_unmap,
+};

--- a/usr/src/uts/i86pc/os/gipt.c
+++ b/usr/src/uts/i86pc/os/gipt.c
@@ -1,0 +1,566 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/gipt.h>
+#include <sys/malloc.h>
+#include <sys/kmem.h>
+#include <sys/sysmacros.h>
+#include <sys/sunddi.h>
+#include <sys/panic.h>
+#include <vm/hat.h>
+#include <vm/as.h>
+
+/*
+ * Generic Indexed Page Table
+ *
+ * There are several applications, such as hardware virtualization or IOMMU
+ * control, which require construction of a page table tree to represent a
+ * virtual address space.  Many features of the existing htable system would be
+ * convenient for this, but its tight coupling to the VM system make it
+ * undesirable for independent consumers.  The GIPT interface exists to provide
+ * page table allocation and indexing on top of which a table hierarchy
+ * (EPT, VT-d, etc) can be built by upstack logic.
+ *
+ * Types:
+ *
+ * gipt_t - Represents a single page table with a physical backing page and
+ *     associated metadata.
+ * gipt_map_t - The workhorse of this facility, it contains an hash table to
+ *     index all of the gipt_t entries which make up the page table tree.
+ * struct gipt_cbs - Callbacks used by the gipt_map_t:
+ *     gipt_pte_type_cb_t - Given a PTE, emit the type (empty/page/table)
+ *     gipt_pte_map_cb_t - Given a PFN, emit a (child) table mapping
+ */
+
+/*
+ * For now, the level shifts are hard-coded to match with standard 4-level
+ * 64-bit paging structures.
+ */
+
+#define	GIPT_HASH(map, va, lvl)			\
+	((((va) >> 12) + ((va) >> 28) + (lvl)) & ((map)->giptm_table_cnt - 1))
+
+const uint_t gipt_level_shift[GIPT_MAX_LEVELS+1] = {
+	12,	/* 4K */
+	21,	/* 2M */
+	30,	/* 1G */
+	39,	/* 512G */
+	48	/* MAX */
+};
+const uint64_t gipt_level_mask[GIPT_MAX_LEVELS+1] = {
+	0xfffffffffffff000ull,	/* 4K */
+	0xffffffffffe00000ull,	/* 2M */
+	0xffffffffc0000000ull,	/* 1G */
+	0xffffff8000000000ull,	/* 512G */
+	0xffff000000000000ull	/* MAX */
+};
+const uint64_t gipt_level_size[GIPT_MAX_LEVELS+1] = {
+	0x0000000000001000ull,	/* 4K */
+	0x0000000000200000ull,	/* 2M */
+	0x0000000040000000ull,	/* 1G */
+	0x0000008000000000ull,	/* 512G */
+	0x0001000000000000ull	/* MAX */
+};
+const uint64_t gipt_level_count[GIPT_MAX_LEVELS+1] = {
+	0x0000000000000001ull,	/* 4K */
+	0x0000000000000200ull,	/* 2M */
+	0x0000000000040000ull,	/* 1G */
+	0x0000000008000000ull,	/* 512G */
+	0x0000001000000000ull	/* MAX */
+};
+
+/*
+ * Allocate a gipt_t structure with corresponding page of memory to hold the
+ * PTEs which it contains.
+ */
+gipt_t *
+gipt_alloc(void)
+{
+	gipt_t *pt;
+	void *page;
+
+	pt = kmem_zalloc(sizeof (*pt), KM_SLEEP);
+	page = kmem_zalloc(PAGESIZE, KM_SLEEP);
+	pt->gipt_kva = page;
+	pt->gipt_pfn = hat_getpfnum(kas.a_hat, page);
+
+	return (pt);
+}
+
+/*
+ * Free a gipt_t structure along with its page of PTE storage.
+ */
+void
+gipt_free(gipt_t *pt)
+{
+	void *page = pt->gipt_kva;
+
+	ASSERT(pt->gipt_pfn != PFN_INVALID);
+	ASSERT(pt->gipt_kva != NULL);
+
+	pt->gipt_pfn = PFN_INVALID;
+	pt->gipt_kva = NULL;
+
+	kmem_free(page, PAGESIZE);
+	kmem_free(pt, sizeof (*pt));
+}
+
+/*
+ * Initialize a gipt_map_t with a max level (must be >= 1) and allocating its
+ * hash table based on a provided size (must be a power of 2).
+ */
+void
+gipt_map_init(gipt_map_t *map, uint_t levels, uint_t hash_table_size,
+    const struct gipt_cbs *cbs, gipt_t *root)
+{
+	VERIFY(map->giptm_root == NULL);
+	VERIFY(map->giptm_hash == NULL);
+	VERIFY3U(levels, >, 0);
+	VERIFY3U(levels, <=, GIPT_MAX_LEVELS);
+	VERIFY(ISP2(hash_table_size));
+	VERIFY(root != NULL);
+
+	mutex_init(&map->giptm_lock, NULL, MUTEX_DEFAULT, NULL);
+	map->giptm_table_cnt = hash_table_size;
+	bcopy(cbs, &map->giptm_cbs, sizeof (*cbs));
+	map->giptm_hash = kmem_alloc(sizeof (list_t) * map->giptm_table_cnt,
+	    KM_SLEEP);
+	for (uint_t i = 0; i < hash_table_size; i++) {
+		list_create(&map->giptm_hash[i], sizeof (gipt_t),
+		    offsetof(gipt_t, gipt_node));
+	}
+	map->giptm_levels = levels;
+
+	/*
+	 * Insert the table root into the hash.  It will be held in existence
+	 * with an extra "valid" reference.  This will prevent its clean-up
+	 * during gipt_map_clean_parents() calls, even if it has no children.
+	 */
+	mutex_enter(&map->giptm_lock);
+	gipt_map_insert(map, root);
+	map->giptm_root = root;
+	root->gipt_valid_cnt++;
+	mutex_exit(&map->giptm_lock);
+}
+
+/*
+ * Clean up a gipt_map_t by removing any lingering gipt_t entries referenced by
+ * it, and freeing its hash table.
+ */
+void
+gipt_map_fini(gipt_map_t *map)
+{
+	const uint_t cnt = map->giptm_table_cnt;
+	const size_t sz = sizeof (list_t) * cnt;
+
+	mutex_enter(&map->giptm_lock);
+	/* Clean up any lingering tables */
+	for (uint_t i = 0; i < cnt; i++) {
+		list_t *list = &map->giptm_hash[i];
+		gipt_t *pt;
+
+		while ((pt = list_remove_head(list)) != NULL) {
+			gipt_free(pt);
+		}
+		ASSERT(list_is_empty(list));
+	}
+
+	kmem_free(map->giptm_hash, sz);
+	map->giptm_hash = NULL;
+	map->giptm_root = NULL;
+	map->giptm_levels = 0;
+	mutex_exit(&map->giptm_lock);
+	mutex_destroy(&map->giptm_lock);
+}
+
+/*
+ * Look in the map for a gipt_t containing a given VA which is located at a
+ * specified level.
+ */
+gipt_t *
+gipt_map_lookup(gipt_map_t *map, uint64_t va, uint_t lvl)
+{
+	gipt_t *pt;
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+	ASSERT3U(lvl, <=, GIPT_MAX_LEVELS);
+
+	/*
+	 * Lookup gipt_t at the VA aligned to the next level up.  For example,
+	 * level 0 corresponds to a page table containing 512 PTEs which cover
+	 * 4k each, spanning a total 2MB. As such, the base VA of that table
+	 * must be aligned to the same 2MB.
+	 */
+	const uint64_t masked_va = va & gipt_level_mask[lvl + 1];
+	const uint_t hash = GIPT_HASH(map, masked_va, lvl);
+
+	/* Only the root is expected to be at the top level. */
+	if (lvl == (map->giptm_levels - 1) && map->giptm_root != NULL) {
+		pt = map->giptm_root;
+
+		ASSERT3U(pt->gipt_level, ==, lvl);
+
+		/*
+		 * It may be so that the VA in question is not covered by the
+		 * range of the table root.
+		 */
+		if (pt->gipt_vaddr != masked_va) {
+			return (NULL);
+		}
+
+		return (pt);
+	}
+
+	list_t *list = &map->giptm_hash[hash];
+	for (pt = list_head(list); pt != NULL; pt = list_next(list, pt)) {
+		if (pt->gipt_vaddr == masked_va && pt->gipt_level == lvl)
+			break;
+	}
+	return (pt);
+}
+
+/*
+ * Look in the map for the deepest (lowest level) gipt_t which contains a given
+ * VA.  This could still fail if the VA is outside the range of the table root.
+ */
+gipt_t *
+gipt_map_lookup_deepest(gipt_map_t *map, uint64_t va)
+{
+	gipt_t *pt = NULL;
+	uint_t lvl;
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+
+	for (lvl = 0; lvl < map->giptm_levels; lvl++) {
+		pt = gipt_map_lookup(map, va, lvl);
+		if (pt != NULL) {
+			break;
+		}
+	}
+	return (pt);
+}
+
+/*
+ * Given a VA inside a gipt_t, calculate (based on the level of that PT) the VA
+ * corresponding to the next entry in the table.  It returns 0 if that VA would
+ * fall beyond the bounds of the table.
+ */
+static __inline__ uint64_t
+gipt_next_va(gipt_t *pt, uint64_t va)
+{
+	const uint_t lvl = pt->gipt_level;
+	const uint64_t masked = va & gipt_level_mask[lvl];
+	const uint64_t max = pt->gipt_vaddr + gipt_level_size[lvl+1];
+	const uint64_t next = masked + gipt_level_size[lvl];
+
+	ASSERT3U(masked, >=, pt->gipt_vaddr);
+	ASSERT3U(masked, <, max);
+
+	/*
+	 * If the "next" VA would be outside this table, including cases where
+	 * it overflowed, indicate an error result.
+	 */
+	if (next >= max || next <= masked) {
+		return (0);
+	}
+	return (next);
+}
+
+/*
+ * For a given VA, find the next VA which corresponds to a valid page mapping.
+ * The gipt_t containing that VA will be indicated via 'ptp'.  (The gipt_t of
+ * the starting VA can be passed in via 'ptp' for a minor optimization).  If
+ * there is no valid mapping higher than 'va' but contained within 'max_va',
+ * then this will indicate failure with 0 returned.
+ */
+uint64_t
+gipt_map_next_page(gipt_map_t *map, uint64_t va, uint64_t max_va, gipt_t **ptp)
+{
+	gipt_t *pt = *ptp;
+	uint64_t cur_va = va;
+	gipt_pte_type_cb_t pte_type = map->giptm_cbs.giptc_pte_type;
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+	ASSERT3U(max_va, !=, 0);
+	ASSERT3U(ptp, !=, NULL);
+
+	/*
+	 * If a starting table is not provided, search the map for the deepest
+	 * table which contains the VA.  If for some reason that VA is beyond
+	 * coverage of the map root, indicate failure.
+	 */
+	if (pt == NULL) {
+		pt = gipt_map_lookup_deepest(map, cur_va);
+		if (pt == NULL) {
+			goto fail;
+		}
+	}
+
+	/*
+	 * From the starting table (at whatever level that may reside), walk
+	 * forward through the PTEs looking for a valid page mapping.
+	 */
+	while (cur_va < max_va) {
+		const uint64_t next_va = gipt_next_va(pt, cur_va);
+		if (next_va == 0) {
+			/*
+			 * The end of this table has been reached.  Ascend one
+			 * level to continue the walk if possible.  If already
+			 * at the root, the end of the table means failure.
+			 */
+			if (pt->gipt_level >= map->giptm_levels) {
+				goto fail;
+			}
+			pt = gipt_map_lookup(map, cur_va, pt->gipt_level + 1);
+			if (pt == NULL) {
+				goto fail;
+			}
+			continue;
+		} else if (next_va >= max_va) {
+			/*
+			 * Terminate the walk with a failure if the VA
+			 * corresponding to the next PTE is beyond the max.
+			 */
+			goto fail;
+		}
+		cur_va = next_va;
+
+		const uint64_t pte = GIPT_VA2PTE(pt, cur_va);
+		const gipt_pte_type_t ptet = pte_type(pte, pt->gipt_level);
+		if (ptet == PTET_EMPTY) {
+			continue;
+		} else if (ptet == PTET_PAGE) {
+			/* A valid page mapping: success. */
+			*ptp = pt;
+			return (cur_va);
+		} else if (ptet == PTET_LINK) {
+			/*
+			 * A child page table is present at this PTE.  Look it
+			 * up from the map.
+			 */
+			ASSERT3U(pt->gipt_level, >, 0);
+			pt = gipt_map_lookup(map, cur_va, pt->gipt_level - 1);
+			ASSERT3P(pt, !=, NULL);
+			break;
+		} else {
+			panic("unexpected PTE type %x @ va %p", ptet, cur_va);
+		}
+	}
+
+	/*
+	 * By this point, the above loop has located a table structure to
+	 * descend into in order to find the next page.
+	 */
+	while (cur_va < max_va) {
+		const uint64_t pte = GIPT_VA2PTE(pt, cur_va);
+		const gipt_pte_type_t ptet = pte_type(pte, pt->gipt_level);
+
+		if (ptet == PTET_EMPTY) {
+			const uint64_t next_va = gipt_next_va(pt, cur_va);
+			if (next_va == 0 || next_va >= max_va) {
+				goto fail;
+			}
+			cur_va = next_va;
+			continue;
+		} else if (ptet == PTET_PAGE) {
+			/* A valid page mapping: success. */
+			*ptp = pt;
+			return (cur_va);
+		} else if (ptet == PTET_LINK) {
+			/*
+			 * A child page table is present at this PTE.  Look it
+			 * up from the map.
+			 */
+			ASSERT3U(pt->gipt_level, >, 0);
+			pt = gipt_map_lookup(map, cur_va, pt->gipt_level - 1);
+			ASSERT3P(pt, !=, NULL);
+		} else {
+			panic("unexpected PTE type %x @ va %p", ptet, cur_va);
+		}
+	}
+
+fail:
+	*ptp = NULL;
+	return (0);
+}
+
+/*
+ * Insert a gipt_t into the map based on its VA and level.  It is up to the
+ * caller to ensure that a duplicate entry does not already exist in the map.
+ */
+void
+gipt_map_insert(gipt_map_t *map, gipt_t *pt)
+{
+	const uint_t hash = GIPT_HASH(map, pt->gipt_vaddr, pt->gipt_level);
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+	ASSERT(gipt_map_lookup(map, pt->gipt_vaddr, pt->gipt_level) == NULL);
+	VERIFY3U(pt->gipt_level, <, map->giptm_levels);
+
+	list_insert_head(&map->giptm_hash[hash], pt);
+}
+
+/*
+ * Remove a gipt_t from the map.
+ */
+void
+gipt_map_remove(gipt_map_t *map, gipt_t *pt)
+{
+	const uint_t hash = GIPT_HASH(map, pt->gipt_vaddr, pt->gipt_level);
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+
+	list_remove(&map->giptm_hash[hash], pt);
+}
+
+/*
+ * Given a VA, create any missing gipt_t entries from the specified level all
+ * the way up to (but not including) the root.  This is done from lowest level
+ * to highest, and stops when an existing table covering that VA is found.
+ * References to any created gipt_t tables, plus the final "found" gipt_t are
+ * stored in 'pts'.  The number of gipt_t pointers stored to 'pts' serves as
+ * the return value (1 <= val <= root level).  It is up to the caller to
+ * populate linking PTEs to the newly created empty tables.
+ */
+static uint_t
+gipt_map_ensure_chain(gipt_map_t *map, uint64_t va, uint_t lvl, gipt_t **pts)
+{
+	const uint_t root_lvl = map->giptm_root->gipt_level;
+	uint_t clvl = lvl, count = 0;
+	gipt_t *child_pt = NULL;
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+	ASSERT3U(lvl, <, root_lvl);
+	ASSERT3P(map->giptm_root, !=, NULL);
+
+	do {
+		const uint64_t pva = (va & gipt_level_mask[clvl + 1]);
+		gipt_t *pt;
+
+		pt = gipt_map_lookup(map, pva, clvl);
+		if (pt != NULL) {
+			ASSERT3U(pva, ==, pt->gipt_vaddr);
+
+			if (child_pt != NULL) {
+				child_pt->gipt_parent = pt;
+			}
+			pts[count++] = pt;
+			return (count);
+		}
+
+		pt = gipt_alloc();
+		pt->gipt_vaddr = pva;
+		pt->gipt_level = clvl;
+		if (child_pt != NULL) {
+			child_pt->gipt_parent = pt;
+		}
+
+		gipt_map_insert(map, pt);
+		child_pt = pt;
+		pts[count++] = pt;
+		clvl++;
+	} while (clvl <= root_lvl);
+
+	return (count);
+}
+
+/*
+ * Ensure that a page table covering a VA at a specified level exists.  This
+ * will create any necessary tables chaining up to the root as well.
+ */
+gipt_t *
+gipt_map_create_parents(gipt_map_t *map, uint64_t va, uint_t lvl)
+{
+	gipt_t *pt, *pts[GIPT_MAX_LEVELS] = { 0 };
+	gipt_pte_type_cb_t pte_type = map->giptm_cbs.giptc_pte_type;
+	gipt_pte_map_cb_t pte_map = map->giptm_cbs.giptc_pte_map;
+	uint64_t *ptep;
+	uint_t i, count;
+
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+
+	count = gipt_map_ensure_chain(map, va, lvl, pts);
+	if (count == 1) {
+		/* Table already exists in the hierarchy */
+		return (pts[0]);
+	}
+	ASSERT3U(count, >, 1);
+
+	/* Make sure there is not already a large page mapping at the top */
+	pt = pts[count - 1];
+	if (pte_type(GIPT_VA2PTE(pt, va), pt->gipt_level) == PTET_PAGE) {
+		const uint_t end = count - 1;
+
+		/*
+		 * Nuke those gipt_t entries which were optimistically created
+		 * for what was found to be a conflicted mapping.
+		 */
+		for (i = 0; i < end; i++) {
+			gipt_map_remove(map, pts[i]);
+			gipt_free(pts[i]);
+		}
+		return (NULL);
+	}
+
+	/* Initialize the appropriate tables from bottom to top */
+	for (i = 1; i < count; i++) {
+		pt = pts[i];
+		ptep = GIPT_VA2PTEP(pt, va);
+
+		/*
+		 * Since gipt_map_ensure_chain() creates missing tables until
+		 * it find a valid one, and that existing table has been
+		 * checked for the existence of a large page, nothing should
+		 * occupy this PTE.
+		 */
+		ASSERT3U(pte_type(*ptep, pt->gipt_level), ==, PTET_EMPTY);
+
+		*ptep = pte_map(pts[i - 1]->gipt_pfn);
+		pt->gipt_valid_cnt++;
+	}
+
+	return (pts[0]);
+}
+
+/*
+ * If a page table is empty, free it from the map, as well as any parent tables
+ * that would subsequently become empty as part of the clean-up.  As noted in
+ * gipt_map_init(), the table root is a special case and will remain in the
+ * map, even when empty.
+ */
+void
+gipt_map_clean_parents(gipt_map_t *map, gipt_t *pt)
+{
+	ASSERT(MUTEX_HELD(&map->giptm_lock));
+
+	while (pt->gipt_valid_cnt == 0) {
+		gipt_t *parent = pt->gipt_parent;
+		uint64_t *ptep = GIPT_VA2PTEP(parent, pt->gipt_vaddr);
+
+		ASSERT3S(map->giptm_cbs.giptc_pte_type(*ptep,
+		    parent->gipt_level), ==, PTET_LINK);
+
+		/*
+		 * For now, it is assumed that all gipt consumers consider PTE
+		 * zeroing as an adequate action for table unmap.
+		 */
+		*ptep = 0;
+
+		parent->gipt_valid_cnt--;
+		gipt_map_remove(map, pt);
+		gipt_free(pt);
+		pt = parent;
+	}
+}

--- a/usr/src/uts/i86pc/sys/gipt.h
+++ b/usr/src/uts/i86pc/sys/gipt.h
@@ -1,0 +1,92 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#ifndef _GIPT_H_
+#define	_GIPT_H_
+
+#include <sys/types.h>
+#include <sys/mutex.h>
+#include <sys/param.h>
+#include <sys/list.h>
+
+struct gipt {
+	list_node_t	gipt_node;
+	uint64_t	gipt_vaddr;
+	uint64_t	gipt_pfn;
+	uint16_t	gipt_level;
+	uint16_t	gipt_valid_cnt;
+	uint32_t	_gipt_pad;
+	struct gipt	*gipt_parent;
+	uint64_t	*gipt_kva;
+	uint64_t	_gipt_pad2;
+};
+typedef struct gipt gipt_t;
+
+typedef enum {
+	PTET_EMPTY	= 0,
+	PTET_PAGE	= 1,
+	PTET_LINK	= 2,
+} gipt_pte_type_t;
+
+/* Given a PTE and its level, determine the type of that PTE */
+typedef gipt_pte_type_t (*gipt_pte_type_cb_t)(uint64_t, uint_t);
+/* Given the PFN of a child table, emit a PTE that references it */
+typedef uint64_t (*gipt_pte_map_cb_t)(uint64_t);
+
+struct gipt_cbs {
+	gipt_pte_type_cb_t	giptc_pte_type;
+	gipt_pte_map_cb_t	giptc_pte_map;
+};
+
+struct gipt_map {
+	kmutex_t	giptm_lock;
+	gipt_t		*giptm_root;
+	list_t		*giptm_hash;
+	struct gipt_cbs	giptm_cbs;
+	size_t		giptm_table_cnt;
+	uint_t		giptm_levels;
+};
+typedef struct gipt_map gipt_map_t;
+
+#define	GIPT_HASH_SIZE_DEFAULT	0x2000
+#define	GIPT_MAX_LEVELS	4
+
+#define	GIPT_VA2IDX(pt, va)			\
+	(((va) - (pt)->gipt_vaddr) >>		\
+	gipt_level_shift[(pt)->gipt_level])
+
+#define	GIPT_VA2PTE(pt, va)	((pt)->gipt_kva[GIPT_VA2IDX(pt, va)])
+#define	GIPT_VA2PTEP(pt, va)	(&(pt)->gipt_kva[GIPT_VA2IDX(pt, va)])
+
+extern const uint_t gipt_level_shift[GIPT_MAX_LEVELS+1];
+extern const uint64_t gipt_level_mask[GIPT_MAX_LEVELS+1];
+extern const uint64_t gipt_level_size[GIPT_MAX_LEVELS+1];
+extern const uint64_t gipt_level_count[GIPT_MAX_LEVELS+1];
+
+extern gipt_t *gipt_alloc(void);
+extern void gipt_free(gipt_t *);
+extern void gipt_map_init(gipt_map_t *, uint_t, uint_t,
+    const struct gipt_cbs *, gipt_t *);
+extern void gipt_map_fini(gipt_map_t *);
+extern gipt_t *gipt_map_lookup(gipt_map_t *, uint64_t, uint_t);
+extern gipt_t *gipt_map_lookup_deepest(gipt_map_t *, uint64_t);
+extern uint64_t gipt_map_next_page(gipt_map_t *, uint64_t, uint64_t,
+    gipt_t **);
+extern void gipt_map_insert(gipt_map_t *, gipt_t *);
+extern void gipt_map_remove(gipt_map_t *, gipt_t *);
+extern gipt_t *gipt_map_create_parents(gipt_map_t *, uint64_t, uint_t);
+extern void gipt_map_clean_parents(gipt_map_t *, gipt_t *);
+
+#endif /* _GIPT_H_ */


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019021401

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019021401-f18934bf4d i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Feb 14 21:48:42 UTC 2019 ====
==== Nightly distributed build completed: Thu Feb 14 22:38:45 UTC 2019 ====

==== Total build time ====

real    0:50:02

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-a7bf5f222a i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.8.0_192-omnios-151029-20181209"

/usr/bin/openssl
OpenSSL 1.1.1a  20 Nov 2018
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1757 (illumos)

Build project:  default
Build taskid:   76

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019021401-f18934bf4d

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:44.3
user  2:33:10.8
sys     19:29.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:34.4
user  2:14:29.9
sys     19:38.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
