### PR TITLE
Fix duplicate VNIC handling

### DIFF
--- a/usr/src/cmd/dlmgmtd/Makefile
+++ b/usr/src/cmd/dlmgmtd/Makefile
@@ -22,6 +22,8 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+#
 
 PROG=		dlmgmtd
 OBJS=		dlmgmt_main.o dlmgmt_door.o dlmgmt_util.o dlmgmt_db.o
@@ -31,6 +33,9 @@ MANIFEST=	dlmgmt.xml
 CFGFILES=	datalink.conf
 
 include ../Makefile.cmd
+
+CSTD = $(CSTD_GNU99)
+C99LMODE = -Xc99=%all
 
 ROOTMANIFESTDIR=	$(ROOTSVCNETWORK)
 ROOTCFGDIR=		$(ROOTETC)/dladm

--- a/usr/src/cmd/dlmgmtd/dlmgmt_door.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_door.c
@@ -21,7 +21,6 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -1259,7 +1258,8 @@ dlmgmt_setzoneid(void *argp, void *retp, size_t *sz, zoneid_t zoneid,
 	 * Before we remove the link from its current zone, make sure that
 	 * there isn't a link with the same name in the destination zone.
 	 */
-	if (link_by_name(linkp->ll_link, newzoneid) != NULL) {
+	if (zoneid != GLOBAL_ZONEID &&
+	    link_by_name(linkp->ll_link, newzoneid) != NULL) {
 		err = EEXIST;
 		goto done;
 	}


### PR DESCRIPTION
The fix imported from illumos-joyent to fix breakage caused by duplicate VNICs was wrong. This reverts it and applies the correct fix which is also being upstreamed in parallel.
Refer to https://www.illumos.org/issues/10001 for more details and testing notes, but I've verified that this works as expected on bloody.