### PR TITLE
Add missing post process step for zadump

### DIFF
--- a/usr/src/lib/brand/shared/zadump/Makefile
+++ b/usr/src/lib/brand/shared/zadump/Makefile
@@ -34,6 +34,11 @@ all: $(PROG)
 
 $(PROG): $(OBJS)
 	$(LINK.c) -o $@ $(OBJS) $(LDFLAGS) $(LDLIBS)
+	$(POST_PROCESS)
+
+%.o: %.c
+	$(COMPILE.c) $<
+	$(POST_PROCESS_O)
 
 $(ROOTSHARED) :=        FILEMODE = 755
 install: all $(ROOTSHARED)


### PR DESCRIPTION
With thanks for @ptribble for reporting:

```
Under "Check ELF runtime attributes"
usr/lib/brand/shared/zadump: non-conforming mcs(1) comment <no $(POST_PROCESS)?>
```

Before:
```
% mcs -p zadump
zadump:

@(#)SunOS 5.11 omnios-r151028-d3d0427bff November 2018


@(#)SunOS 5.11 omnios-r151028-d3d0427bff November 2018


@(#)SunOS 5.11 omnios-r151028-d3d0427bff November 2018

ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1756 (illumos)
```

After:
```
% mcs -p zadump
zadump:

@(#)SunOS 5.11 omnios-master-8f333db69e February 2019
```
