### PR TITLE
10187 ses enumerator blows chunks on US60+8 (r151028)

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -13,13 +13,13 @@ are included at the end of this file.
 
 =======================================================================
 
-## 9941 Noise from cfgadm plugins
+## 10187 ses enumerator blows chunks on US60+8
 
 Packages:
- > system/library
+ > service/fault-management
 
 Archive:
- > https://downloads.omniosce.org/pkg/r151028/9941_backport_r28.p5p
+ > https://hf.omnios.org/r151028/10187_fmd.p5p
 
 =======================================================================
 

--- a/usr/src/lib/fm/topo/modules/common/disk/disk_common.c
+++ b/usr/src/lib/fm/topo/modules/common/disk/disk_common.c
@@ -550,7 +550,7 @@ disk_tnode_create(topo_mod_t *mod, tnode_t *parent,
 		return (-1);
 	}
 
-	if (dnode->ddn_devid != NULL &&
+	if (dnode != NULL && dnode->ddn_devid != NULL &&
 	    disk_add_temp_sensor(mod, dtn, dnode->ddn_devid) != 0) {
 		topo_mod_dprintf(mod, "disk_tnode_create: failed to create "
 		    "temperature sensor node on bay=%d/disk=0",

--- a/usr/src/lib/fm/topo/modules/common/ses/ses.c
+++ b/usr/src/lib/fm/topo/modules/common/ses/ses.c
@@ -1207,6 +1207,9 @@ ses_create_disk(ses_enum_data_t *sdp, tnode_t *pnode, nvlist_t *props)
 
 	/*
 	 * Skip devices that are not in a present (and possibly damaged) state.
+	 * Also, skip devices that this expander is either not fully wired to,
+	 * or are hidden due to SAS zoning, as indicated by the
+	 * SES_ESC_NO_ACCESS state.
 	 */
 	if (nvlist_lookup_uint64(props, SES_PROP_STATUS_CODE, &status) != 0)
 		return (0);
@@ -1216,7 +1219,6 @@ ses_create_disk(ses_enum_data_t *sdp, tnode_t *pnode, nvlist_t *props)
 	    status != SES_ESC_CRITICAL &&
 	    status != SES_ESC_NONCRITICAL &&
 	    status != SES_ESC_UNRECOVERABLE &&
-	    status != SES_ESC_NO_ACCESS &&
 	    status != SES_ESC_UNKNOWN)
 		return (0);
 


### PR DESCRIPTION
Backport from bloody to fix a problem with device enumeration being experienced by an OmniOS user, see https://illumos.topicbox.com/groups/omnios-discuss/T0b1dfc4dfcdd6957-M9aee25acf7b46245e33de563/solaris-fault-manager-fmd-maintenance-issue

User's stack trace, node that the third argument to disk_tnode_create - dnode - is NULL.

```
0803bdf8 ses.so`disk_tnode_create+0x31d(8767630, 9240de0, 0, fdd908e6, 0, 803be2c)
0803be48 ses.so`disk_declare+0x3b(8767630, 9240de0, 0, 803be98)
0803be68 ses.so`disk_declare_non_enumerated+0x16(8767630, 9240de0, 803be98, 803be98)
0803bec8 ses.so`ses_create_disk+0x171(86ccba0, 9240de0, 863b608, 1)
0803bfb8 ses.so`ses_create_generic+0x3cd(86ccba0, 9241f68, 9240f00, 0, fdd90457, fdd9045b)
0803c018 ses.so`ses_create_children+0x170(86ccba0, 9240f00, 17, 0, fdd90457, fdd9045b)
0803c0e8 ses.so`ses_create_chassis+0x7bc(86ccba0, 8638780, 9221140, fec881b0)
0803c118 ses.so`ses_enum+0x114(8767630, 8638780, 863a3a0, 0, 400, 0)
0803c168 libtopo.so.1`topo_mod_enumerate+0xc4(8767630, 8638780, 8539f48, 863a3a0, 0, 400)
0803c1b8 libtopo.so.1`enum_run+0xe9(8554b68, 8631408, a, fec8b545)
0803c208 libtopo.so.1`topo_xml_range_process+0x13e(8554b68, 86aae70, 8631408, 803c238)
0803c258 libtopo.so.1`tf_rdata_new+0x135(8554b68, 863a490, 86aae70, 8638780)
0803c2b8 libtopo.so.1`topo_xml_walk+0x246(8554b68, 863a490, 8641328, 8638780, 8553f40, fec9d000)
0803c2e8 libtopo.so.1`topo_xml_enum+0x67(8554b68, 863a490, 8638780, 8617ac8)
0803c418 libtopo.so.1`topo_file_load+0x139(8554b68, 8638780, 8540f30, 8617a98, 0, 2c)
0803c458 libtopo.so.1`topo_tree_enum+0x89(8553f40, 863fa70, 803c488, fe6de718, 8541350, 8553f40)
0803c478 libtopo.so.1`topo_tree_enum_all+0x20(8553f40, 8541350, 803c4b8, fec81434)
0803c4b8 libtopo.so.1`topo_snap_create+0x13d(8553f40, 803c50c, 0, fec8153a, 807c298, ab6df)
0803c4e8 libtopo.so.1`topo_snap_hold+0x56(8553f40, 0, 803c50c, 8536f08, 0, 803c688)
0803c528 fmd_topo_update+0x9f(8536f08, 808609a, 803c628, 806047f, 0, 0)
0803c538 fmd_topo_init+0xb(0, 0, 0, 0, 8536f08, 8099318)
0803c628 fmd_run+0x118(809a900, ffffffff, 0, 4)
0803c6a8 main+0x344(803c6ac, feef2388, 803c6e8, 80600e8, 7, 803c718)
0803c6e8 _start_crt+0x97(7, 803c718, fefd0d40, 0, 0, 0)
0803c70c _start+0x1a(7, 803c840, 803c854, 803c857, 803c85f, 803c862)
```