### PR TITLE
Import hyperv support from DelphixOS

### DIFF
--- a/exception_lists/copyright
+++ b/exception_lists/copyright
@@ -58,6 +58,8 @@ usr/src/cmd/acpi/common/utnonansi.c
 usr/src/cmd/acpi/common/utprint.c
 usr/src/cmd/acpi/common/utxferror.c
 usr/src/cmd/dtrace/test/tst/common/*/*.out
+usr/src/cmd/hyperv/kvp/THIRDPARTYLICENSE
+usr/src/cmd/hyperv/kvp/THIRDPARTYLICENSE.descrip
 usr/src/cmd/krb5/kadmin/cli/kadmin_ct.c
 usr/src/cmd/krb5/kadmin/cli/kadmin.h
 usr/src/cmd/krb5/kadmin/cli/ss_wrapper.c
@@ -393,6 +395,14 @@ usr/src/tools/btxld/elfh.c
 usr/src/tools/btxld/elfh.h
 usr/src/tools/btxld/imgact_aout.h
 usr/src/tools/smatch/src/*
+usr/src/uts/intel/io/hyperv/netvsc/THIRDPARTYLICENSE
+usr/src/uts/intel/io/hyperv/netvsc/THIRDPARTYLICENSE.descrip
+usr/src/uts/intel/io/hyperv/storvsc/THIRDPARTYLICENSE
+usr/src/uts/intel/io/hyperv/storvsc/THIRDPARTYLICENSE.descrip
+usr/src/uts/intel/io/hyperv/utilities/THIRDPARTYLICENSE
+usr/src/uts/intel/io/hyperv/utilities/THIRDPARTYLICENSE.descrip
+usr/src/uts/intel/io/hyperv/vmbus/THIRDPARTYLICENSE
+usr/src/uts/intel/io/hyperv/vmbus/THIRDPARTYLICENSE.descrip
 usr/src/uts/intel/nsmb/ioc_check.ref
 usr/src/uts/intel/os/splashimage.xpm
 usr/src/uts/common/gssapi/mechs/krb5/crypto/block_size.c

--- a/usr/src/Targetdirs
+++ b/usr/src/Targetdirs
@@ -21,7 +21,7 @@
 #
 # Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2011, Richard Lowe
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2017 by Delphix. All rights reserved.
 # Copyright (c) 2012, Igor Kozhukhov <ikozhukhov@gmail.com>
 # Copyright 2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Copyright (c) 2013 RackTop Systems.
@@ -57,6 +57,7 @@ i386_DIRS=			\
 	/boot/grub/bin		\
 	/platform/i86pc		\
 	/lib/libmvec		\
+        /usr/lib/hyperv		\
 	/usr/lib/brand/lx \
 	/usr/lib/brand/lx/amd64 \
 	/usr/lib/xen		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -489,6 +489,7 @@ i386_SUBDIRS=		\
 	cxgbetool	\
 	diskscan	\
 	nvmeadm		\
+	hyperv		\
 	rtc		\
 	ucodeadm	\
 	xhci		\

--- a/usr/src/cmd/Makefile.check
+++ b/usr/src/cmd/Makefile.check
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
+# Copyright (c) 2011, 2017 by Delphix. All rights reserved.
 # Copyright 2017 Nexenta Systems, Inc.
 #
 
@@ -111,6 +112,7 @@ MANIFEST_SUBDIRS=			\
 	hal/hald/solaris		\
 	halt/smf.$(MACH)		\
 	hostid/smf			\
+	hyperv/kvp			\
 	idmap/idmapd			\
 	ipf/svc				\
 	isns/isnsd			\

--- a/usr/src/cmd/Makefile.cmd
+++ b/usr/src/cmd/Makefile.cmd
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 # Definitions common to command source.
 #
@@ -51,6 +52,7 @@ ROOTBIN=		$(ROOT)/usr/bin
 ROOTLIB=		$(ROOT)/usr/lib
 ROOTLIBSVCBIN=		$(ROOT)/lib/svc/bin
 ROOTLIBSVCMETHOD=	$(ROOT)/lib/svc/method
+ROOTLIBHYPERV=		$(ROOT)/usr/lib/hyperv
 ROOTLIBXEN=		$(ROOT)/usr/lib/xen/bin
 ROOTLIBZONES=		$(ROOT)/lib/zones
 
@@ -342,6 +344,9 @@ $(ROOTETCZONES)/%: %
 	$(INS.file)
 
 $(ROOTLIBZONES)/%: %
+	$(INS.file)
+
+$(ROOTLIBHYPERV)/%: %
 	$(INS.file)
 
 $(ROOTLIBXEN)/%: %

--- a/usr/src/cmd/devfsadm/misc_link.c
+++ b/usr/src/cmd/devfsadm/misc_link.c
@@ -22,6 +22,7 @@
  * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2015, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <regex.h>
@@ -210,6 +211,9 @@ static devfsadm_create_t misc_cbt[] = {
 	    TYPE_EXACT | DRV_EXACT, ILEVEL_1, minor_name,
 	},
 	{ "pseudo", "ddi_pseudo", "tpm",
+	    TYPE_EXACT | DRV_EXACT, ILEVEL_0, minor_name
+	},
+	{ "pseudo", "ddi_pseudo", "hv_kvp",
 	    TYPE_EXACT | DRV_EXACT, ILEVEL_0, minor_name
 	},
 };

--- a/usr/src/cmd/hyperv/Makefile
+++ b/usr/src/cmd/hyperv/Makefile
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+include ../Makefile.cmd
+
+SUBDIRS=	scripts kvp
+
+all	:=	TARGET = all
+install	:=	TARGET = install
+clean	:=	TARGET = clean
+clobber	:=	TARGET = clobber
+lint	:=	TARGET = lint
+
+.KEEP_STATE:
+
+all lint clean clobber install:	$(SUBDIRS)
+
+$(SUBDIRS):	FRC
+	@cd $@; pwd; $(MAKE) $(TARGET)
+
+FRC:

--- a/usr/src/cmd/hyperv/kvp/Makefile
+++ b/usr/src/cmd/hyperv/kvp/Makefile
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+MANIFEST=	kvp.xml
+PROG=		hv_kvp_daemon
+
+SRCS= $(PROG).c
+OBJS= $(PROG).o
+
+include ../../Makefile.cmd
+include ../../Makefile.ctf
+
+ROOTMANIFESTDIR=	$(ROOTSVCSYSTEM)/hyperv
+ROOTCMDDIR=		$(ROOTLIBHYPERV)
+ROOTCMD=		$(ROOTCMDDIR)/$(PROG)
+
+LDLIBS += -lumem -lsocket -lnsl -ldlpi -lgen
+
+HYPERV_LIB= ../../../uts/intel/io/hyperv
+
+INCS += -I$(HYPERV_LIB) -I$(HYPERV_LIB)/utilities
+
+C99MODE=    -xc99=%all
+C99LMODE=   -Xc99=%all
+
+CPPFLAGS += $(CCVERBOSE) $(INCS)
+$(NOT_RELEASE_BUILD)CPPFLAGS += -DDEBUG
+
+CERRWARN += -_gcc=-Wno-uninitialized
+
+# lint complains about unused _umem_* functions
+LINTFLAGS += -xerroff=E_NAME_DEF_NOT_USED2
+LINTFLAGS64 += -xerroff=E_NAME_DEF_NOT_USED2
+
+.KEEP_STATE:
+
+all: $(PROG)
+
+install: all .WAIT $(ROOTCMD) $(ROOTMANIFEST)
+
+$(PROG): $(OBJS)
+	$(LINK.c) -o $(PROG) $(OBJS) $(LDLIBS)
+	$(POST_PROCESS)
+
+clean:
+	$(RM) $(OBJS)
+
+check:	$(CHKMANIFEST)
+
+lint:   lint_SRCS
+
+include ../../Makefile.targ

--- a/usr/src/cmd/hyperv/kvp/Makefile
+++ b/usr/src/cmd/hyperv/kvp/Makefile
@@ -32,6 +32,7 @@ HYPERV_LIB= ../../../uts/intel/io/hyperv
 
 INCS += -I$(HYPERV_LIB) -I$(HYPERV_LIB)/utilities
 
+CSTD=   $(CSTD_GNU99)
 C99MODE=    -xc99=%all
 C99LMODE=   -Xc99=%all
 

--- a/usr/src/cmd/hyperv/kvp/THIRDPARTYLICENSE
+++ b/usr/src/cmd/hyperv/kvp/THIRDPARTYLICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2014 Microsoft Corp.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice unmodified, this list of conditions, and the following
+   disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/usr/src/cmd/hyperv/kvp/THIRDPARTYLICENSE.descrip
+++ b/usr/src/cmd/hyperv/kvp/THIRDPARTYLICENSE.descrip
@@ -1,0 +1,1 @@
+Microsoft Key Exchange Daemon

--- a/usr/src/cmd/hyperv/kvp/hv_kvp_daemon.c
+++ b/usr/src/cmd/hyperv/kvp/hv_kvp_daemon.c
@@ -1,0 +1,1396 @@
+/*
+ * Copyright (c) 2014 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/poll.h>
+#include <sys/utsname.h>
+#include <sys/stat.h>
+#include <sys/stropts.h>
+#include <sys/un.h>
+#include <sys/ethernet.h>
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <libdlpi.h>
+
+#include <netinet/in.h>
+#include <net/if_dl.h>
+#include <net/if_types.h>
+
+#include <assert.h>
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <assert.h>
+#include <libgen.h>
+
+#include "hv_kvp.h"
+#include "hv_utilreg.h"
+typedef uint8_t		__u8;
+typedef uint16_t	__u16;
+typedef uint32_t	__u32;
+typedef uint64_t	__u64;
+
+/*
+ * ENUM Data
+ */
+
+enum key_index {
+	FullyQualifiedDomainName = 0,
+	IntegrationServicesVersion, /* This key is serviced in the kernel */
+	NetworkAddressIPv4,
+	NetworkAddressIPv6,
+	OSBuildNumber,
+	OSName,
+	OSMajorVersion,
+	OSMinorVersion,
+	OSVersion,
+	ProcessorArchitecture
+};
+
+
+enum {
+	IPADDR = 0,
+	NETMASK,
+	GATEWAY,
+	DNS
+};
+
+
+/* Global Variables */
+
+/*
+ * The structure for operation handlers.
+ */
+struct kvp_op_hdlr {
+	int	kvp_op_key;
+	void	(*kvp_op_init)(void);
+	int	(*kvp_op_exec)(struct hv_kvp_msg *kvp_op_msg, void *data);
+};
+
+static struct kvp_op_hdlr kvp_op_hdlrs[HV_KVP_OP_COUNT];
+
+/* OS information */
+static const char *os_name = "";
+static char *os_major = NULL;
+static const char *os_minor = "";
+static const char *os_version;
+static const char *processor_arch;
+static const char *os_build;
+static const char *lic_version = "Illumos Pre-Release version";
+static struct utsname uts_buf;
+
+/* Global flags */
+int is_daemon = 1;
+int is_debugging = 0;
+
+#define	KVP_LOG(priority, fmt...) do	{		\
+	if (is_debugging == 1) {			\
+		if (is_daemon == 1)			\
+			syslog(priority, fmt);		\
+		else					\
+			(void) printf(fmt);		\
+	_NOTE(CONSTCOND)				\
+	} else if (priority < LOG_DEBUG) {		\
+		if (is_daemon == 1)			\
+			syslog(priority, fmt);		\
+		else					\
+			(void) printf(fmt);		\
+	}						\
+	_NOTE(CONSTCOND)				\
+} while (0)
+
+/*
+ * For KVP pool file
+ */
+
+#define	MAX_FILE_NAME		100
+#define	ENTRIES_PER_BLOCK	50
+
+struct kvp_record {
+	char	key[HV_KVP_EXCHANGE_MAX_KEY_SIZE];
+	char	value[HV_KVP_EXCHANGE_MAX_VALUE_SIZE];
+};
+
+struct kvp_pool {
+	int			pool_fd;
+	int			num_blocks;
+	struct kvp_record	*records;
+	int			num_records;
+	char			fname[MAX_FILE_NAME];
+};
+
+static struct kvp_pool kvp_pools[HV_KVP_POOL_COUNT];
+
+
+static void
+kvp_acquire_lock(int pool)
+{
+	struct flock fl = {
+		.l_type = F_WRLCK,
+		.l_whence = SEEK_SET,
+		.l_start = 0,
+		.l_len = 0,
+		.l_pid = getpid()
+	};
+
+	if (fcntl(kvp_pools[pool].pool_fd, F_SETLKW, &fl) == -1) {
+		KVP_LOG(LOG_ERR, "Failed to acquire the lock (%s) pool: %d",
+		    strerror(errno), pool);
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+static void
+kvp_release_lock(int pool)
+{
+	struct flock fl = {
+		.l_type = F_UNLCK,
+		.l_whence = SEEK_SET,
+		.l_start = 0,
+		.l_len = 0,
+		.l_pid = getpid()
+	};
+
+	if (fcntl(kvp_pools[pool].pool_fd, F_SETLK, &fl) == -1) {
+		perror("fcntl");
+		KVP_LOG(LOG_ERR, "Failed to release the lock (%s) pool: %d\n",
+		    strerror(errno), pool);
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+/*
+ * Write in-memory copy of KVP to pool files
+ */
+static void
+kvp_update_file(int pool)
+{
+	FILE *filep;
+
+	kvp_acquire_lock(pool);
+
+	filep = fopen(kvp_pools[pool].fname, "w");
+	if (!filep) {
+		kvp_release_lock(pool);
+		KVP_LOG(LOG_ERR, "Failed to open file, pool: %d\n", pool);
+		exit(EXIT_FAILURE);
+	}
+
+	(void) fwrite(kvp_pools[pool].records, sizeof (struct kvp_record),
+	    kvp_pools[pool].num_records, filep);
+
+	if (ferror(filep) || fclose(filep)) {
+		kvp_release_lock(pool);
+		KVP_LOG(LOG_ERR, "Failed to write file, pool: %d\n", pool);
+		exit(EXIT_FAILURE);
+	}
+
+	kvp_release_lock(pool);
+}
+
+/*
+ * Read KVPs from pool files and store in memory
+ */
+static void
+kvp_update_mem_state(int pool)
+{
+	FILE *filep;
+	size_t records_read = 0;
+	struct kvp_record *record = kvp_pools[pool].records;
+	struct kvp_record *readp;
+	int num_blocks = kvp_pools[pool].num_blocks;
+	int alloc_unit = sizeof (struct kvp_record) * ENTRIES_PER_BLOCK;
+
+	kvp_acquire_lock(pool);
+
+	filep = fopen(kvp_pools[pool].fname, "r");
+	if (!filep) {
+		kvp_release_lock(pool);
+		KVP_LOG(LOG_ERR, "Failed to open file, pool: %d\n", pool);
+		exit(EXIT_FAILURE);
+	}
+	for (;;) {
+		readp = &record[records_read];
+		records_read += fread(readp, sizeof (struct kvp_record),
+		    ENTRIES_PER_BLOCK * num_blocks, filep);
+
+		if (ferror(filep)) {
+			KVP_LOG(LOG_ERR, "Failed to read file, pool: %d\n",
+			    pool);
+			exit(EXIT_FAILURE);
+		}
+
+		if (!feof(filep)) {
+			/*
+			 * Have more data to read. Expand the memory.
+			 */
+			num_blocks++;
+			record = realloc(record, alloc_unit * num_blocks);
+
+			if (record == NULL) {
+				KVP_LOG(LOG_ERR, "malloc failed\n");
+				exit(EXIT_FAILURE);
+			}
+			continue;
+		}
+		break;
+	}
+
+	kvp_pools[pool].num_blocks = num_blocks;
+	kvp_pools[pool].records = record;
+	kvp_pools[pool].num_records = records_read;
+
+	(void) fclose(filep);
+	kvp_release_lock(pool);
+}
+
+
+static int
+kvp_file_init(void)
+{
+	int fd;
+	FILE *filep;
+	size_t records_read;
+	char *fname;
+	struct kvp_record *record;
+	struct kvp_record *readp;
+	int num_blocks;
+	int i;
+	int alloc_unit = sizeof (struct kvp_record) * ENTRIES_PER_BLOCK;
+
+	if (mkdirp("/var/db/hyperv/pool", S_IRUSR | S_IWUSR | S_IROTH) < 0 &&
+	    (errno != EEXIST && errno != EISDIR)) {
+		KVP_LOG(LOG_ERR, " Failed to create /var/db/hyperv/pool\n");
+		exit(EXIT_FAILURE);
+	}
+
+	for (i = 0; i < HV_KVP_POOL_COUNT; i++) {
+		fname = kvp_pools[i].fname;
+		records_read = 0;
+		num_blocks = 1;
+		(void) snprintf(fname, MAX_FILE_NAME,
+		    "/var/db/hyperv/pool/.kvp_pool_%d", i);
+		fd = open(fname, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IROTH);
+
+		if (fd == -1) {
+			return (1);
+		}
+
+
+		filep = fopen(fname, "r");
+		if (!filep) {
+			(void) close(fd);
+			return (1);
+		}
+
+		record = malloc(alloc_unit * num_blocks);
+		if (record == NULL) {
+			(void) close(fd);
+			(void) fclose(filep);
+			return (1);
+		}
+		for (;;) {
+			readp = &record[records_read];
+			records_read += fread(readp, sizeof (struct kvp_record),
+			    ENTRIES_PER_BLOCK, filep);
+
+			if (ferror(filep)) {
+				KVP_LOG(LOG_ERR, "Failed to read file, "
+				    "pool: %d\n", i);
+				exit(EXIT_FAILURE);
+			}
+
+			if (!feof(filep)) {
+				/*
+				 * More data to read.
+				 */
+				num_blocks++;
+				record = realloc(record, alloc_unit *
+				    num_blocks);
+				if (record == NULL) {
+					(void) close(fd);
+					(void) fclose(filep);
+					return (1);
+				}
+				continue;
+			}
+			break;
+		}
+		kvp_pools[i].pool_fd = fd;
+		kvp_pools[i].num_blocks = num_blocks;
+		kvp_pools[i].records = record;
+		kvp_pools[i].num_records = records_read;
+		(void) fclose(filep);
+	}
+
+	return (0);
+}
+
+
+static int
+kvp_key_delete(int pool, __u8 *key, int key_size)
+{
+	int i;
+	int j, k;
+	int num_records;
+	struct kvp_record *record;
+
+	KVP_LOG(LOG_DEBUG, "kvp_key_delete: pool =  %d, "
+	    "key = %s\n", pool, key);
+
+	/* Update in-memory state */
+	kvp_update_mem_state(pool);
+
+	num_records = kvp_pools[pool].num_records;
+	record = kvp_pools[pool].records;
+
+	for (i = 0; i < num_records; i++) {
+		if (memcmp(key, record[i].key, key_size)) {
+			continue;
+		}
+
+		KVP_LOG(LOG_DEBUG, "Found delete key in pool %d.\n",
+		    pool);
+		/*
+		 * We found a match at the end; Just update the number of
+		 * entries and we are done.
+		 */
+		if (i == num_records) {
+			kvp_pools[pool].num_records--;
+			kvp_update_file(pool);
+			return (0);
+		}
+
+		/*
+		 * We found a match in the middle; Move the remaining
+		 * entries up.
+		 */
+		j = i;
+		k = j + 1;
+		for (; k < num_records; k++) {
+			(void) strcpy(record[j].key, record[k].key);
+			(void) strcpy(record[j].value, record[k].value);
+			j++;
+		}
+		kvp_pools[pool].num_records--;
+		kvp_update_file(pool);
+		return (0);
+	}
+	KVP_LOG(LOG_DEBUG, "Not found delete key in pool %d.\n",
+	    pool);
+	return (1);
+}
+
+
+static int
+kvp_key_add_or_modify(int pool, __u8 *key, __u32 key_size, __u8 *value,
+    __u32 value_size)
+{
+	int i;
+	int num_records;
+	struct kvp_record *record;
+	int num_blocks;
+
+	KVP_LOG(LOG_DEBUG, "kvp_key_add_or_modify: pool =  %d, "
+	    "key = %s, value = %s\n,", pool, key, value);
+
+	if ((key_size > HV_KVP_EXCHANGE_MAX_KEY_SIZE) ||
+	    (value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE)) {
+		KVP_LOG(LOG_ERR, "kvp_key_add_or_modify: returning 1\n");
+		return (1);
+	}
+
+	/* Update the in-memory state. */
+	kvp_update_mem_state(pool);
+
+	num_records = kvp_pools[pool].num_records;
+	record = kvp_pools[pool].records;
+	num_blocks = kvp_pools[pool].num_blocks;
+
+	for (i = 0; i < num_records; i++) {
+		if (memcmp(key, record[i].key, key_size)) {
+			continue;
+		}
+
+		/*
+		 * Key exists. Just update the value and we are done.
+		 */
+		(void) memcpy(record[i].value, value, value_size);
+		kvp_update_file(pool);
+		return (0);
+	}
+
+	/*
+	 * Key doesn't exist; Add a new KVP.
+	 */
+	if (num_records == (ENTRIES_PER_BLOCK * num_blocks)) {
+		/* Increase the size of the recodrd array. */
+		record = realloc(record, sizeof (struct kvp_record) *
+		    ENTRIES_PER_BLOCK * (num_blocks + 1));
+
+		if (record == NULL) {
+			return (1);
+		}
+		kvp_pools[pool].num_blocks++;
+	}
+	(void) memcpy(record[i].value, value, value_size);
+	(void) memcpy(record[i].key, key, key_size);
+	kvp_pools[pool].records = record;
+	kvp_pools[pool].num_records++;
+	kvp_update_file(pool);
+	return (0);
+}
+
+
+static int
+kvp_get_value(int pool, __u8 *key, int key_size, __u8 *value,
+    int value_size)
+{
+	int i;
+	int num_records;
+	struct kvp_record *record;
+
+	KVP_LOG(LOG_DEBUG, "kvp_get_value: pool =  %d, key = %s\n,",
+	    pool, key);
+
+	if ((key_size > HV_KVP_EXCHANGE_MAX_KEY_SIZE) ||
+	    (value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE)) {
+		return (1);
+	}
+
+	/* Update the in-memory state first. */
+	kvp_update_mem_state(pool);
+
+	num_records = kvp_pools[pool].num_records;
+	record = kvp_pools[pool].records;
+
+	for (i = 0; i < num_records; i++) {
+		if (memcmp(key, record[i].key, key_size)) {
+			continue;
+		}
+
+		/* Found the key */
+		(void) memcpy(value, record[i].value, value_size);
+		return (0);
+	}
+
+	return (1);
+}
+
+
+static int
+kvp_pool_enumerate(int pool, int idx, __u8 *key, int key_size,
+    __u8 *value, int value_size)
+{
+	struct kvp_record *record;
+
+	KVP_LOG(LOG_DEBUG, "kvp_pool_enumerate: pool = %d, index = %d\n,",
+	    pool, idx);
+
+	/* First update our in-memory state first. */
+	kvp_update_mem_state(pool);
+	record = kvp_pools[pool].records;
+
+	/* Index starts with 0 */
+	if (idx >= kvp_pools[pool].num_records) {
+		return (1);
+	}
+
+	(void) memcpy(key, record[idx].key, key_size);
+	(void) memcpy(value, record[idx].value, value_size);
+	return (0);
+}
+
+
+static void
+kvp_get_os_info(void)
+{
+	char *p;
+
+	(void) uname(&uts_buf);
+	os_build = uts_buf.version;
+	os_version = uts_buf.release;
+	os_name = uts_buf.sysname;
+	processor_arch = uts_buf.machine;
+
+	/*
+	 * Split out the OS major and minor versions
+	 */
+	os_major = strdup(os_version);
+	p = strchr(os_major, '.');
+	if (p != NULL) {
+		*p = '\0';
+		p++;
+		os_minor = p;
+		p = strchr(os_minor, '.');
+		if (p != NULL) {
+			*p = '\0';
+		}
+	}
+}
+
+struct get_mac_arg {
+	char	*gma_findmac;
+	char	*gma_ifname;
+};
+
+static boolean_t
+get_mac_address(const char *linkname, void *arg)
+{
+	struct get_mac_arg *gma = arg;
+	dlpi_handle_t dh;
+	uchar_t physaddr[DLPI_PHYSADDR_MAX];
+	size_t pa_len;
+
+	if (dlpi_open(linkname, &dh, 0) != DLPI_SUCCESS)
+		return (B_FALSE);
+
+	int err = dlpi_get_physaddr(dh, DL_CURR_PHYS_ADDR, physaddr, &pa_len);
+
+	dlpi_close(dh);
+
+	if (err == DLPI_SUCCESS && pa_len > 0) {
+		/*
+		 * Format the MAC address to match the expected formatting
+		 * from the KVP driver.
+		 * The formatted string is 2 characters + ':' per byte + \0
+		 */
+		char mac_str[DLPI_PHYSADDR_MAX * 3];
+		char *macp = mac_str;
+		for (size_t i = 0; i < pa_len; i++) {
+			if (i < pa_len - 1) {
+				macp += snprintf(macp, 4, "%02X:", physaddr[i]);
+			} else {
+				macp += snprintf(macp, 3, "%02X", physaddr[i]);
+			}
+		}
+		if (strncmp(mac_str, gma->gma_findmac,
+		    DLPI_PHYSADDR_MAX * 3) == 0) {
+			/* To be freed by caller */
+			gma->gma_ifname = strdup(linkname);
+			return (B_TRUE);
+		}
+	}
+	return (B_FALSE);
+}
+
+/*
+ * Given the MAC address, return the interface name.
+ * The caller is responsible for freeing the returned string.
+ */
+static char *
+kvp_mac_to_if_name(char *mac)
+{
+	struct get_mac_arg gma = {
+		.gma_findmac = mac,
+		.gma_ifname = NULL
+	};
+
+	dlpi_walk(get_mac_address, &gma, 0);
+
+	return (gma.gma_ifname);
+}
+
+
+static void
+kvp_process_ipconfig_file(char *cmd,
+    char *config_buf, size_t len,
+    size_t element_size, int offset)
+{
+	char buf[256];
+	char *p;
+	char *x;
+	FILE *file;
+
+	/*
+	 * First execute the command.
+	 */
+	file = popen(cmd, "r");
+	if (file == NULL) {
+		return;
+	}
+
+	if (offset == 0) {
+		(void) memset(config_buf, 0, len);
+	}
+	while ((p = fgets(buf, sizeof (buf), file)) != NULL) {
+		if ((len - strlen(config_buf)) < (element_size + 1)) {
+			break;
+		}
+
+		x = strchr(p, '\n');
+		*x = '\0';
+		(void) strlcat(config_buf, p, len);
+		(void) strlcat(config_buf, ";", len);
+	}
+	(void) pclose(file);
+}
+
+
+static void
+kvp_get_ipconfig_info(char *if_name, struct hv_kvp_ipaddr_value *buffer)
+{
+	char cmd[512];
+	char dhcp_info[128];
+	char *p;
+	FILE *file;
+
+	/*
+	 * Retrieve the IPV4 address of default gateway.
+	 */
+	(void) snprintf(cmd, sizeof (cmd),
+	    "netstat -rn | grep %s | awk '/default/ {print $2 }'", if_name);
+
+	/*
+	 * Execute the command to gather gateway IPV4 info.
+	 */
+	kvp_process_ipconfig_file(cmd, (char *)buffer->gate_way,
+	    (MAX_GATEWAY_SIZE * 2), INET_ADDRSTRLEN, 0);
+	/*
+	 * Retrieve the IPV6 address of default gateway.
+	 */
+	(void) snprintf(cmd, sizeof (cmd),
+	    "netstat -rn inet6 | grep %s | awk '/default/ {print $2 }'",
+	    if_name);
+
+	/*
+	 * Execute the command to gather gateway IPV6 info.
+	 */
+	kvp_process_ipconfig_file(cmd, (char *)buffer->gate_way,
+	    (MAX_GATEWAY_SIZE * 2), INET6_ADDRSTRLEN, 1);
+	/*
+	 * we just invoke an external script to get the DNS info.
+	 *
+	 * Following is the expected format of the information from the script:
+	 *
+	 * ipaddr1 (nameserver1)
+	 * ipaddr2 (nameserver2)
+	 * .
+	 * .
+	 */
+	/* Scripts are stored in /usr/lib/hyperv/ directory */
+	(void) snprintf(cmd, sizeof (cmd), "%s",
+	    "sh /usr/lib/hyperv/hv_get_dns_info");
+
+	/*
+	 * Execute the command to get DNS info.
+	 */
+	kvp_process_ipconfig_file(cmd, (char *)buffer->dns_addr,
+	    (MAX_IP_ADDR_SIZE * 2), INET_ADDRSTRLEN, 0);
+
+	/*
+	 * Invoke an external script to get the DHCP state info.
+	 * The parameter to the script is the interface name.
+	 * Here is the expected output:
+	 *
+	 * Enabled: DHCP enabled.
+	 */
+
+
+	(void) snprintf(cmd, sizeof (cmd), "%s %s",
+	    "sh /usr/lib/hyperv/hv_get_dhcp_info", if_name);
+
+	file = popen(cmd, "r");
+	if (file == NULL) {
+		return;
+	}
+
+	p = fgets(dhcp_info, sizeof (dhcp_info), file);
+	if (p == NULL) {
+		(void) pclose(file);
+		return;
+	}
+
+	if (strncmp(p, "Enabled", 7) == 0) {
+		buffer->dhcp_enabled = 1;
+	} else {
+		buffer->dhcp_enabled = 0;
+	}
+
+	(void) pclose(file);
+}
+
+
+static unsigned int
+hweight32(unsigned int *w)
+{
+	unsigned int res = *w - ((*w >> 1) & 0x55555555);
+
+	res = (res & 0x33333333) + ((res >> 2) & 0x33333333);
+	res = (res + (res >> 4)) & 0x0F0F0F0F;
+	res = res + (res >> 8);
+	return ((res + (res >> 16)) & 0x000000FF);
+}
+
+
+static int
+kvp_process_ip_address(void *addrp,
+    int family, char *buffer,
+    int length, int *offset)
+{
+	struct sockaddr_in *addr;
+	struct sockaddr_in6 *addr6;
+	int addr_length;
+	char tmp[50];
+	const char *str;
+
+	if (family == AF_INET) {
+		addr = (struct sockaddr_in *)addrp;
+		str = inet_ntop(family, &addr->sin_addr, tmp, 50);
+		addr_length = INET_ADDRSTRLEN;
+	} else {
+		addr6 = (struct sockaddr_in6 *)addrp;
+		str = inet_ntop(family, &addr6->sin6_addr.s6_addr, tmp, 50);
+		addr_length = INET6_ADDRSTRLEN;
+	}
+
+	if ((length - *offset) < addr_length + 1) {
+		return (EINVAL);
+	}
+	if (str == NULL) {
+		(void) strlcpy(buffer, "inet_ntop failed\n", length);
+		return (errno);
+	}
+	if (*offset == 0) {
+		(void) strlcpy(buffer, tmp, length);
+	} else {
+		(void) strlcat(buffer, tmp, length);
+	}
+	(void) strlcat(buffer, ";", length);
+
+	*offset += strlen(str) + 1;
+	return (0);
+}
+
+
+static int
+kvp_get_ip_info(int family, char *if_name, int op,
+    void *out_buffer, size_t length)
+{
+	struct ifaddrs *ifap;
+	struct ifaddrs *curp;
+	int offset = 0;
+	int sn_offset = 0;
+	int error = 0;
+	char *buffer;
+	size_t buffer_length;
+	struct hv_kvp_ipaddr_value *ip_buffer = NULL;
+	char cidr_mask[5];
+	int weight;
+	int i;
+	unsigned int *w = NULL;
+	char *sn_str;
+	size_t sn_str_length;
+	struct sockaddr_in6 *addr6;
+
+	if (op == HV_KVP_OP_ENUMERATE) {
+		buffer = out_buffer;
+		buffer_length = length;
+	} else {
+		ip_buffer = out_buffer;
+		buffer = (char *)ip_buffer->ip_addr;
+		buffer_length = sizeof (ip_buffer->ip_addr);
+		ip_buffer->addr_family = 0;
+	}
+
+	if (getifaddrs(&ifap)) {
+		(void) strlcpy(buffer, "getifaddrs failed\n", buffer_length);
+		return (errno);
+	}
+
+	curp = ifap;
+	while (curp != NULL) {
+		if (curp->ifa_addr == NULL) {
+			curp = curp->ifa_next;
+			continue;
+		}
+
+		if ((if_name != NULL) &&
+		    (strncmp(curp->ifa_name, if_name, strlen(if_name)))) {
+			/*
+			 * We want info about a specific interface;
+			 * just continue.
+			 */
+			curp = curp->ifa_next;
+			continue;
+		}
+
+		/*
+		 * We support two address families: AF_INET and AF_INET6.
+		 * If family value is 0, we gather both supported
+		 * address families; if not we gather info on
+		 * the specified address family.
+		 */
+		if ((family != 0) && (curp->ifa_addr->sa_family != family)) {
+			curp = curp->ifa_next;
+			continue;
+		}
+		if ((curp->ifa_addr->sa_family != AF_INET) &&
+		    (curp->ifa_addr->sa_family != AF_INET6)) {
+			curp = curp->ifa_next;
+			continue;
+		}
+
+		if (op == HV_KVP_OP_GET_IP_INFO) {
+			/*
+			 * Get the info other than the IP address.
+			 */
+			if (curp->ifa_addr->sa_family == AF_INET) {
+				ip_buffer->addr_family |= ADDR_FAMILY_IPV4;
+
+				/*
+				 * Get subnet info.
+				 */
+				error = kvp_process_ip_address(
+				    curp->ifa_netmask, AF_INET,
+				    (char *)ip_buffer->sub_net,
+				    length, &sn_offset);
+				if (error) {
+					goto kvp_get_ip_info_ipaddr;
+				}
+			} else {
+				ip_buffer->addr_family |= ADDR_FAMILY_IPV6;
+
+				/*
+				 * Get subnet info in CIDR format.
+				 */
+				weight = 0;
+				sn_str = (char *)ip_buffer->sub_net;
+				sn_str_length = sizeof (ip_buffer->sub_net);
+				addr6 = (struct sockaddr_in6 *)(uintptr_t)
+				    curp->ifa_netmask;
+				w = (unsigned int *)(void *)
+				    (&(addr6->sin6_addr.s6_addr[0]));
+
+				for (i = 0; i < 4; i++) {
+					weight += hweight32(&w[i]);
+				}
+
+				(void) snprintf(cidr_mask, sizeof (cidr_mask),
+				    "/%d", weight);
+				if ((length - sn_offset) <
+				    (strlen(cidr_mask) + 1)) {
+					goto kvp_get_ip_info_ipaddr;
+				}
+
+				if (sn_offset == 0) {
+					(void) strlcpy(sn_str, cidr_mask,
+					    sn_str_length);
+				} else {
+					(void) strlcat(sn_str, cidr_mask,
+					    sn_str_length);
+				}
+				(void) strlcat((char *)ip_buffer->sub_net, ";",
+				    sn_str_length);
+				sn_offset += strlen(sn_str) + 1;
+			}
+
+			/*
+			 * Collect other ip configuration info.
+			 */
+			kvp_get_ipconfig_info(if_name, ip_buffer);
+		}
+
+kvp_get_ip_info_ipaddr:
+		error = kvp_process_ip_address(curp->ifa_addr,
+		    curp->ifa_addr->sa_family, buffer, length, &offset);
+		if (error) {
+			goto kvp_get_ip_info_done;
+		}
+
+		curp = curp->ifa_next;
+	}
+
+kvp_get_ip_info_done:
+	freeifaddrs(ifap);
+	return (error);
+}
+
+
+static int
+kvp_get_domain_name(char *buffer, int length)
+{
+	struct addrinfo hints, *info;
+	int error = 0;
+
+	(void) gethostname(buffer, length);
+	(void) memset(&hints, 0, sizeof (hints));
+	hints.ai_family = AF_INET;    /* Get only ipv4 addrinfo. */
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_CANONNAME;
+
+	error = getaddrinfo(buffer, NULL, &hints, &info);
+	if (error != 0) {
+		(void) strlcpy(buffer, "getaddrinfo failed\n", length);
+		return (error);
+	}
+	(void) strlcpy(buffer, info->ai_canonname, length);
+	freeaddrinfo(info);
+	return (error);
+}
+
+
+/* ARGSUSED */
+static int
+kvp_op_getipinfo(struct hv_kvp_msg *op_msg, void *data)
+{
+	struct hv_kvp_ipaddr_value *ip_val;
+	char *if_name;
+	int error = 0;
+
+	assert(op_msg != NULL);
+	KVP_LOG(LOG_DEBUG, "In kvp_op_getipinfo.\n");
+
+	ip_val = &op_msg->body.kvp_ip_val;
+	op_msg->hdr.error = HV_S_OK;
+
+	if_name = kvp_mac_to_if_name((char *)ip_val->adapter_id);
+
+	if (if_name == NULL) {
+		/* No interface found with the mac address. */
+		op_msg->hdr.error = HV_E_FAIL;
+		goto kvp_op_getipinfo_done;
+	}
+
+	error = kvp_get_ip_info(0, if_name,
+	    HV_KVP_OP_GET_IP_INFO, ip_val, (MAX_IP_ADDR_SIZE * 2));
+	if (error)
+		op_msg->hdr.error = HV_E_FAIL;
+	free(if_name);
+
+kvp_op_getipinfo_done:
+	return (error);
+}
+
+static int
+kvp_op_setgetdel(struct hv_kvp_msg *op_msg, void *data)
+{
+	struct kvp_op_hdlr *op_hdlr = (struct kvp_op_hdlr *)data;
+	int error = 0;
+	int op_pool;
+
+	assert(op_msg != NULL);
+	assert(op_hdlr != NULL);
+
+	op_pool = op_msg->hdr.kvp_hdr.pool;
+	op_msg->hdr.error = HV_S_OK;
+
+	switch (op_hdlr->kvp_op_key) {
+	case HV_KVP_OP_SET:
+		if (op_pool == HV_KVP_POOL_AUTO) {
+			/* Auto Pool is not writeable from host side. */
+			error = 1;
+			KVP_LOG(LOG_ERR, "Illegal to write to pool %d "
+			    "from host\n", op_pool);
+		} else {
+			error = kvp_key_add_or_modify(op_pool,
+			    op_msg->body.kvp_set.data.key,
+			    op_msg->body.kvp_set.data.key_size,
+			    op_msg->body.kvp_set.data.msg_value.value,
+			    op_msg->body.kvp_set.data.value_size);
+		}
+		break;
+
+	case HV_KVP_OP_GET:
+		error = kvp_get_value(op_pool,
+		    op_msg->body.kvp_get.data.key,
+		    op_msg->body.kvp_get.data.key_size,
+		    op_msg->body.kvp_get.data.msg_value.value,
+		    op_msg->body.kvp_get.data.value_size);
+		break;
+
+	case HV_KVP_OP_DELETE:
+		if (op_pool == HV_KVP_POOL_AUTO) {
+			/* Auto Pool is not writeable from host side. */
+			error = 1;
+			KVP_LOG(LOG_ERR, "Ilegal to change pool %d from host\n",
+			    op_pool);
+		} else {
+			error = kvp_key_delete(op_pool,
+			    op_msg->body.kvp_delete.key,
+			    op_msg->body.kvp_delete.key_size);
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	if (error != 0)
+		op_msg->hdr.error = HV_S_CONT;
+	return (error);
+}
+
+
+/* ARGSUSED */
+static int
+kvp_op_enumerate(struct hv_kvp_msg *op_msg, void *data)
+{
+	char *key_name, *key_value;
+	int error = 0;
+	int op_pool;
+
+	assert(op_msg != NULL);
+
+	op_pool = op_msg->hdr.kvp_hdr.pool;
+	op_msg->hdr.error = HV_S_OK;
+
+	/*
+	 * If the pool is not HV_KVP_POOL_AUTO, read from the appropriate
+	 * pool and return the KVP according to the index requested.
+	 */
+	if (op_pool != HV_KVP_POOL_AUTO) {
+		if (kvp_pool_enumerate(op_pool,
+		    op_msg->body.kvp_enum_data.index,
+		    op_msg->body.kvp_enum_data.data.key,
+		    HV_KVP_EXCHANGE_MAX_KEY_SIZE,
+		    op_msg->body.kvp_enum_data.data.msg_value.value,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE)) {
+			op_msg->hdr.error = HV_S_CONT;
+			error = -1;
+		}
+		goto kvp_op_enumerate_done;
+	}
+
+	key_name = (char *)op_msg->body.kvp_enum_data.data.key;
+	key_value = (char *)op_msg->body.kvp_enum_data.data.msg_value.value;
+
+	switch (op_msg->body.kvp_enum_data.index) {
+	case FullyQualifiedDomainName:
+		(void) kvp_get_domain_name(key_value,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "FullyQualifiedDomainName");
+		break;
+
+	case IntegrationServicesVersion:
+		(void) strcpy(key_name, "IntegrationServicesVersion");
+		(void) strlcpy(key_value, lic_version,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		break;
+
+	case NetworkAddressIPv4:
+		(void) kvp_get_ip_info(AF_INET, NULL, HV_KVP_OP_ENUMERATE,
+		    key_value, HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "NetworkAddressIPv4");
+		break;
+
+	case NetworkAddressIPv6:
+		(void) kvp_get_ip_info(AF_INET6, NULL, HV_KVP_OP_ENUMERATE,
+		    key_value, HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "NetworkAddressIPv6");
+		break;
+
+	case OSBuildNumber:
+		(void) strlcpy(key_value, os_build,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "OSBuildNumber");
+		break;
+
+	case OSName:
+		(void) strlcpy(key_value, os_name,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "OSName");
+		break;
+
+	case OSMajorVersion:
+		(void) strlcpy(key_value, os_major,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "OSMajorVersion");
+		break;
+
+	case OSMinorVersion:
+		(void) strlcpy(key_value, os_minor,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "OSMinorVersion");
+		break;
+
+	case OSVersion:
+		(void) strlcpy(key_value, os_version,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "OSVersion");
+		break;
+
+	case ProcessorArchitecture:
+		(void) strlcpy(key_value, processor_arch,
+		    HV_KVP_EXCHANGE_MAX_VALUE_SIZE);
+		(void) strcpy(key_name, "ProcessorArchitecture");
+		break;
+
+	default:
+#ifdef DEBUG
+		KVP_LOG(LOG_ERR, "Auto pool Index %d not found.\n",
+		    op_msg->body.kvp_enum_data.index);
+#endif
+		op_msg->hdr.error = HV_S_CONT;
+		error = -1;
+		break;
+	}
+
+kvp_op_enumerate_done:
+	if (error != 0)
+		op_msg->hdr.error = HV_S_CONT;
+	return (error);
+}
+
+
+/*
+ * Load handler, and call init routine if provided.
+ */
+static int
+kvp_op_load(int key, void (*init)(void), int (*exec)(struct hv_kvp_msg *,
+    void *))
+{
+	int error = 0;
+
+	if (key < 0 || key >= HV_KVP_OP_COUNT) {
+		KVP_LOG(LOG_ERR, "Operation key out of supported range\n");
+		error = -1;
+		goto kvp_op_load_done;
+	}
+
+	kvp_op_hdlrs[key].kvp_op_key = key;
+	kvp_op_hdlrs[key].kvp_op_init = init;
+	kvp_op_hdlrs[key].kvp_op_exec = exec;
+
+	if (kvp_op_hdlrs[key].kvp_op_init != NULL)
+		kvp_op_hdlrs[key].kvp_op_init();
+
+kvp_op_load_done:
+	return (error);
+}
+
+
+/*
+ * Initialize the operation hanlders.
+ */
+static int
+kvp_ops_init(void)
+{
+	int i;
+
+	/* Set the initial values. */
+	for (i = 0; i < HV_KVP_OP_COUNT; i++) {
+		kvp_op_hdlrs[i].kvp_op_key = -1;
+		kvp_op_hdlrs[i].kvp_op_init = NULL;
+		kvp_op_hdlrs[i].kvp_op_exec = NULL;
+	}
+
+	return (kvp_op_load(HV_KVP_OP_GET, NULL, kvp_op_setgetdel) |
+	    kvp_op_load(HV_KVP_OP_SET, NULL, kvp_op_setgetdel) |
+	    kvp_op_load(HV_KVP_OP_DELETE, NULL, kvp_op_setgetdel) |
+	    kvp_op_load(HV_KVP_OP_ENUMERATE, kvp_get_os_info,
+	    kvp_op_enumerate) |
+	    kvp_op_load(HV_KVP_OP_GET_IP_INFO, NULL, kvp_op_getipinfo));
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	struct hv_kvp_msg *hv_kvp_dev_buf;
+	struct hv_kvp_msg *hv_msg;
+	struct pollfd hv_kvp_poll_fd[1];
+	int op;
+	int hv_kvp_dev_fd, error, len, r;
+	int ch;
+
+	while ((ch = getopt(argc, argv, "dn")) != -1) {
+		switch (ch) {
+		case 'n':
+			/* Run as regular process for debugging purpose. */
+			is_daemon = 0;
+			break;
+		case 'd':
+			/* Generate debugging output */
+			is_debugging = 1;
+			break;
+		default:
+			break;
+		}
+	}
+
+	openlog("HV_KVP", 0, LOG_USER);
+
+	/* Become daemon first. */
+	if (is_daemon == 1)
+		(void) daemon(1, 0);
+	else
+		KVP_LOG(LOG_DEBUG, "Run as regular process.\n");
+
+	KVP_LOG(LOG_INFO, "HV_KVP starting; pid is: %ld\n", getpid());
+
+	/* Communication buffer hv_kvp_dev_buf */
+	hv_kvp_dev_buf = malloc(sizeof (*hv_kvp_dev_buf));
+	/* Buffer for daemon internal use */
+	hv_msg = malloc(sizeof (*hv_msg));
+
+	/* Memory allocation failed */
+	if (hv_kvp_dev_buf == NULL || hv_msg == NULL) {
+		KVP_LOG(LOG_ERR, "Failed to allocate memory for hv buffer\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Initialize op handlers */
+	if (kvp_ops_init() != 0) {
+		KVP_LOG(LOG_ERR, "Failed to initizlize operation handlers\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (kvp_file_init()) {
+		KVP_LOG(LOG_ERR, "Failed to initialize the p, pool;ools\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Open the Character Device */
+	hv_kvp_dev_fd = open("/dev/" HV_KVP_MINOR_NAME, O_RDWR);
+
+	if (hv_kvp_dev_fd < 0) {
+		KVP_LOG(LOG_ERR, "open /dev/%s failed; error: %d %s\n",
+		    HV_KVP_MINOR_NAME, errno, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	/* Initialize the struct for polling the char device */
+	hv_kvp_poll_fd[0].fd = hv_kvp_dev_fd;
+	hv_kvp_poll_fd[0].events = (POLLIN | POLLRDNORM);
+
+	/* Register the daemon to the KVP driver */
+	(void) memset(hv_kvp_dev_buf, 0, sizeof (*hv_kvp_dev_buf));
+	hv_kvp_dev_buf->hdr.kvp_hdr.operation = HV_KVP_OP_REGISTER;
+	len = write(hv_kvp_dev_fd, hv_kvp_dev_buf, sizeof (*hv_kvp_dev_buf));
+
+
+	for (;;) {
+		r = poll(hv_kvp_poll_fd, 1, INFTIM);
+
+		KVP_LOG(LOG_DEBUG, "poll returned r = %d, revent = 0x%x\n",
+		    r, hv_kvp_poll_fd[0].revents);
+
+		if (r == 0 || (r < 0 && errno == EAGAIN) ||
+		    (r < 0 && errno == EINTR)) {
+			/* Nothing to read */
+			continue;
+		}
+
+		if (r < 0) {
+			/*
+			 * For pread return failure other than EAGAIN,
+			 * we want to exit.
+			 */
+			KVP_LOG(LOG_ERR, "Poll failed.\n");
+			perror("poll");
+			exit(EIO);
+		}
+
+		/* Read from character device */
+		len = pread(hv_kvp_dev_fd, hv_kvp_dev_buf,
+		    sizeof (*hv_kvp_dev_buf), 0);
+
+		if (len < 0) {
+			KVP_LOG(LOG_ERR, "Read failed.\n");
+			perror("pread");
+			exit(EIO);
+		}
+
+		if (len != sizeof (struct hv_kvp_msg)) {
+			KVP_LOG(LOG_ERR, "read len is: %d\n", len);
+			continue;
+		}
+
+		/* Copy hv_kvp_dev_buf to hv_msg */
+		(void) memcpy(hv_msg, hv_kvp_dev_buf, sizeof (*hv_msg));
+
+		/*
+		 * We will use the KVP header information to pass back
+		 * the error from this daemon. So, first save the op
+		 * and pool info to local variables.
+		 */
+
+		op = hv_msg->hdr.kvp_hdr.operation;
+
+		if (op < 0 || op >= HV_KVP_OP_COUNT ||
+		    kvp_op_hdlrs[op].kvp_op_exec == NULL) {
+			KVP_LOG(LOG_WARNING,
+			    "Unsupported operation OP = %d\n", op);
+			hv_msg->hdr.error = HV_ERROR_NOT_SUPPORTED;
+		} else {
+			/*
+			 * Call the operateion handler's execution routine.
+			 */
+			error = kvp_op_hdlrs[op].kvp_op_exec(hv_msg,
+			    (void *)&kvp_op_hdlrs[op]);
+			if (error != 0) {
+				assert(hv_msg->hdr.error != HV_S_OK);
+				if (hv_msg->hdr.error != HV_S_CONT)
+					KVP_LOG(LOG_WARNING,
+					    "Operation failed OP = %d, "
+					    "error = 0x%x\n", op, error);
+			}
+		}
+
+		/*
+		 * Send the value back to the kernel. The response is
+		 * already in the receive buffer.
+		 */
+hv_kvp_done:
+		len = pwrite(hv_kvp_dev_fd, hv_msg,
+		    sizeof (*hv_kvp_dev_buf), 0);
+
+		if (len != sizeof (struct hv_kvp_msg)) {
+			KVP_LOG(LOG_ERR, "write len is: %d\n", len);
+			goto hv_kvp_done;
+		}
+	}
+	/* NOTREACHED */
+}

--- a/usr/src/cmd/hyperv/kvp/kvp.xml
+++ b/usr/src/cmd/hyperv/kvp/kvp.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+CDDL HEADER START
+
+This file and its contents are supplied under the terms of the
+Common Development and Distribution License ("CDDL"), version 1.0.
+You may only use this file in accordance with the terms of version
+1.0 of the CDDL.
+
+A full copy of the text of the CDDL should have accompanied this
+source.  A copy of the CDDL is also available via the Internet at
+http://www.illumos.org/license/CDDL.
+
+CDDL HEADER END
+
+Copyright (c) 2017 by Delphix. All rights reserved.
+
+	NOTE:  This service manifest is not editable; its contents will
+	be overwritten by package or patch operations, including
+	operating system upgrade.  Make customizations in a different
+	file.
+-->
+
+<service_bundle type='manifest' name='hv-kvp-daemon'>
+
+<service
+	name='system/hyperv/key-value-exchange'
+	type='service'
+	version='1'>
+
+	<create_default_instance enabled='false' />
+
+	<single_instance/>
+
+	<dependency
+		name='devices'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/system/device/local' />
+	</dependency>
+
+	<exec_method
+		type='method'
+		name='start'
+		exec='/usr/lib/hyperv/hv_kvp_daemon -d'
+		timeout_seconds='60'>
+	</exec_method>
+
+	<exec_method
+		type='method'
+		name='stop'
+		exec=':kill'
+		timeout_seconds='60' />
+
+	<stability value='Unstable' />
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'> Hyper-V Key-Value Exchange Daemon </loctext>
+		</common_name>
+	</template>
+</service>
+
+</service_bundle>

--- a/usr/src/cmd/hyperv/scripts/Makefile
+++ b/usr/src/cmd/hyperv/scripts/Makefile
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+PROG=		hv_get_dhcp_info hv_get_dns_info
+ALL=		$(PROG)
+
+include		../../Makefile.cmd
+
+all:	$(PROG)
+
+LIBHYPERVPROG=	$(PROG:%=$(ROOTLIBHYPERV)/%)
+
+install: all $(LIBHYPERVPROG)
+
+lint:
+
+clean:
+	$(RM) $(PROG)
+
+include ../../Makefile.targ

--- a/usr/src/cmd/hyperv/scripts/hv_get_dhcp_info.sh
+++ b/usr/src/cmd/hyperv/scripts/hv_get_dhcp_info.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+# This script retrieves the DHCP state of a given interface. It is primarily
+# used by the kvp daemon. It takes the name of the interface as input, and
+# outputs either "Enabled" or "Disabled" to stdout depeneding on whether that
+# interface has a DHCP address.
+#
+
+if [[ -n $1 ]]; then
+	intf=$1
+else
+	intf=hv_netvsc0
+fi
+
+ipadm show-addr -p -o type $intf/ 2>/dev/null | grep dhcp >/dev/null
+if [[ $? -eq 0 ]]; then
+	echo "Enabled"
+else
+	echo "Disabled"
+fi

--- a/usr/src/cmd/hyperv/scripts/hv_get_dns_info.sh
+++ b/usr/src/cmd/hyperv/scripts/hv_get_dns_info.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+# This script parses /etc/resolv.conf and prints the address of the first
+# nameserver. It is primarily used by the kvp daemon.
+#
+
+awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf || exit 1

--- a/usr/src/pkg/manifests/driver-hyperv-pv.mf
+++ b/usr/src/pkg/manifests/driver-hyperv-pv.mf
@@ -1,0 +1,58 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+# The default for payload-bearing actions in this package is to appear in the
+# global zone only.  See the include file for greater detail, as well as
+# information about overriding the defaults.
+#
+<include global_zone_only_component>
+set name=pkg.fmri value=pkg:/driver/hyperv/pv@$(PKGVERS)
+set name=pkg.description value="Hyper-V Enlightened Drivers"
+set name=pkg.summary value="Hyper-V Enlightened Drivers"
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Virtualization
+set name=variant.arch value=i386
+dir path=kernel group=sys
+dir path=kernel/drv group=sys
+dir path=kernel/drv/$(ARCH64) group=sys
+dir path=kernel/misc group=sys
+dir path=kernel/misc/$(ARCH64) group=sys
+$(i386_ONLY)driver name=hv_heartbeat
+$(i386_ONLY)driver name=hv_kvp perms="* 0600 root sys"
+$(i386_ONLY)driver name=hv_netvsc
+$(i386_ONLY)driver name=hv_shutdown
+$(i386_ONLY)driver name=hv_storvsc class=scsi-self-identifying
+$(i386_ONLY)driver name=hv_timesync
+$(i386_ONLY)driver name=hv_vmbus
+file path=kernel/drv/$(ARCH64)/hv_heartbeat group=sys
+file path=kernel/drv/$(ARCH64)/hv_kvp group=sys
+file path=kernel/drv/$(ARCH64)/hv_netvsc group=sys
+file path=kernel/drv/$(ARCH64)/hv_shutdown group=sys
+file path=kernel/drv/$(ARCH64)/hv_storvsc group=sys
+file path=kernel/drv/$(ARCH64)/hv_timesync group=sys
+file path=kernel/drv/$(ARCH64)/hv_vmbus group=sys
+file path=kernel/drv/hv_heartbeat group=sys
+file path=kernel/drv/hv_kvp group=sys
+file path=kernel/drv/hv_netvsc group=sys
+file path=kernel/drv/hv_netvsc.conf group=sys
+file path=kernel/drv/hv_shutdown group=sys
+file path=kernel/drv/hv_storvsc group=sys
+file path=kernel/drv/hv_timesync group=sys
+file path=kernel/drv/hv_vmbus group=sys
+file path=kernel/drv/hv_vmbus.conf group=sys
+file path=kernel/misc/$(ARCH64)/hyperv group=sys mode=0755
+file path=kernel/misc/hyperv group=sys mode=0755
+license lic_CDDL license=lic_CDDL

--- a/usr/src/pkg/manifests/driver-hyperv-pv.mf
+++ b/usr/src/pkg/manifests/driver-hyperv-pv.mf
@@ -44,15 +44,7 @@ file path=kernel/drv/$(ARCH64)/hv_shutdown group=sys
 file path=kernel/drv/$(ARCH64)/hv_storvsc group=sys
 file path=kernel/drv/$(ARCH64)/hv_timesync group=sys
 file path=kernel/drv/$(ARCH64)/hv_vmbus group=sys
-file path=kernel/drv/hv_heartbeat group=sys
-file path=kernel/drv/hv_kvp group=sys
-file path=kernel/drv/hv_netvsc group=sys
 file path=kernel/drv/hv_netvsc.conf group=sys
-file path=kernel/drv/hv_shutdown group=sys
-file path=kernel/drv/hv_storvsc group=sys
-file path=kernel/drv/hv_timesync group=sys
-file path=kernel/drv/hv_vmbus group=sys
 file path=kernel/drv/hv_vmbus.conf group=sys
 file path=kernel/misc/$(ARCH64)/hyperv group=sys mode=0755
-file path=kernel/misc/hyperv group=sys mode=0755
 license lic_CDDL license=lic_CDDL

--- a/usr/src/pkg/manifests/system-hyperv-tools.mf
+++ b/usr/src/pkg/manifests/system-hyperv-tools.mf
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+# The default for payload-bearing actions in this package is to appear in the
+# global zone only.  See the include file for greater detail, as well as
+# information about overriding the defaults.
+#
+<include global_zone_only_component>
+set name=pkg.fmri value=pkg:/system/hyperv/tools@$(PKGVERS)
+set name=pkg.description value="Supporting tools for the Hyper-V platform"
+set name=pkg.summary value="Supporting tools for the Hyper-V platform"
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Virtualization
+set name=variant.arch value=i386
+dir path=lib
+dir path=lib/svc
+dir path=lib/svc/manifest group=sys
+dir path=lib/svc/manifest/system group=sys
+dir path=lib/svc/manifest/system/hyperv group=sys
+dir path=usr group=sys
+dir path=usr/lib
+dir path=usr/lib/hyperv
+file path=lib/svc/manifest/system/hyperv/kvp.xml group=sys mode=0444
+file path=usr/lib/hyperv/hv_get_dhcp_info mode=0555
+file path=usr/lib/hyperv/hv_get_dns_info mode=0555
+file path=usr/lib/hyperv/hv_kvp_daemon mode=0555
+license lic_CDDL license=lic_CDDL
+depend fmri=driver/hyperv/pv type=require

--- a/usr/src/uts/intel/Makefile.files
+++ b/usr/src/uts/intel/Makefile.files
@@ -23,6 +23,7 @@
 # Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2018, Joyent, Inc.
 # Copyright 2018 Nexenta Systems, Inc.
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 
 #
@@ -418,6 +419,55 @@ VMXNET3S_OBJS =	vmxnet3_main.o \
 		vmxnet3_rx.o \
 		vmxnet3_tx.o \
 		vmxnet3_utils.o
+
+#
+# Hyper-V VMBUS virtual bus
+#
+HV_VMBUS_OBJS =	\
+	vmbus_ic.o \
+	vmbus.o \
+	vmbus_xact.o \
+	vmbus_br.o \
+	vmbus_chan.o
+
+#
+# Hyper-V HYPERV misc driver
+#
+HV_HYPERV_OBJS = \
+	hyperv_busdma.o \
+	hyperv.o \
+	hyperv_machdep.o
+
+#
+# Hyper-V NETVSC driver
+#
+HV_NETVSC_OBJS = \
+	hn_nvs.o \
+	hn_rndis.o \
+	if_hn.o \
+	hn_gld.o \
+	subr_bufring.o
+
+#
+# Hyper-V STORVSC driver
+#
+HV_STORVSC_OBJS = \
+	hv_storvsc_drv_illumos.o
+
+#
+# Hyper-V Utility drivers
+#
+HV_HEARTBEAT_OBJS = \
+	vmbus_heartbeat.o
+
+HV_KVP_OBJS = \
+	hv_kvp.o
+
+HV_SHUTDOWN_OBJS = \
+	vmbus_shutdown.o
+
+HV_TIMESYNC_OBJS = \
+	vmbus_timesync.o
 
 #
 # VMware PVSCSI SCSI Controller

--- a/usr/src/uts/intel/Makefile.intel
+++ b/usr/src/uts/intel/Makefile.intel
@@ -24,6 +24,7 @@
 # Copyright 2016 Joyent, Inc.
 # Copyright 2016 Garrett D'Amore <garrett@damore.org>
 # Copyright 2018 Nexenta Systems, Inc.
+# Copyright (c) 2014, 2017 by Delphix. All rights reserved.
 #
 
 #
@@ -381,6 +382,18 @@ DRV_KMODS	+= pppt
 DRV_KMODS	+= iptun
 DRV_KMODS	+= vmxnet3s
 DRV_KMODS	+= pvscsi
+
+#
+# HYPER-V driver
+#
+DRV_KMODS	+= hv_vmbus
+DRV_KMODS	+= hv_heartbeat
+DRV_KMODS	+= hv_timesync
+DRV_KMODS	+= hv_shutdown
+DRV_KMODS	+= hv_kvp
+DRV_KMODS	+= hv_storvsc
+DRV_KMODS	+= hv_netvsc
+MISC_KMODS	+= hyperv
 
 #
 # Common code drivers

--- a/usr/src/uts/intel/Makefile.rules
+++ b/usr/src/uts/intel/Makefile.rules
@@ -23,6 +23,7 @@
 # Use is subject to license terms.
 # Copyright 2018 Joyent, Inc.  All rights reserved.
 # Copyright 2017 Nexenta Systems, Inc.
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 
 #
@@ -231,6 +232,26 @@ $(OBJS_DIR)/%.o:		$(UTSBASE)/intel/io/vgatext/%.c
 	$(CTFCONVERT_O)
 
 $(OBJS_DIR)/%.o:		$(UTSBASE)/intel/io/vmxnet3s/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+$(OBJS_DIR)/%.o:		$(UTSBASE)/intel/io/hyperv/storvsc/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+$(OBJS_DIR)/%.o:		$(UTSBASE)/intel/io/hyperv/netvsc/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+$(OBJS_DIR)/%.o:		$(UTSBASE)/intel/io/hyperv/utilities/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+$(OBJS_DIR)/%.o:		$(UTSBASE)/intel/io/hyperv/vmbus/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+$(OBJS_DIR)/%.o:	$(UTSBASE)/intel/io/hyperv/vmbus/$(SUBARCH_DIR)/%.c
 	$(COMPILE.c) -o $@ $<
 	$(CTFCONVERT_O)
 
@@ -453,6 +474,21 @@ $(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/vgatext/%.c
 	@($(LHEAD) $(LINT.c) $< $(LTAIL))
 
 $(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/vmxnet3s/%.c
+	@($(LHEAD) $(LINT.c) $< $(LTAIL))
+
+$(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/hyperv/netvsc/%.c
+	@($(LHEAD) $(LINT.c) $< $(LTAIL))
+
+$(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/hyperv/storvsc/%.c
+	@($(LHEAD) $(LINT.c) $< $(LTAIL))
+
+$(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/hyperv/utilities/%.c
+	@($(LHEAD) $(LINT.c) $< $(LTAIL))
+
+$(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/hyperv/vmbus/%.c
+	@($(LHEAD) $(LINT.c) $< $(LTAIL))
+
+$(LINTS_DIR)/%.ln:	$(UTSBASE)/intel/io/hyperv/vmbus/$(SUBARCH_DIR)/%.c
 	@($(LHEAD) $(LINT.c) $< $(LTAIL))
 
 $(LINTS_DIR)/%.ln:		$(UTSBASE)/intel/io/scsi/adapters/pvscsi/%.c

--- a/usr/src/uts/intel/hv_heartbeat/Makefile
+++ b/usr/src/uts/intel/hv_heartbeat/Makefile
@@ -1,0 +1,80 @@
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE		= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= hv_heartbeat
+OBJECTS		= $(HV_HEARTBEAT_OBJS:%=$(OBJS_DIR)/%)
+LINTS		= $(HV_HEARTBEAT_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/intel/Makefile.intel
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+LINT_TARGET	= $(MODULE).lint
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+
+INC_PATH += -I$(UTSBASE)/intel/io/hyperv
+LDFLAGS += -dy -N misc/hyperv -N drv/hv_vmbus
+
+LINTTAGS += -erroff=E_STATIC_UNUSED
+
+#
+# lint pass one enforcement
+#
+CFLAGS += $(CCVERBOSE)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hv_kvp/Makefile
+++ b/usr/src/uts/intel/hv_kvp/Makefile
@@ -1,0 +1,81 @@
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE		= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= hv_kvp
+OBJECTS		= $(HV_KVP_OBJS:%=$(OBJS_DIR)/%)
+LINTS		= $(HV_KVP_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/intel/Makefile.intel
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+LINT_TARGET	= $(MODULE).lint
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+
+INC_PATH += -I$(UTSBASE)/intel/io/hyperv
+LDFLAGS += -dy -N misc/hyperv -N drv/hv_vmbus
+
+LINTTAGS += -erroff=E_BAD_PTR_CAST_ALIGN
+LINTTAGS += -erroff=E_EXPR_NULL_EFFECT
+
+#
+# lint pass one enforcement
+#
+CFLAGS += $(CCVERBOSE)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hv_netvsc/Makefile
+++ b/usr/src/uts/intel/hv_netvsc/Makefile
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+UTSBASE=	../..
+
+MODULE=		hv_netvsc
+OBJECTS=	$(HV_NETVSC_OBJS:%=$(OBJS_DIR)/%)
+LINTS=		$(HV_NETVSC_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE=	$(ROOT_DRV_DIR)/$(MODULE)
+CONF_SRCDIR=	$(UTSBASE)/intel/io/hyperv/netvsc
+
+include		$(UTSBASE)/intel/Makefile.intel
+
+ALL_TARGET=	$(BINARY) $(CONFMOD)
+LINT_TARGET=	$(MODULE).lint
+INSTALL_TARGET=	$(BINARY) $(ROOTMODULE) $(ROOT_CONFFILE)
+
+INC_PATH +=	-I$(UTSBASE)/intel/io/hyperv
+LDFLAGS	+=	-dy -N misc/hyperv -N drv/hv_vmbus -N misc/mac
+
+LINTTAGS +=	-erroff=E_BAD_PTR_CAST_ALIGN
+LINTTAGS +=	-erroff=E_CONSTANT_CONDITION
+LINTTAGS +=     -erroff=E_STATIC_UNUSED
+LINTTAGS +=     -erroff=E_ASSIGN_NARROW_CONV
+
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+def:		$(DEF_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+include		$(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hv_shutdown/Makefile
+++ b/usr/src/uts/intel/hv_shutdown/Makefile
@@ -1,0 +1,80 @@
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE		= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= hv_shutdown
+OBJECTS		= $(HV_SHUTDOWN_OBJS:%=$(OBJS_DIR)/%)
+LINTS		= $(HV_SHUTDOWN_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/intel/Makefile.intel
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+LINT_TARGET	= $(MODULE).lint
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+
+INC_PATH += -I$(UTSBASE)/intel/io/hyperv
+LDFLAGS += -dy -N misc/hyperv -N drv/hv_vmbus
+
+LINTTAGS += -erroff=E_STATIC_UNUSED
+
+#
+# lint pass one enforcement
+#
+CFLAGS += $(CCVERBOSE)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hv_storvsc/Makefile
+++ b/usr/src/uts/intel/hv_storvsc/Makefile
@@ -1,0 +1,81 @@
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE		= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= hv_storvsc
+OBJECTS		= $(HV_STORVSC_OBJS:%=$(OBJS_DIR)/%)
+LINTS		= $(HV_STORVSC_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/intel/Makefile.intel
+
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+LINT_TARGET	= $(MODULE).lint
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+
+INC_PATH += -I$(UTSBASE)/intel/io/hyperv
+
+#
+# lint pass one enforcement
+#
+CFLAGS += $(CCVERBOSE)
+LDFLAGS += -dy -N misc/scsi -N misc/hyperv -N drv/hv_vmbus
+
+LINTTAGS +=     -erroff=E_ASSIGN_NARROW_CONV
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hv_timesync/Makefile
+++ b/usr/src/uts/intel/hv_timesync/Makefile
@@ -1,0 +1,80 @@
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE		= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= hv_timesync
+OBJECTS		= $(HV_TIMESYNC_OBJS:%=$(OBJS_DIR)/%)
+LINTS		= $(HV_TIMESYNC_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/intel/Makefile.intel
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+LINT_TARGET	= $(MODULE).lint
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+
+INC_PATH += -I$(UTSBASE)/intel/io/hyperv
+LDFLAGS += -dy -N misc/hyperv -N drv/hv_vmbus
+
+LINTTAGS += -erroff=E_STATIC_UNUSED
+
+#
+# lint pass one enforcement
+#
+CFLAGS += $(CCVERBOSE)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hv_vmbus/Makefile
+++ b/usr/src/uts/intel/hv_vmbus/Makefile
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+UTSBASE=	../..
+
+MODULE=		hv_vmbus
+OBJECTS=	$(HV_VMBUS_OBJS:%=$(OBJS_DIR)/%)
+LINTS=		$(HV_VMBUS_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE=	$(ROOT_DRV_DIR)/$(MODULE)
+CONF_SRCDIR=	$(UTSBASE)/intel/io/hyperv/vmbus
+
+include		$(UTSBASE)/intel/Makefile.intel
+
+ALL_TARGET=	$(BINARY) $(CONFMOD)
+LINT_TARGET=	$(MODULE).lint
+INSTALL_TARGET=	$(BINARY) $(ROOTMODULE) $(ROOT_CONFFILE)
+
+INC_PATH +=	-I$(UTSBASE)/intel/io/hyperv
+INC_PATH +=	-I$(UTSBASE)/i86pc
+CPPFLAGS +=	-D_MACHDEP
+LDFLAGS	+=	-dy -N misc/hyperv
+
+C99MODE=	-xc99=%all
+C99LMODE=	-Xc99=%all
+
+LINTTAGS +=	-erroff=E_BAD_PTR_CAST_ALIGN
+LINTTAGS +=	-erroff=E_CONSTANT_CONDITION
+LINTTAGS +=	-erroff=E_STATIC_UNUSED
+LINTTAGS +=	-erroff=E_ASSIGN_NARROW_CONV
+
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+def:		$(DEF_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+include		$(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/hyperv/Makefile
+++ b/usr/src/uts/intel/hyperv/Makefile
@@ -1,0 +1,55 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+UTSBASE=	../..
+
+MODULE=		hyperv
+OBJECTS=	$(HV_HYPERV_OBJS:%=$(OBJS_DIR)/%)
+LINTS=		$(HV_HYPERV_OBJS:%.o=$(LINTS_DIR)/%.ln)
+ROOTMODULE=	$(ROOT_MISC_DIR)/$(MODULE)
+
+include		$(UTSBASE)/intel/Makefile.intel
+
+ALL_TARGET=	$(BINARY)
+LINT_TARGET=	$(MODULE).lint
+INSTALL_TARGET=	$(BINARY) $(ROOTMODULE)
+
+INC_PATH +=	-I$(UTSBASE)/intel/io/hyperv
+LDFLAGS	+=	-dy
+
+LINTTAGS +=	-erroff=E_BAD_PTR_CAST_ALIGN
+LINTTAGS +=	-erroff=E_CONSTANT_CONDITION
+LINTTAGS +=	-erroff=E_STATIC_UNUSED
+LINTTAGS +=	-erroff=E_FUNC_SET_NOT_USED
+
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+clean.lint:	$(CLEAN_LINT_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+def:		$(DEF_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+lint:		$(LINT_DEPS)
+
+modlintlib:	$(MODLINTLIB_DEPS)
+
+include		$(UTSBASE)/intel/Makefile.targ

--- a/usr/src/uts/intel/io/hyperv/netvsc/THIRDPARTYLICENSE
+++ b/usr/src/uts/intel/io/hyperv/netvsc/THIRDPARTYLICENSE
@@ -1,0 +1,66 @@
+Copyright (c) 2009-2012,2016 Microsoft Corp.
+Copyright (c) 2010-2012 Citrix Inc.
+Copyright (c) 2012 NetApp Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice unmodified, this list of conditions, and the following
+   disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 2010 Jonathan Armani <armani@openbsd.org>
+Copyright (c) 2010 Fabien Romano <fabien@openbsd.org>
+Copyright (c) 2010 Michael Knudsen <mk@openbsd.org>
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Copyright (c) 2007, 2008 Kip Macy <kmacy@freebsd.org>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/usr/src/uts/intel/io/hyperv/netvsc/THIRDPARTYLICENSE.descrip
+++ b/usr/src/uts/intel/io/hyperv/netvsc/THIRDPARTYLICENSE.descrip
@@ -1,0 +1,1 @@
+Microsoft NetVSC driver

--- a/usr/src/uts/intel/io/hyperv/netvsc/buf_ring.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/buf_ring.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2007-2009 Kip Macy <kmacy@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ *
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef	_SYS_BUF_RING_H_
+#define	_SYS_BUF_RING_H_
+
+#include <sys/hyperv_illumos.h>
+#include <sys/errno.h>
+#include <sys/atomic.h>
+#include <sys/debug.h>
+#include <sys/cpuvar.h>
+#include <sys/disp.h>
+#include <sys/cpu.h>
+
+#ifdef DEBUG_BUFRING
+#include <sys/mutex.h>
+#endif
+
+struct buf_ring {
+	volatile uint32_t	br_prod_head;
+	volatile uint32_t	br_prod_tail;
+	int			br_prod_size;
+	int			br_prod_mask;
+	uint64_t		br_drops;
+	volatile uint32_t	br_cons_head __aligned(CACHE_LINE_SIZE);
+	volatile uint32_t	br_cons_tail;
+	int			br_cons_size;
+	int			br_cons_mask;
+#ifdef DEBUG_BUFRING
+	kmutex_t		*br_lock;
+#endif
+	void			*br_ring[] __aligned(CACHE_LINE_SIZE);
+};
+
+static inline boolean_t
+buf_ring_full(struct buf_ring *br)
+{
+	return (((br->br_prod_head + 1) & br->br_prod_mask) ==
+	    br->br_cons_tail);
+}
+
+static inline boolean_t
+buf_ring_empty(struct buf_ring *br)
+{
+	return (br->br_cons_head == br->br_prod_tail);
+}
+
+static inline int
+buf_ring_count(struct buf_ring *br)
+{
+	return ((br->br_prod_size + br->br_prod_tail - br->br_cons_tail)
+	    & br->br_prod_mask);
+}
+
+struct buf_ring *buf_ring_alloc(int count, int flags, kmutex_t *lock);
+void buf_ring_free(struct buf_ring *br);
+int buf_ring_enqueue(struct buf_ring *br, void *buf);
+void *buf_ring_dequeue_mc(struct buf_ring *br);
+void *buf_ring_dequeue_sc(struct buf_ring *br);
+
+
+#endif /* _SYS_BUF_RING_H_ */

--- a/usr/src/uts/intel/io/hyperv/netvsc/hn_gld.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hn_gld.c
@@ -1,0 +1,827 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ * Generic Lan Driver interface for netvsc.
+ */
+
+#include <sys/sysmacros.h>
+#include <sys/debug.h>
+#include <sys/mac_provider.h>
+#include <sys/mac_ether.h>
+#include <inet/ip.h>
+#include <sys/vlan.h>
+
+#include "if_hnvar.h"
+#include "hn_rndis.h"
+#include "if_hnreg.h"
+#include "hn_nvs.h"
+
+static mblk_t		*hn_tx_ring_send(void *, mblk_t *);
+static int		hn_m_getstat(void *, uint_t, uint64_t *);
+static int		hn_m_start(void *);
+static void		hn_m_stop(void *);
+static int		hn_m_setpromisc(void *, boolean_t);
+static int		hn_m_multicst(void *, boolean_t, const uint8_t *);
+static boolean_t	hn_m_getcapab(void *, mac_capab_t, void *);
+static int		hn_m_getprop(void *, const char *, mac_prop_id_t,
+			    uint_t, void *);
+static int		hn_m_setprop(void *, const char *, mac_prop_id_t,
+			    uint_t, const void *);
+static void		hn_m_propinfo(void *, const char *, mac_prop_id_t,
+			    mac_prop_info_handle_t);
+
+/* Read-only properties */
+#define	HN_PROP_NVS_VERSION		"_nvs_version"
+#define	HN_PROP_NDIS_VERSION		"_ndis_version"
+#define	HN_PROP_HOST_CAPABILITIES	"_host_capabilities"
+#define	HN_PROP_RX_RINGS_USED		"_rx_rings_used"
+#define	HN_PROP_RX_RINGS		"_rx_rings"
+#define	HN_PROP_TX_RINGS_USED		"_tx_rings_used"
+#define	HN_PROP_TX_RINGS		"_tx_rings"
+#define	HN_PROP_TX_CHIM_MAXSIZE		"_tx_chimney_maxsize"
+
+/* Writeable properties */
+#define	HN_PROP_TRUST_HOST_CKSUM	"_trust_host_cksum"
+#define	HN_PROP_TX_CHIM_SIZE		"_tx_chimney_size"
+
+char *hn_priv_props[] = {
+	HN_PROP_NVS_VERSION,
+	HN_PROP_NDIS_VERSION,
+	HN_PROP_HOST_CAPABILITIES,
+	HN_PROP_RX_RINGS_USED,
+	HN_PROP_RX_RINGS,
+	HN_PROP_TX_RINGS_USED,
+	HN_PROP_TX_RINGS,
+	HN_PROP_TX_CHIM_MAXSIZE,
+	HN_PROP_TRUST_HOST_CKSUM,
+	HN_PROP_TX_CHIM_SIZE,
+	NULL
+};
+
+#define	HN_M_CALLBACK_FLAGS \
+	(MC_GETCAPAB | MC_PROPERTIES)
+
+/* MAC callbacks */
+static mac_callbacks_t hn_mac_callbacks = {
+	.mc_callbacks =	HN_M_CALLBACK_FLAGS,
+	.mc_getstat =	hn_m_getstat,
+	.mc_start =	hn_m_start,
+	.mc_stop =	hn_m_stop,
+	.mc_setpromisc = hn_m_setpromisc,
+	.mc_multicst =	hn_m_multicst,
+	.mc_unicst =	NULL,
+	.mc_tx =	NULL,
+	.mc_ioctl =	NULL,
+	.mc_getcapab =	hn_m_getcapab,
+	.mc_getprop =	hn_m_getprop,
+	.mc_setprop =	hn_m_setprop,
+	.mc_propinfo =	hn_m_propinfo
+};
+
+extern int hn_tso_maxlen;
+
+int
+hn_get_priv_prop(struct hn_softc *sc, const char *prop_name,
+    uint_t prop_val_size, void *prop_val)
+{
+	int value;
+
+	HN_LOCK(sc);
+
+	/*
+	 * Note: private prop values are always passed as strings
+	 */
+	if (strcmp(prop_name, HN_PROP_NVS_VERSION) == 0) {
+		(void) snprintf(prop_val, prop_val_size, "0x%x",
+		    sc->hn_nvs_ver);
+		goto done;
+	} else if (strcmp(prop_name, HN_PROP_NDIS_VERSION) == 0) {
+		(void) snprintf(prop_val, prop_val_size, "%u.%u",
+		    HN_NDIS_VERSION_MAJOR(sc->hn_ndis_ver),
+		    HN_NDIS_VERSION_MINOR(sc->hn_ndis_ver));
+		goto done;
+	} else if (strcmp(prop_name, HN_PROP_HOST_CAPABILITIES) == 0) {
+		uint32_t caps = sc->hn_caps;
+		(void) snprintf(prop_val, prop_val_size, "%s%s%s%s%s%s%s%s%s",
+		    (caps & HN_CAP_VLAN) ?	"VLAN " : "",
+		    (caps & HN_CAP_MTU) ?	"MTU " : "",
+		    (caps & HN_CAP_IPCS) ?	"IPCS " : "",
+		    (caps & HN_CAP_TCP4CS) ?	"TCP4CS " : "",
+		    (caps & HN_CAP_TCP6CS) ?	"TCP6CS " : "",
+		    (caps & HN_CAP_UDP4CS) ?	"UDP4CS " : "",
+		    (caps & HN_CAP_UDP6CS) ?	"UDP6CS " : "",
+		    (caps & HN_CAP_TSO4) ?	"TSO4 " : "",
+		    (caps & HN_CAP_TSO6) ?	"TSO6 " : "");
+		goto done;
+	} else if (strcmp(prop_name, HN_PROP_RX_RINGS_USED) == 0) {
+		value = sc->hn_rx_ring_inuse;
+	} else if (strcmp(prop_name, HN_PROP_RX_RINGS) == 0) {
+		value = sc->hn_rx_ring_cnt;
+	} else if (strcmp(prop_name, HN_PROP_TX_RINGS_USED) == 0) {
+		value = sc->hn_tx_ring_inuse;
+	} else if (strcmp(prop_name, HN_PROP_TX_RINGS) == 0) {
+		value = sc->hn_tx_ring_cnt;
+	} else if (strcmp(prop_name, HN_PROP_TX_CHIM_MAXSIZE) == 0) {
+		value = sc->hn_chim_szmax;
+	} else if (strcmp(prop_name, HN_PROP_TX_CHIM_SIZE) == 0) {
+		value = sc->hn_tx_ring[0].hn_chim_size;
+	} else if (strcmp(prop_name, HN_PROP_TRUST_HOST_CKSUM) == 0) {
+		value = (sc->hn_rx_ring[0].hn_trust_hcsum == 0) ? 0 : 1;
+	} else {
+		HN_UNLOCK(sc);
+		return (ENOTSUP);
+	}
+
+	(void) snprintf(prop_val, prop_val_size, "%d", value);
+done:
+	HN_UNLOCK(sc);
+	return (0);
+}
+
+static int
+hn_m_getprop(void *data, const char *prop_name, mac_prop_id_t prop_id,
+    uint_t prop_val_size, void *prop_val)
+{
+	struct hn_softc *sc = data;
+	int error = 0;
+
+	switch (prop_id) {
+	case MAC_PROP_MTU:
+		ASSERT(prop_val_size >= sizeof (uint32_t));
+		bcopy(&sc->hn_mtu, prop_val, sizeof (uint32_t));
+		break;
+	case MAC_PROP_PRIVATE:
+		error = hn_get_priv_prop(sc, prop_name, prop_val_size,
+		    prop_val);
+		break;
+	default:
+		HN_WARN(sc, "hn_get_prop property %d not supported", prop_id);
+		error = ENOTSUP;
+	}
+	return (error);
+}
+
+/*ARGSUSED*/
+int
+hn_set_priv_prop(struct hn_softc *sc, const char *prop_name,
+    uint_t prop_val_size, const void *prop_val)
+{
+	long value = -1;
+	int error = 0;
+
+	HN_DEBUG(sc, 2, "Setting private property %s to %s",
+	    prop_name, (const char *)prop_val);
+	/*
+	 * Note: private prop values are always passed as strings
+	 */
+	if (strcmp(prop_name, HN_PROP_TRUST_HOST_CKSUM) == 0) {
+		(void) ddi_strtol(prop_val, (char **)NULL, 0, &value);
+		if (value == 0 || value == 1) {
+			int hcsum = (value == 1) ? HN_TRUST_HCSUM_ALL : 0;
+			HN_LOCK(sc);
+			for (int i = 0; i < sc->hn_rx_ring_inuse; ++i) {
+				struct hn_rx_ring *rxr = &sc->hn_rx_ring[i];
+				rxr->hn_trust_hcsum = hcsum;
+			}
+			HN_UNLOCK(sc);
+			return (0);
+		} else {
+			error = EINVAL;
+		}
+	} else if (strcmp(prop_name, HN_PROP_TX_CHIM_SIZE) == 0) {
+		(void) ddi_strtol(prop_val, (char **)NULL, 0, &value);
+		if (value >= 0 && value <= sc->hn_chim_szmax) {
+			HN_LOCK(sc);
+			hn_set_chim_size(sc, value);
+			HN_UNLOCK(sc);
+			return (0);
+		} else {
+			error = EINVAL;
+		}
+	} else {
+		HN_DEBUG(sc, 2, "Unknown private property");
+		error = EINVAL;
+	}
+
+	return (error);
+}
+
+/*ARGSUSED*/
+static int
+hn_m_setprop(void *data, const char *prop_name, mac_prop_id_t prop_id,
+    uint_t prop_val_size, const void *prop_val)
+{
+	struct hn_softc *sc = data;
+	uint32_t new_mtu;
+	int error;
+
+	switch (prop_id) {
+	case MAC_PROP_MTU:
+		ASSERT(prop_val_size >= sizeof (uint32_t));
+		bcopy(prop_val, &new_mtu, sizeof (new_mtu));
+		error = hn_change_mtu(sc, new_mtu);
+		break;
+	case MAC_PROP_PRIVATE:
+		error = hn_set_priv_prop(sc, prop_name, prop_val_size,
+		    prop_val);
+		break;
+	default:
+		HN_WARN(sc, "hn_set_prop property %d not supported", prop_id);
+		error = ENOTSUP;
+	}
+
+	return (error);
+}
+
+void
+hn_priv_prop_info(struct hn_softc *sc, const char *prop_name,
+    mac_prop_info_handle_t prh)
+{
+	char valstr[64];
+	int value;
+
+	/*
+	 * Note: private prop values are always passed as strings
+	 */
+	if (strcmp(prop_name, HN_PROP_NVS_VERSION) == 0 ||
+	    strcmp(prop_name, HN_PROP_NDIS_VERSION) == 0 ||
+	    strcmp(prop_name, HN_PROP_HOST_CAPABILITIES) == 0 ||
+	    strcmp(prop_name, HN_PROP_RX_RINGS_USED) == 0 ||
+	    strcmp(prop_name, HN_PROP_RX_RINGS) == 0 ||
+	    strcmp(prop_name, HN_PROP_TX_RINGS_USED) == 0 ||
+	    strcmp(prop_name, HN_PROP_TX_RINGS) == 0 ||
+	    strcmp(prop_name, HN_PROP_TX_CHIM_MAXSIZE) == 0) {
+		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);
+		return;
+	} else if (strcmp(prop_name, HN_PROP_TRUST_HOST_CKSUM) == 0) {
+		value = HN_DEFAULT_TRUST_HOST_CKSUM;
+	} else if (strcmp(prop_name, HN_PROP_TX_CHIM_SIZE) == 0) {
+		value = sc->hn_chim_szmax;
+	} else {
+		return;
+	}
+
+	(void) snprintf(valstr, sizeof (valstr), "%d", value);
+	mac_prop_info_set_default_str(prh, valstr);
+}
+
+/*ARGSUSED*/
+static void
+hn_m_propinfo(void *data, const char *prop_name, mac_prop_id_t prop_id,
+    mac_prop_info_handle_t prop_handle)
+{
+	struct hn_softc *sc = data;
+
+	switch (prop_id) {
+	case MAC_PROP_MTU:
+		mac_prop_info_set_range_uint32(prop_handle, 0, HN_MTU_MAX);
+		break;
+	case MAC_PROP_PRIVATE:
+		hn_priv_prop_info(sc, prop_name, prop_handle);
+		break;
+	default:
+		HN_WARN(sc, "hn_prop_info: property %d not supported", prop_id);
+	}
+}
+
+static void
+hn_get_rx_stat(struct hn_softc *sc, uint_t stat, uint64_t *val)
+{
+	uint64_t counter = 0;
+
+	for (int i = 0; i < sc->hn_rx_ring_cnt; i++) {
+		struct hn_rx_ring *rxr = &sc->hn_rx_ring[i];
+		hn_rx_stats_t *stats = &rxr->hn_rx_stats;
+
+		mutex_enter(&rxr->hn_rx_lock);
+		switch (stat) {
+		case MAC_STAT_MULTIRCV:
+			counter += stats->mcast_pkts;
+			break;
+		case MAC_STAT_BRDCSTRCV:
+			counter += stats->bcast_pkts;
+			break;
+		case MAC_STAT_NORCVBUF:
+			counter += stats->norxbufs;
+			break;
+		case MAC_STAT_IERRORS:
+			counter += stats->ierrors;
+			break;
+		case MAC_STAT_RBYTES:
+			counter += stats->bytes;
+			break;
+		case MAC_STAT_IPACKETS:
+			counter += stats->pkts;
+			break;
+		default:
+			/* can only happen if bug in hn_m_getstat */
+			ASSERT(0);
+		}
+		mutex_exit(&rxr->hn_rx_lock);
+	}
+	*val = counter;
+}
+
+static void
+hn_get_tx_stat(struct hn_softc *sc, uint_t stat, uint64_t *val)
+{
+	uint64_t counter = 0;
+
+	for (int i = 0; i < sc->hn_tx_ring_cnt; i++) {
+		struct hn_tx_ring *txr = &sc->hn_tx_ring[i];
+		hn_tx_stats_t *stats = &txr->hn_tx_stats;
+
+		mutex_enter(&txr->hn_tx_lock);
+		switch (stat) {
+		case MAC_STAT_MULTIXMT:
+			counter += stats->mcast_pkts;
+			break;
+		case MAC_STAT_BRDCSTXMT:
+			counter += stats->bcast_pkts;
+			break;
+		case MAC_STAT_NOXMTBUF:
+			counter += stats->no_txdescs;
+			break;
+		case MAC_STAT_OERRORS:
+			counter += stats->send_failed + stats->dma_failed;
+			break;
+		case MAC_STAT_OBYTES:
+			counter += stats->bytes;
+			break;
+		case MAC_STAT_OPACKETS:
+			counter += stats->pkts;
+			break;
+		default:
+			/* can only happen if bug in hn_m_getstat */
+			ASSERT(0);
+		}
+		mutex_exit(&txr->hn_tx_lock);
+	}
+	*val = counter;
+}
+
+static int
+hn_m_getstat(void *data, uint_t stat, uint64_t *val)
+{
+	struct hn_softc *sc = data;
+
+	HN_DEBUG(sc, 3, "getstat(%u)", stat);
+
+	switch (stat) {
+	case MAC_STAT_MULTIRCV:
+	case MAC_STAT_BRDCSTRCV:
+	case MAC_STAT_NORCVBUF:
+	case MAC_STAT_IERRORS:
+	case MAC_STAT_RBYTES:
+	case MAC_STAT_IPACKETS:
+		hn_get_rx_stat(sc, stat, val);
+		break;
+
+	case MAC_STAT_MULTIXMT:
+	case MAC_STAT_BRDCSTXMT:
+	case MAC_STAT_NOXMTBUF:
+	case MAC_STAT_OERRORS:
+	case MAC_STAT_OBYTES:
+	case MAC_STAT_OPACKETS:
+		hn_get_tx_stat(sc, stat, val);
+		break;
+
+	case MAC_STAT_IFSPEED:
+		return (ENOTSUP);
+
+	case MAC_STAT_COLLISIONS:
+		*val = 0;
+		break;
+
+	case ETHER_STAT_LINK_DUPLEX:
+		*val = LINK_DUPLEX_FULL;
+		break;
+
+	default:
+		return (ENOTSUP);
+	}
+
+	return (0);
+}
+
+/*
+ * Retrieve a value for one of the statistics for a particular rx ring
+ */
+int
+hn_rx_ring_stat(mac_ring_driver_t rh, uint_t stat, uint64_t *val)
+{
+	struct hn_rx_ring *rxr = (struct hn_rx_ring *)rh;
+	hn_rx_stats_t *stats = &rxr->hn_rx_stats;
+	int error = 0;
+
+	mutex_enter(&rxr->hn_rx_lock);
+
+	switch (stat) {
+	case MAC_STAT_RBYTES:
+		*val = stats->bytes;
+		break;
+
+	case MAC_STAT_IPACKETS:
+		*val = stats->pkts;
+		break;
+
+	case MAC_STAT_IERRORS:
+		*val = stats->ierrors;
+		break;
+
+	default:
+		*val = 0;
+		error = ENOTSUP;
+	}
+
+	mutex_exit(&rxr->hn_rx_lock);
+
+	return (error);
+}
+
+/*
+ * Retrieve a value for one of the statistics for a particular tx ring
+ */
+int
+hn_tx_ring_stat(mac_ring_driver_t rh, uint_t stat, uint64_t *val)
+{
+	struct hn_tx_ring *txr = (struct hn_tx_ring *)rh;
+	hn_tx_stats_t *stats = &txr->hn_tx_stats;
+	int error = 0;
+
+	mutex_enter(&txr->hn_tx_lock);
+
+	switch (stat) {
+	case MAC_STAT_OBYTES:
+		*val = stats->bytes;
+		break;
+
+	case MAC_STAT_OPACKETS:
+		*val = stats->pkts;
+		break;
+
+	case MAC_STAT_OERRORS:
+		*val = stats->send_failed + stats->dma_failed;
+		break;
+
+	default:
+		*val = 0;
+		error = ENOTSUP;
+	}
+
+	mutex_exit(&txr->hn_tx_lock);
+
+	return (error);
+}
+
+int
+hn_m_start(void *data)
+{
+	struct hn_softc *sc = data;
+
+	HN_DEBUG(sc, 1, "start()");
+
+	hn_init(sc);
+
+	return (0);
+}
+
+void
+hn_m_stop(void *data)
+{
+	struct hn_softc *sc = data;
+
+	HN_DEBUG(sc, 1, "stop()");
+
+	HN_LOCK(sc);
+	hn_stop(sc);
+	HN_UNLOCK(sc);
+}
+
+/*
+ * Set the MAC address for the device.
+ */
+static int
+hn_addmac(void *arg, const uint8_t *mac_addr)
+{
+	hn_rx_group_t *rx_group = arg;
+	struct hn_softc *sc = rx_group->sc;
+
+	HN_DEBUG(sc, 2, "addmac("MACADDR_FMT_PRETTY")",
+	    MACADDR_FMT_ARGS(mac_addr));
+
+	if (sc->hn_mac_addr_set) {
+		HN_WARN(sc, "hn_addmac: MAC address already set");
+		return (ENOSPC);
+	}
+
+	/* check if device is already configured with this MAC address */
+	if (memcmp(mac_addr, sc->hn_macaddr, ETHERADDRL) != 0) {
+		if (hn_rndis_set_eaddr(sc, mac_addr) != 0)
+			return (EIO);
+		bcopy(mac_addr, sc->hn_macaddr, ETHERADDRL);
+	}
+
+	sc->hn_mac_addr_set = B_TRUE;
+
+	return (0);
+}
+
+/*
+ * Do nothing as the netvsc device only supports one MAC address.
+ */
+/*ARGSUSED*/
+static int
+hn_remmac(void *arg, const uint8_t *mac_addr)
+{
+	hn_rx_group_t *rx_group = arg;
+	struct hn_softc *sc = rx_group->sc;
+
+	HN_DEBUG(sc, 2, "remmac("MACADDR_FMT_PRETTY")",
+	    MACADDR_FMT_ARGS(mac_addr));
+
+	sc->hn_mac_addr_set = B_FALSE;
+
+	return (0);
+}
+
+/*ARGSUSED*/
+static int
+hn_m_multicst(void *data, boolean_t add, const uint8_t *macaddr)
+{
+	struct hn_softc *sc = data;
+
+	HN_DEBUG(sc, 2, "multicast(%s, "MACADDR_FMT_PRETTY")",
+	    add ? "add" : "remove", MACADDR_FMT_ARGS(macaddr));
+
+	/*
+	 * Multicast address filtering is not currently supported.
+	 * We accept all multicast addresses.
+	 */
+
+	return (0);
+}
+
+/*
+ * Set the promiscuity of the device.
+ */
+int
+hn_m_setpromisc(void *data, boolean_t promisc)
+{
+	struct hn_softc *sc = data;
+
+	HN_LOCK(sc);
+	HN_DEBUG(sc, 2, "setpromisc(%s)", promisc ? "TRUE" : "FALSE");
+	sc->hn_promiscuous = promisc;
+
+	(void) hn_set_rxfilter(sc);
+	HN_UNLOCK(sc);
+
+	return (0);
+}
+
+/*ARGSUSED*/
+static int
+hn_rx_ring_intr_enable(mac_intr_handle_t intrh)
+{
+	return (ENOTSUP);
+}
+
+/*ARGSUSED*/
+static int
+hn_rx_ring_intr_disable(mac_intr_handle_t intrh)
+{
+	return (ENOTSUP);
+}
+
+/*ARGSUSED*/
+mblk_t *
+hn_rx_ring_poll(void *arg, int bytes)
+{
+	/*
+	 * Polled mode is currently not implemented, however we must still
+	 * provide a function to the framework.
+	 */
+	return (NULL);
+}
+
+static int
+hn_rx_ring_start(mac_ring_driver_t rh, uint64_t mr_gen_num)
+{
+	struct hn_rx_ring *rxr = (struct hn_rx_ring *)rh;
+
+	mutex_enter(&rxr->hn_rx_lock);
+	rxr->hn_ring_gen_num = mr_gen_num;
+	mutex_exit(&rxr->hn_rx_lock);
+	return (0);
+}
+
+static mblk_t *
+hn_tx_ring_send(void *arg, mblk_t *mp)
+{
+	struct hn_tx_ring *txr = arg;
+
+	mutex_enter(&txr->hn_tx_lock);
+	mblk_t *mps_left = hn_xmit(txr, mp);
+	mutex_exit(&txr->hn_tx_lock);
+
+	return (mps_left);
+}
+
+/*
+ * Callback function for MAC layer to register all rings.
+ */
+/* ARGSUSED */
+static void
+hn_fill_ring(void *arg, mac_ring_type_t rtype, const int rg_index,
+    const int index, mac_ring_info_t *infop, mac_ring_handle_t rh)
+{
+	struct hn_softc *sc = arg;
+	mac_intr_t *mintr = &infop->mri_intr;
+
+	switch (rtype) {
+	case MAC_RING_TYPE_RX: {
+		ASSERT(index < sc->hn_rx_ring_cnt);
+
+		struct hn_rx_ring *rxr = &sc->hn_rx_ring[index];
+
+		rxr->hn_ring_handle = rh;
+
+		infop->mri_driver = (mac_ring_driver_t)rxr;
+		infop->mri_start = hn_rx_ring_start;
+		infop->mri_stop = NULL;
+		infop->mri_poll = (mac_ring_poll_t)hn_rx_ring_poll;
+		infop->mri_stat = hn_rx_ring_stat;
+
+		mintr->mi_handle = (mac_intr_handle_t)rxr;
+		mintr->mi_enable = hn_rx_ring_intr_enable;
+		mintr->mi_disable = hn_rx_ring_intr_disable;
+		mintr->mi_ddi_handle = NULL;
+		break;
+	}
+	case MAC_RING_TYPE_TX: {
+		ASSERT(index < sc->hn_tx_ring_cnt);
+
+		struct hn_tx_ring *txr = &sc->hn_tx_ring[index];
+
+		txr->hn_ring_handle = rh;
+
+		infop->mri_driver = (mac_ring_driver_t)txr;
+		infop->mri_start = NULL;
+		infop->mri_stop = NULL;
+		infop->mri_tx = hn_tx_ring_send;
+		infop->mri_stat = hn_tx_ring_stat;
+		mintr->mi_ddi_handle = NULL;
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static void
+hn_fill_group(void *arg, mac_ring_type_t rtype, const int index,
+    mac_group_info_t *infop, mac_group_handle_t gh)
+{
+	struct hn_softc *sc = arg;
+
+	switch (rtype) {
+	case MAC_RING_TYPE_RX: {
+		hn_rx_group_t *rx_group = &sc->hn_rx_group;
+
+		ASSERT0(index);
+
+		rx_group->group_handle = gh;
+		rx_group->index = index;
+		rx_group->sc = sc;
+
+		infop->mgi_driver = (mac_group_driver_t)rx_group;
+		infop->mgi_start = NULL;
+		infop->mgi_stop = NULL;
+		infop->mgi_addmac = hn_addmac;
+		infop->mgi_remmac = hn_remmac;
+		infop->mgi_count = sc->hn_rx_ring_inuse;
+
+		break;
+	}
+	case MAC_RING_TYPE_TX:
+		break;
+	default:
+		break;
+	}
+}
+
+static boolean_t
+hn_m_getcapab(void *data, mac_capab_t cap, void *cap_data)
+{
+	struct hn_softc *sc = data;
+
+	switch (cap) {
+	case MAC_CAPAB_HCKSUM: {
+		uint32_t *tx_hcksum_flags = cap_data;
+
+		/*
+		 * We advertise our capabilities only if tx hcksum offload is
+		 * enabled.  On receive, the stack will accept checksummed
+		 * packets anyway, even if we haven't said we can deliver
+		 * them.
+		 */
+
+		*tx_hcksum_flags = sc->hn_hcksum_flags;
+		break;
+	}
+	case MAC_CAPAB_LSO: {
+		mac_capab_lso_t *cap_lso = cap_data;
+
+		if ((sc->hn_lso_flags & LSO_TX_BASIC_TCP_IPV4) == 0)
+			return (B_FALSE);
+
+		int tso_maxlen = hn_tso_maxlen;
+		if (tso_maxlen <= 0 || tso_maxlen > IP_MAXPACKET)
+			tso_maxlen = IP_MAXPACKET;
+		tso_maxlen = MIN(tso_maxlen, sc->hn_ndis_tso_szmax);
+		cap_lso->lso_flags = LSO_TX_BASIC_TCP_IPV4;
+		cap_lso->lso_basic_tcp_ipv4.lso_max = tso_maxlen;
+		break;
+	}
+	case MAC_CAPAB_RINGS: {
+		mac_capab_rings_t *cap_rings = cap_data;
+
+		switch (cap_rings->mr_type) {
+		case MAC_RING_TYPE_RX:
+			cap_rings->mr_group_type = MAC_GROUP_TYPE_STATIC;
+			cap_rings->mr_rnum = sc->hn_rx_ring_inuse;
+			cap_rings->mr_gnum = 1;
+			cap_rings->mr_rget = hn_fill_ring;
+			cap_rings->mr_gget = hn_fill_group;
+			cap_rings->mr_gaddring = NULL;
+			cap_rings->mr_gremring = NULL;
+
+			break;
+		case MAC_RING_TYPE_TX:
+			cap_rings->mr_group_type = MAC_GROUP_TYPE_STATIC;
+			cap_rings->mr_rnum = sc->hn_tx_ring_inuse;
+			cap_rings->mr_gnum = 0;
+			cap_rings->mr_rget = hn_fill_ring;
+			cap_rings->mr_gget = NULL;
+
+			break;
+		default:
+			break;
+		}
+		break;
+	}
+
+	default:
+		return (B_FALSE);
+	}
+	return (B_TRUE);
+}
+
+int
+hn_register_mac(struct hn_softc *sc)
+{
+	int error;
+	mac_register_t *mac;
+
+	/*
+	 * Get MAC address of adapter
+	 */
+	error = hn_rndis_get_eaddr(sc, sc->hn_macaddr);
+	if (error != 0) {
+		HN_WARN(sc, "Failed to retrieve MAC address");
+		return (error);
+	}
+
+	if ((mac = mac_alloc(MAC_VERSION)) == NULL)
+		return (EINVAL);
+
+	mac->m_type_ident = MAC_PLUGIN_IDENT_ETHER;
+	mac->m_driver = sc;
+	mac->m_dip = sc->hn_dev;
+	mac->m_src_addr = sc->hn_macaddr;
+	mac->m_callbacks = &hn_mac_callbacks;
+	mac->m_min_sdu = HN_MTU_MIN;
+	mac->m_max_sdu = sc->hn_mtu;
+	mac->m_margin = VLAN_TAGSZ;
+	mac->m_priv_props = hn_priv_props;
+	mac->m_v12n = MAC_VIRT_LEVEL1;
+
+	error = mac_register(mac, &sc->hn_mac_hdl);
+	mac_free(mac);
+
+	return (error);
+}

--- a/usr/src/uts/intel/io/hyperv/netvsc/hn_nvs.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hn_nvs.c
@@ -1,0 +1,727 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2010-2012 Citrix Inc.
+ * Copyright (c) 2012 NetApp Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ * Network Virtualization Service.
+ */
+
+#include <sys/sysmacros.h>
+#include <sys/kmem.h>
+#include <sys/debug.h>
+#include <sys/bitmap.h>
+#include <sys/atomic.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/ddi.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include <sys/vmbus_xact.h>
+
+#include "if_hnvar.h"
+#include "hn_rndis.h"
+#include "if_hnreg.h"
+#include "hn_nvs.h"
+
+static int			hn_nvs_conn_chim(struct hn_softc *);
+static int			hn_nvs_conn_rxbuf(struct hn_softc *);
+static void			hn_nvs_disconn_chim(struct hn_softc *);
+static void			hn_nvs_disconn_rxbuf(struct hn_softc *);
+static int			hn_nvs_conf_ndis(struct hn_softc *, int);
+static int			hn_nvs_init_ndis(struct hn_softc *);
+static int			hn_nvs_doinit(struct hn_softc *, uint32_t);
+static int			hn_nvs_init(struct hn_softc *);
+static const void		*hn_nvs_xact_execute(struct hn_softc *,
+				    struct vmbus_xact *, void *, int,
+				    size_t *, uint32_t);
+static void			hn_nvs_sent_none(struct hn_nvs_sendctx *,
+				    struct hn_softc *, struct vmbus_channel *,
+				    const void *, int);
+
+struct hn_nvs_sendctx		hn_nvs_sendctx_none =
+    HN_NVS_SENDCTX_INITIALIZER(hn_nvs_sent_none, NULL);
+
+static const uint32_t		hn_nvs_version[] = {
+	HN_NVS_VERSION_5,
+	HN_NVS_VERSION_4,
+	HN_NVS_VERSION_2,
+	HN_NVS_VERSION_1
+};
+
+static const void *
+hn_nvs_xact_execute(struct hn_softc *sc, struct vmbus_xact *xact,
+    void *req, int reqlen, size_t *resplen0, uint32_t type)
+{
+	struct hn_nvs_sendctx sndc;
+	size_t resplen, min_resplen = *resplen0;
+	const struct hn_nvs_hdr *hdr;
+	int error;
+
+	ASSERT3U(min_resplen, >=, sizeof (*hdr));
+
+	/*
+	 * Execute the xact setup by the caller.
+	 */
+	hn_nvs_sendctx_init(&sndc, hn_nvs_sent_xact, xact);
+
+	vmbus_xact_activate(xact);
+	error = hn_nvs_send(sc->hn_prichan, VMBUS_CHANPKT_FLAG_RC,
+	    req, reqlen, &sndc);
+	if (error) {
+		vmbus_xact_deactivate(xact);
+		return (NULL);
+	}
+	hdr = vmbus_chan_xact_wait(sc->hn_prichan, xact, &resplen,
+	    B_TRUE);
+
+	/*
+	 * Check this NVS response message.
+	 */
+	if (resplen < min_resplen) {
+		HN_WARN(sc, "invalid NVS resp len %lu", resplen);
+		return (NULL);
+	}
+	if (hdr->nvs_type != type) {
+		HN_WARN(sc, "unexpected NVS resp 0x%08x, expect 0x%08x",
+		    hdr->nvs_type, type);
+		return (NULL);
+	}
+	/* All pass! */
+	*resplen0 = resplen;
+	return (hdr);
+}
+
+static inline int
+hn_nvs_req_send(struct hn_softc *sc, void *req, int reqlen)
+{
+
+	return (hn_nvs_send(sc->hn_prichan, VMBUS_CHANPKT_FLAG_NONE,
+	    req, reqlen, &hn_nvs_sendctx_none));
+}
+
+static int
+hn_nvs_conn_rxbuf(struct hn_softc *sc)
+{
+	struct vmbus_xact *xact = NULL;
+	struct hn_nvs_rxbuf_conn *conn;
+	const struct hn_nvs_rxbuf_connresp *resp;
+	size_t resp_len;
+	uint32_t status;
+	int error, rxbuf_size;
+
+	/*
+	 * Limit RXBUF size for old NVS.
+	 */
+	if (sc->hn_nvs_ver <= HN_NVS_VERSION_2)
+		rxbuf_size = HN_RXBUF_SIZE_COMPAT;
+	else
+		rxbuf_size = HN_RXBUF_SIZE;
+
+	/*
+	 * Connect the RXBUF GPADL to the primary channel.
+	 *
+	 * NOTE:
+	 * Only primary channel has RXBUF connected to it.  Sub-channels
+	 * just share this RXBUF.
+	 */
+	error = vmbus_chan_gpadl_connect(sc->hn_prichan,
+	    sc->hn_rxbuf_dma.hv_paddr, rxbuf_size, &sc->hn_rxbuf_gpadl);
+	if (error) {
+		HN_WARN(sc, "rxbuf gpadl conn failed: %d", error);
+		goto cleanup;
+	}
+
+	/*
+	 * Connect RXBUF to NVS.
+	 */
+
+	xact = vmbus_xact_get(sc->hn_xact, sizeof (*conn));
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for nvs rxbuf conn");
+		error = ENXIO;
+		goto cleanup;
+	}
+	conn = vmbus_xact_req_data(xact);
+	conn->nvs_type = HN_NVS_TYPE_RXBUF_CONN;
+	conn->nvs_gpadl = sc->hn_rxbuf_gpadl;
+	conn->nvs_sig = HN_NVS_RXBUF_SIG;
+
+	resp_len = sizeof (*resp);
+	resp = hn_nvs_xact_execute(sc, xact, conn, sizeof (*conn), &resp_len,
+	    HN_NVS_TYPE_RXBUF_CONNRESP);
+	if (resp == NULL) {
+		HN_WARN(sc, "exec nvs rxbuf conn failed");
+		error = EIO;
+		goto cleanup;
+	}
+
+	status = resp->nvs_status;
+	vmbus_xact_put(xact);
+	xact = NULL;
+
+	if (status != HN_NVS_STATUS_OK) {
+		HN_WARN(sc, "nvs rxbuf conn failed: %u", status);
+		error = EIO;
+		goto cleanup;
+	}
+	sc->hn_flags |= HN_FLAG_RXBUF_CONNECTED;
+
+	return (0);
+
+cleanup:
+	if (xact != NULL)
+		vmbus_xact_put(xact);
+	hn_nvs_disconn_rxbuf(sc);
+	return (error);
+}
+
+static int
+hn_nvs_conn_chim(struct hn_softc *sc)
+{
+	struct vmbus_xact *xact = NULL;
+	struct hn_nvs_chim_conn *chim;
+	const struct hn_nvs_chim_connresp *resp;
+	size_t resp_len;
+	uint32_t status, sectsz;
+	int error;
+
+	/*
+	 * Connect chimney sending buffer GPADL to the primary channel.
+	 *
+	 * NOTE:
+	 * Only primary channel has chimney sending buffer connected to it.
+	 * Sub-channels just share this chimney sending buffer.
+	 */
+	error = vmbus_chan_gpadl_connect(sc->hn_prichan,
+	    sc->hn_chim_dma.hv_paddr, HN_CHIM_SIZE, &sc->hn_chim_gpadl);
+	if (error) {
+		HN_WARN(sc, "chim gpadl conn failed: %d", error);
+		goto cleanup;
+	}
+
+	/*
+	 * Connect chimney sending buffer to NVS
+	 */
+
+	xact = vmbus_xact_get(sc->hn_xact, sizeof (*chim));
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for nvs chim conn");
+		error = ENXIO;
+		goto cleanup;
+	}
+	chim = vmbus_xact_req_data(xact);
+	chim->nvs_type = HN_NVS_TYPE_CHIM_CONN;
+	chim->nvs_gpadl = sc->hn_chim_gpadl;
+	chim->nvs_sig = HN_NVS_CHIM_SIG;
+
+	resp_len = sizeof (*resp);
+	resp = hn_nvs_xact_execute(sc, xact, chim, sizeof (*chim), &resp_len,
+	    HN_NVS_TYPE_CHIM_CONNRESP);
+	if (resp == NULL) {
+		HN_WARN(sc, "exec nvs chim conn failed");
+		error = EIO;
+		goto cleanup;
+	}
+
+	status = resp->nvs_status;
+	sectsz = resp->nvs_sectsz;
+	vmbus_xact_put(xact);
+	xact = NULL;
+
+	if (status != HN_NVS_STATUS_OK) {
+		HN_WARN(sc, "nvs chim conn failed: %u", status);
+		error = EIO;
+		goto cleanup;
+	}
+	if (sectsz == 0) {
+		/*
+		 * Can't use chimney sending buffer; done!
+		 */
+		HN_WARN(sc, "zero chimney sending buffer section size");
+		sc->hn_chim_szmax = 0;
+		sc->hn_chim_cnt = 0;
+		sc->hn_flags |= HN_FLAG_CHIM_CONNECTED;
+		return (0);
+	}
+
+	sc->hn_chim_szmax = sectsz;
+	sc->hn_chim_cnt = HN_CHIM_SIZE / sc->hn_chim_szmax;
+	if (HN_CHIM_SIZE % sc->hn_chim_szmax != 0) {
+		HN_WARN(sc, "chimney sending sections are "
+		    "not properly aligned");
+	}
+	if ((sc->hn_chim_cnt & BT_ULMASK) != 0) {
+		HN_WARN(sc, "discard %d chimney sending sections",
+		    sc->hn_chim_cnt & BT_ULMASK);
+	}
+
+	sc->hn_chim_bmap_cnt = sc->hn_chim_cnt >> BT_ULSHIFT;
+	sc->hn_chim_bmap = kmem_zalloc(sc->hn_chim_bmap_cnt * sizeof (ulong_t),
+	    KM_SLEEP);
+
+	/* Done! */
+	sc->hn_flags |= HN_FLAG_CHIM_CONNECTED;
+	HN_DEBUG(sc, 1, "chimney sending buffer %d/%d",
+	    sc->hn_chim_szmax, sc->hn_chim_cnt);
+	return (0);
+
+cleanup:
+	if (xact != NULL)
+		vmbus_xact_put(xact);
+	hn_nvs_disconn_chim(sc);
+	return (error);
+}
+
+static void
+hn_nvs_disconn_rxbuf(struct hn_softc *sc)
+{
+	int error;
+
+	if (sc->hn_flags & HN_FLAG_RXBUF_CONNECTED) {
+		struct hn_nvs_rxbuf_disconn disconn;
+
+		/*
+		 * Disconnect RXBUF from NVS.
+		 */
+		(void) memset(&disconn, 0, sizeof (disconn));
+		disconn.nvs_type = HN_NVS_TYPE_RXBUF_DISCONN;
+		disconn.nvs_sig = HN_NVS_RXBUF_SIG;
+
+		/* NOTE: No response. */
+		error = hn_nvs_req_send(sc, &disconn, sizeof (disconn));
+		if (error) {
+			HN_WARN(sc, "send nvs rxbuf disconn failed: %d",
+			    error);
+			/*
+			 * Fine for a revoked channel, since the hypervisor
+			 * does not drain TX bufring for a revoked channel.
+			 */
+			if (!vmbus_chan_is_revoked(sc->hn_prichan))
+				sc->hn_flags |= HN_FLAG_RXBUF_REF;
+		}
+		sc->hn_flags &= ~HN_FLAG_RXBUF_CONNECTED;
+
+		/*
+		 * Wait for the hypervisor to receive this NVS request.
+		 *
+		 * NOTE:
+		 * The TX bufring will not be drained by the hypervisor,
+		 * if the primary channel is revoked.
+		 */
+		while (!vmbus_chan_tx_empty(sc->hn_prichan) &&
+		    !vmbus_chan_is_revoked(sc->hn_prichan))
+			delay(1);
+		/*
+		 * Linger long enough for NVS to disconnect RXBUF.
+		 */
+		delay(MSEC_TO_TICK(200));
+	}
+
+	if (sc->hn_rxbuf_gpadl != 0) {
+		/*
+		 * Disconnect RXBUF from primary channel.
+		 */
+		error = vmbus_chan_gpadl_disconnect(sc->hn_prichan,
+		    sc->hn_rxbuf_gpadl);
+		if (error) {
+			HN_WARN(sc, "rxbuf gpadl disconn failed: %d",
+			    error);
+			sc->hn_flags |= HN_FLAG_RXBUF_REF;
+		}
+		sc->hn_rxbuf_gpadl = 0;
+	}
+}
+
+static void
+hn_nvs_disconn_chim(struct hn_softc *sc)
+{
+	int error;
+
+	if (sc->hn_flags & HN_FLAG_CHIM_CONNECTED) {
+		struct hn_nvs_chim_disconn disconn;
+
+		/*
+		 * Disconnect chimney sending buffer from NVS.
+		 */
+		(void) memset(&disconn, 0, sizeof (disconn));
+		disconn.nvs_type = HN_NVS_TYPE_CHIM_DISCONN;
+		disconn.nvs_sig = HN_NVS_CHIM_SIG;
+
+		/* NOTE: No response. */
+		error = hn_nvs_req_send(sc, &disconn, sizeof (disconn));
+		if (error) {
+			HN_WARN(sc, "send nvs chim disconn failed: %d",
+			    error);
+			/*
+			 * Fine for a revoked channel, since the hypervisor
+			 * does not drain TX bufring for a revoked channel.
+			 */
+			if (!vmbus_chan_is_revoked(sc->hn_prichan))
+				sc->hn_flags |= HN_FLAG_CHIM_REF;
+		}
+		sc->hn_flags &= ~HN_FLAG_CHIM_CONNECTED;
+
+		/*
+		 * Wait for the hypervisor to receive this NVS request.
+		 *
+		 * NOTE:
+		 * The TX bufring will not be drained by the hypervisor,
+		 * if the primary channel is revoked.
+		 */
+		while (!vmbus_chan_tx_empty(sc->hn_prichan) &&
+		    !vmbus_chan_is_revoked(sc->hn_prichan))
+			delay(1);
+		/*
+		 * Linger long enough for NVS to disconnect chimney
+		 * sending buffer.
+		 */
+		delay(MSEC_TO_TICK(200));
+	}
+
+	if (sc->hn_chim_gpadl != 0) {
+		/*
+		 * Disconnect chimney sending buffer from primary channel.
+		 */
+		error = vmbus_chan_gpadl_disconnect(sc->hn_prichan,
+		    sc->hn_chim_gpadl);
+		if (error) {
+			HN_WARN(sc, "chim gpadl disconn failed: %d", error);
+			sc->hn_flags |= HN_FLAG_CHIM_REF;
+		}
+		sc->hn_chim_gpadl = 0;
+	}
+
+	if (sc->hn_chim_bmap != NULL) {
+		kmem_free(sc->hn_chim_bmap, sc->hn_chim_bmap_cnt *
+		    sizeof (ulong_t));
+		sc->hn_chim_bmap = NULL;
+		sc->hn_chim_bmap_cnt = 0;
+	}
+}
+
+static int
+hn_nvs_doinit(struct hn_softc *sc, uint32_t nvs_ver)
+{
+	struct vmbus_xact *xact;
+	struct hn_nvs_init *init;
+	const struct hn_nvs_init_resp *resp;
+	size_t resp_len;
+	uint32_t status;
+
+	xact = vmbus_xact_get(sc->hn_xact, sizeof (*init));
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for nvs init");
+		return (ENXIO);
+	}
+	init = vmbus_xact_req_data(xact);
+	init->nvs_type = HN_NVS_TYPE_INIT;
+	init->nvs_ver_min = nvs_ver;
+	init->nvs_ver_max = nvs_ver;
+
+	resp_len = sizeof (*resp);
+	resp = hn_nvs_xact_execute(sc, xact, init, sizeof (*init), &resp_len,
+	    HN_NVS_TYPE_INIT_RESP);
+	if (resp == NULL) {
+		HN_WARN(sc, "exec init failed");
+		vmbus_xact_put(xact);
+		return (EIO);
+	}
+
+	status = resp->nvs_status;
+	vmbus_xact_put(xact);
+
+	if (status != HN_NVS_STATUS_OK) {
+		/*
+		 * Caller may try another NVS version, and will log
+		 * error if there are no more NVS versions to try,
+		 * so don't bark out loud here.
+		 */
+		HN_DEBUG(sc, 1, "nvs init failed for ver 0x%x", nvs_ver);
+		return (EINVAL);
+	}
+	return (0);
+}
+
+/*
+ * Configure MTU and enable VLAN.
+ */
+static int
+hn_nvs_conf_ndis(struct hn_softc *sc, int mtu)
+{
+	struct hn_nvs_ndis_conf conf;
+	int error;
+
+	(void) memset(&conf, 0, sizeof (conf));
+	conf.nvs_type = HN_NVS_TYPE_NDIS_CONF;
+	conf.nvs_mtu = mtu;
+	conf.nvs_caps = HN_NVS_NDIS_CONF_VLAN;
+
+	/* NOTE: No response. */
+	error = hn_nvs_req_send(sc, &conf, sizeof (conf));
+	if (error) {
+		HN_WARN(sc, "send nvs ndis conf failed: %d", error);
+		return (error);
+	}
+
+	HN_DEBUG(sc, 1, "nvs ndis conf done");
+	sc->hn_caps |= HN_CAP_MTU | HN_CAP_VLAN;
+	return (0);
+}
+
+static int
+hn_nvs_init_ndis(struct hn_softc *sc)
+{
+	struct hn_nvs_ndis_init ndis;
+	int error;
+
+	(void) memset(&ndis, 0, sizeof (ndis));
+	ndis.nvs_type = HN_NVS_TYPE_NDIS_INIT;
+	ndis.nvs_ndis_major = HN_NDIS_VERSION_MAJOR(sc->hn_ndis_ver);
+	ndis.nvs_ndis_minor = HN_NDIS_VERSION_MINOR(sc->hn_ndis_ver);
+
+	/* NOTE: No response. */
+	error = hn_nvs_req_send(sc, &ndis, sizeof (ndis));
+	if (error)
+		HN_WARN(sc, "send nvs ndis init failed: %d", error);
+	return (error);
+}
+
+static int
+hn_nvs_init(struct hn_softc *sc)
+{
+	int i, error;
+
+	if (i_ddi_devi_attached(sc->hn_dev)) {
+		/*
+		 * NVS version and NDIS version MUST NOT be changed.
+		 */
+		HN_DEBUG(sc, 1, "reinit NVS version 0x%x, "
+		    "NDIS version %u.%u", sc->hn_nvs_ver,
+		    HN_NDIS_VERSION_MAJOR(sc->hn_ndis_ver),
+		    HN_NDIS_VERSION_MINOR(sc->hn_ndis_ver));
+
+		error = hn_nvs_doinit(sc, sc->hn_nvs_ver);
+		if (error) {
+			HN_WARN(sc, "reinit NVS version 0x%x failed: %d",
+			    sc->hn_nvs_ver, error);
+			return (error);
+		}
+		goto done;
+	}
+
+	/*
+	 * Find the supported NVS version and set NDIS version accordingly.
+	 */
+	for (i = 0; i < (sizeof (hn_nvs_version) / sizeof (uint32_t)); ++i) {
+		error = hn_nvs_doinit(sc, hn_nvs_version[i]);
+		if (!error) {
+			sc->hn_nvs_ver = hn_nvs_version[i];
+
+			/* Set NDIS version according to NVS version. */
+			sc->hn_ndis_ver = HN_NDIS_VERSION_6_30;
+			if (sc->hn_nvs_ver <= HN_NVS_VERSION_4)
+				sc->hn_ndis_ver = HN_NDIS_VERSION_6_1;
+
+			HN_DEBUG(sc, 1, "NVS version 0x%x, "
+			    "NDIS version %u.%u", sc->hn_nvs_ver,
+			    HN_NDIS_VERSION_MAJOR(sc->hn_ndis_ver),
+			    HN_NDIS_VERSION_MINOR(sc->hn_ndis_ver));
+			goto done;
+		}
+	}
+	HN_WARN(sc, "no NVS available");
+	return (ENXIO);
+
+done:
+	if (sc->hn_nvs_ver >= HN_NVS_VERSION_5)
+		sc->hn_caps |= HN_CAP_HASHVAL;
+	return (0);
+}
+
+int
+hn_nvs_attach(struct hn_softc *sc, int mtu)
+{
+	int error;
+
+	/*
+	 * Initialize NVS.
+	 */
+	error = hn_nvs_init(sc);
+	if (error)
+		return (error);
+
+	if (sc->hn_nvs_ver >= HN_NVS_VERSION_2) {
+		/*
+		 * Configure NDIS before initializing it.
+		 */
+		error = hn_nvs_conf_ndis(sc, mtu);
+		if (error)
+			return (error);
+	}
+
+	/*
+	 * Initialize NDIS.
+	 */
+	error = hn_nvs_init_ndis(sc);
+	if (error)
+		return (error);
+
+	/*
+	 * Connect RXBUF.
+	 */
+	error = hn_nvs_conn_rxbuf(sc);
+	if (error)
+		return (error);
+
+	/*
+	 * Connect chimney sending buffer.
+	 */
+	error = hn_nvs_conn_chim(sc);
+	if (error) {
+		hn_nvs_disconn_rxbuf(sc);
+		return (error);
+	}
+	return (0);
+}
+
+void
+hn_nvs_detach(struct hn_softc *sc)
+{
+
+	/* NOTE: there are no requests to stop the NVS. */
+	hn_nvs_disconn_rxbuf(sc);
+	hn_nvs_disconn_chim(sc);
+}
+
+/*ARGSUSED*/
+void
+hn_nvs_sent_xact(struct hn_nvs_sendctx *sndc,
+    struct hn_softc *sc, struct vmbus_channel *chan,
+    const void *data, int dlen)
+{
+
+	vmbus_xact_wakeup(sndc->hn_cbarg, data, dlen);
+}
+
+/*ARGSUSED*/
+static void
+hn_nvs_sent_none(struct hn_nvs_sendctx *sndc,
+    struct hn_softc *sc, struct vmbus_channel *chan,
+    const void *data, int dlen)
+{
+}
+
+int
+hn_nvs_alloc_subchans(struct hn_softc *sc, int *nsubch0)
+{
+	struct vmbus_xact *xact;
+	struct hn_nvs_subch_req *req;
+	const struct hn_nvs_subch_resp *resp;
+	int error, nsubch_req;
+	uint32_t nsubch;
+	size_t resp_len;
+
+	nsubch_req = *nsubch0;
+	ASSERT3S(nsubch_req, >, 0);
+
+	xact = vmbus_xact_get(sc->hn_xact, sizeof (*req));
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for nvs subch alloc");
+		return (ENXIO);
+	}
+	req = vmbus_xact_req_data(xact);
+	req->nvs_type = HN_NVS_TYPE_SUBCH_REQ;
+	req->nvs_op = HN_NVS_SUBCH_OP_ALLOC;
+	req->nvs_nsubch = nsubch_req;
+
+	resp_len = sizeof (*resp);
+	resp = hn_nvs_xact_execute(sc, xact, req, sizeof (*req), &resp_len,
+	    HN_NVS_TYPE_SUBCH_RESP);
+	if (resp == NULL) {
+		HN_WARN(sc, "exec nvs subch alloc failed");
+		error = EIO;
+		goto done;
+	}
+	if (resp->nvs_status != HN_NVS_STATUS_OK) {
+		HN_WARN(sc, "nvs subch alloc failed: %x",
+		    resp->nvs_status);
+		error = EIO;
+		goto done;
+	}
+
+	nsubch = resp->nvs_nsubch;
+	if (nsubch > nsubch_req) {
+		HN_WARN(sc, "%u subchans are allocated, requested %d",
+		    nsubch, nsubch_req);
+		nsubch = nsubch_req;
+	}
+	*nsubch0 = nsubch;
+	error = 0;
+done:
+	vmbus_xact_put(xact);
+	return (error);
+}
+
+int
+hn_nvs_send_rndis_sglist(struct vmbus_channel *chan, uint32_t rndis_mtype,
+    struct hn_nvs_sendctx *sndc, struct vmbus_gpa *gpa, int gpa_cnt)
+{
+	struct hn_nvs_rndis rndis;
+
+	rndis.nvs_type = HN_NVS_TYPE_RNDIS;
+	rndis.nvs_rndis_mtype = rndis_mtype;
+	rndis.nvs_chim_idx = HN_NVS_CHIM_IDX_INVALID;
+	rndis.nvs_chim_sz = 0;
+
+	return (hn_nvs_send_sglist(chan, gpa, gpa_cnt,
+	    &rndis, sizeof (rndis), sndc));
+}
+
+int
+hn_nvs_send_rndis_ctrl(struct vmbus_channel *chan,
+    struct hn_nvs_sendctx *sndc, struct vmbus_gpa *gpa, int gpa_cnt)
+{
+
+	return hn_nvs_send_rndis_sglist(chan, HN_NVS_RNDIS_MTYPE_CTRL,
+	    sndc, gpa, gpa_cnt);
+}

--- a/usr/src/uts/intel/io/hyperv/netvsc/hn_nvs.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hn_nvs.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2010-2012 Citrix Inc.
+ * Copyright (c) 2012 NetApp Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HN_NVS_H
+#define	_HN_NVS_H
+
+#include "if_hnreg.h"
+
+#include <sys/vmbus.h>
+
+struct hn_nvs_sendctx;
+struct vmbus_channel;
+struct hn_softc;
+
+typedef void (*hn_nvs_sent_t)(struct hn_nvs_sendctx *, struct hn_softc *,
+    struct vmbus_channel *, const void *, int);
+
+struct hn_nvs_sendctx {
+	hn_nvs_sent_t	hn_cb;
+	void		*hn_cbarg;
+};
+
+#define	HN_NVS_SENDCTX_INITIALIZER(cb, cbarg)	\
+{						\
+	.hn_cb		= cb,			\
+	.hn_cbarg	= cbarg			\
+}
+
+static inline void
+hn_nvs_sendctx_init(struct hn_nvs_sendctx *sndc, hn_nvs_sent_t cb, void *cbarg)
+{
+
+	sndc->hn_cb = cb;
+	sndc->hn_cbarg = cbarg;
+}
+
+static inline int
+hn_nvs_send(struct vmbus_channel *chan, uint16_t flags,
+    void *nvs_msg, int nvs_msglen, struct hn_nvs_sendctx *sndc)
+{
+
+	return (vmbus_chan_send(chan, VMBUS_CHANPKT_TYPE_INBAND, flags,
+	    nvs_msg, nvs_msglen, (uint64_t)(uintptr_t)sndc));
+}
+
+static inline int
+hn_nvs_send_sglist(struct vmbus_channel *chan, struct vmbus_gpa sg[], int sglen,
+    void *nvs_msg, int nvs_msglen, struct hn_nvs_sendctx *sndc)
+{
+
+	return (vmbus_chan_send_sglist(chan, sg, sglen, nvs_msg, nvs_msglen,
+	    (uint64_t)(uintptr_t)sndc));
+}
+
+int		hn_nvs_attach(struct hn_softc *sc, int mtu);
+void		hn_nvs_detach(struct hn_softc *sc);
+int		hn_nvs_alloc_subchans(struct hn_softc *sc, int *nsubch);
+void		hn_nvs_sent_xact(struct hn_nvs_sendctx *sndc,
+		    struct hn_softc *sc, struct vmbus_channel *chan,
+		    const void *data, int dlen);
+int		hn_nvs_send_rndis_ctrl(struct vmbus_channel *chan,
+		    struct hn_nvs_sendctx *sndc, struct vmbus_gpa *gpa,
+		    int gpa_cnt);
+int		hn_nvs_send_rndis_sglist(struct vmbus_channel *chan,
+		    uint32_t rndis_mtype, struct hn_nvs_sendctx *sndc,
+		    struct vmbus_gpa *gpa, int gpa_cnt);
+
+extern struct hn_nvs_sendctx	hn_nvs_sendctx_none;
+
+#endif /* !_HN_NVS_H */

--- a/usr/src/uts/intel/io/hyperv/netvsc/hn_rndis.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hn_rndis.c
@@ -1,0 +1,1023 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2010-2012 Citrix Inc.
+ * Copyright (c) 2012 NetApp Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/sysmacros.h>
+#include <sys/socket.h>
+#include <sys/mutex.h>
+#include <inet/ip.h>
+
+#include <sys/ethernet.h>
+#include <sys/atomic.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus_xact.h>
+
+#include "hn_rndis.h"
+#include "if_hnvar.h"
+#include "if_hnreg.h"
+#include "ndis.h"
+#include "hn_nvs.h"
+
+#define	HN_RNDIS_RID_COMPAT_MASK	0xffff
+#define	HN_RNDIS_RID_COMPAT_MAX		HN_RNDIS_RID_COMPAT_MASK
+
+#define	HN_RNDIS_XFER_SIZE		2048
+
+#define	HN_NDIS_TXCSUM_CAP_IP4		\
+	(NDIS_TXCSUM_CAP_IP4 | NDIS_TXCSUM_CAP_IP4OPT)
+#define	HN_NDIS_TXCSUM_CAP_TCP4		\
+	(NDIS_TXCSUM_CAP_TCP4 | NDIS_TXCSUM_CAP_TCP4OPT)
+#define	HN_NDIS_TXCSUM_CAP_TCP6		\
+	(NDIS_TXCSUM_CAP_TCP6 | NDIS_TXCSUM_CAP_TCP6OPT | \
+	NDIS_TXCSUM_CAP_IP6EXT)
+#define	HN_NDIS_TXCSUM_CAP_UDP6		\
+	(NDIS_TXCSUM_CAP_UDP6 | NDIS_TXCSUM_CAP_IP6EXT)
+#define	HN_NDIS_LSOV2_CAP_IP6		\
+	(NDIS_LSOV2_CAP_IP6EXT | NDIS_LSOV2_CAP_TCP6OPT)
+
+static const void	*hn_rndis_xact_exec1(struct hn_softc *,
+			    struct vmbus_xact *, size_t,
+			    struct hn_nvs_sendctx *, size_t *);
+static const void	*hn_rndis_xact_execute(struct hn_softc *,
+			    struct vmbus_xact *, uint32_t, size_t, size_t *,
+			    uint32_t);
+static int		hn_rndis_query(struct hn_softc *, uint32_t,
+			    const void *, size_t, void *, size_t *);
+static int		hn_rndis_query2(struct hn_softc *, uint32_t,
+			    const void *, size_t, void *, size_t *, size_t);
+static int		hn_rndis_set(struct hn_softc *, uint32_t,
+			    const void *, size_t);
+static int		hn_rndis_init(struct hn_softc *);
+static int		hn_rndis_halt(struct hn_softc *);
+static int		hn_rndis_conf_offload(struct hn_softc *, int);
+static int		hn_rndis_query_hwcaps(struct hn_softc *,
+			    struct ndis_offload *);
+
+static inline uint32_t
+hn_rndis_rid(struct hn_softc *sc)
+{
+	uint32_t rid;
+
+again:
+	rid = atomic_inc_32_nv(&sc->hn_rndis_rid) - 1;
+	if (rid == 0)
+		goto again;
+
+	/* Use upper 16 bits for non-compat RNDIS messages. */
+	return ((rid & 0xffff) << 16);
+}
+
+void
+hn_rndis_rx_ctrl(struct hn_softc *sc, const void *data, int dlen)
+{
+	const struct rndis_comp_hdr *comp;
+	const struct rndis_msghdr *hdr;
+
+	ASSERT3U(dlen, >=, sizeof (*hdr));
+	hdr = data;
+
+	switch (hdr->rm_type) {
+	case REMOTE_NDIS_INITIALIZE_CMPLT:
+	case REMOTE_NDIS_QUERY_CMPLT:
+	case REMOTE_NDIS_SET_CMPLT:
+	case REMOTE_NDIS_KEEPALIVE_CMPLT:	/* unused */
+		if (dlen < sizeof (*comp)) {
+			HN_WARN(sc, "invalid RNDIS cmplt");
+			return;
+		}
+		comp = data;
+
+		ASSERT3U(comp->rm_rid, >, HN_RNDIS_RID_COMPAT_MAX);
+		vmbus_xact_ctx_wakeup(sc->hn_xact, comp, dlen);
+		break;
+
+	case REMOTE_NDIS_RESET_CMPLT:
+		/*
+		 * Reset completed, no rid.
+		 *
+		 * NOTE:
+		 * RESET is not issued by hn(4), so this message should
+		 * _not_ be observed.
+		 */
+		HN_WARN(sc, "RESET cmplt received");
+		break;
+
+	default:
+		HN_WARN(sc, "unknown RNDIS msg 0x%x", hdr->rm_type);
+		break;
+	}
+}
+
+int
+hn_rndis_get_eaddr(struct hn_softc *sc, uint8_t *eaddr)
+{
+	size_t eaddr_len;
+	int error;
+
+	eaddr_len = ETHERADDRL;
+	error = hn_rndis_query(sc, OID_802_3_PERMANENT_ADDRESS, NULL, 0,
+	    eaddr, &eaddr_len);
+	if (error)
+		return (error);
+	if (eaddr_len != ETHERADDRL) {
+		HN_WARN(sc, "invalid eaddr len %lu", eaddr_len);
+		return (EINVAL);
+	}
+	return (0);
+}
+
+int
+hn_rndis_get_linkstatus(struct hn_softc *sc, uint32_t *link_status)
+{
+	size_t size;
+	int error;
+
+	size = sizeof (*link_status);
+	error = hn_rndis_query(sc, OID_GEN_MEDIA_CONNECT_STATUS, NULL, 0,
+	    link_status, &size);
+	if (error)
+		return (error);
+	if (size != sizeof (uint32_t)) {
+		HN_WARN(sc, "invalid link status len %lu", size);
+		return (EINVAL);
+	}
+	return (0);
+}
+
+static const void *
+hn_rndis_xact_exec1(struct hn_softc *sc, struct vmbus_xact *xact, size_t reqlen,
+    struct hn_nvs_sendctx *sndc, size_t *comp_len)
+{
+	struct vmbus_gpa gpa[HN_XACT_REQ_PGCNT];
+	int gpa_cnt, error;
+	paddr_t paddr;
+
+	ASSERT3U(reqlen, <=, HN_XACT_REQ_SIZE);
+	ASSERT(reqlen > 0);
+
+	/*
+	 * Setup the SG list.
+	 */
+	paddr = vmbus_xact_req_paddr(xact);
+	ASSERT0(paddr & PAGEOFFSET);
+	for (gpa_cnt = 0; gpa_cnt < HN_XACT_REQ_PGCNT; ++gpa_cnt) {
+		int len = PAGESIZE;
+
+		if (reqlen == 0)
+			break;
+		if (reqlen < len)
+			len = reqlen;
+
+		gpa[gpa_cnt].gpa_page = btop(paddr) + gpa_cnt;
+		gpa[gpa_cnt].gpa_len = len;
+		gpa[gpa_cnt].gpa_ofs = 0;
+
+		reqlen -= len;
+	}
+	/*
+	 * The length of the data must match the total length of all buffers
+	 */
+	ASSERT0(reqlen);
+
+	/*
+	 * Send this RNDIS control message and wait for its completion
+	 * message.
+	 */
+	vmbus_xact_activate(xact);
+	error = hn_nvs_send_rndis_ctrl(sc->hn_prichan, sndc, gpa, gpa_cnt);
+	if (error) {
+		vmbus_xact_deactivate(xact);
+		HN_WARN(sc, "RNDIS ctrl send failed: %d", error);
+		return (NULL);
+	}
+	return (vmbus_chan_xact_wait(sc->hn_prichan, xact, comp_len,
+	    B_TRUE));
+}
+
+static const void *
+hn_rndis_xact_execute(struct hn_softc *sc, struct vmbus_xact *xact,
+    uint32_t rid, size_t reqlen, size_t *comp_len0, uint32_t comp_type)
+{
+	const struct rndis_comp_hdr *comp;
+	size_t comp_len, min_complen = *comp_len0;
+
+	ASSERT3U(rid, >, HN_RNDIS_RID_COMPAT_MAX);
+	ASSERT3U(min_complen, >=, sizeof (*comp));
+
+	/*
+	 * Execute the xact setup by the caller.
+	 */
+	comp = hn_rndis_xact_exec1(sc, xact, reqlen, &hn_nvs_sendctx_none,
+	    &comp_len);
+	if (comp == NULL)
+		return (NULL);
+
+	/*
+	 * Check this RNDIS complete message.
+	 */
+	if (comp_len < min_complen) {
+		if (comp_len >= sizeof (*comp)) {
+			/* rm_status field is valid */
+			HN_WARN(sc, "invalid RNDIS comp len %lu, "
+			    "status 0x%08x", comp_len, comp->rm_status);
+		} else {
+			HN_WARN(sc, "invalid RNDIS comp len %lu", comp_len);
+		}
+		return (NULL);
+	}
+	if (comp->rm_len < min_complen) {
+		HN_WARN(sc, "invalid RNDIS comp msglen %u", comp->rm_len);
+		return (NULL);
+	}
+	if (comp->rm_type != comp_type) {
+		HN_WARN(sc, "unexpected RNDIS comp 0x%08x, "
+		    "expect 0x%08x", comp->rm_type, comp_type);
+		return (NULL);
+	}
+	if (comp->rm_rid != rid) {
+		HN_WARN(sc, "RNDIS comp rid mismatch %u, "
+		    "expect %u", comp->rm_rid, rid);
+		return (NULL);
+	}
+	/* All pass! */
+	*comp_len0 = comp_len;
+	return (comp);
+}
+
+static int
+hn_rndis_query(struct hn_softc *sc, uint32_t oid,
+    const void *idata, size_t idlen, void *odata, size_t *odlen0)
+{
+
+	return (hn_rndis_query2(sc, oid, idata, idlen, odata, odlen0, *odlen0));
+}
+
+static int
+hn_rndis_query2(struct hn_softc *sc, uint32_t oid,
+    const void *idata, size_t idlen, void *odata, size_t *odlen0,
+    size_t min_odlen)
+{
+	struct rndis_query_req *req;
+	const struct rndis_query_comp *comp;
+	struct vmbus_xact *xact;
+	size_t reqlen, odlen = *odlen0, comp_len;
+	int error, ofs;
+	uint32_t rid;
+
+	reqlen = sizeof (*req) + idlen;
+	xact = vmbus_xact_get(sc->hn_xact, reqlen);
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for RNDIS query 0x%08x", oid);
+		return (ENXIO);
+	}
+	rid = hn_rndis_rid(sc);
+	req = vmbus_xact_req_data(xact);
+	req->rm_type = REMOTE_NDIS_QUERY_MSG;
+	req->rm_len = reqlen;
+	req->rm_rid = rid;
+	req->rm_oid = oid;
+	/*
+	 * XXX
+	 * This is _not_ RNDIS Spec conforming:
+	 * "This MUST be set to 0 when there is no input data
+	 *  associated with the OID."
+	 *
+	 * If this field was set to 0 according to the RNDIS Spec,
+	 * Hyper-V would set non-SUCCESS status in the query
+	 * completion.
+	 */
+	req->rm_infobufoffset = RNDIS_QUERY_REQ_INFOBUFOFFSET;
+
+	if (idlen > 0) {
+		req->rm_infobuflen = idlen;
+		/* Input data immediately follows RNDIS query. */
+		(void) memcpy(req + 1, idata, idlen);
+	}
+
+	comp_len = sizeof (*comp) + min_odlen;
+	comp = hn_rndis_xact_execute(sc, xact, rid, reqlen, &comp_len,
+	    REMOTE_NDIS_QUERY_CMPLT);
+	if (comp == NULL) {
+		HN_WARN(sc, "exec RNDIS query 0x%08x failed", oid);
+		error = EIO;
+		goto done;
+	}
+
+	if (comp->rm_status != RNDIS_STATUS_SUCCESS) {
+		HN_WARN(sc, "RNDIS query 0x%08x failed: "
+		    "status 0x%08x", oid, comp->rm_status);
+		error = EIO;
+		goto done;
+	}
+	if (comp->rm_infobuflen == 0 || comp->rm_infobufoffset == 0) {
+		/* No output data! */
+		HN_WARN(sc, "RNDIS query 0x%08x, no data", oid);
+		*odlen0 = 0;
+		error = 0;
+		goto done;
+	}
+
+	/*
+	 * Check output data length and offset.
+	 */
+	/* ofs is the offset from the beginning of comp. */
+	ofs = RNDIS_QUERY_COMP_INFOBUFOFFSET_ABS(comp->rm_infobufoffset);
+	if (ofs < sizeof (*comp) || ofs + comp->rm_infobuflen > comp_len) {
+		HN_WARN(sc, "RNDIS query invalid comp ib off/len, "
+		    "%u/%u", comp->rm_infobufoffset, comp->rm_infobuflen);
+		error = EINVAL;
+		goto done;
+	}
+
+	/*
+	 * Save output data.
+	 */
+	if (comp->rm_infobuflen < odlen)
+		odlen = comp->rm_infobuflen;
+	(void) memcpy(odata, ((const uint8_t *)comp) + ofs, odlen);
+	*odlen0 = odlen;
+
+	error = 0;
+done:
+	vmbus_xact_put(xact);
+	return (error);
+}
+
+int
+hn_rndis_query_rsscaps(struct hn_softc *sc, int *rxr_cnt0)
+{
+	struct ndis_rss_caps in, caps;
+	size_t caps_len;
+	int error, indsz, rxr_cnt, hash_fnidx;
+	uint32_t hash_func = 0, hash_types = 0;
+
+	*rxr_cnt0 = 0;
+
+	if (sc->hn_ndis_ver < HN_NDIS_VERSION_6_20)
+		return (EOPNOTSUPP);
+
+	(void) memset(&in, 0, sizeof (in));
+	in.ndis_hdr.ndis_type = NDIS_OBJTYPE_RSS_CAPS;
+	in.ndis_hdr.ndis_rev = NDIS_RSS_CAPS_REV_2;
+	in.ndis_hdr.ndis_size = NDIS_RSS_CAPS_SIZE;
+
+	caps_len = NDIS_RSS_CAPS_SIZE;
+	error = hn_rndis_query2(sc, OID_GEN_RECEIVE_SCALE_CAPABILITIES,
+	    &in, NDIS_RSS_CAPS_SIZE, &caps, &caps_len, NDIS_RSS_CAPS_SIZE_6_0);
+	if (error)
+		return (error);
+
+	/*
+	 * Preliminary verification.
+	 */
+	if (caps.ndis_hdr.ndis_type != NDIS_OBJTYPE_RSS_CAPS) {
+		HN_WARN(sc, "invalid NDIS objtype 0x%02x",
+		    caps.ndis_hdr.ndis_type);
+		return (EINVAL);
+	}
+	if (caps.ndis_hdr.ndis_rev < NDIS_RSS_CAPS_REV_1) {
+		HN_WARN(sc, "invalid NDIS objrev 0x%02x",
+		    caps.ndis_hdr.ndis_rev);
+		return (EINVAL);
+	}
+	if (caps.ndis_hdr.ndis_size > caps_len) {
+		HN_WARN(sc, "invalid NDIS objsize %u, "
+		    "data size %lu", caps.ndis_hdr.ndis_size, caps_len);
+		return (EINVAL);
+	} else if (caps.ndis_hdr.ndis_size < NDIS_RSS_CAPS_SIZE_6_0) {
+		HN_WARN(sc, "invalid NDIS objsize %u",
+		    caps.ndis_hdr.ndis_size);
+		return (EINVAL);
+	}
+
+	/*
+	 * Save information for later RSS configuration.
+	 */
+	if (caps.ndis_nrxr == 0) {
+		HN_WARN(sc, "0 RX rings!?");
+		return (EINVAL);
+	}
+	HN_DEBUG(sc, 1, "%u RX rings", caps.ndis_nrxr);
+	rxr_cnt = caps.ndis_nrxr;
+
+	if (caps.ndis_hdr.ndis_size == NDIS_RSS_CAPS_SIZE &&
+	    caps.ndis_hdr.ndis_rev >= NDIS_RSS_CAPS_REV_2) {
+		if (caps.ndis_nind > NDIS_HASH_INDCNT) {
+			HN_WARN(sc, "too many RSS indirect table entries %u",
+			    caps.ndis_nind);
+			return (EOPNOTSUPP);
+		}
+		if (!ISP2(caps.ndis_nind)) {
+			HN_WARN(sc, "RSS indirect table size is not "
+			    "power-of-2 %u", caps.ndis_nind);
+		}
+
+		HN_DEBUG(sc, 1, "RSS indirect table size %u", caps.ndis_nind);
+		indsz = caps.ndis_nind;
+	} else {
+		indsz = NDIS_HASH_INDCNT;
+	}
+	if (indsz < rxr_cnt) {
+		HN_WARN(sc, "# of RX rings (%d) > "
+		    "RSS indirect table size %d", rxr_cnt, indsz);
+		rxr_cnt = indsz;
+	}
+
+	/*
+	 * NOTE:
+	 * Toeplitz is at the lowest bit, and it is prefered; so ffs(),
+	 * instead of fls(), is used here.
+	 */
+	hash_fnidx = ffs(caps.ndis_caps & NDIS_RSS_CAP_HASHFUNC_MASK);
+	if (hash_fnidx == 0) {
+		HN_WARN(sc, "no hash functions, caps 0x%08x", caps.ndis_caps);
+		return (EOPNOTSUPP);
+	}
+	hash_func = 1 << (hash_fnidx - 1); /* ffs is 1-based */
+
+	if (caps.ndis_caps & NDIS_RSS_CAP_IPV4)
+		hash_types |= NDIS_HASH_IPV4 | NDIS_HASH_TCP_IPV4;
+	if (caps.ndis_caps & NDIS_RSS_CAP_IPV6)
+		hash_types |= NDIS_HASH_IPV6 | NDIS_HASH_TCP_IPV6;
+	if (caps.ndis_caps & NDIS_RSS_CAP_IPV6_EX)
+		hash_types |= NDIS_HASH_IPV6_EX | NDIS_HASH_TCP_IPV6_EX;
+	if (hash_types == 0) {
+		HN_WARN(sc, "no hash types, caps 0x%08x", caps.ndis_caps);
+		return (EOPNOTSUPP);
+	}
+
+	/* Commit! */
+	sc->hn_rss_ind_size = indsz;
+	sc->hn_rss_hash = hash_func | hash_types;
+	*rxr_cnt0 = rxr_cnt;
+	return (0);
+}
+
+static int
+hn_rndis_set(struct hn_softc *sc, uint32_t oid, const void *data, size_t dlen)
+{
+	struct rndis_set_req *req;
+	const struct rndis_set_comp *comp;
+	struct vmbus_xact *xact;
+	size_t reqlen, comp_len;
+	uint32_t rid;
+	int error;
+
+	ASSERT(dlen > 0);
+
+	reqlen = sizeof (*req) + dlen;
+	xact = vmbus_xact_get(sc->hn_xact, reqlen);
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for RNDIS set 0x%08x", oid);
+		return (ENXIO);
+	}
+	rid = hn_rndis_rid(sc);
+	req = vmbus_xact_req_data(xact);
+	req->rm_type = REMOTE_NDIS_SET_MSG;
+	req->rm_len = reqlen;
+	req->rm_rid = rid;
+	req->rm_oid = oid;
+	req->rm_infobuflen = dlen;
+	req->rm_infobufoffset = RNDIS_SET_REQ_INFOBUFOFFSET;
+	/* Data immediately follows RNDIS set. */
+	(void) memcpy(req + 1, data, dlen);
+
+	comp_len = sizeof (*comp);
+	comp = hn_rndis_xact_execute(sc, xact, rid, reqlen, &comp_len,
+	    REMOTE_NDIS_SET_CMPLT);
+	if (comp == NULL) {
+		HN_WARN(sc, "exec RNDIS set 0x%08x failed", oid);
+		error = EIO;
+		goto done;
+	}
+
+	if (comp->rm_status != RNDIS_STATUS_SUCCESS) {
+		HN_WARN(sc, "RNDIS set 0x%08x failed: "
+		    "status 0x%08x", oid, comp->rm_status);
+		error = EIO;
+		goto done;
+	}
+	error = 0;
+done:
+	vmbus_xact_put(xact);
+	return (error);
+}
+
+static int
+hn_rndis_conf_offload(struct hn_softc *sc, int mtu)
+{
+	struct ndis_offload hwcaps;
+	struct ndis_offload_params params;
+	uint32_t caps = 0;
+	size_t paramsz;
+	int error, tso_maxsz, tso_minsg;
+
+	error = hn_rndis_query_hwcaps(sc, &hwcaps);
+	if (error) {
+		HN_WARN(sc, "hwcaps query failed: %d", error);
+		return (error);
+	}
+
+	/* NOTE: 0 means "no change" */
+	(void) memset(&params, 0, sizeof (params));
+
+	params.ndis_hdr.ndis_type = NDIS_OBJTYPE_DEFAULT;
+	if (sc->hn_ndis_ver < HN_NDIS_VERSION_6_30) {
+		params.ndis_hdr.ndis_rev = NDIS_OFFLOAD_PARAMS_REV_2;
+		paramsz = NDIS_OFFLOAD_PARAMS_SIZE_6_1;
+	} else {
+		params.ndis_hdr.ndis_rev = NDIS_OFFLOAD_PARAMS_REV_3;
+		paramsz = NDIS_OFFLOAD_PARAMS_SIZE;
+	}
+	params.ndis_hdr.ndis_size = paramsz;
+
+	/*
+	 * TSO4/TSO6 setup.
+	 */
+	tso_maxsz = IP_MAXPACKET;
+	tso_minsg = 2;
+	if (hwcaps.ndis_lsov2.ndis_ip4_encap & NDIS_OFFLOAD_ENCAP_8023) {
+		caps |= HN_CAP_TSO4;
+		params.ndis_lsov2_ip4 = NDIS_OFFLOAD_LSOV2_ON;
+
+		if (hwcaps.ndis_lsov2.ndis_ip4_maxsz < tso_maxsz)
+			tso_maxsz = hwcaps.ndis_lsov2.ndis_ip4_maxsz;
+		if (hwcaps.ndis_lsov2.ndis_ip4_minsg > tso_minsg)
+			tso_minsg = hwcaps.ndis_lsov2.ndis_ip4_minsg;
+	}
+#ifdef notyet
+	if ((hwcaps.ndis_lsov2.ndis_ip6_encap & NDIS_OFFLOAD_ENCAP_8023) &&
+	    (hwcaps.ndis_lsov2.ndis_ip6_opts & HN_NDIS_LSOV2_CAP_IP6) ==
+	    HN_NDIS_LSOV2_CAP_IP6) {
+		caps |= HN_CAP_TSO6;
+		params.ndis_lsov2_ip6 = NDIS_OFFLOAD_LSOV2_ON;
+
+		if (hwcaps.ndis_lsov2.ndis_ip6_maxsz < tso_maxsz)
+			tso_maxsz = hwcaps.ndis_lsov2.ndis_ip6_maxsz;
+		if (hwcaps.ndis_lsov2.ndis_ip6_minsg > tso_minsg)
+			tso_minsg = hwcaps.ndis_lsov2.ndis_ip6_minsg;
+	}
+#endif
+	sc->hn_ndis_tso_szmax = 0;
+	sc->hn_ndis_tso_sgmin = 0;
+	if (caps & (HN_CAP_TSO4 | HN_CAP_TSO6)) {
+		ASSERT3U(tso_maxsz, <=, IP_MAXPACKET);
+		ASSERT3U(tso_minsg, >=, 2);
+		if (tso_maxsz < tso_minsg * mtu) {
+			HN_WARN(sc, "invalid NDIS TSO config: "
+			    "maxsz %d, minsg %d, mtu %d; "
+			    "disable TSO4 and TSO6",
+			    tso_maxsz, tso_minsg, mtu);
+			caps &= ~(HN_CAP_TSO4 | HN_CAP_TSO6);
+			params.ndis_lsov2_ip4 = NDIS_OFFLOAD_LSOV2_OFF;
+			params.ndis_lsov2_ip6 = NDIS_OFFLOAD_LSOV2_OFF;
+		} else {
+			sc->hn_ndis_tso_szmax = tso_maxsz;
+			sc->hn_ndis_tso_sgmin = tso_minsg;
+			HN_DEBUG(sc, 1, "NDIS TSO szmax %d sgmin %d",
+			    sc->hn_ndis_tso_szmax, sc->hn_ndis_tso_sgmin);
+		}
+	}
+
+	/* IPv4 checksum */
+	if ((hwcaps.ndis_csum.ndis_ip4_txcsum & HN_NDIS_TXCSUM_CAP_IP4) ==
+	    HN_NDIS_TXCSUM_CAP_IP4) {
+		caps |= HN_CAP_IPCS;
+		params.ndis_ip4csum = NDIS_OFFLOAD_PARAM_TX;
+	}
+	if (hwcaps.ndis_csum.ndis_ip4_rxcsum & NDIS_RXCSUM_CAP_IP4) {
+		if (params.ndis_ip4csum == NDIS_OFFLOAD_PARAM_TX)
+			params.ndis_ip4csum = NDIS_OFFLOAD_PARAM_TXRX;
+		else
+			params.ndis_ip4csum = NDIS_OFFLOAD_PARAM_RX;
+	}
+
+	/* TCP4 checksum */
+	if ((hwcaps.ndis_csum.ndis_ip4_txcsum & HN_NDIS_TXCSUM_CAP_TCP4) ==
+	    HN_NDIS_TXCSUM_CAP_TCP4) {
+		caps |= HN_CAP_TCP4CS;
+		params.ndis_tcp4csum = NDIS_OFFLOAD_PARAM_TX;
+	}
+	if (hwcaps.ndis_csum.ndis_ip4_rxcsum & NDIS_RXCSUM_CAP_TCP4) {
+		if (params.ndis_tcp4csum == NDIS_OFFLOAD_PARAM_TX)
+			params.ndis_tcp4csum = NDIS_OFFLOAD_PARAM_TXRX;
+		else
+			params.ndis_tcp4csum = NDIS_OFFLOAD_PARAM_RX;
+	}
+
+	/* UDP4 checksum */
+	if (hwcaps.ndis_csum.ndis_ip4_txcsum & NDIS_TXCSUM_CAP_UDP4) {
+		caps |= HN_CAP_UDP4CS;
+		params.ndis_udp4csum = NDIS_OFFLOAD_PARAM_TX;
+	}
+	if (hwcaps.ndis_csum.ndis_ip4_rxcsum & NDIS_RXCSUM_CAP_UDP4) {
+		if (params.ndis_udp4csum == NDIS_OFFLOAD_PARAM_TX)
+			params.ndis_udp4csum = NDIS_OFFLOAD_PARAM_TXRX;
+		else
+			params.ndis_udp4csum = NDIS_OFFLOAD_PARAM_RX;
+	}
+
+	/* TCP6 checksum */
+	if ((hwcaps.ndis_csum.ndis_ip6_txcsum & HN_NDIS_TXCSUM_CAP_TCP6) ==
+	    HN_NDIS_TXCSUM_CAP_TCP6) {
+		caps |= HN_CAP_TCP6CS;
+		params.ndis_tcp6csum = NDIS_OFFLOAD_PARAM_TX;
+	}
+	if (hwcaps.ndis_csum.ndis_ip6_rxcsum & NDIS_RXCSUM_CAP_TCP6) {
+		if (params.ndis_tcp6csum == NDIS_OFFLOAD_PARAM_TX)
+			params.ndis_tcp6csum = NDIS_OFFLOAD_PARAM_TXRX;
+		else
+			params.ndis_tcp6csum = NDIS_OFFLOAD_PARAM_RX;
+	}
+
+	/* UDP6 checksum */
+	if ((hwcaps.ndis_csum.ndis_ip6_txcsum & HN_NDIS_TXCSUM_CAP_UDP6) ==
+	    HN_NDIS_TXCSUM_CAP_UDP6) {
+		caps |= HN_CAP_UDP6CS;
+		params.ndis_udp6csum = NDIS_OFFLOAD_PARAM_TX;
+	}
+	if (hwcaps.ndis_csum.ndis_ip6_rxcsum & NDIS_RXCSUM_CAP_UDP6) {
+		if (params.ndis_udp6csum == NDIS_OFFLOAD_PARAM_TX)
+			params.ndis_udp6csum = NDIS_OFFLOAD_PARAM_TXRX;
+		else
+			params.ndis_udp6csum = NDIS_OFFLOAD_PARAM_RX;
+	}
+
+	HN_DEBUG(sc, 1, "offload csum: "
+	    "ip4 %u, tcp4 %u, udp4 %u, tcp6 %u, udp6 %u",
+	    params.ndis_ip4csum,
+	    params.ndis_tcp4csum,
+	    params.ndis_udp4csum,
+	    params.ndis_tcp6csum,
+	    params.ndis_udp6csum);
+	HN_DEBUG(sc, 1, "offload lsov2: ip4 %u, ip6 %u",
+	    params.ndis_lsov2_ip4, params.ndis_lsov2_ip6);
+
+	error = hn_rndis_set(sc, OID_TCP_OFFLOAD_PARAMETERS, &params, paramsz);
+	if (error) {
+		HN_WARN(sc, "offload config failed: %d", error);
+		return (error);
+	}
+
+	HN_DEBUG(sc, 1, "offload config done");
+	sc->hn_caps |= caps;
+	return (0);
+}
+
+int
+hn_rndis_conf_rss(struct hn_softc *sc, uint16_t flags)
+{
+	struct ndis_rssprm_toeplitz *rss = &sc->hn_rss;
+	struct ndis_rss_params *prm = &rss->rss_params;
+	int error, rss_size;
+
+	/*
+	 * Only NDIS 6.20+ is supported:
+	 * We only support 4bytes element in indirect table, which has been
+	 * adopted since NDIS 6.20.
+	 */
+	ASSERT3U(sc->hn_ndis_ver, >=, HN_NDIS_VERSION_6_20);
+
+	/* XXX only one can be specified through, popcnt? */
+	ASSERT(sc->hn_rss_hash & NDIS_HASH_FUNCTION_MASK);
+	ASSERT(sc->hn_rss_hash & NDIS_HASH_TYPE_MASK);
+	ASSERT3S(sc->hn_rss_ind_size, >, 0);
+
+	HN_DEBUG(sc, 1, "RSS indirect table size %d, hash 0x%08x",
+	    sc->hn_rss_ind_size, sc->hn_rss_hash);
+
+	/*
+	 * NOTE:
+	 * DO NOT whack rss_key and rss_ind, which are setup by the caller.
+	 */
+	(void) memset(prm, 0, sizeof (*prm));
+	rss_size = NDIS_RSSPRM_TOEPLITZ_SIZE(sc->hn_rss_ind_size);
+
+	prm->ndis_hdr.ndis_type = NDIS_OBJTYPE_RSS_PARAMS;
+	prm->ndis_hdr.ndis_rev = NDIS_RSS_PARAMS_REV_2;
+	prm->ndis_hdr.ndis_size = rss_size;
+	prm->ndis_flags = flags;
+	prm->ndis_hash = sc->hn_rss_hash;
+	prm->ndis_indsize = sizeof (rss->rss_ind[0]) * sc->hn_rss_ind_size;
+	prm->ndis_indoffset =
+	    offsetof(struct ndis_rssprm_toeplitz, rss_ind[0]);
+	prm->ndis_keysize = sizeof (rss->rss_key);
+	prm->ndis_keyoffset =
+	    offsetof(struct ndis_rssprm_toeplitz, rss_key[0]);
+
+	error = hn_rndis_set(sc, OID_GEN_RECEIVE_SCALE_PARAMETERS,
+	    rss, rss_size);
+	if (error) {
+		HN_WARN(sc, "RSS config failed: %d", error);
+	} else {
+		HN_DEBUG(sc, 1, "RSS config done");
+	}
+	return (error);
+}
+
+int
+hn_rndis_set_rxfilter(struct hn_softc *sc, uint32_t filter)
+{
+	int error;
+
+	error = hn_rndis_set(sc, OID_GEN_CURRENT_PACKET_FILTER,
+	    &filter, sizeof (filter));
+	if (error) {
+		HN_WARN(sc, "set RX filter 0x%08x failed: %d",
+		    filter, error);
+	} else {
+		HN_DEBUG(sc, 1, "set RX filter 0x%08x done", filter);
+	}
+	return (error);
+}
+
+/*
+ * Helper function to convert basic ascii (first 128 characters) to utf16LE
+ */
+static void
+basic_ascii_2_utf16(const char *src, char *dst, int src_len)
+{
+	for (int i = 0, j = 0; i < src_len; i++, j += 2) {
+		dst[j] = src[i];
+		dst[j + 1] = 0;
+	}
+}
+
+#define	EADDR_CONFIG_STR "NetworkAddress"
+#define	EADDR_CONFIG_STRLEN 14
+
+/*
+ * Note: for this feature to work properly, MAC address spoofing must be
+ * enabled in Hyper-V.
+ */
+int
+hn_rndis_set_eaddr(struct hn_softc *sc, const uint8_t *mac_addr)
+{
+	int error;
+	char data[sizeof (struct rndis_set_parameter) +
+	    EADDR_CONFIG_STRLEN * 2 + ETHERADDRL * 4];
+	struct rndis_set_parameter *rsp = (void *)data;
+
+	rsp->rm_type = REMOTE_NDIS_SET_PARAM_STRING;
+	/* Twice the length because we convert string to utf16 */
+	rsp->rm_namelen = EADDR_CONFIG_STRLEN * 2;
+	rsp->rm_nameoffset = sizeof (struct rndis_set_parameter);
+	/*
+	 * Four times the length because we use 2 hex chars for each MAC byte
+	 * and then convert string to utf16
+	 */
+	rsp->rm_valuelen = ETHERADDRL * 4;
+	rsp->rm_valueoffset = rsp->rm_nameoffset + rsp->rm_namelen;
+
+	char *name_utf16 = &data[rsp->rm_nameoffset];
+	char *value_utf16 = &data[rsp->rm_valueoffset];
+
+	ASSERT3P(&data[sizeof (data)], ==, &value_utf16[rsp->rm_valuelen]);
+
+	basic_ascii_2_utf16(EADDR_CONFIG_STR, name_utf16, EADDR_CONFIG_STRLEN);
+
+	char mac_addr_str[ETHERADDRL * 2 + 1];
+	(void) snprintf(mac_addr_str, sizeof (mac_addr_str), MACADDR_FMT,
+	    MACADDR_FMT_ARGS(mac_addr));
+
+	basic_ascii_2_utf16(mac_addr_str, value_utf16, ETHERADDRL * 2);
+
+	/*
+	 * Note: we cannot use OID_802_3_PERMANENT_ADDRESS or
+	 * OID_802_3_CURRENT_ADDRESS to set the mac address, only to get it.
+	 */
+	error = hn_rndis_set(sc, OID_GEN_RNDIS_CONFIG_PARAMETER,
+	    data, sizeof (data));
+	if (error) {
+		HN_WARN(sc, "set MAC addr to %s failed: %d",
+		    mac_addr_str, error);
+	}
+
+	return (error);
+}
+
+static int
+hn_rndis_init(struct hn_softc *sc)
+{
+	struct rndis_init_req *req;
+	const struct rndis_init_comp *comp;
+	struct vmbus_xact *xact;
+	size_t comp_len;
+	uint32_t rid;
+	int error;
+
+	xact = vmbus_xact_get(sc->hn_xact, sizeof (*req));
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for RNDIS init");
+		return (ENXIO);
+	}
+	rid = hn_rndis_rid(sc);
+	req = vmbus_xact_req_data(xact);
+	req->rm_type = REMOTE_NDIS_INITIALIZE_MSG;
+	req->rm_len = sizeof (*req);
+	req->rm_rid = rid;
+	req->rm_ver_major = RNDIS_VERSION_MAJOR;
+	req->rm_ver_minor = RNDIS_VERSION_MINOR;
+	req->rm_max_xfersz = HN_RNDIS_XFER_SIZE;
+
+	comp_len = RNDIS_INIT_COMP_SIZE_MIN;
+	comp = hn_rndis_xact_execute(sc, xact, rid, sizeof (*req), &comp_len,
+	    REMOTE_NDIS_INITIALIZE_CMPLT);
+	if (comp == NULL) {
+		HN_WARN(sc, "exec RNDIS init failed");
+		error = EIO;
+		goto done;
+	}
+
+	if (comp->rm_status != RNDIS_STATUS_SUCCESS) {
+		HN_WARN(sc, "RNDIS init failed: status 0x%08x",
+		    comp->rm_status);
+		error = EIO;
+		goto done;
+	}
+	HN_DEBUG(sc, 1, "RNDIS ver %u.%u, pktsz %u, pktcnt %u, "
+	    "align %u", comp->rm_ver_major, comp->rm_ver_minor,
+	    comp->rm_pktmaxsz, comp->rm_pktmaxcnt,
+	    1U << comp->rm_align);
+	error = 0;
+done:
+	vmbus_xact_put(xact);
+	return (error);
+}
+
+static int
+hn_rndis_halt(struct hn_softc *sc)
+{
+	struct vmbus_xact *xact;
+	struct rndis_halt_req *halt;
+	struct hn_nvs_sendctx sndc;
+	size_t comp_len;
+
+	xact = vmbus_xact_get(sc->hn_xact, sizeof (*halt));
+	if (xact == NULL) {
+		HN_WARN(sc, "no xact for RNDIS halt");
+		return (ENXIO);
+	}
+	halt = vmbus_xact_req_data(xact);
+	halt->rm_type = REMOTE_NDIS_HALT_MSG;
+	halt->rm_len = sizeof (*halt);
+	halt->rm_rid = hn_rndis_rid(sc);
+
+	/* No RNDIS completion; rely on NVS message send completion */
+	hn_nvs_sendctx_init(&sndc, hn_nvs_sent_xact, xact);
+	(void) hn_rndis_xact_exec1(sc, xact, sizeof (*halt), &sndc, &comp_len);
+
+	vmbus_xact_put(xact);
+	HN_DEBUG(sc, 1, "RNDIS halt done");
+	return (0);
+}
+
+static int
+hn_rndis_query_hwcaps(struct hn_softc *sc, struct ndis_offload *caps)
+{
+	struct ndis_offload in;
+	size_t caps_len, size;
+	int error;
+
+	(void) memset(&in, 0, sizeof (in));
+	in.ndis_hdr.ndis_type = NDIS_OBJTYPE_OFFLOAD;
+	if (sc->hn_ndis_ver >= HN_NDIS_VERSION_6_30) {
+		in.ndis_hdr.ndis_rev = NDIS_OFFLOAD_REV_3;
+		size = NDIS_OFFLOAD_SIZE;
+	} else if (sc->hn_ndis_ver >= HN_NDIS_VERSION_6_1) {
+		in.ndis_hdr.ndis_rev = NDIS_OFFLOAD_REV_2;
+		size = NDIS_OFFLOAD_SIZE_6_1;
+	} else {
+		in.ndis_hdr.ndis_rev = NDIS_OFFLOAD_REV_1;
+		size = NDIS_OFFLOAD_SIZE_6_0;
+	}
+	in.ndis_hdr.ndis_size = size;
+
+	caps_len = NDIS_OFFLOAD_SIZE;
+	error = hn_rndis_query2(sc, OID_TCP_OFFLOAD_HARDWARE_CAPABILITIES,
+	    &in, size, caps, &caps_len, NDIS_OFFLOAD_SIZE_6_0);
+	if (error)
+		return (error);
+
+	/*
+	 * Preliminary verification.
+	 */
+	if (caps->ndis_hdr.ndis_type != NDIS_OBJTYPE_OFFLOAD) {
+		HN_WARN(sc, "invalid NDIS objtype 0x%02x",
+		    caps->ndis_hdr.ndis_type);
+		return (EINVAL);
+	}
+	if (caps->ndis_hdr.ndis_rev < NDIS_OFFLOAD_REV_1) {
+		HN_WARN(sc, "invalid NDIS objrev 0x%02x",
+		    caps->ndis_hdr.ndis_rev);
+		return (EINVAL);
+	}
+	if (caps->ndis_hdr.ndis_size > caps_len) {
+		HN_WARN(sc, "invalid NDIS objsize %u, "
+		    "data size %lu", caps->ndis_hdr.ndis_size, caps_len);
+		return (EINVAL);
+	} else if (caps->ndis_hdr.ndis_size < NDIS_OFFLOAD_SIZE_6_0) {
+		HN_WARN(sc, "invalid NDIS objsize %u",
+		    caps->ndis_hdr.ndis_size);
+		return (EINVAL);
+	}
+
+	/*
+	 * NOTE:
+	 * caps->ndis_hdr.ndis_size MUST be checked before accessing
+	 * NDIS 6.1+ specific fields.
+	 */
+	HN_DEBUG(sc, 1, "hwcaps rev %u",
+	    caps->ndis_hdr.ndis_rev);
+
+	HN_DEBUG(sc, 1, "hwcaps csum: "
+	    "ip4 tx 0x%x/0x%x rx 0x%x/0x%x, "
+	    "ip6 tx 0x%x/0x%x rx 0x%x/0x%x",
+	    caps->ndis_csum.ndis_ip4_txcsum,
+	    caps->ndis_csum.ndis_ip4_txenc,
+	    caps->ndis_csum.ndis_ip4_rxcsum,
+	    caps->ndis_csum.ndis_ip4_rxenc,
+	    caps->ndis_csum.ndis_ip6_txcsum,
+	    caps->ndis_csum.ndis_ip6_txenc,
+	    caps->ndis_csum.ndis_ip6_rxcsum,
+	    caps->ndis_csum.ndis_ip6_rxenc);
+	HN_DEBUG(sc, 1, "hwcaps lsov2: "
+	    "ip4 maxsz %u minsg %u encap 0x%x, "
+	    "ip6 maxsz %u minsg %u encap 0x%x opts 0x%x",
+	    caps->ndis_lsov2.ndis_ip4_maxsz,
+	    caps->ndis_lsov2.ndis_ip4_minsg,
+	    caps->ndis_lsov2.ndis_ip4_encap,
+	    caps->ndis_lsov2.ndis_ip6_maxsz,
+	    caps->ndis_lsov2.ndis_ip6_minsg,
+	    caps->ndis_lsov2.ndis_ip6_encap,
+	    caps->ndis_lsov2.ndis_ip6_opts);
+
+	return (0);
+}
+
+int
+hn_rndis_attach(struct hn_softc *sc, int mtu)
+{
+	int error;
+
+	/*
+	 * Initialize RNDIS.
+	 */
+	error = hn_rndis_init(sc);
+	if (error)
+		return (error);
+
+	/*
+	 * Configure NDIS offload settings.
+	 */
+	(void) hn_rndis_conf_offload(sc, mtu);
+	return (0);
+}
+
+void
+hn_rndis_detach(struct hn_softc *sc)
+{
+
+	/* Halt the RNDIS. */
+	(void) hn_rndis_halt(sc);
+}

--- a/usr/src/uts/intel/io/hyperv/netvsc/hn_rndis.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hn_rndis.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2010-2012 Citrix Inc.
+ * Copyright (c) 2012 NetApp Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HN_RNDIS_H
+#define	_HN_RNDIS_H
+
+#include "rndis.h"
+
+struct hn_softc;
+
+int		hn_rndis_attach(struct hn_softc *sc, int mtu);
+void		hn_rndis_detach(struct hn_softc *sc);
+int		hn_rndis_conf_rss(struct hn_softc *sc, uint16_t flags);
+int		hn_rndis_query_rsscaps(struct hn_softc *sc, int *rxr_cnt);
+int		hn_rndis_get_eaddr(struct hn_softc *sc, uint8_t *eaddr);
+/* link_status: NDIS_MEDIA_STATE_ */
+int		hn_rndis_get_linkstatus(struct hn_softc *sc,
+		    uint32_t *link_status);
+/* filter: NDIS_PACKET_TYPE_. */
+int		hn_rndis_set_rxfilter(struct hn_softc *sc, uint32_t filter);
+int		hn_rndis_set_eaddr(struct hn_softc *sc,
+		    const uint8_t *mac_addr);
+void		hn_rndis_rx_ctrl(struct hn_softc *sc, const void *data,
+		    int dlen);
+
+#endif /* !_HN_RNDIS_H */

--- a/usr/src/uts/intel/io/hyperv/netvsc/hv_netvsc.conf
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hv_netvsc.conf
@@ -30,3 +30,7 @@
 # tx_cksum_offload - enable hardware checksum offload ( 0 | 1 )
 # tx_desc_cnt - number of tx descriptors (512 - 8192 in powers of 2)
 #
+
+rx_rings=4,4;
+tx_rings=4,4;
+tx_desc_cnt=8192,8192;

--- a/usr/src/uts/intel/io/hyperv/netvsc/hv_netvsc.conf
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hv_netvsc.conf
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+# Device parameters can be overriden here
+# Usage: param=val0,val1,val2,...;
+#   where val0 is the value to be used by device netvsc0,
+#   val1 is the value to be used by device netvsc1, etc.
+#
+# Example below sets 2 rx rings for netvsc0 and 4 rx rings for netvsc1:
+# rx_rings=2,4;
+#
+
+#
+# Valid parameters:
+# rx_rings - number of rx rings
+# tx_rings - number of tx rings
+# lso - enable large send offload ( 0 | 1 )
+# tx_cksum_offload - enable hardware checksum offload ( 0 | 1 )
+# tx_desc_cnt - number of tx descriptors (512 - 8192 in powers of 2)
+#

--- a/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
@@ -1,0 +1,3360 @@
+/*
+ * Copyright (c) 2010-2012 Citrix Inc.
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2004-2006 Kip Macy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/sysmacros.h>
+#include <sys/sunddi.h>
+#include <sys/socket.h>
+#include <sys/strsubr.h>
+#include <inet/ip.h>
+#include <inet/ip6.h>
+#include <inet/tcp.h>
+#include <sys/dlpi.h>
+#include <netinet/in.h>
+#include <netinet/udp.h>
+
+#include <sys/mutex.h>
+#include <sys/errno.h>
+#include <sys/types.h>
+#include <sys/atomic.h>
+#include <sys/sdt.h>
+
+#include <sys/conf.h>
+#include <sys/mac_provider.h>
+#include <sys/mac_ether.h>
+#include <sys/vlan.h>
+#include <sys/pattr.h>
+#include <sys/strsun.h>
+#include <sys/stream.h>
+#include <sys/debug.h>
+
+#include <sys/hyperv.h>
+#include <sys/hyperv_busdma.h>
+#include <sys/vmbus_xact.h>
+#include <sys/vmbus.h>
+
+#include "if_hnreg.h"
+#include "if_hnvar.h"
+#include "hn_rndis.h"
+#include "hn_nvs.h"
+#include "ndis.h"
+#include "buf_ring.h"
+
+#include <sys/hyperv_illumos.h>
+
+#define	NETVSC_DEVNAME "hv_netvsc"
+
+static uchar_t hn_broadcast[ETHERADDRL] = {
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+
+#define	HN_RNDIS_PKT_LEN					\
+	(sizeof (struct rndis_packet_msg) +			\
+	HN_RNDIS_PKTINFO_SIZE(HN_NDIS_HASH_VALUE_SIZE) +	\
+	HN_RNDIS_PKTINFO_SIZE(NDIS_VLAN_INFO_SIZE) +		\
+	HN_RNDIS_PKTINFO_SIZE(NDIS_LSO2_INFO_SIZE) +		\
+	HN_RNDIS_PKTINFO_SIZE(NDIS_TXCSUM_INFO_SIZE))
+#define	HN_RNDIS_PKT_BOUNDARY		0x1000
+#define	HN_RNDIS_PKT_ALIGN		CACHE_LINE_SIZE
+
+#define	HN_TX_DATA_BOUNDARY		0x1000
+#define	HN_TX_DATA_MAXSIZE		IP_MAXPACKET
+#define	HN_TX_DATA_SEGSIZE		0x1000
+/* -1 for RNDIS packet message */
+#define	HN_TX_DATA_SEGCNT_MAX		(HN_GPACNT_MAX - 1)
+
+#define	HN_PKTBUF_LEN_DEF		(16 * 1024)
+
+struct hn_txdesc {
+	mblk_t			*m;
+	struct hn_tx_ring	*txr;
+	uint32_t		flags;		/* HN_TXD_FLAG_ */
+	struct hn_nvs_sendctx	send_ctx;
+	uint32_t		chim_index;
+	int			chim_size;
+	uint64_t		rndis_pkt_paddr;
+	struct rndis_packet_msg *rndis_pkt;
+	ddi_dma_handle_t	rndis_pkt_dmah;
+	ddi_acc_handle_t	rndis_pkt_datah;
+	size_t			rndis_pkt_buflen;
+};
+
+#define	HN_TXD_FLAG_ONLIST		0x0001
+#define	HN_TXD_FLAG_DMAMAP		0x0002
+
+struct hn_rxinfo {
+	uint32_t			vlan_info;
+	uint32_t			csum_info;
+	uint32_t			hash_info;
+	uint32_t			hash_value;
+};
+
+#define	HN_RXINFO_VLAN			0x0001
+#define	HN_RXINFO_CSUM			0x0002
+#define	HN_RXINFO_HASHINF		0x0004
+#define	HN_RXINFO_HASHVAL		0x0008
+#define	HN_RXINFO_ALL			\
+	(HN_RXINFO_VLAN |		\
+	HN_RXINFO_CSUM |		\
+	HN_RXINFO_HASHINF |		\
+	HN_RXINFO_HASHVAL)
+
+#define	HN_NDIS_VLAN_INFO_INVALID	0xffffffff
+#define	HN_NDIS_RXCSUM_INFO_INVALID	0
+#define	HN_NDIS_HASH_INFO_INVALID	0
+
+
+static void			hn_chan_callback(struct vmbus_channel *,
+				    void *);
+
+static int			hn_rndis_rxinfo(const void *, int,
+				    struct hn_rxinfo *);
+static void			hn_rndis_rx_data(struct hn_rx_ring *,
+				    const void *, int);
+static void			hn_rndis_rx_status(struct hn_softc *,
+				    const void *, int);
+
+static void			hn_nvs_handle_notify(struct hn_softc *,
+				    const struct vmbus_chanpkt_hdr *);
+static void			hn_nvs_handle_comp(struct hn_softc *,
+				    struct vmbus_channel *,
+				    const struct vmbus_chanpkt_hdr *);
+static void			hn_nvs_handle_rxbuf(struct hn_rx_ring *,
+				    struct vmbus_channel *,
+				    const struct vmbus_chanpkt_hdr *);
+static void			hn_nvs_ack_rxbuf(struct hn_rx_ring *,
+				    struct vmbus_channel *, uint64_t);
+
+static int			hn_chan_attach(struct hn_softc *,
+				    struct vmbus_channel *);
+static void			hn_chan_detach(struct hn_softc *,
+				    struct vmbus_channel *);
+static int			hn_attach_subchans(struct hn_softc *);
+static void			hn_detach_allchans(struct hn_softc *);
+static void			hn_detach_impl(struct hn_softc *);
+
+static void			hn_update_ring_inuse(struct hn_softc *, int);
+static int			hn_synth_attach(struct hn_softc *, int);
+static void			hn_synth_detach(struct hn_softc *);
+static int			hn_synth_alloc_subchans(struct hn_softc *,
+				    int *);
+static boolean_t		hn_synth_attachable(const struct hn_softc *);
+static void			hn_suspend(struct hn_softc *);
+static void			hn_suspend_data(struct hn_softc *);
+static void			hn_suspend_mgmt(struct hn_softc *);
+static void			hn_resume(struct hn_softc *);
+static void			hn_resume_data(struct hn_softc *);
+static void			hn_resume_mgmt(struct hn_softc *);
+static void			hn_chan_drain(struct hn_softc *,
+				    struct vmbus_channel *);
+
+static void			hn_update_link_status(struct hn_softc *);
+static void			hn_change_network(struct hn_softc *);
+static void			hn_link_taskfunc(void *);
+static void			hn_netchg_taskfunc(void *);
+static void			hn_link_status(struct hn_softc *);
+
+static int			hn_create_rx_data(struct hn_softc *);
+static void			hn_destroy_rx_data(struct hn_softc *);
+static void			hn_rss_ind_fixup(struct hn_softc *);
+static int			hn_rxpkt(struct hn_rx_ring *, const void *,
+				    int, const struct hn_rxinfo *);
+static uint32_t			hn_get_implied_hcksum(struct hn_rx_ring *,
+				    const mblk_t *);
+
+static int			hn_tx_ring_create(struct hn_softc *, int);
+static void			hn_tx_ring_destroy(struct hn_tx_ring *);
+static int			hn_create_tx_data(struct hn_softc *);
+static void			hn_fixup_tx_data(struct hn_softc *);
+static void			hn_destroy_tx_data(struct hn_softc *);
+static void			hn_txdesc_dmamap_destroy(struct hn_txdesc *);
+#ifdef txagg
+static void			hn_txdesc_gc(struct hn_tx_ring *,
+				    struct hn_txdesc *);
+#endif
+static int			hn_encap(struct hn_tx_ring *,
+				    struct hn_txdesc *, mblk_t *);
+static int			hn_txpkt(struct hn_tx_ring *,
+				    struct hn_txdesc *);
+static boolean_t		hn_tx_ring_pending(struct hn_tx_ring *);
+static void			hn_resume_tx(struct hn_softc *, int);
+
+static void			hn_txpkt_done(struct hn_nvs_sendctx *,
+				    struct hn_softc *, struct vmbus_channel *,
+				    const void *, int);
+static int			hn_txpkt_sglist(struct hn_tx_ring *,
+				    struct hn_txdesc *);
+static int			hn_txpkt_chim(struct hn_tx_ring *,
+				    struct hn_txdesc *);
+
+/*
+ * Global Tunables
+ */
+
+/*
+ * HN_DEBUG() level.
+ * 0 - disabled
+ * 1 - attach, config, milestones
+ * 2 - stats, props, more verbose
+ * 3 - more verbose
+ * 4 - most verbose: each tx/rx pkt
+ */
+int hn_debug = 0;
+
+/*
+ * Trust tcp/udp/ip checksum verification on host side.
+ */
+boolean_t hn_trust_host_cksum = HN_DEFAULT_TRUST_HOST_CKSUM;
+/*
+ * Limit TSO burst size
+ */
+int hn_tso_maxlen = IP_MAXPACKET;
+/*
+ * Limit chimney send size
+ * (chimney is used to send small packets more efficiently. 0 = use default)
+ */
+int hn_tx_chimney_size = 0;
+/*
+ * Enable hardware offloading of tx checksumming.
+ * Can be overriden in driver.conf.
+ */
+boolean_t hn_tx_hcksum_enable_default = B_TRUE;
+/*
+ * Enable Large Send Offload.
+ * Can be overriden in driver.conf.
+ */
+boolean_t hn_lso_enable_default = B_TRUE;
+/*
+ * default number of tx descriptors per ring.
+ * Can be overriden in driver.conf.
+ */
+#define	HN_TX_DESC_CNT_DEFAULT	512
+#define	HN_TX_DESC_CNT_MIN	512
+#define	HN_TX_DESC_CNT_MAX	8192
+int hn_txdesc_cnt_default = HN_TX_DESC_CNT_DEFAULT;
+
+/*
+ * Globals
+ */
+
+/*
+ * Assign each channel to a different cpu.
+ */
+uint32_t hn_cpu_index = 0;
+
+static const uint8_t
+hn_rss_key_default[NDIS_HASH_KEYSIZE_TOEPLITZ] = {
+	0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2,
+	0x41, 0x67, 0x25, 0x3d, 0x43, 0xa3, 0x8f, 0xb0,
+	0xd0, 0xca, 0x2b, 0xcb, 0xae, 0x7b, 0x30, 0xb4,
+	0x77, 0xcb, 0x2d, 0xa3, 0x80, 0x30, 0xf2, 0x0c,
+	0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa
+};
+
+/*
+ * Get the numeric value of the property "name" in netvsc.conf for
+ * the corresponding device instance.
+ * If the property isn't found or if it doesn't satisfy the conditions,
+ * "def" is returned.
+ */
+static int
+hn_getprop(struct hn_softc *sc, char *name, int min, int max, int def)
+{
+	int ret = def;
+	int *props;
+	uint_t nprops;
+
+	ASSERT(def >= min && def <= max);
+
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, sc->hn_dev,
+	    DDI_PROP_DONTPASS, name, &props, &nprops) == DDI_PROP_SUCCESS) {
+		if (sc->hn_instance < nprops) {
+			ret = props[sc->hn_instance];
+			HN_NOTE(sc, "property %s configured to %d", name, ret);
+		} else {
+			HN_WARN(sc, "property %s not available for this "
+			    "device", name);
+		}
+		ddi_prop_free(props);
+	}
+
+	if (ret < min || ret > max) {
+		HN_WARN(sc, "property %s out of range (%d <= %d <= %d), "
+		    "setting to default (%d)", name, min, ret, max, def);
+		ret = def;
+	}
+
+	HN_DEBUG(sc, 2, "hn_getprop(%s) -> %d", name, ret);
+
+	return (ret);
+}
+
+static void
+hn_init_properties(struct hn_softc *sc)
+{
+	/*
+	 * NOTE:
+	 * The # of RX rings to use is same as the # of channels to use.
+	 */
+	sc->hn_rx_ring_cnt = hn_getprop(sc, "rx_rings", 1, HN_RING_CNT_DEF_MAX,
+	    min(ncpus, HN_RING_CNT_DEF_MAX));
+
+	/*
+	 * # of TX rings is limited by the number of channels (i.e RX rings)
+	 */
+	sc->hn_tx_ring_cnt = hn_getprop(sc, "tx_rings", 1, sc->hn_rx_ring_cnt,
+	    sc->hn_rx_ring_cnt);
+
+	sc->hn_lso_enable = hn_getprop(sc, "lso", B_FALSE, B_TRUE,
+	    hn_lso_enable_default);
+
+	sc->hn_tx_hcksum_enable = hn_getprop(sc, "tx_cksum_offload", B_FALSE,
+	    B_TRUE, hn_tx_hcksum_enable_default);
+
+	/* TODO: find txdesc_cnt hard limit, or get it from host */
+	sc->hn_txdesc_cnt = hn_getprop(sc, "tx_desc_cnt", HN_TX_DESC_CNT_MIN,
+	    HN_TX_DESC_CNT_MAX, hn_txdesc_cnt_default);
+	if (!ISP2(sc->hn_txdesc_cnt)) {
+		HN_WARN(sc, "number of tx descriptors (%d) must be a power "
+		    "of 2, defaulting to %d", sc->hn_txdesc_cnt,
+		    HN_TX_DESC_CNT_DEFAULT);
+		sc->hn_txdesc_cnt = HN_TX_DESC_CNT_DEFAULT;
+	}
+
+	/*
+	 * Set the leader CPU for channels.
+	 */
+	sc->hn_cpu = (atomic_add_32_nv(&hn_cpu_index, sc->hn_rx_ring_cnt) -
+	    sc->hn_rx_ring_cnt) % ncpus;
+}
+
+int
+hn_change_mtu(struct hn_softc *sc, uint32_t new_mtu)
+{
+	int error = 0;
+
+	if (new_mtu > HN_MTU_MAX || new_mtu < HN_MTU_MIN)
+		return (EINVAL);
+
+	HN_LOCK(sc);
+	ASSERT(sc->hn_flags & HN_FLAG_SYNTH_ATTACHED);
+
+	if ((sc->hn_caps & HN_CAP_MTU) == 0) {
+		/* changing mtu is not supported */
+		HN_UNLOCK(sc);
+		return (ENOTSUP);
+	}
+
+	if (new_mtu == sc->hn_mtu) {
+		HN_UNLOCK(sc);
+		return (0);
+	}
+
+	HN_DEBUG(sc, 2, "hn_change_mtu: %d --> %d", sc->hn_mtu, new_mtu);
+
+	if (sc->hn_running)
+		hn_suspend(sc);
+
+	sc->hn_mtu = new_mtu;
+
+	/*
+	 * Detach the synthetics parts, i.e. NVS, RNDIS and channels.
+	 * Essentially we need to disconnect & reconnect the back end of the
+	 * interface in order to change the MTU.
+	 */
+	hn_synth_detach(sc);
+
+	/*
+	 * Reattach the synthetic parts, i.e. NVS and RNDIS,
+	 * with the new MTU setting.
+	 */
+	error = hn_synth_attach(sc, sc->hn_mtu);
+	if (error != 0) {
+		HN_WARN(sc, "hn_change_mtu: hn_synth_attach failed, %d",
+		    error);
+		HN_UNLOCK(sc);
+		return (EIO);
+	}
+
+	if (sc->hn_tx_ring[0].hn_chim_size > sc->hn_chim_szmax)
+		hn_set_chim_size(sc, sc->hn_chim_szmax);
+
+	error = mac_maxsdu_update(sc->hn_mac_hdl, new_mtu);
+	if (error != 0) {
+		HN_WARN(sc, "Unable to update mac with %d mtu: %d",
+		    new_mtu, error);
+		HN_UNLOCK(sc);
+		return (EIO);
+	}
+
+	/* All done!  Resume now. */
+	hn_resume(sc);
+
+	HN_UNLOCK(sc);
+
+	return (0);
+}
+
+
+static int
+hn_kstat_update(kstat_t *ksp, int rw)
+{
+	struct hn_softc *sc = ksp->ks_private;
+	hn_kstats_t *sp = ksp->ks_data;
+
+	if (rw == KSTAT_WRITE)
+		return (EACCES);
+
+	sp->tx_ring_cnt.value.ui32 = sc->hn_tx_ring_cnt;
+	sp->tx_ring_inuse.value.ui32 = sc->hn_tx_ring_inuse;
+	sp->rx_ring_cnt.value.ui32 = sc->hn_rx_ring_cnt;
+	sp->rx_ring_inuse.value.ui32 = sc->hn_rx_ring_inuse;
+
+	sp->tx_send_failed.value.ui64 = 0;
+	sp->tx_no_descs.value.ui64 = 0;
+	sp->tx_mblk_pulledup.value.ui64 = 0;
+	sp->tx_chimney_tried.value.ui64 = 0;
+	sp->tx_chimney_sent.value.ui64 = 0;
+	sp->tx_dma_failed.value.ui64 = 0;
+#ifdef DEBUG
+	sp->tx_descs_used.value.ui64 = 0;
+#endif
+
+	for (int i = 0; i < sc->hn_tx_ring_inuse; i++) {
+		struct hn_tx_ring *txr = &sc->hn_tx_ring[i];
+		hn_tx_stats_t *txs = &txr->hn_tx_stats;
+		mutex_enter(&txr->hn_tx_lock);
+		sp->tx_send_failed.value.ui64 += txs->send_failed;
+		sp->tx_no_descs.value.ui64 += txs->no_txdescs;
+		sp->tx_mblk_pulledup.value.ui64 += txs->pulledup;
+		sp->tx_chimney_tried.value.ui64 += txs->chimney_tried;
+		sp->tx_chimney_sent.value.ui64 += txs->chimney_sent;
+		sp->tx_dma_failed.value.ui64 += txs->dma_failed;
+#ifdef DEBUG
+		sp->tx_descs_used.value.ui64 +=
+		    (txr->hn_txdesc_cnt - txr->hn_txdesc_avail);
+#endif
+		mutex_exit(&txr->hn_tx_lock);
+	}
+
+	sp->rx_no_bufs.value.ui64 = 0;
+	sp->rx_csum_ip.value.ui64 = 0;
+	sp->rx_csum_tcp.value.ui64 = 0;
+	sp->rx_csum_udp.value.ui64 = 0;
+	sp->rx_csum_trusted.value.ui64 = 0;
+
+	for (int i = 0; i < sc->hn_rx_ring_inuse; i++) {
+		struct hn_rx_ring *rxr = &sc->hn_rx_ring[i];
+		hn_rx_stats_t *rxs = &rxr->hn_rx_stats;
+		mutex_enter(&rxr->hn_rx_lock);
+		sp->rx_no_bufs.value.ui64 += rxs->norxbufs;
+		sp->rx_csum_ip.value.ui64 += rxs->csum_ip;
+		sp->rx_csum_tcp.value.ui64 += rxs->csum_tcp;
+		sp->rx_csum_udp.value.ui64 += rxs->csum_udp;
+		sp->rx_csum_trusted.value.ui64 += rxs->csum_trusted;
+		mutex_exit(&rxr->hn_rx_lock);
+	}
+
+	return (0);
+}
+
+
+static int
+hn_kstat_init(struct hn_softc *sc)
+{
+	hn_kstats_t *sp;
+
+	sc->hn_kstats = kstat_create(NETVSC_DEVNAME, sc->hn_instance,
+	    "statistics", "dev",  KSTAT_TYPE_NAMED,
+	    sizeof (hn_kstats_t) / sizeof (kstat_named_t), 0);
+	if (sc->hn_kstats == NULL) {
+		HN_WARN(sc, "Failed to allocate kstats");
+		return (EINVAL);
+	}
+
+	sc->hn_kstats->ks_update = hn_kstat_update;
+	sc->hn_kstats->ks_private = sc;
+
+	sp = sc->hn_kstats->ks_data;
+
+	kstat_named_init(&sp->tx_ring_cnt, "tx_ring_cnt",
+	    KSTAT_DATA_UINT32);
+	kstat_named_init(&sp->tx_ring_inuse, "tx_ring_inuse",
+	    KSTAT_DATA_UINT32);
+	kstat_named_init(&sp->rx_ring_cnt, "rx_ring_cnt",
+	    KSTAT_DATA_UINT32);
+	kstat_named_init(&sp->rx_ring_inuse, "rx_ring_inuse",
+	    KSTAT_DATA_UINT32);
+
+	kstat_named_init(&sp->tx_send_failed, "tx_send_failed",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->tx_no_descs, "tx_no_descs",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->tx_mblk_pulledup, "tx_mblk_pulledup",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->tx_chimney_tried, "tx_chimney_tried",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->tx_chimney_sent, "tx_chimney_sent",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->tx_dma_failed, "tx_dma_failed",
+	    KSTAT_DATA_ULONG);
+#ifdef DEBUG
+	kstat_named_init(&sp->tx_descs_used, "tx_descs_used",
+	    KSTAT_DATA_ULONG);
+#endif
+
+	kstat_named_init(&sp->rx_no_bufs, "rx_no_bufs",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->rx_csum_ip, "rx_csum_ip",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->rx_csum_tcp, "rx_csum_tcp",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->rx_csum_udp, "rx_csum_udp",
+	    KSTAT_DATA_ULONG);
+	kstat_named_init(&sp->rx_csum_trusted, "rx_csum_trusted",
+	    KSTAT_DATA_ULONG);
+
+	kstat_install(sc->hn_kstats);
+
+	return (0);
+}
+
+static int
+hn_txpkt_sglist(struct hn_tx_ring *txr, struct hn_txdesc *txd)
+{
+
+	ASSERT3U(txd->chim_index, ==, HN_NVS_CHIM_IDX_INVALID);
+	ASSERT3S(txd->chim_size, ==, 0);
+
+	return (hn_nvs_send_rndis_sglist(txr->hn_chan, HN_NVS_RNDIS_MTYPE_DATA,
+	    &txd->send_ctx, txr->hn_gpa, txr->hn_gpa_cnt));
+}
+
+static int
+hn_txpkt_chim(struct hn_tx_ring *txr, struct hn_txdesc *txd)
+{
+	struct hn_nvs_rndis rndis;
+
+	ASSERT(txd->chim_index != HN_NVS_CHIM_IDX_INVALID);
+	ASSERT3S(txd->chim_size, >, 0);
+
+	rndis.nvs_type = HN_NVS_TYPE_RNDIS;
+	rndis.nvs_rndis_mtype = HN_NVS_RNDIS_MTYPE_DATA;
+	rndis.nvs_chim_idx = txd->chim_index;
+	rndis.nvs_chim_sz = txd->chim_size;
+
+	return (hn_nvs_send(txr->hn_chan, VMBUS_CHANPKT_FLAG_RC,
+	    &rndis, sizeof (rndis), &txd->send_ctx));
+}
+
+uint32_t
+hn_chim_alloc(struct hn_softc *sc)
+{
+	int i, bmap_cnt = sc->hn_chim_bmap_cnt;
+	ulong_t *bmap = sc->hn_chim_bmap;
+
+	for (i = 0; i < bmap_cnt; ++i) {
+		int result, idx;
+		uint32_t chim_idx;
+
+		idx = lowbit(~bmap[i]);
+		if (idx == 0)
+			continue;
+
+		--idx; /* lowbit is 1-based */
+
+		chim_idx = (i << BT_ULSHIFT) + idx;
+		ASSERT3U(chim_idx, <, sc->hn_chim_cnt);
+
+		BT_ATOMIC_SET_EXCL(bmap, chim_idx, result);
+		if (result == 0)
+			return (chim_idx);
+	}
+	return (HN_NVS_CHIM_IDX_INVALID);
+}
+
+void
+hn_chim_free(struct hn_softc *sc, uint32_t chim_idx)
+{
+	ASSERT3U(chim_idx >> BT_ULSHIFT, <, sc->hn_chim_bmap_cnt);
+	ASSERT(BT_TEST(sc->hn_chim_bmap, chim_idx));
+
+	BT_ATOMIC_CLEAR(sc->hn_chim_bmap, chim_idx);
+}
+
+int
+hn_set_rxfilter(struct hn_softc *sc)
+{
+	uint32_t filter;
+	int error = 0;
+
+	HN_LOCK_ASSERT(sc);
+
+	/*
+	 * We currently support only two modes (based on Linux implementation):
+	 *  - non-promiscuous mode, accepting all multicast packets
+	 *  - promiscuous mode
+	 */
+	if (sc->hn_promiscuous) {
+		filter = NDIS_PACKET_TYPE_PROMISCUOUS;
+	} else {
+		filter = NDIS_PACKET_TYPE_DIRECTED |
+		    NDIS_PACKET_TYPE_BROADCAST |
+		    NDIS_PACKET_TYPE_ALL_MULTICAST;
+	}
+
+	if (sc->hn_rx_filter != filter) {
+		error = hn_rndis_set_rxfilter(sc, filter);
+		if (!error)
+			sc->hn_rx_filter = filter;
+	}
+	return (error);
+}
+
+static void
+hn_rss_ind_fixup(struct hn_softc *sc)
+{
+	struct ndis_rssprm_toeplitz *rss = &sc->hn_rss;
+	int i, nchan;
+
+	nchan = sc->hn_rx_ring_inuse;
+	/*
+	 * RSS requires more than one channel to be configured
+	 */
+	ASSERT(nchan > 1);
+
+	/*
+	 * Check indirect table to make sure that all channels in it
+	 * can be used.
+	 */
+	for (i = 0; i < NDIS_HASH_INDCNT; ++i) {
+		if (rss->rss_ind[i] >= nchan) {
+			/*
+			 * TODO: this looks like a terrible way to "fix"
+			 * RSS index mapping.
+			 */
+			HN_WARN(sc, "RSS indirect table %d fixup: %u -> %d",
+			    i, rss->rss_ind[i], nchan - 1);
+			rss->rss_ind[i] = nchan - 1;
+		}
+	}
+}
+
+static int
+hn_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	struct hn_softc *sc;
+	int error;
+
+	/*
+	 * We do not currently support DDI_RESUME
+	 */
+	if (cmd != DDI_ATTACH)
+		return (DDI_FAILURE);
+
+	sc = kmem_zalloc(sizeof (struct hn_softc), KM_SLEEP);
+	HN_LOCK_INIT(sc);
+	mutex_init(&sc->hn_mgmt_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	sc->hn_dev = dip;
+	sc->hn_instance = ddi_get_instance(dip);
+
+	/*
+	 * Get the primary channel for the netvsc device
+	 */
+	sc->hn_prichan = vmbus_get_channel(dip);
+
+	ddi_set_driver_private(dip, sc);
+
+	hn_init_properties(sc);
+
+	/*
+	 * Setup taskqueue for management tasks, e.g. link status.
+	 */
+	sc->hn_mgmt_taskq0 = ddi_taskq_create(dip, "hn_mgmt", 1,
+	    TASKQ_DEFAULTPRI, 0);
+
+	/*
+	 * Create enough TX/RX rings, even if only limited number of
+	 * channels can be allocated.
+	 */
+	error = hn_create_tx_data(sc);
+	if (error != 0)
+		goto failed;
+	error = hn_create_rx_data(sc);
+	if (error != 0)
+		goto failed;
+
+	/*
+	 * Create transaction context for NVS and RNDIS transactions.
+	 */
+	sc->hn_xact = vmbus_xact_ctx_create(dip,
+	    HN_XACT_REQ_SIZE, HN_XACT_RESP_SIZE, 0);
+	if (sc->hn_xact == NULL) {
+		error = ENXIO;
+		goto failed;
+	}
+
+	/*
+	 * Install orphan handler for the revocation of this device's
+	 * primary channel.
+	 *
+	 * NOTE:
+	 * The processing order is critical here:
+	 * Install the orphan handler, _before_ testing whether this
+	 * device's primary channel has been revoked or not.
+	 */
+	vmbus_chan_set_orphan(sc->hn_prichan, sc->hn_xact);
+	if (vmbus_chan_is_revoked(sc->hn_prichan)) {
+		error = ENXIO;
+		goto failed;
+	}
+
+	sc->hn_mtu = ETHERMTU;
+	/*
+	 * Attach the synthetic parts, i.e. NVS and RNDIS.
+	 */
+	error = hn_synth_attach(sc, sc->hn_mtu);
+	if (error != 0)
+		goto failed;
+
+	/*
+	 * Fixup TX stuffs after synthetic parts are attached.
+	 */
+	hn_fixup_tx_data(sc);
+
+	error = hn_kstat_init(sc);
+	if (error != 0)
+		goto failed;
+
+	/*
+	 * Register device with the MAC framework.
+	 * We need to do this after the synthetic parts are attached as we
+	 * have to query for the MAC address.
+	 */
+	error = hn_register_mac(sc);
+	if (error != 0)
+		goto failed;
+
+	/*
+	 * Kick off link status check.
+	 */
+	sc->hn_mgmt_taskq = sc->hn_mgmt_taskq0;
+	hn_update_link_status(sc);
+
+	return (DDI_SUCCESS);
+
+failed:
+	if (sc->hn_flags & HN_FLAG_SYNTH_ATTACHED)
+		hn_synth_detach(sc);
+
+	hn_detach_impl(sc);
+
+	return (DDI_FAILURE);
+}
+
+static void
+hn_detach_impl(struct hn_softc *sc)
+{
+	if (sc->hn_xact != NULL && vmbus_chan_is_revoked(sc->hn_prichan)) {
+		/*
+		 * In case that the vmbus missed the orphan handler
+		 * installation.
+		 */
+		(void) vmbus_xact_ctx_orphan(sc->hn_xact);
+	}
+
+	HN_LOCK(sc);
+	if (sc->hn_flags & HN_FLAG_SYNTH_ATTACHED) {
+		ASSERT(!sc->hn_running);
+		hn_suspend_mgmt(sc);
+		hn_synth_detach(sc);
+	}
+	HN_UNLOCK(sc);
+
+	if (sc->hn_mac_hdl != NULL)
+		VERIFY0(mac_unregister(sc->hn_mac_hdl));
+
+	if (sc->hn_kstats != NULL)
+		kstat_delete(sc->hn_kstats);
+
+	hn_destroy_rx_data(sc);
+	hn_destroy_tx_data(sc);
+
+	ddi_taskq_destroy(sc->hn_mgmt_taskq0);
+
+	if (sc->hn_xact != NULL) {
+		/*
+		 * Uninstall the orphan handler _before_ the xact is
+		 * destructed.
+		 */
+		vmbus_chan_unset_orphan(sc->hn_prichan);
+		vmbus_xact_ctx_destroy(sc->hn_xact);
+	}
+
+	mutex_destroy(&sc->hn_mgmt_lock);
+	HN_LOCK_DESTROY(sc);
+
+	kmem_free(sc, sizeof (*sc));
+}
+
+static int
+hn_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	struct hn_softc *sc = ddi_get_driver_private(dip);
+
+	HN_DEBUG(sc, 1, "detach()");
+
+	if (cmd != DDI_DETACH) {
+		return (DDI_FAILURE);
+	}
+
+	hn_detach_impl(sc);
+
+	return (DDI_SUCCESS);
+}
+
+static void
+hn_link_status(struct hn_softc *sc)
+{
+	uint32_t link_status;
+	int error;
+
+	error = hn_rndis_get_linkstatus(sc, &link_status);
+	if (error) {
+		/* XXX what to do? */
+		HN_WARN(sc, "Failed to get link status, %d", error);
+		return;
+	}
+
+	if (link_status == NDIS_MEDIA_STATE_CONNECTED)
+		sc->hn_link_flags |= HN_LINK_FLAG_LINKUP;
+	else
+		sc->hn_link_flags &= ~HN_LINK_FLAG_LINKUP;
+
+	mac_link_update(sc->hn_mac_hdl,
+	    (sc->hn_link_flags & HN_LINK_FLAG_LINKUP) ?
+	    LINK_STATE_UP : LINK_STATE_DOWN);
+}
+
+static void
+hn_link_taskfunc(void *xsc)
+{
+	struct hn_softc *sc = xsc;
+
+	if (sc->hn_link_flags & HN_LINK_FLAG_NETCHG)
+		return;
+	hn_link_status(sc);
+}
+
+/*
+ * TODO: test this function.
+ */
+static void
+hn_netchg_taskfunc(void *xsc)
+{
+	struct hn_softc *sc = xsc;
+
+	/* Prevent any link status checks from running. */
+	sc->hn_link_flags |= HN_LINK_FLAG_NETCHG;
+
+	/*
+	 * FreeBSD comment:
+	 * Fake up a [link down --> link up] state change; 5 seconds
+	 * delay is used, which closely simulates miibus reaction
+	 * upon link down event.
+	 */
+
+	sc->hn_link_flags &= ~HN_LINK_FLAG_LINKUP;
+	mac_link_update(sc->hn_mac_hdl, LINK_STATE_DOWN);
+
+	delay(SEC_TO_TICK(5));
+
+	/* Re-allow link status checks. */
+	sc->hn_link_flags &= ~HN_LINK_FLAG_NETCHG;
+	hn_link_status(sc);
+}
+
+static void
+hn_update_link_status(struct hn_softc *sc)
+{
+	mutex_enter(&sc->hn_mgmt_lock);
+	if (sc->hn_mgmt_taskq != NULL) {
+		(void) ddi_taskq_dispatch(sc->hn_mgmt_taskq, hn_link_taskfunc,
+		    sc, TQ_SLEEP);
+	}
+	mutex_exit(&sc->hn_mgmt_lock);
+}
+
+static void
+hn_change_network(struct hn_softc *sc)
+{
+	mutex_enter(&sc->hn_mgmt_lock);
+	if (sc->hn_mgmt_taskq != NULL) {
+		(void) ddi_taskq_dispatch(sc->hn_mgmt_taskq, hn_netchg_taskfunc,
+		    sc, TQ_SLEEP);
+	}
+	mutex_exit(&sc->hn_mgmt_lock);
+}
+
+static int
+hn_txdesc_dmamap_load(struct hn_tx_ring *txr, struct hn_txdesc *txd,
+    mblk_t *mp, int pktlen)
+{
+	ASSERT3U(txd->chim_index, ==, HN_NVS_CHIM_IDX_INVALID);
+
+	txr->hn_gpa[0].gpa_page = btop(txd->rndis_pkt_paddr);
+	txr->hn_gpa[0].gpa_ofs = txd->rndis_pkt_paddr & PAGEOFFSET;
+	txr->hn_gpa[0].gpa_len = pktlen;
+
+	int nsegs = 1; /* First seg is used by RNDIS packet */
+	for (; mp != NULL; mp = mp->b_cont) {
+		ddi_dma_cookie_t cookie;
+		uint_t cookie_count;
+
+		if (MBLKL(mp) == 0)
+			continue;
+
+		int ret = ddi_dma_addr_bind_handle(txr->hn_data_dmah, NULL,
+		    (caddr_t)mp->b_rptr, MBLKL(mp),
+		    DDI_DMA_RDWR | DDI_DMA_STREAMING, DDI_DMA_DONTWAIT, NULL,
+		    &cookie, &cookie_count);
+		if (ret != DDI_DMA_MAPPED) {
+			HN_WARN(txr->hn_sc, "ddi_dma_addr_bind_handle() "
+			    "failed, [error=%d]", ret);
+			return (ENOMEM);
+		}
+		ASSERT(cookie_count > 0);
+		for (int i = 0; i < cookie_count; i++) {
+			if (nsegs == HN_GPACNT_MAX) {
+				(void) ddi_dma_unbind_handle(txr->hn_data_dmah);
+				return (EAGAIN);
+			}
+			struct vmbus_gpa *gpa = &txr->hn_gpa[nsegs];
+			gpa->gpa_page = btop(cookie.dmac_laddress);
+			gpa->gpa_ofs = cookie.dmac_laddress & PAGEOFFSET;
+			gpa->gpa_len = cookie.dmac_size;
+			ddi_dma_nextcookie(txr->hn_data_dmah, &cookie);
+			nsegs++;
+		}
+		/*
+		 * XXX: HACK
+		 * We do a hack here by unbinding the handle before the data
+		 * has been sent in order to be able to re-use the same handle.
+		 * The assumption here is that data copying is not necessary
+		 * as the DMA constraints are relaxed enough.
+		 * Alternatively, we could try to access the HAT directly to
+		 * retrieve the physical addresses by calling hat_getpfnum().
+		 */
+		(void) ddi_dma_unbind_handle(txr->hn_data_dmah);
+	}
+	txr->hn_gpa_cnt = nsegs;
+
+	DTRACE_PROBE2(segs, int, nsegs, int, txr->hn_pkt_length);
+
+	txd->flags |= HN_TXD_FLAG_DMAMAP;
+
+	return (0);
+}
+
+static void
+hn_txdesc_put(struct hn_tx_ring *txr, struct hn_txdesc *txd)
+{
+	ASSERT0(txd->flags & HN_TXD_FLAG_ONLIST);
+
+	if (txd->chim_index != HN_NVS_CHIM_IDX_INVALID) {
+		ASSERT0(txd->flags & HN_TXD_FLAG_DMAMAP);
+		hn_chim_free(txr->hn_sc, txd->chim_index);
+		txd->chim_index = HN_NVS_CHIM_IDX_INVALID;
+	} else if (txd->flags & HN_TXD_FLAG_DMAMAP) {
+		txd->flags &= ~HN_TXD_FLAG_DMAMAP;
+	}
+
+	if (txd->m != NULL) {
+		freemsg(txd->m);
+		txd->m = NULL;
+	}
+
+	txd->flags |= HN_TXD_FLAG_ONLIST;
+#ifdef DEBUG
+	atomic_inc_32((uint32_t *)&txr->hn_txdesc_avail);
+#endif
+	(void) buf_ring_enqueue(txr->hn_txdesc_br, txd);
+}
+
+static struct hn_txdesc *
+hn_txdesc_get(struct hn_tx_ring *txr)
+{
+	struct hn_txdesc *txd;
+
+	txd = buf_ring_dequeue_sc(txr->hn_txdesc_br);
+
+	if (txd != NULL) {
+#ifdef DEBUG
+		atomic_dec_32((uint32_t *)&txr->hn_txdesc_avail);
+#endif
+		ASSERT3P(txd->m, ==, NULL);
+		ASSERT3U(txd->chim_index, ==, HN_NVS_CHIM_IDX_INVALID);
+		ASSERT(txd->flags & HN_TXD_FLAG_ONLIST);
+		ASSERT0(txd->flags & HN_TXD_FLAG_DMAMAP);
+		txd->flags &= ~HN_TXD_FLAG_ONLIST;
+	}
+	return (txd);
+}
+
+static boolean_t
+hn_tx_ring_pending(struct hn_tx_ring *txr)
+{
+	return (!buf_ring_full(txr->hn_txdesc_br));
+}
+
+/* ARGSUSED */
+static void
+hn_txpkt_done(struct hn_nvs_sendctx *sndc, struct hn_softc *sc,
+    struct vmbus_channel *chan, const void *data, int dlen)
+{
+	struct hn_txdesc *txd = sndc->hn_cbarg;
+	struct hn_tx_ring *txr;
+
+	txr = txd->txr;
+	ASSERT3P(txr->hn_chan, ==, chan);
+
+	hn_txdesc_put(txr, txd);
+
+	/*
+	 * We have freed some buffers so we can now resume transmission of
+	 * packets.
+	 */
+	if (txr->hn_reschedule) {
+		txr->hn_reschedule = B_FALSE;
+		mac_tx_ring_update(txr->hn_sc->hn_mac_hdl, txr->hn_ring_handle);
+	}
+}
+
+static inline uint32_t
+hn_rndis_pktmsg_offset(uint32_t ofs)
+{
+	ASSERT3U(ofs, >=, sizeof (struct rndis_packet_msg));
+	return (ofs - offsetof(struct rndis_packet_msg, rm_dataoffset));
+}
+
+static inline void *
+hn_rndis_pktinfo_append(struct rndis_packet_msg *pkt, size_t pktsize,
+    size_t pi_dlen, uint32_t pi_type)
+{
+	const size_t pi_size = HN_RNDIS_PKTINFO_SIZE(pi_dlen);
+	struct rndis_pktinfo *pi;
+
+	ASSERT0(pi_size & RNDIS_PACKET_MSG_OFFSET_ALIGNMASK);
+
+	/*
+	 * Per-packet-info does not move; it only grows.
+	 *
+	 * NOTE:
+	 * rm_pktinfooffset in this phase counts from the beginning
+	 * of rndis_packet_msg.
+	 */
+	ASSERT3U(pkt->rm_pktinfooffset + pkt->rm_pktinfolen + pi_size, <=,
+	    pktsize);
+	pi = (struct rndis_pktinfo *)((uint8_t *)pkt + pkt->rm_pktinfooffset +
+	    pkt->rm_pktinfolen);
+	pkt->rm_pktinfolen += pi_size;
+
+	pi->rm_size = pi_size;
+	pi->rm_type = pi_type;
+	pi->rm_pktinfooffset = RNDIS_PKTINFO_OFFSET;
+
+	/* Data immediately follow per-packet-info. */
+	pkt->rm_dataoffset += pi_size;
+
+	/* Update RNDIS packet msg length */
+	pkt->rm_len += pi_size;
+
+	return (pi->rm_data);
+}
+
+/*
+ * Prepare the RNDIS packet (it prepends the data).
+ * Return the length of the RNDIS packet.
+ *
+ * For reference:
+ *     [MS-RNDIS] - v20140501
+ *     chapter 2.2.14 - REMOTE_NDIS_PACKET_MSG
+ */
+static int
+hn_tx_prepare_rndis_pkt(struct hn_softc *sc, struct rndis_packet_msg *pkt,
+    mblk_t *mp, int dlen, int txr_idx)
+{
+	uint32_t hck_flags, lso_flag, mss;
+	uint32_t hck_start = 0;
+	uint32_t *pi_data;
+	int pktlen;
+
+	pkt->rm_type = REMOTE_NDIS_PACKET_MSG;
+	pkt->rm_len = sizeof (*pkt) + dlen;
+	pkt->rm_dataoffset = sizeof (*pkt);
+	pkt->rm_datalen = dlen;
+	pkt->rm_oobdataoffset = 0;
+	pkt->rm_oobdatalen = 0;
+	pkt->rm_oobdataelements = 0;
+	pkt->rm_pktinfooffset = sizeof (*pkt);
+	pkt->rm_pktinfolen = 0;
+	pkt->rm_vchandle = 0;
+	pkt->rm_reserved = 0;
+
+	/*
+	 * Set the hash value for this packet, so that the host could
+	 * dispatch the TX done event for this packet back to this TX
+	 * ring's channel.
+	 */
+	pi_data = hn_rndis_pktinfo_append(pkt, HN_RNDIS_PKT_LEN,
+	    HN_NDIS_HASH_VALUE_SIZE, HN_NDIS_PKTINFO_TYPE_HASHVAL);
+	*pi_data = txr_idx;
+
+	/*
+	 * Get hardware checksum and lso info for mblk
+	 */
+	hcksum_retrieve(mp, NULL, NULL, &hck_start, NULL, NULL, NULL,
+	    &hck_flags);
+	mac_lso_get(mp, &mss, &lso_flag);
+
+	unsigned char *ptr = mp->b_rptr;
+	uint32_t sap = ntohs(((struct ether_header *)ptr)->ether_type);
+
+	/*
+	 * If applicable, append vlan info to packet info
+	 */
+	if (sap == ETHERTYPE_VLAN) {
+		struct ether_vlan_header *eth = (void *)ptr;
+		sap = ntohs(eth->ether_type);
+
+		pi_data = hn_rndis_pktinfo_append(pkt, HN_RNDIS_PKT_LEN,
+		    NDIS_VLAN_INFO_SIZE, NDIS_PKTINFO_TYPE_VLAN);
+		*pi_data = NDIS_VLAN_INFO_MAKE(
+		    VLAN_ID(eth->ether_tci),
+		    VLAN_PRI(eth->ether_tci),
+		    VLAN_CFI(eth->ether_tci));
+
+		ptr += sizeof (struct ether_vlan_header);
+	} else {
+		ptr += sizeof (struct ether_header);
+	}
+
+	/*
+	 * Ethernet and IP headers may be in different mblk segments.
+	 */
+	ASSERT3P(ptr, <=, mp->b_wptr);
+	if (ptr == mp->b_wptr) {
+		mp = mp->b_cont;
+		ptr = mp->b_rptr;
+	}
+
+	HN_DEBUG(sc, 4, "size %u, hck_flags=0x%x, lso_flag=0x%x, hck_start=%d, "
+	    "ether_type=0x%x", dlen, hck_flags, lso_flag, hck_start, sap);
+
+	if (lso_flag & HW_LSO) {
+		/*
+		 * The only type of LSO that we support is for IPv4.
+		 * We advertise LSO_TX_BASIC_TCP_IPV4 for MAC_CAPAB_LSO.
+		 * IPv6 is not yet supported in the framework.
+		 */
+		ASSERT3U(sap, ==, ETHERTYPE_IP);
+
+		pi_data = hn_rndis_pktinfo_append(pkt, HN_RNDIS_PKT_LEN,
+		    NDIS_LSO2_INFO_SIZE, NDIS_PKTINFO_TYPE_LSO);
+
+		/*
+		 * Some hardware requires this to be 0, otherwise it generates
+		 * improper ip header checksums.
+		 */
+		ipha_t *ipha = (ipha_t *)ptr;
+		ipha->ipha_hdr_checksum = 0;
+
+		/*
+		 * TODO: figure out why it is ok to put 0 for the tcp checksum
+		 * offset.
+		 */
+		*pi_data = NDIS_LSO2_INFO_MAKEIPV4(0, mss);
+	} else if (hck_flags != 0) {
+		/*
+		 * The only checksum offload that we support is
+		 * HCKSUM_INET_PARTIAL as advertised for MAC_CAPAB_HCKSUM.
+		 */
+		ASSERT3U(hck_flags, ==, HCK_PARTIALCKSUM);
+
+		pi_data = hn_rndis_pktinfo_append(pkt, HN_RNDIS_PKT_LEN,
+		    NDIS_TXCSUM_INFO_SIZE, NDIS_PKTINFO_TYPE_CSUM);
+
+		uint8_t l4proto;
+
+		if (sap == ETHERTYPE_IP) {
+			ipha_t *ipha = (ipha_t *)ptr;
+			l4proto = ipha->ipha_protocol;
+			*pi_data = NDIS_TXCSUM_INFO_IPV4;
+		} else if (sap == ETHERTYPE_IPV6) {
+			ip6_t *ip6 = (ip6_t *)ptr;
+			l4proto = ip6->ip6_nxt;
+			*pi_data = NDIS_TXCSUM_INFO_IPV6;
+		} else {
+			HN_WARN(sc, "hn_tx_prepare_rndis_pkt: unexpected L3 "
+			    "protocol: 0x%04x", sap);
+			*pi_data = 0;
+			goto skip_cksum;
+		}
+
+		switch (l4proto) {
+		case IPPROTO_TCP:
+			*pi_data |= NDIS_TXCSUM_INFO_TCPCS;
+
+			/*
+			 * TODO: figure out why it is ok to put 0 for
+			 * the tcp checksum offset.
+			 * Normally we'd need to specify what's the
+			 * offset of the TCP checksum field using
+			 * NDIS_TXCSUM_INFO_THOFF() but in practice it
+			 * seems to be fine to leave this field as 0.
+			 */
+			break;
+		case IPPROTO_UDP:
+			/*
+			 * TODO: Investigate / test?
+			 * There seemed to be issues with UDP checksum
+			 * calculation on W2008 hosts and in some cases
+			 * in W2012 hosts. In Linux, they disable UDP
+			 * checksum offload in those case:
+			 * http://lxr.free-electrons.com/source/
+			 *   drivers/net/hyperv/netvsc_drv.c#L486
+			 * It seems like in FreeBSD, they were also
+			 * doing this until commit on 09/20/2016,
+			 * 9dd94538df4fa56fb715d19b93802fe67f5bbf4c
+			 * (https://reviews.freebsd.org/D7948)
+			 * which removed that restriction.
+			 */
+			*pi_data |= NDIS_TXCSUM_INFO_UDPCS;
+			break;
+		default:
+			/*
+			 * FIXME: we can end up here if we have a TCP or UDP
+			 * IPv6 packet with extension headers. As a result,
+			 * proper checksum offload flags will not be set for
+			 * this packet and it has a high chance to be dropped
+			 * by the receiver.
+			 */
+			HN_WARN(sc, "hn_tx_prepare_rndis_pkt: unexpected "
+			    "transport protocol: 0x%04x", l4proto);
+		}
+	}
+
+skip_cksum:
+	pktlen = pkt->rm_pktinfooffset + pkt->rm_pktinfolen;
+	/* Convert RNDIS packet message offsets as per 2.2.14 */
+	pkt->rm_dataoffset = hn_rndis_pktmsg_offset(pkt->rm_dataoffset);
+	pkt->rm_pktinfooffset = hn_rndis_pktmsg_offset(pkt->rm_pktinfooffset);
+
+	return (pktlen);
+}
+
+/*
+ * NOTE:
+ * If this function fails, then both txd and mp will be freed.
+ */
+static int
+hn_encap(struct hn_tx_ring *txr, struct hn_txdesc *txd, mblk_t *mp)
+{
+	struct hn_softc *sc = txr->hn_sc;
+	hn_tx_stats_t *stats = &txr->hn_tx_stats;
+	int error;
+	int pktlen; /* length of rndis packet header */
+
+	ASSERT3P(mp->b_next, ==, NULL);
+
+	int dlen = 0;
+	for (mblk_t *m = mp; m != NULL; m = m->b_cont) {
+		dlen += MBLKL(m);
+	}
+	txr->hn_pkt_length = dlen;
+
+	/*
+	 * Look at the ethernet header to figure out if the packet is unicast,
+	 * multicast or broadcast.
+	 * We do this here while the mblk is still available.
+	 */
+	if (mp->b_rptr[0] & 0x1) {
+		if (bcmp(mp->b_rptr, hn_broadcast, ETHERADDRL) != 0)
+			txr->hn_pkt_type = HN_MULTICAST;
+		else
+			txr->hn_pkt_type = HN_BROADCAST;
+	} else {
+		txr->hn_pkt_type = HN_UNICAST;
+	}
+
+	if (dlen + HN_RNDIS_PKT_LEN < txr->hn_chim_size) {
+		/*
+		 * Fast path: Chimney sending.
+		 * This packet is small enough to fit into a chimney sending
+		 * buffer.  Try allocating one chimney sending buffer now.
+		 */
+		stats->chimney_tried++;
+		txd->chim_index = hn_chim_alloc(sc);
+		if (txd->chim_index != HN_NVS_CHIM_IDX_INVALID) {
+			caddr_t chim = sc->hn_chim +
+			    (txd->chim_index * sc->hn_chim_szmax);
+			/*
+			 * Directly fill the chimney sending buffer w/ the
+			 * RNDIS packet message.
+			 */
+			struct rndis_packet_msg *pkt = (void *)chim;
+			pktlen = hn_tx_prepare_rndis_pkt(sc, pkt, mp, dlen,
+			    txr->hn_tx_idx);
+
+			/* Copy message into chimney (mblk is freed) */
+			mcopymsg(mp, chim + pktlen);
+			txd->m = NULL;
+
+			txd->chim_size = pkt->rm_len;
+			txr->hn_gpa_cnt = 0;
+			stats->chimney_sent++;
+			txr->hn_sendpkt = hn_txpkt_chim;
+			goto done;
+		}
+	}
+
+	pktlen = hn_tx_prepare_rndis_pkt(sc, txd->rndis_pkt, mp, dlen,
+	    txr->hn_tx_idx);
+
+	/* send packet with page buffer */
+	error = hn_txdesc_dmamap_load(txr, txd, mp, pktlen);
+	/* check if we have too many segments */
+	if (error == EAGAIN) {
+		mblk_t *nmp = msgpullup(mp, -1);
+		freemsg(mp);
+		mp = nmp;
+		stats->pulledup++;
+		error = hn_txdesc_dmamap_load(txr, txd, mp, pktlen);
+	}
+	if (error != 0) {
+		/*
+		 * This mblk is not linked w/ the txd yet, so free it now.
+		 */
+		freemsg(mp);
+		hn_txdesc_put(txr, txd);
+		stats->dma_failed++;
+		return (error);
+	}
+
+	txd->m = mp;
+	txd->chim_index = HN_NVS_CHIM_IDX_INVALID;
+	txd->chim_size = 0;
+	txr->hn_sendpkt = hn_txpkt_sglist;
+done:
+	/* Set the completion routine */
+	hn_nvs_sendctx_init(&txd->send_ctx, hn_txpkt_done, txd);
+
+	return (0);
+}
+
+/*
+ * NOTE:
+ * If this function fails, then both the txd and mblk will be freed.
+ */
+static int
+hn_txpkt(struct hn_tx_ring *txr, struct hn_txdesc *txd)
+{
+	int error;
+	hn_tx_stats_t *stats = &txr->hn_tx_stats;
+
+	error = txr->hn_sendpkt(txr, txd);
+
+	if (error == 0) {
+		if (txr->hn_pkt_type == HN_MULTICAST)
+			stats->mcast_pkts++;
+		else if (txr->hn_pkt_type == HN_BROADCAST)
+			stats->bcast_pkts++;
+		stats->pkts++;
+		stats->bytes += txr->hn_pkt_length;
+	} else {
+		/*
+		 * This should "really rarely" happen.
+		 *
+		 * XXX Too many RX to be acked or too many sideband
+		 * commands to run?
+		 */
+		stats->send_failed++;
+		HN_WARN(txr->hn_sc, "send failed, err=%d", error);
+
+		/* discard packet */
+		hn_txdesc_put(txr, txd);
+	}
+	return (error);
+}
+
+int
+hn_rxpkt(struct hn_rx_ring *rxr, const void *data, int dlen,
+    const struct hn_rxinfo *info)
+{
+	struct hn_softc *sc = rxr->hn_sc;
+	hn_rx_stats_t *stats = &rxr->hn_rx_stats;
+
+	ASSERT(MUTEX_HELD(&rxr->hn_rx_lock));
+
+	if (!sc->hn_running)
+		return (0);
+
+	/*
+	 * Bail out if packet contains more data than configured MTU.
+	 */
+	if (dlen > (sc->hn_mtu + sizeof (struct ether_vlan_header))) {
+		HN_DEBUG(sc, 3, "discarding oversized packet");
+		return (0);
+	}
+
+	mblk_t *mp = allocb(dlen, 0);
+	if (mp == NULL) {
+		stats->norxbufs++;
+		stats->ierrors++;
+		return (0);
+	}
+	/*
+	 * We cannot bind the buffer provided by vsc, so we must always
+	 * copy it.
+	 */
+	bcopy(data, mp->b_rptr, dlen);
+	mp->b_wptr = mp->b_rptr + dlen;
+
+	/* receive side checksum offload */
+	uint32_t hcksum_flags = 0;
+	if (info->csum_info != HN_NDIS_RXCSUM_INFO_INVALID) {
+		if (info->csum_info & NDIS_RXCSUM_INFO_IPCS_OK) {
+			hcksum_flags |= HCK_IPV4_HDRCKSUM_OK;
+			stats->csum_ip++;
+		}
+
+		if (info->csum_info & NDIS_RXCSUM_INFO_UDPCS_OK) {
+			hcksum_flags |= HCK_FULLCKSUM_OK;
+			stats->csum_udp++;
+		}
+
+		if (info->csum_info & NDIS_RXCSUM_INFO_TCPCS_OK) {
+			hcksum_flags |= HCK_FULLCKSUM_OK;
+			stats->csum_tcp++;
+		}
+	} else {
+		/*
+		 * FreeBSD's implementation seems to suggest that the host
+		 * might omit filling up csum_info even though the checksums
+		 * have actually been checked.
+		 */
+		hcksum_flags = hn_get_implied_hcksum(rxr, mp);
+	}
+
+	if (hcksum_flags != 0)
+		mac_hcksum_set(mp, 0, 0, 0, 0, hcksum_flags);
+
+	/*
+	 * Look at the ethernet header to figure out if the packet is unicast,
+	 * multicast or broadcast.
+	 */
+	if (mp->b_rptr[0] & 0x1) {
+		if (bcmp(mp->b_rptr, hn_broadcast, ETHERADDRL) != 0)
+			stats->mcast_pkts++;
+		else
+			stats->bcast_pkts++;
+	}
+	stats->pkts++;
+	stats->bytes += dlen;
+
+	/*
+	 * Enqueue pending received packets so that we can send them all
+	 * at once to the MAC framework in hn_nvs_handle_rxbuf().
+	 */
+	if (rxr->hn_mps != NULL) {
+		ASSERT(rxr->hn_mp_tail != NULL);
+		rxr->hn_mp_tail->b_next = mp;
+		rxr->hn_mp_tail = mp;
+	} else {
+		rxr->hn_mps = mp;
+		rxr->hn_mp_tail = mp;
+	}
+
+	return (0);
+}
+
+void
+hn_stop(struct hn_softc *sc)
+{
+	HN_LOCK_ASSERT(sc);
+	if (!sc->hn_running)
+		return;
+
+	ASSERT(sc->hn_flags & HN_FLAG_SYNTH_ATTACHED);
+
+	/* Clear RUNNING _before_ hn_suspend_data() */
+	sc->hn_running = B_FALSE;
+	hn_suspend_data(sc);
+}
+static void
+hn_init_locked(struct hn_softc *sc)
+{
+	HN_LOCK_ASSERT(sc);
+
+	if (!(sc->hn_flags & HN_FLAG_SYNTH_ATTACHED))
+		return;
+
+	if (sc->hn_running)
+		return;
+
+	/* Configure RX filter */
+	(void) hn_set_rxfilter(sc);
+
+	/* Clear TX 'suspended' bit. */
+	hn_resume_tx(sc, sc->hn_tx_ring_inuse);
+
+	/* Everything is ready; unleash! */
+	sc->hn_running = B_TRUE;
+}
+
+void
+hn_init(void *xsc)
+{
+	struct hn_softc *sc = xsc;
+
+	HN_LOCK(sc);
+	hn_init_locked(sc);
+	HN_UNLOCK(sc);
+}
+
+/*
+ * Do a sanity check of the received packet.
+ * Return the relevant hardware checksum flags depending on the protocol
+ * of the packet.
+ *
+ * Returns flags to be passed to mac_hcksum_set().
+ */
+static uint32_t
+hn_get_implied_hcksum(struct hn_rx_ring *rxr, const mblk_t *mp)
+{
+	unsigned char *ptr = mp->b_rptr;
+	int dlen = MBLKL(mp);
+	uint32_t sap;
+
+	ASSERT3P(mp->b_cont, ==, NULL);
+
+	/*
+	 * sanity check that we do not read past the buffer size
+	 */
+	if (dlen < sizeof (struct ether_vlan_header))
+		return (0);
+
+	sap = ntohs(((struct ether_header *)ptr)->ether_type);
+	if (sap == ETHERTYPE_VLAN) {
+		sap = ntohs(((struct ether_vlan_header *)ptr)->ether_type);
+		ptr += sizeof (struct ether_vlan_header);
+		dlen -= sizeof (struct ether_vlan_header);
+	} else {
+		ptr += sizeof (struct ether_header);
+		dlen -= sizeof (struct ether_header);
+	}
+
+	/*
+	 * check that the packet has an IPv4 header
+	 */
+	if (sap != ETHERTYPE_IP)
+		return (0);
+
+	if (dlen < sizeof (ipha_t))
+		return (0);
+
+	ipha_t *ipha = (ipha_t *)ptr;
+	int iphlen = IPH_HDR_LENGTH(ipha);
+
+	if (iphlen < sizeof (ipha_t))
+		return (0);
+
+	/*
+	 * Ignore IP fragments.
+	 */
+	if (IS_V4_FRAGMENT(ipha->ipha_fragment_offset_and_flags))
+		return (0);
+
+	int iplen = ntohs(ipha->ipha_length);
+	if (dlen < iplen)
+		return (0);
+
+	ptr += iphlen;
+	dlen -= iphlen;
+
+	switch (ipha->ipha_protocol) {
+	case IPPROTO_TCP:
+		/*
+		 * TODO: not sure if we need those checks in Illumos
+		 */
+		if (iplen < iphlen + sizeof (tcph_t))
+			return (0);
+		int tcphlen = TCP_HDR_LENGTH(ptr);
+		if (tcphlen < sizeof (tcph_t) || tcphlen + iphlen > iplen)
+			return (0);
+
+		if (rxr->hn_trust_hcsum & HN_TRUST_HCSUM_TCP) {
+			rxr->hn_rx_stats.csum_trusted++;
+			return (HCK_FULLCKSUM_OK | HCK_IPV4_HDRCKSUM_OK);
+		}
+		break;
+	case IPPROTO_UDP:
+		/*
+		 * TODO: not sure if we need this check in Illumos
+		 */
+		if (iplen < iphlen + sizeof (struct udphdr))
+			return (0);
+
+		if (rxr->hn_trust_hcsum & HN_TRUST_HCSUM_UDP) {
+			rxr->hn_rx_stats.csum_trusted++;
+			return (HCK_FULLCKSUM_OK | HCK_IPV4_HDRCKSUM_OK);
+		}
+		break;
+	default:
+		if (iplen < iphlen)
+			return (0);
+
+		if (rxr->hn_trust_hcsum & HN_TRUST_HCSUM_IP) {
+			rxr->hn_rx_stats.csum_trusted++;
+			return (HCK_IPV4_HDRCKSUM_OK);
+		}
+	}
+
+	return (0);
+}
+
+static int
+hn_create_rx_data(struct hn_softc *sc)
+{
+	/*
+	 * Create RXBUF for reception.
+	 *
+	 * NOTE:
+	 * - It is shared by all channels.
+	 * - A large enough buffer is allocated, certain version of NVSes
+	 *   may further limit the usable space.
+	 */
+	sc->hn_rxbuf = hyperv_dmamem_alloc(sc->hn_dev,
+	    PAGESIZE, 0, HN_RXBUF_SIZE, &sc->hn_rxbuf_dma,
+	    DDI_DMA_RDWR);
+	if (sc->hn_rxbuf == NULL) {
+		HN_WARN(sc, "allocate rxbuf failed");
+		return (ENOMEM);
+	}
+
+	sc->hn_rx_ring_inuse = sc->hn_rx_ring_cnt;
+
+	sc->hn_rx_ring = kmem_zalloc(sizeof (struct hn_rx_ring) *
+	    sc->hn_rx_ring_cnt, KM_SLEEP);
+
+	for (int i = 0; i < sc->hn_rx_ring_cnt; i++) {
+		struct hn_rx_ring *rxr = &sc->hn_rx_ring[i];
+		rxr->hn_sc = sc;
+
+		rxr->hn_br = hyperv_dmamem_alloc(sc->hn_dev, PAGESIZE, 0,
+		    HN_TXBR_SIZE + HN_RXBR_SIZE,
+		    &rxr->hn_br_dma, DDI_DMA_RDWR);
+		if (rxr->hn_br == NULL) {
+			HN_WARN(sc, "allocate bufring failed");
+			return (ENOMEM);
+		}
+
+		if (hn_trust_host_cksum)
+			rxr->hn_trust_hcsum = HN_TRUST_HCSUM_ALL;
+
+		if (i < sc->hn_tx_ring_cnt)
+			rxr->hn_txr = &sc->hn_tx_ring[i];
+		rxr->hn_pktbuf_len = HN_PKTBUF_LEN_DEF;
+		rxr->hn_pktbuf = kmem_zalloc(rxr->hn_pktbuf_len, KM_SLEEP);
+		rxr->hn_rx_idx = i;
+		rxr->hn_rxbuf = sc->hn_rxbuf;
+	}
+
+	return (0);
+}
+
+static void
+hn_destroy_rx_data(struct hn_softc *sc)
+{
+	if (sc->hn_rxbuf != NULL) {
+		if ((sc->hn_flags & HN_FLAG_RXBUF_REF) == 0)
+			hyperv_dmamem_free(&sc->hn_rxbuf_dma);
+		else
+			HN_WARN(sc, "RXBUF is referenced");
+		sc->hn_rxbuf = NULL;
+	}
+
+	if (sc->hn_rx_ring_cnt == 0)
+		return;
+
+	for (int i = 0; i < sc->hn_rx_ring_cnt; i++) {
+		struct hn_rx_ring *rxr = &sc->hn_rx_ring[i];
+
+		if (rxr->hn_br != NULL) {
+			if ((rxr->hn_rx_flags & HN_RX_FLAG_BR_REF) == 0) {
+				hyperv_dmamem_free(&rxr->hn_br_dma);
+			} else {
+				HN_WARN(sc,
+				    "%dth channel bufring is referenced", i);
+			}
+			rxr->hn_br = NULL;
+		}
+
+		if (rxr->hn_pktbuf != NULL) {
+			kmem_free(rxr->hn_pktbuf, rxr->hn_pktbuf_len);
+			rxr->hn_pktbuf = NULL;
+		}
+	}
+	if (sc->hn_rx_ring != NULL) {
+		kmem_free(sc->hn_rx_ring, sizeof (struct hn_rx_ring) *
+		    sc->hn_rx_ring_cnt);
+	}
+	sc->hn_rx_ring = NULL;
+
+	sc->hn_rx_ring_cnt = 0;
+	sc->hn_rx_ring_inuse = 0;
+}
+
+/*
+ * DMA alignment and boundary constraints for RNDIS packet
+ */
+CTASSERT(ISP2(HN_RNDIS_PKT_BOUNDARY));
+static ddi_dma_attr_t hn_tx_rndis_dma_attr = {
+	.dma_attr_version =	DMA_ATTR_V0,
+	.dma_attr_addr_lo =	0x0000000000000000ull,
+	.dma_attr_addr_hi =	0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_count_max =	0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_align =	HN_RNDIS_PKT_ALIGN,
+	.dma_attr_burstsizes =	0x0000000000001FFFull,
+	.dma_attr_minxfer =	0x00000001,
+	.dma_attr_maxxfer =	0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_seg =		HN_RNDIS_PKT_BOUNDARY - 1,
+	.dma_attr_sgllen =	1,
+	.dma_attr_granular =	0x00000001,
+	.dma_attr_flags =	0
+};
+
+/*
+ * DMA alignment and boundary constraints for TX data
+ */
+CTASSERT(ISP2(HN_TX_DATA_BOUNDARY));
+static ddi_dma_attr_t hn_tx_dma_attr = {
+	.dma_attr_version =	DMA_ATTR_V0,
+	.dma_attr_addr_lo =	0x0000000000000000ull,
+	.dma_attr_addr_hi =	0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_count_max =	0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_align =	1,
+	.dma_attr_burstsizes =	0x0000000000001FFFull,
+	.dma_attr_minxfer =	0x00000001,
+	.dma_attr_maxxfer =	HN_TX_DATA_MAXSIZE,
+	.dma_attr_seg =		HN_TX_DATA_BOUNDARY - 1,
+	.dma_attr_sgllen =	HN_TX_DATA_SEGCNT_MAX,
+	.dma_attr_granular =	0x00000001,
+	.dma_attr_flags =	0
+};
+
+static ddi_device_acc_attr_t hn_dev_acc_attr = {
+	DDI_DEVICE_ATTR_V0,
+	DDI_STRUCTURE_LE_ACC,
+	DDI_STRICTORDER_ACC,
+	DDI_DEFAULT_ACC,
+};
+
+static int
+hn_tx_ring_create(struct hn_softc *sc, int id)
+{
+	struct hn_tx_ring *txr = &sc->hn_tx_ring[id];
+	int error;
+
+	txr->hn_sc = sc;
+	txr->hn_tx_idx = id;
+
+	mutex_init(&txr->hn_tx_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	/*
+	 * A bufring can hold one buffer less than its size
+	 */
+	txr->hn_txdesc_cnt = sc->hn_txdesc_cnt - 1;
+	txr->hn_txdesc = kmem_zalloc(sizeof (struct hn_txdesc) *
+	    txr->hn_txdesc_cnt, KM_SLEEP);
+	txr->hn_txdesc_br = buf_ring_alloc(txr->hn_txdesc_cnt + 1, KM_SLEEP,
+	    &txr->hn_tx_lock);
+	/*
+	 * XXX: HACK
+	 * Allocate a DMA handle for the TX data. Note that we only use it to
+	 * get the physical address for the memory and unbind it right after,
+	 * thus we require only one per ring.
+	 */
+	error = ddi_dma_alloc_handle(sc->hn_dev, &hn_tx_dma_attr,
+	    DDI_DMA_SLEEP, NULL, &txr->hn_data_dmah);
+	if (error != DDI_SUCCESS) {
+		HN_WARN(sc, "failed to allocate data_dmah, "
+		    "error %d", error);
+		return (EINVAL);
+	}
+
+	for (int i = 0; i < txr->hn_txdesc_cnt; i++) {
+		struct hn_txdesc *txd = &txr->hn_txdesc[i];
+		ddi_dma_cookie_t cookie;
+		uint_t segcount;
+
+		txd->txr = txr;
+		txd->chim_index = HN_NVS_CHIM_IDX_INVALID;
+
+		/*
+		 * Allocate a DMA handle for the RNDIS packet
+		 */
+		error = ddi_dma_alloc_handle(sc->hn_dev, &hn_tx_rndis_dma_attr,
+		    DDI_DMA_SLEEP, NULL, &txd->rndis_pkt_dmah);
+		if (error != DDI_SUCCESS) {
+			HN_WARN(sc, "failed to allocate rndis_packet_dmah[%d], "
+			    "error %d", i, error);
+			return (EINVAL);
+		}
+
+		/*
+		 * Allocate memory for the RNDIS packet
+		 */
+		error = ddi_dma_mem_alloc(txd->rndis_pkt_dmah, HN_RNDIS_PKT_LEN,
+		    &hn_dev_acc_attr, DDI_DMA_CONSISTENT, DDI_DMA_SLEEP, NULL,
+		    (caddr_t *)&txd->rndis_pkt, &txd->rndis_pkt_buflen,
+		    &txd->rndis_pkt_datah);
+		if (error != DDI_SUCCESS) {
+			HN_WARN(sc, "failed to allocate memory for "
+			    "rndis_pkt[%d], error %d", i, error);
+			ddi_dma_free_handle(&txd->rndis_pkt_dmah);
+			return (EINVAL);
+		}
+
+		/*
+		 * Map the memory of the RNDIS packet
+		 */
+		error = ddi_dma_addr_bind_handle(txd->rndis_pkt_dmah, NULL,
+		    (caddr_t)txd->rndis_pkt, txd->rndis_pkt_buflen,
+		    DDI_DMA_RDWR | DDI_DMA_STREAMING, DDI_DMA_SLEEP, NULL,
+		    &cookie, &segcount);
+		if (error != DDI_DMA_MAPPED) {
+			HN_WARN(sc, "failed to bind rndis_packet_dmah[%d], "
+			    "error %d", i, error);
+			ddi_dma_mem_free(&txd->rndis_pkt_datah);
+			ddi_dma_free_handle(&txd->rndis_pkt_dmah);
+			return (EINVAL);
+		}
+
+		ASSERT3U(segcount, ==, 1);
+		txd->rndis_pkt_paddr = cookie.dmac_laddress;
+
+		/* All set, put it to list */
+		txd->flags |= HN_TXD_FLAG_ONLIST;
+		error = buf_ring_enqueue(txr->hn_txdesc_br, txd);
+		ASSERT0(error);
+	}
+	txr->hn_txdesc_avail = txr->hn_txdesc_cnt;
+
+	return (0);
+}
+
+static void
+hn_txdesc_dmamap_destroy(struct hn_txdesc *txd)
+{
+	ASSERT3P(txd->m, ==, NULL);
+	ASSERT0(txd->flags & HN_TXD_FLAG_DMAMAP);
+
+	(void) ddi_dma_unbind_handle(txd->rndis_pkt_dmah);
+	ddi_dma_mem_free(&txd->rndis_pkt_datah);
+	ddi_dma_free_handle(&txd->rndis_pkt_dmah);
+}
+
+#ifdef txagg
+static void
+hn_txdesc_gc(struct hn_tx_ring *txr, struct hn_txdesc *txd)
+{
+	KASSERT(txd->refs == 0 || txd->refs == 1,
+	    ("invalid txd refs %d", txd->refs));
+
+	/* Aggregated txds will be freed by their aggregating txd. */
+	if (txd->refs > 0 && (txd->flags & HN_TXD_FLAG_ONAGG) == 0) {
+		int freed;
+
+		freed = hn_txdesc_put(txr, txd);
+		KASSERT(freed, ("can't free txdesc"));
+	}
+}
+#endif
+
+static void
+hn_tx_ring_destroy(struct hn_tx_ring *txr)
+{
+	struct hn_softc *sc = txr->hn_sc;
+	struct hn_txdesc *txd;
+
+	if (txr->hn_txdesc == NULL)
+		return;
+
+	if (txr->hn_data_dmah != NULL)
+		ddi_dma_free_handle(&txr->hn_data_dmah);
+
+#ifdef txagg
+	/*
+	 * NOTE:
+	 * Because the freeing of aggregated txds will be deferred
+	 * to the aggregating txd, two passes are used here:
+	 * - The first pass GCes any pending txds.  This GC is necessary,
+	 *   since if the channels are revoked, hypervisor will not
+	 *   deliver send-done for all pending txds.
+	 * - The second pass frees the busdma stuffs, i.e. after all txds
+	 *   were freed.
+	 */
+	for (int i = 0; i < txr->hn_txdesc_cnt; ++i)
+		hn_txdesc_gc(txr, &txr->hn_txdesc[i]);
+	for (int i = 0; i < txr->hn_txdesc_cnt; ++i)
+		hn_txdesc_dmamap_destroy(&txr->hn_txdesc[i]);
+#else
+	mutex_enter(&txr->hn_tx_lock);
+	if (i_ddi_devi_attached(sc->hn_dev) && hn_tx_ring_pending(txr)) {
+		HN_WARN(sc, "leaking %d descriptors from tx ring %d",
+		    buf_ring_count(txr->hn_txdesc_br), txr->hn_tx_idx);
+	}
+	while ((txd = buf_ring_dequeue_sc(txr->hn_txdesc_br)) != NULL)
+		hn_txdesc_dmamap_destroy(txd);
+	mutex_exit(&txr->hn_tx_lock);
+#endif
+
+	kmem_free(txr->hn_txdesc, sizeof (struct hn_txdesc) *
+	    txr->hn_txdesc_cnt);
+	txr->hn_txdesc = NULL;
+	buf_ring_free(txr->hn_txdesc_br);
+
+	mutex_destroy(&txr->hn_tx_lock);
+}
+
+static int
+hn_create_tx_data(struct hn_softc *sc)
+{
+	/*
+	 * Create TXBUF for chimney sending.
+	 *
+	 * NOTE: It is shared by all channels.
+	 */
+	sc->hn_chim = hyperv_dmamem_alloc(sc->hn_dev,
+	    PAGESIZE, 0, HN_CHIM_SIZE, &sc->hn_chim_dma,
+	    DDI_DMA_RDWR);
+	if (sc->hn_chim == NULL) {
+		HN_WARN(sc, "allocate tx chimney buf failed");
+		return (ENOMEM);
+	}
+
+	sc->hn_tx_ring_inuse = sc->hn_tx_ring_cnt;
+
+	sc->hn_tx_ring = kmem_zalloc(sizeof (struct hn_tx_ring) *
+	    sc->hn_tx_ring_cnt, KM_SLEEP);
+
+	for (int i = 0; i < sc->hn_tx_ring_cnt; i++) {
+		int error;
+
+		error = hn_tx_ring_create(sc, i);
+		if (error)
+			return (error);
+	}
+
+	return (0);
+}
+
+void
+hn_set_chim_size(struct hn_softc *sc, int chim_size)
+{
+	int i;
+
+	for (i = 0; i < sc->hn_tx_ring_cnt; ++i)
+		sc->hn_tx_ring[i].hn_chim_size = chim_size;
+}
+
+static void
+hn_fixup_tx_data(struct hn_softc *sc)
+{
+	/*
+	 * TX chimney is used as a fast path to send small packets.
+	 */
+	hn_set_chim_size(sc, sc->hn_chim_szmax);
+	if (hn_tx_chimney_size > 0 &&
+	    hn_tx_chimney_size < sc->hn_chim_szmax)
+		hn_set_chim_size(sc, hn_tx_chimney_size);
+
+	/*
+	 * Determine which hardware checksum offloading features
+	 * are enabled.
+	 */
+	sc->hn_hcksum_flags = 0;
+	if (sc->hn_tx_hcksum_enable) {
+		if ((sc->hn_caps & HN_CAP_L4CS) == HN_CAP_L4CS)
+			sc->hn_hcksum_flags |= HCKSUM_INET_PARTIAL;
+	}
+
+	/*
+	 * Determine if Large Send Offload is enabled.
+	 */
+	sc->hn_lso_flags = 0;
+	if (sc->hn_lso_enable && (sc->hn_caps & HN_CAP_TSO4))
+		sc->hn_lso_flags = LSO_TX_BASIC_TCP_IPV4;
+}
+static void
+hn_destroy_tx_data(struct hn_softc *sc)
+{
+	int i;
+
+	if (sc->hn_chim != NULL) {
+		if ((sc->hn_flags & HN_FLAG_CHIM_REF) == 0) {
+			hyperv_dmamem_free(&sc->hn_chim_dma);
+		} else {
+			HN_WARN(sc,
+			    "chimney sending buffer is referenced");
+		}
+		sc->hn_chim = NULL;
+	}
+
+	if (sc->hn_tx_ring_cnt == 0)
+		return;
+
+	for (i = 0; i < sc->hn_tx_ring_cnt; ++i)
+		hn_tx_ring_destroy(&sc->hn_tx_ring[i]);
+
+	kmem_free(sc->hn_tx_ring, sizeof (struct hn_tx_ring) *
+	    sc->hn_tx_ring_cnt);
+	sc->hn_tx_ring = NULL;
+
+	sc->hn_tx_ring_cnt = 0;
+	sc->hn_tx_ring_inuse = 0;
+}
+
+mblk_t *
+hn_xmit(struct hn_tx_ring *txr, mblk_t *mp)
+{
+	struct hn_txdesc *txd;
+	int error;
+
+	/*
+	 * If the tx is suspended (e.g. we are doing an MTU change), return
+	 * we will reschedule the packets once interface is resumed.
+	 */
+	if (__predict_false(txr->hn_suspended))
+		return (mp);
+
+	ASSERT3P(mp, !=, NULL);
+	ASSERT3P(mp->b_next, ==, NULL);
+
+	txd = hn_txdesc_get(txr);
+	if (txd == NULL) {
+		/*
+		 * We set hn_reschedule and check for descriptors again. If we
+		 * still get no descriptors, this guarantees that
+		 * hn_txpkt_done() will be called some time in the future and
+		 * will call mac_tx_ring_update().
+		 */
+		txr->hn_reschedule = B_TRUE;
+		txd = hn_txdesc_get(txr);
+		if (txd == NULL) {
+			/*
+			 * No descriptors available for now, return the packet
+			 * back to the MAC framework so it can reschedule a send
+			 * later.
+			 */
+			txr->hn_tx_stats.no_txdescs++;
+			return (mp);
+		} else {
+			txr->hn_reschedule = B_FALSE;
+		}
+	}
+
+	/*
+	 * Note: on error, both txd and mp are freed; discard packet
+	 */
+	error = hn_encap(txr, txd, mp);
+	if (error == 0)
+		error = hn_txpkt(txr, txd);
+
+	return (NULL);
+}
+
+/*
+ * Like any other enlightened driver, netvsc uses channels in order to
+ * communicate with the primary partition (i.e. netvsp in this case). Each
+ * channel is bi-directional and can be tied to a given CPU. In the case of
+ * netvsc, we need one channel for each rx/tx ring pair. Each device receives
+ * exactly one primary channel from vmbus, but can request additional
+ * sub-channels. The primary channel must be used for all management
+ * communications with the primary partition, but other than that it is
+ * almost identical to sub-channels.
+ */
+static int
+hn_chan_attach(struct hn_softc *sc, struct vmbus_channel *chan)
+{
+	struct vmbus_chan_br cbr;
+	struct hn_rx_ring *rxr;
+	struct hn_tx_ring *txr = NULL;
+	int idx, error;
+
+	idx = vmbus_chan_subidx(chan);
+
+	/*
+	 * Link this channel to RX/TX ring.
+	 */
+	ASSERT3S(idx, >=, 0);
+	ASSERT3S(idx, <, sc->hn_rx_ring_inuse);
+
+	rxr = &sc->hn_rx_ring[idx];
+	ASSERT0(rxr->hn_rx_flags & HN_RX_FLAG_ATTACHED);
+	rxr->hn_rx_flags |= HN_RX_FLAG_ATTACHED;
+
+	HN_DEBUG(sc, 1, "link RX ring %d to chan%u", idx,
+	    vmbus_chan_id(chan));
+
+	if (idx < sc->hn_tx_ring_inuse) {
+		txr = &sc->hn_tx_ring[idx];
+		ASSERT0(txr->hn_tx_flags & HN_TX_FLAG_ATTACHED);
+
+		txr->hn_tx_flags |= HN_TX_FLAG_ATTACHED;
+
+		txr->hn_chan = chan;
+		HN_DEBUG(sc, 1, "link TX ring %d to chan%u", idx,
+		    vmbus_chan_id(chan));
+	}
+
+	/* Bind this channel to a proper CPU. */
+	vmbus_chan_cpu_set(chan, (sc->hn_cpu + idx) % ncpus);
+
+	/*
+	 * Open this channel
+	 */
+	cbr.cbr = rxr->hn_br;
+	cbr.cbr_paddr = rxr->hn_br_dma.hv_paddr;
+	cbr.cbr_txsz = HN_TXBR_SIZE;
+	cbr.cbr_rxsz = HN_RXBR_SIZE;
+	error = vmbus_chan_open_br(chan, &cbr, NULL, 0, hn_chan_callback, rxr);
+	if (error != 0) {
+		if (error == EISCONN) {
+			HN_WARN(sc, "bufring is connected after "
+			    "chan%u open failure", vmbus_chan_id(chan));
+			rxr->hn_rx_flags |= HN_RX_FLAG_BR_REF;
+		} else {
+			HN_WARN(sc, "open chan%u failed: %d",
+			    vmbus_chan_id(chan), error);
+		}
+	}
+	return (error);
+}
+
+static void
+hn_chan_detach(struct hn_softc *sc, struct vmbus_channel *chan)
+{
+	struct hn_rx_ring *rxr;
+	int idx, error;
+
+	idx = vmbus_chan_subidx(chan);
+
+	/*
+	 * Link this channel to RX/TX ring.
+	 */
+	ASSERT3S(idx, >=, 0);
+	ASSERT3S(idx, <, sc->hn_rx_ring_inuse);
+	rxr = &sc->hn_rx_ring[idx];
+
+	ASSERT(rxr->hn_rx_flags & HN_RX_FLAG_ATTACHED);
+	rxr->hn_rx_flags &= ~HN_RX_FLAG_ATTACHED;
+
+	if (idx < sc->hn_tx_ring_inuse) {
+		struct hn_tx_ring *txr = &sc->hn_tx_ring[idx];
+
+		ASSERT(txr->hn_tx_flags & HN_TX_FLAG_ATTACHED);
+		txr->hn_tx_flags &= ~HN_TX_FLAG_ATTACHED;
+	}
+
+	/*
+	 * Close this channel.
+	 *
+	 * NOTE:
+	 * Channel closing does _not_ destroy the target channel.
+	 */
+	error = vmbus_chan_close_direct(chan);
+	if (error == EISCONN) {
+		HN_WARN(sc, "chan%u bufring is connected "
+		    "after being closed", vmbus_chan_id(chan));
+		rxr->hn_rx_flags |= HN_RX_FLAG_BR_REF;
+	} else if (error) {
+		HN_WARN(sc, "chan%u close failed: %d",
+		    vmbus_chan_id(chan), error);
+	}
+}
+
+static int
+hn_attach_subchans(struct hn_softc *sc)
+{
+	struct vmbus_channel **subchans;
+	int subchan_cnt = sc->hn_rx_ring_inuse - 1;
+	int i, error = 0;
+
+	ASSERT(subchan_cnt > 0);
+
+	/* Attach the sub-channels. */
+	subchans = vmbus_subchan_get(sc->hn_prichan, subchan_cnt);
+	for (i = 0; i < subchan_cnt; ++i) {
+		int error1;
+
+		error1 = hn_chan_attach(sc, subchans[i]);
+		if (error1) {
+			error = error1;
+			/* Move on; all channels will be detached later. */
+		}
+	}
+	vmbus_subchan_rel(subchans, subchan_cnt);
+
+	if (error) {
+		HN_WARN(sc, "sub-channels attach failed: %d", error);
+	} else {
+		HN_DEBUG(sc, 1, "%d sub-channels attached", subchan_cnt);
+	}
+	return (error);
+}
+
+static void
+hn_detach_allchans(struct hn_softc *sc)
+{
+	struct vmbus_channel **subchans;
+	int subchan_cnt = sc->hn_rx_ring_inuse - 1;
+	int i;
+
+	if (subchan_cnt == 0)
+		goto back;
+
+	/* Detach the sub-channels. */
+	subchans = vmbus_subchan_get(sc->hn_prichan, subchan_cnt);
+	for (i = 0; i < subchan_cnt; ++i)
+		hn_chan_detach(sc, subchans[i]);
+	vmbus_subchan_rel(subchans, subchan_cnt);
+
+back:
+	/*
+	 * Detach the primary channel, _after_ all sub-channels
+	 * are detached.
+	 */
+	hn_chan_detach(sc, sc->hn_prichan);
+
+	/* Wait for sub-channels to be destroyed, if any. */
+	vmbus_subchan_drain(sc->hn_prichan);
+
+	for (i = 0; i < sc->hn_rx_ring_cnt; ++i)
+		VERIFY0(sc->hn_rx_ring[i].hn_rx_flags & HN_RX_FLAG_ATTACHED);
+
+	for (i = 0; i < sc->hn_tx_ring_cnt; ++i)
+		VERIFY0(sc->hn_tx_ring[i].hn_tx_flags & HN_TX_FLAG_ATTACHED);
+}
+
+static int
+hn_synth_alloc_subchans(struct hn_softc *sc, int *nsubch)
+{
+	struct vmbus_channel **subchans;
+	int nchan, rxr_cnt, error;
+
+	nchan = *nsubch + 1;
+	if (nchan == 1) {
+		/*
+		 * Multiple RX/TX rings are not requested.
+		 */
+		*nsubch = 0;
+		return (0);
+	}
+
+	/*
+	 * Query RSS capabilities, e.g. # of RX rings, and # of indirect
+	 * table entries.
+	 */
+	error = hn_rndis_query_rsscaps(sc, &rxr_cnt);
+	if (error) {
+		/* No RSS; this is benign. */
+		*nsubch = 0;
+		return (0);
+	}
+	HN_DEBUG(sc, 1, "RX rings offered %u, requested %d", rxr_cnt, nchan);
+
+	if (nchan > rxr_cnt)
+		nchan = rxr_cnt;
+	if (nchan == 1) {
+		HN_WARN(sc, "only 1 channel is supported, no vRSS");
+		*nsubch = 0;
+		return (0);
+	}
+
+	/*
+	 * Allocate sub-channels from NVS.
+	 */
+	*nsubch = nchan - 1;
+	error = hn_nvs_alloc_subchans(sc, nsubch);
+	if (error || *nsubch == 0) {
+		/* Failed to allocate sub-channels. */
+		*nsubch = 0;
+		return (0);
+	}
+
+	/*
+	 * Wait for all sub-channels to become ready before moving on.
+	 */
+	subchans = vmbus_subchan_get(sc->hn_prichan, *nsubch);
+	vmbus_subchan_rel(subchans, *nsubch);
+	return (0);
+}
+
+static boolean_t
+hn_synth_attachable(const struct hn_softc *sc)
+{
+	int i;
+
+	if (sc->hn_flags & HN_FLAG_ERRORS)
+		return (B_FALSE);
+
+	for (i = 0; i < sc->hn_rx_ring_cnt; ++i) {
+		const struct hn_rx_ring *rxr = &sc->hn_rx_ring[i];
+
+		if (rxr->hn_rx_flags & HN_RX_FLAG_BR_REF)
+			return (B_FALSE);
+	}
+	return (B_TRUE);
+}
+
+static int
+hn_synth_attach(struct hn_softc *sc, int mtu)
+{
+	struct ndis_rssprm_toeplitz *rss = &sc->hn_rss;
+	int error, nsubch, nchan, i;
+	uint32_t old_caps;
+	boolean_t attached_nvs = B_FALSE, attached_rndis = B_FALSE;
+
+	ASSERT0(sc->hn_flags & HN_FLAG_SYNTH_ATTACHED);
+
+	if (!hn_synth_attachable(sc))
+		return (ENXIO);
+
+	/* Save capabilities for later verification. */
+	old_caps = sc->hn_caps;
+	sc->hn_caps = 0;
+
+	/* Clear RSS stuffs. */
+	sc->hn_rss_ind_size = 0;
+	sc->hn_rss_hash = 0;
+
+	/*
+	 * Attach the primary channel _before_ attaching NVS and RNDIS.
+	 */
+	error = hn_chan_attach(sc, sc->hn_prichan);
+	if (error != 0)
+		goto failed;
+
+	/*
+	 * Attach NVS.
+	 */
+	error = hn_nvs_attach(sc, mtu);
+	if (error != 0)
+		goto failed;
+	attached_nvs = B_TRUE;
+
+	/*
+	 * Attach RNDIS _after_ NVS is attached.
+	 */
+	error = hn_rndis_attach(sc, mtu);
+	if (error != 0)
+		goto failed;
+	attached_rndis = B_TRUE;
+
+	/*
+	 * Make sure capabilities are not changed.
+	 */
+	if (i_ddi_devi_attached(sc->hn_dev) && old_caps != sc->hn_caps) {
+		HN_WARN(sc, "caps mismatch old 0x%08x, new 0x%08x",
+		    old_caps, sc->hn_caps);
+		error = ENXIO;
+		goto failed;
+	}
+
+	/*
+	 * Allocate sub-channels for multi-TX/RX rings.
+	 *
+	 * NOTE:
+	 * The # of RX rings that can be used is equivalent to the # of
+	 * channels to be requested.
+	 */
+	nsubch = sc->hn_rx_ring_inuse - 1;
+	error = hn_synth_alloc_subchans(sc, &nsubch);
+	if (error != 0)
+		goto failed;
+	/* NOTE: _Full_ synthetic parts detach is required now. */
+	sc->hn_flags |= HN_FLAG_SYNTH_ATTACHED;
+
+	/*
+	 * Set the # of TX/RX rings that could be used according to
+	 * the # of channels that NVS offered.
+	 */
+	nchan = nsubch + 1;
+	hn_update_ring_inuse(sc, nchan);
+	if (nchan == 1) {
+		/* Only the primary channel can be used; done */
+		goto back;
+	}
+
+	/*
+	 * Attach the sub-channels.
+	 *
+	 * NOTE: hn_update_ring_inuse() _must_ have been called.
+	 */
+	error = hn_attach_subchans(sc);
+	if (error != 0)
+		goto failed;
+
+	/*
+	 * Configure RSS key and indirect table _after_ all sub-channels
+	 * are attached.
+	 */
+	if ((sc->hn_flags & HN_FLAG_HAS_RSSKEY) == 0) {
+		/*
+		 * RSS key is not set yet; set it to the default RSS key.
+		 */
+		HN_DEBUG(sc, 1, "setup default RSS key");
+		(void) memcpy(rss->rss_key, hn_rss_key_default,
+		    sizeof (rss->rss_key));
+		sc->hn_flags |= HN_FLAG_HAS_RSSKEY;
+	}
+
+	if ((sc->hn_flags & HN_FLAG_HAS_RSSIND) == 0) {
+		/*
+		 * RSS indirect table is not set yet; set it up in round-
+		 * robin fashion.
+		 */
+		HN_DEBUG(sc, 1, "setup default RSS indirect table");
+		for (i = 0; i < NDIS_HASH_INDCNT; ++i)
+			rss->rss_ind[i] = i % nchan;
+		sc->hn_flags |= HN_FLAG_HAS_RSSIND;
+	} else {
+		/*
+		 * # of usable channels may be changed, so we have to
+		 * make sure that all entries in RSS indirect table
+		 * are valid.
+		 *
+		 * NOTE: hn_update_ring_inuse() _must_ have been called.
+		 */
+		hn_rss_ind_fixup(sc);
+	}
+
+	error = hn_rndis_conf_rss(sc, NDIS_RSS_FLAG_NONE);
+	if (error != 0)
+		goto failed;
+back:
+	return (0);
+
+failed:
+	if (sc->hn_flags & HN_FLAG_SYNTH_ATTACHED) {
+		hn_synth_detach(sc);
+	} else {
+		if (attached_rndis)
+			hn_rndis_detach(sc);
+		if (attached_nvs)
+			hn_nvs_detach(sc);
+		hn_chan_detach(sc, sc->hn_prichan);
+		/* Restore old capabilities. */
+		sc->hn_caps = old_caps;
+	}
+	return (error);
+}
+
+/*
+ * NOTE:
+ * The interface must have been suspended though hn_suspend(), before
+ * this function get called.
+ */
+static void
+hn_synth_detach(struct hn_softc *sc)
+{
+
+	ASSERT(sc->hn_flags & HN_FLAG_SYNTH_ATTACHED);
+
+	/* Detach the RNDIS first. */
+	hn_rndis_detach(sc);
+
+	/* Detach NVS. */
+	hn_nvs_detach(sc);
+
+	/* Detach all of the channels. */
+	hn_detach_allchans(sc);
+
+	sc->hn_flags &= ~HN_FLAG_SYNTH_ATTACHED;
+}
+
+static void
+hn_update_ring_inuse(struct hn_softc *sc, int ring_cnt)
+{
+	ASSERT(ring_cnt > 0);
+	VERIFY3U(ring_cnt, <=, sc->hn_rx_ring_inuse);
+
+	/*
+	 * Changing the amount of rings is not supported after
+	 * mac_register() has been called.
+	 */
+	if (i_ddi_devi_attached(sc->hn_dev)) {
+		VERIFY3U(ring_cnt, ==, sc->hn_rx_ring_inuse);
+		VERIFY3U(ring_cnt, >=, sc->hn_tx_ring_inuse);
+		return;
+	}
+
+	/*
+	 * Rings in use must be initialized to the same number as
+	 * rings count.
+	 */
+	VERIFY3U(sc->hn_rx_ring_cnt, ==, sc->hn_rx_ring_inuse);
+	VERIFY3U(sc->hn_tx_ring_cnt, ==, sc->hn_tx_ring_inuse);
+
+	if (ring_cnt < sc->hn_rx_ring_cnt) {
+		HN_WARN(sc, "Rings in use (%d) < configured rings (%d) ",
+		    ring_cnt, sc->hn_rx_ring_cnt);
+	}
+
+	/*
+	 * The number of tx rings is limited by the number of channels, which
+	 * is identical to the number of rx rings.
+	 */
+	if (sc->hn_tx_ring_inuse > ring_cnt)
+		sc->hn_tx_ring_inuse = ring_cnt;
+
+	sc->hn_rx_ring_inuse = ring_cnt;
+
+	HN_DEBUG(sc, 1, "using %d TX rings, %d RX rings",
+	    sc->hn_tx_ring_inuse, sc->hn_rx_ring_inuse);
+}
+
+static void
+hn_chan_drain(struct hn_softc *sc, struct vmbus_channel *chan)
+{
+
+	/*
+	 * NOTE:
+	 * The TX bufring will not be drained by the hypervisor,
+	 * if the primary channel is revoked.
+	 */
+	while (!vmbus_chan_rx_empty(chan) ||
+	    (!vmbus_chan_is_revoked(sc->hn_prichan) &&
+	    !vmbus_chan_tx_empty(chan)))
+		delay(1);
+	vmbus_chan_intr_drain(chan);
+}
+
+static void
+hn_suspend_data(struct hn_softc *sc)
+{
+	struct vmbus_channel **subch = NULL;
+	struct hn_tx_ring *txr;
+	int i, nsubch;
+
+	HN_LOCK_ASSERT(sc);
+
+	/*
+	 * Suspend TX.
+	 */
+	for (i = 0; i < sc->hn_tx_ring_inuse; ++i) {
+		txr = &sc->hn_tx_ring[i];
+
+		mutex_enter(&txr->hn_tx_lock);
+		txr->hn_suspended = B_TRUE;
+		mutex_exit(&txr->hn_tx_lock);
+		/* No one is able to send more packets now. */
+
+		/*
+		 * Wait for all pending sends to finish.
+		 *
+		 * NOTE:
+		 * We will _not_ receive all pending send-done, if the
+		 * primary channel is revoked.
+		 */
+		while (hn_tx_ring_pending(txr) &&
+		    !vmbus_chan_is_revoked(sc->hn_prichan))
+			delay(1); /* 1 tick */
+		/* TODO: timeout ? */
+		if (hn_tx_ring_pending(txr)) {
+			HN_WARN(sc, "tx ring %d suspended while %d "
+			    "descriptors are still inflight", i,
+			    buf_ring_count(txr->hn_txdesc_br));
+		}
+	}
+
+	/*
+	 * Disable RX by clearing RX filter.
+	 */
+	sc->hn_rx_filter = NDIS_PACKET_TYPE_NONE;
+	(void) hn_rndis_set_rxfilter(sc, sc->hn_rx_filter);
+
+	/*
+	 * Give RNDIS enough time to flush all pending data packets.
+	 */
+	delay(MSEC_TO_TICK(200));
+
+	/*
+	 * Drain RX/TX bufrings and interrupts.
+	 */
+	nsubch = sc->hn_rx_ring_inuse - 1;
+	if (nsubch > 0)
+		subch = vmbus_subchan_get(sc->hn_prichan, nsubch);
+
+	if (subch != NULL) {
+		for (i = 0; i < nsubch; ++i)
+			hn_chan_drain(sc, subch[i]);
+	}
+	hn_chan_drain(sc, sc->hn_prichan);
+
+	if (subch != NULL)
+		vmbus_subchan_rel(subch, nsubch);
+}
+
+static void
+hn_suspend_mgmt(struct hn_softc *sc)
+{
+	/*
+	 * Make sure that hn_mgmt_taskq0 can no longer be accessed
+	 * through hn_mgmt_taskq.
+	 */
+	mutex_enter(&sc->hn_mgmt_lock);
+	sc->hn_mgmt_taskq = NULL;
+	mutex_exit(&sc->hn_mgmt_lock);
+
+	/*
+	 * Make sure that all pending management tasks are completed.
+	 */
+	ddi_taskq_wait(sc->hn_mgmt_taskq0);
+}
+
+static void
+hn_suspend(struct hn_softc *sc)
+{
+
+	if (sc->hn_running)
+		hn_suspend_data(sc);
+	hn_suspend_mgmt(sc);
+}
+
+static void
+hn_resume_tx(struct hn_softc *sc, int tx_ring_cnt)
+{
+	int i;
+
+	ASSERT3U(tx_ring_cnt, <=, sc->hn_tx_ring_cnt);
+
+	for (i = 0; i < tx_ring_cnt; ++i) {
+		struct hn_tx_ring *txr = &sc->hn_tx_ring[i];
+
+		mutex_enter(&txr->hn_tx_lock);
+		txr->hn_suspended = B_FALSE;
+		mutex_exit(&txr->hn_tx_lock);
+
+		/*
+		 * Notify MAC that we can resume sending packets
+		 */
+		mac_tx_ring_update(txr->hn_sc->hn_mac_hdl, txr->hn_ring_handle);
+	}
+}
+
+static void
+hn_resume_data(struct hn_softc *sc)
+{
+	/*
+	 * Re-enable RX.
+	 */
+	(void) hn_set_rxfilter(sc);
+
+	/*
+	 * Make sure to clear suspend status on "all" TX rings,
+	 * since hn_tx_ring_inuse can be changed after
+	 * hn_suspend_data().
+	 */
+	hn_resume_tx(sc, sc->hn_tx_ring_cnt);
+}
+
+static void
+hn_resume_mgmt(struct hn_softc *sc)
+{
+	mutex_enter(&sc->hn_mgmt_lock);
+	sc->hn_mgmt_taskq = sc->hn_mgmt_taskq0;
+	mutex_exit(&sc->hn_mgmt_lock);
+
+	/*
+	 * Kick off network change detection, if it was pending.
+	 * If no network change was pending, start link status
+	 * checks, which is more lightweight than network change
+	 * detection.
+	 */
+	if (sc->hn_link_flags & HN_LINK_FLAG_NETCHG)
+		hn_change_network(sc);
+	else
+		hn_update_link_status(sc);
+}
+
+static void
+hn_resume(struct hn_softc *sc)
+{
+
+	if (sc->hn_running)
+		hn_resume_data(sc);
+	hn_resume_mgmt(sc);
+}
+
+static void
+hn_rndis_rx_status(struct hn_softc *sc, const void *data, int dlen)
+{
+	const struct rndis_status_msg *msg;
+	int ofs;
+
+	if (dlen < sizeof (*msg)) {
+		HN_WARN(sc, "invalid RNDIS status");
+		return;
+	}
+	msg = data;
+
+	switch (msg->rm_status) {
+	case RNDIS_STATUS_MEDIA_CONNECT:
+	case RNDIS_STATUS_MEDIA_DISCONNECT:
+		hn_update_link_status(sc);
+		break;
+
+	case RNDIS_STATUS_TASK_OFFLOAD_CURRENT_CONFIG:
+		/* Not really useful; ignore. */
+		break;
+
+	case RNDIS_STATUS_NETWORK_CHANGE:
+		ofs = RNDIS_STBUFOFFSET_ABS(msg->rm_stbufoffset);
+		if (dlen < ofs + msg->rm_stbuflen ||
+		    msg->rm_stbuflen < sizeof (uint32_t)) {
+			HN_WARN(sc, "network changed");
+		} else {
+			uint32_t change;
+
+			(void) memcpy(&change, ((const uint8_t *)msg) + ofs,
+			    sizeof (change));
+			HN_WARN(sc, "network changed, change %u", change);
+		}
+		hn_change_network(sc);
+		break;
+
+	default:
+		HN_WARN(sc, "unknown RNDIS status 0x%08x", msg->rm_status);
+		break;
+	}
+}
+
+static int
+hn_rndis_rxinfo(const void *info_data, int info_dlen, struct hn_rxinfo *info)
+{
+	const struct rndis_pktinfo *pi = info_data;
+	uint32_t mask = 0;
+
+	while (info_dlen != 0) {
+		const void *data;
+		uint32_t dlen;
+
+		if (__predict_false(info_dlen < sizeof (*pi)))
+			return (EINVAL);
+		if (__predict_false(info_dlen < pi->rm_size))
+			return (EINVAL);
+		info_dlen -= pi->rm_size;
+
+		if (__predict_false(pi->rm_size & RNDIS_PKTINFO_SIZE_ALIGNMASK))
+			return (EINVAL);
+		if (__predict_false(pi->rm_size < pi->rm_pktinfooffset))
+			return (EINVAL);
+		dlen = pi->rm_size - pi->rm_pktinfooffset;
+		data = pi->rm_data;
+
+		switch (pi->rm_type) {
+		case NDIS_PKTINFO_TYPE_VLAN:
+			if (__predict_false(dlen < NDIS_VLAN_INFO_SIZE))
+				return (EINVAL);
+			info->vlan_info = *((const uint32_t *)data);
+			mask |= HN_RXINFO_VLAN;
+			break;
+
+		case NDIS_PKTINFO_TYPE_CSUM:
+			if (__predict_false(dlen < NDIS_RXCSUM_INFO_SIZE))
+				return (EINVAL);
+			info->csum_info = *((const uint32_t *)data);
+			mask |= HN_RXINFO_CSUM;
+			break;
+
+		case HN_NDIS_PKTINFO_TYPE_HASHVAL:
+			if (__predict_false(dlen < HN_NDIS_HASH_VALUE_SIZE))
+				return (EINVAL);
+			info->hash_value = *((const uint32_t *)data);
+			mask |= HN_RXINFO_HASHVAL;
+			break;
+
+		case HN_NDIS_PKTINFO_TYPE_HASHINF:
+			if (__predict_false(dlen < HN_NDIS_HASH_INFO_SIZE))
+				return (EINVAL);
+			info->hash_info = *((const uint32_t *)data);
+			mask |= HN_RXINFO_HASHINF;
+			break;
+
+		default:
+			goto next;
+		}
+
+		if (mask == HN_RXINFO_ALL) {
+			/* All found; done */
+			break;
+		}
+next:
+		pi = (const struct rndis_pktinfo *)
+		    ((const uint8_t *)pi + pi->rm_size);
+	}
+
+	/*
+	 * Final fixup.
+	 * - If there is no hash value, invalidate the hash info.
+	 */
+	if ((mask & HN_RXINFO_HASHVAL) == 0)
+		info->hash_info = HN_NDIS_HASH_INFO_INVALID;
+	return (0);
+}
+
+static inline boolean_t
+hn_rndis_check_overlap(int off, int len, int check_off, int check_len)
+{
+
+	if (off < check_off) {
+		if (__predict_true(off + len <= check_off))
+			return (B_FALSE);
+	} else if (off > check_off) {
+		if (__predict_true(check_off + check_len <= off))
+			return (B_FALSE);
+	}
+	return (B_TRUE);
+}
+
+static void
+hn_rndis_rx_data(struct hn_rx_ring *rxr, const void *data, int dlen)
+{
+	struct hn_softc *sc = rxr->hn_sc;
+	const struct rndis_packet_msg *pkt;
+	struct hn_rxinfo info;
+	int data_off, pktinfo_off, data_len, pktinfo_len;
+
+	/*
+	 * Check length.
+	 */
+	if (__predict_false(dlen < sizeof (*pkt))) {
+		HN_WARN(sc, "invalid RNDIS packet msg");
+		return;
+	}
+	pkt = data;
+
+	if (__predict_false(dlen < pkt->rm_len)) {
+		HN_WARN(sc, "truncated RNDIS packet msg, "
+		    "dlen %d, msglen %u", dlen, pkt->rm_len);
+		return;
+	}
+	if (__predict_false(pkt->rm_len <
+	    pkt->rm_datalen + pkt->rm_oobdatalen + pkt->rm_pktinfolen)) {
+		HN_WARN(sc, "invalid RNDIS packet msglen, "
+		    "msglen %u, data %u, oob %u, pktinfo %u",
+		    pkt->rm_len, pkt->rm_datalen, pkt->rm_oobdatalen,
+		    pkt->rm_pktinfolen);
+		return;
+	}
+	if (__predict_false(pkt->rm_datalen == 0)) {
+		HN_WARN(sc, "invalid RNDIS packet msg, no data");
+		return;
+	}
+
+	/*
+	 * Check offests.
+	 */
+#define	IS_OFFSET_INVALID(ofs)			\
+	((ofs) < RNDIS_PACKET_MSG_OFFSET_MIN ||	\
+	((ofs) & RNDIS_PACKET_MSG_OFFSET_ALIGNMASK))
+
+	/* XXX Hyper-V does not meet data offset alignment requirement */
+	if (__predict_false(pkt->rm_dataoffset < RNDIS_PACKET_MSG_OFFSET_MIN)) {
+		HN_WARN(sc, "invalid RNDIS packet msg, data offset %u",
+		    pkt->rm_dataoffset);
+		return;
+	}
+	if (__predict_false(pkt->rm_oobdataoffset > 0 &&
+	    IS_OFFSET_INVALID(pkt->rm_oobdataoffset))) {
+		HN_WARN(sc, "invalid RNDIS packet msg, oob offset %u",
+		    pkt->rm_oobdataoffset);
+		return;
+	}
+	if (__predict_true(pkt->rm_pktinfooffset > 0) &&
+	    __predict_false(IS_OFFSET_INVALID(pkt->rm_pktinfooffset))) {
+		HN_WARN(sc, "invalid RNDIS packet msg, pktinfo offset %u",
+		    pkt->rm_pktinfooffset);
+		return;
+	}
+
+#undef IS_OFFSET_INVALID
+
+	data_off = RNDIS_PACKET_MSG_OFFSET_ABS(pkt->rm_dataoffset);
+	data_len = pkt->rm_datalen;
+	pktinfo_off = RNDIS_PACKET_MSG_OFFSET_ABS(pkt->rm_pktinfooffset);
+	pktinfo_len = pkt->rm_pktinfolen;
+
+	/*
+	 * Check OOB coverage.
+	 */
+	if (__predict_false(pkt->rm_oobdatalen != 0)) {
+		int oob_off, oob_len;
+
+		HN_WARN(sc, "got oobdata");
+		oob_off = RNDIS_PACKET_MSG_OFFSET_ABS(pkt->rm_oobdataoffset);
+		oob_len = pkt->rm_oobdatalen;
+
+		if (__predict_false(oob_off + oob_len > pkt->rm_len)) {
+			HN_WARN(sc, "invalid RNDIS packet msg, "
+			    "oob overflow, msglen %u, oob abs %d len %d",
+			    pkt->rm_len, oob_off, oob_len);
+			return;
+		}
+
+		/*
+		 * Check against data.
+		 */
+		if (hn_rndis_check_overlap(oob_off, oob_len,
+		    data_off, data_len)) {
+			HN_WARN(sc, "invalid RNDIS packet msg, "
+			    "oob overlaps data, oob abs %d len %d, "
+			    "data abs %d len %d",
+			    oob_off, oob_len, data_off, data_len);
+			return;
+		}
+
+		/*
+		 * Check against pktinfo.
+		 */
+		if (pktinfo_len != 0 &&
+		    hn_rndis_check_overlap(oob_off, oob_len,
+		    pktinfo_off, pktinfo_len)) {
+			HN_WARN(sc, "invalid RNDIS packet msg, "
+			    "oob overlaps pktinfo, oob abs %d len %d, "
+			    "pktinfo abs %d len %d",
+			    oob_off, oob_len, pktinfo_off, pktinfo_len);
+			return;
+		}
+	}
+
+	/*
+	 * Check per-packet-info coverage and find useful per-packet-info.
+	 */
+	info.vlan_info = HN_NDIS_VLAN_INFO_INVALID;
+	info.csum_info = HN_NDIS_RXCSUM_INFO_INVALID;
+	info.hash_info = HN_NDIS_HASH_INFO_INVALID;
+	if (__predict_true(pktinfo_len != 0)) {
+		boolean_t overlap;
+		int error;
+
+		if (__predict_false(pktinfo_off + pktinfo_len > pkt->rm_len)) {
+			HN_WARN(sc, "invalid RNDIS packet msg, "
+			    "pktinfo overflow, msglen %u, "
+			    "pktinfo abs %d len %d",
+			    pkt->rm_len, pktinfo_off, pktinfo_len);
+			return;
+		}
+
+		/*
+		 * Check packet info coverage.
+		 */
+		overlap = hn_rndis_check_overlap(pktinfo_off, pktinfo_len,
+		    data_off, data_len);
+		if (__predict_false(overlap)) {
+			HN_WARN(sc, "invalid RNDIS packet msg, "
+			    "pktinfo overlap data, pktinfo abs %d len %d, "
+			    "data abs %d len %d",
+			    pktinfo_off, pktinfo_len, data_off, data_len);
+			return;
+		}
+
+		/*
+		 * Find useful per-packet-info.
+		 */
+		error = hn_rndis_rxinfo(((const uint8_t *)pkt) + pktinfo_off,
+		    pktinfo_len, &info);
+		if (__predict_false(error)) {
+			HN_WARN(sc, "invalid RNDIS packet msg pktinfo");
+			return;
+		}
+	}
+
+	if (__predict_false(data_off + data_len > pkt->rm_len)) {
+		HN_WARN(sc, "invalid RNDIS packet msg, "
+		    "data overflow, msglen %u, data abs %d len %d",
+		    pkt->rm_len, data_off, data_len);
+		return;
+	}
+	mutex_enter(&rxr->hn_rx_lock);
+	(void) hn_rxpkt(rxr, ((const uint8_t *)pkt) + data_off,
+	    data_len, &info);
+	mutex_exit(&rxr->hn_rx_lock);
+}
+
+static void
+hn_rndis_rxpkt(struct hn_rx_ring *rxr, const void *data, int dlen)
+{
+	struct hn_softc *sc = rxr->hn_sc;
+	const struct rndis_msghdr *hdr;
+
+	if (__predict_false(dlen < sizeof (*hdr))) {
+		HN_WARN(sc, "invalid RNDIS msg");
+		return;
+	}
+	hdr = data;
+
+	if (__predict_true(hdr->rm_type == REMOTE_NDIS_PACKET_MSG)) {
+		/* Hot data path. */
+		hn_rndis_rx_data(rxr, data, dlen);
+		/* Done! */
+		return;
+	}
+
+	if (hdr->rm_type == REMOTE_NDIS_INDICATE_STATUS_MSG)
+		hn_rndis_rx_status(sc, data, dlen);
+	else
+		hn_rndis_rx_ctrl(sc, data, dlen);
+}
+
+static void
+hn_nvs_handle_notify(struct hn_softc *sc, const struct vmbus_chanpkt_hdr *pkt)
+{
+	const struct hn_nvs_hdr *hdr;
+
+	if (VMBUS_CHANPKT_DATALEN(pkt) < sizeof (*hdr)) {
+		HN_WARN(sc, "invalid nvs notify");
+		return;
+	}
+	hdr = VMBUS_CHANPKT_CONST_DATA(pkt);
+
+	if (hdr->nvs_type == HN_NVS_TYPE_TXTBL_NOTE) {
+		/* Useless; ignore */
+		return;
+	}
+	HN_WARN(sc, "got notify, nvs type %u", hdr->nvs_type);
+}
+
+static void
+hn_nvs_handle_comp(struct hn_softc *sc, struct vmbus_channel *chan,
+    const struct vmbus_chanpkt_hdr *pkt)
+{
+	struct hn_nvs_sendctx *sndc;
+
+	sndc = (struct hn_nvs_sendctx *)(uintptr_t)pkt->cph_xactid;
+	sndc->hn_cb(sndc, sc, chan, VMBUS_CHANPKT_CONST_DATA(pkt),
+	    VMBUS_CHANPKT_DATALEN(pkt));
+	/*
+	 * NOTE:
+	 * 'sndc' CAN NOT be accessed anymore, since it can be freed by
+	 * its callback.
+	 */
+}
+
+static void
+hn_nvs_handle_rxbuf(struct hn_rx_ring *rxr, struct vmbus_channel *chan,
+    const struct vmbus_chanpkt_hdr *pkthdr)
+{
+	struct hn_softc *sc = rxr->hn_sc;
+	const struct vmbus_chanpkt_rxbuf *pkt;
+	const struct hn_nvs_hdr *nvs_hdr;
+	int count, i, hlen;
+
+	if (__predict_false(VMBUS_CHANPKT_DATALEN(pkthdr) <
+	    sizeof (*nvs_hdr))) {
+		HN_WARN(sc, "invalid nvs RNDIS");
+		return;
+	}
+	nvs_hdr = VMBUS_CHANPKT_CONST_DATA(pkthdr);
+
+	/* Make sure that this is a RNDIS message. */
+	if (__predict_false(nvs_hdr->nvs_type != HN_NVS_TYPE_RNDIS)) {
+		HN_WARN(sc, "nvs type %u, not RNDIS", nvs_hdr->nvs_type);
+		return;
+	}
+
+	hlen = VMBUS_CHANPKT_GETLEN(pkthdr->cph_hlen);
+	if (__predict_false(hlen < sizeof (*pkt))) {
+		HN_WARN(sc, "invalid rxbuf chanpkt");
+		return;
+	}
+	pkt = (const struct vmbus_chanpkt_rxbuf *)pkthdr;
+
+	if (__predict_false(pkt->cp_rxbuf_id != HN_NVS_RXBUF_SIG)) {
+		HN_WARN(sc, "invalid rxbuf_id 0x%08x", pkt->cp_rxbuf_id);
+		return;
+	}
+
+	count = pkt->cp_rxbuf_cnt;
+	if (__predict_false(hlen <
+	    offsetof(struct vmbus_chanpkt_rxbuf, cp_rxbuf[count]))) {
+		HN_WARN(sc, "invalid rxbuf_cnt %d", count);
+		return;
+	}
+
+	/* Each range represents 1 RNDIS pkt that contains 1 Ethernet frame */
+	for (i = 0; i < count; ++i) {
+		int ofs, len;
+
+		ofs = pkt->cp_rxbuf[i].rb_ofs;
+		len = pkt->cp_rxbuf[i].rb_len;
+		if (__predict_false(ofs + len > HN_RXBUF_SIZE)) {
+			HN_WARN(sc, "%dth RNDIS msg overflow rxbuf, "
+			    "ofs %d, len %d", i, ofs, len);
+			continue;
+		}
+		hn_rndis_rxpkt(rxr, rxr->hn_rxbuf + ofs, len);
+	}
+
+	/*
+	 * Send all the pending mblks to the MAC framework
+	 */
+	if (rxr->hn_mps) {
+		mac_rx_ring(sc->hn_mac_hdl, rxr->hn_ring_handle, rxr->hn_mps,
+		    rxr->hn_ring_gen_num);
+		rxr->hn_mps = NULL;
+		rxr->hn_mp_tail = NULL;
+	}
+	ASSERT3P(rxr->hn_mp_tail, ==, NULL);
+
+	/*
+	 * Ack the consumed RXBUF associated w/ this channel packet,
+	 * so that this RXBUF can be recycled by the hypervisor.
+	 */
+	hn_nvs_ack_rxbuf(rxr, chan, pkt->cp_hdr.cph_xactid);
+}
+
+static void
+hn_nvs_ack_rxbuf(struct hn_rx_ring *rxr, struct vmbus_channel *chan,
+    uint64_t tid)
+{
+	struct hn_nvs_rndis_ack ack;
+	struct hn_softc *sc = rxr->hn_sc;
+	int retries, error;
+
+	ack.nvs_type = HN_NVS_TYPE_RNDIS_ACK;
+	ack.nvs_status = HN_NVS_STATUS_OK;
+
+	retries = 0;
+again:
+	error = vmbus_chan_send(chan, VMBUS_CHANPKT_TYPE_COMP,
+	    VMBUS_CHANPKT_FLAG_NONE, &ack, sizeof (ack), tid);
+	if (__predict_false(error == EAGAIN)) {
+		/*
+		 * NOTE:
+		 * This should _not_ happen in real world, since the
+		 * consumption of the TX bufring from the TX path is
+		 * controlled.
+		 */
+		if (rxr->hn_ack_failed == 0)
+			HN_WARN(sc, "RXBUF ack retry");
+		rxr->hn_ack_failed++;
+		retries++;
+		if (retries < 10) {
+			DELAY(100);
+			goto again;
+		}
+		/* RXBUF leaks! */
+		HN_WARN(sc, "RXBUF ack failed");
+	}
+}
+
+static void
+hn_chan_callback(struct vmbus_channel *chan, void *xrxr)
+{
+	struct hn_rx_ring *rxr = xrxr;
+	struct hn_softc *sc = rxr->hn_sc;
+
+	for (;;) {
+		struct vmbus_chanpkt_hdr *pkt = rxr->hn_pktbuf;
+		int error, pktlen;
+
+		pktlen = rxr->hn_pktbuf_len;
+		error = vmbus_chan_recv_pkt(chan, pkt, &pktlen);
+		if (__predict_false(error == ENOBUFS)) {
+			void *nbuf;
+			int nlen;
+
+			/*
+			 * Expand channel packet buffer.
+			 *
+			 * XXX
+			 * Use KM_SLEEP here, since allocation failure
+			 * is fatal.
+			 */
+			nlen = rxr->hn_pktbuf_len * 2;
+			while (nlen < pktlen)
+				nlen *= 2;
+			nbuf = kmem_zalloc(nlen, KM_SLEEP);
+
+			HN_DEBUG(sc, 1, "expand pktbuf %d -> %d",
+			    rxr->hn_pktbuf_len, nlen);
+
+			kmem_free(rxr->hn_pktbuf, rxr->hn_pktbuf_len);
+			rxr->hn_pktbuf = nbuf;
+			rxr->hn_pktbuf_len = nlen;
+			/* Retry! */
+			continue;
+		} else if (__predict_false(error == EAGAIN)) {
+			/* No more channel packets; done! */
+			break;
+		}
+		/*
+		 * We do not expect any other type of error.
+		 */
+		ASSERT3S(error, ==, 0);
+
+		switch (pkt->cph_type) {
+		case VMBUS_CHANPKT_TYPE_COMP:
+			hn_nvs_handle_comp(sc, chan, pkt);
+			break;
+
+		case VMBUS_CHANPKT_TYPE_RXBUF:
+			hn_nvs_handle_rxbuf(rxr, chan, pkt);
+			break;
+
+		case VMBUS_CHANPKT_TYPE_INBAND:
+			hn_nvs_handle_notify(sc, pkt);
+			break;
+
+		default:
+			HN_WARN(sc, "unknown chan pkt %u", pkt->cph_type);
+			break;
+		}
+	}
+}
+
+/*
+ * Structures used by the module loader
+ */
+
+#define	HN_DRIVER_VERSION_STRING "1.0"
+#define	HN_IDENT "Hyper-V Network Interface " HN_DRIVER_VERSION_STRING
+
+DDI_DEFINE_STREAM_OPS(
+	netvsc_dev_ops,
+	nulldev,
+	nulldev,
+	hn_attach,
+	hn_detach,
+	nodev,
+	NULL,
+	D_NEW | D_MP,
+	NULL,
+	ddi_quiesce_not_supported);
+
+static struct modldrv netvsc_modldrv = {
+	&mod_driverops,		/* drv_modops */
+	HN_IDENT,		/* drv_linkinfo */
+	&netvsc_dev_ops		/* drv_dev_ops */
+};
+
+static struct modlinkage netvsc_modlinkage = {
+	MODREV_1,			/* ml_rev */
+	{ &netvsc_modldrv, NULL }	/* ml_linkage */
+};
+
+/* Module load entry point */
+int
+_init(void)
+{
+	int ret;
+
+	mac_init_ops(&netvsc_dev_ops, NETVSC_DEVNAME);
+	ret = mod_install(&netvsc_modlinkage);
+	if (ret != DDI_SUCCESS) {
+		mac_fini_ops(&netvsc_dev_ops);
+	}
+
+	return (ret);
+}
+
+/* Module unload entry point */
+int
+_fini(void)
+{
+	int ret;
+
+	ret = mod_remove(&netvsc_modlinkage);
+	if (ret == DDI_SUCCESS) {
+		mac_fini_ops(&netvsc_dev_ops);
+	}
+
+	return (ret);
+}
+
+/* Module info entry point */
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&netvsc_modlinkage, modinfop));
+}

--- a/usr/src/uts/intel/io/hyperv/netvsc/if_hnreg.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/if_hnreg.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _IF_HNREG_H_
+#define	_IF_HNREG_H_
+
+#include <sys/sysmacros.h>
+#include <sys/hyperv_illumos.h>
+
+/*
+ * NDIS protocol version numbers
+ */
+#define	HN_NDIS_VERSION_6_1		0x00060001
+#define	HN_NDIS_VERSION_6_20		0x00060014
+#define	HN_NDIS_VERSION_6_30		0x0006001e
+#define	HN_NDIS_VERSION_MAJOR(ver)	(((ver) & 0xffff0000) >> 16)
+#define	HN_NDIS_VERSION_MINOR(ver)	((ver) & 0xffff)
+
+/*
+ * NVS versions.
+ */
+#define	HN_NVS_VERSION_1		0x00002
+#define	HN_NVS_VERSION_2		0x30002
+#define	HN_NVS_VERSION_4		0x40000
+#define	HN_NVS_VERSION_5		0x50000
+
+#define	HN_NVS_RXBUF_SIG		0xcafe
+#define	HN_NVS_CHIM_SIG			0xface
+
+#define	HN_NVS_CHIM_IDX_INVALID		0xffffffff
+
+#define	HN_NVS_RNDIS_MTYPE_DATA		0
+#define	HN_NVS_RNDIS_MTYPE_CTRL		1
+
+/*
+ * NVS message transacion status codes.
+ */
+#define	HN_NVS_STATUS_OK		1
+#define	HN_NVS_STATUS_FAILED		2
+
+/*
+ * NVS request/response message types.
+ */
+#define	HN_NVS_TYPE_INIT		1
+#define	HN_NVS_TYPE_INIT_RESP		2
+#define	HN_NVS_TYPE_NDIS_INIT		100
+#define	HN_NVS_TYPE_RXBUF_CONN		101
+#define	HN_NVS_TYPE_RXBUF_CONNRESP	102
+#define	HN_NVS_TYPE_RXBUF_DISCONN	103
+#define	HN_NVS_TYPE_CHIM_CONN		104
+#define	HN_NVS_TYPE_CHIM_CONNRESP	105
+#define	HN_NVS_TYPE_CHIM_DISCONN	106
+#define	HN_NVS_TYPE_RNDIS		107
+#define	HN_NVS_TYPE_RNDIS_ACK		108
+#define	HN_NVS_TYPE_NDIS_CONF		125
+#define	HN_NVS_TYPE_VFASSOC_NOTE	128	/* notification */
+#define	HN_NVS_TYPE_SET_DATAPATH	129
+#define	HN_NVS_TYPE_SUBCH_REQ		133
+#define	HN_NVS_TYPE_SUBCH_RESP		133	/* same as SUBCH_REQ */
+#define	HN_NVS_TYPE_TXTBL_NOTE		134	/* notification */
+
+/*
+ * Any size less than this one will _not_ work, e.g. hn_nvs_init
+ * only has 12B valid data, however, if only 12B data were sent,
+ * Hypervisor would never reply.
+ */
+#define	HN_NVS_REQSIZE_MIN		32
+
+/* NVS message common header */
+struct hn_nvs_hdr {
+	uint32_t	nvs_type;
+} __packed;
+
+struct hn_nvs_init {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_INIT */
+	uint32_t	nvs_ver_min;
+	uint32_t	nvs_ver_max;
+	uint8_t		nvs_rsvd[20];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_init) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_init_resp {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_INIT_RESP */
+	uint32_t	nvs_ver;	/* deprecated */
+	uint32_t	nvs_rsvd;
+	uint32_t	nvs_status;	/* HN_NVS_STATUS_ */
+} __packed;
+
+/* No reponse */
+struct hn_nvs_ndis_conf {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_NDIS_CONF */
+	uint32_t	nvs_mtu;
+	uint32_t	nvs_rsvd;
+	uint64_t	nvs_caps;	/* HN_NVS_NDIS_CONF_ */
+	uint8_t		nvs_rsvd1[12];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_ndis_conf) >= HN_NVS_REQSIZE_MIN);
+
+#define	HN_NVS_NDIS_CONF_SRIOV		0x0004
+#define	HN_NVS_NDIS_CONF_VLAN		0x0008
+
+/* No response */
+struct hn_nvs_ndis_init {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_NDIS_INIT */
+	uint32_t	nvs_ndis_major;	/* NDIS_VERSION_MAJOR_ */
+	uint32_t	nvs_ndis_minor;	/* NDIS_VERSION_MINOR_ */
+	uint8_t		nvs_rsvd[20];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_ndis_init) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_rxbuf_conn {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_RXBUF_CONN */
+	uint32_t	nvs_gpadl;	/* RXBUF vmbus GPADL */
+	uint16_t	nvs_sig;	/* HN_NVS_RXBUF_SIG */
+	uint8_t		nvs_rsvd[22];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_rxbuf_conn) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_rxbuf_sect {
+	uint32_t	nvs_start;
+	uint32_t	nvs_slotsz;
+	uint32_t	nvs_slotcnt;
+	uint32_t	nvs_end;
+} __packed;
+
+struct hn_nvs_rxbuf_connresp {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_RXBUF_CONNRESP */
+	uint32_t	nvs_status;	/* HN_NVS_STATUS_ */
+	uint32_t	nvs_nsect;	/* # of elem in nvs_sect */
+	struct hn_nvs_rxbuf_sect nvs_sect[];
+} __packed;
+
+/* No response */
+struct hn_nvs_rxbuf_disconn {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_RXBUF_DISCONN */
+	uint16_t	nvs_sig;	/* HN_NVS_RXBUF_SIG */
+	uint8_t		nvs_rsvd[26];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_rxbuf_disconn) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_chim_conn {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_CHIM_CONN */
+	uint32_t	nvs_gpadl;	/* chimney buf vmbus GPADL */
+	uint16_t	nvs_sig;	/* NDIS_NVS_CHIM_SIG */
+	uint8_t		nvs_rsvd[22];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_chim_conn) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_chim_connresp {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_CHIM_CONNRESP */
+	uint32_t	nvs_status;	/* HN_NVS_STATUS_ */
+	uint32_t	nvs_sectsz;	/* section size */
+} __packed;
+
+/* No response */
+struct hn_nvs_chim_disconn {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_CHIM_DISCONN */
+	uint16_t	nvs_sig;	/* HN_NVS_CHIM_SIG */
+	uint8_t		nvs_rsvd[26];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_chim_disconn) >= HN_NVS_REQSIZE_MIN);
+
+#define	HN_NVS_SUBCH_OP_ALLOC		1
+
+struct hn_nvs_subch_req {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_SUBCH_REQ */
+	uint32_t	nvs_op;		/* HN_NVS_SUBCH_OP_ */
+	uint32_t	nvs_nsubch;
+	uint8_t		nvs_rsvd[20];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_subch_req) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_subch_resp {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_SUBCH_RESP */
+	uint32_t	nvs_status;	/* HN_NVS_STATUS_ */
+	uint32_t	nvs_nsubch;
+} __packed;
+
+struct hn_nvs_rndis {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_RNDIS */
+	uint32_t	nvs_rndis_mtype; /* HN_NVS_RNDIS_MTYPE_ */
+	/*
+	 * Chimney sending buffer index and size.
+	 *
+	 * NOTE:
+	 * If nvs_chim_idx is set to HN_NVS_CHIM_IDX_INVALID
+	 * and nvs_chim_sz is set to 0, then chimney sending
+	 * buffer is _not_ used by this RNDIS message.
+	 */
+	uint32_t	nvs_chim_idx;
+	uint32_t	nvs_chim_sz;
+	uint8_t		nvs_rsvd[16];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_rndis) >= HN_NVS_REQSIZE_MIN);
+
+struct hn_nvs_rndis_ack {
+	uint32_t	nvs_type;	/* HN_NVS_TYPE_RNDIS_ACK */
+	uint32_t	nvs_status;	/* HN_NVS_STATUS_ */
+	uint8_t		nvs_rsvd[24];
+} __packed;
+CTASSERT(sizeof (struct hn_nvs_rndis_ack) >= HN_NVS_REQSIZE_MIN);
+
+/*
+ * RNDIS extension
+ */
+
+/* Per-packet hash info */
+#define	HN_NDIS_HASH_INFO_SIZE		sizeof (uint32_t)
+#define	HN_NDIS_PKTINFO_TYPE_HASHINF	NDIS_PKTINFO_TYPE_ORIG_NBLIST
+/* NDIS_HASH_ */
+
+/* Per-packet hash value */
+#define	HN_NDIS_HASH_VALUE_SIZE		sizeof (uint32_t)
+#define	HN_NDIS_PKTINFO_TYPE_HASHVAL	NDIS_PKTINFO_TYPE_PKT_CANCELID
+
+/* Per-packet-info size */
+#define	HN_RNDIS_PKTINFO_SIZE(dlen)	\
+	offsetof(struct rndis_pktinfo, rm_data[dlen])
+
+#endif	/* !_IF_HNREG_H_ */

--- a/usr/src/uts/intel/io/hyperv/netvsc/if_hnvar.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/if_hnvar.h
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _IF_HNVAR_H_
+#define	_IF_HNVAR_H_
+
+#include <sys/ethernet.h>
+#include <sys/mac.h>
+#include <sys/mutex.h>
+#include <sys/debug.h>
+
+#include <sys/vmbus.h>
+#include <sys/hyperv_busdma.h>
+
+#include "ndis.h"
+
+#define	HN_CHIM_SIZE			(15 * 1024 * 1024)
+
+#define	HN_RXBUF_SIZE			(16 * 1024 * 1024)
+#define	HN_RXBUF_SIZE_COMPAT		(15 * 1024 * 1024)
+
+/* Claimed to be 12232B */
+#define	HN_MTU_MAX			(9 * 1024)
+#define	HN_MTU_MIN			60
+
+#define	HN_TXBR_SIZE			(128 * PAGESIZE)
+#define	HN_RXBR_SIZE			(128 * PAGESIZE)
+
+#define	HN_XACT_REQ_PGCNT		2
+#define	HN_XACT_RESP_PGCNT		2
+#define	HN_XACT_REQ_SIZE		(HN_XACT_REQ_PGCNT * PAGESIZE)
+#define	HN_XACT_RESP_SIZE		(HN_XACT_RESP_PGCNT * PAGESIZE)
+
+#define	HN_GPACNT_MAX			32
+
+#define	HN_RING_CNT_DEF_MAX		8
+
+#define	HN_DEFAULT_TRUST_HOST_CKSUM	B_FALSE
+
+struct hn_txdesc;
+struct buf_ring;
+struct hn_tx_ring;
+
+typedef struct hn_rx_stats {
+	uint64_t	pkts;
+	uint64_t	mcast_pkts;
+	uint64_t	bcast_pkts;
+	uint64_t	bytes;
+	uint64_t	norxbufs;
+	uint64_t	ierrors;
+	uint64_t	csum_ip;
+	uint64_t	csum_tcp;
+	uint64_t	csum_udp;
+	uint64_t	csum_trusted;
+} hn_rx_stats_t;
+
+struct hn_rx_ring {
+	struct hn_softc	*hn_sc;
+	struct hn_tx_ring *hn_txr;
+	void		*hn_pktbuf;
+	int		hn_pktbuf_len;
+	uint8_t		*hn_rxbuf;	/* shadow sc->hn_rxbuf */
+	int		hn_rx_idx;
+	kmutex_t	hn_rx_lock;
+	mblk_t		*hn_mps;
+	mblk_t		*hn_mp_tail;
+
+	/* Trust csum verification on host side */
+	int		hn_trust_hcsum;	/* HN_TRUST_HCSUM_ */
+
+	hn_rx_stats_t	hn_rx_stats;	/* protected by hn_rx_lock */
+
+	/* GLD related */
+	mac_ring_handle_t hn_ring_handle;
+	uint64_t	hn_ring_gen_num;
+	ulong_t		hn_ack_failed;
+
+	/* Rarely used stuffs */
+	int		hn_rx_flags;
+
+	void		*hn_br;		/* TX/RX bufring */
+	struct hyperv_dma hn_br_dma;
+} __aligned(CACHE_LINE_SIZE);
+
+#define	HN_TRUST_HCSUM_IP	0x0001
+#define	HN_TRUST_HCSUM_TCP	0x0002
+#define	HN_TRUST_HCSUM_UDP	0x0004
+#define	HN_TRUST_HCSUM_ALL	(HN_TRUST_HCSUM_IP | HN_TRUST_HCSUM_TCP | \
+    HN_TRUST_HCSUM_UDP)
+
+#define	HN_RX_FLAG_ATTACHED	0x0001
+#define	HN_RX_FLAG_BR_REF	0x0002
+
+typedef struct hn_tx_stats {
+	uint64_t	pkts;
+	uint64_t	mcast_pkts;
+	uint64_t	bcast_pkts;
+	uint64_t	bytes;
+	uint64_t	no_txdescs;
+	uint64_t	send_failed;
+	uint64_t	pulledup;
+	uint64_t	chimney_tried;
+	uint64_t	chimney_sent;
+	uint64_t	dma_failed;
+} hn_tx_stats_t;
+
+typedef enum hn_pkt_type {
+	HN_UNICAST,
+	HN_MULTICAST,
+	HN_BROADCAST
+} hn_pkt_type_t;
+
+struct hn_tx_ring {
+	struct hn_softc	*hn_sc;
+	struct buf_ring	*hn_txdesc_br;
+	int		hn_txdesc_cnt;
+	int		hn_txdesc_avail;
+	int		hn_tx_idx;
+	int		hn_tx_flags;
+	kmutex_t	hn_tx_lock;
+	struct vmbus_channel *hn_chan;
+	int		hn_chim_size;
+
+	/* info about next packet to send */
+	int		(*hn_sendpkt)(struct hn_tx_ring *, struct hn_txdesc *);
+	hn_pkt_type_t	hn_pkt_type;
+	int		hn_pkt_length;
+
+	ddi_dma_handle_t hn_data_dmah;
+	boolean_t	hn_suspended;
+	int		hn_gpa_cnt;
+	struct vmbus_gpa hn_gpa[HN_GPACNT_MAX];
+	hn_tx_stats_t	hn_tx_stats;	/* protected by hn_tx_lock */
+	boolean_t	hn_reschedule;	/* flow control (br empty, etc.) */
+	mac_ring_handle_t hn_ring_handle;
+	struct hn_txdesc *hn_txdesc;
+} __aligned(CACHE_LINE_SIZE);
+
+#define	HN_TX_FLAG_ATTACHED	0x0001
+#define	HN_TX_FLAG_HASHVAL	0x0002	/* support HASHVAL pktinfo */
+
+typedef struct hn_rx_group {
+	uint32_t		index;		/* Group index */
+	mac_group_handle_t	group_handle;   /* call back group handle */
+	struct hn_softc		*sc;		/* Pointer to the driver */
+} hn_rx_group_t;
+
+typedef struct hn_kstats {
+	kstat_named_t	tx_ring_cnt;
+	kstat_named_t	tx_ring_inuse;
+	kstat_named_t	rx_ring_cnt;
+	kstat_named_t	rx_ring_inuse;
+
+	kstat_named_t	tx_send_failed;
+	kstat_named_t	tx_no_descs;
+	kstat_named_t	tx_mblk_pulledup;
+	kstat_named_t	tx_chimney_tried;
+	kstat_named_t	tx_chimney_sent;
+	kstat_named_t	tx_dma_failed;
+	kstat_named_t	tx_descs_used;
+
+	kstat_named_t	rx_no_bufs;
+	kstat_named_t	rx_csum_ip;
+	kstat_named_t	rx_csum_tcp;
+	kstat_named_t	rx_csum_udp;
+	kstat_named_t	rx_csum_trusted;
+} hn_kstats_t;
+
+/*
+ * Device-specific softc structure
+ */
+struct hn_softc {
+	dev_info_t		*hn_dev;
+	int			hn_instance;
+	boolean_t		hn_running;
+	mac_handle_t		hn_mac_hdl;
+	boolean_t		hn_promiscuous;
+	uint8_t			hn_macaddr[ETHERADDRL];
+	boolean_t		hn_mac_addr_set;
+	int			hn_mtu;
+	boolean_t		hn_tx_hcksum_enable;
+	uint32_t		hn_hcksum_flags;
+	boolean_t		hn_lso_enable;
+	uint32_t		hn_lso_flags;
+	int			hn_txdesc_cnt;
+	kmutex_t		hn_lock;
+	struct vmbus_channel	*hn_prichan;
+	kstat_t			*hn_kstats;
+
+	int			hn_rx_ring_cnt;
+	int			hn_rx_ring_inuse;
+	struct hn_rx_ring	*hn_rx_ring;
+	hn_rx_group_t		hn_rx_group;
+
+	int			hn_tx_ring_cnt;
+	int			hn_tx_ring_inuse;
+	struct hn_tx_ring	*hn_tx_ring;
+
+	caddr_t			hn_chim;
+	ulong_t			*hn_chim_bmap;
+	int			hn_chim_bmap_cnt;
+	int			hn_chim_cnt;
+	int			hn_chim_szmax;
+
+	int			hn_cpu;
+	struct vmbus_xact_ctx	*hn_xact;
+	uint32_t		hn_nvs_ver;
+	uint32_t		hn_rx_filter;
+
+	kmutex_t		hn_mgmt_lock;	/* protect hn_mgmt_taskq */
+	ddi_taskq_t		*hn_mgmt_taskq;
+	ddi_taskq_t		*hn_mgmt_taskq0;
+	uint32_t		hn_link_flags;	/* HN_LINK_FLAG_ */
+
+	uint32_t		hn_caps;	/* HN_CAP_ */
+	uint32_t		hn_flags;	/* HN_FLAG_ */
+	void			*hn_rxbuf;
+	uint32_t		hn_rxbuf_gpadl;
+	struct hyperv_dma	hn_rxbuf_dma;
+
+	uint32_t		hn_chim_gpadl;
+	struct hyperv_dma	hn_chim_dma;
+
+	uint32_t		hn_rndis_rid;
+	uint32_t		hn_ndis_ver;
+	int			hn_ndis_tso_szmax;
+	int			hn_ndis_tso_sgmin;
+
+	int			hn_rss_ind_size;
+	uint32_t		hn_rss_hash;	/* NDIS_HASH_ */
+	struct ndis_rssprm_toeplitz hn_rss;
+};
+
+#define	HN_FLAG_RXBUF_CONNECTED		0x0001
+#define	HN_FLAG_CHIM_CONNECTED		0x0002
+#define	HN_FLAG_HAS_RSSKEY		0x0004
+#define	HN_FLAG_HAS_RSSIND		0x0008
+#define	HN_FLAG_SYNTH_ATTACHED		0x0010
+#define	HN_FLAG_RXBUF_REF		0x0040
+#define	HN_FLAG_CHIM_REF		0x0080
+
+#define	HN_FLAG_ERRORS			(HN_FLAG_RXBUF_REF | HN_FLAG_CHIM_REF)
+
+#define	HN_CAP_VLAN			0x0001
+#define	HN_CAP_MTU			0x0002
+#define	HN_CAP_IPCS			0x0004
+#define	HN_CAP_TCP4CS			0x0008
+#define	HN_CAP_TCP6CS			0x0010
+#define	HN_CAP_UDP4CS			0x0020
+#define	HN_CAP_UDP6CS			0x0040
+#define	HN_CAP_TSO4			0x0080
+#define	HN_CAP_TSO6			0x0100
+#define	HN_CAP_HASHVAL			0x0200
+
+#define	HN_CAP_L4CS	(HN_CAP_TCP4CS | HN_CAP_TCP6CS | \
+			HN_CAP_UDP4CS | HN_CAP_UDP6CS)
+
+#define	HN_WARN(dev, fmt...)	dev_err((dev)->hn_dev, CE_WARN, fmt)
+#define	HN_NOTE(dev, fmt...)	dev_err((dev)->hn_dev, CE_NOTE, fmt)
+
+extern int hn_debug;
+
+#define	HN_DEBUG(dev, level, fmt...) {	\
+	if (level <= hn_debug) {	\
+		dev_err((dev)->hn_dev, CE_NOTE, fmt);	\
+	}	\
+}
+
+#define	HN_LOCK_INIT(sc)		\
+	mutex_init(&(sc)->hn_lock, NULL, MUTEX_DEFAULT, NULL)
+#define	HN_LOCK_ASSERT(sc)		ASSERT(MUTEX_HELD(&(sc)->hn_lock))
+#define	HN_LOCKED(sc)			MUTEX_HELD(&(sc)->hn_lock)
+#define	HN_LOCK_DESTROY(sc)		mutex_destroy(&(sc)->hn_lock)
+#define	HN_LOCK(sc)			mutex_enter(&(sc)->hn_lock)
+#define	HN_UNLOCK(sc)			mutex_exit(&(sc)->hn_lock)
+
+#define	MACADDR_FMT "%02x%02x%02x%02x%02x%02x"
+#define	MACADDR_FMT_PRETTY "%02x:%02x:%02x:%02x:%02x:%02x"
+#define	MACADDR_FMT_ARGS(mac) mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+
+#define	HN_LINK_FLAG_LINKUP		0x0001
+#define	HN_LINK_FLAG_NETCHG		0x0002
+
+void	hn_init(void *);
+void	hn_stop(struct hn_softc *);
+int	hn_register_mac(struct hn_softc *);
+int	hn_change_mtu(struct hn_softc *, uint32_t);
+mblk_t	*hn_xmit(struct hn_tx_ring *, mblk_t *);
+int	hn_set_rxfilter(struct hn_softc *);
+void	hn_set_chim_size(struct hn_softc *, int);
+
+#endif	/* !_IF_HNVAR_H_ */

--- a/usr/src/uts/intel/io/hyperv/netvsc/ndis.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/ndis.h
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _NET_NDIS_H_
+#define	_NET_NDIS_H_
+
+#define	NDIS_MEDIA_STATE_CONNECTED	0
+#define	NDIS_MEDIA_STATE_DISCONNECTED	1
+
+#define	NDIS_NETCHANGE_TYPE_POSSIBLE	1
+#define	NDIS_NETCHANGE_TYPE_DEFINITE	2
+#define	NDIS_NETCHANGE_TYPE_FROMMEDIA	3
+
+#define	NDIS_OFFLOAD_SET_NOCHG		0
+#define	NDIS_OFFLOAD_SET_ON		1
+#define	NDIS_OFFLOAD_SET_OFF		2
+
+/* a.k.a GRE MAC */
+#define	NDIS_ENCAP_TYPE_NVGRE		0x00000001
+
+#define	NDIS_HASH_FUNCTION_MASK		0x000000FF	/* see hash function */
+#define	NDIS_HASH_TYPE_MASK		0x00FFFF00	/* see hash type */
+
+/* hash function */
+#define	NDIS_HASH_FUNCTION_TOEPLITZ	0x00000001
+
+/* hash type */
+#define	NDIS_HASH_IPV4			0x00000100
+#define	NDIS_HASH_TCP_IPV4		0x00000200
+#define	NDIS_HASH_IPV6			0x00000400
+#define	NDIS_HASH_IPV6_EX		0x00000800
+#define	NDIS_HASH_TCP_IPV6		0x00001000
+#define	NDIS_HASH_TCP_IPV6_EX		0x00002000
+
+#define	NDIS_HASH_KEYSIZE_TOEPLITZ	40
+#define	NDIS_HASH_INDCNT		128
+
+#define	NDIS_OBJTYPE_DEFAULT		0x80
+#define	NDIS_OBJTYPE_RSS_CAPS		0x88
+#define	NDIS_OBJTYPE_RSS_PARAMS		0x89
+#define	NDIS_OBJTYPE_OFFLOAD		0xa7
+
+struct ndis_object_hdr {
+	uint8_t			ndis_type;	/* NDIS_OBJTYPE_ */
+	uint8_t			ndis_rev;	/* type specific */
+	uint16_t		ndis_size;	/* incl. this hdr */
+};
+
+/*
+ * OID_TCP_OFFLOAD_PARAMETERS
+ * ndis_type: NDIS_OBJTYPE_DEFAULT
+ */
+struct ndis_offload_params {
+	struct ndis_object_hdr	ndis_hdr;
+	uint8_t			ndis_ip4csum;	/* NDIS_OFFLOAD_PARAM_ */
+	uint8_t			ndis_tcp4csum;	/* NDIS_OFFLOAD_PARAM_ */
+	uint8_t			ndis_udp4csum;	/* NDIS_OFFLOAD_PARAM_ */
+	uint8_t			ndis_tcp6csum;	/* NDIS_OFFLOAD_PARAM_ */
+	uint8_t			ndis_udp6csum;	/* NDIS_OFFLOAD_PARAM_ */
+	uint8_t			ndis_lsov1;	/* NDIS_OFFLOAD_PARAM_ */
+	uint8_t			ndis_ipsecv1;	/* NDIS_OFFLOAD_IPSECV1_ */
+	uint8_t			ndis_lsov2_ip4;	/* NDIS_OFFLOAD_LSOV2_ */
+	uint8_t			ndis_lsov2_ip6;	/* NDIS_OFFLOAD_LSOV2_ */
+	uint8_t			ndis_tcp4conn;	/* 0 */
+	uint8_t			ndis_tcp6conn;	/* 0 */
+	uint32_t		ndis_flags;	/* 0 */
+	/* NDIS >= 6.1 */
+	uint8_t			ndis_ipsecv2;	/* NDIS_OFFLOAD_IPSECV2_ */
+	uint8_t			ndis_ipsecv2_ip4; /* NDIS_OFFLOAD_IPSECV2_ */
+	/* NDIS >= 6.30 */
+	uint8_t			ndis_rsc_ip4;	/* NDIS_OFFLOAD_RSC_ */
+	uint8_t			ndis_rsc_ip6;	/* NDIS_OFFLOAD_RSC_ */
+	uint8_t			ndis_encap;	/* NDIS_OFFLOAD_SET_ */
+	uint8_t			ndis_encap_types; /* NDIS_ENCAP_TYPE_ */
+};
+
+#define	NDIS_OFFLOAD_PARAMS_SIZE	sizeof (struct ndis_offload_params)
+#define	NDIS_OFFLOAD_PARAMS_SIZE_6_1	\
+	offsetof(struct ndis_offload_params, ndis_rsc_ip4)
+
+#define	NDIS_OFFLOAD_PARAMS_REV_2	2	/* NDIS 6.1 */
+#define	NDIS_OFFLOAD_PARAMS_REV_3	3	/* NDIS 6.30 */
+
+#define	NDIS_OFFLOAD_PARAM_NOCHG	0	/* common */
+#define	NDIS_OFFLOAD_PARAM_OFF		1
+#define	NDIS_OFFLOAD_PARAM_TX		2
+#define	NDIS_OFFLOAD_PARAM_RX		3
+#define	NDIS_OFFLOAD_PARAM_TXRX		4
+
+/* NDIS_OFFLOAD_PARAM_NOCHG */
+#define	NDIS_OFFLOAD_LSOV1_OFF		1
+#define	NDIS_OFFLOAD_LSOV1_ON		2
+
+/* NDIS_OFFLOAD_PARAM_NOCHG */
+#define	NDIS_OFFLOAD_IPSECV1_OFF	1
+#define	NDIS_OFFLOAD_IPSECV1_AH		2
+#define	NDIS_OFFLOAD_IPSECV1_ESP	3
+#define	NDIS_OFFLOAD_IPSECV1_AH_ESP	4
+
+/* NDIS_OFFLOAD_PARAM_NOCHG */
+#define	NDIS_OFFLOAD_LSOV2_OFF		1
+#define	NDIS_OFFLOAD_LSOV2_ON		2
+
+/* NDIS_OFFLOAD_PARAM_NOCHG */
+#define	NDIS_OFFLOAD_IPSECV2_OFF	1
+#define	NDIS_OFFLOAD_IPSECV2_AH		2
+#define	NDIS_OFFLOAD_IPSECV2_ESP	3
+#define	NDIS_OFFLOAD_IPSECV2_AH_ESP	4
+
+/* NDIS_OFFLOAD_PARAM_NOCHG */
+#define	NDIS_OFFLOAD_RSC_OFF		1
+#define	NDIS_OFFLOAD_RSC_ON		2
+
+/*
+ * OID_GEN_RECEIVE_SCALE_CAPABILITIES
+ * ndis_type: NDIS_OBJTYPE_RSS_CAPS
+ */
+struct ndis_rss_caps {
+	struct ndis_object_hdr		ndis_hdr;
+	uint32_t			ndis_caps;	/* NDIS_RSS_CAP_ */
+	uint32_t			ndis_nmsi;	/* # of MSIs */
+	uint32_t			ndis_nrxr;	/* # of RX rings */
+	/* NDIS >= 6.30 */
+	uint16_t			ndis_nind;	/* # of indtbl ent. */
+	uint16_t			ndis_pad;
+};
+
+#define	NDIS_RSS_CAPS_SIZE		\
+	offsetof(struct ndis_rss_caps, ndis_pad)
+#define	NDIS_RSS_CAPS_SIZE_6_0		\
+	offsetof(struct ndis_rss_caps, ndis_nind)
+
+#define	NDIS_RSS_CAPS_REV_1		1	/* NDIS 6.{0,1,20} */
+#define	NDIS_RSS_CAPS_REV_2		2	/* NDIS 6.30 */
+
+#define	NDIS_RSS_CAP_MSI		0x01000000
+#define	NDIS_RSS_CAP_CLASSIFY_ISR	0x02000000
+#define	NDIS_RSS_CAP_CLASSIFY_DPC	0x04000000
+#define	NDIS_RSS_CAP_MSIX		0x08000000
+#define	NDIS_RSS_CAP_IPV4		0x00000100
+#define	NDIS_RSS_CAP_IPV6		0x00000200
+#define	NDIS_RSS_CAP_IPV6_EX		0x00000400
+#define	NDIS_RSS_CAP_HASH_TOEPLITZ	NDIS_HASH_FUNCTION_TOEPLITZ
+#define	NDIS_RSS_CAP_HASHFUNC_MASK	NDIS_HASH_FUNCTION_MASK
+
+/*
+ * OID_GEN_RECEIVE_SCALE_PARAMETERS
+ * ndis_type: NDIS_OBJTYPE_RSS_PARAMS
+ */
+struct ndis_rss_params {
+	struct ndis_object_hdr		ndis_hdr;
+	uint16_t			ndis_flags;	/* NDIS_RSS_FLAG_ */
+	uint16_t			ndis_bcpu;	/* base cpu 0 */
+	uint32_t			ndis_hash;	/* NDIS_HASH_ */
+	uint16_t			ndis_indsize;	/* indirect table */
+	uint32_t			ndis_indoffset;
+	uint16_t			ndis_keysize;	/* hash key */
+	uint32_t			ndis_keyoffset;
+	/* NDIS >= 6.20 */
+	uint32_t			ndis_cpumaskoffset;
+	uint32_t			ndis_cpumaskcnt;
+	uint32_t			ndis_cpumaskentsz;
+};
+
+#define	NDIS_RSS_PARAMS_SIZE		sizeof (struct ndis_rss_params)
+#define	NDIS_RSS_PARAMS_SIZE_6_0	\
+	offsetof(struct ndis_rss_params, ndis_cpumaskoffset)
+
+#define	NDIS_RSS_PARAMS_REV_1		1	/* NDIS 6.0 */
+#define	NDIS_RSS_PARAMS_REV_2		2	/* NDIS 6.20 */
+
+#define	NDIS_RSS_FLAG_NONE		0x0000
+#define	NDIS_RSS_FLAG_BCPU_UNCHG	0x0001
+#define	NDIS_RSS_FLAG_HASH_UNCHG	0x0002
+#define	NDIS_RSS_FLAG_IND_UNCHG		0x0004
+#define	NDIS_RSS_FLAG_KEY_UNCHG		0x0008
+#define	NDIS_RSS_FLAG_DISABLE		0x0010
+
+/* non-standard convenient struct */
+struct ndis_rssprm_toeplitz {
+	struct ndis_rss_params		rss_params;
+	/* Toeplitz hash key */
+	uint8_t				rss_key[NDIS_HASH_KEYSIZE_TOEPLITZ];
+	/* Indirect table */
+	uint32_t			rss_ind[NDIS_HASH_INDCNT];
+};
+
+#define	NDIS_RSSPRM_TOEPLITZ_SIZE(nind)	\
+	offsetof(struct ndis_rssprm_toeplitz, rss_ind[nind])
+
+/*
+ * OID_TCP_OFFLOAD_HARDWARE_CAPABILITIES
+ * ndis_type: NDIS_OBJTYPE_OFFLOAD
+ */
+
+#define	NDIS_OFFLOAD_ENCAP_NONE		0x0000
+#define	NDIS_OFFLOAD_ENCAP_NULL		0x0001
+#define	NDIS_OFFLOAD_ENCAP_8023		0x0002
+#define	NDIS_OFFLOAD_ENCAP_8023PQ	0x0004
+#define	NDIS_OFFLOAD_ENCAP_8023PQ_OOB	0x0008
+#define	NDIS_OFFLOAD_ENCAP_RFC1483	0x0010
+
+struct ndis_csum_offload {
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_ip4_txenc;
+	uint32_t			ndis_ip4_txcsum;
+#define	NDIS_TXCSUM_CAP_IP4OPT		0x001
+#define	NDIS_TXCSUM_CAP_TCP4OPT		0x004
+#define	NDIS_TXCSUM_CAP_TCP4		0x010
+#define	NDIS_TXCSUM_CAP_UDP4		0x040
+#define	NDIS_TXCSUM_CAP_IP4		0x100
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_ip4_rxenc;
+	uint32_t			ndis_ip4_rxcsum;
+#define	NDIS_RXCSUM_CAP_IP4OPT		0x001
+#define	NDIS_RXCSUM_CAP_TCP4OPT		0x004
+#define	NDIS_RXCSUM_CAP_TCP4		0x010
+#define	NDIS_RXCSUM_CAP_UDP4		0x040
+#define	NDIS_RXCSUM_CAP_IP4		0x100
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_ip6_txenc;
+	uint32_t			ndis_ip6_txcsum;
+#define	NDIS_TXCSUM_CAP_IP6EXT		0x001
+#define	NDIS_TXCSUM_CAP_TCP6OPT		0x004
+#define	NDIS_TXCSUM_CAP_TCP6		0x010
+#define	NDIS_TXCSUM_CAP_UDP6		0x040
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_ip6_rxenc;
+	uint32_t			ndis_ip6_rxcsum;
+#define	NDIS_RXCSUM_CAP_IP6EXT		0x001
+#define	NDIS_RXCSUM_CAP_TCP6OPT		0x004
+#define	NDIS_RXCSUM_CAP_TCP6		0x010
+#define	NDIS_RXCSUM_CAP_UDP6		0x040
+};
+
+struct ndis_lsov1_offload {
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_encap;
+	uint32_t			ndis_maxsize;
+	uint32_t			ndis_minsegs;
+	uint32_t			ndis_opts;
+};
+
+struct ndis_ipsecv1_offload {
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_encap;
+	uint32_t			ndis_ah_esp;
+	uint32_t			ndis_xport_tun;
+	uint32_t			ndis_ip4_opts;
+	uint32_t			ndis_flags;
+	uint32_t			ndis_ip4_ah;
+	uint32_t			ndis_ip4_esp;
+};
+
+struct ndis_lsov2_offload {
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_ip4_encap;
+	uint32_t			ndis_ip4_maxsz;
+	uint32_t			ndis_ip4_minsg;
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_ip6_encap;
+	uint32_t			ndis_ip6_maxsz;
+	uint32_t			ndis_ip6_minsg;
+	uint32_t			ndis_ip6_opts;
+#define	NDIS_LSOV2_CAP_IP6EXT		0x001
+#define	NDIS_LSOV2_CAP_TCP6OPT		0x004
+};
+
+struct ndis_ipsecv2_offload {
+	/* NDIS_OFFLOAD_ENCAP_ */
+	uint32_t			ndis_encap;
+	uint16_t			ndis_ip6;
+	uint16_t			ndis_ip4opt;
+	uint16_t			ndis_ip6ext;
+	uint16_t			ndis_ah;
+	uint16_t			ndis_esp;
+	uint16_t			ndis_ah_esp;
+	uint16_t			ndis_xport;
+	uint16_t			ndis_tun;
+	uint16_t			ndis_xport_tun;
+	uint16_t			ndis_lso;
+	uint16_t			ndis_extseq;
+	uint32_t			ndis_udp_esp;
+	uint32_t			ndis_auth;
+	uint32_t			ndis_crypto;
+	uint32_t			ndis_sa_caps;
+};
+
+struct ndis_rsc_offload {
+	uint16_t			ndis_ip4;
+	uint16_t			ndis_ip6;
+};
+
+struct ndis_encap_offload {
+	uint32_t			ndis_flags;
+	uint32_t			ndis_maxhdr;
+};
+
+struct ndis_offload {
+	struct ndis_object_hdr		ndis_hdr;
+	struct ndis_csum_offload	ndis_csum;
+	struct ndis_lsov1_offload	ndis_lsov1;
+	struct ndis_ipsecv1_offload	ndis_ipsecv1;
+	struct ndis_lsov2_offload	ndis_lsov2;
+	uint32_t			ndis_flags;
+	/* NDIS >= 6.1 */
+	struct ndis_ipsecv2_offload	ndis_ipsecv2;
+	/* NDIS >= 6.30 */
+	struct ndis_rsc_offload		ndis_rsc;
+	struct ndis_encap_offload	ndis_encap_gre;
+};
+
+#define	NDIS_OFFLOAD_SIZE		sizeof (struct ndis_offload)
+#define	NDIS_OFFLOAD_SIZE_6_0		\
+	offsetof(struct ndis_offload, ndis_ipsecv2)
+#define	NDIS_OFFLOAD_SIZE_6_1		\
+	offsetof(struct ndis_offload, ndis_rsc)
+
+#define	NDIS_OFFLOAD_REV_1		1	/* NDIS 6.0 */
+#define	NDIS_OFFLOAD_REV_2		2	/* NDIS 6.1 */
+#define	NDIS_OFFLOAD_REV_3		3	/* NDIS 6.30 */
+
+/*
+ * Per-packet-info
+ */
+
+/* VLAN */
+#define	NDIS_VLAN_INFO_SIZE		sizeof (uint32_t)
+#define	NDIS_VLAN_INFO_PRI_MASK		0x0007
+#define	NDIS_VLAN_INFO_CFI_MASK		0x0008
+#define	NDIS_VLAN_INFO_ID_MASK		0xfff0
+#define	NDIS_VLAN_INFO_MAKE(id, pri, cfi)	\
+	(((pri) & NDIS_VLAN_INFO_PRI_MASK) |	\
+	(((cfi) & 0x1) << 3) | (((id) & 0xfff) << 4))
+#define	NDIS_VLAN_INFO_ID(inf)		(((inf) & NDIS_VLAN_INFO_ID_MASK) >> 4)
+#define	NDIS_VLAN_INFO_CFI(inf)		(((inf) & NDIS_VLAN_INFO_CFI_MASK) >> 3)
+#define	NDIS_VLAN_INFO_PRI(inf)		((inf) & NDIS_VLAN_INFO_PRI_MASK)
+
+/* Reception checksum */
+#define	NDIS_RXCSUM_INFO_SIZE		sizeof (uint32_t)
+#define	NDIS_RXCSUM_INFO_TCPCS_FAILED	0x0001
+#define	NDIS_RXCSUM_INFO_UDPCS_FAILED	0x0002
+#define	NDIS_RXCSUM_INFO_IPCS_FAILED	0x0004
+#define	NDIS_RXCSUM_INFO_TCPCS_OK	0x0008
+#define	NDIS_RXCSUM_INFO_UDPCS_OK	0x0010
+#define	NDIS_RXCSUM_INFO_IPCS_OK	0x0020
+#define	NDIS_RXCSUM_INFO_LOOPBACK	0x0040
+#define	NDIS_RXCSUM_INFO_TCPCS_INVAL	0x0080
+#define	NDIS_RXCSUM_INFO_IPCS_INVAL	0x0100
+
+/* LSOv2 */
+#define	NDIS_LSO2_INFO_SIZE		sizeof (uint32_t)
+#define	NDIS_LSO2_INFO_MSS_MASK		0x000fffff
+#define	NDIS_LSO2_INFO_THOFF_MASK	0x3ff00000
+#define	NDIS_LSO2_INFO_ISLSO2		0x40000000
+#define	NDIS_LSO2_INFO_ISIPV6		0x80000000
+
+#define	NDIS_LSO2_INFO_MAKE(thoff, mss)				\
+	((((uint32_t)(mss)) & NDIS_LSO2_INFO_MSS_MASK) |	\
+	((((uint32_t)(thoff)) & 0x3ff) << 20) |	NDIS_LSO2_INFO_ISLSO2)
+
+#define	NDIS_LSO2_INFO_MAKEIPV4(thoff, mss)			\
+	NDIS_LSO2_INFO_MAKE((thoff), (mss))
+
+#define	NDIS_LSO2_INFO_MAKEIPV6(thoff, mss)			\
+	(NDIS_LSO2_INFO_MAKE((thoff), (mss)) | NDIS_LSO2_INFO_ISIPV6)
+
+/* Transmission checksum */
+#define	NDIS_TXCSUM_INFO_SIZE		sizeof (uint32_t)
+#define	NDIS_TXCSUM_INFO_IPV4		0x00000001
+#define	NDIS_TXCSUM_INFO_IPV6		0x00000002
+#define	NDIS_TXCSUM_INFO_TCPCS		0x00000004
+#define	NDIS_TXCSUM_INFO_UDPCS		0x00000008
+#define	NDIS_TXCSUM_INFO_IPCS		0x00000010
+#define	NDIS_TXCSUM_INFO_THOFF(thoff)	\
+	(((uint32_t)(thoff) & 0x3ff) << 20)
+
+#endif	/* !_NET_NDIS_H_ */

--- a/usr/src/uts/intel/io/hyperv/netvsc/rndis.h
+++ b/usr/src/uts/intel/io/hyperv/netvsc/rndis.h
@@ -1,0 +1,399 @@
+/*	$FreeBSD$ */
+/*	$OpenBSD: if_urndisreg.h,v 1.19 2013/11/21 14:08:05 mpi Exp $ */
+
+/*
+ * Copyright (c) 2010 Jonathan Armani <armani@openbsd.org>
+ * Copyright (c) 2010 Fabien Romano <fabien@openbsd.org>
+ * Copyright (c) 2010 Michael Knudsen <mk@openbsd.org>
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef	_NET_RNDIS_H_
+#define	_NET_RNDIS_H_
+
+#include <sys/sysmacros.h>
+
+/* Canonical major/minor version as of 22th Aug. 2016. */
+#define	RNDIS_VERSION_MAJOR		0x00000001
+#define	RNDIS_VERSION_MINOR		0x00000000
+
+#define	RNDIS_STATUS_SUCCESS		0x00000000L
+#define	RNDIS_STATUS_PENDING		0x00000103L
+#define	RNDIS_STATUS_MEDIA_CONNECT	0x4001000BL
+#define	RNDIS_STATUS_MEDIA_DISCONNECT	0x4001000CL
+#define	RNDIS_STATUS_NETWORK_CHANGE	0x40010018L
+#define	RNDIS_STATUS_TASK_OFFLOAD_CURRENT_CONFIG	0x40020006L
+#define	RNDIS_STATUS_BUFFER_OVERFLOW	0x80000005L
+#define	RNDIS_STATUS_FAILURE		0xC0000001L
+#define	RNDIS_STATUS_NOT_SUPPORTED	0xC00000BBL
+#define	RNDIS_STATUS_RESOURCES		0xC000009AL
+#define	RNDIS_STATUS_INVALID_DATA	0xC0010015L
+
+#define	OID_GEN_SUPPORTED_LIST		0x00010101
+#define	OID_GEN_HARDWARE_STATUS		0x00010102
+#define	OID_GEN_MEDIA_SUPPORTED		0x00010103
+#define	OID_GEN_MEDIA_IN_USE		0x00010104
+#define	OID_GEN_MAXIMUM_LOOKAHEAD	0x00010105
+#define	OID_GEN_MAXIMUM_FRAME_SIZE	0x00010106
+#define	OID_GEN_LINK_SPEED		0x00010107
+#define	OID_GEN_TRANSMIT_BUFFER_SPACE	0x00010108
+#define	OID_GEN_RECEIVE_BUFFER_SPACE	0x00010109
+#define	OID_GEN_TRANSMIT_BLOCK_SIZE	0x0001010A
+#define	OID_GEN_RECEIVE_BLOCK_SIZE	0x0001010B
+#define	OID_GEN_VENDOR_ID		0x0001010C
+#define	OID_GEN_VENDOR_DESCRIPTION	0x0001010D
+#define	OID_GEN_CURRENT_PACKET_FILTER	0x0001010E
+#define	OID_GEN_CURRENT_LOOKAHEAD	0x0001010F
+#define	OID_GEN_DRIVER_VERSION		0x00010110
+#define	OID_GEN_MAXIMUM_TOTAL_SIZE	0x00010111
+#define	OID_GEN_PROTOCOL_OPTIONS	0x00010112
+#define	OID_GEN_MAC_OPTIONS		0x00010113
+#define	OID_GEN_MEDIA_CONNECT_STATUS	0x00010114
+#define	OID_GEN_MAXIMUM_SEND_PACKETS	0x00010115
+#define	OID_GEN_VENDOR_DRIVER_VERSION	0x00010116
+#define	OID_GEN_SUPPORTED_GUIDS		0x00010117
+#define	OID_GEN_NETWORK_LAYER_ADDRESSES	0x00010118
+#define	OID_GEN_TRANSPORT_HEADER_OFFSET	0x00010119
+#define	OID_GEN_RECEIVE_SCALE_CAPABILITIES	0x00010203
+#define	OID_GEN_RECEIVE_SCALE_PARAMETERS	0x00010204
+#define	OID_GEN_MACHINE_NAME		0x0001021A
+#define	OID_GEN_RNDIS_CONFIG_PARAMETER	0x0001021B
+#define	OID_GEN_VLAN_ID			0x0001021C
+
+#define	OID_802_3_PERMANENT_ADDRESS	0x01010101
+#define	OID_802_3_CURRENT_ADDRESS	0x01010102
+#define	OID_802_3_MULTICAST_LIST	0x01010103
+#define	OID_802_3_MAXIMUM_LIST_SIZE	0x01010104
+#define	OID_802_3_MAC_OPTIONS		0x01010105
+#define	OID_802_3_RCV_ERROR_ALIGNMENT	0x01020101
+#define	OID_802_3_XMIT_ONE_COLLISION	0x01020102
+#define	OID_802_3_XMIT_MORE_COLLISIONS	0x01020103
+#define	OID_802_3_XMIT_DEFERRED		0x01020201
+#define	OID_802_3_XMIT_MAX_COLLISIONS	0x01020202
+#define	OID_802_3_RCV_OVERRUN		0x01020203
+#define	OID_802_3_XMIT_UNDERRUN		0x01020204
+#define	OID_802_3_XMIT_HEARTBEAT_FAILURE	0x01020205
+#define	OID_802_3_XMIT_TIMES_CRS_LOST	0x01020206
+#define	OID_802_3_XMIT_LATE_COLLISIONS	0x01020207
+
+#define	OID_TCP_OFFLOAD_PARAMETERS	0xFC01020C
+#define	OID_TCP_OFFLOAD_HARDWARE_CAPABILITIES	0xFC01020D
+
+#define	RNDIS_MEDIUM_802_3		0x00000000
+
+/* Device flags */
+#define	RNDIS_DF_CONNECTIONLESS		0x00000001
+#define	RNDIS_DF_CONNECTION_ORIENTED	0x00000002
+
+/*
+ * Common RNDIS message header.
+ */
+struct rndis_msghdr {
+	uint32_t rm_type;
+	uint32_t rm_len;
+};
+
+/*
+ * RNDIS data message
+ */
+#define	REMOTE_NDIS_PACKET_MSG		0x00000001
+
+struct rndis_packet_msg {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_dataoffset;
+	uint32_t rm_datalen;
+	uint32_t rm_oobdataoffset;
+	uint32_t rm_oobdatalen;
+	uint32_t rm_oobdataelements;
+	uint32_t rm_pktinfooffset;
+	uint32_t rm_pktinfolen;
+	uint32_t rm_vchandle;
+	uint32_t rm_reserved;
+};
+
+/*
+ * Minimum value for rm_dataoffset, rm_oobdataoffset, and
+ * rm_pktinfooffset.
+ */
+#define	RNDIS_PACKET_MSG_OFFSET_MIN		\
+	(sizeof (struct rndis_packet_msg) -	\
+	offsetof(struct rndis_packet_msg, rm_dataoffset))
+
+/* Offset from the beginning of rndis_packet_msg. */
+#define	RNDIS_PACKET_MSG_OFFSET_ABS(ofs)	\
+	((ofs) + offsetof(struct rndis_packet_msg, rm_dataoffset))
+
+#define	RNDIS_PACKET_MSG_OFFSET_ALIGN		4
+#define	RNDIS_PACKET_MSG_OFFSET_ALIGNMASK	\
+	(RNDIS_PACKET_MSG_OFFSET_ALIGN - 1)
+
+/* Per-packet-info for RNDIS data message */
+struct rndis_pktinfo {
+	uint32_t rm_size;
+	uint32_t rm_type;		/* NDIS_PKTINFO_TYPE_ */
+	uint32_t rm_pktinfooffset;
+	uint8_t rm_data[];
+};
+
+#define	RNDIS_PKTINFO_OFFSET		\
+	offsetof(struct rndis_pktinfo, rm_data[0])
+#define	RNDIS_PKTINFO_SIZE_ALIGN	4
+#define	RNDIS_PKTINFO_SIZE_ALIGNMASK	(RNDIS_PKTINFO_SIZE_ALIGN - 1)
+
+#define	NDIS_PKTINFO_TYPE_CSUM		0
+#define	NDIS_PKTINFO_TYPE_IPSEC		1
+#define	NDIS_PKTINFO_TYPE_LSO		2
+#define	NDIS_PKTINFO_TYPE_CLASSIFY	3
+/* reserved 4 */
+#define	NDIS_PKTINFO_TYPE_SGLIST	5
+#define	NDIS_PKTINFO_TYPE_VLAN		6
+#define	NDIS_PKTINFO_TYPE_ORIG		7
+#define	NDIS_PKTINFO_TYPE_PKT_CANCELID	8
+#define	NDIS_PKTINFO_TYPE_ORIG_NBLIST	9
+#define	NDIS_PKTINFO_TYPE_CACHE_NBLIST	10
+#define	NDIS_PKTINFO_TYPE_PKT_PAD	11
+
+/*
+ * RNDIS control messages
+ */
+
+/*
+ * Common header for RNDIS completion messages.
+ *
+ * NOTE: It does not apply to REMOTE_NDIS_RESET_CMPLT.
+ */
+struct rndis_comp_hdr {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_status;
+};
+
+/* Initialize the device. */
+#define	REMOTE_NDIS_INITIALIZE_MSG	0x00000002
+#define	REMOTE_NDIS_INITIALIZE_CMPLT	0x80000002
+
+struct rndis_init_req {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_ver_major;
+	uint32_t rm_ver_minor;
+	uint32_t rm_max_xfersz;
+};
+
+struct rndis_init_comp {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_status;
+	uint32_t rm_ver_major;
+	uint32_t rm_ver_minor;
+	uint32_t rm_devflags;
+	uint32_t rm_medium;
+	uint32_t rm_pktmaxcnt;
+	uint32_t rm_pktmaxsz;
+	uint32_t rm_align;
+	uint32_t rm_aflistoffset;
+	uint32_t rm_aflistsz;
+};
+
+#define	RNDIS_INIT_COMP_SIZE_MIN	\
+	offsetof(struct rndis_init_comp, rm_aflistsz)
+
+/* Halt the device.  No response sent. */
+#define	REMOTE_NDIS_HALT_MSG		0x00000003
+
+struct rndis_halt_req {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+};
+
+/* Send a query object. */
+#define	REMOTE_NDIS_QUERY_MSG		0x00000004
+#define	REMOTE_NDIS_QUERY_CMPLT		0x80000004
+
+struct rndis_query_req {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_oid;
+	uint32_t rm_infobuflen;
+	uint32_t rm_infobufoffset;
+	uint32_t rm_devicevchdl;
+};
+
+#define	RNDIS_QUERY_REQ_INFOBUFOFFSET		\
+	(sizeof (struct rndis_query_req) -	\
+	offsetof(struct rndis_query_req, rm_rid))
+
+struct rndis_query_comp {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_status;
+	uint32_t rm_infobuflen;
+	uint32_t rm_infobufoffset;
+};
+
+/* infobuf offset from the beginning of rndis_query_comp. */
+#define	RNDIS_QUERY_COMP_INFOBUFOFFSET_ABS(ofs)	\
+	((ofs) + offsetof(struct rndis_query_req, rm_rid))
+
+/* Send a set object request. */
+#define	REMOTE_NDIS_SET_MSG		0x00000005
+#define	REMOTE_NDIS_SET_CMPLT		0x80000005
+
+struct rndis_set_req {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_oid;
+	uint32_t rm_infobuflen;
+	uint32_t rm_infobufoffset;
+	uint32_t rm_devicevchdl;
+};
+
+#define	RNDIS_SET_REQ_INFOBUFOFFSET		\
+	(sizeof (struct rndis_set_req) -		\
+	offsetof(struct rndis_set_req, rm_rid))
+
+struct rndis_set_comp {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_status;
+};
+
+/*
+ * Parameter used by OID_GEN_RNDIS_CONFIG_PARAMETER.
+ */
+#define	REMOTE_NDIS_SET_PARAM_NUMERIC	0x00000000
+#define	REMOTE_NDIS_SET_PARAM_STRING	0x00000002
+
+struct rndis_set_parameter {
+	uint32_t rm_nameoffset;
+	uint32_t rm_namelen;
+	uint32_t rm_type;
+	uint32_t rm_valueoffset;
+	uint32_t rm_valuelen;
+};
+
+/* Perform a soft reset on the device. */
+#define	REMOTE_NDIS_RESET_MSG		0x00000006
+#define	REMOTE_NDIS_RESET_CMPLT		0x80000006
+
+struct rndis_reset_req {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+};
+
+struct rndis_reset_comp {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_status;
+	uint32_t rm_adrreset;
+};
+
+/* 802.3 link-state or undefined message error.  Sent by device. */
+#define	REMOTE_NDIS_INDICATE_STATUS_MSG	0x00000007
+
+struct rndis_status_msg {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_status;
+	uint32_t rm_stbuflen;
+	uint32_t rm_stbufoffset;
+	/* rndis_diag_info */
+};
+
+/* stbuf offset from the beginning of rndis_status_msg. */
+#define	RNDIS_STBUFOFFSET_ABS(ofs)	\
+	((ofs) + offsetof(struct rndis_status_msg, rm_status))
+
+/*
+ * Immediately after rndis_status_msg.rm_stbufoffset, if a control
+ * message is malformatted, or a packet message contains inappropriate
+ * content.
+ */
+struct rndis_diag_info {
+	uint32_t rm_diagstatus;
+	uint32_t rm_erroffset;
+};
+
+/* Keepalive messsage.  May be sent by device. */
+#define	REMOTE_NDIS_KEEPALIVE_MSG	0x00000008
+#define	REMOTE_NDIS_KEEPALIVE_CMPLT	0x80000008
+
+struct rndis_keepalive_req {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+};
+
+struct rndis_keepalive_comp {
+	uint32_t rm_type;
+	uint32_t rm_len;
+	uint32_t rm_rid;
+	uint32_t rm_status;
+};
+
+/* Packet filter bits used by OID_GEN_CURRENT_PACKET_FILTER */
+#define	NDIS_PACKET_TYPE_NONE			0x00000000
+#define	NDIS_PACKET_TYPE_DIRECTED		0x00000001
+#define	NDIS_PACKET_TYPE_MULTICAST		0x00000002
+#define	NDIS_PACKET_TYPE_ALL_MULTICAST		0x00000004
+#define	NDIS_PACKET_TYPE_BROADCAST		0x00000008
+#define	NDIS_PACKET_TYPE_SOURCE_ROUTING		0x00000010
+#define	NDIS_PACKET_TYPE_PROMISCUOUS		0x00000020
+#define	NDIS_PACKET_TYPE_SMT			0x00000040
+#define	NDIS_PACKET_TYPE_ALL_LOCAL		0x00000080
+#define	NDIS_PACKET_TYPE_GROUP			0x00001000
+#define	NDIS_PACKET_TYPE_ALL_FUNCTIONAL		0x00002000
+#define	NDIS_PACKET_TYPE_FUNCTIONAL		0x00004000
+#define	NDIS_PACKET_TYPE_MAC_FRAME		0x00008000
+
+/*
+ * Packet filter description for use with printf(9) %b identifier.
+ */
+#define	NDIS_PACKET_TYPES				\
+	"\20\1DIRECT\2MULTICAST\3ALLMULTI\4BROADCAST"	\
+	"\5SRCROUTE\6PROMISC\7SMT\10ALLLOCAL"		\
+	"\11GROUP\12ALLFUNC\13FUNC\14MACFRAME"
+
+/* RNDIS offsets */
+#define	RNDIS_HEADER_OFFSET	((uint32_t)sizeof (struct rndis_msghdr))
+#define	RNDIS_DATA_OFFSET	\
+	((uint32_t)(sizeof (struct rndis_packet_msg) - RNDIS_HEADER_OFFSET))
+
+#endif	/* !_NET_RNDIS_H_ */

--- a/usr/src/uts/intel/io/hyperv/netvsc/subr_bufring.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/subr_bufring.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2007, 2008 Kip Macy <kmacy@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/param.h>
+#include <sys/kmem.h>
+#include <sys/debug.h>
+#include <sys/sysmacros.h>
+#include <sys/errno.h>
+#include <sys/atomic.h>
+#include <sys/cpuvar.h>
+#include <sys/disp.h>
+#include <sys/cpu.h>
+
+#include "buf_ring.h"
+
+
+/* ARGSUSED */
+struct buf_ring *
+buf_ring_alloc(int count, int flags, kmutex_t *lock)
+{
+	struct buf_ring *br;
+
+	/*
+	 * buf ring must be size power of 2
+	 */
+	VERIFY(ISP2(count));
+
+	br = kmem_zalloc(sizeof (struct buf_ring) + count * sizeof (caddr_t),
+	    flags);
+	if (br == NULL)
+		return (NULL);
+#ifdef DEBUG_BUFRING
+	br->br_lock = lock;
+#endif
+	br->br_prod_size = br->br_cons_size = count;
+	br->br_prod_mask = br->br_cons_mask = count-1;
+	br->br_prod_head = br->br_cons_head = 0;
+	br->br_prod_tail = br->br_cons_tail = 0;
+
+	return (br);
+}
+
+void
+buf_ring_free(struct buf_ring *br)
+{
+	kmem_free(br, sizeof (struct buf_ring) + br->br_prod_size *
+	    sizeof (caddr_t));
+}
+
+/*
+ * multi-producer safe lock-free ring buffer enqueue
+ *
+ */
+int
+buf_ring_enqueue(struct buf_ring *br, void *buf)
+{
+	uint32_t prod_head, prod_next, cons_tail;
+	int cas = -1;
+#ifdef DEBUG_BUFRING
+	int i;
+	for (i = br->br_cons_head; i != br->br_prod_head;
+	    i = ((i + 1) & br->br_cons_mask)) {
+		if (br->br_ring[i] == buf) {
+			panic("buf=%p already enqueue at %d prod=%d cons=%d",
+			    buf, i, br->br_prod_tail, br->br_cons_tail);
+		}
+	}
+#endif
+	kpreempt_disable();
+	do {
+		prod_head = br->br_prod_head;
+		prod_next = (prod_head + 1) & br->br_prod_mask;
+		cons_tail = br->br_cons_tail;
+
+		if (prod_next == cons_tail) {
+			membar_consumer();
+			if (prod_head == br->br_prod_head &&
+			    cons_tail == br->br_cons_tail) {
+				br->br_drops++;
+				kpreempt_enable();
+				return (ENOBUFS);
+			}
+			continue;
+		}
+		cas = atomic_cas_32(&br->br_prod_head, prod_head, prod_next);
+	} while (cas != prod_head);
+
+#ifdef DEBUG_BUFRING
+	if (br->br_ring[prod_head] != NULL)
+		panic("dangling value in enqueue");
+#endif
+	br->br_ring[prod_head] = buf;
+
+	/*
+	 * If there are other enqueues in progress
+	 * that preceded us, we need to wait for them
+	 * to complete
+	 */
+	while (br->br_prod_tail != prod_head)
+		SMT_PAUSE();
+
+	br->br_prod_tail = prod_next;
+	kpreempt_enable();
+	return (0);
+}
+
+/*
+ * multi-consumer safe dequeue
+ *
+ */
+void *
+buf_ring_dequeue_mc(struct buf_ring *br)
+{
+	uint32_t cons_head, cons_next, cas;
+	void *buf;
+
+	kpreempt_disable();
+	do {
+		cons_head = br->br_cons_head;
+		cons_next = (cons_head + 1) & br->br_cons_mask;
+
+		if (cons_head == br->br_prod_tail) {
+			kpreempt_enable();
+			return (NULL);
+		}
+		cas = atomic_cas_32(&br->br_cons_head, cons_head, cons_next);
+	} while (cas != cons_head);
+
+	buf = br->br_ring[cons_head];
+#ifdef DEBUG_BUFRING
+	br->br_ring[cons_head] = NULL;
+#endif
+	/*
+	 * If there are other dequeues in progress
+	 * that preceded us, we need to wait for them
+	 * to complete
+	 */
+	while (br->br_cons_tail != cons_head)
+		SMT_PAUSE();
+
+	br->br_cons_tail = cons_next;
+	kpreempt_enable();
+
+	return (buf);
+}
+
+/*
+ * single-consumer dequeue
+ * use where dequeue is protected by a lock
+ * e.g. a network driver's tx queue lock
+ */
+void *
+buf_ring_dequeue_sc(struct buf_ring *br)
+{
+	uint32_t cons_head, cons_next;
+	uint32_t prod_tail;
+	void *buf;
+
+	cons_head = br->br_cons_head;
+	prod_tail = br->br_prod_tail;
+
+	if (cons_head == prod_tail)
+		return (NULL);
+
+	cons_next = (cons_head + 1) & br->br_cons_mask;
+
+	br->br_cons_head = cons_next;
+	buf = br->br_ring[cons_head];
+
+#ifdef DEBUG_BUFRING
+	br->br_ring[cons_head] = NULL;
+	if (!MUTEX_HELD(br->br_lock))
+		panic("lock not held on single consumer dequeue");
+	if (br->br_cons_tail != cons_head) {
+		panic("inconsistent list cons_tail=%d cons_head=%d",
+		    br->br_cons_tail, cons_head);
+	}
+#endif
+	br->br_cons_tail = cons_next;
+	return (buf);
+}

--- a/usr/src/uts/intel/io/hyperv/storvsc/THIRDPARTYLICENSE
+++ b/usr/src/uts/intel/io/hyperv/storvsc/THIRDPARTYLICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2009-2012,2016 Microsoft Corp.
+Copyright (c) 2010-2012 Citrix Inc.
+Copyright (c) 2012 NetApp Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice unmodified, this list of conditions, and the following
+   disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/usr/src/uts/intel/io/hyperv/storvsc/THIRDPARTYLICENSE.descrip
+++ b/usr/src/uts/intel/io/hyperv/storvsc/THIRDPARTYLICENSE.descrip
@@ -1,0 +1,1 @@
+Microsoft StorVSC driver

--- a/usr/src/uts/intel/io/hyperv/storvsc/hv_storvsc_drv_illumos.c
+++ b/usr/src/uts/intel/io/hyperv/storvsc/hv_storvsc_drv_illumos.c
@@ -1920,6 +1920,7 @@ storvsc_config_one(dev_info_t *pdip, storvsc_softc_t *sc, int target, int lun,
 					HS_DEBUG(sc->hs_dip, 2,
 					    "target %d, lun %d, found guid: %s",
 					    target, lun, guid);
+					ddi_devid_free_guid(guid);
 				}
 				ddi_devid_free(devid);
 			}

--- a/usr/src/uts/intel/io/hyperv/storvsc/hv_storvsc_drv_illumos.c
+++ b/usr/src/uts/intel/io/hyperv/storvsc/hv_storvsc_drv_illumos.c
@@ -1,0 +1,2700 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ * StorVSC driver for Hyper-V.  This driver presents a SCSI HBA interface
+ * by plugging into the SCSA transport layer.
+ * scsi_pkts are converted into VSCSI protocol messages which are delivered
+ * to the parent partition StorVSP driver over the Hyper-V VMBUS.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/callo.h>
+#include <sys/ksynch.h>
+#include <sys/conf.h>
+#include <sys/sunddi.h>
+#include <sys/devops.h>
+#include <sys/cmn_err.h>
+#include <sys/pci.h>
+#include <sys/scsi/scsi.h>
+#include <sys/uio.h>
+#include <sys/cpuvar.h>
+#include <sys/reboot.h>
+#include <sys/fs/dv_node.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include <sys/dditypes.h>
+#include <sys/ddidmareq.h>
+#include "hv_vstorage.h"
+
+/*
+ * These values are defined by Microsoft and should not be changed unless
+ * the FreeBSD drivers, which this code is derived from, have also changed them.
+ */
+#define	STORVSC_MAX_LUNS_PER_TARGET	(64)
+#define	STORVSC_MAX_IO_REQUESTS		(STORVSC_MAX_LUNS_PER_TARGET * 2)
+#define	BLKVSC_MAX_IDE_DISKS_PER_TARGET	(1)
+#define	BLKVSC_MAX_IO_REQUESTS		STORVSC_MAX_IO_REQUESTS
+#define	STORVSC_MAX_TARGETS		(2)
+#define	VSTOR_PKT_SIZE	(sizeof (struct vstor_packet) - vmscsi_size_delta)
+
+#define	MAXCPU				256
+
+#define	STORVSC_IDENT			"Hyper-V SCSI Interface"
+#define	STORVSC_TGT_PRIV_SIZE		2
+
+#define	AP2PRIV(ap)	((ap)->a_hba_tran->tran_hba_private)
+#define	PKT2REQ(pkt)	((struct hv_storvsc_request *)((pkt)->pkt_ha_private))
+#define	PKT2CMD(pkt)	((storvsc_cmd_t *)&(PKT2REQ(pkt)->hvs_cmd))
+#define	CMD2PKT(cmd)	((struct scsi_pkt *)((cmd)->cmd_pkt))
+#define	SDEV2PRIV(sd)	((sd)->sd_address.a_hba_tran->tran_hba_private)
+
+#define	STORVSC_FLAG_CDB_EXT	0x0001
+#define	STORVSC_FLAG_SCB_EXT	0x0002
+#define	STORVSC_FLAG_PRIV_EXT	0x0004
+#define	STORVSC_FLAG_TAG	0x0008
+#define	STORVSC_FLAG_IO_READ	0x0010
+#define	STORVSC_FLAG_IO_WRITE	0x0020
+#define	STORVSC_FLAG_IO_IOPB	0x0040
+#define	STORVSC_FLAG_DONE	0x0080
+#define	STORVSC_FLAG_DMA_VALID	0x0100
+#define	STORVSC_FLAG_XARQ	0x0200
+#define	STORVSC_FLAG_TIMED_OUT	0x0400
+#define	STORVSC_FLAG_ABORTED	0x0800
+#define	STORVSC_FLAG_RESET_BUS	0x1000
+#define	STORVSC_FLAG_RESET_DEV	0x2000
+#define	STORVSC_FLAG_SRB_ERROR	0x4000
+#define	STORVSC_FLAG_TRANSPORT	0x8000
+#define	STORVSC_FLAG_DEV_GONE	0x10000
+
+#define	STORVSC_FLAG_IO_MASK	0x0030
+
+#define	STORVSC_STATUS_MASK	(STATUS_MASK | STATUS_TASK_ABORT)
+
+#define	STORVSC_FLAGS_RESET \
+	(STORVSC_FLAG_RESET_BUS | STORVSC_FLAG_RESET_DEV)
+
+#define	STORVSC_FLAGS_EXT \
+	(STORVSC_FLAG_CDB_EXT | STORVSC_FLAG_SCB_EXT | STORVSC_FLAG_PRIV_EXT)
+
+#define	STORVSC_DATA_SEGCNT_MAX		128
+#define	STORVSC_DATA_SEGSZ_MAX		4096		/* PAGESIZE */
+#define	STORVSC_DATA_SIZE_MAX		\
+	(STORVSC_DATA_SEGCNT_MAX * STORVSC_DATA_SEGSZ_MAX)
+
+enum storvsc_request_type {
+	WRITE_TYPE,
+	READ_TYPE,
+	UNKNOWN_TYPE
+};
+
+int hv_storvsc_chan_cnt = 0;
+uint_t hv_storvsc_use_win8ext_flags = 1;
+static uint_t hv_storvsc_ringbuffer_size;
+
+#define	STORVSC_MAX_IO						\
+    vmbus_chan_prplist_nelem(hv_storvsc_ringbuffer_size,	\
+    STORVSC_DATA_SEGCNT_MAX, VSTOR_PKT_SIZE)
+
+/*
+ * The storvsc_cmd defines the internal state for each scsi_pkt. The
+ * structure holds the appropriate state to convert between SCSA layers
+ * and the underlying hypervisor.
+ */
+typedef struct storvsc_cmd {
+	struct scsi_pkt		*cmd_pkt;
+	uint8_t			cmd_cdb[SCSI_CDB_SIZE];
+	struct scsi_arq_status	cmd_scb;
+	uint64_t		cmd_tgt_priv[STORVSC_TGT_PRIV_SIZE];
+	size_t			cmd_tgtlen;
+	size_t			cmd_len;
+	size_t			cmd_statuslen;
+	int			cmd_flags;
+	ddi_dma_handle_t	cmd_handle;
+	ddi_dma_cookie_t	cmd_cookie;
+	uint_t			cmd_cookiec;
+	uint_t			cmd_winindex;
+	uint_t			cmd_nwin;
+	off_t			cmd_dma_offset;
+	size_t			cmd_dma_len;
+	uint_t			cmd_dma_count;
+	uint_t			cmd_total_dma_count;
+	int			cmd_target;
+	int			cmd_lun;
+	struct storvsc_softc	*cmd_sc;
+	struct buf		*cmd_arq_buf;
+	int			cmd_rqslen;
+	struct scsi_pkt		cmd_cached_pkt;
+	buf_t			*cmd_bp;
+} storvsc_cmd_t;
+
+struct storvsc_gpa_range {
+	struct vmbus_gpa_range	gpa_range;
+	uint64_t		gpa_page[STORVSC_DATA_SEGCNT_MAX];
+} __packed;
+
+struct hv_storvsc_request {
+	struct vstor_packet		vstor_packet;
+	int				prp_cnt;
+	struct storvsc_gpa_range	prp_list;
+	void				*sense_data;
+	uint8_t				sense_info_len;
+	struct scsi_pkt			*pkt;
+	timeout_id_t			timeout_id;
+	/* Synchronize the request/response if needed */
+	ksema_t				synch_sema;
+	storvsc_cmd_t			hvs_cmd;
+};
+
+/*
+ * The size of the vmscsi_request has changed in win8. The
+ * additional size is for the newly added elements in the
+ * structure. These elements are valid only when we are talking
+ * to a win8 host.
+ * Track the correct size we need to apply.
+ */
+static int vmscsi_size_delta = sizeof (struct vmscsi_win8_extension);
+
+typedef struct storvsc_device {
+	list_node_t	list;
+	int		target;
+	int		lun;
+	dev_info_t	*dip;
+	dev_info_t	*pdip;
+} storvsc_device_t;
+
+
+typedef struct storvsc_softc {
+	struct vmbus_channel		*hs_chan;
+	kmutex_t			hs_lock;
+	struct storvsc_driver_props	*hs_drv_props;
+	struct hv_storvsc_request	hs_init_req;
+	uint32_t			hs_nchan;
+	struct vmbus_channel		*hs_sel_chan[MAXCPU];
+	struct hv_storvsc_request	hs_reset_req;
+	uint32_t			hs_num_out_reqs;
+	boolean_t			hs_destroy;
+	boolean_t			hs_drain_notify;
+	ksema_t				hs_drain_sema;
+	dev_info_t			*hs_dip;
+	int				hs_instance;
+	scsi_hba_tran_t			*hs_tran;
+	int				hs_num_active_commands;
+	struct kmem_cache		*hs_req_cache;
+	int				hs_num_luns;
+	list_t				hs_devnodes;
+	kstat_t				*hs_stats;
+} storvsc_softc_t;
+
+/*
+ * Bus/adapter reset functionality on the Hyper-V host is
+ * buggy and it will be disabled until
+ * it can be further tested.
+ */
+#define	HVS_HOST_RESET 0
+
+struct storvsc_driver_props {
+	char		*drv_name;
+	char		*drv_desc;
+	uint8_t		drv_max_luns_per_target;
+	uint32_t	drv_max_ios_per_target;		/* Not used */
+	uint32_t	drv_ringbuffer_size;
+};
+
+enum hv_storage_type {
+	DRIVER_BLKVSC,
+	DRIVER_STORVSC,
+	DRIVER_UNKNOWN
+};
+
+#define	HS_MAX_ADAPTERS 10
+
+/*
+ * Used to check if the host supports mult-channel I/O. The host
+ * will set the chan_prop.flag bit to indicate support.
+ */
+#define	HV_STORAGE_SUPPORTS_MULTI_CHANNEL 0x1
+
+/* {ba6163d9-04a1-4d29-b605-72e2ffb1dc7f} */
+static const struct hyperv_guid gStorVscDeviceType = {
+	.hv_guid = {0xd9, 0x63, 0x61, 0xba, 0xa1, 0x04, 0x29, 0x4d,
+	    0xb6, 0x05, 0x72, 0xe2, 0xff, 0xb1, 0xdc, 0x7f}
+};
+
+/* {32412632-86cb-44a2-9b5c-50d1417354f5} */
+static const struct hyperv_guid gBlkVscDeviceType = {
+	.hv_guid = {0x32, 0x26, 0x41, 0x32, 0xcb, 0x86, 0xa2, 0x44,
+	    0x9b, 0x5c, 0x50, 0xd1, 0x41, 0x73, 0x54, 0xf5}
+};
+
+static struct storvsc_driver_props g_drv_props_table[] = {
+	{"blkvsc", "Hyper-V IDE Storage Interface",
+	    BLKVSC_MAX_IDE_DISKS_PER_TARGET, BLKVSC_MAX_IO_REQUESTS, 0},
+	{"storvsc", "Hyper-V SCSI Storage Interface",
+	    STORVSC_MAX_LUNS_PER_TARGET, STORVSC_MAX_IO_REQUESTS, 0}
+};
+
+/*
+ * Sense buffer size changed in win8; have a run-time
+ * variable to track the size we should use.
+ */
+static int sense_buffer_size = PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE;
+
+/*
+ * The storage protocol version is determined during the
+ * initial exchange with the host.  It will indicate which
+ * storage functionality is available in the host.
+ */
+static int vmstor_proto_version;
+
+struct vmstor_proto {
+	int proto_version;
+	int sense_buffer_size;
+	int vmscsi_size_delta;
+};
+
+static const struct vmstor_proto vmstor_proto_list[] = {
+	{
+	    VMSTOR_PROTOCOL_VERSION_WIN10,
+	    POST_WIN7_STORVSC_SENSE_BUFFER_SIZE,
+	    0
+	},
+	{
+	    VMSTOR_PROTOCOL_VERSION_WIN8_1,
+	    POST_WIN7_STORVSC_SENSE_BUFFER_SIZE,
+	    0
+	},
+	{
+	    VMSTOR_PROTOCOL_VERSION_WIN8,
+	    POST_WIN7_STORVSC_SENSE_BUFFER_SIZE,
+	    0
+	},
+	{
+	    VMSTOR_PROTOCOL_VERSION_WIN7,
+	    PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE,
+	    sizeof (struct vmscsi_win8_extension),
+	},
+	{
+	    VMSTOR_PROTOCOL_VERSION_WIN6,
+	    PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE,
+	    sizeof (struct vmscsi_win8_extension),
+	}
+};
+
+typedef struct storvsc_stats {
+	kstat_named_t vscstat_reads;
+	kstat_named_t vscstat_writes;
+	kstat_named_t vscstat_non_rw;
+	kstat_named_t vscstat_timeouts;
+	kstat_named_t vscstat_pending;
+	kstat_named_t vscstat_chansend[MAXCPU];
+} storvsc_stats_t;
+
+#define	VSC_INCR_STAT(sc, x)						\
+	if ((sc)->hs_stats != NULL) {					\
+		storvsc_stats_t *sp;					\
+		sp = (storvsc_stats_t *)(sc)->hs_stats->ks_data;	\
+		atomic_inc_64(&sp->x.value.ui64);			\
+	}
+
+#define	VSC_DECR_STAT(sc, x) \
+	if ((sc)->hs_stats != NULL) {					\
+		storvsc_stats_t *sp;					\
+		sp = (storvsc_stats_t *)(sc)->hs_stats->ks_data;	\
+		atomic_dec_64(&sp->x.value.ui64);			\
+	}
+
+#define	HS_WARN(dip, fmt...)	dev_err((dip), CE_WARN, fmt)
+#define	HS_NOTE(dip, fmt...)	dev_err((dip), CE_NOTE, fmt)
+
+int hs_debug = 0;
+
+#define	HS_DEBUG(dip, level, fmt...) {		\
+	if (level <= hs_debug) {		\
+		dev_err((dip), CE_NOTE, fmt);	\
+	}					\
+}
+
+
+/* static functions */
+static int storvsc_attach(dev_info_t *, ddi_attach_cmd_t);
+static int storvsc_detach(dev_info_t *, ddi_detach_cmd_t);
+static int storvsc_ioctl(dev_t, int, intptr_t, int, cred_t *, int *);
+static void hv_storvsc_on_channel_callback(struct vmbus_channel *chan,
+    void *xsc);
+static enum hv_storage_type storvsc_get_storage_type(dev_info_t *);
+static int create_storvsc_request(storvsc_cmd_t *cmd);
+static void storvsc_io_done(struct hv_storvsc_request *reqp);
+static void storvsc_destroy_pkt(struct scsi_address *, struct scsi_pkt *);
+static void storvsc_dmafree(struct scsi_address *, struct scsi_pkt *);
+static void storvsc_timeout(void *arg);
+static void storvsc_init_kstat(storvsc_softc_t *sc);
+
+static struct cb_ops storvsc_cb_ops = {
+	.cb_open = scsi_hba_open,
+	.cb_close = scsi_hba_close,
+	.cb_strategy = nodev,
+	.cb_print = nodev,
+	.cb_dump = nodev,
+	.cb_read = nodev,
+	.cb_write = nodev,
+	.cb_ioctl = storvsc_ioctl,
+	.cb_devmap = nodev,
+	.cb_mmap = nodev,
+	.cb_segmap = nodev,
+	.cb_chpoll = nochpoll,
+	.cb_prop_op = ddi_prop_op,
+	.cb_str = NULL,
+	.cb_flag = D_MP,
+	.cb_rev = CB_REV,
+	.cb_aread = nodev,
+	.cb_awrite = nodev
+};
+
+static struct dev_ops storvsc_ops = {
+	.devo_rev = DEVO_REV,
+	.devo_refcnt = 0,
+	.devo_getinfo = ddi_no_info,
+	.devo_identify = nulldev,
+	.devo_probe = nulldev,
+	.devo_attach = storvsc_attach,
+	.devo_detach = storvsc_detach,
+	.devo_reset = nodev,
+	.devo_cb_ops = &storvsc_cb_ops,
+	.devo_bus_ops = NULL,
+	.devo_power = NULL,
+	.devo_quiesce = ddi_quiesce_not_supported
+};
+
+static struct modldrv modldrv = {
+	&mod_driverops,
+	STORVSC_IDENT,
+	&storvsc_ops,
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&modldrv,
+	NULL
+};
+
+static void *storvsc_sstate;
+
+static ddi_dma_attr_t storvsc_io_dma_attr = {
+	.dma_attr_version =	DMA_ATTR_V0,
+	.dma_attr_addr_lo =	0x0000000000000000ull,
+	.dma_attr_addr_hi =	0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_count_max =	0xFFF,
+	.dma_attr_align =	0x0000000000001000ull,
+	.dma_attr_burstsizes =	0x0000000000000FFFull,
+	.dma_attr_minxfer =	0x00000001,
+	.dma_attr_maxxfer =	STORVSC_DATA_SIZE_MAX,
+	.dma_attr_seg =		STORVSC_DATA_SEGSZ_MAX - 1,
+	.dma_attr_sgllen =	STORVSC_DATA_SEGCNT_MAX,
+	.dma_attr_granular =	512,
+	.dma_attr_flags =	DDI_DMA_FLAGERR
+};
+
+static void
+storvsc_subchan_attach(struct storvsc_softc *sc,
+    struct vmbus_channel *new_channel)
+{
+	struct vmstor_chan_props props;
+
+	(void) memset(&props, 0, sizeof (props));
+
+	vmbus_chan_cpu_rr(new_channel);
+	VERIFY0(vmbus_chan_open(new_channel,
+	    sc->hs_drv_props->drv_ringbuffer_size,
+	    sc->hs_drv_props->drv_ringbuffer_size,
+	    (void *)&props,
+	    sizeof (struct vmstor_chan_props),
+	    hv_storvsc_on_channel_callback, sc));
+}
+
+/*
+ * @brief Send multi-channel creation request to host
+ *
+ * @param device  a Hyper-V device pointer
+ * @param max_chans  the max channels supported by vmbus
+ */
+static void
+storvsc_send_multichannel_request(struct storvsc_softc *sc, int max_subch)
+{
+	struct vmbus_channel **subchan;
+	struct hv_storvsc_request *request;
+	struct vstor_packet *vstor_packet;
+	uint16_t request_subch;
+	int i;
+
+	/* get sub-channel count that need to create */
+	request_subch = MIN(max_subch, max_ncpus - 1);
+
+	request = &sc->hs_init_req;
+
+	/* request the host to create multi-channel */
+	(void) memset(request, 0, sizeof (struct hv_storvsc_request));
+
+	sema_init(&request->synch_sema, 0, ("stor_synch_sema"),
+	    SEMA_DRIVER, NULL);
+
+	vstor_packet = &request->vstor_packet;
+
+	vstor_packet->operation = VSTOR_OPERATION_CREATE_MULTI_CHANNELS;
+	vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+	vstor_packet->u.multi_channels_cnt = request_subch;
+
+	VERIFY0(vmbus_chan_send(sc->hs_chan,
+	    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+	    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request));
+
+	sema_p(&request->synch_sema);
+
+	if (vstor_packet->operation != VSTOR_OPERATION_COMPLETEIO ||
+	    vstor_packet->status != 0) {
+		HS_WARN(sc->hs_dip,
+		    "Storvsc_error: create multi-channel invalid operation "
+		    "(%d) or status (%u)",
+		    vstor_packet->operation, vstor_packet->status);
+		return;
+	}
+
+	/* Update channel count */
+	sc->hs_nchan = request_subch + 1;
+
+	/* Wait for sub-channels setup to complete. */
+	subchan = vmbus_subchan_get(sc->hs_chan, request_subch);
+
+	/* Attach the sub-channels. */
+	for (i = 0; i < request_subch; ++i)
+		storvsc_subchan_attach(sc, subchan[i]);
+
+	/* Release the sub-channels. */
+	vmbus_subchan_rel(subchan, request_subch);
+
+	if (boothowto & RB_VERBOSE) {
+		HS_DEBUG(sc->hs_dip, 1, "Storvsc create multi-channel success "
+		    "(cnt = %d)!", request_subch + 1);
+	}
+}
+
+#if TEST_CHANNEL
+static int
+hv_channel_test(struct storvsc_softc *sc)
+{
+	struct hv_storvsc_request *request;
+	struct vstor_packet *vstor_packet;
+
+	request = &sc->hs_init_req;
+	(void) memset(request, 0, sizeof (struct hv_storvsc_request));
+	vstor_packet = &request->vstor_packet;
+	request->hvs_cmd.cmd_sc = sc;
+
+	sema_init(&request->synch_sema, 0, ("stor_synch_sema"),
+	    SEMA_DRIVER, NULL);
+
+	/*
+	 * Query channel properties
+	 */
+	(void) memset(vstor_packet, 0, sizeof (struct vstor_packet));
+	vstor_packet->operation = VSTOR_OPERATION_QUERYPROPERTIES;
+	vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+
+	int ret = vmbus_chan_send(sc->hs_chan,
+	    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+	    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+
+	sema_p(&request->synch_sema);
+	sema_destroy(&request->synch_sema);
+	return (ret);
+}
+#endif
+
+/*
+ * @brief initialize channel connection to parent partition
+ *
+ * @param dev  a Hyper-V device pointer
+ * @returns  0 on success, non-zero error on failure
+ */
+static int
+hv_storvsc_channel_init(struct storvsc_softc *sc)
+{
+	int ret = 0, i;
+	struct hv_storvsc_request *request = &sc->hs_init_req;
+	struct vstor_packet *vstor_packet = &request->vstor_packet;
+	uint16_t max_subch = 0;
+	boolean_t support_multichannel = B_FALSE;
+	uint32_t version;
+
+	(void) memset(request, 0, sizeof (struct hv_storvsc_request));
+	request->hvs_cmd.cmd_sc = sc;
+
+	/*
+	 * Initiate the vsc/vsp initialization protocol on the open channel
+	 */
+	sema_init(&request->synch_sema, 0, ("stor_synch_sema"),
+	    SEMA_DRIVER, NULL);
+
+	vstor_packet->operation = VSTOR_OPERATION_BEGININITIALIZATION;
+	vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+
+	ret = vmbus_chan_send(sc->hs_chan,
+	    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+	    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+
+	if (ret != 0)
+		goto cleanup;
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: begin initialization sent...");
+
+	sema_p(&request->synch_sema);
+
+	if (vstor_packet->operation != VSTOR_OPERATION_COMPLETEIO ||
+	    vstor_packet->status != 0) {
+		HS_WARN(sc->hs_dip,
+		    "channel_init: begin initialization failed! "
+		    "operation: 0x%x, status: 0x%x",
+		    vstor_packet->operation, vstor_packet->status);
+		/* TODO:  ret = -1 */
+		ASSERT(0);
+		goto cleanup;
+	}
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: begin initialization done.");
+
+	for (i = 0; i < sizeof (vmstor_proto_list) /
+	    sizeof (vmstor_proto_list[0]); i++) {
+		/* reuse the packet for version range supported */
+
+		(void) memset(vstor_packet, 0, sizeof (struct vstor_packet));
+		vstor_packet->operation = VSTOR_OPERATION_QUERYPROTOCOLVERSION;
+		vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+
+		vstor_packet->u.version.major_minor =
+		    vmstor_proto_list[i].proto_version;
+
+		/* revision is only significant for Windows guests */
+		vstor_packet->u.version.revision = 0;
+
+		ret = vmbus_chan_send(sc->hs_chan,
+		    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+		    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+
+		if (ret != 0)
+			goto cleanup;
+
+		sema_p(&request->synch_sema);
+
+		if (vstor_packet->operation != VSTOR_OPERATION_COMPLETEIO) {
+			ret = EINVAL;
+			goto cleanup;
+		}
+		if (vstor_packet->status == 0) {
+			vmstor_proto_version =
+			    vmstor_proto_list[i].proto_version;
+			sense_buffer_size =
+			    vmstor_proto_list[i].sense_buffer_size;
+			vmscsi_size_delta =
+			    vmstor_proto_list[i].vmscsi_size_delta;
+			break;
+		}
+	}
+
+	if (sense_buffer_size < SENSE_LENGTH) {
+		HS_WARN(sc->hs_dip,
+		    "sense_buffer size < SENSE_LENGTH, %d < %d",
+		    (int)sense_buffer_size, (int)SENSE_LENGTH);
+	}
+
+	if (vstor_packet->status != 0) {
+		ret = EINVAL;
+		goto cleanup;
+	}
+
+	/*
+	 * Query channel properties
+	 */
+	(void) memset(vstor_packet, 0, sizeof (struct vstor_packet));
+	vstor_packet->operation = VSTOR_OPERATION_QUERYPROPERTIES;
+	vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+
+	ret = vmbus_chan_send(sc->hs_chan,
+	    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+	    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+
+	if (ret != 0)
+		goto cleanup;
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: query properties sent...");
+
+	sema_p(&request->synch_sema);
+
+	/* TODO: Check returned version */
+	if (vstor_packet->operation != VSTOR_OPERATION_COMPLETEIO ||
+	    vstor_packet->status != 0) {
+		goto cleanup;
+	}
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: query properties done.");
+
+	max_subch = vstor_packet->u.chan_props.max_channel_cnt;
+	if (hv_storvsc_chan_cnt > 0 && hv_storvsc_chan_cnt < (max_subch + 1))
+		max_subch = hv_storvsc_chan_cnt - 1;
+
+	/* multi-channels feature is supported by WIN8 and above version */
+	version = vmbus_get_version();
+	if (version != VMBUS_VERSION_WIN7 && version != VMBUS_VERSION_WS2008 &&
+	    (vstor_packet->u.chan_props.flags &
+	    HV_STORAGE_SUPPORTS_MULTI_CHANNEL)) {
+		support_multichannel = B_TRUE;
+	}
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: channel properties:");
+	HS_DEBUG(sc->hs_dip, 1, "max_chans: %d, version: 0x%x", max_subch + 1,
+	    version);
+	HS_DEBUG(sc->hs_dip, 1, "proto_ver: 0x%x, path_id: 0x%x, "
+	    "target_id: 0x%x", vstor_packet->u.chan_props.proto_ver,
+	    vstor_packet->u.chan_props.path_id,
+	    vstor_packet->u.chan_props.target_id);
+	HS_DEBUG(sc->hs_dip, 1, "unique_id: 0x%"PRIx64,
+	    vstor_packet->u.chan_props.unique_id);
+
+	dev_err(sc->hs_dip, CE_CONT, "?max chans %d%s\n", max_subch + 1,
+	    support_multichannel ? ", multi-chan capable" : "");
+
+	(void) memset(vstor_packet, 0, sizeof (struct vstor_packet));
+	vstor_packet->operation = VSTOR_OPERATION_ENDINITIALIZATION;
+	vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+
+	ret = vmbus_chan_send(sc->hs_chan,
+	    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+	    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+
+	if (ret != 0) {
+		goto cleanup;
+	}
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: end initialization sent...");
+
+	sema_p(&request->synch_sema);
+
+	if (vstor_packet->operation != VSTOR_OPERATION_COMPLETEIO ||
+	    vstor_packet->status != 0)
+		goto cleanup;
+
+	HS_DEBUG(sc->hs_dip, 1, "channel_init: end initialization done.");
+
+	/*
+	 * If multi-channel is supported, send multichannel create
+	 * request to host.
+	 */
+	if (support_multichannel && max_subch > 0)
+		storvsc_send_multichannel_request(sc, max_subch);
+cleanup:
+	sema_destroy(&request->synch_sema);
+	return (ret);
+}
+
+/*
+ * @brief Open channel connection to parent partition StorVSP driver
+ *
+ * Open and initialize channel connection to parent partition StorVSP driver.
+ *
+ * @param pointer to a Hyper-V device
+ * @returns 0 on success, non-zero error on failure
+ */
+static int
+hv_storvsc_connect_vsp(struct storvsc_softc *sc)
+{
+	int ret = 0;
+	struct vmstor_chan_props props;
+
+	(void) memset(&props, 0, sizeof (struct vmstor_chan_props));
+
+	/*
+	 * Open the channel
+	 */
+	vmbus_chan_cpu_rr(sc->hs_chan);
+	ret = vmbus_chan_open(
+	    sc->hs_chan,
+	    sc->hs_drv_props->drv_ringbuffer_size,
+	    sc->hs_drv_props->drv_ringbuffer_size,
+	    (void *)&props,
+	    sizeof (struct vmstor_chan_props),
+	    hv_storvsc_on_channel_callback, sc);
+
+	if (ret != 0)
+		return (ret);
+
+	ret = hv_storvsc_channel_init(sc);
+	return (ret);
+}
+
+#if HVS_HOST_RESET
+static int
+hv_storvsc_host_reset(struct storvsc_softc *sc)
+{
+	int ret = 0;
+
+	struct hv_storvsc_request *request;
+	struct vstor_packet *vstor_packet;
+
+	request = &sc->hs_reset_req;
+	request->hvs_cmd.cmd_sc = sc;
+	vstor_packet = &request->vstor_packet;
+
+	sema_init(&request->synch_sema, 0, ("stor_synch_sema"),
+	    SEMA_DRIVER, NULL);
+
+	vstor_packet->operation = VSTOR_OPERATION_RESETBUS;
+	vstor_packet->flags = REQUEST_COMPLETION_FLAG;
+
+	ret = vmbus_chan_send(dev->channel,
+	    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+	    vstor_packet, VSTOR_PKT_SIZE,
+	    (uint64_t)(uintptr_t)&sc->hs_reset_req);
+
+	if (ret != 0) {
+		goto cleanup;
+	}
+
+	sema_p(&request->synch_sema);
+
+	/*
+	 * At this point, all outstanding requests in the adapter
+	 * should have been flushed out and return to us
+	 */
+
+cleanup:
+	sema_destroy(&request->synch_sema);
+	return (ret);
+}
+#endif /* HVS_HOST_RESET */
+
+/*
+ * @brief Function to initiate an I/O request
+ *
+ * @param device Hyper-V device pointer
+ * @param request pointer to a request structure
+ * @returns 0 on success, non-zero error on failure
+ */
+static int
+hv_storvsc_io_request(struct storvsc_softc *sc,
+    struct hv_storvsc_request *request)
+{
+	struct vstor_packet *vstor_packet = &request->vstor_packet;
+	struct vmbus_channel *outgoing_channel = NULL;
+	int ret = 0, ch_sel;
+
+	vstor_packet->flags |= REQUEST_COMPLETION_FLAG;
+	vstor_packet->u.vm_srb.length =
+	    sizeof (struct vmscsi_req) - vmscsi_size_delta;
+	vstor_packet->u.vm_srb.sense_info_len = sense_buffer_size;
+	vstor_packet->u.vm_srb.transfer_len =
+	    request->prp_list.gpa_range.gpa_len;
+	vstor_packet->operation = VSTOR_OPERATION_EXECUTESRB;
+
+	/*
+	 * XXX - investigate to see if sending I/O to the same lun across
+	 * different channels is problematic.
+	 */
+	ch_sel = (vstor_packet->u.vm_srb.lun + CPU->cpu_id) % sc->hs_nchan;
+	outgoing_channel = sc->hs_sel_chan[ch_sel];
+
+	if (request->prp_list.gpa_range.gpa_len) {
+		ret = vmbus_chan_send_prplist(outgoing_channel,
+		    &request->prp_list.gpa_range, request->prp_cnt,
+		    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+		HS_DEBUG(sc->hs_dip, 4,
+		    "vmbus_chan_send_prplist - packet: %p, req: %p, ret %d",
+		    (void *)vstor_packet, (void *)request, ret);
+	} else {
+		ret = vmbus_chan_send(outgoing_channel,
+		    VMBUS_CHANPKT_TYPE_INBAND, VMBUS_CHANPKT_FLAG_RC,
+		    vstor_packet, VSTOR_PKT_SIZE, (uint64_t)(uintptr_t)request);
+		HS_DEBUG(sc->hs_dip, 4,
+		    "vmbus_chan_send - packet: %p, req: %p, ret %d",
+		    (void *)vstor_packet, (void *)request, ret);
+	}
+
+	/* statistic for successful request sending on each channel */
+	if (!ret) {
+		VSC_INCR_STAT(sc, vscstat_chansend[ch_sel]);
+	}
+
+	if (ret != 0) {
+		HS_WARN(sc->hs_dip, "Unable to send packet %p ret %d",
+		    (void *)vstor_packet, ret);
+	} else {
+		switch (vstor_packet->u.vm_srb.u.cdb[0]) {
+		case SCMD_READ:
+		case SCMD_READ_G1:
+			VSC_INCR_STAT(sc, vscstat_reads);
+			break;
+		case SCMD_WRITE:
+		case SCMD_WRITE_G1:
+			VSC_INCR_STAT(sc, vscstat_writes);
+			break;
+		default:
+			VSC_INCR_STAT(sc, vscstat_non_rw);
+			break;
+		}
+	}
+	/*
+	 * Always increment the outstanding and pending counters
+	 * even if there is an error. They will get decremented
+	 * when we call storvsc_complete_command().
+	 */
+	atomic_inc_32(&sc->hs_num_out_reqs);
+	VSC_INCR_STAT(sc, vscstat_pending);
+
+	return (ret);
+}
+
+/*
+ * Process IO_COMPLETION_OPERATION and ready
+ * the result to be completed for upper layer
+ * processing.
+ */
+static void
+hv_storvsc_on_iocompletion(struct storvsc_softc *sc,
+    struct vstor_packet *vstor_packet, struct hv_storvsc_request *request)
+{
+	struct vmscsi_req *vm_srb;
+	storvsc_cmd_t *cmd = &request->hvs_cmd;
+
+	vm_srb = &vstor_packet->u.vm_srb;
+
+	HS_DEBUG(sc->hs_dip, 3,
+	    "%s completed, cmd: 0x%x, request: 0x%p"
+	    " status: 0x%x, target: %d, lun: %d", __func__,
+	    vm_srb->u.cdb[0], (void *)request, vm_srb->scsi_status,
+	    cmd->cmd_target, cmd->cmd_lun);
+
+	/*
+	 * Copy some fields of the host's response into the request structure,
+	 * because the fields will be used later in storvsc_io_done().
+	 */
+	request->vstor_packet.u.vm_srb.scsi_status = vm_srb->scsi_status;
+	request->vstor_packet.u.vm_srb.srb_status = vm_srb->srb_status;
+	request->vstor_packet.u.vm_srb.transfer_len = vm_srb->transfer_len;
+
+	if (((vm_srb->scsi_status & 0xFF) == STATUS_CHECK) &&
+	    (vm_srb->srb_status & SRB_STATUS_AUTOSENSE_VALID)) {
+		/* Autosense data available */
+
+		ASSERT3U(vm_srb->sense_info_len, <=, request->sense_info_len);
+
+		(void) memcpy(request->sense_data, vm_srb->u.sense_data,
+		    vm_srb->sense_info_len);
+
+		request->sense_info_len = vm_srb->sense_info_len;
+	}
+
+	/*
+	 * The current SCSI handling on the host side does
+	 * not correctly handle:
+	 * INQUIRY command with page code parameter set to 0x80
+	 * MODE_SENSE command with cmd[2] == 0x1c
+	 *
+	 * Setup srb and scsi status so this won't be fatal.
+	 * We do this so we can distinguish truly fatal failues
+	 * (srb status == 0x4) and off-line the device in that case.
+	 */
+	if ((vm_srb->srb_status & SRB_STATUS_ERROR) &&
+	    (((vm_srb->u.cdb[0] == SCMD_INQUIRY) &&
+	    (vm_srb->u.cdb[2] == 0x80)) ||
+	    (vm_srb->u.cdb[0] == SCMD_MODE_SENSE))) {
+		request->vstor_packet.u.vm_srb.scsi_status = STATUS_GOOD;
+		request->vstor_packet.u.vm_srb.srb_status = SRB_STATUS_SUCCESS;
+	}
+
+	/* Complete request by passing to the SCSA layer */
+	storvsc_io_done(request);
+}
+
+static void
+hv_storvsc_on_channel_callback(struct vmbus_channel *channel, void *xsc)
+{
+	int ret = 0;
+	struct storvsc_softc *sc = xsc;
+	int bytes_recvd;
+	uint64_t request_id = 0;
+	uint8_t packet[roundup(sizeof (struct vstor_packet), 8)];
+	struct hv_storvsc_request *request;
+	struct vstor_packet *vstor_packet;
+
+	bytes_recvd = roundup(VSTOR_PKT_SIZE, 8);
+	ret = vmbus_chan_recv(channel, packet, &bytes_recvd, &request_id);
+	ASSERT3S(ret, !=, ENOBUFS);
+	/* XXX check bytes_recvd to make sure that it contains enough data */
+
+	while ((ret == 0) && (bytes_recvd > 0)) {
+		request = (struct hv_storvsc_request *)(uintptr_t)request_id;
+		vstor_packet = (struct vstor_packet *)packet;
+
+		if ((request == &sc->hs_init_req) ||
+		    (request == &sc->hs_reset_req)) {
+			ASSERT3U(vstor_packet->operation, ==,
+			    VSTOR_OPERATION_COMPLETEIO);
+			(void) memcpy(&request->vstor_packet, packet,
+			    sizeof (struct vstor_packet));
+			sema_v(&request->synch_sema);
+		} else {
+			switch (vstor_packet->operation) {
+			case VSTOR_OPERATION_COMPLETEIO:
+				if (request == NULL) {
+					/* might not be spurious, so panic */
+					panic("storvsc received a "
+					    "packet with NULL request id in "
+					    "COMPLETEIO operation.");
+				}
+
+				hv_storvsc_on_iocompletion(sc,
+				    vstor_packet, request);
+				break;
+			case VSTOR_OPERATION_REMOVEDEVICE:
+			case VSTOR_OPERATION_ENUMERATE_BUS:
+			default:
+				HS_NOTE(sc->hs_dip,
+				    "operation: %d not yet implemented.",
+				    vstor_packet->operation);
+				break;
+			}
+		}
+
+		bytes_recvd = roundup(VSTOR_PKT_SIZE, 8),
+		    ret = vmbus_chan_recv(channel, packet, &bytes_recvd,
+		    &request_id);
+		ASSERT3S(ret, !=, ENOBUFS);
+		/*
+		 * XXX check bytes_recvd to make sure that it contains
+		 * enough data
+		 */
+	}
+}
+
+static void
+storvsc_create_chan_sel(struct storvsc_softc *sc)
+{
+	struct vmbus_channel **subch;
+	int i, nsubch;
+
+	sc->hs_sel_chan[0] = sc->hs_chan;
+	nsubch = sc->hs_nchan - 1;
+	if (nsubch == 0)
+		return;
+
+	subch = vmbus_subchan_get(sc->hs_chan, nsubch);
+	for (i = 0; i < nsubch; i++)
+		sc->hs_sel_chan[i + 1] = subch[i];
+	vmbus_subchan_rel(subch, nsubch);
+}
+
+static int
+req_cache_constructor(void *buf, void *cdrarg, int kmflags)
+{
+	storvsc_softc_t  *sc = cdrarg;
+	struct hv_storvsc_request *reqp = (struct hv_storvsc_request *)buf;
+	storvsc_cmd_t	*cmd = &(reqp->hvs_cmd);
+	struct scsi_address ap;
+	int		error;
+	int (*callback)(caddr_t) = (kmflags == KM_SLEEP) ? SLEEP_FUNC :
+	    NULL_FUNC;
+
+	(void) memset(reqp, 0, sizeof (struct hv_storvsc_request));
+	cmd->cmd_sc = sc;
+
+	/*
+	 * Allocate cmd_handle, per request initialization done
+	 * in req_cache_constructor
+	 */
+	error = ddi_dma_alloc_handle(sc->hs_dip, &storvsc_io_dma_attr,
+	    callback, NULL, &cmd->cmd_handle);
+	if (error != DDI_SUCCESS) {
+		HS_WARN(sc->hs_dip,
+		    "failed to create storvsc dma handle, "
+		    "error: 0x%x", error);
+		return (-1);
+	}
+
+	ap.a_hba_tran = sc->hs_tran;
+	ap.a_target = 0;
+	ap.a_lun = 0;
+
+	/* Setup ARQ buffer. */
+	if ((cmd->cmd_arq_buf = scsi_alloc_consistent_buf(&ap,
+	    (struct buf *)NULL, sense_buffer_size, B_READ,
+	    callback, NULL)) == NULL) {
+		HS_WARN(sc->hs_dip, "failed to allocate ARQ buffer");
+		goto free_handle;
+	}
+	cmd->cmd_rqslen = sense_buffer_size;
+
+	return (0);
+free_handle:
+	ddi_dma_free_handle(&cmd->cmd_handle);
+
+	return (-1);
+}
+
+/* ARGSUSED cdrarg */
+static void
+req_cache_destructor(void *buf, void *cdrarg)
+{
+	struct hv_storvsc_request *reqp = (struct hv_storvsc_request *)buf;
+	storvsc_cmd_t	*cmd = &(reqp->hvs_cmd);
+
+	if (cmd->cmd_handle) {
+		ddi_dma_free_handle(&cmd->cmd_handle);
+		cmd->cmd_handle = NULL;
+	}
+
+	if (cmd->cmd_arq_buf) {
+		scsi_free_consistent_buf(cmd->cmd_arq_buf);
+		cmd->cmd_arq_buf = NULL;
+	}
+}
+
+
+static int
+storvsc_init_requests(struct storvsc_softc *sc)
+{
+	char		buf[32];
+
+	(void) sprintf(buf, "storvsc%d_cache", sc->hs_instance);
+	sc->hs_req_cache = kmem_cache_create(buf,
+	    sizeof (struct hv_storvsc_request), 0,
+	    req_cache_constructor, req_cache_destructor, NULL, (void *)sc,
+	    NULL, 0);
+
+	if (sc->hs_req_cache == NULL)
+		return (DDI_FAILURE);
+
+	return (DDI_SUCCESS);
+}
+
+static void
+storvsc_fini_requests(struct storvsc_softc *sc)
+{
+	kmem_cache_destroy(sc->hs_req_cache);
+	sc->hs_req_cache = NULL;
+}
+
+static int
+create_storvsc_request(storvsc_cmd_t *cmd)
+{
+	struct scsi_pkt *pkt = CMD2PKT(cmd);
+	struct hv_storvsc_request *reqp = PKT2REQ(pkt);
+
+	/* refer to struct vmscsi_req for meanings of these two fields */
+	reqp->vstor_packet.u.vm_srb.port = cmd->cmd_sc->hs_instance;
+	reqp->vstor_packet.u.vm_srb.path_id = 0;
+
+	reqp->vstor_packet.u.vm_srb.target_id = cmd->cmd_target;
+	reqp->vstor_packet.u.vm_srb.lun = cmd->cmd_lun;
+	reqp->vstor_packet.u.vm_srb.cdb_len = cmd->cmd_len;
+
+	bcopy(cmd->cmd_cdb, &reqp->vstor_packet.u.vm_srb.u.cdb,	cmd->cmd_len);
+
+	if (hv_storvsc_use_win8ext_flags) {
+		reqp->vstor_packet.u.vm_srb.win8_extension.time_out_value =
+		    pkt->pkt_time;
+		reqp->vstor_packet.u.vm_srb.win8_extension.srb_flags |=
+		    SRB_FLAGS_DISABLE_SYNCH_TRANSFER;
+	}
+
+	switch (cmd->cmd_flags & STORVSC_FLAG_IO_MASK) {
+	case STORVSC_FLAG_IO_WRITE:
+		reqp->vstor_packet.u.vm_srb.data_in = WRITE_TYPE;
+		if (hv_storvsc_use_win8ext_flags) {
+			reqp->vstor_packet.u.vm_srb.win8_extension.srb_flags |=
+			    SRB_FLAGS_DATA_OUT;
+		}
+		break;
+	case STORVSC_FLAG_IO_READ:
+		reqp->vstor_packet.u.vm_srb.data_in = READ_TYPE;
+		if (hv_storvsc_use_win8ext_flags) {
+			reqp->vstor_packet.u.vm_srb.win8_extension.srb_flags |=
+			    SRB_FLAGS_DATA_IN;
+		}
+		break;
+	case 0x00: /* no data transfer */
+		reqp->vstor_packet.u.vm_srb.data_in = UNKNOWN_TYPE;
+		if (hv_storvsc_use_win8ext_flags) {
+			/* LINTED */
+			reqp->vstor_packet.u.vm_srb.win8_extension.srb_flags |=
+			    SRB_FLAGS_NO_DATA_TRANSFER;
+		}
+		break;
+	default:
+		HS_WARN(cmd->cmd_sc->hs_dip,
+		    "Error: cmd %p - unexpected data direction: 0x%x",
+		    (void *)cmd, (cmd->cmd_flags & STORVSC_FLAG_IO_MASK));
+		return (EINVAL);
+	}
+
+	/*
+	 * Since we always allocate arq_buf, we will need it to get sense data
+	 */
+	reqp->sense_data = (caddr_t)cmd->cmd_arq_buf->b_un.b_addr;
+	reqp->sense_info_len = cmd->cmd_rqslen;
+
+	if ((cmd->cmd_flags & STORVSC_FLAG_XARQ) != 0)
+		bzero(reqp->sense_data, cmd->cmd_rqslen);
+
+	reqp->pkt = pkt;
+	return (0);
+}
+
+
+static void
+storvsc_set_command_status(storvsc_cmd_t *cmd)
+{
+	int	stats;
+
+	if (cmd->cmd_flags & STORVSC_FLAG_TIMED_OUT) {
+		cmd->cmd_pkt->pkt_reason = CMD_TIMEOUT;
+		cmd->cmd_pkt->pkt_statistics |= (STAT_TIMEOUT|STAT_ABORTED);
+		cmd->cmd_pkt->pkt_state |= (STATE_GOT_BUS | STATE_GOT_TARGET |
+		    STATE_SENT_CMD | STATE_GOT_STATUS);
+	} else if (cmd->cmd_flags & STORVSC_FLAG_ABORTED) {
+		cmd->cmd_pkt->pkt_reason = CMD_ABORTED;
+		cmd->cmd_pkt->pkt_statistics |= (STAT_TIMEOUT|STAT_ABORTED);
+	} else if (cmd->cmd_flags & STORVSC_FLAGS_RESET) {
+		cmd->cmd_pkt->pkt_reason = CMD_RESET;
+		if (cmd->cmd_flags & STORVSC_FLAG_RESET_BUS)
+			stats = STAT_BUS_RESET;
+		else
+			stats = STAT_DEV_RESET;
+		cmd->cmd_pkt->pkt_statistics |= stats;
+	} else if (cmd->cmd_flags & STORVSC_FLAG_SRB_ERROR) {
+		cmd->cmd_pkt->pkt_reason = CMD_TRAN_ERR;
+		cmd->cmd_pkt->pkt_state |= (STATE_GOT_BUS | STATE_GOT_TARGET |
+		    STATE_SENT_CMD | STATE_GOT_STATUS);
+	} else if (cmd->cmd_flags & STORVSC_FLAG_DEV_GONE) {
+		cmd->cmd_pkt->pkt_reason = CMD_DEV_GONE;
+		cmd->cmd_pkt->pkt_state |= (STATE_GOT_BUS | STATE_GOT_TARGET |
+		    STATE_SENT_CMD | STATE_GOT_STATUS);
+	}
+}
+
+static void
+storvsc_complete_command(storvsc_cmd_t *cmd)
+{
+	struct scsi_pkt *pkt = CMD2PKT(cmd);
+	storvsc_softc_t *sc = cmd->cmd_sc;
+
+	atomic_dec_32(&sc->hs_num_out_reqs);
+	VSC_DECR_STAT(sc, vscstat_pending);
+
+	if (sc->hs_drain_notify && (sc->hs_num_out_reqs == 0)) {
+		sema_v(&sc->hs_drain_sema);
+	}
+
+	if (pkt != NULL) {
+		if ((cmd->cmd_flags & STORVSC_FLAG_IO_IOPB) &&
+		    (cmd->cmd_flags & STORVSC_FLAG_IO_READ)) {
+			(void) ddi_dma_sync(cmd->cmd_handle, 0, 0,
+			    DDI_DMA_SYNC_FORCPU);
+		}
+
+		storvsc_set_command_status(cmd);
+		cmd->cmd_flags |= STORVSC_FLAG_DONE;
+		cmd->cmd_flags &= ~STORVSC_FLAG_TRANSPORT;
+		membar_producer();
+
+		if (((pkt->pkt_flags & FLAG_NOINTR) == 0) && pkt->pkt_comp) {
+			(*pkt->pkt_comp)(pkt);
+		}
+	}
+}
+
+static void
+prepare_pkt(storvsc_cmd_t *cmd)
+{
+	struct scsi_pkt	*pkt = CMD2PKT(cmd);
+
+	/*
+	 * Reinitialize some fields because the packet may
+	 * have been resubmitted.
+	 */
+	pkt->pkt_reason = CMD_CMPLT;
+	pkt->pkt_state = 0;
+	pkt->pkt_statistics = 0;
+
+	/* Zero status byte */
+	*(pkt->pkt_scbp) = 0;
+
+	if (cmd->cmd_flags & STORVSC_FLAG_DMA_VALID) {
+		ASSERT(cmd->cmd_dma_count != 0);
+		pkt->pkt_resid = cmd->cmd_dma_count;
+
+		/*
+		 * Consistent packets need to be sync'ed first
+		 * (only for data going out).
+		 */
+		if ((cmd->cmd_flags & STORVSC_FLAG_IO_IOPB) != 0) {
+			(void) ddi_dma_sync(cmd->cmd_handle, 0, 0,
+			    DDI_DMA_SYNC_FORDEV);
+		}
+	}
+}
+
+static int
+storvsc_start(struct scsi_address *ap, struct scsi_pkt *pkt)
+{
+	storvsc_softc_t  *sc = ap->a_hba_tran->tran_hba_private;
+	storvsc_cmd_t    *cmd = PKT2CMD(pkt);
+	struct hv_storvsc_request	*reqp = PKT2REQ(pkt);
+	int rc;
+
+	ASSERT3P(cmd->cmd_pkt, ==, pkt);
+	ASSERT3P(cmd->cmd_sc, ==, sc);
+	ASSERT3P(reqp, !=, NULL);
+
+	prepare_pkt(cmd);
+
+	cmd->cmd_target = ap->a_target;
+	cmd->cmd_lun = ap->a_lun;
+	cmd->cmd_flags |= STORVSC_FLAG_TRANSPORT;
+
+	if ((rc = create_storvsc_request(cmd)) != 0) {
+		HS_WARN(sc->hs_dip,
+		    "failed to create storvsc request, err: %d", rc);
+		return (TRAN_FATAL_ERROR);
+	}
+
+	/* Setup timeout before submitting actual I/O */
+	if (pkt->pkt_time > 0) {
+		reqp->timeout_id = timeout(storvsc_timeout, reqp,
+		    SEC_TO_TICK(pkt->pkt_time));
+	} else {
+		reqp->timeout_id = NULL;
+	}
+
+	pkt->pkt_state |= (STATE_GOT_BUS | STATE_GOT_TARGET);
+
+	if ((rc = hv_storvsc_io_request(sc, reqp)) != 0) {
+		HS_WARN(sc->hs_dip,
+		    "hv_storvsc_io_request failed with %d", rc);
+		pkt->pkt_state |= STAT_ABORTED;
+		pkt->pkt_reason = CMD_TRAN_ERR;
+		storvsc_complete_command(cmd);
+		return (TRAN_BADPKT);
+	}
+
+	pkt->pkt_state |= STATE_SENT_CMD;
+
+	HS_DEBUG(sc->hs_dip, 3,
+	    "%s: submitted cmd: 0x%x, pkt: %p, "
+	    "timeout: %d, target: %d, lun: %d", __func__,
+	    cmd->cmd_cdb[0], (void *)pkt, pkt->pkt_time,
+	    cmd->cmd_target, cmd->cmd_lun);
+	return (TRAN_ACCEPT);
+}
+
+static int
+storvsc_reset(struct scsi_address *ap, int level)
+{
+	storvsc_softc_t *sc = AP2PRIV(ap);
+
+#if HVS_HOST_RESET
+	int res;
+	if ((res = hv_storvsc_host_reset(sc)) != 0) {
+		HS_WARN(sc->hs_dip,
+		    "hv_storvsc_host_reset failed with %d", res);
+		return (0);
+	}
+	return (1);
+#else
+	HS_WARN(sc->hs_dip, "%s reset not supported.",
+	    (level == RESET_TARGET) ? "dev" : "bus");
+	return (0);
+#endif	/* HVS_HOST_RESET */
+}
+
+/*
+ * Hyper-V guarantees that every valid I/O will be returned so
+ * there is no need to abort a command.
+ */
+/* ARGSUSED */
+static int
+storvsc_abort(struct scsi_address *ap, struct scsi_pkt *pkt)
+{
+	return (0);
+}
+
+/* ARGSUSED */
+static int
+storvsc_getcap(struct scsi_address *ap, char *cap, int tgtonly)
+{
+	if (cap == NULL)
+		return (-1);
+
+	switch (scsi_hba_lookup_capstr(cap)) {
+	case SCSI_CAP_CDB_LEN:
+		return (CDB_GROUP4);
+	/* enable tag queuing and disconnected mode */
+	case SCSI_CAP_ARQ:
+	case SCSI_CAP_TAGGED_QING:
+	case SCSI_CAP_DISCONNECT:
+		return (1);
+	case SCSI_CAP_SCSI_VERSION:
+		return (SCSI_VERSION_2);
+	default:
+		return (-1);
+	}
+}
+
+/* ARGSUSED */
+static int
+storvsc_setcap(struct scsi_address *ap, char *cap, int value, int tgtonly)
+{
+	switch (scsi_hba_lookup_capstr(cap)) {
+	case SCSI_CAP_TAGGED_QING:
+		return (1);
+	default:
+		return (0);
+	}
+}
+
+static void
+storvsc_cmd_ext_free(storvsc_cmd_t *cmd)
+{
+	struct scsi_pkt *pkt = CMD2PKT(cmd);
+
+	if (cmd->cmd_flags & STORVSC_FLAG_CDB_EXT) {
+		kmem_free(pkt->pkt_cdbp, cmd->cmd_len);
+		cmd->cmd_flags &= ~STORVSC_FLAG_CDB_EXT;
+	}
+	if (cmd->cmd_flags & STORVSC_FLAG_SCB_EXT) {
+		kmem_free(pkt->pkt_scbp, cmd->cmd_statuslen);
+		cmd->cmd_flags &= ~STORVSC_FLAG_SCB_EXT;
+	}
+	if (cmd->cmd_flags & STORVSC_FLAG_PRIV_EXT) {
+		kmem_free(pkt->pkt_private, cmd->cmd_tgtlen);
+		cmd->cmd_flags &= ~STORVSC_FLAG_PRIV_EXT;
+	}
+}
+
+static int
+storvsc_cmd_ext_alloc(storvsc_cmd_t *cmd, int kf)
+{
+	void		*buf;
+	struct scsi_pkt *pkt = CMD2PKT(cmd);
+
+	if (cmd->cmd_len > sizeof (cmd->cmd_cdb)) {
+		if ((buf = kmem_zalloc(cmd->cmd_len, kf)) == NULL)
+			goto out;
+		pkt->pkt_cdbp = buf;
+		cmd->cmd_flags |= STORVSC_FLAG_CDB_EXT;
+	}
+
+	if (cmd->cmd_statuslen > sizeof (cmd->cmd_scb)) {
+		if ((buf = kmem_zalloc(cmd->cmd_statuslen, kf)) == NULL)
+			goto out;
+		pkt->pkt_scbp = buf;
+		cmd->cmd_flags |= STORVSC_FLAG_SCB_EXT;
+		cmd->cmd_rqslen = (cmd->cmd_statuslen - sizeof (cmd->cmd_scb));
+		/* XXX - investigate */
+		cmd->cmd_rqslen = MIN(SENSE_BUFFER_SIZE,
+		    cmd->cmd_statuslen - sizeof (cmd->cmd_scb));
+		ASSERT3U(cmd->cmd_rqslen, <=, SENSE_BUFFER_SIZE);
+	}
+
+	if (cmd->cmd_tgtlen > sizeof (cmd->cmd_tgt_priv)) {
+		if ((buf = kmem_zalloc(cmd->cmd_tgtlen, kf)) == NULL)
+			goto out;
+		pkt->pkt_private = buf;
+		cmd->cmd_flags |= STORVSC_FLAG_PRIV_EXT;
+	}
+
+	return (DDI_SUCCESS);
+out:
+	storvsc_cmd_ext_free(cmd);
+
+	return (DDI_FAILURE);
+}
+
+static struct scsi_pkt *
+storvsc_init_pkt(struct scsi_address *ap, struct scsi_pkt *pkt, struct buf *bp,
+    int cmdlen, int statuslen, int tgtlen, int flags,
+    int (*callback)(), caddr_t arg)
+{
+	struct hv_storvsc_request	*reqp = NULL;
+	int		kf = (callback == SLEEP_FUNC) ? KM_SLEEP: KM_NOSLEEP;
+	storvsc_softc_t	*sc;
+	storvsc_cmd_t	*cmd = NULL;
+	boolean_t	is_new;
+	int		rc;
+	int		i;
+
+	sc = ap->a_hba_tran->tran_hba_private;
+	ASSERT(sc != NULL);
+
+	if (ap->a_lun >= sc->hs_num_luns) {
+		HS_WARN(sc->hs_dip, "bad lun provided: %d (MAX: %d)",
+		    ap->a_lun, sc->hs_num_luns);
+		return (NULL);
+	}
+
+	/* Allocate a new SCSI packet */
+	if (pkt == NULL) {
+		ddi_dma_handle_t		saved_handle;
+		struct buf			*saved_arqbuf;
+		int				saved_rqslen;
+
+		if ((reqp = kmem_cache_alloc(sc->hs_req_cache, kf)) == NULL)
+			return (NULL);
+
+		cmd = &reqp->hvs_cmd;
+		saved_handle = cmd->cmd_handle;
+		saved_arqbuf = cmd->cmd_arq_buf;
+		saved_rqslen = cmd->cmd_rqslen;
+
+		bzero(reqp, sizeof (struct hv_storvsc_request));
+
+		cmd->cmd_sc = sc;
+		cmd->cmd_handle = saved_handle;
+		cmd->cmd_arq_buf = saved_arqbuf;
+		cmd->cmd_rqslen = saved_rqslen;
+
+		pkt = &cmd->cmd_cached_pkt;
+		pkt->pkt_ha_private = (opaque_t)reqp;
+		reqp->pkt = pkt;
+
+		pkt->pkt_address = *ap;
+		pkt->pkt_scbp = (uint8_t *)&cmd->cmd_scb;
+		pkt->pkt_cdbp = (uint8_t *)&cmd->cmd_cdb;
+		pkt->pkt_cdblen = cmdlen;
+		pkt->pkt_private = (opaque_t)&cmd->cmd_tgt_priv;
+
+		cmd->cmd_tgtlen = tgtlen;
+		cmd->cmd_statuslen = statuslen;
+		cmd->cmd_len = cmdlen;
+		cmd->cmd_pkt = pkt;
+
+		reqp->vstor_packet.u.vm_srb.cdb_len = cmdlen; /* XXX */
+
+		is_new = B_TRUE;
+
+		/* Allocate extended buffers */
+		if ((cmdlen > sizeof (cmd->cmd_cdb)) ||
+		    (statuslen > sizeof (cmd->cmd_scb)) ||
+		    (tgtlen > sizeof (cmd->cmd_tgt_priv))) {
+			if (storvsc_cmd_ext_alloc(cmd, kf) != DDI_SUCCESS) {
+				HS_WARN(sc->hs_dip,
+				    "extent allocation failed");
+				goto out;
+			}
+		}
+	} else {
+		cmd = PKT2CMD(pkt);
+		ASSERT(cmd->cmd_nwin > 0);
+		ASSERT3P(pkt->pkt_cdbp, ==, &cmd->cmd_cdb);
+		is_new = B_FALSE;
+	}
+
+	ASSERT0(cmd->cmd_flags & STORVSC_FLAG_TRANSPORT);
+
+	/*
+	 * upper layer (target) drivers will fill
+	 * the cdb before calling "tran_start",
+	 * make sure its initialized here.
+	 */
+	bzero(pkt->pkt_cdbp, sizeof (cmd->cmd_cdb));
+
+	if (flags & PKT_XARQ)
+		cmd->cmd_flags |= STORVSC_FLAG_XARQ;
+
+	/* Handle partial DMA transfers */
+	if (cmd->cmd_nwin > 0) {
+		if (++cmd->cmd_winindex >= cmd->cmd_nwin)
+			return (NULL);
+		if (ddi_dma_getwin(cmd->cmd_handle, cmd->cmd_winindex,
+		    &cmd->cmd_dma_offset, &cmd->cmd_dma_len,
+		    &cmd->cmd_cookie, &cmd->cmd_cookiec) == DDI_FAILURE) {
+			HS_WARN(sc->hs_dip, "failed activating dma window %d",
+			    cmd->cmd_winindex);
+			return (NULL);
+		}
+		goto handle_dma_cookies;
+	}
+
+	/* Setup data buffer. */
+	if (bp != NULL && bp->b_bcount > 0 &&
+	    (cmd->cmd_flags & STORVSC_FLAG_DMA_VALID) == 0) {
+		int	dma_flags;
+
+		if (bp->b_flags & B_READ) {
+			cmd->cmd_flags |= STORVSC_FLAG_IO_READ;
+			dma_flags = DDI_DMA_READ;
+		} else {
+			cmd->cmd_flags |= STORVSC_FLAG_IO_WRITE;
+			dma_flags = DDI_DMA_WRITE;
+		}
+
+		if (flags & PKT_CONSISTENT) {
+			cmd->cmd_flags |= STORVSC_FLAG_IO_IOPB;
+			dma_flags |= DDI_DMA_CONSISTENT;
+		}
+
+		if (flags & PKT_DMA_PARTIAL)
+			dma_flags |= DDI_DMA_PARTIAL;
+
+		ASSERT(cmd->cmd_handle != NULL);
+
+		rc = ddi_dma_buf_bind_handle(cmd->cmd_handle, bp,
+		    dma_flags, callback, arg, &cmd->cmd_cookie,
+		    &cmd->cmd_cookiec);
+
+		if (rc == DDI_DMA_PARTIAL_MAP) {
+			cmd->cmd_winindex = 0;
+			(void) ddi_dma_numwin(cmd->cmd_handle, &cmd->cmd_nwin);
+			(void) ddi_dma_getwin(cmd->cmd_handle,
+			    cmd->cmd_winindex, &cmd->cmd_dma_offset,
+			    &cmd->cmd_dma_len, &cmd->cmd_cookie,
+			    &cmd->cmd_cookiec);
+		} else if (rc && (rc != DDI_DMA_MAPPED)) {
+			HS_WARN(sc->hs_dip,
+			    "failed to bind storvsc data request dma, "
+			    "error: 0x%x", rc);
+
+			switch (rc) {
+			case DDI_DMA_NORESOURCES:
+				bioerror(bp, 0);
+				break;
+			case DDI_DMA_BADATTR:
+			case DDI_DMA_NOMAPPING:
+				bioerror(bp, EFAULT);
+				break;
+			case DDI_DMA_TOOBIG:
+			default:
+				bioerror(bp, EINVAL);
+				break;
+			}
+			cmd->cmd_flags &= ~STORVSC_FLAG_DMA_VALID;
+			goto out;
+		}
+handle_dma_cookies:
+		cmd->cmd_flags |= STORVSC_FLAG_DMA_VALID;
+		cmd->cmd_dma_count = 0;
+
+		ASSERT(cmd->cmd_cookiec > 0);
+		ASSERT3U(cmd->cmd_cookiec, <=, STORVSC_DATA_SEGCNT_MAX);
+
+		HS_DEBUG(sc->hs_dip, 6, "dma_buf_bind, got: %d cookies",
+		    cmd->cmd_cookiec);
+
+		/* NOTE: gpa_ofs is from first cookie */
+		reqp = PKT2REQ(pkt);
+		reqp->prp_list.gpa_range.gpa_ofs =
+		    cmd->cmd_cookie.dmac_laddress & PAGEOFFSET;
+
+		/*
+		 * Calculate total amount of bytes for this I/O and
+		 * store cookies for further processing.
+		 */
+		for (i = 0; i < cmd->cmd_cookiec; i++) {
+			reqp->prp_list.gpa_page[i] =
+			    btop(cmd->cmd_cookie.dmac_laddress);
+
+			ASSERT(!P2BOUNDARY(cmd->cmd_cookie.dmac_laddress,
+			    cmd->cmd_cookie.dmac_size, PAGESIZE));
+
+			IMPLY(i > 0,
+			    (cmd->cmd_cookie.dmac_laddress & PAGEOFFSET) == 0);
+
+			cmd->cmd_dma_count += cmd->cmd_cookie.dmac_size;
+			cmd->cmd_total_dma_count += cmd->cmd_cookie.dmac_size;
+			ddi_dma_nextcookie(cmd->cmd_handle, &cmd->cmd_cookie);
+		}
+		reqp->prp_list.gpa_range.gpa_len = cmd->cmd_dma_count;
+		ASSERT3U(reqp->prp_list.gpa_range.gpa_len, <=,
+		    STORVSC_DATA_SIZE_MAX);
+		reqp->prp_cnt = cmd->cmd_cookiec;
+		cmd->cmd_bp = bp;
+
+		pkt->pkt_resid = (bp->b_bcount - cmd->cmd_total_dma_count);
+	} else {
+		reqp->prp_list.gpa_range.gpa_len = 0; /* don't use prp_list */
+		cmd->cmd_bp = NULL;
+	}
+	return (pkt);
+out:
+	if (is_new) {
+		storvsc_destroy_pkt(ap, pkt);
+	}
+
+	return (NULL);
+}
+
+static void
+storvsc_destroy_pkt(struct scsi_address *ap, struct scsi_pkt *pkt)
+{
+	storvsc_cmd_t *cmd = PKT2CMD(pkt);
+	storvsc_softc_t *sc = AP2PRIV(ap);
+
+	ASSERT3P(sc, ==, cmd->cmd_sc);
+	storvsc_dmafree(ap, pkt);
+	if ((cmd->cmd_flags & STORVSC_FLAGS_EXT) != 0)
+		storvsc_cmd_ext_free(cmd);
+	kmem_cache_free(sc->hs_req_cache, PKT2REQ(pkt));
+}
+
+/* ARGSUSED ap */
+static void
+storvsc_dmafree(struct scsi_address *ap, struct scsi_pkt *pkt)
+{
+	storvsc_cmd_t	*cmd = PKT2CMD(pkt);
+
+	ASSERT(cmd != NULL);
+	if ((cmd->cmd_flags & STORVSC_FLAG_DMA_VALID) != 0) {
+		(void) ddi_dma_unbind_handle(cmd->cmd_handle);
+		cmd->cmd_flags &= ~STORVSC_FLAG_DMA_VALID;
+	}
+}
+
+/* ARGSUSED ap pkt */
+static void
+storvsc_sync_pkt(struct scsi_address *ap, struct scsi_pkt *pkt)
+{
+}
+
+/* ARGSUSED ap flag callback arg */
+static int
+storvsc_reset_notify(struct scsi_address *ap, int flag,
+    void (*callback)(caddr_t), caddr_t arg)
+{
+	return (DDI_FAILURE);
+}
+
+static int
+storvsc_inquiry_target(storvsc_softc_t *sc, int target, int lun, uchar_t evpd,
+    uchar_t page, int (*callback)(caddr_t), caddr_t callback_arg,
+    caddr_t buf, int len)
+{
+	struct scsi_address ap;
+	int ret = -1;
+	struct buf *b;
+	struct scsi_pkt *pkt = NULL;
+
+	ap.a_target = (ushort_t)target;
+	ap.a_lun = (uint8_t)lun;
+	ap.a_hba_tran = sc->hs_tran;
+
+	if ((b = scsi_alloc_consistent_buf(&ap, (struct buf *)NULL, len, B_READ,
+	    callback, callback_arg)) == NULL)
+		return (-1);
+
+	if ((pkt = scsi_init_pkt(&ap, (struct scsi_pkt *)NULL, b,
+	    CDB_GROUP0, sizeof (struct scsi_arq_status), 0, 0,
+	    callback, callback_arg)) == NULL)
+		goto free_buf;
+
+	pkt->pkt_cdbp[0] = SCMD_INQUIRY;
+	pkt->pkt_cdbp[1] = evpd;
+	pkt->pkt_cdbp[2] = page;
+	pkt->pkt_cdbp[3] = (len & 0xff00) >> 8;
+	pkt->pkt_cdbp[4] = (len & 0x00ff);
+	pkt->pkt_cdbp[5] = 0;
+
+	if (buf != NULL)
+		bzero(buf, len);
+	/* bcopy(cdb, pkt->pkt_cdbp, CDB_GROUP0); */
+	bzero((caddr_t)b->b_un.b_addr, len);
+
+	if ((ret = scsi_poll(pkt)) == 0 && buf != NULL)
+		bcopy((caddr_t)b->b_un.b_addr, buf, len);
+
+	if (pkt->pkt_reason != CMD_CMPLT)
+		ret = -1;
+
+	scsi_free_consistent_buf(b);
+	scsi_destroy_pkt(pkt);
+	return (ret);
+free_buf:
+	scsi_free_consistent_buf(b);
+
+	return (-1);
+}
+
+static int
+storvsc_config_one(dev_info_t *pdip, storvsc_softc_t *sc, int target, int lun,
+    dev_info_t **childp)
+{
+	dev_info_t *dip;
+	char *nodename = NULL;
+	int ncompatible = 0;
+	char **compatible = NULL;
+	struct scsi_inquiry inq;
+	storvsc_device_t *devnode;
+	int dtype;
+	int err;
+	int rv = 0;
+	struct scsi_device *sd;
+
+	HS_DEBUG(sc->hs_dip, 2, "target %d, lun %d, child %p, parent %p",
+	    target, lun, (void *)childp, (void *)pdip);
+
+	err = storvsc_inquiry_target(sc, target, lun, 0, 0, NULL_FUNC, 0,
+	    (caddr_t)&inq, sizeof (struct scsi_inquiry));
+	if (err != 0) {
+		HS_DEBUG(sc->hs_dip, 2,
+		    "!failed inquiry for target: %d, lun: %d",
+		    target, lun);
+	}
+
+	/* Find devnode */
+	for (devnode = list_head(&sc->hs_devnodes); devnode != NULL;
+	    devnode = list_next(&sc->hs_devnodes, devnode)) {
+		if (devnode->target == target && devnode->lun == lun)
+			break;
+	}
+
+	if (devnode != NULL) {
+		if (err != 0) {
+			/* Target disappeared, drop devnode */
+			if (i_ddi_devi_attached(devnode->dip)) {
+				char    *devname;
+				/* Get full devname */
+				devname = kmem_alloc(MAXPATHLEN, KM_SLEEP);
+
+				(void) ddi_deviname(devnode->dip, devname);
+				/* Clean cache and name */
+				(void) devfs_clean(devnode->pdip, devname + 1,
+				    DV_CLEAN_FORCE);
+				kmem_free(devname, MAXPATHLEN);
+			}
+			(void) ndi_devi_offline(devnode->dip, NDI_DEVI_REMOVE);
+
+			list_remove(&sc->hs_devnodes, devnode);
+			kmem_free(devnode, sizeof (*devnode));
+		} else if (childp != NULL) {
+			/* Target exists */
+			*childp = devnode->dip;
+		}
+		return (NDI_SUCCESS);
+	} else if (err != 0) {
+		/* Target doesn't exist */
+		return (NDI_FAILURE);
+	}
+
+	dtype = inq.inq_dtype & DTYPE_MASK;
+	if (dtype != DTYPE_DIRECT) {
+		HS_DEBUG(sc->hs_dip, 2, "invalid dtype: 0x%x for target: %d, "
+		    "lun: %d", dtype, target, lun);
+		rv = NDI_FAILURE;
+		goto out;
+	}
+
+	HS_DEBUG(sc->hs_dip, 2,
+	    "Got inq status - dtype: 0x%x, vid: %s, pid: %s",
+	    inq.inq_dtype, inq.inq_vid, inq.inq_pid);
+
+	scsi_hba_nodename_compatible_get(&inq, NULL, dtype, NULL,
+	    &nodename, &compatible, &ncompatible);
+	if (nodename == NULL) {
+		HS_WARN(sc->hs_dip,
+		    "!failed hba_nodename_compatible for instance: %d", target);
+		rv = NDI_FAILURE;
+		goto out;
+	}
+
+	HS_DEBUG(sc->hs_dip, 2, "target %d, lun %d, found nodename: %s",
+	    target, lun, nodename);
+
+	if (ndi_devi_alloc(pdip, nodename, DEVI_SID_NODEID,
+	    &dip) != NDI_SUCCESS) {
+		HS_WARN(sc->hs_dip, "!failed to alloc device instance");
+		rv = NDI_FAILURE;
+		goto out;
+	}
+
+	if (ndi_prop_update_string(DDI_DEV_T_NONE, dip,
+	    "device-type", "scsi") != DDI_PROP_SUCCESS ||
+	    ndi_prop_update_int(DDI_DEV_T_NONE, dip,
+	    SCSI_ADDR_PROP_TARGET, target) != DDI_PROP_SUCCESS ||
+	    ndi_prop_update_int(DDI_DEV_T_NONE, dip,
+	    SCSI_ADDR_PROP_LUN, lun) != DDI_PROP_SUCCESS ||
+	    ndi_prop_update_int64(DDI_DEV_T_NONE, dip,
+	    SCSI_ADDR_PROP_LUN64, (int64_t)lun) != DDI_PROP_SUCCESS ||
+	    ndi_prop_update_string_array(DDI_DEV_T_NONE, dip,
+	    "compatible", compatible, ncompatible) != DDI_PROP_SUCCESS) {
+		HS_WARN(sc->hs_dip,
+		    "!failed to update props for target %d", target);
+		(void) ndi_devi_free(dip);
+		rv = NDI_FAILURE;
+		goto out;
+	}
+
+	sd = kmem_zalloc(sizeof (struct scsi_device), KM_SLEEP);
+	sd->sd_address.a_hba_tran = sc->hs_tran;
+	sd->sd_address.a_target = (uint16_t)target;
+	sd->sd_address.a_lun = (uint8_t)lun;
+	sd->sd_dev = dip;
+	/*
+	 * This checks if pages 0x80 & 0x83 are supported and
+	 * decorates the dip with any of those data available
+	 */
+	if (scsi_device_identity(sd, SLEEP_FUNC) == 0) {
+		ddi_devid_t	devid;
+		char		*guid = NULL;
+		uchar_t		*inq83 = NULL;
+		uint_t		inq83_len = 0xFF;
+		uint64_t	*wwnp = NULL;
+		uint64_t	wwn;
+
+		inq83 = NULL;
+		if (scsi_device_prop_lookup_byte_array(sd,
+		    SCSI_DEVICE_PROP_PATH, "inquiry-page-83",
+		    &inq83, &inq83_len) == DDI_PROP_SUCCESS) {
+
+			/*
+			 * Check the "Assoctiation" field (bits 5:4 in
+			 * byte 5).
+			 */
+			if ((inq83[5] & 0x30) != 0) {
+				HS_WARN(sc->hs_dip,
+				    "guid is not associated with the "
+				    "lun %d, target %d", lun, target);
+			}
+
+			wwnp = (uint64_t *)(void *)(&inq83[8]);
+			wwn = BE_64(*wwnp);
+			HS_DEBUG(sc->hs_dip, 2,
+			    "target %d, lun %d, found wwn w%016"PRIx64,
+			    target, lun, wwn);
+
+			if ((rv = ddi_devid_scsi_encode(
+			    DEVID_SCSI_ENCODE_VERSION_LATEST, NULL,
+			    (uchar_t *)&inq, sizeof (struct scsi_inquiry),
+			    NULL, 0, inq83, (size_t)inq83_len,
+			    &devid)) == DDI_SUCCESS) {
+				/* extract GUID from DEVID */
+				guid = ddi_devid_to_guid(devid);
+				if (guid != NULL) {
+					HS_DEBUG(sc->hs_dip, 2,
+					    "target %d, lun %d, found guid: %s",
+					    target, lun, guid);
+				}
+				ddi_devid_free(devid);
+			}
+		}
+
+		if (inq83 != NULL) {
+			scsi_device_prop_free(sd, SCSI_DEVICE_PROP_PATH, inq83);
+		}
+	} else {
+		HS_DEBUG(sc->hs_dip, 2,
+		    "device_identity failed - target %d, lun %d",
+		    target, lun);
+	}
+	kmem_free(sd, sizeof (struct scsi_device));
+
+	if ((devnode = kmem_zalloc(sizeof (*devnode), KM_SLEEP)) == NULL) {
+		ndi_prop_remove_all(dip);
+		(void) ndi_devi_free(dip);
+		return (NDI_FAILURE);
+	}
+
+	if ((rv = ndi_devi_online(dip, NDI_ONLINE_ATTACH)) != NDI_SUCCESS) {
+		HS_WARN(sc->hs_dip,
+		    "!failed to online target:%d, lun %d, err: %d",
+		    target, lun, rv);
+		kmem_free(devnode, sizeof (*devnode));
+		ndi_prop_remove_all(dip);
+		(void) ndi_devi_free(dip);
+		rv = NDI_FAILURE;
+		goto out;
+	}
+
+	devnode->target = target;
+	devnode->lun = lun;
+	devnode->dip = dip;
+	devnode->pdip = pdip;
+	list_insert_tail(&sc->hs_devnodes, devnode);
+
+	if (childp != NULL)
+		*childp = dip;
+
+	rv = NDI_SUCCESS;
+out:
+	if (nodename != NULL)
+		scsi_hba_nodename_compatible_free(nodename, compatible);
+	return (rv);
+}
+
+static int
+storvsc_config_all(dev_info_t *pdip, storvsc_softc_t *sc)
+{
+	int target, lun;
+
+	for (target = 0; target < STORVSC_MAX_TARGETS; target++) {
+		for (lun = 0; lun < STORVSC_MAX_LUNS_PER_TARGET; lun++) {
+			/* ndi_devi_enter is done in storvsc_bus_config */
+			(void) storvsc_config_one(pdip, sc, target, lun, NULL);
+		}
+	}
+
+	return (NDI_SUCCESS);
+}
+
+static int
+storvsc_parse_devname(char *devname, int *target, int *lun)
+{
+	char cname[SCSI_MAXNAMELEN];
+	char *ptr;
+	char *tgtp = NULL;
+	char *lunp = NULL;
+	char *name, *addr;
+	int ret = NDI_SUCCESS;
+	long num;
+
+	if (target == NULL || lun == NULL)
+		return (NDI_FAILURE);
+
+	(void) strlcpy(cname, devname, sizeof (cname));
+	/* split name into "name@addr" */
+	i_ddi_parse_name(cname, &name, &addr, NULL);
+
+	tgtp = addr;
+	if ((ptr = strchr(addr, ',')) != NULL) {
+		lunp = ptr + 1;
+		ptr = '\0';
+	}
+
+	if (tgtp != NULL) {
+		(void) ddi_strtol(tgtp, NULL, 0x10, &num);
+		*target = num;
+	} else {
+		ret = NDI_FAILURE;
+	}
+
+	if (lunp != NULL) {
+		(void) ddi_strtol(lunp, NULL, 0x10, &num);
+		*lun = num;
+	} else {
+		ret = NDI_FAILURE;
+	}
+	return (ret);
+}
+
+static int
+storvsc_bus_config(dev_info_t *pdip, uint_t flags, ddi_bus_config_op_t op,
+    void *arg, dev_info_t **childp)
+{
+	scsi_hba_tran_t *tran;
+	storvsc_softc_t	*sc;
+	int circ;
+	int ret = NDI_FAILURE;
+	int target = 0, lun = 0;
+
+	tran = ddi_get_driver_private(pdip);
+	sc = tran->tran_hba_private;
+
+	ndi_devi_enter(pdip, &circ);
+	switch (op) {
+	case BUS_CONFIG_ONE:
+		if (storvsc_parse_devname(arg, &target, &lun) != NDI_SUCCESS) {
+			return (NDI_FAILURE);
+		}
+		ret = storvsc_config_one(pdip, sc, target, lun, childp);
+		break;
+	case BUS_CONFIG_DRIVER:
+	case BUS_CONFIG_ALL:
+		ret = storvsc_config_all(pdip, sc);
+		break;
+	default:
+		break;
+	}
+
+	if (ret == NDI_SUCCESS)
+		ret = ndi_busop_bus_config(pdip, flags, op, arg, childp, 0);
+	ndi_devi_exit(pdip, circ);
+	return (ret);
+}
+
+
+/* ARGSUSED hba_dip tgt_dip hba_tran */
+static int
+storvsc_tgt_init(dev_info_t *hba_dip, dev_info_t *tgt_dip,
+    scsi_hba_tran_t *hba_tran, struct scsi_device *sd)
+{
+	storvsc_softc_t *sc = SDEV2PRIV(sd);
+
+	ASSERT3P(sc, !=, NULL);
+
+	if (sd->sd_address.a_lun >= sc->hs_num_luns ||
+	    sd->sd_address.a_target >= STORVSC_MAX_TARGETS)
+		return (DDI_FAILURE);
+
+	return (DDI_SUCCESS);
+}
+
+/* ARGSUSED hba_dip tgt_dip hba_tran sd */
+static void
+storvsc_tgt_free(dev_info_t *hba_dip, dev_info_t *tgt_dip,
+    scsi_hba_tran_t *hba_tran, struct scsi_device *sd)
+{
+}
+
+static int
+storvsc_hba_setup(storvsc_softc_t *sc)
+{
+	scsi_hba_tran_t *hba_tran;
+	int		tran_flags;
+
+	hba_tran = sc->hs_tran = scsi_hba_tran_alloc(sc->hs_dip,
+	    SCSI_HBA_CANSLEEP);
+	ASSERT(sc->hs_tran != NULL);
+
+	hba_tran->tran_hba_private = sc;
+	hba_tran->tran_tgt_private = NULL;
+
+	hba_tran->tran_tgt_init = storvsc_tgt_init;
+	hba_tran->tran_tgt_free = storvsc_tgt_free;
+	hba_tran->tran_tgt_probe = scsi_hba_probe;
+
+	hba_tran->tran_start = storvsc_start;
+	hba_tran->tran_reset = storvsc_reset;
+	hba_tran->tran_abort = storvsc_abort;
+	hba_tran->tran_getcap = storvsc_getcap;
+	hba_tran->tran_setcap = storvsc_setcap;
+	hba_tran->tran_init_pkt = storvsc_init_pkt;
+	hba_tran->tran_destroy_pkt = storvsc_destroy_pkt;
+
+	hba_tran->tran_dmafree = storvsc_dmafree;
+	hba_tran->tran_sync_pkt = storvsc_sync_pkt;
+	hba_tran->tran_reset_notify = storvsc_reset_notify;
+
+	hba_tran->tran_quiesce = NULL;
+	hba_tran->tran_unquiesce = NULL;
+	hba_tran->tran_bus_reset = NULL;
+
+	hba_tran->tran_add_eventcall = NULL;
+	hba_tran->tran_get_eventcookie = NULL;
+	hba_tran->tran_post_event = NULL;
+	hba_tran->tran_remove_eventcall = NULL;
+
+	hba_tran->tran_bus_config = storvsc_bus_config;
+
+	hba_tran->tran_interconnect_type = INTERCONNECT_SAS;
+
+	tran_flags = (SCSI_HBA_TRAN_SCB | SCSI_HBA_TRAN_CDB |
+	    SCSI_HBA_TRAN_CLONE);
+
+	if (scsi_hba_attach_setup(sc->hs_dip, &storvsc_io_dma_attr,
+	    hba_tran, tran_flags) != DDI_SUCCESS) {
+		HS_WARN(sc->hs_dip, "failed to attach HBA");
+		scsi_hba_tran_free(hba_tran);
+		sc->hs_tran = NULL;
+		return (-1);
+	}
+
+	return (DDI_SUCCESS);
+}
+
+static void
+storvsc_init_kstat(storvsc_softc_t *sc)
+{
+	int	ndata;
+	storvsc_stats_t *sp = NULL;
+	char name[32] = { 0 };
+
+	ndata = (sizeof (storvsc_stats_t) /
+	    sizeof (kstat_named_t)) - MAXCPU;
+	ndata += sc->hs_nchan;
+
+	mutex_enter(&sc->hs_lock);
+	sc->hs_stats = kstat_create("storvsc", ddi_get_instance(sc->hs_dip),
+	    "vscstats", "misc", KSTAT_TYPE_NAMED, ndata, 0);
+
+	if (sc->hs_stats == NULL) {
+		HS_WARN(sc->hs_dip,
+		    "%s: Failed to create kstats", __func__);
+		mutex_exit(&sc->hs_lock);
+		return;
+	}
+
+	sp = (storvsc_stats_t *)sc->hs_stats->ks_data;
+	kstat_named_init(&sp->vscstat_reads, "reads", KSTAT_DATA_UINT64);
+	kstat_named_init(&sp->vscstat_writes, "writes", KSTAT_DATA_UINT64);
+	kstat_named_init(&sp->vscstat_non_rw, "other", KSTAT_DATA_UINT64);
+	kstat_named_init(&sp->vscstat_timeouts, "timeouts", KSTAT_DATA_UINT64);
+	kstat_named_init(&sp->vscstat_pending, "pending", KSTAT_DATA_UINT64);
+	for (int i = 0; i < sc->hs_nchan; i++) {
+		struct vmbus_channel *chanp = sc->hs_sel_chan[i];
+		if (chanp != NULL) {
+			(void) snprintf(name, sizeof (name), "%s.%d", "chan",
+			    vmbus_chan_id(chanp));
+			kstat_named_init(&sp->vscstat_chansend[i], name,
+			    KSTAT_DATA_UINT64);
+		}
+	}
+	sc->hs_stats->ks_private = sc;
+	sc->hs_stats->ks_update = nulldev;
+
+	kstat_install(sc->hs_stats);
+	mutex_exit(&sc->hs_lock);
+}
+
+/*
+ * @brief StorVSC attach function
+ *
+ * Function responsible for allocating per-device structures,
+ * setting up SCSA interfaces and scanning for available LUNs to
+ * be used for SCSI device peripherals.
+ *
+ * @param a device
+ * @returns 0 on success or an error on failure
+ */
+static int
+storvsc_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	int instance, ret;
+	storvsc_softc_t	*sc;
+	enum hv_storage_type stor_type;
+
+	stor_type = storvsc_get_storage_type(dip);
+	if (stor_type == DRIVER_UNKNOWN)
+		return (ENODEV);
+
+	/* Invoke iport attach if this is an iport node */
+	if (scsi_hba_iport_unit_address(dip) != NULL)
+		return (DDI_SUCCESS);
+
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:
+	default:
+		return (DDI_FAILURE);
+	}
+
+	instance = ddi_get_instance(dip);
+
+	/* Allocate softstate information */
+	if (ddi_soft_state_zalloc(storvsc_sstate, instance) != DDI_SUCCESS) {
+		cmn_err(CE_WARN,
+		    "ddi_soft_state_zalloc() failed for instance %d", instance);
+		return (DDI_FAILURE);
+	}
+
+	if ((sc = ddi_get_soft_state(storvsc_sstate, instance)) == NULL) {
+		cmn_err(CE_WARN, "failed to get soft state for instance %d",
+		    instance);
+		goto fail;
+	}
+	HS_DEBUG(dip, 1, "Attaching storvsc: Allocated softstate");
+
+	/*
+	 * Indicate that we are 'sizeof (scsi_*(9S))' clean, we use
+	 * scsi_pkt_size() instead.
+	 */
+	scsi_size_clean(dip);
+
+	/* Setup HBA instance */
+	sc->hs_instance = instance;
+	sc->hs_dip = dip;
+	sc->hs_num_luns = STORVSC_MAX_LUNS_PER_TARGET;
+	mutex_init(&sc->hs_lock, "storvsc instance mutex", MUTEX_DRIVER, NULL);
+	list_create(&sc->hs_devnodes, sizeof (storvsc_device_t),
+	    offsetof(storvsc_device_t, list));
+
+	sc->hs_nchan = 1;
+	sc->hs_chan = vmbus_get_channel(sc->hs_dip);
+	ASSERT3P(sc->hs_chan, !=, NULL);
+
+	/* fill in driver specific properties */
+	sc->hs_drv_props = &g_drv_props_table[stor_type];
+	hv_storvsc_ringbuffer_size = (64 * PAGESIZE);
+	sc->hs_drv_props->drv_ringbuffer_size = hv_storvsc_ringbuffer_size;
+
+	if ((storvsc_init_requests(sc)) != DDI_SUCCESS) {
+		HS_WARN(sc->hs_dip, "failed to create request cache");
+		goto fail;
+	}
+
+	sc->hs_destroy = B_FALSE;
+	sc->hs_drain_notify = B_FALSE;
+	sema_init(&sc->hs_drain_sema, 0, ("stor_synch_sema"),
+	    SEMA_DRIVER, NULL);
+
+	ret = hv_storvsc_connect_vsp(sc);
+	if (ret != 0)
+		goto free_cache;
+	HS_DEBUG(sc->hs_dip, 1, "Attaching storvsc: connected to vsp");
+
+	/* Construct cpu to channel mapping */
+	storvsc_create_chan_sel(sc);
+
+	/* OS specific scsi configuration */
+	HS_DEBUG(sc->hs_dip, 1, "Attaching storvsc: setup io");
+
+	if (storvsc_hba_setup(sc) != 0) {
+		HS_WARN(sc->hs_dip, "failed to setup HBA");
+		goto free_cache;
+	}
+	HS_DEBUG(sc->hs_dip, 1, "Attaching storvsc: hba setup done.");
+
+	storvsc_init_kstat(sc);
+
+	ddi_report_dev(sc->hs_dip);
+	return (DDI_SUCCESS);
+
+free_cache:
+	storvsc_fini_requests(sc);
+fail:
+	ddi_soft_state_free(storvsc_sstate, instance);
+
+	return (DDI_FAILURE);
+}
+
+
+static int
+storvsc_ioctl(dev_t dev, int cmd, intptr_t data, int mode, cred_t *credp,
+    int *rval)
+{
+	int		ret;
+
+	if (ddi_get_soft_state(storvsc_sstate, getminor(dev)) == NULL) {
+		cmn_err(CE_WARN, "invalid device instance: %d", getminor(dev));
+		return (ENXIO);
+	}
+
+	/* Try to handle command in a common way */
+	if ((ret = scsi_hba_ioctl(dev, cmd, data, mode, credp, rval)) != ENOTTY)
+		return (ret);
+
+	cmn_err(CE_WARN, "unsupported IOCTL command: 0x%X", cmd);
+
+	return (ENXIO);
+}
+
+int
+_init(void)
+{
+	int	status;
+
+	if ((status = ddi_soft_state_init(&storvsc_sstate,
+	    sizeof (struct storvsc_softc), HS_MAX_ADAPTERS)) != 0) {
+		cmn_err(CE_WARN, "ddi_soft_state_init() failed");
+		return (status);
+	}
+
+	if ((status = scsi_hba_init(&modlinkage)) != 0) {
+		cmn_err(CE_WARN, "scsi_hba_init() failed");
+		ddi_soft_state_fini(&storvsc_sstate);
+		return (status);
+	}
+
+	if ((status = mod_install(&modlinkage)) != 0) {
+		cmn_err(CE_WARN, "mod_install() failed");
+		ddi_soft_state_fini(&storvsc_sstate);
+		scsi_hba_fini(&modlinkage);
+	}
+
+	return (status);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+
+	return (mod_info(&modlinkage, modinfop));
+}
+
+int
+_fini(void)
+{
+	int	status;
+
+	if ((status = mod_remove(&modlinkage)) == 0) {
+		ddi_soft_state_fini(&storvsc_sstate);
+		scsi_hba_fini(&modlinkage);
+	}
+
+	return (status);
+}
+
+
+/*
+ * @brief StorVSC device detach function
+ *
+ * This function is responsible for safely detaching a
+ * StorVSC device.  This includes waiting for inbound responses
+ * to complete and freeing associated per-device structures.
+ *
+ * @param dev a device
+ * returns 0 on success
+ */
+static int
+storvsc_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	int instance;
+	storvsc_softc_t *sc;
+
+	switch (cmd) {
+	case DDI_DETACH:
+		break;
+	case DDI_SUSPEND:
+	default:
+		return (DDI_FAILURE);
+	}
+
+	instance = ddi_get_instance(dip);
+	if ((sc = ddi_get_soft_state(storvsc_sstate, instance)) == NULL) {
+		HS_WARN(dip, "failed to get soft state for instance %d",
+		    instance);
+		return (DDI_FAILURE);
+	}
+
+	mutex_enter(&sc->hs_lock);
+	sc->hs_destroy = B_TRUE;
+
+	/*
+	 * At this point, all outbound traffic should be disabled. We
+	 * only allow inbound traffic (responses) to proceed so that
+	 * outstanding requests can be completed.
+	 */
+
+	sc->hs_drain_notify = B_TRUE;
+	sema_p(&sc->hs_drain_sema);
+	sc->hs_drain_notify = B_FALSE;
+
+	/*
+	 * Since we have already drained, we don't need to busy wait.
+	 * The call to close the channel will reset the callback
+	 * under the protection of the incoming channel lock.
+	 */
+
+	vmbus_chan_close(sc->hs_chan);
+
+	storvsc_fini_requests(sc);
+
+	kstat_delete(sc->hs_stats);
+	mutex_exit(&sc->hs_lock);
+	ddi_soft_state_free(storvsc_sstate, instance);
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * @brief timeout handler for requests
+ *
+ * This function is called as a result of a callout expiring.
+ *
+ * @param arg pointer to a request
+ */
+static void
+storvsc_timeout(void *arg)
+{
+	struct hv_storvsc_request *reqp = arg;
+	storvsc_cmd_t *cmd = &reqp->hvs_cmd;
+	struct storvsc_softc *sc = cmd->cmd_sc;
+	struct scsi_pkt *pkt = reqp->pkt;
+
+	HS_WARN(sc->hs_dip,
+	    "IO (reqp = 0x%p) did not return for %u seconds.",
+	    (void *)reqp, pkt->pkt_time);
+	VSC_INCR_STAT(sc, vscstat_timeouts);
+}
+
+static void
+storvsc_scsi_good_cmd(storvsc_cmd_t *cmd, uint8_t status)
+{
+	struct scsi_pkt *pkt = CMD2PKT(cmd);
+
+	pkt->pkt_state |= (STATE_GOT_BUS | STATE_GOT_TARGET | STATE_SENT_CMD |
+	    STATE_GOT_STATUS);
+	if (cmd->cmd_flags & (STORVSC_FLAG_DMA_VALID))
+		pkt->pkt_state |= STATE_XFERRED_DATA;
+	pkt->pkt_reason = CMD_CMPLT;
+	pkt->pkt_resid = 0;
+	*(pkt->pkt_scbp) = status;
+}
+
+#define	SHORT_INQUIRY_LENGTH    36
+
+static uint32_t
+is_scsi_valid(const struct scsi_inquiry *inq)
+{
+	if ((inq->inq_dtype & DTYPE_MASK) == DTYPE_UNKNOWN)
+		return (0);
+	if ((inq->inq_dtype & DPQ_MASK) == DPQ_NEVER)
+		return (0);
+	return (1);
+}
+
+/*
+ * completion function before returning to SCSA
+ *
+ * I/O process has been completed and the result needs
+ * to be passed to the SCSA layer.
+ * Free resources related to this request.
+ *
+ * @param reqp pointer to a request structure
+ */
+static void
+storvsc_io_done(struct hv_storvsc_request *reqp)
+{
+	struct vmscsi_req *vm_srb = &reqp->vstor_packet.u.vm_srb;
+	storvsc_cmd_t *cmd = &reqp->hvs_cmd;
+	struct scsi_pkt *pkt = CMD2PKT(cmd);
+	dev_info_t *dip = cmd->cmd_sc->hs_dip;
+	uchar_t scsi_status = (vm_srb->scsi_status & STORVSC_STATUS_MASK);
+
+	if (reqp->timeout_id)
+		(void) untimeout(reqp->timeout_id);
+
+	/* XXX - what if the pkt was freed? */
+	if (pkt->pkt_state & STATE_GOT_STATUS) {
+		HS_NOTE(dip, "%s: cmd 0x%x, I/O was already handled, "
+		    "dropping it", __func__, pkt->pkt_cdbp[0]);
+		return;
+	}
+
+	*(pkt->pkt_scbp) = scsi_status;
+	int srb_status = SRB_STATUS(vm_srb->srb_status);
+	switch (scsi_status) {
+		case STATUS_GOOD:
+			if (srb_status != SRB_STATUS_SUCCESS) {
+				/*
+				 * If there are errors, for example, invalid
+				 * LUN, host will inform VM through SRB status.
+				 */
+				if (srb_status == SRB_STATUS_INVALID_LUN) {
+					HS_DEBUG(dip, 6,
+					    "invalid LUN %d for op: 0x%x",
+					    vm_srb->lun, pkt->pkt_cdbp[0]);
+				} else {
+					HS_WARN(dip,
+					    "Unknown SRB flag: 0x%x for op: "
+					    "0x%x", srb_status,
+					    pkt->pkt_cdbp[0]);
+				}
+
+				/*
+				 * XXX For a selection timeout, all of the LUNs
+				 * on the target will be gone.  It works for
+				 * SCSI disks, but does not work for IDE disks.
+				 *
+				 * For CMD_DEV_GONE, it will only get
+				 * rid of the device(s) specified by the path.
+				 */
+				if (storvsc_get_storage_type(dip) ==
+				    DRIVER_STORVSC) {
+					pkt->pkt_reason = CMD_TIMEOUT;
+					cmd->cmd_flags |=
+					    STORVSC_FLAG_TIMED_OUT;
+				} else {
+					pkt->pkt_reason = CMD_DEV_GONE;
+					cmd->cmd_flags |= STORVSC_FLAG_DEV_GONE;
+				}
+			} else {
+				storvsc_scsi_good_cmd(cmd, STATUS_GOOD);
+			}
+
+			if ((pkt->pkt_cdbp != NULL) &&
+			    (pkt->pkt_cdbp[0] == SCMD_INQUIRY) &&
+			    (pkt->pkt_cdbp[1] == 0) &&
+			    (pkt->pkt_cdbp[2] == 0) &&
+			    srb_status == SRB_STATUS_SUCCESS) {
+				int resp_xfer_len, resp_buf_len, data_len;
+				buf_t *bp = cmd->cmd_bp;
+				bp_mapin(bp);
+
+				struct scsi_inquiry *inq =
+				    (struct scsi_inquiry *)bp->b_un.b_addr;
+				uint8_t *resp_buf = (uint8_t *)bp->b_un.b_addr;
+
+				/* Get the buffer length reported by host */
+				resp_xfer_len = vm_srb->transfer_len;
+				/* Get the available buffer length */
+				resp_buf_len = resp_xfer_len >= 5 ?
+				    resp_buf[4] + 5 : 0;
+				data_len = (resp_buf_len < resp_xfer_len) ?
+				    resp_buf_len : resp_xfer_len;
+				if (data_len >= 5) {
+					HS_DEBUG(dip, 6, "?storvsc "
+					    "inquiry (%d) [%x %x %x %x %x "
+					    "... ]",
+					    data_len, resp_buf[0],
+					    resp_buf[1], resp_buf[2],
+					    resp_buf[3], resp_buf[4]);
+				}
+				/*
+				 * XXX: Manually fix the wrong response
+				 * returned from WS2012
+				 */
+				if (!is_scsi_valid(inq) &&
+				    (vmstor_proto_version ==
+				    VMSTOR_PROTOCOL_VERSION_WIN8_1 ||
+				    vmstor_proto_version ==
+				    VMSTOR_PROTOCOL_VERSION_WIN8 ||
+				    vmstor_proto_version ==
+				    VMSTOR_PROTOCOL_VERSION_WIN7)) {
+					if (data_len >= 4 &&
+					    (resp_buf[2] == 0 ||
+					    resp_buf[3] == 0)) {
+						/*
+						 * SPC-3
+						 */
+						inq->inq_ansi = RDF_SCSI_SPC3;
+						inq->inq_rdf = RDF_SCSI2;
+						HS_NOTE(dip, "?storvsc "
+						    "fix version and resp fmt "
+						    "for 0x%x\n",
+						    vmstor_proto_version);
+					}
+				} else if (data_len >= SHORT_INQUIRY_LENGTH) {
+					/*
+					 * XXX: Upgrade SPC2 to SPC3 if host
+					 * is WIN8 or WIN2012 R2 in order to
+					 * support UNMAP feature.
+					 */
+					if (strncmp(
+					    inq->inq_vid, "Msft", 4) == 0 &&
+					    inq->inq_ansi == RDF_SCSI_SPC2 &&
+					    (vmstor_proto_version ==
+					    VMSTOR_PROTOCOL_VERSION_WIN8_1 ||
+					    vmstor_proto_version ==
+					    VMSTOR_PROTOCOL_VERSION_WIN8)) {
+						inq->inq_ansi = RDF_SCSI_SPC3;
+						HS_DEBUG(dip, 5, "storvsc "
+						    "upgrades SPC2 to SPC3");
+					}
+				}
+			}
+			break;
+		case STATUS_CHECK:
+			{
+			struct scsi_arq_status *astat = (void*)(pkt->pkt_scbp);
+			uint8_t		*sensedata;
+			int		arq_size;
+
+			pkt->pkt_state |= STATE_ARQ_DONE;
+
+			if ((vm_srb->srb_status & SRB_STATUS_AUTOSENSE_VALID)
+			    != 0) {
+				arq_size = (cmd->cmd_rqslen >=
+				    sense_buffer_size) ? sense_buffer_size :
+				    cmd->cmd_rqslen;
+
+				astat->sts_rqpkt_resid =  arq_size -
+				    reqp->sense_info_len;
+				astat->sts_rqpkt_resid = sense_buffer_size -
+				    arq_size;
+				sensedata = (uint8_t *)&astat->sts_sensedata;
+				bcopy(cmd->cmd_arq_buf->b_un.b_addr, sensedata,
+				    arq_size);
+
+				pkt->pkt_state |= STATE_XARQ_DONE;
+			} else {
+				astat->sts_rqpkt_resid = 0;
+			}
+
+			astat->sts_rqpkt_statistics = 0;
+			astat->sts_rqpkt_reason = CMD_CMPLT;
+			(*(uint8_t *)&astat->sts_rqpkt_status) = STATUS_GOOD;
+			astat->sts_rqpkt_state  = STATE_GOT_BUS |
+			    STATE_GOT_TARGET | STATE_SENT_CMD |
+			    STATE_XFERRED_DATA | STATE_GOT_STATUS;
+
+			if ((vm_srb->srb_status & SRB_STATUS_SUCCESS) != 0) {
+				cmd->cmd_flags |= STORVSC_FLAG_SRB_ERROR;
+				pkt->pkt_reason = CMD_TRAN_ERR;
+				pkt->pkt_state |= (STATE_GOT_BUS |
+				    STATE_GOT_TARGET | STATE_SENT_CMD |
+				    STATE_GOT_STATUS);
+			} else {
+				storvsc_scsi_good_cmd(cmd,
+				    (vm_srb->scsi_status & 0xFF));
+			}
+			}
+			break;
+		default:
+			HS_WARN(dip, "Command 0x%x failed! "
+			    "status %d, aborting", CMD2PKT(cmd)->pkt_cdbp[0],
+			    vm_srb->scsi_status);
+			/* for now, fail it */
+			cmd->cmd_flags |= STORVSC_FLAG_ABORTED;
+			break;
+	}
+
+	if (reqp->prp_list.gpa_range.gpa_len != 0) {
+		pkt->pkt_resid = reqp->prp_list.gpa_range.gpa_len -
+		    vm_srb->transfer_len;
+		/* INQ hack, seems like host only sends std inq data 36 bytes */
+		if ((pkt->pkt_cdbp[0] == SCMD_INQUIRY) &&
+		    (vm_srb->transfer_len == 36)) {
+			pkt->pkt_resid = 0;
+		}
+	}
+
+	/* TODO:  timeout/retries & frozen (?) */
+	storvsc_complete_command(cmd);
+}
+
+/*
+ * @brief Determine type of storage device from GUID
+ *
+ * Using the type GUID, determine if this is a StorVSC (paravirtual
+ * SCSI or BlkVSC (paravirtual IDE) device.
+ *
+ * @param dev a device
+ * returns an enum
+ */
+static enum hv_storage_type
+storvsc_get_storage_type(dev_info_t *dev)
+{
+	if (vmbus_probe_guid(dev, &gBlkVscDeviceType) == 0)
+		return (DRIVER_BLKVSC);
+	if (vmbus_probe_guid(dev, &gStorVscDeviceType) == 0)
+		return (DRIVER_STORVSC);
+	return (DRIVER_UNKNOWN);
+}

--- a/usr/src/uts/intel/io/hyperv/storvsc/hv_vstorage.h
+++ b/usr/src/uts/intel/io/hyperv/storvsc/hv_vstorage.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2009-2012 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef __HV_VSTORAGE_H__
+#define	__HV_VSTORAGE_H__
+
+/*
+ * Major/minor macros.  Minor version is in LSB, meaning that earlier flat
+ * version numbers will be interpreted as "0.x" (i.e., 1 becomes 0.1).
+ */
+
+#define	VMSTOR_PROTOCOL_MAJOR(VERSION_)		(((VERSION_) >> 8) & 0xff)
+#define	VMSTOR_PROTOCOL_MINOR(VERSION_)		(((VERSION_)) & 0xff)
+#define	VMSTOR_PROTOCOL_VERSION(MAJOR_, MINOR_)	\
+	((((MAJOR_) & 0xff) << 8) | (((MINOR_) & 0xff)))
+
+#define	VMSTOR_PROTOCOL_VERSION_WIN6		VMSTOR_PROTOCOL_VERSION(2, 0)
+#define	VMSTOR_PROTOCOL_VERSION_WIN7		VMSTOR_PROTOCOL_VERSION(4, 2)
+#define	VMSTOR_PROTOCOL_VERSION_WIN8		VMSTOR_PROTOCOL_VERSION(5, 1)
+#define	VMSTOR_PROTOCOL_VERSION_WIN8_1		VMSTOR_PROTOCOL_VERSION(6, 0)
+#define	VMSTOR_PROTOCOL_VERSION_WIN10		VMSTOR_PROTOCOL_VERSION(6, 2)
+/*
+ * Invalid version.
+ */
+#define	VMSTOR_INVALID_PROTOCOL_VERSION  -1
+
+/*
+ * Version history:
+ * V1 Beta                    0.1
+ * V1 RC < 2008/1/31          1.0
+ * V1 RC > 2008/1/31          2.0
+ * Win7: 4.2
+ * Win8: 5.1
+ */
+
+#define	VMSTOR_PROTOCOL_VERSION_CURRENT	VMSTOR_PROTOCOL_VERSION(5, 1)
+
+/*
+ *  Packet structure ops describing virtual storage requests.
+ */
+enum vstor_packet_ops {
+	VSTOR_OPERATION_COMPLETEIO		= 1,
+	VSTOR_OPERATION_REMOVEDEVICE		= 2,
+	VSTOR_OPERATION_EXECUTESRB		= 3,
+	VSTOR_OPERATION_RESETLUN		= 4,
+	VSTOR_OPERATION_RESETADAPTER		= 5,
+	VSTOR_OPERATION_RESETBUS		= 6,
+	VSTOR_OPERATION_BEGININITIALIZATION	= 7,
+	VSTOR_OPERATION_ENDINITIALIZATION	= 8,
+	VSTOR_OPERATION_QUERYPROTOCOLVERSION	= 9,
+	VSTOR_OPERATION_QUERYPROPERTIES		= 10,
+	VSTOR_OPERATION_ENUMERATE_BUS		= 11,
+	VSTOR_OPERATION_FCHBA_DATA		= 12,
+	VSTOR_OPERATION_CREATE_MULTI_CHANNELS	= 13,
+	VSTOR_OPERATION_MAXIMUM			= 13
+};
+
+
+/*
+ *  Platform neutral description of a scsi request -
+ *  this remains the same across the write regardless of 32/64 bit
+ *  note: it's patterned off the Windows DDK SCSI_PASS_THROUGH structure
+ */
+
+#define	CDB16GENERIC_LENGTH			0x10
+#define	SENSE_BUFFER_SIZE			0x14
+#define	MAX_DATA_BUFFER_LENGTH_WITH_PADDING	0x14
+
+#define	POST_WIN7_STORVSC_SENSE_BUFFER_SIZE	0x14
+#define	PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE	0x12
+
+
+struct vmscsi_win8_extension {
+	/*
+	 * The following were added in Windows 8
+	 */
+	uint16_t reserve;
+	uint8_t  queue_tag;
+	uint8_t  queue_action;
+	uint32_t srb_flags;
+	uint32_t time_out_value;
+	uint32_t queue_sort_ey;
+} __packed;
+
+struct vmscsi_req {
+	uint16_t length;
+	uint8_t  srb_status;
+	uint8_t  scsi_status;
+
+	/* HBA number, set to the order number detected by initiator. */
+	uint8_t  port;
+	/* SCSI bus number or bus_id, different from CAM's path_id. */
+	uint8_t  path_id;
+
+	uint8_t  target_id;
+	uint8_t  lun;
+
+	uint8_t  cdb_len;
+	uint8_t  sense_info_len;
+	uint8_t  data_in;
+	uint8_t  reserved;
+
+	uint32_t transfer_len;
+
+	union {
+		uint8_t cdb[CDB16GENERIC_LENGTH];
+
+		uint8_t sense_data[SENSE_BUFFER_SIZE];
+
+		uint8_t reserved_array[MAX_DATA_BUFFER_LENGTH_WITH_PADDING];
+	} u;
+
+	/*
+	 * The following was added in win8.
+	 */
+	struct vmscsi_win8_extension win8_extension;
+
+} __packed;
+
+/*
+ *  This structure is sent during the initialization phase to get the different
+ *  properties of the channel.
+ */
+
+struct vmstor_chan_props {
+	uint16_t proto_ver;
+	uint8_t  path_id;
+	uint8_t  target_id;
+
+	uint16_t max_channel_cnt;
+
+	/*
+	 * Note: port number is only really known on the client side
+	 */
+	uint16_t port;
+	uint32_t flags;
+	uint32_t max_transfer_bytes;
+
+	/*
+	 *  This id is unique for each channel and will correspond with
+	 *  vendor specific data in the inquiry_ata
+	 */
+	uint64_t unique_id;
+
+} __packed;
+
+/*
+ *  This structure is sent during the storage protocol negotiations.
+ */
+
+struct vmstor_proto_ver
+{
+	/*
+	 * Major (MSW) and minor (LSW) version numbers.
+	 */
+	uint16_t major_minor;
+
+	uint16_t revision;			/* always zero */
+} __packed;
+
+/*
+ * Channel Property Flags
+ */
+
+#define	STORAGE_CHANNEL_REMOVABLE_FLAG		0x1
+#define	STORAGE_CHANNEL_EMULATED_IDE_FLAG	0x2
+
+
+struct vstor_packet {
+	/*
+	 * Requested operation type
+	 */
+	enum vstor_packet_ops operation;
+
+	/*
+	 * Flags - see below for values
+	 */
+	uint32_t flags;
+
+	/*
+	 * Status of the request returned from the server side.
+	 */
+	uint32_t status;
+
+	union
+	{
+		/*
+		 * Structure used to forward SCSI commands from the client to
+		 * the server.
+		 */
+		struct vmscsi_req vm_srb;
+
+		/*
+		 * Structure used to query channel properties.
+		 */
+		struct vmstor_chan_props chan_props;
+
+		/*
+		 * Used during version negotiations.
+		 */
+		struct vmstor_proto_ver version;
+
+		/*
+		 * Number of multichannels to create
+		 */
+		uint16_t multi_channels_cnt;
+	} u;
+
+} __packed;
+
+
+/*
+ * SRB (SCSI Request Block) Status Codes
+ */
+#define	SRB_STATUS_PENDING		0x00
+#define	SRB_STATUS_SUCCESS		0x01
+#define	SRB_STATUS_ABORTED		0x02
+#define	SRB_STATUS_ERROR		0x04
+#define	SRB_STATUS_INVALID_LUN		0X20
+
+/*
+ * SRB Status Masks (can be combined with above status codes)
+ */
+#define	SRB_STATUS_QUEUE_FROZEN		0x40
+#define	SRB_STATUS_AUTOSENSE_VALID	0x80
+
+#define	SRB_STATUS(status)	\
+	((status) & ~(SRB_STATUS_AUTOSENSE_VALID | SRB_STATUS_QUEUE_FROZEN))
+
+/*
+ * SRB Flag Bits
+ */
+
+#define	SRB_FLAGS_QUEUE_ACTION_ENABLE		0x00000002
+#define	SRB_FLAGS_DISABLE_DISCONNECT		0x00000004
+#define	SRB_FLAGS_DISABLE_SYNCH_TRANSFER	0x00000008
+#define	SRB_FLAGS_BYPASS_FROZEN_QUEUE		0x00000010
+#define	SRB_FLAGS_DISABLE_AUTOSENSE		0x00000020
+#define	SRB_FLAGS_DATA_IN			0x00000040
+#define	SRB_FLAGS_DATA_OUT			0x00000080
+#define	SRB_FLAGS_NO_DATA_TRANSFER		0x00000000
+#define	SRB_FLAGS_UNSPECIFIED_DIRECTION	(SRB_FLAGS_DATA_IN | SRB_FLAGS_DATA_OUT)
+#define	SRB_FLAGS_NO_QUEUE_FREEZE		0x00000100
+#define	SRB_FLAGS_ADAPTER_CACHE_ENABLE		0x00000200
+#define	SRB_FLAGS_FREE_SENSE_BUFFER		0x00000400
+/*
+ *  Packet flags
+ */
+
+/*
+ *  This flag indicates that the server should send back a completion for this
+ *  packet.
+ */
+#define	REQUEST_COMPLETION_FLAG	0x1
+
+/*
+ *  This is the set of flags that the vsc can set in any packets it sends
+ */
+#define	VSC_LEGAL_FLAGS (REQUEST_COMPLETION_FLAG)
+
+#endif /* __HV_VSTORAGE_H__ */

--- a/usr/src/uts/intel/io/hyperv/sys/hyperv.h
+++ b/usr/src/uts/intel/io/hyperv/sys/hyperv.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _SYS_HYPERV_H
+#define	_SYS_HYPERV_H
+
+#include <sys/hyperv_illumos.h>
+
+#define	MSR_HV_TIME_REF_COUNT		0x40000020
+
+#define	CPUID_HV_MSR_TIME_REFCNT	0x0002	/* MSR_HV_TIME_REF_COUNT */
+#define	CPUID_HV_MSR_SYNIC		0x0004	/* MSRs for SynIC */
+#define	CPUID_HV_MSR_SYNTIMER		0x0008	/* MSRs for SynTimer */
+#define	CPUID_HV_MSR_APIC		0x0010	/* MSR_HV_{EOI,ICR,TPR} */
+/* MSR_HV_GUEST_OS_ID MSR_HV_HYPERCALL */
+#define	CPUID_HV_MSR_HYPERCALL		0x0020
+#define	CPUID_HV_MSR_VP_INDEX		0x0040	/* MSR_HV_VP_INDEX */
+#define	CPUID_HV_MSR_GUEST_IDLE		0x0400	/* MSR_HV_GUEST_IDLE */
+
+#define	HYPERV_TIMER_NS_FACTOR		100ULL
+#define	HYPERV_TIMER_FREQ		(NANOSEC / HYPERV_TIMER_NS_FACTOR)
+
+struct hyperv_guid {
+	uint8_t		hv_guid[16];
+} __packed;
+
+#define	HYPERV_GUID_STRLEN	40
+
+int		hyperv_guid2str(const struct hyperv_guid *, char *, size_t);
+
+extern uint_t	hyperv_features;	/* CPUID_HV_MSR_ */
+
+#endif /* _SYS_HYPERV_H */

--- a/usr/src/uts/intel/io/hyperv/sys/hyperv_busdma.h
+++ b/usr/src/uts/intel/io/hyperv/sys/hyperv_busdma.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HYPERV_BUSDMA_H_
+#define	_HYPERV_BUSDMA_H_
+
+#include <sys/inttypes.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/ddi_impldefs.h>
+
+typedef struct hyperv_dma {
+	caddr_t			hv_vaddr;
+	paddr_t			hv_paddr; /* bus address */
+	ddi_dma_handle_t	hv_dmah; /* hv_dtag */
+	ddi_acc_handle_t	hv_acch;
+	ddi_dma_cookie_t	hv_dmac;
+} hv_dma_t;
+
+
+caddr_t		hyperv_dmamem_alloc(dev_info_t *dip, uint64_t alignment,
+		    uint64_t boundary, size_t size, hv_dma_t *dma,
+		    int dma_flags);
+void		hyperv_dmamem_free(hv_dma_t *dma);
+
+#endif	/* !_HYPERV_BUSDMA_H_ */

--- a/usr/src/uts/intel/io/hyperv/sys/hyperv_illumos.h
+++ b/usr/src/uts/intel/io/hyperv/sys/hyperv_illumos.h
@@ -1,0 +1,92 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HYPERV_ILLUMOS_H
+#define	_HYPERV_ILLUMOS_H
+
+#include <sys/mutex.h>
+#include <sys/semaphore.h>
+#include <sys/queue.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/ddi_impldefs.h>
+
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#include <sys/ccompile.h>
+#include <sys/param.h>
+#include <sys/dditypes.h>
+
+#define	PAGE_SIZE	PAGESIZE
+#define	PAGE_SHIFT	PAGESHIFT
+/*
+ * hyperv driver's soft state structure
+ */
+typedef struct hyperv_state {
+	dev_info_t	*dip;	/* dev_info */
+} hv_state_t;
+
+
+#define	__packed	__attribute__((packed))
+#define	__aligned(x)	__attribute__((__aligned__(x)))
+
+#define	CACHE_LINE_SIZE	64
+
+/*
+ * GNU C version 2.96 adds explicit branch prediction so that
+ * the CPU back-end can hint the processor and also so that
+ * code blocks can be reordered such that the predicted path
+ * sees a more linear flow, thus improving cache behavior, etc.
+ *
+ * The following two macros provide us with a way to utilize this
+ * compiler feature.  Use __predict_true() if you expect the expression
+ * to evaluate to true, and __predict_false() if you expect the
+ * expression to evaluate to false.
+ *
+ * A few notes about usage:
+ *
+ *	* Generally, __predict_false() error condition checks (unless
+ *	  you have some _strong_ reason to do otherwise, in which case
+ *	  document it), and/or __predict_true() `no-error' condition
+ *	  checks, assuming you want to optimize for the no-error case.
+ *
+ *	* Other than that, if you don't know the likelihood of a test
+ *	  succeeding from empirical or other `hard' evidence, don't
+ *	  make predictions.
+ *
+ *	* These are meant to be used in places that are run `a lot'.
+ *	  It is wasteful to make predictions in code that is run
+ *	  seldomly (e.g. at subsystem initialization time) as the
+ *	  basic block reordering that this affects can often generate
+ *	  larger code.
+ */
+#if defined(__GNUC__)
+#define	__predict_true(exp)	__builtin_expect((exp), 1)
+#define	__predict_false(exp)	__builtin_expect((exp), 0)
+#define	__compiler_membar()	__asm__ __volatile__(" " : : : "memory")
+#else
+#define	__predict_true(exp)	(exp)
+#define	__predict_false(exp)	(exp)
+#define	__compiler_membar()
+#endif
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif	/* _HYPERV_ILLUMOS_H */

--- a/usr/src/uts/intel/io/hyperv/sys/hyperv_illumos.h
+++ b/usr/src/uts/intel/io/hyperv/sys/hyperv_illumos.h
@@ -42,9 +42,6 @@ typedef struct hyperv_state {
 } hv_state_t;
 
 
-#define	__packed	__attribute__((packed))
-#define	__aligned(x)	__attribute__((__aligned__(x)))
-
 #define	CACHE_LINE_SIZE	64
 
 /*

--- a/usr/src/uts/intel/io/hyperv/sys/vmbus.h
+++ b/usr/src/uts/intel/io/hyperv/sys/vmbus.h
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_H_
+#define	_VMBUS_H_
+
+#include <sys/param.h>
+#include <sys/ddi_impldefs.h>
+#include <sys/dditypes.h>
+#include <sys/sunddi.h>
+#include <sys/hyperv_illumos.h>
+
+
+/*
+ * VMBUS version is 32 bit, upper 16 bit for major_number and lower
+ * 16 bit for minor_number.
+ *
+ * 0.13  --  Windows Server 2008
+ * 1.1   --  Windows 7
+ * 2.4   --  Windows 8
+ * 3.0   --  Windows 8.1
+ */
+#define	VMBUS_VERSION_WS2008		((0 << 16) | (13))
+#define	VMBUS_VERSION_WIN7		((1 << 16) | (1))
+#define	VMBUS_VERSION_WIN8		((2 << 16) | (4))
+#define	VMBUS_VERSION_WIN8_1		((3 << 16) | (0))
+
+#define	VMBUS_VERSION_MAJOR(ver)	(((uint32_t)(ver)) >> 16)
+#define	VMBUS_VERSION_MINOR(ver)	(((uint32_t)(ver)) & 0xffff)
+
+#define	VMBUS_DEVICEID		"deviceid"
+#define	VMBUS_CLASSID		"classid"
+#define	VMBUS_VERSION		"version"
+#define	VMBUS_STATE		"state"
+#define	VMBUS_STATE_ONLINE	"online"
+#define	VMBUS_STATE_OFFLINE	"offline"
+
+/*
+ * GPA stuffs.
+ */
+struct vmbus_gpa_range {
+	uint32_t	gpa_len;
+	uint32_t	gpa_ofs;
+	uint64_t	gpa_page[];
+} __packed;
+
+/* This is actually vmbus_gpa_range.gpa_page[1] */
+struct vmbus_gpa {
+	uint32_t	gpa_len;
+	uint32_t	gpa_ofs;
+	uint64_t	gpa_page;
+} __packed;
+
+#define	VMBUS_CHANPKT_SIZE_SHIFT	3
+
+#define	VMBUS_CHANPKT_GETLEN(pktlen)	\
+	(((int)(pktlen)) << VMBUS_CHANPKT_SIZE_SHIFT)
+
+struct vmbus_chanpkt_hdr {
+	uint16_t	cph_type;	/* VMBUS_CHANPKT_TYPE_ */
+	uint16_t	cph_hlen;	/* header len, in 8 bytes */
+	uint16_t	cph_tlen;	/* total len, in 8 bytes */
+	uint16_t	cph_flags;	/* VMBUS_CHANPKT_FLAG_ */
+	uint64_t	cph_xactid;
+} __packed;
+
+#define	VMBUS_CHANPKT_TYPE_INBAND	0x0006
+#define	VMBUS_CHANPKT_TYPE_RXBUF	0x0007
+#define	VMBUS_CHANPKT_TYPE_GPA		0x0009
+#define	VMBUS_CHANPKT_TYPE_COMP		0x000b
+
+#define	VMBUS_CHANPKT_FLAG_NONE		0
+#define	VMBUS_CHANPKT_FLAG_RC		0x0001	/* report completion */
+
+#define	VMBUS_CHANPKT_CONST_DATA(pkt)		\
+	(const void *)((const uint8_t *)(pkt) +	\
+	VMBUS_CHANPKT_GETLEN((pkt)->cph_hlen))
+
+/* Include padding */
+#define	VMBUS_CHANPKT_DATALEN(pkt)		\
+	(VMBUS_CHANPKT_GETLEN((pkt)->cph_tlen) -\
+	VMBUS_CHANPKT_GETLEN((pkt)->cph_hlen))
+
+struct vmbus_rxbuf_desc {
+	uint32_t	rb_len;
+	uint32_t	rb_ofs;
+} __packed;
+
+struct vmbus_chanpkt_rxbuf {
+	struct vmbus_chanpkt_hdr cp_hdr;
+	uint16_t	cp_rxbuf_id;
+	uint16_t	cp_rsvd;
+	uint32_t	cp_rxbuf_cnt;
+	struct vmbus_rxbuf_desc cp_rxbuf[];
+} __packed;
+
+struct vmbus_chan_br {
+	void		*cbr;
+	paddr_t		cbr_paddr;
+	int		cbr_txsz;
+	int		cbr_rxsz;
+};
+
+struct vmbus_channel;
+struct vmbus_xact;
+struct vmbus_xact_ctx;
+struct hyperv_guid;
+struct task;
+
+typedef void	(*vmbus_chan_callback_t)(struct vmbus_channel *, void *);
+
+inline struct vmbus_channel *
+vmbus_get_channel(dev_info_t *dev)
+{
+	return (ddi_get_parent_data(dev));
+}
+
+/*
+ * vmbus_chan_open_br()
+ *
+ * Return values:
+ * 0			Succeeded.
+ * EISCONN		Failed, and the memory passed through 'br' is still
+ *			connected.  Callers must _not_ free the the memory
+ *			passed through 'br', if this error happens.
+ * other values		Failed.  The memory passed through 'br' is no longer
+ *			connected.  Callers are free to do anything with the
+ *			memory passed through 'br'.
+ *
+ *
+ *
+ * vmbus_chan_close_direct()
+ *
+ * NOTE:
+ * Callers of this function _must_ make sure to close all sub-channels before
+ * closing the primary channel.
+ *
+ * Return values:
+ * 0			Succeeded.
+ * EISCONN		Failed, and the memory associated with the bufring
+ *			is still connected.  Callers must _not_ free the the
+ *			memory associated with the bufring, if this error
+ *			happens.
+ * other values		Failed.  The memory associated with the bufring is
+ *			no longer connected.  Callers are free to do anything
+ *			with the memory associated with the bufring.
+ */
+int		vmbus_chan_open(struct vmbus_channel *chan,
+		    int txbr_size, int rxbr_size, const void *udata, int udlen,
+		    vmbus_chan_callback_t cb, void *cbarg);
+int		vmbus_chan_open_br(struct vmbus_channel *chan,
+		    const struct vmbus_chan_br *cbr, const void *udata,
+		    int udlen, vmbus_chan_callback_t cb, void *cbarg);
+void		vmbus_chan_close(struct vmbus_channel *chan);
+int		vmbus_chan_close_direct(struct vmbus_channel *chan);
+void		vmbus_chan_intr_drain(struct vmbus_channel *chan);
+void		vmbus_chan_run_task(struct vmbus_channel *chan,
+		    task_func_t *task);
+void		vmbus_chan_set_orphan(struct vmbus_channel *chan,
+		    struct vmbus_xact_ctx *);
+void		vmbus_chan_unset_orphan(struct vmbus_channel *chan);
+const void	*vmbus_chan_xact_wait(const struct vmbus_channel *chan,
+		    struct vmbus_xact *xact, size_t *resp_len,
+		    boolean_t can_sleep);
+
+int		vmbus_chan_gpadl_connect(struct vmbus_channel *chan,
+		    paddr_t paddr, int size, uint32_t *gpadl);
+int		vmbus_chan_gpadl_disconnect(struct vmbus_channel *chan,
+		    uint32_t gpadl);
+
+void		vmbus_chan_cpu_set(struct vmbus_channel *chan, int cpu);
+void		vmbus_chan_cpu_rr(struct vmbus_channel *chan);
+void		vmbus_chan_set_readbatch(struct vmbus_channel *chan,
+		    boolean_t on);
+
+struct vmbus_channel **
+		vmbus_subchan_get(struct vmbus_channel *pri_chan,
+		    int subchan_cnt);
+void		vmbus_subchan_rel(struct vmbus_channel **subchan,
+		    int subchan_cnt);
+void		vmbus_subchan_drain(struct vmbus_channel *pri_chan);
+
+int		vmbus_chan_recv(struct vmbus_channel *chan, void *data,
+		    int *dlen, uint64_t *xactid);
+int		vmbus_chan_recv_pkt(struct vmbus_channel *chan,
+		    struct vmbus_chanpkt_hdr *pkt, int *pktlen);
+
+int		vmbus_chan_send(struct vmbus_channel *chan, uint16_t type,
+		    uint16_t flags, void *data, int dlen, uint64_t xactid);
+int		vmbus_chan_send_sglist(struct vmbus_channel *chan,
+		    struct vmbus_gpa sg[], int sglen, void *data, int dlen,
+		    uint64_t xactid);
+int		vmbus_chan_send_prplist(struct vmbus_channel *chan,
+		    struct vmbus_gpa_range *prp, int prp_cnt, void *data,
+		    int dlen, uint64_t xactid);
+
+uint32_t	vmbus_chan_id(const struct vmbus_channel *chan);
+uint32_t	vmbus_chan_subidx(const struct vmbus_channel *chan);
+boolean_t	vmbus_chan_is_primary(const struct vmbus_channel *chan);
+boolean_t	vmbus_chan_is_revoked(const struct vmbus_channel *chan);
+const struct hyperv_guid *
+		vmbus_chan_guid_inst(const struct vmbus_channel *chan);
+uint32_t	vmbus_get_version(void);
+int		vmbus_probe_guid(dev_info_t *dev,
+		    const struct hyperv_guid *guid);
+int		vmbus_chan_prplist_nelem(int br_size, int prpcnt_max,
+		    int dlen_max);
+boolean_t	vmbus_chan_rx_empty(const struct vmbus_channel *chan);
+boolean_t	vmbus_chan_tx_empty(const struct vmbus_channel *chan);
+ddi_taskq_t *
+		vmbus_chan_mgmt_tq(const struct vmbus_channel *chan);
+
+void		vmbus_walk_children(int (*)(dev_info_t *, void *), void *);
+
+#endif	/* !_VMBUS_H_ */

--- a/usr/src/uts/intel/io/hyperv/sys/vmbus_xact.h
+++ b/usr/src/uts/intel/io/hyperv/sys/vmbus_xact.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_XACT_H_
+#define	_VMBUS_XACT_H_
+
+#include <sys/param.h>
+
+struct vmbus_xact;
+struct vmbus_xact_ctx;
+
+struct vmbus_xact_ctx	*vmbus_xact_ctx_create(dev_info_t *dip,
+			    size_t req_size, size_t resp_size,
+			    size_t priv_size);
+void			vmbus_xact_ctx_destroy(struct vmbus_xact_ctx *ctx);
+boolean_t		vmbus_xact_ctx_orphan(struct vmbus_xact_ctx *ctx);
+
+struct vmbus_xact	*vmbus_xact_get(struct vmbus_xact_ctx *ctx,
+			    size_t req_len);
+void			vmbus_xact_put(struct vmbus_xact *xact);
+
+void			*vmbus_xact_req_data(const struct vmbus_xact *xact);
+paddr_t			vmbus_xact_req_paddr(const struct vmbus_xact *xact);
+void			*vmbus_xact_priv(const struct vmbus_xact *xact,
+			    size_t priv_len);
+void			vmbus_xact_activate(struct vmbus_xact *xact);
+void			vmbus_xact_deactivate(struct vmbus_xact *xact);
+const void		*vmbus_xact_wait(struct vmbus_xact *xact,
+			    size_t *resp_len);
+const void		*vmbus_xact_busywait(struct vmbus_xact *xact,
+			    size_t *resp_len);
+const void		*vmbus_xact_poll(struct vmbus_xact *xact,
+			    size_t *resp_len);
+void			vmbus_xact_wakeup(struct vmbus_xact *xact,
+			    const void *data, size_t dlen);
+void			vmbus_xact_ctx_wakeup(struct vmbus_xact_ctx *ctx,
+			    const void *data, size_t dlen);
+
+#endif	/* !_VMBUS_XACT_H_ */

--- a/usr/src/uts/intel/io/hyperv/utilities/THIRDPARTYLICENSE
+++ b/usr/src/uts/intel/io/hyperv/utilities/THIRDPARTYLICENSE
@@ -1,0 +1,52 @@
+Copyright (c) 2014,2016 Microsoft Corp.
+Copyright (c) 2012 NetApp Inc.
+Copyright (c) 2012 Citrix Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice unmodified, this list of conditions, and the following
+   disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (c) 2007 The NetBSD Foundation, Inc.
+All rights reserved.
+
+This code is derived from software contributed to The NetBSD Foundation
+by Dieter Baron.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/usr/src/uts/intel/io/hyperv/utilities/THIRDPARTYLICENSE.descrip
+++ b/usr/src/uts/intel/io/hyperv/utilities/THIRDPARTYLICENSE.descrip
@@ -1,0 +1,1 @@
+Microsoft Utility drivers

--- a/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
@@ -1,0 +1,1035 @@
+/*
+ * Copyright (c) 2014,2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ *	Author:	Sainath Varanasi.
+ *	Date:	4/2012
+ *	Email:	bsdic@microsoft.com
+ */
+
+#include <sys/param.h>
+#include <sys/conf.h>
+#include <sys/uio.h>
+#include <sys/reboot.h>
+#include <sys/lock.h>
+#include <sys/poll.h>
+#include <sys/proc.h>
+#include <sys/un.h>
+#include <sys/signal.h>
+#include <sys/syslog.h>
+#include <sys/systm.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/mutex.h>
+#include <sys/sunddi.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include "hv_utilreg.h"
+#include "vmbus_icreg.h"
+#include "vmbus_icvar.h"
+
+#include "unicode.h"
+#include "hv_kvp.h"
+
+/* hv_kvp defines */
+#define	BUFFERSIZE	sizeof (struct hv_kvp_msg)
+#define	kvp_hdr		hdr.kvp_hdr
+
+#define	KVP_FWVER_MAJOR		3
+#define	KVP_FWVER		VMBUS_IC_VERSION(KVP_FWVER_MAJOR, 0)
+
+#define	KVP_MSGVER_MAJOR	4
+#define	KVP_MSGVER		VMBUS_IC_VERSION(KVP_MSGVER_MAJOR, 0)
+
+#define	HV_KVP_DAEMON_TIMEOUT	5
+
+enum kvp_debug_level {
+	HV_KVP_LOG_NONE		= 0,
+	HV_KVP_LOG_ERR		= 1,
+	HV_KVP_LOG_INFO		= 2,
+	HV_KVP_LOG_ALL
+};
+
+/*
+ * hv_kvp debug log level
+ */
+int hv_kvp_log = HV_KVP_LOG_ERR;
+
+#define	hv_kvp_log_error(sc, ...) do {					\
+	if (hv_kvp_log >= HV_KVP_LOG_ERR)				\
+		dev_err((sc)->dev, CE_WARN, __VA_ARGS__);	\
+_NOTE(CONSTCOND) } while (0)
+
+#define	hv_kvp_log_info(sc, ...) do {					\
+	if (hv_kvp_log >= HV_KVP_LOG_INFO)				\
+		dev_err((sc)->dev, CE_NOTE, __VA_ARGS__);	\
+_NOTE(CONSTCOND) } while (0)
+
+static void *hv_kvp_state;
+
+/*
+ * Global state to track and synchronize multiple
+ * KVP transaction requests from the host.
+ */
+typedef struct hv_kvp_sc {
+	struct vmbus_ic_softc	util_sc;
+	dev_info_t		*dev;
+
+	/*
+	 * Unless specified the pending mutex should be
+	 * used to alter the values of the following parameters:
+	 * 1. req_in_progress
+	 * 2. req_timed_out
+	 */
+	kmutex_t		pending_mutex;
+
+	/* Used to sleep while waiting for a response from the daemon */
+	kcondvar_t		pending_cv;
+
+	ddi_taskq_t		*requesttq;
+
+	/* To track if transaction is active or not */
+	boolean_t		req_in_progress;
+	/* Tracks if daemon did not reply back in time */
+	boolean_t		req_timed_out;
+	/* Tracks if daemon is serving a request currently */
+	boolean_t		daemon_busy;
+
+	/* Length of host message */
+	uint32_t		host_msg_len;
+
+	/* Host message id */
+	uint64_t		host_msg_id;
+
+	/* Current kvp message from the host */
+	struct hv_kvp_msg	*host_kvp_msg;
+
+	/* Current kvp message for daemon */
+	struct hv_kvp_msg	daemon_kvp_msg;
+
+	/* Rcv buffer for communicating with the host */
+	uint8_t			*rcv_buf;
+
+	/* Device semaphore to control communication */
+	ksema_t			dev_sema;
+
+	/* Indicates if daemon registered with driver */
+	boolean_t		register_done;
+
+	/* Character device status */
+	boolean_t		dev_accessed;
+
+	struct proc		*daemon_task;
+
+	struct pollhead		hv_kvp_pollhead;
+} hv_kvp_sc;
+
+/* hv_kvp prototypes */
+static int	hv_kvp_req_in_progress(hv_kvp_sc *sc);
+static void	hv_kvp_transaction_init(hv_kvp_sc *sc, uint32_t, uint64_t,
+		    uint8_t *);
+static void	hv_kvp_send_msg_to_daemon(hv_kvp_sc *sc);
+static void	hv_kvp_process_request(void *context);
+
+/*
+ * hv_kvp low level functions
+ */
+
+/*
+ * Check if kvp transaction is in progres
+ */
+static int
+hv_kvp_req_in_progress(hv_kvp_sc *sc)
+{
+
+	return (sc->req_in_progress);
+}
+
+
+/*
+ * This routine is called whenever a message is received from the host
+ */
+static void
+hv_kvp_transaction_init(hv_kvp_sc *sc, uint32_t rcv_len,
+    uint64_t request_id, uint8_t *rcv_buf)
+{
+
+	/* Store all the relevant message details in the global structure */
+	/* Do not need to use mutex for req_in_progress here */
+	sc->req_in_progress = B_TRUE;
+	sc->host_msg_len = rcv_len;
+	sc->host_msg_id = request_id;
+	sc->rcv_buf = rcv_buf;
+	sc->host_kvp_msg = (struct hv_kvp_msg *)&rcv_buf[
+	    sizeof (struct hv_vmbus_pipe_hdr) +
+	    sizeof (struct hv_vmbus_icmsg_hdr)];
+}
+
+/*
+ * Convert ip related info in umsg from utf8 to utf16 and store in hmsg
+ */
+static int
+hv_kvp_convert_utf8_ipinfo_to_utf16(struct hv_kvp_msg *umsg,
+    struct hv_kvp_ip_msg *host_ip_msg)
+{
+	int err_ip, err_subnet, err_gway, err_dns, err_adap;
+	int UNUSED_FLAG = 1;
+
+	(void) utf8_to_utf16((uint16_t *)host_ip_msg->kvp_ip_val.ip_addr,
+	    MAX_IP_ADDR_SIZE,
+	    (char *)umsg->body.kvp_ip_val.ip_addr,
+	    strlen((char *)umsg->body.kvp_ip_val.ip_addr),
+	    UNUSED_FLAG,
+	    &err_ip);
+	(void) utf8_to_utf16((uint16_t *)host_ip_msg->kvp_ip_val.sub_net,
+	    MAX_IP_ADDR_SIZE,
+	    (char *)umsg->body.kvp_ip_val.sub_net,
+	    strlen((char *)umsg->body.kvp_ip_val.sub_net),
+	    UNUSED_FLAG,
+	    &err_subnet);
+	(void) utf8_to_utf16((uint16_t *)host_ip_msg->kvp_ip_val.gate_way,
+	    MAX_GATEWAY_SIZE,
+	    (char *)umsg->body.kvp_ip_val.gate_way,
+	    strlen((char *)umsg->body.kvp_ip_val.gate_way),
+	    UNUSED_FLAG,
+	    &err_gway);
+	(void) utf8_to_utf16((uint16_t *)host_ip_msg->kvp_ip_val.dns_addr,
+	    MAX_IP_ADDR_SIZE,
+	    (char *)umsg->body.kvp_ip_val.dns_addr,
+	    strlen((char *)umsg->body.kvp_ip_val.dns_addr),
+	    UNUSED_FLAG,
+	    &err_dns);
+	(void) utf8_to_utf16((uint16_t *)host_ip_msg->kvp_ip_val.adapter_id,
+	    MAX_IP_ADDR_SIZE,
+	    (char *)umsg->body.kvp_ip_val.adapter_id,
+	    strlen((char *)umsg->body.kvp_ip_val.adapter_id),
+	    UNUSED_FLAG,
+	    &err_adap);
+
+	host_ip_msg->kvp_ip_val.dhcp_enabled =
+	    umsg->body.kvp_ip_val.dhcp_enabled;
+	host_ip_msg->kvp_ip_val.addr_family = umsg->body.kvp_ip_val.addr_family;
+
+	return (err_ip | err_subnet | err_gway | err_dns | err_adap);
+}
+
+/*
+ * If the umsg's adapter_id is set to a vmbus networking device, replace the
+ * adapter GUID with its driver binding name.
+ */
+static int
+hv_kvp_walk_netdevs_cb(dev_info_t *dev, void *arg)
+{
+	char *classid;
+	struct hv_kvp_msg *umsg = arg;
+
+	if (strncmp(ddi_get_name(dev), "hv_netvsc", sizeof ("hv_netvsc")) != 0)
+		return (DDI_WALK_CONTINUE);
+
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dev, 0, VMBUS_CLASSID,
+	    &classid) != DDI_PROP_SUCCESS)
+		return (DDI_WALK_CONTINUE);
+	/*
+	 * The string in the 'kvp_ip_val.adapter_id' has
+	 * braces around the GUID; skip the leading brace
+	 * in 'kvp_ip_val.adapter_id'.
+	 */
+	if (strncmp(classid, ((char *)&umsg->body.kvp_ip_val.adapter_id) + 1,
+	    HYPERV_GUID_STRLEN) == 0) {
+		(void) strlcpy((char *)umsg->body.kvp_ip_val.adapter_id,
+		    ddi_get_name(dev), MAX_ADAPTER_ID_SIZE);
+
+		ddi_prop_free(classid);
+		return (DDI_WALK_TERMINATE);
+	}
+
+	ddi_prop_free(classid);
+	return (DDI_WALK_CONTINUE);
+}
+
+/*
+ * Convert ip related info in hmsg from utf16 to utf8 and store in umsg
+ */
+static int
+hv_kvp_convert_utf16_ipinfo_to_utf8(struct hv_kvp_ip_msg *host_ip_msg,
+    struct hv_kvp_msg *umsg)
+{
+	int err_ip, err_subnet, err_gway, err_dns, err_adap;
+	int UNUSED_FLAG = 1;
+
+	/* IP Address */
+	(void) utf16_to_utf8((char *)umsg->body.kvp_ip_val.ip_addr,
+	    MAX_IP_ADDR_SIZE,
+	    (uint16_t *)host_ip_msg->kvp_ip_val.ip_addr,
+	    MAX_IP_ADDR_SIZE,
+	    UNUSED_FLAG,
+	    &err_ip);
+
+	/* Adapter ID : GUID */
+	(void) utf16_to_utf8((char *)umsg->body.kvp_ip_val.adapter_id,
+	    MAX_ADAPTER_ID_SIZE,
+	    (uint16_t *)host_ip_msg->kvp_ip_val.adapter_id,
+	    MAX_ADAPTER_ID_SIZE,
+	    UNUSED_FLAG,
+	    &err_adap);
+
+	/*
+	 * Replace the Adapter ID GUID if the adapter is a vmbus networking
+	 * device.
+	 */
+	vmbus_walk_children(&hv_kvp_walk_netdevs_cb, umsg);
+
+	/* Address Family , DHCP , SUBNET, Gateway, DNS */
+	umsg->kvp_hdr.operation = host_ip_msg->operation;
+	umsg->body.kvp_ip_val.addr_family = host_ip_msg->kvp_ip_val.addr_family;
+	umsg->body.kvp_ip_val.dhcp_enabled =
+	    host_ip_msg->kvp_ip_val.dhcp_enabled;
+	(void) utf16_to_utf8((char *)umsg->body.kvp_ip_val.sub_net,
+	    MAX_IP_ADDR_SIZE, (uint16_t *)host_ip_msg->kvp_ip_val.sub_net,
+	    MAX_IP_ADDR_SIZE,
+	    UNUSED_FLAG,
+	    &err_subnet);
+
+	(void) utf16_to_utf8((char *)umsg->body.kvp_ip_val.gate_way,
+	    MAX_GATEWAY_SIZE, (uint16_t *)host_ip_msg->kvp_ip_val.gate_way,
+	    MAX_GATEWAY_SIZE,
+	    UNUSED_FLAG,
+	    &err_gway);
+
+	(void) utf16_to_utf8((char *)umsg->body.kvp_ip_val.dns_addr,
+	    MAX_IP_ADDR_SIZE, (uint16_t *)host_ip_msg->kvp_ip_val.dns_addr,
+	    MAX_IP_ADDR_SIZE,
+	    UNUSED_FLAG,
+	    &err_dns);
+
+	return (err_ip | err_subnet | err_gway | err_dns | err_adap);
+}
+
+
+/*
+ * Prepare a user kvp msg based on host kvp msg (utf16 to utf8)
+ * Ensure utf16_utf8 takes care of the additional string terminating char!!
+ */
+static int
+hv_kvp_convert_hostmsg_to_usermsg(struct hv_kvp_msg *hmsg,
+    struct hv_kvp_msg *umsg)
+{
+	int utf_err = 0;
+	uint32_t value_type;
+	char *umsg_value;
+	struct hv_kvp_ip_msg *host_ip_msg;
+
+	host_ip_msg = (struct hv_kvp_ip_msg *)hmsg;
+	(void) memset(umsg, 0, sizeof (struct hv_kvp_msg));
+
+	umsg->kvp_hdr.operation = hmsg->kvp_hdr.operation;
+	umsg->kvp_hdr.pool = hmsg->kvp_hdr.pool;
+
+	switch (umsg->kvp_hdr.operation) {
+	case HV_KVP_OP_SET_IP_INFO:
+		(void) hv_kvp_convert_utf16_ipinfo_to_utf8(host_ip_msg, umsg);
+		break;
+
+	case HV_KVP_OP_GET_IP_INFO:
+		(void) utf16_to_utf8((char *)umsg->body.kvp_ip_val.adapter_id,
+		    MAX_ADAPTER_ID_SIZE,
+		    (uint16_t *)host_ip_msg->kvp_ip_val.adapter_id,
+		    MAX_ADAPTER_ID_SIZE, 1, &utf_err);
+
+		umsg->body.kvp_ip_val.addr_family =
+		    host_ip_msg->kvp_ip_val.addr_family;
+		break;
+
+	case HV_KVP_OP_SET:
+		value_type = hmsg->body.kvp_set.data.value_type;
+		umsg_value = (char *)umsg->body.kvp_set.data.msg_value.value;
+
+		switch (value_type) {
+		case HV_REG_SZ:
+			umsg->body.kvp_set.data.value_size =
+			    utf16_to_utf8(umsg_value,
+			    HV_KVP_EXCHANGE_MAX_VALUE_SIZE - 1,
+			    (uint16_t *)hmsg->body.kvp_set.data.msg_value.value,
+			    hmsg->body.kvp_set.data.value_size, 1, &utf_err);
+			/* utf8 encoding */
+			umsg->body.kvp_set.data.value_size =
+			    umsg->body.kvp_set.data.value_size / 2;
+			break;
+
+		case HV_REG_U32:
+			umsg->body.kvp_set.data.value_size =
+			    snprintf(umsg_value, HV_KVP_EXCHANGE_MAX_VALUE_SIZE,
+			    "%lu", (unsigned long)
+			    hmsg->body.kvp_set.data.msg_value.value_u32) + 1;
+			break;
+
+		case HV_REG_U64:
+			umsg->body.kvp_set.data.value_size =
+			    snprintf(umsg_value, HV_KVP_EXCHANGE_MAX_VALUE_SIZE,
+			    "%llu", (unsigned long long)
+			    hmsg->body.kvp_set.data.msg_value.value_u64) + 1;
+			break;
+		}
+
+		umsg->body.kvp_set.data.key_size =
+		    utf16_to_utf8((char *)umsg->body.kvp_set.data.key,
+		    HV_KVP_EXCHANGE_MAX_KEY_SIZE - 1,
+		    (uint16_t *)hmsg->body.kvp_set.data.key,
+		    hmsg->body.kvp_set.data.key_size, 1, &utf_err);
+
+		/* utf8 encoding */
+		umsg->body.kvp_set.data.key_size =
+		    umsg->body.kvp_set.data.key_size / 2;
+		break;
+
+	case HV_KVP_OP_GET:
+		umsg->body.kvp_get.data.key_size =
+		    utf16_to_utf8((char *)umsg->body.kvp_get.data.key,
+		    HV_KVP_EXCHANGE_MAX_KEY_SIZE - 1,
+		    (uint16_t *)hmsg->body.kvp_get.data.key,
+		    hmsg->body.kvp_get.data.key_size, 1, &utf_err);
+		/* utf8 encoding */
+		umsg->body.kvp_get.data.key_size =
+		    umsg->body.kvp_get.data.key_size / 2;
+		break;
+
+	case HV_KVP_OP_DELETE:
+		umsg->body.kvp_delete.key_size =
+		    utf16_to_utf8((char *)umsg->body.kvp_delete.key,
+		    HV_KVP_EXCHANGE_MAX_KEY_SIZE - 1,
+		    (uint16_t *)hmsg->body.kvp_delete.key,
+		    hmsg->body.kvp_delete.key_size, 1, &utf_err);
+		/* utf8 encoding */
+		umsg->body.kvp_delete.key_size =
+		    umsg->body.kvp_delete.key_size / 2;
+		break;
+
+	case HV_KVP_OP_ENUMERATE:
+		umsg->body.kvp_enum_data.index =
+		    hmsg->body.kvp_enum_data.index;
+		break;
+
+	default:
+		return (EINVAL);
+	}
+
+	return (0);
+}
+
+
+/*
+ * Prepare a host kvp msg based on user kvp msg (utf8 to utf16)
+ */
+static int
+hv_kvp_convert_usermsg_to_hostmsg(struct hv_kvp_msg *umsg,
+    struct hv_kvp_msg *hmsg)
+{
+	int hkey_len = 0, hvalue_len = 0, utf_err = 0;
+	struct hv_kvp_exchg_msg_value *host_exchg_data;
+	char *key_name, *value;
+
+	struct hv_kvp_ip_msg *host_ip_msg = (struct hv_kvp_ip_msg *)hmsg;
+
+	switch (hmsg->kvp_hdr.operation) {
+	case HV_KVP_OP_GET_IP_INFO:
+		return (hv_kvp_convert_utf8_ipinfo_to_utf16(umsg, host_ip_msg));
+
+	case HV_KVP_OP_SET_IP_INFO:
+	case HV_KVP_OP_SET:
+	case HV_KVP_OP_DELETE:
+		return (0);
+
+	case HV_KVP_OP_ENUMERATE:
+		host_exchg_data = &hmsg->body.kvp_enum_data.data;
+		key_name = (char *)umsg->body.kvp_enum_data.data.key;
+		hkey_len = utf8_to_utf16((uint16_t *)host_exchg_data->key,
+		    ((HV_KVP_EXCHANGE_MAX_KEY_SIZE / 2) - 2),
+		    key_name, strlen(key_name), 1, &utf_err);
+		/* utf16 encoding */
+		host_exchg_data->key_size = 2 * (hkey_len + 1);
+		value = (char *)umsg->body.kvp_enum_data.data.msg_value.value;
+		hvalue_len = utf8_to_utf16(
+		    (uint16_t *)host_exchg_data->msg_value.value,
+		    ((HV_KVP_EXCHANGE_MAX_VALUE_SIZE / 2) - 2),
+		    value, strlen(value), 1, &utf_err);
+		host_exchg_data->value_size = 2 * (hvalue_len + 1);
+		host_exchg_data->value_type = HV_REG_SZ;
+
+		if (hvalue_len < 0)
+			return (EINVAL);
+
+		return (0);
+
+	case HV_KVP_OP_GET:
+		host_exchg_data = &hmsg->body.kvp_get.data;
+		value = (char *)umsg->body.kvp_get.data.msg_value.value;
+		hvalue_len = utf8_to_utf16(
+		    (uint16_t *)host_exchg_data->msg_value.value,
+		    ((HV_KVP_EXCHANGE_MAX_VALUE_SIZE / 2) - 2),
+		    value, strlen(value), 1, &utf_err);
+		/* Convert value size to uft16 */
+		host_exchg_data->value_size = 2 * (hvalue_len + 1);
+		/* Use values by string */
+		host_exchg_data->value_type = HV_REG_SZ;
+
+		if ((hkey_len < 0) || (hvalue_len < 0))
+			return (EINVAL);
+
+		return (0);
+
+	default:
+		return (EINVAL);
+	}
+}
+
+
+/*
+ * Send the response back to the host.
+ */
+static void
+hv_kvp_respond_host(hv_kvp_sc *sc, uint32_t error)
+{
+	struct hv_vmbus_icmsg_hdr *hv_icmsg_hdrp;
+
+	hv_icmsg_hdrp = (struct hv_vmbus_icmsg_hdr *)
+	    &sc->rcv_buf[sizeof (struct hv_vmbus_pipe_hdr)];
+
+	hv_icmsg_hdrp->status = error;
+	hv_icmsg_hdrp->icflags = HV_ICMSGHDRFLAG_TRANSACTION |
+	    HV_ICMSGHDRFLAG_RESPONSE;
+
+	error = vmbus_chan_send(vmbus_get_channel(sc->dev),
+	    VMBUS_CHANPKT_TYPE_INBAND, 0, sc->rcv_buf, sc->host_msg_len,
+	    sc->host_msg_id);
+	if (error)
+		hv_kvp_log_info(sc,
+		    "%s: hv_kvp_respond_host: sendpacket error:%d",
+		    __func__, error);
+}
+
+
+/*
+ * This is the main kvp kernel process that interacts with both user daemon
+ * and the host
+ */
+static void
+hv_kvp_send_msg_to_daemon(hv_kvp_sc *sc)
+{
+	struct hv_kvp_msg *hmsg = sc->host_kvp_msg;
+	struct hv_kvp_msg *umsg = &sc->daemon_kvp_msg;
+
+	/* Prepare kvp_msg to be sent to user */
+	if (hv_kvp_convert_hostmsg_to_usermsg(hmsg, umsg) != 0) {
+		hv_kvp_log_info(sc,
+		    "%s: daemon_kvp_msg: Invalid operation : %d",
+		    __func__, umsg->kvp_hdr.operation);
+	}
+
+	/* Send the msg to user via function deamon_read - setting sema */
+	sema_v(&sc->dev_sema);
+
+	/* We should wake up the daemon, in case it's doing poll() */
+	pollwakeup(&sc->hv_kvp_pollhead, POLLIN);
+}
+
+
+/*
+ * Function to read the kvp request buffer from host
+ * and interact with daemon
+ */
+static void
+hv_kvp_process_request(void *context)
+{
+	uint8_t *kvp_buf;
+	struct vmbus_channel *channel;
+	int recvlen = 0;
+	uint64_t requestid;
+	struct hv_vmbus_icmsg_hdr *icmsghdrp;
+	int ret = 0, error;
+	hv_kvp_sc *sc = (hv_kvp_sc*)context;
+
+	hv_kvp_log_info(sc, "%s: entering hv_kvp_process_request", __func__);
+
+	kvp_buf = sc->util_sc.ic_buf;
+	channel = vmbus_get_channel(sc->dev);
+
+	recvlen = sc->util_sc.ic_buflen;
+	ret = vmbus_chan_recv(channel, kvp_buf, &recvlen, &requestid);
+	/*
+	 * hvkvp recvbuf must be large enough
+	 */
+	ASSERT3S(ret, !=, ENOBUFS);
+	/* XXX check recvlen to make sure that it contains enough data */
+
+	while ((ret == 0) && (recvlen > 0)) {
+		icmsghdrp = (struct hv_vmbus_icmsg_hdr *)
+		    &kvp_buf[sizeof (struct hv_vmbus_pipe_hdr)];
+
+		hv_kvp_transaction_init(sc, recvlen, requestid, kvp_buf);
+		if (icmsghdrp->icmsgtype == HV_ICMSGTYPE_NEGOTIATE) {
+			error = vmbus_ic_negomsg(&sc->util_sc,
+			    kvp_buf, &recvlen, KVP_FWVER, KVP_MSGVER);
+			/* XXX handle vmbus_ic_negomsg failure. */
+			if (!error)
+				hv_kvp_respond_host(sc, HV_S_OK);
+			else
+				hv_kvp_respond_host(sc, HV_E_FAIL);
+			/*
+			 * It is ok to not acquire the mutex before setting
+			 * req_in_progress here because negotiation is the
+			 * first thing that happens and hence there is no
+			 * chance of a race condition.
+			 */
+
+			sc->req_in_progress = B_FALSE;
+			hv_kvp_log_info(sc, "%s :version negotiated",
+			    __func__);
+
+		} else {
+			if (!sc->daemon_busy) {
+
+				hv_kvp_log_info(sc,
+				    "%s: issuing query to daemon", __func__);
+				mutex_enter(&sc->pending_mutex);
+				sc->req_timed_out = B_FALSE;
+				sc->daemon_busy = B_TRUE;
+				mutex_exit(&sc->pending_mutex);
+
+				hv_kvp_send_msg_to_daemon(sc);
+				hv_kvp_log_info(sc,
+				    "%s: waiting for daemon", __func__);
+			}
+
+			/* Wait 5 seconds for daemon to respond back */
+			mutex_enter(&sc->pending_mutex);
+			while (sc->daemon_busy) {
+				(void) cv_reltimedwait(&sc->pending_cv,
+				    &sc->pending_mutex,
+				    SEC_TO_TICK(HV_KVP_DAEMON_TIMEOUT),
+				    TR_CLOCK_TICK);
+			}
+			mutex_exit(&sc->pending_mutex);
+			hv_kvp_log_info(sc, "%s: came out of wait", __func__);
+		}
+
+		mutex_enter(&sc->pending_mutex);
+
+		/*
+		 * Notice that once req_timed_out is set to true
+		 * it will remain true until the next request is
+		 * sent to the daemon. The response from daemon
+		 * is forwarded to host only when this flag is
+		 * false.
+		 */
+		sc->req_timed_out = B_TRUE;
+
+		/*
+		 * Cancel request if so need be.
+		 */
+		if (hv_kvp_req_in_progress(sc)) {
+			hv_kvp_log_info(sc, "%s: request was still active "
+			    "after wait so failing", __func__);
+			hv_kvp_respond_host(sc, HV_E_FAIL);
+			sc->req_in_progress = B_FALSE;
+		}
+
+		mutex_exit(&sc->pending_mutex);
+
+		/*
+		 * Try reading next buffer
+		 */
+		recvlen = sc->util_sc.ic_buflen;
+		ret = vmbus_chan_recv(channel, kvp_buf, &recvlen, &requestid);
+		/*
+		 * KVP recvbuf must be large enough
+		 */
+		ASSERT3S(ret, !=, ENOBUFS);
+		/* XXX check recvlen contains enough data */
+
+		hv_kvp_log_info(sc, "%s: read: context %p, ret =%d, "
+		    "recvlen=%d", __func__, context, ret, recvlen);
+	}
+}
+
+
+/*
+ * Callback routine that gets called whenever there is a message from host
+ */
+/* ARGSUSED */
+static void
+hv_kvp_callback(struct vmbus_channel *chan, void *context)
+{
+	hv_kvp_sc *sc = (hv_kvp_sc*)context;
+	/*
+	 * The first request from host will not be handled until daemon is
+	 * registered.  when callback is triggered without a registered daemon,
+	 * callback just return.  When a new daemon gets registered, this
+	 * callback is trigged from _write op.
+	 */
+	if (sc->register_done) {
+		hv_kvp_log_info(sc, "%s: Queuing work item", __func__);
+		(void) ddi_taskq_dispatch(sc->requesttq,
+		    hv_kvp_process_request, sc, DDI_SLEEP);
+	}
+}
+
+/* ARGSUSED */
+static int
+hv_kvp_dev_open(dev_t *devp, int oflags, int devtype, cred_t *cred)
+{
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, getminor(*devp));
+
+	hv_kvp_log_info(sc, "%s: Opened device \"hv_kvp_device\" "
+	    "successfully.", __func__);
+	if (sc->dev_accessed)
+		return (EBUSY);
+
+	sc->daemon_task = curproc;
+	sc->dev_accessed = B_TRUE;
+	sc->daemon_busy = B_FALSE;
+	return (0);
+}
+
+
+/* ARGSUSED */
+static int
+hv_kvp_dev_close(dev_t dev, int fflag, int otype, cred_t *cred)
+{
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, getminor(dev));
+
+	hv_kvp_log_info(sc, "%s: Closing device \"hv_kvp_device\".",
+	    __func__);
+	sc->dev_accessed = B_FALSE;
+	sc->register_done = B_FALSE;
+	return (0);
+}
+
+
+/*
+ * hv_kvp_daemon read invokes this function
+ * acts as a send to daemon
+ */
+/* ARGSUSED */
+static int
+hv_kvp_dev_daemon_read(dev_t dev, struct uio *uio, cred_t *cred)
+{
+	size_t amt;
+	int error = 0;
+	struct hv_kvp_msg *hv_kvp_dev_buf;
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, getminor(dev));
+
+	/* Read is not allowed util registering is done. */
+	if (!sc->register_done)
+		return (EPERM);
+
+	sema_p(&sc->dev_sema);
+
+	hv_kvp_dev_buf = kmem_zalloc(sizeof (struct hv_kvp_msg), KM_SLEEP);
+	(void) memcpy(hv_kvp_dev_buf, &sc->daemon_kvp_msg,
+	    sizeof (struct hv_kvp_msg));
+
+	amt = MIN(uio->uio_resid, uio->uio_offset >= BUFFERSIZE + 1 ? 0 :
+	    BUFFERSIZE + 1 - uio->uio_offset);
+
+	if ((error = uiomove(hv_kvp_dev_buf, amt, UIO_READ, uio)) != 0) {
+		hv_kvp_log_info(sc, "%s: hv_kvp uiomove read failed!",
+		    __func__);
+	}
+
+	kmem_free(hv_kvp_dev_buf, sizeof (struct hv_kvp_msg));
+	return (error);
+}
+
+
+/*
+ * hv_kvp_daemon write invokes this function
+ * acts as a receive from daemon
+ */
+/* ARGSUSED */
+static int
+hv_kvp_dev_daemon_write(dev_t dev, struct uio *uio, cred_t *cred)
+{
+	size_t amt;
+	int error = 0;
+	struct hv_kvp_msg *hv_kvp_dev_buf;
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, getminor(dev));
+
+	uio->uio_offset = 0;
+	hv_kvp_dev_buf = kmem_zalloc(sizeof (struct hv_kvp_msg), KM_SLEEP);
+
+	amt = MIN(uio->uio_resid, BUFFERSIZE);
+	error = uiomove(hv_kvp_dev_buf, amt, UIO_WRITE, uio);
+
+	if (error != 0) {
+		kmem_free(hv_kvp_dev_buf, sizeof (struct hv_kvp_msg));
+		return (error);
+	}
+	(void) memcpy(&sc->daemon_kvp_msg, hv_kvp_dev_buf,
+	    sizeof (struct hv_kvp_msg));
+
+	kmem_free(hv_kvp_dev_buf, sizeof (struct hv_kvp_msg));
+	if (sc->register_done == B_FALSE) {
+		if (sc->daemon_kvp_msg.kvp_hdr.operation ==
+		    HV_KVP_OP_REGISTER) {
+			sc->register_done = B_TRUE;
+			hv_kvp_callback(vmbus_get_channel(sc->dev), sc);
+		} else {
+			hv_kvp_log_info(sc, "%s, KVP Registration Failed",
+			    __func__);
+			return (EINVAL);
+		}
+	} else {
+
+		mutex_enter(&sc->pending_mutex);
+
+		if (!sc->req_timed_out) {
+			struct hv_kvp_msg *hmsg = sc->host_kvp_msg;
+			struct hv_kvp_msg *umsg = &sc->daemon_kvp_msg;
+
+			error = hv_kvp_convert_usermsg_to_hostmsg(umsg, hmsg);
+			hv_kvp_respond_host(sc, umsg->hdr.error);
+			cv_broadcast(&sc->pending_cv);
+			sc->req_in_progress = B_FALSE;
+			if (umsg->hdr.error != HV_S_OK)
+				hv_kvp_log_info(sc,
+				    "%s, Error 0x%x from daemon",
+				    __func__, umsg->hdr.error);
+			if (error)
+				hv_kvp_log_info(sc, "%s, Error from convert",
+				    __func__);
+		}
+
+		sc->daemon_busy = B_FALSE;
+		mutex_exit(&sc->pending_mutex);
+	}
+
+	return (error);
+}
+
+
+/*
+ * hv_kvp_daemon poll invokes this function to check if data is available
+ * for daemon to read.
+ */
+/* ARGSUSED */
+static int
+hv_kvp_dev_daemon_poll(dev_t dev, short events, int anyyet, short *reventsp,
+    struct pollhead **phpp)
+{
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, getminor(dev));
+
+	mutex_enter(&sc->pending_mutex);
+	/*
+	 * We check global flag daemon_busy for the data availiability for
+	 * userland to read. Deamon_busy is set to true before driver has data
+	 * for daemon to read. It is set to false after daemon sends
+	 * then response back to driver.
+	 */
+	if (sc->daemon_busy == B_TRUE) {
+		*reventsp = POLLIN;
+	} else {
+		*reventsp = 0;
+		if (!anyyet)
+			*phpp = &sc->hv_kvp_pollhead;
+	}
+
+	mutex_exit(&sc->pending_mutex);
+
+	return (0);
+}
+
+static int
+hv_kvp_attach(dev_info_t *dev, ddi_attach_cmd_t cmd)
+{
+	int error;
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_ATTACH)
+		return (DDI_FAILURE);
+
+	/* create character device */
+	if (ddi_create_minor_node(dev, HV_KVP_MINOR_NAME, S_IFCHR, instance,
+	    DDI_PSEUDO, 0) == DDI_FAILURE) {
+		ddi_remove_minor_node(dev, NULL);
+		return (DDI_FAILURE);
+	}
+
+	if ((error = ddi_soft_state_zalloc(hv_kvp_state, instance)) !=
+	    DDI_SUCCESS) {
+		ddi_remove_minor_node(dev, NULL);
+		return (error);
+	}
+
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, instance);
+
+	sc->dev = dev;
+	sema_init(&sc->dev_sema, 0, "hv_kvp device semaphore", SEMA_DRIVER,
+	    NULL);
+	mutex_init(&sc->pending_mutex, "hv_kvp pending mutex", MUTEX_DRIVER,
+	    NULL);
+	cv_init(&sc->pending_cv, "hv_kvp pending condvar", CV_DRIVER, NULL);
+
+	sc->requesttq = ddi_taskq_create(sc->dev, "kvp request", 1,
+	    TASKQ_DEFAULTPRI, 0);
+
+	if (sc->requesttq == NULL) {
+		ddi_soft_state_free(hv_kvp_state, instance);
+		ddi_remove_minor_node(dev, NULL);
+		return (error);
+	}
+
+	error = vmbus_ic_attach(dev, hv_kvp_callback, &sc->util_sc);
+	if (error != 0) {
+		ddi_soft_state_free(hv_kvp_state, instance);
+		ddi_remove_minor_node(dev, NULL);
+		ddi_taskq_destroy(sc->requesttq);
+	}
+
+	return (error);
+}
+
+static int
+hv_kvp_detach(dev_info_t *dev, ddi_detach_cmd_t cmd)
+{
+	int error;
+	int instance = ddi_get_instance(dev);
+	hv_kvp_sc *sc = ddi_get_soft_state(hv_kvp_state, instance);
+
+	if (cmd != DDI_DETACH)
+		return (DDI_FAILURE);
+
+	error = vmbus_ic_detach(dev, &sc->util_sc);
+	if (error != 0) {
+		hv_kvp_log_error(sc, "detatch failed, error: %d", error);
+		return (error);
+	}
+
+	if (sc->daemon_task != NULL)
+		psignal(sc->daemon_task, SIGKILL);
+
+	if (sc->requesttq != NULL)
+		ddi_taskq_destroy(sc->requesttq);
+
+	ddi_soft_state_free(hv_kvp_state, instance);
+	ddi_remove_minor_node(dev, HV_KVP_MINOR_NAME);
+
+	return (DDI_SUCCESS);
+}
+
+static struct cb_ops hv_kvp_cb_ops = {
+	.cb_open =	hv_kvp_dev_open,
+	.cb_close =	hv_kvp_dev_close,
+	.cb_strategy =	nodev,
+	.cb_print =	nodev,
+	.cb_dump =	nodev,
+	.cb_read =	hv_kvp_dev_daemon_read,
+	.cb_write =	hv_kvp_dev_daemon_write,
+	.cb_ioctl =	nodev,
+	.cb_devmap =	nodev,
+	.cb_mmap =	nodev,
+	.cb_segmap =	nodev,
+	.cb_chpoll =	hv_kvp_dev_daemon_poll,
+	.cb_prop_op =	ddi_prop_op,
+	.cb_str =	NULL,
+	.cb_flag =	D_NEW | D_MP
+};
+
+static struct dev_ops hv_kvp_dev_ops = {
+	.devo_rev =		DEVO_REV,
+	.devo_refcnt =		0,
+	.devo_getinfo =		ddi_getinfo_1to1,
+	.devo_identify =	nulldev,
+	.devo_probe =		nulldev,
+	.devo_attach =		hv_kvp_attach,
+	.devo_detach =		hv_kvp_detach,
+	.devo_reset =		nodev,
+	.devo_cb_ops =		&hv_kvp_cb_ops,
+	.devo_bus_ops =		NULL,
+	.devo_power =		NULL,
+	.devo_quiesce =		ddi_quiesce_not_needed,
+};
+
+extern struct mod_ops mod_driverops;
+
+static struct modldrv hv_kvp_modldrv = {
+	&mod_driverops,
+	"Hyper-V KVP Driver",
+	&hv_kvp_dev_ops,
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&hv_kvp_modldrv,
+	NULL
+};
+
+int
+_init(void)
+{
+	int error;
+
+	if ((error = ddi_soft_state_init(&hv_kvp_state,
+	    sizeof (struct hv_kvp_sc), 0)) != 0)
+		return (error);
+
+	if ((error = mod_install(&modlinkage)) != 0)
+		ddi_soft_state_fini(&hv_kvp_state);
+
+	return (error);
+}
+
+int
+_fini(void)
+{
+	int error;
+
+	if ((error = mod_remove(&modlinkage)) == 0)
+		ddi_soft_state_fini(&hv_kvp_state);
+
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.h
+++ b/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.h
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2014,2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HV_KVP_H
+#define	_HV_KVP_H
+/*
+ * An implementation of HyperV key value pair (KVP) functionality for FreeBSD
+ *
+ */
+
+/*
+ * Maximum value size - used for both key names and value data, and includes
+ * any applicable NULL terminators.
+ *
+ * Note:  This limit is somewhat arbitrary, but falls easily within what is
+ * supported for all native guests (back to Win 2000) and what is reasonable
+ * for the IC KVP exchange functionality.  Note that Windows Me/98/95 are
+ * limited to 255 character key names.
+ *
+ * MSDN recommends not storing data values larger than 2048 bytes in the
+ * registry.
+ *
+ * Note:  This value is used in defining the KVP exchange message - this value
+ * cannot be modified without affecting the message size and compatibility.
+ */
+
+/*
+ * bytes, including any null terminators
+ */
+#define	HV_KVP_EXCHANGE_MAX_VALUE_SIZE    (2048)
+
+
+/*
+ * Maximum key size - the registry limit for the length of an entry name
+ * is 256 characters, including the null terminator
+ */
+#define	HV_KVP_EXCHANGE_MAX_KEY_SIZE    (512)
+
+
+/*
+ * In FreeBSD, we implement the KVP functionality in two components:
+ * 1) The kernel component which is packaged as part of the hv_utils driver
+ * is responsible for communicating with the host and responsible for
+ * implementing the host/guest protocol. 2) A user level daemon that is
+ * responsible for data gathering.
+ *
+ * Host/Guest Protocol: The host iterates over an index and expects the guest
+ * to assign a key name to the index and also return the value corresponding to
+ * the key. The host will have atmost one KVP transaction outstanding at any
+ * given point in time. The host side iteration stops when the guest returns
+ * an error. Microsoft has specified the following mapping of key names to
+ * host specified index:
+ *
+ *  Index		Key Name
+ *	0		FullyQualifiedDomainName
+ *	1		IntegrationServicesVersion
+ *	2		NetworkAddressIPv4
+ *	3		NetworkAddressIPv6
+ *	4		OSBuildNumber
+ *	5		OSName
+ *	6		OSMajorVersion
+ *	7		OSMinorVersion
+ *	8		OSVersion
+ *	9		ProcessorArchitecture
+ *
+ * The Windows host expects the Key Name and Key Value to be encoded in utf16.
+ *
+ * Guest Kernel/KVP Daemon Protocol: As noted earlier, we implement all of the
+ * data gathering functionality in a user mode daemon. The user level daemon
+ * is also responsible for binding the key name to the index as well. The
+ * kernel and user-level daemon communicate using a connector channel.
+ *
+ * The user mode component first registers with the
+ * the kernel component. Subsequently, the kernel component requests, data
+ * for the specified keys. In response to this message the user mode component
+ * fills in the value corresponding to the specified key. We overload the
+ * sequence field in the cn_msg header to define our KVP message types.
+ *
+ *
+ * The kernel component simply acts as a conduit for communication between the
+ * Windows host and the user-level daemon. The kernel component passes up the
+ * index received from the Host to the user-level daemon. If the index is
+ * valid (supported), the corresponding key as well as its
+ * value (both are strings) is returned. If the index is invalid
+ * (not supported), a NULL key string is returned.
+ */
+
+#define	HV_KVP_MINOR_NAME	"hv_kvp_dev"
+
+/*
+ * Registry value types.
+ */
+#define	HV_REG_SZ		1
+#define	HV_REG_U32		4
+#define	HV_REG_U64		8
+
+
+/*
+ * Daemon code supporting IP injection.
+ */
+#define	HV_KVP_OP_REGISTER    4
+
+
+enum hv_kvp_exchg_op {
+	HV_KVP_OP_GET = 0,
+	HV_KVP_OP_SET,
+	HV_KVP_OP_DELETE,
+	HV_KVP_OP_ENUMERATE,
+	HV_KVP_OP_GET_IP_INFO,
+	HV_KVP_OP_SET_IP_INFO,
+	HV_KVP_OP_COUNT /* Number of operations, must be last. */
+};
+
+enum hv_kvp_exchg_pool {
+	HV_KVP_POOL_EXTERNAL = 0,
+	HV_KVP_POOL_GUEST,
+	HV_KVP_POOL_AUTO,
+	HV_KVP_POOL_AUTO_EXTERNAL,
+	HV_KVP_POOL_AUTO_INTERNAL,
+	HV_KVP_POOL_COUNT /* Number of pools, must be last. */
+};
+
+#define	ADDR_FAMILY_NONE		0x00
+#define	ADDR_FAMILY_IPV4		0x01
+#define	ADDR_FAMILY_IPV6		0x02
+
+#define	MAX_ADAPTER_ID_SIZE		128
+#define	MAX_IP_ADDR_SIZE		1024
+#define	MAX_GATEWAY_SIZE		512
+
+
+struct hv_kvp_ipaddr_value {
+	uint16_t adapter_id[MAX_ADAPTER_ID_SIZE];
+	uint8_t  addr_family;
+	uint8_t  dhcp_enabled;
+	uint16_t ip_addr[MAX_IP_ADDR_SIZE];
+	uint16_t sub_net[MAX_IP_ADDR_SIZE];
+	uint16_t gate_way[MAX_GATEWAY_SIZE];
+	uint16_t dns_addr[MAX_IP_ADDR_SIZE];
+}__attribute__((packed));
+
+struct hv_kvp_hdr {
+	uint8_t		operation;
+	uint8_t		pool;
+	uint16_t	pad;
+} __attribute__((packed));
+
+struct hv_kvp_exchg_msg_value {
+	uint32_t value_type;
+	uint32_t key_size;
+	uint32_t value_size;
+	uint8_t  key[HV_KVP_EXCHANGE_MAX_KEY_SIZE];
+	union {
+		uint8_t  value[HV_KVP_EXCHANGE_MAX_VALUE_SIZE];
+		uint32_t value_u32;
+		uint64_t value_u64;
+	} msg_value;
+} __attribute__((packed));
+
+struct hv_kvp_msg_enumerate {
+	uint32_t index;
+	struct hv_kvp_exchg_msg_value data;
+} __attribute__((packed));
+
+struct hv_kvp_msg_get {
+	struct hv_kvp_exchg_msg_value data;
+} __attribute__((packed));
+
+struct hv_kvp_msg_set {
+	struct hv_kvp_exchg_msg_value data;
+} __attribute__((packed));
+
+struct hv_kvp_msg_delete {
+	uint32_t key_size;
+	uint8_t key[HV_KVP_EXCHANGE_MAX_KEY_SIZE];
+} __attribute__((packed));
+
+struct hv_kvp_register {
+	uint8_t version[HV_KVP_EXCHANGE_MAX_KEY_SIZE];
+} __attribute__((packed));
+
+struct hv_kvp_msg {
+	union {
+		struct hv_kvp_hdr kvp_hdr;
+		uint32_t error;
+	} hdr;
+	union {
+		struct hv_kvp_msg_get		kvp_get;
+		struct hv_kvp_msg_set		kvp_set;
+		struct hv_kvp_msg_delete	kvp_delete;
+		struct hv_kvp_msg_enumerate	kvp_enum_data;
+		struct hv_kvp_ipaddr_value	kvp_ip_val;
+		struct hv_kvp_register		kvp_register;
+	} body;
+} __attribute__((packed));
+
+struct hv_kvp_ip_msg {
+	uint8_t operation;
+	uint8_t pool;
+	struct hv_kvp_ipaddr_value kvp_ip_val;
+} __attribute__((packed));
+
+#endif /* _HV_KVP_H */

--- a/usr/src/uts/intel/io/hyperv/utilities/hv_utilreg.h
+++ b/usr/src/uts/intel/io/hyperv/utilities/hv_utilreg.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HV_UTILREG_H_
+#define	_HV_UTILREG_H_
+
+#include <sys/hyperv_illumos.h> /* for __packed */
+
+/*
+ * Some Hyper-V status codes.
+ */
+#define	HV_S_OK				0x00000000
+#define	HV_E_FAIL			0x80004005
+#define	HV_S_CONT			0x80070103
+#define	HV_ERROR_NOT_SUPPORTED		0x80070032
+#define	HV_ERROR_MACHINE_LOCKED		0x800704F7
+#define	HV_ERROR_DEVICE_NOT_CONNECTED	0x8007048F
+#define	HV_INVALIDARG			0x80070057
+#define	HV_GUID_NOTFOUND		0x80041002
+
+/*
+ * Common defines for Hyper-V ICs
+ */
+#define	HV_ICMSGTYPE_NEGOTIATE		0
+#define	HV_ICMSGTYPE_HEARTBEAT		1
+#define	HV_ICMSGTYPE_KVPEXCHANGE	2
+#define	HV_ICMSGTYPE_SHUTDOWN		3
+#define	HV_ICMSGTYPE_TIMESYNC		4
+#define	HV_ICMSGTYPE_VSS		5
+
+#define	HV_ICMSGHDRFLAG_TRANSACTION	1
+#define	HV_ICMSGHDRFLAG_REQUEST		2
+#define	HV_ICMSGHDRFLAG_RESPONSE	4
+
+typedef struct hv_vmbus_pipe_hdr {
+	uint32_t flags;
+	uint32_t msgsize;
+} __packed hv_vmbus_pipe_hdr;
+
+typedef struct hv_vmbus_ic_version {
+	uint16_t major;
+	uint16_t minor;
+} __packed hv_vmbus_ic_version;
+
+typedef struct hv_vmbus_icmsg_hdr {
+	hv_vmbus_ic_version	icverframe;
+	uint16_t		icmsgtype;
+	hv_vmbus_ic_version	icvermsg;
+	uint16_t		icmsgsize;
+	uint32_t		status;
+	uint8_t			ictransaction_id;
+	uint8_t			icflags;
+	uint8_t			reserved[2];
+} __packed hv_vmbus_icmsg_hdr;
+
+typedef struct hv_vmbus_icmsg_negotiate {
+	uint16_t		icframe_vercnt;
+	uint16_t		icmsg_vercnt;
+	uint32_t		reserved;
+	hv_vmbus_ic_version	icversion_data[1]; /* any size array */
+} __packed hv_vmbus_icmsg_negotiate;
+
+#endif	/* !_HV_UTILREG_H_ */

--- a/usr/src/uts/intel/io/hyperv/utilities/unicode.h
+++ b/usr/src/uts/intel/io/hyperv/utilities/unicode.h
@@ -1,0 +1,216 @@
+/* $NetBSD: unicode.h,v 1.1.1.1 2007/03/06 00:10:39 dillo Exp $ */
+
+/*
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HV_UNICODE_H_
+#define	_HV_UNICODE_H_
+
+#include <sys/types.h>
+
+#define	UNICODE_DECOMPOSE		0x01
+#define	UNICODE_PRECOMPOSE		0x02
+#define	UNICODE_UTF8_LATIN1_FALLBACK	0x03
+
+size_t utf8_to_utf16(uint16_t *, size_t, const char *, size_t, int, int *);
+size_t utf16_to_utf8(char *, size_t, const uint16_t *, size_t, int, int *);
+
+size_t
+utf8_to_utf16(uint16_t *dst, size_t dst_len, const char *src, size_t src_len,
+    int flags, int *errp)
+{
+	const unsigned char *s;
+	size_t spos, dpos;
+	int error;
+	uint16_t c;
+
+#define	IS_CONT(c)	(((c)&0xc0) == 0x80)
+
+	error = 0;
+	s = (const unsigned char *)src;
+	spos = dpos = 0;
+	while (spos < src_len) {
+		if (s[spos] < 0x80) {
+			c = s[spos++];
+		} else if ((flags & UNICODE_UTF8_LATIN1_FALLBACK) &&
+		    (spos >= src_len || !IS_CONT(s[spos+1])) &&
+		    s[spos] >= 0xa0) {
+			/* not valid UTF-8, assume ISO 8859-1 */
+			c = s[spos++];
+		} else if (s[spos] < 0xc0 || s[spos] >= 0xf5) {
+			/*
+			 * continuation byte without lead byte
+			 * or lead byte for codepoint above 0x10ffff
+			 */
+			error++;
+			spos++;
+			continue;
+		} else if (s[spos] < 0xe0) {
+			if (spos >= src_len || !IS_CONT(s[spos+1])) {
+				spos++;
+				error++;
+				continue;
+			}
+			c = ((s[spos] & 0x3f) << 6) | (s[spos+1] & 0x3f);
+			spos += 2;
+			if (c < 0x80) {
+				/* overlong encoding */
+				error++;
+				continue;
+			}
+		} else if (s[spos] < 0xf0) {
+			if (spos >= src_len-2 || !IS_CONT(s[spos+1]) ||
+			    !IS_CONT(s[spos+2])) {
+				spos++;
+				error++;
+				continue;
+			}
+			c = ((s[spos] & 0x0f) << 12) | ((s[spos+1] & 0x3f) << 6)
+			    | (s[spos+2] & 0x3f);
+			spos += 3;
+			if (c < 0x800 || (c & 0xdf00) == 0xd800) {
+				/* overlong encoding or encoded surrogate */
+				error++;
+				continue;
+			}
+		} else {
+			uint32_t cc;
+			/* UTF-16 surrogate pair */
+
+			if (spos >= src_len-3 || !IS_CONT(s[spos+1]) ||
+			    !IS_CONT(s[spos+2]) || !IS_CONT(s[spos+3])) {
+				spos++;
+				error++;
+				continue;
+			}
+			cc = ((s[spos] & 0x03) << 18) |
+			    ((s[spos+1] & 0x3f) << 12) |
+			    ((s[spos+2] & 0x3f) << 6) | (s[spos+3] & 0x3f);
+			spos += 4;
+			if (cc < 0x10000) {
+				/* overlong encoding */
+				error++;
+				continue;
+			}
+			if (dst && dpos < dst_len)
+				dst[dpos] = (0xd800 | ((cc-0x10000)>>10));
+			dpos++;
+			c = 0xdc00 | ((cc-0x10000) & 0x3ffff);
+		}
+
+		if (dst && dpos < dst_len)
+			dst[dpos] = c;
+		dpos++;
+	}
+
+	if (errp)
+		*errp = error;
+
+	return (dpos);
+
+#undef IS_CONT
+}
+
+
+/* ARGSUSED */
+size_t
+utf16_to_utf8(char *dst, size_t dst_len, const uint16_t *src, size_t src_len,
+    int flags, int *errp)
+{
+	uint16_t spos, dpos;
+	int error;
+
+#define	CHECK_LENGTH(l)	(dpos > dst_len-(l) ? dst = NULL : NULL)
+#define	ADD_BYTE(b)	(dst ? dst[dpos] = (b) : 0, dpos++)
+
+	error = 0;
+	dpos = 0;
+	for (spos = 0; spos < src_len; spos++) {
+		if (src[spos] < 0x80) {
+			CHECK_LENGTH(1);
+			ADD_BYTE(src[spos]);
+		} else if (src[spos] < 0x800) {
+			CHECK_LENGTH(2);
+			ADD_BYTE(0xc0 | (src[spos]>>6));
+			ADD_BYTE(0x80 | (src[spos] & 0x3f));
+		} else if ((src[spos] & 0xdc00) == 0xd800) {
+			uint32_t c;
+			/* first surrogate */
+			if (spos == src_len - 1 ||
+			    (src[spos] & 0xdc00) != 0xdc00) {
+				/* no second surrogate present */
+				error++;
+				continue;
+			}
+			spos++;
+			CHECK_LENGTH(4);
+			c = (((src[spos]&0x3ff) << 10) |
+			    (src[spos+1]&0x3ff)) + 0x10000;
+			ADD_BYTE(0xf0 | (c>>18));
+			ADD_BYTE(0x80 | ((c>>12) & 0x3f));
+			ADD_BYTE(0x80 | ((c>>6) & 0x3f));
+			ADD_BYTE(0x80 | (c & 0x3f));
+		} else if ((src[spos] & 0xdc00) == 0xdc00) {
+			/* second surrogate without preceding first surrogate */
+			error++;
+		} else {
+			CHECK_LENGTH(3);
+			ADD_BYTE(0xe0 | src[spos]>>12);
+			ADD_BYTE(0x80 | ((src[spos]>>6) & 0x3f));
+			ADD_BYTE(0x80 | (src[spos] & 0x3f));
+		}
+	}
+
+	if (errp)
+		*errp = error;
+
+	return (dpos);
+
+#undef ADD_BYTE
+#undef CHECK_LENGTH
+}
+
+#endif	/* !_HV_UNICODE_H_ */

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_heartbeat.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_heartbeat.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2014,2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/conf.h>
+#include <sys/sunddi.h>
+#include <sys/devops.h>
+#include <sys/cmn_err.h>
+
+#include <sys/param.h>
+#include <sys/systm.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include "vmbus_icvar.h"
+#include "vmbus_icreg.h"
+
+#define	VMBUS_HEARTBEAT_FWVER_MAJOR	3
+#define	VMBUS_HEARTBEAT_FWVER		\
+	VMBUS_IC_VERSION(VMBUS_HEARTBEAT_FWVER_MAJOR, 0)
+
+#define	VMBUS_HEARTBEAT_MSGVER_MAJOR	3
+#define	VMBUS_HEARTBEAT_MSGVER		\
+	VMBUS_IC_VERSION(VMBUS_HEARTBEAT_MSGVER_MAJOR, 0)
+
+const struct vmbus_ic_desc vmbus_heartbeat_descs[] = {
+	{
+		.ic_guid = { .hv_guid = {
+		    0x39, 0x4f, 0x16, 0x57, 0x15, 0x91, 0x78, 0x4e,
+		    0xab, 0x55, 0x38, 0x2f, 0x3b, 0xd5, 0x42, 0x2d} },
+		.ic_desc = "Hyper-V Heartbeat"
+	},
+	VMBUS_IC_DESC_END
+};
+
+static void *vmbus_heartbeat_state;
+
+static void
+vmbus_heartbeat_cb(struct vmbus_channel *chan, void *xsc)
+{
+	struct vmbus_ic_softc *sc = xsc;
+	struct vmbus_icmsg_hdr *hdr;
+	int dlen, error = 0;
+	uint64_t xactid;
+	void *data;
+
+	/*
+	 * Receive request.
+	 */
+	data = sc->ic_buf;
+	dlen = sc->ic_buflen;
+	error = vmbus_chan_recv(chan, data, &dlen, &xactid);
+	/*
+	 * icbuf must be large enough.
+	 */
+	ASSERT3S(error, !=, ENOBUFS);
+	if (error)
+		return;
+
+	if (dlen < sizeof (*hdr)) {
+		dev_err(sc->ic_dev, CE_WARN, "invalid data len %d", dlen);
+		return;
+	}
+	hdr = data;
+
+	/*
+	 * Update request, which will be echoed back as response.
+	 */
+	switch (hdr->ic_type) {
+	case VMBUS_ICMSG_TYPE_NEGOTIATE:
+		error = vmbus_ic_negomsg(sc, data, &dlen,
+		    VMBUS_HEARTBEAT_FWVER, VMBUS_HEARTBEAT_MSGVER);
+		if (error != 0) {
+			dev_err(sc->ic_dev, CE_WARN,
+			    "vmbus_ic_negomsg failed, error: %d, data: 0x%p,"
+			    " dlen: %d", error, data, dlen);
+			return;
+		}
+		break;
+
+	case VMBUS_ICMSG_TYPE_HEARTBEAT:
+		/* Only ic_seq is a must */
+		if (dlen < VMBUS_ICMSG_HEARTBEAT_SIZE_MIN) {
+			dev_err(sc->ic_dev, CE_WARN,
+			    "invalid heartbeat len %d", dlen);
+			return;
+		}
+		((struct vmbus_icmsg_heartbeat *)data)->ic_seq++;
+		break;
+
+	default:
+		dev_err(sc->ic_dev, CE_WARN, "got 0x%08x icmsg",
+		    hdr->ic_type);
+		break;
+	}
+
+	/*
+	 * Send response by echoing the request back.
+	 */
+	(void) vmbus_ic_sendresp(sc, chan, data, dlen, xactid);
+}
+
+static int
+vmbus_heartbeat_attach(dev_info_t *dev, ddi_attach_cmd_t cmd)
+{
+	int err;
+	struct vmbus_ic_softc *sc;
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_ATTACH)
+		return (DDI_FAILURE);
+
+	if ((err = ddi_soft_state_zalloc(vmbus_heartbeat_state, instance)) !=
+	    DDI_SUCCESS)
+		return (err);
+
+	sc = ddi_get_soft_state(vmbus_heartbeat_state, instance);
+	err = vmbus_ic_attach(dev, vmbus_heartbeat_cb, sc);
+	if (err != 0)
+		ddi_soft_state_free(vmbus_heartbeat_state, instance);
+
+	return (err);
+}
+
+static int
+vmbus_heartbeat_detach(dev_info_t *dev, ddi_detach_cmd_t cmd)
+{
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_DETACH)
+		return (DDI_FAILURE);
+
+	int err = vmbus_ic_detach(dev,
+	    ddi_get_soft_state(vmbus_heartbeat_state, instance));
+	if (err == 0)
+		ddi_soft_state_free(vmbus_heartbeat_state, instance);
+	return (err);
+}
+
+static struct cb_ops vmbus_heartbeat_cb_ops = {
+	.cb_open =	nulldev,
+	.cb_close =	nulldev,
+	.cb_strategy =	nodev,
+	.cb_print =	nodev,
+	.cb_dump =	nodev,
+	.cb_read =	nodev,
+	.cb_write =	nodev,
+	.cb_ioctl =	nodev,
+	.cb_devmap =	nodev,
+	.cb_mmap =	nodev,
+	.cb_segmap =	nodev,
+	.cb_chpoll =	nochpoll,
+	.cb_prop_op =	ddi_prop_op,
+	.cb_str =	NULL,
+	.cb_flag =	D_NEW | D_MP
+};
+
+static struct dev_ops vmbus_heartbeat_dev_ops = {
+	.devo_rev =		DEVO_REV,
+	.devo_refcnt =		0,
+	.devo_getinfo =		ddi_getinfo_1to1,
+	.devo_identify =	nulldev,
+	.devo_probe =		nulldev,
+	.devo_attach =		vmbus_heartbeat_attach,
+	.devo_detach =		vmbus_heartbeat_detach,
+	.devo_reset =		nodev,
+	.devo_cb_ops =		&vmbus_heartbeat_cb_ops,
+	.devo_bus_ops =		NULL,
+	.devo_power =		NULL,
+	.devo_quiesce =		ddi_quiesce_not_needed
+};
+
+extern struct mod_ops mod_driverops;
+
+static struct modldrv vmbus_heartbeat_modldrv = {
+	&mod_driverops,
+	"Hyper-V Heartbeat Driver",
+	&vmbus_heartbeat_dev_ops,
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&vmbus_heartbeat_modldrv,
+	NULL
+};
+
+int
+_init(void)
+{
+	int error;
+
+	if ((error = ddi_soft_state_init(&vmbus_heartbeat_state,
+	    sizeof (struct vmbus_ic_softc), 0)) != 0)
+		return (error);
+
+	if ((error = mod_install(&modlinkage)) != 0)
+		ddi_soft_state_fini(&vmbus_heartbeat_state);
+	return (error);
+}
+
+int
+_fini(void)
+{
+	int error;
+
+	if ((error = mod_remove(&modlinkage)) == 0)
+		ddi_soft_state_fini(&vmbus_heartbeat_state);
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_ic.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_ic.c
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2014,2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ * A common driver for all hyper-V util services.
+ */
+
+#include <sys/sunddi.h>
+#include <sys/devops.h>
+#include <sys/cmn_err.h>
+#include <sys/param.h>
+#include <sys/kmem.h>
+#include <sys/reboot.h>
+#include <sys/systm.h>
+#include <sys/debug.h>
+
+#include <sys/hyperv.h>
+#include <sys/hyperv_illumos.h>
+#include <sys/vmbus.h>
+#include "vmbus_icreg.h"
+#include "vmbus_icvar.h"
+
+#define	VMBUS_IC_BRSIZE		(4 * PAGE_SIZE)
+
+#define	VMBUS_IC_VERCNT		2
+#define	VMBUS_IC_NEGOSZ		\
+	offsetof(struct vmbus_icmsg_negotiate, ic_ver[VMBUS_IC_VERCNT])
+
+int
+vmbus_ic_negomsg(struct vmbus_ic_softc *sc, void *data, int *dlen0,
+    uint32_t fw_ver, uint32_t msg_ver)
+{
+	struct vmbus_icmsg_negotiate *nego;
+	int i, cnt, dlen = *dlen0, error;
+	uint32_t sel_fw_ver = 0, sel_msg_ver = 0;
+	boolean_t has_fw_ver, has_msg_ver;
+
+	/*
+	 * Preliminary message verification.
+	 */
+	if (dlen < sizeof (*nego)) {
+		dev_err(sc->ic_dev, CE_WARN, "truncated ic negotiate, len %d",
+		    dlen);
+		return (EINVAL);
+	}
+	nego = data;
+
+	if (nego->ic_fwver_cnt == 0) {
+		dev_err(sc->ic_dev, CE_WARN, "ic negotiate does not contain "
+		    "framework version %u", nego->ic_fwver_cnt);
+		return (EINVAL);
+	}
+	if (nego->ic_msgver_cnt == 0) {
+		dev_err(sc->ic_dev, CE_WARN, "ic negotiate does not contain "
+		    "message version %u", nego->ic_msgver_cnt);
+		return (EINVAL);
+	}
+
+	cnt = nego->ic_fwver_cnt + nego->ic_msgver_cnt;
+	if (dlen < offsetof(struct vmbus_icmsg_negotiate, ic_ver[cnt])) {
+		dev_err(sc->ic_dev, CE_WARN, "ic negotiate does not contain "
+		    "versions %d", dlen);
+		return (EINVAL);
+	}
+
+	error = EOPNOTSUPP;
+
+	/*
+	 * Find the best match framework version.
+	 */
+	has_fw_ver = B_FALSE;
+	has_msg_ver = B_FALSE;
+	for (i = 0; i < nego->ic_fwver_cnt; ++i) {
+		if (VMBUS_ICVER_LE(nego->ic_ver[i], fw_ver)) {
+			if (!has_fw_ver) {
+				sel_fw_ver = nego->ic_ver[i];
+				has_fw_ver = B_TRUE;
+			} else if (VMBUS_ICVER_GT(nego->ic_ver[i],
+			    sel_fw_ver)) {
+				sel_fw_ver = nego->ic_ver[i];
+			}
+		}
+	}
+	if (!has_fw_ver) {
+		dev_err(sc->ic_dev, CE_WARN, "failed to select framework "
+		    "version");
+		goto done;
+	}
+
+	/*
+	 * Fine the best match message version.
+	 */
+	for (i = nego->ic_fwver_cnt;
+	    i < nego->ic_fwver_cnt + nego->ic_msgver_cnt; ++i) {
+		if (VMBUS_ICVER_LE(nego->ic_ver[i], msg_ver)) {
+			if (!has_msg_ver) {
+				sel_msg_ver = nego->ic_ver[i];
+				has_msg_ver = B_TRUE;
+			} else if (VMBUS_ICVER_GT(nego->ic_ver[i],
+			    sel_msg_ver)) {
+				sel_msg_ver = nego->ic_ver[i];
+			}
+		}
+	}
+	if (!has_msg_ver) {
+		dev_err(sc->ic_dev, CE_WARN, "failed to select message "
+		    "version");
+		goto done;
+	}
+
+	error = 0;
+done:
+	if (!has_fw_ver || !has_msg_ver) {
+		if (has_fw_ver) {
+			dev_err(sc->ic_dev, CE_NOTE, "sel framework version: "
+			    "%u.%u",
+			    VMBUS_ICVER_MAJOR(sel_fw_ver),
+			    VMBUS_ICVER_MINOR(sel_fw_ver));
+		}
+		for (i = 0; i < nego->ic_fwver_cnt; i++) {
+			dev_err(sc->ic_dev, CE_NOTE, "supp framework version: "
+			    "%u.%u",
+			    VMBUS_ICVER_MAJOR(nego->ic_ver[i]),
+			    VMBUS_ICVER_MINOR(nego->ic_ver[i]));
+		}
+
+		if (has_msg_ver) {
+			dev_err(sc->ic_dev, CE_NOTE, "sel message version: "
+			    "%u.%u",
+			    VMBUS_ICVER_MAJOR(sel_msg_ver),
+			    VMBUS_ICVER_MINOR(sel_msg_ver));
+		}
+		for (i = nego->ic_fwver_cnt;
+		    i < nego->ic_fwver_cnt + nego->ic_msgver_cnt; i++) {
+			dev_err(sc->ic_dev, CE_NOTE, "supp message version: "
+			    "%u.%u",
+			    VMBUS_ICVER_MAJOR(nego->ic_ver[i]),
+			    VMBUS_ICVER_MINOR(nego->ic_ver[i]));
+		}
+	}
+	if (error)
+		return (error);
+
+	/* Record the selected versions. */
+	sc->ic_fwver = sel_fw_ver;
+	sc->ic_msgver = sel_msg_ver;
+
+	/* One framework version. */
+	nego->ic_fwver_cnt = 1;
+	nego->ic_ver[0] = sel_fw_ver;
+
+	/* One message version. */
+	nego->ic_msgver_cnt = 1;
+	nego->ic_ver[1] = sel_msg_ver;
+
+	/* Update data size. */
+	nego->ic_hdr.ic_dsize = VMBUS_IC_NEGOSZ -
+	    sizeof (struct vmbus_icmsg_hdr);
+
+	/* Update total size, if necessary. */
+	if (dlen < VMBUS_IC_NEGOSZ)
+		*dlen0 = VMBUS_IC_NEGOSZ;
+
+	return (0);
+}
+
+/*
+ * Generic attach/detach functions for utility drivers.
+ *
+ * statep is the soft state pointer returned by ddi_get_soft_state()
+ * for the device instance.
+ */
+int
+vmbus_ic_attach(dev_info_t *dev, vmbus_chan_callback_t cb,
+    struct vmbus_ic_softc *sc)
+{
+	struct vmbus_channel *chan = vmbus_get_channel(dev);
+	int error = 0;
+
+	VERIFY3U(VMBUS_IC_NEGOSZ, <, VMBUS_IC_BRSIZE);
+
+	sc->ic_dev = dev;
+	sc->ic_buflen = VMBUS_IC_BRSIZE;
+	sc->ic_buf = kmem_zalloc(VMBUS_IC_BRSIZE, KM_SLEEP);
+
+	/*
+	 * These services are not performance critical and do not need
+	 * batched reading. Furthermore, some services such as KVP can
+	 * only handle one message from the host at a time.
+	 * Turn off batched reading for all util drivers before we open the
+	 * channel.
+	 */
+	vmbus_chan_set_readbatch(chan, B_FALSE);
+
+	error = vmbus_chan_open(chan, VMBUS_IC_BRSIZE, VMBUS_IC_BRSIZE, NULL, 0,
+	    cb, sc);
+	if (error) {
+		kmem_free(sc->ic_buf, VMBUS_IC_BRSIZE);
+		return (error);
+	}
+	return (0);
+}
+
+int
+vmbus_ic_detach(dev_info_t *dev, struct vmbus_ic_softc *sc)
+{
+	char *state;
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dev, DDI_PROP_DONTPASS,
+	    VMBUS_STATE, &state) != DDI_SUCCESS) {
+		dev_err(dev, CE_WARN, "cannot find property \"%s\"",
+		    VMBUS_STATE);
+		return (DDI_FAILURE);
+	}
+
+	/*
+	 * We only detach devices if we've been asked to by vmbus_child_delete.
+	 * So check to see if the state has been set to "offline".
+	 */
+	if (strcmp(state, VMBUS_STATE_OFFLINE) != 0) {
+		ddi_prop_free(state);
+		return (DDI_FAILURE);
+	}
+	ddi_prop_free(state);
+
+	vmbus_chan_close(vmbus_get_channel(dev));
+	kmem_free(sc->ic_buf, VMBUS_IC_BRSIZE);
+
+	return (0);
+}
+
+int
+vmbus_ic_sendresp(struct vmbus_ic_softc *sc, struct vmbus_channel *chan,
+    void *data, int dlen, uint64_t xactid)
+{
+	struct vmbus_icmsg_hdr *hdr;
+	int error;
+
+	ASSERT3U(dlen, >=, sizeof (*hdr));
+	hdr = data;
+
+	hdr->ic_flags = VMBUS_ICMSG_FLAG_XACT | VMBUS_ICMSG_FLAG_RESP;
+	error = vmbus_chan_send(chan, VMBUS_CHANPKT_TYPE_INBAND, 0,
+	    data, dlen, xactid);
+	if (error != 0)
+		dev_err(sc->ic_dev, CE_WARN, "resp send failed: %d", error);
+	return (error);
+}

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_icreg.h
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_icreg.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_ICREG_H_
+#define	_VMBUS_ICREG_H_
+
+#include <sys/sysmacros.h>
+
+#define	VMBUS_ICMSG_TYPE_NEGOTIATE	0
+#define	VMBUS_ICMSG_TYPE_HEARTBEAT	1
+#define	VMBUS_ICMSG_TYPE_KVP		2
+#define	VMBUS_ICMSG_TYPE_SHUTDOWN	3
+#define	VMBUS_ICMSG_TYPE_TIMESYNC	4
+#define	VMBUS_ICMSG_TYPE_VSS		5
+
+#define	VMBUS_ICMSG_STATUS_OK		0x00000000
+#define	VMBUS_ICMSG_STATUS_FAIL		0x80004005
+
+#define	VMBUS_IC_VERSION(major, minor)	((major) | (((uint32_t)(minor)) << 16))
+#define	VMBUS_ICVER_MAJOR(ver)		((ver) & 0xffff)
+#define	VMBUS_ICVER_MINOR(ver)		(((ver) & 0xffff0000) >> 16)
+#define	VMBUS_ICVER_SWAP(ver)		\
+	((VMBUS_ICVER_MAJOR((ver)) << 16) | VMBUS_ICVER_MINOR((ver)))
+#define	VMBUS_ICVER_LE(v1, v2)		\
+	(VMBUS_ICVER_SWAP((v1)) <= VMBUS_ICVER_SWAP((v2)))
+#define	VMBUS_ICVER_GT(v1, v2)		\
+	(VMBUS_ICVER_SWAP((v1)) > VMBUS_ICVER_SWAP((v2)))
+
+struct vmbus_pipe_hdr {
+	uint32_t		ph_flags;
+	uint32_t		ph_msgsz;
+} __packed;
+
+struct vmbus_icmsg_hdr {
+	struct vmbus_pipe_hdr	ic_pipe;
+	uint32_t		ic_fwver;	/* framework version */
+	uint16_t		ic_type;
+	uint32_t		ic_msgver;	/* message version */
+	uint16_t		ic_dsize;	/* data size */
+	uint32_t		ic_status;	/* VMBUS_ICMSG_STATUS_ */
+	uint8_t			ic_xactid;
+	uint8_t			ic_flags;	/* VMBUS_ICMSG_FLAG_ */
+	uint8_t			ic_rsvd[2];
+} __packed;
+
+#define	VMBUS_ICMSG_FLAG_XACT		0x0001
+#define	VMBUS_ICMSG_FLAG_REQ		0x0002
+#define	VMBUS_ICMSG_FLAG_RESP		0x0004
+
+/* VMBUS_ICMSG_TYPE_NEGOTIATE */
+struct vmbus_icmsg_negotiate {
+	struct vmbus_icmsg_hdr	ic_hdr;
+	uint16_t		ic_fwver_cnt;
+	uint16_t		ic_msgver_cnt;
+	uint32_t		ic_rsvd;
+	/*
+	 * This version array contains two set of supported
+	 * versions:
+	 * - The first set consists of #ic_fwver_cnt supported framework
+	 *   versions.
+	 * - The second set consists of #ic_msgver_cnt supported message
+	 *   versions.
+	 */
+	uint32_t		ic_ver[];
+} __packed;
+
+/* VMBUS_ICMSG_TYPE_HEARTBEAT */
+struct vmbus_icmsg_heartbeat {
+	struct vmbus_icmsg_hdr	ic_hdr;
+	uint64_t		ic_seq;
+	uint32_t		ic_rsvd[8];
+} __packed;
+
+#define	VMBUS_ICMSG_HEARTBEAT_SIZE_MIN	\
+	offsetof(struct vmbus_icmsg_heartbeat, ic_rsvd[0])
+
+/* VMBUS_ICMSG_TYPE_SHUTDOWN */
+struct vmbus_icmsg_shutdown {
+	struct vmbus_icmsg_hdr	ic_hdr;
+	uint32_t		ic_code;
+	uint32_t		ic_timeo;
+	uint32_t		ic_haltflags;
+	uint8_t			ic_msg[2048];
+} __packed;
+
+#define	VMBUS_ICMSG_SHUTDOWN_SIZE_MIN	\
+	offsetof(struct vmbus_icmsg_shutdown, ic_msg[0])
+
+/* VMBUS_ICMSG_TYPE_TIMESYNC */
+struct vmbus_icmsg_timesync {
+	struct vmbus_icmsg_hdr	ic_hdr;
+	uint64_t		ic_hvtime;
+	uint64_t		ic_vmtime;
+	uint64_t		ic_rtt;
+	uint8_t			ic_tsflags;	/* VMBUS_ICMSG_TS_FLAG_ */
+} __packed;
+
+/* VMBUS_ICMSG_TYPE_TIMESYNC, MSGVER4 */
+struct vmbus_icmsg_timesync4 {
+	struct vmbus_icmsg_hdr	ic_hdr;
+	uint64_t		ic_hvtime;
+	uint64_t		ic_vmtime;
+	uint64_t		ic_sent_tc;
+	uint8_t			ic_tsflags;	/* VMBUS_ICMSG_TS_FLAG_ */
+	uint8_t			ic_rsvd[5];
+} __packed;
+
+#define	VMBUS_ICMSG_TS_FLAG_SYNC	0x01
+#define	VMBUS_ICMSG_TS_FLAG_SAMPLE	0x02
+
+#define	VMBUS_ICMSG_TS_BASE		116444736000000000ULL
+
+#endif	/* !_VMBUS_ICREG_H_ */

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_icvar.h
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_icvar.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_ICVAR_H_
+#define	_VMBUS_ICVAR_H_
+
+#include <sys/dditypes.h>
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+
+struct vmbus_ic_softc {
+	dev_info_t		*ic_dev;
+	uint8_t			*ic_buf;
+	int			ic_buflen;
+	uint32_t		ic_fwver;	/* framework version */
+	uint32_t		ic_msgver;	/* message version */
+};
+
+struct vmbus_ic_desc {
+	const struct hyperv_guid	ic_guid;
+	const char			*ic_desc;
+};
+
+#define	VMBUS_IC_DESC_END	{ .ic_desc = NULL }
+
+int vmbus_ic_attach(dev_info_t *dev, vmbus_chan_callback_t cb,
+    struct vmbus_ic_softc *sc);
+int vmbus_ic_detach(dev_info_t *dev, struct vmbus_ic_softc *sc);
+int vmbus_ic_negomsg(struct vmbus_ic_softc *, void *data, int *dlen,
+    uint32_t fw_ver, uint32_t msg_ver);
+int vmbus_ic_sendresp(struct vmbus_ic_softc *sc, struct vmbus_channel *chan,
+    void *data, int dlen, uint64_t xactid);
+
+#endif /* !_VMBUS_ICVAR_H_ */

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_shutdown.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_shutdown.c
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2014,2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+
+#include <sys/conf.h>
+#include <sys/sunddi.h>
+#include <sys/devops.h>
+#include <sys/cmn_err.h>
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/uadmin.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include "vmbus_icreg.h"
+#include "vmbus_icvar.h"
+
+#define	VMBUS_SHUTDOWN_FWVER_MAJOR	3
+#define	VMBUS_SHUTDOWN_FWVER		\
+	VMBUS_IC_VERSION(VMBUS_SHUTDOWN_FWVER_MAJOR, 0)
+
+#define	VMBUS_SHUTDOWN_MSGVER_MAJOR	3
+#define	VMBUS_SHUTDOWN_MSGVER		\
+	VMBUS_IC_VERSION(VMBUS_SHUTDOWN_MSGVER_MAJOR, 0)
+
+const struct vmbus_ic_desc vmbus_shutdown_descs[] = {
+	{
+		.ic_guid = { .hv_guid = {
+		    0x31, 0x60, 0x0b, 0x0e, 0x13, 0x52, 0x34, 0x49,
+		    0x81, 0x8b, 0x38, 0xd9, 0x0c, 0xed, 0x39, 0xdb } },
+		.ic_desc = "Hyper-V Shutdown"
+	},
+	VMBUS_IC_DESC_END
+};
+
+static void *vmbus_shutdown_state;
+#define	SHUTDOWN_TIMEOUT_SECS	(60 * 5)
+
+/* ARGSUSED */
+static void
+vmbus_poweroff(void *arg)
+{
+	(void) kadmin(A_SHUTDOWN, AD_POWEROFF, NULL, kcred);
+}
+
+static void
+vmbus_shutdown_cb(struct vmbus_channel *chan, void *xsc)
+{
+	struct vmbus_ic_softc *sc = xsc;
+	struct vmbus_icmsg_hdr *hdr;
+	struct vmbus_icmsg_shutdown *msg;
+	int dlen, error = 0, do_shutdown = 0;
+	uint64_t xactid;
+	void *data;
+	proc_t *initpp;
+
+	/*
+	 * Receive request.
+	 */
+	data = sc->ic_buf;
+	dlen = sc->ic_buflen;
+	error = vmbus_chan_recv(chan, data, &dlen, &xactid);
+	ASSERT3S(error, !=, ENOBUFS);
+	if (error)
+		return;
+
+	if (dlen < sizeof (*hdr)) {
+		dev_err(sc->ic_dev, CE_WARN, "invalid data len %d", dlen);
+		return;
+	}
+	hdr = data;
+
+	/*
+	 * Update request, which will be echoed back as response.
+	 */
+	switch (hdr->ic_type) {
+	case VMBUS_ICMSG_TYPE_NEGOTIATE:
+		error = vmbus_ic_negomsg(sc, data, &dlen,
+		    VMBUS_SHUTDOWN_FWVER, VMBUS_SHUTDOWN_MSGVER);
+		if (error)
+			return;
+		break;
+
+	case VMBUS_ICMSG_TYPE_SHUTDOWN:
+		if (dlen < VMBUS_ICMSG_SHUTDOWN_SIZE_MIN) {
+			dev_err(sc->ic_dev, CE_WARN,
+			    "invalid shutdown len %d", dlen);
+			return;
+		}
+		msg = data;
+
+		/* XXX ic_flags definition? */
+		if (msg->ic_haltflags == 0 || msg->ic_haltflags == 1) {
+			dev_err(sc->ic_dev, CE_NOTE, "shutdown requested");
+			hdr->ic_status = VMBUS_ICMSG_STATUS_OK;
+			do_shutdown = 1;
+		} else {
+			dev_err(sc->ic_dev, CE_WARN, "unknown shutdown flags "
+			    "0x%08x", msg->ic_haltflags);
+			hdr->ic_status = VMBUS_ICMSG_STATUS_FAIL;
+		}
+		break;
+
+	default:
+		dev_err(sc->ic_dev, CE_NOTE, "got 0x%08x icmsg",
+		    hdr->ic_type);
+		break;
+	}
+
+	/*
+	 * Send response by echoing the request back.
+	 */
+	(void) vmbus_ic_sendresp(sc, chan, data, dlen, xactid);
+
+	if (do_shutdown) {
+		/*
+		 * If we're still booting and init(1) isn't set up yet,
+		 * simply halt.
+		 */
+		mutex_enter(&pidlock);
+		initpp = prfind(P_INITPID);
+		mutex_exit(&pidlock);
+		if (initpp == NULL) {
+			extern void halt(char *);
+			halt("Power off the System");
+		}
+
+		/*
+		 * Graceful shutdown with inittab and all getting involved
+		 */
+		psignal(initpp, SIGPWR);
+
+		(void) timeout(vmbus_poweroff, NULL,
+		    SHUTDOWN_TIMEOUT_SECS * drv_usectohz(MICROSEC));
+	}
+}
+
+static int
+vmbus_shutdown_attach(dev_info_t *dev, ddi_attach_cmd_t cmd)
+{
+	int err;
+	struct vmbus_ic_softc *sc;
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_ATTACH)
+		return (DDI_FAILURE);
+
+	if ((err = ddi_soft_state_zalloc(vmbus_shutdown_state, instance)) !=
+	    DDI_SUCCESS)
+		return (err);
+
+	sc = ddi_get_soft_state(vmbus_shutdown_state, instance);
+	err = vmbus_ic_attach(dev, vmbus_shutdown_cb, sc);
+	if (err != 0)
+		ddi_soft_state_free(vmbus_shutdown_state, instance);
+
+	return (err);
+}
+
+static int
+vmbus_shutdown_detach(dev_info_t *dev, ddi_detach_cmd_t cmd)
+{
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_DETACH)
+		return (DDI_FAILURE);
+
+	int err = vmbus_ic_detach(dev,
+	    ddi_get_soft_state(vmbus_shutdown_state, instance));
+	if (err == 0)
+		ddi_soft_state_free(vmbus_shutdown_state, instance);
+	return (err);
+}
+
+static struct cb_ops vmbus_shutdown_cb_ops = {
+	.cb_open =	nulldev,
+	.cb_close =	nulldev,
+	.cb_strategy =	nodev,
+	.cb_print =	nodev,
+	.cb_dump =	nodev,
+	.cb_read =	nodev,
+	.cb_write =	nodev,
+	.cb_ioctl =	nodev,
+	.cb_devmap =	nodev,
+	.cb_mmap =	nodev,
+	.cb_segmap =	nodev,
+	.cb_chpoll =	nochpoll,
+	.cb_prop_op =	ddi_prop_op,
+	.cb_str =	NULL,
+	.cb_flag =	D_NEW | D_MP
+};
+
+static struct dev_ops vmbus_shutdown_dev_ops = {
+	.devo_rev =		DEVO_REV,
+	.devo_refcnt =		0,
+	.devo_getinfo =		ddi_getinfo_1to1,
+	.devo_identify =	nulldev,
+	.devo_probe =		nulldev,
+	.devo_attach =		vmbus_shutdown_attach,
+	.devo_detach =		vmbus_shutdown_detach,
+	.devo_reset =		nodev,
+	.devo_cb_ops =		&vmbus_shutdown_cb_ops,
+	.devo_bus_ops =		NULL,
+	.devo_power =		NULL,
+	.devo_quiesce =		ddi_quiesce_not_needed
+};
+
+extern struct mod_ops mod_driverops;
+
+static struct modldrv vmbus_shutdown_modldrv = {
+	&mod_driverops,
+	"Hyper-V Shutdown Driver",
+	&vmbus_shutdown_dev_ops,
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&vmbus_shutdown_modldrv,
+	NULL
+};
+
+int
+_init(void)
+{
+	int error;
+
+	if ((error = ddi_soft_state_init(&vmbus_shutdown_state,
+	    sizeof (struct vmbus_ic_softc), 0)) != 0)
+		return (error);
+
+	if ((error = mod_install(&modlinkage)) != 0)
+		ddi_soft_state_fini(&vmbus_shutdown_state);
+	return (error);
+}
+
+int
+_fini(void)
+{
+	int error;
+
+	if ((error = mod_remove(&modlinkage)) == 0)
+		ddi_soft_state_fini(&vmbus_shutdown_state);
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_timesync.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_timesync.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2014,2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/conf.h>
+#include <sys/sunddi.h>
+#include <sys/devops.h>
+#include <sys/cmn_err.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/time.h>
+#include <sys/x86_archext.h>
+#include <sys/reboot.h>
+
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include "vmbus_icreg.h"
+#include "vmbus_icvar.h"
+
+#define	VMBUS_TIMESYNC_FWVER_MAJOR	3
+#define	VMBUS_TIMESYNC_FWVER		\
+	VMBUS_IC_VERSION(VMBUS_TIMESYNC_FWVER_MAJOR, 0)
+
+#define	VMBUS_TIMESYNC_MSGVER_MAJOR	4
+#define	VMBUS_TIMESYNC_MSGVER		\
+	VMBUS_IC_VERSION(VMBUS_TIMESYNC_MSGVER_MAJOR, 0)
+
+#define	VMBUS_TIMESYNC_MSGVER4(sc)	\
+	VMBUS_ICVER_LE(VMBUS_IC_VERSION(4, 0), (sc)->ic_msgver)
+
+#define	VMBUS_TIMESYNC_DORTT(sc)       \
+	(VMBUS_TIMESYNC_MSGVER4((sc)) && \
+	(hyperv_features & CPUID_HV_MSR_TIME_REFCNT))
+
+const struct vmbus_ic_desc vmbus_timesync_descs[] = {
+	{
+		.ic_guid = { .hv_guid = {
+		    0x30, 0xe6, 0x27, 0x95, 0xae, 0xd0, 0x7b, 0x49,
+		    0xad, 0xce, 0xe8, 0x0a, 0xb0, 0x17, 0x5c, 0xaf } },
+		.ic_desc = "Hyper-V Timesync"
+	},
+	VMBUS_IC_DESC_END
+};
+
+static void *vmbus_timesync_state;
+
+/*
+ * Ignore the sync request.
+ */
+int vmbus_ts_ignore_sync = 0;
+
+/*
+ * Trigger a sample sync when drift exceeds this threshold (ms).
+ * Ignore the sample request when set to 0.
+ */
+int vmbus_ts_sample_thresh = 100;
+
+/*
+ * Increase sample request verbosity
+ */
+boolean_t vmbus_ts_sample_verbose = B_FALSE;
+
+static void
+vmbus_timesync(struct vmbus_ic_softc *sc, uint64_t hvtime, uint64_t sent_tc,
+    uint8_t tsflags)
+{
+	hrtime_t hv_ns, vm_ns;
+	uint64_t rtt = 0;
+	timestruc_t now;
+
+	if (VMBUS_TIMESYNC_DORTT(sc))
+		rtt = rdmsr(MSR_HV_TIME_REF_COUNT) - sent_tc;
+
+	hv_ns = (hvtime - VMBUS_ICMSG_TS_BASE + rtt) * HYPERV_TIMER_NS_FACTOR;
+	gethrestime(&now);
+	vm_ns = now.tv_sec * NANOSEC + now.tv_nsec;
+
+	if ((tsflags & VMBUS_ICMSG_TS_FLAG_SYNC) && !vmbus_ts_ignore_sync) {
+		timestruc_t hv_ts;
+
+		if (boothowto & RB_VERBOSE) {
+			dev_err(sc->ic_dev, CE_NOTE, "apply sync request, "
+			    "hv: %lld, vm: %lld", hv_ns, vm_ns);
+		}
+		hv_ts.tv_sec = hv_ns / NANOSEC;
+		hv_ts.tv_nsec = hv_ns % NANOSEC;
+		mutex_enter(&tod_lock);
+		tod_set(hv_ts);
+		set_hrestime(&hv_ts);
+		mutex_exit(&tod_lock);
+		/* Done! */
+		return;
+	}
+
+	if ((tsflags & VMBUS_ICMSG_TS_FLAG_SAMPLE) &&
+	    vmbus_ts_sample_thresh >= 0) {
+		int64_t diff;
+
+		if (vmbus_ts_sample_verbose) {
+			dev_err(sc->ic_dev, CE_NOTE, "sample request, "
+			    "hv: %lld, vm: %lld", hv_ns, vm_ns);
+		}
+
+		if (hv_ns > vm_ns)
+			diff = hv_ns - vm_ns;
+		else
+			diff = vm_ns - hv_ns;
+		/* nanosec -> millisec */
+		diff /= 1000000;
+
+		if (diff > vmbus_ts_sample_thresh) {
+			timestruc_t hv_ts;
+
+			if (boothowto & RB_VERBOSE) {
+				dev_err(sc->ic_dev, CE_NOTE,
+				    "apply sample request, hv: %lld, "
+				    "vm: %lld", hv_ns, vm_ns);
+			}
+			hv_ts.tv_sec = hv_ns / NANOSEC;
+			hv_ts.tv_nsec = hv_ns % NANOSEC;
+			mutex_enter(&tod_lock);
+			tod_set(hv_ts);
+			set_hrestime(&hv_ts);
+			mutex_exit(&tod_lock);
+		}
+		/* Done */
+		return;
+	}
+}
+
+static void
+vmbus_timesync_cb(struct vmbus_channel *chan, void *xsc)
+{
+	struct vmbus_ic_softc *sc = xsc;
+	struct vmbus_icmsg_hdr *hdr;
+	int dlen, error = 0;
+	uint64_t xactid;
+	void *data;
+
+	/*
+	 * Receive request.
+	 */
+	data = sc->ic_buf;
+	dlen = sc->ic_buflen;
+	error = vmbus_chan_recv(chan, data, &dlen, &xactid);
+	/*
+	 * icbuf must be large enough
+	 */
+	ASSERT3S(error, !=, ENOBUFS);
+	if (error)
+		return;
+
+	if (dlen < sizeof (*hdr)) {
+		dev_err(sc->ic_dev, CE_WARN, "invalid data len %d", dlen);
+		return;
+	}
+	hdr = data;
+
+	/*
+	 * Update request, which will be echoed back as response.
+	 */
+	switch (hdr->ic_type) {
+	case VMBUS_ICMSG_TYPE_NEGOTIATE:
+		error = vmbus_ic_negomsg(sc, data, &dlen,
+		    VMBUS_TIMESYNC_FWVER, VMBUS_TIMESYNC_MSGVER);
+		if (error)
+			return;
+		if (VMBUS_TIMESYNC_DORTT(sc))
+			dev_err(sc->ic_dev, CE_WARN, "RTT");
+		break;
+
+	case VMBUS_ICMSG_TYPE_TIMESYNC:
+		if (VMBUS_TIMESYNC_MSGVER4(sc)) {
+			const struct vmbus_icmsg_timesync4 *msg4;
+
+			if (dlen < sizeof (*msg4)) {
+				dev_err(sc->ic_dev, CE_WARN,
+				    "invalid timesync4 len %d", dlen);
+				return;
+			}
+			msg4 = data;
+			vmbus_timesync(sc, msg4->ic_hvtime, msg4->ic_sent_tc,
+			    msg4->ic_tsflags);
+		} else {
+			const struct vmbus_icmsg_timesync *msg;
+
+			if (dlen < sizeof (*msg)) {
+				dev_err(sc->ic_dev, CE_WARN, "invalid timesync "
+				    "len %d", dlen);
+				return;
+			}
+			msg = data;
+			vmbus_timesync(sc, msg->ic_hvtime, 0, msg->ic_tsflags);
+		}
+		break;
+
+	default:
+		dev_err(sc->ic_dev, CE_NOTE, "got 0x%08x icmsg",
+		    hdr->ic_type);
+		break;
+	}
+
+	/*
+	 * Send response by echoing the request back.
+	 */
+	(void) vmbus_ic_sendresp(sc, chan, data, dlen, xactid);
+}
+
+static int
+vmbus_timesync_attach(dev_info_t *dev, ddi_attach_cmd_t cmd)
+{
+	int err;
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_ATTACH)
+		return (DDI_FAILURE);
+
+	if ((err = ddi_soft_state_zalloc(vmbus_timesync_state, instance)) !=
+	    DDI_SUCCESS)
+		return (err);
+
+	err = vmbus_ic_attach(dev, vmbus_timesync_cb,
+	    ddi_get_soft_state(vmbus_timesync_state, instance));
+	if (err != 0)
+		ddi_soft_state_free(vmbus_timesync_state, instance);
+
+	return (err);
+}
+
+static int
+vmbus_timesync_detach(dev_info_t *dev, ddi_detach_cmd_t cmd)
+{
+	int instance = ddi_get_instance(dev);
+
+	if (cmd != DDI_DETACH)
+		return (DDI_FAILURE);
+
+	int err = vmbus_ic_detach(dev,
+	    ddi_get_soft_state(vmbus_timesync_state, instance));
+	if (err == 0)
+		ddi_soft_state_free(vmbus_timesync_state, instance);
+	return (err);
+}
+
+static struct cb_ops vmbus_timesync_cb_ops = {
+	.cb_open =	nulldev,
+	.cb_close =	nulldev,
+	.cb_strategy =	nodev,
+	.cb_print =	nodev,
+	.cb_dump =	nodev,
+	.cb_read =	nodev,
+	.cb_write =	nodev,
+	.cb_ioctl =	nodev,
+	.cb_devmap =	nodev,
+	.cb_mmap =	nodev,
+	.cb_segmap =	nodev,
+	.cb_chpoll =	nochpoll,
+	.cb_prop_op =	ddi_prop_op,
+	.cb_str =	NULL,
+	.cb_flag =	D_NEW | D_MP
+};
+
+static struct dev_ops vmbus_timesync_dev_ops = {
+	.devo_rev =		DEVO_REV,
+	.devo_refcnt =		0,
+	.devo_getinfo =		ddi_getinfo_1to1,
+	.devo_identify =	nulldev,
+	.devo_probe =		nulldev,
+	.devo_attach =		vmbus_timesync_attach,
+	.devo_detach =		vmbus_timesync_detach,
+	.devo_reset =		nodev,
+	.devo_cb_ops =		&vmbus_timesync_cb_ops,
+	.devo_bus_ops =		NULL,
+	.devo_power =		NULL,
+	.devo_quiesce =		ddi_quiesce_not_needed
+};
+
+extern struct mod_ops mod_driverops;
+
+static struct modldrv vmbus_timesync_modldrv = {
+	&mod_driverops,
+	"Hyper-V Timesync Driver",
+	&vmbus_timesync_dev_ops,
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&vmbus_timesync_modldrv,
+	NULL
+};
+
+int
+_init(void)
+{
+	int error;
+
+	if ((error = ddi_soft_state_init(&vmbus_timesync_state,
+	    sizeof (struct vmbus_ic_softc), 0)) != 0)
+		return (error);
+
+	if ((error = mod_install(&modlinkage)) != 0)
+		ddi_soft_state_fini(&vmbus_timesync_state);
+	return (error);
+}
+
+int
+_fini(void)
+{
+	int error;
+
+	if ((error = mod_remove(&modlinkage)) == 0)
+		ddi_soft_state_fini(&vmbus_timesync_state);
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/THIRDPARTYLICENSE
+++ b/usr/src/uts/intel/io/hyperv/vmbus/THIRDPARTYLICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014,2016 Microsoft Corp.
+Copyright (c) 2012 NetApp Inc.
+Copyright (c) 2012 Citrix Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice unmodified, this list of conditions, and the following
+   disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/usr/src/uts/intel/io/hyperv/vmbus/THIRDPARTYLICENSE.descrip
+++ b/usr/src/uts/intel/io/hyperv/vmbus/THIRDPARTYLICENSE.descrip
@@ -1,0 +1,1 @@
+Microsoft VMBus and Hyperv drivers

--- a/usr/src/uts/intel/io/hyperv/vmbus/amd64/hyperv_machdep.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/amd64/hyperv_machdep.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <vmbus/hyperv_machdep.h>
+
+/* ARGSUSED */
+uint64_t
+hypercall_md(volatile void *hc_addr, uint64_t in_val,
+    uint64_t in_paddr, uint64_t out_paddr)
+{
+	uint64_t status = 0;
+
+	__asm__ __volatile__("mov %0, %%r8" : : "r" (out_paddr): "r8");
+	__asm__ __volatile__("call *%3" : "=a" (status) :
+	    "c" (in_val), "d" (in_paddr), "m" (hc_addr));
+	return (status);
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/hv_vmbus.conf
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hv_vmbus.conf
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+name="hv_vmbus" class="root";

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ * Implements low-level interactions with Hypver-V/Azure
+ */
+
+#include <sys/param.h>
+#include <sys/modctl.h>
+#include <sys/conf.h>
+#include <sys/types.h>
+#include <sys/inttypes.h>
+#include <sys/cmn_err.h>
+#include <sys/x86_archext.h>
+
+#include <sys/hyperv_illumos.h>
+#include <sys/hyperv_busdma.h>
+#include <vmbus/hyperv_machdep.h>
+
+#include "hyperv_reg.h"
+#include "hyperv_var.h"
+#include <sys/hyperv.h>
+
+#define	HYPERV_ILLUMOS_BUILD		0ULL
+#define	HYPERV_ILLUMOS_VERSION		511ULL
+#define	HYPERV_ILLUMOS_OSID		0ULL
+
+#define	MSR_HV_GUESTID_BUILD_ILLUMOS	\
+	(HYPERV_ILLUMOS_BUILD & MSR_HV_GUESTID_BUILD_MASK)
+#define	MSR_HV_GUESTID_VERSION_ILLUMOS	\
+	((HYPERV_ILLUMOS_VERSION << MSR_HV_GUESTID_VERSION_SHIFT) & \
+	MSR_HV_GUESTID_VERSION_MASK)
+#define	MSR_HV_GUESTID_OSID_ILLUMOS	\
+	((HYPERV_ILLUMOS_OSID << MSR_HV_GUESTID_OSID_SHIFT) & \
+	MSR_HV_GUESTID_OSID_MASK)
+
+#define	MSR_HV_GUESTID_ILLUMOS		\
+	(MSR_HV_GUESTID_BUILD_ILLUMOS |	\
+	MSR_HV_GUESTID_VERSION_ILLUMOS | \
+	MSR_HV_GUESTID_OSID_ILLUMOS |	\
+	MSR_HV_GUESTID_OSTYPE_ILLUMOS)
+
+#ifdef	DEBUG
+#define	hyperv_log(level, fmt...)	\
+	cmn_err(level, fmt);
+
+#define	HYPERCALL_LOG_STATUS(status)				\
+{								\
+	switch (status) {					\
+	case HYPERCALL_STATUS_SUCCESS:				\
+		break;						\
+	case HYPERCALL_STATUS_INVALID_HYPERCALL_INPUT:		\
+		hyperv_log(CE_WARN,				\
+		    "%s: Invalid hypercall input", __func__);	\
+		break;						\
+	case HYPERCALL_STATUS_INVALID_ALIGNMENT:		\
+		hyperv_log(CE_WARN,				\
+		    "%s: Invalid alignment", __func__);		\
+		break;						\
+	case HYPERCALL_STATUS_INSUFFICIENT_BUFFERS:		\
+		hyperv_log(CE_WARN,				\
+		    "%s: Insufficient buffers", __func__);	\
+		break;						\
+	case HYPERCALL_STATUS_INSUFFICIENT_MEMORY:		\
+		hyperv_log(CE_WARN,				\
+		    "%s: Insufficient memory", __func__);	\
+		break;						\
+	case HYPERCALL_STATUS_INVALID_CONNECTION_ID:		\
+		hyperv_log(CE_WARN,				\
+		    "%s: Invalid connection id", __func__);	\
+		break;						\
+	case HYPERCALL_STATUS_INVALID_HYPERCALL_CODE:		\
+		hyperv_log(CE_WARN,				\
+		    "%s: Invalid hypercall code", __func__);	\
+		break;						\
+	default:						\
+		hyperv_log(CE_WARN, "%s: Unknown status: %d",	\
+		    __func__, status);				\
+		break;						\
+	}							\
+}
+#else
+#define	hyperv_log(level, fmt...)
+#define	HYPERCALL_LOG_STATUS(status)
+#endif
+
+struct hypercall_ctx {
+	caddr_t		hc_addr;
+	hv_dma_t	hc_dma;
+};
+static struct hypercall_ctx	hypercall_context;
+
+uint_t		hyperv_recommends;
+
+/*
+ * Hyper-V Feature identification obtained by
+ * reading the CPUID_LEAF_HV_FEATURES cpuid.
+ * Results are in the following registers:
+ * hyperv_features (EAX):
+ *   This indicates which features are available to this partition
+ *   based upon current partition privileges.
+ * hyperv_features1 (EBX):
+ *   This indicates which flags were specified at partition creation.
+ * hyperv_pm_features (ECX):
+ *   This contains power management related information.
+ * hyperv_features3 (EDX):
+ *   This indicates which miscellaneous features are available to the partition.
+ */
+uint_t			hyperv_features;
+static uint_t		hyperv_features1;
+static uint_t		hyperv_pm_features;
+static uint_t		hyperv_features3;
+
+static boolean_t		hyperv_identify(void);
+static void			hypercall_memfree(void);
+
+hv_status_t
+hypercall_post_message(paddr_t msg_paddr)
+{
+	hv_status_t status;
+	status = hypercall_md(hypercall_context.hc_addr,
+	    HYPERCALL_POST_MESSAGE, msg_paddr, 0) & HYPERCALL_STATUS_MASK;
+	HYPERCALL_LOG_STATUS(status);
+	return (status);
+}
+
+hv_status_t
+hypercall_signal_event(paddr_t monprm_paddr)
+{
+	hv_status_t status;
+	status = hypercall_md(hypercall_context.hc_addr,
+	    HYPERCALL_SIGNAL_EVENT, monprm_paddr, 0) & HYPERCALL_STATUS_MASK;
+	HYPERCALL_LOG_STATUS(status);
+	return (status);
+}
+
+/* Get my partition id */
+hv_status_t
+hv_vmbus_get_partitionid(uint64_t part_paddr)
+{
+	hv_status_t status;
+	status = hypercall_md(hypercall_context.hc_addr,
+	    HV_CALL_GET_PARTITIONID, 0, part_paddr) & HYPERCALL_STATUS_MASK;
+	HYPERCALL_LOG_STATUS(status);
+	return (status);
+}
+
+int
+hyperv_guid2str(const struct hyperv_guid *guid, char *buf, size_t sz)
+{
+	const uint8_t *d = guid->hv_guid;
+
+	return snprintf(buf, sz, "%02x%02x%02x%02x-"
+	    "%02x%02x-%02x%02x-%02x%02x-"
+	    "%02x%02x%02x%02x%02x%02x",
+	    d[3], d[2], d[1], d[0],
+	    d[5], d[4], d[7], d[6], d[8], d[9],
+	    d[10], d[11], d[12], d[13], d[14], d[15]);
+}
+
+void
+do_cpuid(uint32_t eax, uint32_t *regs)
+{
+	struct cpuid_regs cp;
+	cp.cp_eax = eax;
+	(void) __cpuid_insn(&cp);
+	regs[0] = cp.cp_eax;
+	regs[1] = cp.cp_ebx;
+	regs[2] = cp.cp_ecx;
+	regs[3] = cp.cp_edx;
+	cmn_err(CE_CONT,
+	    "?do_cpuid: cpuid leaf=0x%08x, eax=0x%08x, ebx=0x%08x, "
+	    "ecx=0x%08x, edx=0x%08x\n", eax, regs[0], regs[1],
+	    regs[2], regs[3]);
+}
+
+/*
+ * Check if Hyper-V supported in currently booted environment
+ * And if so what features are available.
+ */
+static boolean_t
+hyperv_identify(void)
+{
+	uint32_t regs[4];
+	unsigned int maxleaf;
+
+	if ((get_hwenv() & HW_MICROSOFT) == 0) {
+		cmn_err(CE_WARN,
+		    "hyperv_identify: NOT Hyper-V environment: 0x%x",
+		    get_hwenv());
+		return (B_FALSE);
+	}
+
+	cmn_err(CE_CONT, "?hyperv_identify: Checking Hyper-V features...\n");
+	do_cpuid(CPUID_LEAF_HV_MAXLEAF, regs);
+	maxleaf = regs[0];
+	if (maxleaf < CPUID_LEAF_HV_LIMITS) {
+		cmn_err(CE_WARN,
+		    "hyperv_identify: max leaves mismatch, maxleaf=0x%08x",
+		    maxleaf);
+		return (B_FALSE);
+	}
+
+	do_cpuid(CPUID_LEAF_HV_INTERFACE, regs);
+	if (regs[0] != CPUID_HV_IFACE_HYPERV) {
+		cmn_err(CE_WARN,
+		    "hyperv_identify: Hyper-V signature mismatch=0x%08x",
+		    regs[0]);
+		return (B_FALSE);
+	}
+
+	do_cpuid(CPUID_LEAF_HV_FEATURES, regs);
+	if ((regs[0] & CPUID_HV_MSR_HYPERCALL) == 0) {
+		/*
+		 * Hyper-V w/o Hypercall is impossible; someone
+		 * is faking Hyper-V.
+		 */
+		cmn_err(CE_WARN,
+		    "hyperv_identify: Hypercall Interface not supported, "
+		    "please contact your system administrator!");
+		return (B_FALSE);
+	}
+
+	hyperv_features = regs[0]; /* EAX */
+	hyperv_features1 = regs[1]; /* EBX */
+	hyperv_pm_features = regs[2]; /* ECX */
+	hyperv_features3 = regs[3]; /* EDX */
+
+	do_cpuid(CPUID_LEAF_HV_IDENTITY, regs);
+	printf("Hyper-V Version: %d.%d.%d [SP%d]\n",
+	    regs[1] >> 16, regs[1] & 0xffff, regs[0], regs[2]);
+
+	printf("  Features=0x%b\n", hyperv_features,
+	    "\020"
+	    "\001VPRUNTIME"	/* MSR_HV_VP_RUNTIME */
+	    "\002TMREFCNT"	/* MSR_HV_TIME_REF_COUNT */
+	    "\003SYNIC"		/* MSRs for SynIC */
+	    "\004SYNTM"		/* MSRs for SynTimer */
+	    "\005APIC"		/* MSR_HV_{EOI,ICR,TPR} */
+	    "\006HYPERCALL"	/* MSR_HV_{GUEST_OS_ID,HYPERCALL} */
+	    "\007VPINDEX"	/* MSR_HV_VP_INDEX */
+	    "\010RESET"		/* MSR_HV_RESET */
+	    "\011STATS"		/* MSR_HV_STATS_ */
+	    "\012REFTSC"	/* MSR_HV_REFERENCE_TSC */
+	    "\013IDLE"		/* MSR_HV_GUEST_IDLE */
+	    "\014TMFREQ"	/* MSR_HV_{TSC,APIC}_FREQUENCY */
+	    "\015DEBUG");	/* MSR_HV_SYNTH_DEBUG_ */
+	printf("  Features1=0x%b\n", hyperv_features1,
+	    "\020"
+	    "\001CreatePartitions"
+	    "\002AccessPartitionId"
+	    "\003AccessMemoryPool"
+	    "\004AdjustMessageBuffers"
+	    "\005PostMessages"
+	    "\006SignalEvents"
+	    "\007CreatePort"
+	    "\008ConnectPort"
+	    "\009AccessStats"
+	    "\012Debugging"
+	    "\013CpuManagement"
+	    "\014ConfigureProfiler"
+	    "\015EnableExpandedStackwalking");
+	printf("  Features2(PM)=0x%b [C%u]\n",
+	    (hyperv_pm_features & ~CPUPM_HV_CSTATE_MASK),
+	    "\020"
+	    "\005C3HPET",	/* HPET is required for C3 state */
+	    CPUPM_HV_CSTATE(hyperv_pm_features));
+	printf("  Features3=0x%b\n", hyperv_features3,
+	    "\020"
+	    "\001MWAIT"		/* MWAIT */
+	    "\002DEBUG"		/* guest debug support */
+	    "\003PERFMON"	/* performance monitor */
+	    "\004PCPUDPE"	/* physical CPU dynamic partition event */
+	    "\005XMMHC"		/* hypercall input through XMM regs */
+	    "\006IDLE"		/* guest idle support */
+	    "\007SLEEP"		/* hypervisor sleep support */
+	    "\010NUMA"		/* NUMA distance query support */
+	    "\011TMFREQ"	/* timer frequency query (TSC, LAPIC) */
+	    "\012SYNCMC"	/* inject synthetic machine checks */
+	    "\013CRASH"		/* MSRs for guest crash */
+	    "\014DEBUGMSR"	/* MSRs for guest debug */
+	    "\015NPIEP"		/* NPIEP */
+	    "\016HVDIS");	/* disabling hypervisor */
+
+	do_cpuid(CPUID_LEAF_HV_RECOMMENDS, regs);
+	hyperv_recommends = regs[0];
+	cmn_err(CE_CONT,
+	    "?hyperv_identify:  Recommends: %08x %08x\n", regs[0], regs[1]);
+
+	do_cpuid(CPUID_LEAF_HV_LIMITS, regs);
+	cmn_err(CE_CONT,
+	    "?hyperv_identify:  Limits: Vcpu:%d Lcpu:%d Int:%d\n",
+	    regs[0], regs[1], regs[2]);
+
+	if (maxleaf >= CPUID_LEAF_HV_HWFEATURES) {
+		do_cpuid(CPUID_LEAF_HV_HWFEATURES, regs);
+		cmn_err(CE_CONT,
+		    "?hyperv_identify:  HW Features: %08x, AMD: %08x\n",
+		    regs[0], regs[3]);
+	}
+
+	return (B_TRUE);
+}
+
+static int
+hyperv_init(void)
+{
+	cmn_err(CE_CONT, "?hyperv_init: Checking Hyper-V support...\n");
+	if (!hyperv_identify()) {
+		cmn_err(CE_WARN,
+		    "hyperv_init: Hyper-V not supported on this environment");
+		return (-1);
+	}
+
+	/* Set guest id */
+	wrmsr(MSR_HV_GUEST_OS_ID, MSR_HV_GUESTID_ILLUMOS);
+	return (0);
+}
+
+static void
+hypercall_memfree(void)
+{
+	hyperv_dmamem_free(&hypercall_context.hc_dma);
+	hypercall_context.hc_addr = NULL;
+}
+
+
+/*
+ * Enable Hypercall interface
+ *
+ * All hypercalls are invoked using special opcode.
+ * Since this opcode can vary among hyper-v implementations,
+ * this is done through a special "Hypercall Page", used by
+ * the hypervisor to abstract the differences.
+ *
+ * We enable Hypercall interface by:
+ * - Creating a "Hypercall Page" in guest memory
+ * - Programming the Hypercall MSR (MSR_HV_HYPERCALL)
+ *   with the GPA (guest physical address) of the above page.
+ */
+int
+hypercall_create(dev_info_t *dip)
+{
+	uint64_t hc, hc_orig;
+
+	if (dip == NULL || (get_hwenv() & HW_MICROSOFT) == 0)
+		return (DDI_FAILURE);
+
+	dev_err(dip, CE_CONT, "?hypercall_create: Enabling Hypercall "
+	    "interface...\n");
+
+	/* Get the 'reserved' bits, which requires preservation. */
+	hc_orig = rdmsr(MSR_HV_HYPERCALL);
+	dev_err(dip, CE_CONT,
+	    "?hypercall_create: Current Hypercall MSR: 0x%"PRId64"\n", hc_orig);
+
+	/* Create a hypercall page */
+	hypercall_context.hc_addr = hyperv_dmamem_alloc(dip,
+	    PAGE_SIZE, 0, PAGE_SIZE, &hypercall_context.hc_dma, DDI_DMA_RDWR);
+	if (hypercall_context.hc_addr == NULL) {
+		dev_err(dip, CE_WARN,
+		    "hypercall_create: Hypercall Page allocation failed");
+		goto fail;
+	}
+
+	dev_err(dip, CE_CONT,
+	    "?hypercall_create: Hypercall Page allocation done: 0x%p\n",
+	    (void *)hypercall_context.hc_addr);
+
+	/*
+	 * Setup the Hypercall page.
+	 *
+	 * NOTE: 'reserved' bits (11:1) MUST be preserved.
+	 * And bit 0 must be set to 1 to indicate enable Hypercall Page.
+	 */
+	hc = ((hypercall_context.hc_dma.hv_paddr >> PAGE_SHIFT) <<
+	    MSR_HV_HYPERCALL_PGSHIFT) |
+	    (hc_orig & MSR_HV_HYPERCALL_RSVD_MASK) |
+	    MSR_HV_HYPERCALL_ENABLE;
+
+	dev_err(dip, CE_CONT,
+	    "?hypercall_create: Programming Hypercall MSR: 0x%"PRId64"\n", hc);
+
+	wrmsr(MSR_HV_HYPERCALL, hc);
+
+	/*
+	 * Confirm that Hypercall page did get setup.
+	 */
+	hc = rdmsr(MSR_HV_HYPERCALL);
+
+	if ((hc & MSR_HV_HYPERCALL_ENABLE) == 0) {
+		dev_err(dip, CE_CONT,
+		    "?hypercall_create: Verify Hypercall MSR: 0x%"PRId64
+		    "failed\n", hc);
+		hypercall_memfree();
+		goto fail;
+	}
+
+	dev_err(dip, CE_CONT,
+	    "?hypercall_create: Verified Hypercall MSR: 0x%"PRId64"\n", hc);
+	dev_err(dip, CE_CONT,
+	    "?hypercall_create: Enabling Hypercall interface - SUCCESS !\n");
+	return (DDI_SUCCESS);
+fail:
+	dev_err(dip, CE_WARN,
+	    "hypercall_create: Enabling Hypercall interface - FAILED.");
+	return (DDI_FAILURE);
+}
+
+/*
+ * Disable Hypercall interface
+ */
+void
+hypercall_destroy()
+{
+	uint64_t hc;
+
+	if (hypercall_context.hc_addr == NULL)
+		return;
+
+	cmn_err(CE_NOTE,
+	    "hypercall_destroy: Disabling Hypercall interface...");
+
+	/* Disable Hypercall */
+	hc = rdmsr(MSR_HV_HYPERCALL);
+	wrmsr(MSR_HV_HYPERCALL, (hc & MSR_HV_HYPERCALL_RSVD_MASK));
+	hypercall_memfree();
+
+	cmn_err(CE_NOTE,
+	    "hypercall_destroy: Disabling Hypercall interface - done.");
+}
+
+static struct modldrv hyperv_modldrv = {
+	&mod_miscops,
+	"Hyper-V Driver"
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&hyperv_modldrv,
+	NULL
+};
+
+int
+_init(void)
+{
+	if (hyperv_init() != 0)
+		return (ENOTSUP);
+
+	int error = mod_install(&modlinkage);
+	return (error);
+}
+
+int
+_fini(void)
+{
+	int error;
+
+	error = mod_remove(&modlinkage);
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv_busdma.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv_busdma.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/cmn_err.h>
+#include <sys/sysmacros.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/ddi_impldefs.h>
+#include <sys/param.h>
+#include <sys/hyperv_busdma.h>
+#include <sys/hyperv_illumos.h>
+
+/* Some dma attr defaults */
+#define	HV_DMA_ALIGN		0x0000000000001000ull	/* 4KB */
+#define	HV_DMA_MAX_SEGLEN	0x0000000000001000ull	/* 4KB */
+#define	HV_DMA_MAX_CNT		0x0000000000001000ull	/* 4KB */
+
+/* DMA default attributes */
+static ddi_dma_attr_t hc_default_dma_attr = {
+	.dma_attr_version = DMA_ATTR_V0,
+	.dma_attr_addr_lo = 0,
+	.dma_attr_addr_hi = 0xFFFFFFFFFFFFFFFFull,
+	.dma_attr_count_max = 0x7FFFFFFF,
+	.dma_attr_align = HV_DMA_ALIGN,
+	.dma_attr_burstsizes = 0x00001FFF,
+	.dma_attr_minxfer = 1,
+	.dma_attr_maxxfer = 0xFFFFFFFF,
+	.dma_attr_seg = 0xFFFFFFFFULL,
+	.dma_attr_sgllen = 1,
+	.dma_attr_granular = 0x00000001,
+	.dma_attr_flags = DDI_DMA_FLAGERR,
+};
+
+
+/* ARGSUSED */
+caddr_t
+hyperv_dmamem_alloc(dev_info_t *dip, uint64_t alignment,
+    uint64_t boundary, size_t size, hv_dma_t *dma, int dma_flags)
+{
+	int error = DDI_FAILURE;
+	size_t real_size = 0;
+	ddi_dma_attr_t hc_dma_attr;
+	uint_t ccnt = 0; /* cookie count */
+	static ddi_device_acc_attr_t hc_acc_attr = {
+		DDI_DEVICE_ATTR_V0,
+		DDI_STRUCTURE_LE_ACC,
+		DDI_STRICTORDER_ACC,
+		DDI_DEFAULT_ACC,
+	};
+
+	ASSERT(dip);
+	ASSERT(dma);
+
+	hc_dma_attr = hc_default_dma_attr;
+	hc_dma_attr.dma_attr_align = alignment;	/* alignment in bytes */
+	hc_dma_attr.dma_attr_minxfer = 1;  /* minimum transfer */
+
+	/* maximum number of segments */
+	hc_dma_attr.dma_attr_sgllen = 1;
+
+	dma->hv_dmah = NULL;
+	dma->hv_vaddr = NULL;
+	dma->hv_paddr = NULL;
+	dma->hv_acch = NULL;
+
+	if ((error = ddi_dma_alloc_handle(dip, &hc_dma_attr, DDI_DMA_SLEEP,
+	    NULL, &dma->hv_dmah)) != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN,
+		    "failed to allocate DMA handle, err: 0x%x", error);
+		return (NULL);
+	}
+
+	error = ddi_dma_mem_alloc(dma->hv_dmah, size, &hc_acc_attr,
+	    DDI_DMA_CONSISTENT, DDI_DMA_SLEEP, NULL,
+	    &dma->hv_vaddr, &real_size, &dma->hv_acch);
+	if (error != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN,
+		    "failed to allocate DMA memory, size: %lu, err: 0x%x",
+		    size, error);
+		goto fail;
+	}
+
+	if (size != real_size) {
+		dev_err(dip, CE_WARN,
+		    "requested size: %lu != real size: %lu", size, real_size);
+	}
+
+	/* dma_flags => DDI_DMA_WRITE/READ etc */
+	error = ddi_dma_addr_bind_handle(dma->hv_dmah, NULL, dma->hv_vaddr,
+	    real_size, dma_flags, DDI_DMA_SLEEP,
+	    NULL, &dma->hv_dmac, &ccnt);
+	if (error != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN,
+		    "failed to bind DMA memory, err: 0x%x", error);
+		goto fail;
+	}
+
+	if (ccnt != 1) { /* since sgllen = 1 */
+		dev_err(dip, CE_WARN,
+		    "unusable DMA mappings (too many segments: %d)", ccnt);
+		goto fail;
+	}
+
+	dma->hv_paddr = dma->hv_dmac.dmac_laddress;
+	/*
+	 * Host is strict about making sure that any reserved
+	 * fields and padding are zero initialized.
+	 */
+	bzero(dma->hv_vaddr, real_size);
+	return (dma->hv_vaddr);
+
+fail:
+	if (dma->hv_vaddr != NULL) {
+		ddi_dma_mem_free(&dma->hv_acch);
+	}
+	if (dma->hv_dmah != NULL) {
+		if (ddi_dma_unbind_handle(dma->hv_dmah) != DDI_SUCCESS)
+			dev_err(dip, CE_WARN, "failed to unbind DMA handle");
+		ddi_dma_free_handle(&dma->hv_dmah);
+		dma->hv_dmah = NULL;
+	}
+	return (NULL);
+}
+
+void
+hyperv_dmamem_free(hv_dma_t *dma)
+{
+	ASSERT3P(dma, !=, NULL);
+
+	if (dma->hv_acch != NULL)
+		ddi_dma_mem_free(&dma->hv_acch);
+
+	if (dma->hv_dmah != NULL) {
+		(void) ddi_dma_unbind_handle(dma->hv_dmah);
+		ddi_dma_free_handle(&dma->hv_dmah);
+	}
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv_machdep.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv_machdep.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HYPERV_MACHDEP_H_
+#define	_HYPERV_MACHDEP_H_
+
+#include <sys/param.h>
+
+uint64_t	hypercall_md(volatile void *hc_addr, uint64_t in_val,
+		    uint64_t in_paddr, uint64_t out_paddr);
+
+#endif	/* !_HYPERV_MACHDEP_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv_reg.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv_reg.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _HYPERV_REG_H_
+#define	_HYPERV_REG_H_
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/hyperv_illumos.h>
+
+/*
+ * Hyper-V Synthetic MSRs
+ */
+
+#define	MSR_HV_GUEST_OS_ID		0x40000000
+#define	MSR_HV_GUESTID_BUILD_MASK	0xffffULL
+#define	MSR_HV_GUESTID_VERSION_MASK	0x0000ffffffff0000ULL
+#define	MSR_HV_GUESTID_VERSION_SHIFT	16
+#define	MSR_HV_GUESTID_OSID_MASK	0x00ff000000000000ULL
+#define	MSR_HV_GUESTID_OSID_SHIFT	48
+#define	MSR_HV_GUESTID_OSTYPE_MASK	0x7f00000000000000ULL
+#define	MSR_HV_GUESTID_OSTYPE_SHIFT	56
+#define	MSR_HV_GUESTID_OPENSRC		0x8000000000000000ULL
+#define	MSR_HV_GUESTID_OSTYPE_LINUX	\
+	((0x01ULL << MSR_HV_GUESTID_OSTYPE_SHIFT) | MSR_HV_GUESTID_OPENSRC)
+#define	MSR_HV_GUESTID_OSTYPE_FREEBSD	\
+	((0x02ULL << MSR_HV_GUESTID_OSTYPE_SHIFT) | MSR_HV_GUESTID_OPENSRC)
+#define	MSR_HV_GUESTID_OSTYPE_ILLUMOS   \
+	((0x03ULL << MSR_HV_GUESTID_OSTYPE_SHIFT) | MSR_HV_GUESTID_OPENSRC)
+
+#define	MSR_HV_HYPERCALL		0x40000001
+#define	MSR_HV_HYPERCALL_ENABLE		0x0001ULL
+#define	MSR_HV_HYPERCALL_RSVD_MASK	0x0ffeULL
+#define	MSR_HV_HYPERCALL_PGSHIFT	12
+
+#define	MSR_HV_VP_INDEX			0x40000002
+
+#define	MSR_HV_SCONTROL			0x40000080
+#define	MSR_HV_SCTRL_ENABLE		0x0001ULL
+#define	MSR_HV_SCTRL_RSVD_MASK		0xfffffffffffffffeULL
+
+#define	MSR_HV_SIEFP			0x40000082
+#define	MSR_HV_SIEFP_ENABLE		0x0001ULL
+#define	MSR_HV_SIEFP_RSVD_MASK		0x0ffeULL
+#define	MSR_HV_SIEFP_PGSHIFT		12
+
+#define	MSR_HV_SIMP			0x40000083
+#define	MSR_HV_SIMP_ENABLE		0x0001ULL
+#define	MSR_HV_SIMP_RSVD_MASK		0x0ffeULL
+#define	MSR_HV_SIMP_PGSHIFT		12
+
+#define	MSR_HV_EOM			0x40000084
+
+#define	MSR_HV_SINT0			0x40000090
+#define	MSR_HV_SINT_VECTOR_MASK		0x00ffULL
+#define	MSR_HV_SINT_RSVD1_MASK		0xff00ULL
+#define	MSR_HV_SINT_MASKED		0x00010000ULL
+#define	MSR_HV_SINT_AUTOEOI		0x00020000ULL
+#define	MSR_HV_SINT_RSVD2_MASK		0xfffffffffffc0000ULL
+#define	MSR_HV_SINT_RSVD_MASK		\
+	(MSR_HV_SINT_RSVD1_MASK | MSR_HV_SINT_RSVD2_MASK)
+
+#define	MSR_HV_STIMER0_CONFIG		0x400000b0
+#define	MSR_HV_STIMER_CFG_ENABLE	0x0001ULL
+#define	MSR_HV_STIMER_CFG_PERIODIC	0x0002ULL
+#define	MSR_HV_STIMER_CFG_LAZY		0x0004ULL
+#define	MSR_HV_STIMER_CFG_AUTOEN	0x0008ULL
+#define	MSR_HV_STIMER_CFG_SINT_MASK	0x000f0000ULL
+#define	MSR_HV_STIMER_CFG_SINT_SHIFT	16
+
+#define	MSR_HV_STIMER0_COUNT		0x400000b1
+
+/*
+ * CPUID leaves
+ */
+
+#define	CPUID_LEAF_HV_MAXLEAF		0x40000000
+
+#define	CPUID_LEAF_HV_INTERFACE		0x40000001
+#define	CPUID_HV_IFACE_HYPERV		0x31237648	/* HV#1 */
+
+#define	CPUID_LEAF_HV_IDENTITY		0x40000002
+
+#define	CPUID_LEAF_HV_FEATURES		0x40000003
+/* EAX: features include/hyperv.h CPUID_HV_MSR */
+/* ECX: power management features */
+#define	CPUPM_HV_CSTATE_MASK		0x000f	/* deepest C-state */
+#define	CPUPM_HV_C3_HPET		0x0010	/* C3 requires HPET */
+#define	CPUPM_HV_CSTATE(f)		((f) & CPUPM_HV_CSTATE_MASK)
+/* EDX: features3 */
+#define	CPUID3_HV_MWAIT			0x0001	/* MWAIT */
+/* Hypercall input through XMM regs */
+#define	CPUID3_HV_XMM_HYPERCALL		0x0010
+#define	CPUID3_HV_GUEST_IDLE		0x0020	/* guest idle */
+#define	CPUID3_HV_NUMA			0x0080	/* NUMA distance query */
+/* timer frequency query (TSC, LAPIC) */
+#define	CPUID3_HV_TIME_FREQ		0x0100
+#define	CPUID3_HV_MSR_CRASH		0x0400	/* MSRs for guest crash */
+
+#define	CPUID_LEAF_HV_RECOMMENDS	0x40000004
+#define	CPUID_LEAF_HV_LIMITS		0x40000005
+#define	CPUID_LEAF_HV_HWFEATURES	0x40000006
+
+/*
+ * Hyper-V Monitor Notification Facility
+ */
+struct hyperv_mon_param {
+	uint32_t	mp_connid;
+	uint16_t	mp_evtflag_ofs;
+	uint16_t	mp_rsvd;
+} __packed;
+
+/*
+ * Hyper-V message types
+ */
+#define	HYPERV_MSGTYPE_NONE		0
+#define	HYPERV_MSGTYPE_CHANNEL		1
+#define	HYPERV_MSGTYPE_TIMER_EXPIRED	0x80000010
+
+/*
+ * Hypercall status codes
+ */
+#define	HYPERCALL_STATUS_SUCCESS			0
+#define	HYPERCALL_STATUS_INVALID_HYPERCALL_CODE		2
+#define	HYPERCALL_STATUS_INVALID_HYPERCALL_INPUT	3
+#define	HYPERCALL_STATUS_INVALID_ALIGNMENT		4
+#define	HYPERCALL_STATUS_INSUFFICIENT_MEMORY		11
+#define	HYPERCALL_STATUS_INVALID_CONNECTION_ID		18
+#define	HYPERCALL_STATUS_INSUFFICIENT_BUFFERS		19
+#define	HYPERCALL_STATUS_MASK				0xFFFF
+
+/*
+ * Hypercall input values
+ */
+#define	HYPERCALL_POST_MESSAGE		0x005c
+#define	HYPERCALL_SIGNAL_EVENT		0x005d
+
+/*
+ * Hypercall input parameters
+ */
+#define	HYPERCALL_PARAM_ALIGN		8
+#if 0
+/*
+ * XXX
+ * <<Hypervisor Top Level Functional Specification 4.0b>> requires
+ * input parameters size to be multiple of 8, however, many post
+ * message input parameters do _not_ meet this requirement.
+ */
+#define	HYPERCALL_PARAM_SIZE_ALIGN	8
+#endif
+
+/*
+ * HYPERCALL_POST_MESSAGE
+ */
+#define	HYPERCALL_POSTMSGIN_DSIZE_MAX	240
+#define	HYPERCALL_POSTMSGIN_SIZE	256
+
+struct hypercall_postmsg_in {
+	uint32_t	hc_connid;
+	uint32_t	hc_rsvd;
+	uint32_t	hc_msgtype;	/* HYPERV_MSGTYPE_ */
+	uint32_t	hc_dsize;
+	uint8_t		hc_data[HYPERCALL_POSTMSGIN_DSIZE_MAX];
+} __packed;
+CTASSERT(sizeof (struct hypercall_postmsg_in) == HYPERCALL_POSTMSGIN_SIZE);
+
+/*
+ * HYPERCALL_SIGNAL_EVENT
+ *
+ * struct hyperv_mon_param.
+ */
+
+#endif	/* !_HYPERV_REG_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv_var.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv_var.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef	_HYPERV_VAR_H_
+#define	_HYPERV_VAR_H_
+
+#include <sys/types.h>
+
+extern uint_t	hyperv_recommends;
+
+typedef uint16_t hv_status_t;
+typedef enum {
+	HV_CALL_GET_PARTITIONID = 0x0046,
+	HV_CALL_POST_MESSAGE	= 0x005c,
+	HV_CALL_SIGNAL_EVENT	= 0x005d,
+} hv_vmbus_call_code;
+
+int		hypercall_create(dev_info_t *);
+void		hypercall_destroy(void);
+hv_status_t	hypercall_post_message(paddr_t msg_paddr);
+hv_status_t	hypercall_signal_event(paddr_t monprm_paddr);
+
+#endif	/* !_HYPERV_VAR_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/ia32/hyperv_machdep.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/ia32/hyperv_machdep.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <vmbus/hyperv_machdep.h>
+
+/* ARGSUSED */
+uint64_t
+hypercall_md(volatile void *hc_addr, uint64_t in_val,
+    uint64_t in_paddr, uint64_t out_paddr)
+{
+	uint32_t in_val_hi = in_val >> 32;
+	uint32_t in_val_lo = in_val & 0xFFFFFFFF;
+	uint32_t status_hi = 0;
+	uint32_t status_lo = 0;
+	uint32_t in_paddr_hi = in_paddr >> 32;
+	uint32_t in_paddr_lo = in_paddr & 0xFFFFFFFF;
+	uint32_t out_paddr_hi = out_paddr >> 32;
+	uint32_t out_paddr_lo = out_paddr & 0xFFFFFFFF;
+
+	__asm__ __volatile__("call *%8" : "=d"(status_hi), "=a"(status_lo) :
+	    "d" (in_val_hi), "a" (in_val_lo),
+	    "b" (in_paddr_hi), "c" (in_paddr_lo),
+	    "D"(out_paddr_hi), "S"(out_paddr_lo),
+	    "m" (hc_addr));
+	return (status_lo | ((uint64_t)status_hi << 32));
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -1,0 +1,1453 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+/*
+ * VM Bus Driver Implementation
+ */
+#include <sys/hyperv.h>
+#include <sys/vmbus_xact.h>
+#include <vmbus/hyperv_var.h>
+#include <vmbus/vmbus_var.h>
+#include <vmbus/vmbus_reg.h>
+#include <vmbus/vmbus_chanvar.h>
+#include <sys/types.h>
+#include <sys/conf.h>
+#include <sys/cpuvar.h>
+#include <sys/callo.h>
+#include <sys/sysmacros.h>
+#include <sys/smp_impldefs.h>
+#include <sys/x_call.h>
+#include <sys/x86_archext.h>
+#include <sys/sunndi.h>
+
+#define	curcpu	CPU->cpu_id
+
+#define	VMBUS_GPADL_START		0xe1e10
+
+struct vmbus_msghc {
+	struct vmbus_xact		*mh_xact;
+	struct hypercall_postmsg_in	mh_inprm_save;
+};
+
+kmutex_t vmbus_lock;
+
+
+static int			vmbus_attach(dev_info_t *, ddi_attach_cmd_t);
+static int			vmbus_detach(dev_info_t *, ddi_detach_cmd_t);
+static int			vmbus_init(struct vmbus_softc *);
+static int			vmbus_connect(struct vmbus_softc *, uint32_t);
+static int			vmbus_req_channels(struct vmbus_softc *sc);
+static void			vmbus_disconnect(struct vmbus_softc *);
+static int			vmbus_scan(struct vmbus_softc *);
+static void			vmbus_scan_teardown(struct vmbus_softc *);
+static void			vmbus_scan_done(struct vmbus_softc *,
+				    const struct vmbus_message *);
+static void			vmbus_chanmsg_handle(struct vmbus_softc *,
+				    const struct vmbus_message *);
+static void			vmbus_msg_task(void *);
+static void			vmbus_synic_setup(void *);
+static void			vmbus_synic_teardown(void *);
+static int			vmbus_dma_alloc(struct vmbus_softc *);
+static void			vmbus_dma_free(struct vmbus_softc *);
+static int			vmbus_intr_setup(struct vmbus_softc *);
+static void			vmbus_intr_teardown(struct vmbus_softc *);
+static int			vmbus_doattach(struct vmbus_softc *);
+static void			vmbus_event_proc_dummy(struct vmbus_softc *,
+				    int);
+
+typedef void (*vmbus_xcall_func_t)(void *);
+static void			vmbus_xcall(vmbus_xcall_func_t, void *);
+
+static void			*vmbus_state = NULL;
+static struct vmbus_softc	*vmbus_sc;
+
+static const uint32_t		vmbus_version[] = {
+	VMBUS_VERSION_WIN8_1,
+	VMBUS_VERSION_WIN8,
+	VMBUS_VERSION_WIN7,
+	VMBUS_VERSION_WS2008
+};
+
+static const vmbus_chanmsg_proc_t
+vmbus_chanmsg_handlers[VMBUS_CHANMSG_TYPE_MAX] = {
+	VMBUS_CHANMSG_PROC(CHOFFER_DONE, vmbus_scan_done),
+	VMBUS_CHANMSG_PROC_WAKEUP(CONNECT_RESP)
+};
+
+static __inline struct vmbus_softc *
+vmbus_get_softc(void)
+{
+	return (vmbus_sc);
+}
+
+void
+vmbus_msghc_reset(struct vmbus_msghc *mh, size_t dsize)
+{
+	struct hypercall_postmsg_in *inprm;
+
+	if (dsize > HYPERCALL_POSTMSGIN_DSIZE_MAX)
+		panic("invalid data size %llu", (u_longlong_t)dsize);
+
+	inprm = vmbus_xact_req_data(mh->mh_xact);
+	(void) memset(inprm, 0, HYPERCALL_POSTMSGIN_SIZE);
+	inprm->hc_connid = VMBUS_CONNID_MESSAGE;
+	inprm->hc_msgtype = HYPERV_MSGTYPE_CHANNEL;
+	inprm->hc_dsize = (uint32_t)dsize;
+}
+
+struct vmbus_msghc *
+vmbus_msghc_get(struct vmbus_softc *sc, size_t dsize)
+{
+	struct vmbus_msghc *mh = NULL;
+	struct vmbus_xact *xact;
+
+	if (dsize > HYPERCALL_POSTMSGIN_DSIZE_MAX)
+		panic("invalid data size %llu", (u_longlong_t)dsize);
+
+	xact = vmbus_xact_get(sc->vmbus_xc,
+	    dsize + offsetof(struct hypercall_postmsg_in, hc_data[0]));
+	if (xact == NULL)
+		return (NULL);
+
+	mh = vmbus_xact_priv(xact, sizeof (*mh));
+	mh->mh_xact = xact;
+
+	vmbus_msghc_reset(mh, dsize);
+	return (mh);
+}
+
+/* ARGSUSED */
+void
+vmbus_msghc_put(struct vmbus_softc *sc, struct vmbus_msghc *mh)
+{
+
+	vmbus_xact_put(mh->mh_xact);
+}
+
+void *
+vmbus_msghc_dataptr(struct vmbus_msghc *mh)
+{
+	struct hypercall_postmsg_in *inprm;
+
+	inprm = vmbus_xact_req_data(mh->mh_xact);
+	return (inprm->hc_data);
+}
+
+int
+vmbus_msghc_exec_noresult(struct vmbus_msghc *mh)
+{
+	clock_t delay_us = MILLISEC;
+	struct hypercall_postmsg_in *inprm;
+	paddr_t inprm_paddr;
+	int i;
+
+	inprm = vmbus_xact_req_data(mh->mh_xact);
+	inprm_paddr = vmbus_xact_req_paddr(mh->mh_xact);
+
+	/*
+	 * Save the input parameter so that we could restore the input
+	 * parameter if the Hypercall failed.
+	 *
+	 * XXX
+	 * Is this really necessary?!  i.e. Will the Hypercall ever
+	 * overwrite the input parameter?
+	 */
+	(void) memcpy(&mh->mh_inprm_save, inprm, HYPERCALL_POSTMSGIN_SIZE);
+
+	/*
+	 * In order to cope with transient failures, e.g. insufficient
+	 * resources on host side, we retry the post message Hypercall
+	 * several times.  20 retries seem sufficient.
+	 */
+#define	HC_RETRY_MAX	20
+
+	for (i = 0; i < HC_RETRY_MAX; ++i) {
+		uint64_t status;
+
+		status = hypercall_post_message(inprm_paddr);
+		if (status == HYPERCALL_STATUS_SUCCESS)
+			return (0);
+
+		drv_usecwait(delay_us);
+		if (delay_us < MICROSEC * 2)
+			delay_us *= 2;
+
+		/* Restore input parameter and try again */
+		(void) memcpy(inprm, &mh->mh_inprm_save,
+		    HYPERCALL_POSTMSGIN_SIZE);
+	}
+
+#undef HC_RETRY_MAX
+
+	return (EIO);
+}
+
+/* ARGSUSED */
+int
+vmbus_msghc_exec(struct vmbus_softc *sc, struct vmbus_msghc *mh)
+{
+	int error;
+
+	vmbus_xact_activate(mh->mh_xact);
+	error = vmbus_msghc_exec_noresult(mh);
+	if (error)
+		vmbus_xact_deactivate(mh->mh_xact);
+	return (error);
+}
+
+/* ARGSUSED */
+void
+vmbus_msghc_exec_cancel(struct vmbus_softc *sc, struct vmbus_msghc *mh)
+{
+
+	vmbus_xact_deactivate(mh->mh_xact);
+}
+
+/* ARGSUSED */
+const struct vmbus_message *
+vmbus_msghc_wait_result(struct vmbus_softc *sc, struct vmbus_msghc *mh)
+{
+	size_t resp_len;
+
+	return (vmbus_xact_wait(mh->mh_xact, &resp_len));
+}
+
+/* ARGSUSED */
+const struct vmbus_message *
+vmbus_msghc_poll_result(struct vmbus_softc *sc, struct vmbus_msghc *mh)
+{
+	size_t resp_len;
+
+	return (vmbus_xact_poll(mh->mh_xact, &resp_len));
+}
+
+void
+vmbus_msghc_wakeup(struct vmbus_softc *sc, const struct vmbus_message *msg)
+{
+	vmbus_xact_ctx_wakeup(sc->vmbus_xc, msg, sizeof (*msg));
+}
+
+uint32_t
+vmbus_gpadl_alloc(struct vmbus_softc *sc)
+{
+	uint32_t gpadl;
+
+again:
+	gpadl = atomic_inc_32_nv(&sc->vmbus_gpadl) - 1;
+	if (gpadl == 0)
+		goto again;
+	return (gpadl);
+}
+
+static int
+vmbus_connect(struct vmbus_softc *sc, uint32_t version)
+{
+	struct vmbus_chanmsg_connect *req;
+	const struct vmbus_message *msg;
+	struct vmbus_msghc *mh;
+	int error, done = 0;
+
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL)
+		return (ENXIO);
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_CONNECT;
+	req->chm_ver = version;
+	req->chm_evtflags = sc->vmbus_evtflags_dma.hv_paddr;
+	req->chm_mnf1 = sc->vmbus_mnf1_dma.hv_paddr;
+	req->chm_mnf2 = sc->vmbus_mnf2_dma.hv_paddr;
+
+	error = vmbus_msghc_exec(sc, mh);
+	if (error) {
+		vmbus_msghc_put(sc, mh);
+		return (error);
+	}
+
+	msg = vmbus_msghc_wait_result(sc, mh);
+	done = ((const struct vmbus_chanmsg_connect_resp *)
+	    msg->msg_data)->chm_done;
+
+	vmbus_msghc_put(sc, mh);
+
+	return (done ? 0 : EOPNOTSUPP);
+}
+
+static int
+vmbus_init(struct vmbus_softc *sc)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(vmbus_version); ++i) {
+		int error;
+
+		error = vmbus_connect(sc, vmbus_version[i]);
+		if (!error) {
+			char version[16];
+
+			sc->vmbus_version = vmbus_version[i];
+			(void) snprintf(version, sizeof (version),
+			    "%u.%u", VMBUS_VERSION_MAJOR(sc->vmbus_version),
+			    VMBUS_VERSION_MINOR(sc->vmbus_version));
+			dev_err(sc->vmbus_dev, CE_NOTE, "version %s",
+			    version);
+			(void) ddi_prop_update_string(DDI_DEV_T_NONE,
+			    sc->vmbus_dev, VMBUS_VERSION, version);
+			return (0);
+		}
+	}
+	return (ENXIO);
+}
+
+static void
+vmbus_disconnect(struct vmbus_softc *sc)
+{
+	struct vmbus_chanmsg_disconnect *req;
+	struct vmbus_msghc *mh;
+	int error;
+
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL) {
+		dev_err(sc->vmbus_dev, CE_WARN,
+		    "can not get msg hypercall for disconnect");
+		return;
+	}
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_DISCONNECT;
+
+	error = vmbus_msghc_exec_noresult(mh);
+	vmbus_msghc_put(sc, mh);
+
+	if (error) {
+		dev_err(sc->vmbus_dev, CE_WARN,
+		    "disconnect msg hypercall failed");
+	}
+}
+
+static int
+vmbus_req_channels(struct vmbus_softc *sc)
+{
+	struct vmbus_chanmsg_chrequest *req;
+	struct vmbus_msghc *mh;
+	int error;
+
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL)
+		return (ENXIO);
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_CHREQUEST;
+
+	error = vmbus_msghc_exec_noresult(mh);
+	vmbus_msghc_put(sc, mh);
+
+	return (error);
+}
+
+static void
+vmbus_scan_done_task(void *xsc)
+{
+	struct vmbus_softc *sc = xsc;
+
+	mutex_enter(&vmbus_lock);
+	sc->vmbus_scandone = B_TRUE;
+	cv_broadcast(&sc->vmbus_scandone_cv);
+	mutex_exit(&vmbus_lock);
+}
+
+/* ARGSUSED */
+static void
+vmbus_scan_done(struct vmbus_softc *sc,
+    const struct vmbus_message *msg)
+{
+
+	if (ddi_taskq_dispatch(sc->vmbus_devtq,
+	    vmbus_scan_done_task, sc, DDI_SLEEP) != DDI_SUCCESS) {
+		dev_err(sc->vmbus_dev, CE_WARN, "dispatch of "
+		    "vmbus_scan_done_task failed");
+	}
+}
+
+static int
+vmbus_scan(struct vmbus_softc *sc)
+{
+	int error;
+
+	/*
+	 * This taskqueue serializes vmbus devices' attach and detach
+	 * for channel offer and rescind messages.
+	 */
+	sc->vmbus_devtq = ddi_taskq_create(sc->vmbus_dev,
+	    "vmbus dev", 1, maxclsyspri, TASKQ_PREPOPULATE);
+
+	/*
+	 * This taskqueue handles sub-channel detach, so that vmbus
+	 * device's detach running in vmbus_devtq can drain its sub-
+	 * channels.
+	 */
+	sc->vmbus_subchtq = ddi_taskq_create(sc->vmbus_dev,
+	    "vmbus subch", 1, maxclsyspri, TASKQ_PREPOPULATE);
+
+	/*
+	 * Start vmbus scanning.
+	 */
+	error = vmbus_req_channels(sc);
+	if (error) {
+		dev_err(sc->vmbus_dev, CE_WARN, "channel request failed: %d",
+		    error);
+		return (error);
+	}
+
+	/*
+	 * Wait for all vmbus devices from the initial channel offers to be
+	 * attached.
+	 */
+	ASSERT(MUTEX_HELD(&vmbus_lock));
+	while (!sc->vmbus_scandone)
+		cv_wait(&sc->vmbus_scandone_cv, &vmbus_lock);
+
+	dev_err(sc->vmbus_dev, CE_CONT, "?device scan, probe and attach "
+	    "done\n");
+	return (0);
+}
+
+static void
+vmbus_scan_teardown(struct vmbus_softc *sc)
+{
+
+	ASSERT(MUTEX_HELD(&vmbus_lock));
+	if (sc->vmbus_devtq != NULL) {
+		mutex_exit(&vmbus_lock);
+		ddi_taskq_destroy(sc->vmbus_devtq);
+		mutex_enter(&vmbus_lock);
+		sc->vmbus_devtq = NULL;
+	}
+	if (sc->vmbus_subchtq != NULL) {
+		mutex_exit(&vmbus_lock);
+		ddi_taskq_destroy(sc->vmbus_subchtq);
+		mutex_enter(&vmbus_lock);
+		sc->vmbus_subchtq = NULL;
+	}
+}
+
+static void
+vmbus_chanmsg_handle(struct vmbus_softc *sc, const struct vmbus_message *msg)
+{
+	vmbus_chanmsg_proc_t msg_proc;
+	uint32_t msg_type;
+
+	msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;
+	if (msg_type >= VMBUS_CHANMSG_TYPE_MAX) {
+		dev_err(sc->vmbus_dev, CE_WARN, "unknown message type 0x%x",
+		    msg_type);
+		return;
+	}
+
+	msg_proc = vmbus_chanmsg_handlers[msg_type];
+	if (msg_proc != NULL)
+		msg_proc(sc, msg);
+
+	/* Channel specific processing */
+	vmbus_chan_msgproc(sc, msg);
+}
+
+static void
+vmbus_msg_task(void *arg)
+{
+	struct vmbus_message *msg_base = (struct vmbus_message *)arg;
+	volatile struct vmbus_message *msg;
+	struct vmbus_softc *sc = vmbus_get_softc();
+
+	msg = msg_base + VMBUS_SINT_MESSAGE;
+	for (;;) {
+		if (msg->msg_type == HYPERV_MSGTYPE_NONE) {
+			/* No message */
+			break;
+		} else if (msg->msg_type == HYPERV_MSGTYPE_CHANNEL) {
+			/* Channel message */
+			vmbus_chanmsg_handle(sc, (struct vmbus_message *)msg);
+		}
+
+		msg->msg_type = HYPERV_MSGTYPE_NONE;
+		/*
+		 * Make sure the write to msg_type (i.e. set to
+		 * HYPERV_MSGTYPE_NONE) happens before we read the
+		 * msg_flags and EOMing. Otherwise, the EOMing will
+		 * not deliver any more messages since there is no
+		 * empty slot
+		 *
+		 * NOTE:
+		 * membar_sync() is used here, since
+		 * atomic_thread_fence_seq_cst()
+		 * will become compiler fence on UP kernel.
+		 */
+		membar_sync();
+		if (msg->msg_flags & VMBUS_MSGFLAG_PENDING) {
+			/*
+			 * This will cause message queue rescan to possibly
+			 * deliver another msg from the hypervisor
+			 */
+			wrmsr(MSR_HV_EOM, 0);
+		}
+	}
+}
+
+static int
+vmbus_handle_intr1(struct vmbus_softc *sc, int cpu)
+{
+	volatile struct vmbus_message *msg;
+	struct vmbus_message *msg_base;
+
+	msg_base = VMBUS_PCPU_GET(sc, message, cpu);
+
+	/*
+	 * Check event timer.
+	 *
+	 * TODO: move this to independent IDT vector.
+	 */
+	msg = msg_base + VMBUS_SINT_TIMER;
+	if (msg->msg_type == HYPERV_MSGTYPE_TIMER_EXPIRED) {
+		msg->msg_type = HYPERV_MSGTYPE_NONE;
+
+		/*
+		 * Make sure the write to msg_type (i.e. set to
+		 * HYPERV_MSGTYPE_NONE) happens before we read the
+		 * msg_flags and EOMing. Otherwise, the EOMing will
+		 * not deliver any more messages since there is no
+		 * empty slot
+		 *
+		 * NOTE:
+		 * membar_sync() is used here, since
+		 * atomic_thread_fence_seq_cst()
+		 * will become compiler fence on UP kernel.
+		 */
+		membar_sync();
+		if (msg->msg_flags & VMBUS_MSGFLAG_PENDING) {
+			/*
+			 * This will cause message queue rescan to possibly
+			 * deliver another msg from the hypervisor
+			 */
+			wrmsr(MSR_HV_EOM, 0);
+		}
+	}
+
+	/*
+	 * Check events.  Hot path for network and storage I/O data; high rate.
+	 *
+	 * NOTE:
+	 * As recommended by the Windows guest fellows, we check events before
+	 * checking messages.
+	 */
+	sc->vmbus_event_proc(sc, cpu);
+
+	/*
+	 * Check messages.  Mainly management stuffs; ultra low rate.
+	 */
+	msg = msg_base + VMBUS_SINT_MESSAGE;
+	if (__predict_false(msg->msg_type != HYPERV_MSGTYPE_NONE)) {
+		/*
+		 * Pass in the msg_base to the vmbus_msg_task so that it knows
+		 * which message to process.
+		 */
+		(void) ddi_taskq_dispatch(VMBUS_PCPU_GET(sc, message_tq, cpu),
+		    vmbus_msg_task, msg_base, DDI_SLEEP);
+	}
+
+	return (DDI_INTR_CLAIMED);
+}
+
+uint_t
+vmbus_handle_intr(struct vmbus_softc *sc)
+{
+	int cpu = curcpu;
+
+	/*
+	 * Disable preemption.
+	 */
+	kpreempt_disable();
+
+	/*
+	 * Do a little interrupt counting.
+	 */
+	VMBUS_PCPU_GET(sc, intr_cnt, cpu)++;
+
+	int rc = vmbus_handle_intr1(sc, cpu);
+
+	/*
+	 * Enable preemption.
+	 */
+	kpreempt_enable();
+	return (rc);
+
+}
+
+static void
+vmbus_synic_setup(void *xsc)
+{
+	struct vmbus_softc *sc = xsc;
+	int cpu = curcpu;
+	uint64_t val, orig;
+	uint32_t sint;
+
+	if (hyperv_features & CPUID_HV_MSR_VP_INDEX) {
+		/* Save virtual processor id. */
+		VMBUS_PCPU_GET(sc, vcpuid, cpu) = rdmsr(MSR_HV_VP_INDEX);
+	} else {
+		/* Set virtual processor id to 0 for compatibility. */
+		VMBUS_PCPU_GET(sc, vcpuid, cpu) = 0;
+	}
+
+	/*
+	 * Setup the SynIC message.
+	 */
+	orig = rdmsr(MSR_HV_SIMP);
+	val = MSR_HV_SIMP_ENABLE | (orig & MSR_HV_SIMP_RSVD_MASK) |
+	    ((VMBUS_PCPU_GET(sc, message_dma.hv_paddr, cpu) >> PAGE_SHIFT) <<
+	    MSR_HV_SIMP_PGSHIFT);
+	wrmsr(MSR_HV_SIMP, val);
+
+	/*
+	 * Setup the SynIC event flags.
+	 */
+	orig = rdmsr(MSR_HV_SIEFP);
+	val = MSR_HV_SIEFP_ENABLE | (orig & MSR_HV_SIEFP_RSVD_MASK) |
+	    ((VMBUS_PCPU_GET(sc, event_flags_dma.hv_paddr, cpu)
+	    >> PAGE_SHIFT) << MSR_HV_SIEFP_PGSHIFT);
+	wrmsr(MSR_HV_SIEFP, val);
+
+
+	/*
+	 * Configure and unmask SINT for message and event flags.
+	 */
+	sint = MSR_HV_SINT0 + VMBUS_SINT_MESSAGE;
+	orig = rdmsr(sint);
+	val = sc->vmbus_idtvec | MSR_HV_SINT_AUTOEOI |
+	    (orig & MSR_HV_SINT_RSVD_MASK);
+	dev_err(sc->vmbus_dev, CE_CONT, "?SINT val %llx\n", (u_longlong_t)val);
+	wrmsr(sint, val);
+
+	/*
+	 * Configure and unmask SINT for timer.
+	 */
+	sint = MSR_HV_SINT0 + VMBUS_SINT_TIMER;
+	orig = rdmsr(sint);
+	val = sc->vmbus_idtvec | MSR_HV_SINT_AUTOEOI |
+	    (orig & MSR_HV_SINT_RSVD_MASK);
+	wrmsr(sint, val);
+
+	/*
+	 * All done; enable SynIC.
+	 */
+	orig = rdmsr(MSR_HV_SCONTROL);
+	val = MSR_HV_SCTRL_ENABLE | (orig & MSR_HV_SCTRL_RSVD_MASK);
+	wrmsr(MSR_HV_SCONTROL, val);
+}
+
+/* ARGSUSED */
+static void
+vmbus_synic_teardown(void *arg)
+{
+	uint64_t orig;
+	uint32_t sint;
+
+	/*
+	 * Disable SynIC.
+	 */
+	orig = rdmsr(MSR_HV_SCONTROL);
+	wrmsr(MSR_HV_SCONTROL, (orig & MSR_HV_SCTRL_RSVD_MASK));
+
+	/*
+	 * Mask message and event flags SINT.
+	 */
+	sint = MSR_HV_SINT0 + VMBUS_SINT_MESSAGE;
+	orig = rdmsr(sint);
+	wrmsr(sint, orig | MSR_HV_SINT_MASKED);
+
+	/*
+	 * Mask timer SINT.
+	 */
+	sint = MSR_HV_SINT0 + VMBUS_SINT_TIMER;
+	orig = rdmsr(sint);
+	wrmsr(sint, orig | MSR_HV_SINT_MASKED);
+
+	/*
+	 * Teardown SynIC message.
+	 */
+	orig = rdmsr(MSR_HV_SIMP);
+	wrmsr(MSR_HV_SIMP, (orig & MSR_HV_SIMP_RSVD_MASK));
+
+	/*
+	 * Teardown SynIC event flags.
+	 */
+	orig = rdmsr(MSR_HV_SIEFP);
+	wrmsr(MSR_HV_SIEFP, (orig & MSR_HV_SIEFP_RSVD_MASK));
+}
+
+static int
+vmbus_dma_alloc(struct vmbus_softc *sc)
+{
+	uint8_t *evtflags;
+	int cpu;
+
+	for (cpu = 0; cpu < ncpus; cpu++) {
+		void *ptr;
+
+		/*
+		 * Per-cpu messages and event flags.
+		 */
+		ptr = hyperv_dmamem_alloc(sc->vmbus_dev, PAGE_SIZE, 0,
+		    PAGE_SIZE, VMBUS_PCPU_PTR(sc, message_dma, cpu),
+		    DDI_DMA_RDWR);
+		if (ptr == NULL)
+			return (ENOMEM);
+		VMBUS_PCPU_GET(sc, message, cpu) = ptr;
+
+		ptr = hyperv_dmamem_alloc(sc->vmbus_dev, PAGE_SIZE, 0,
+		    PAGE_SIZE, VMBUS_PCPU_PTR(sc, event_flags_dma, cpu),
+		    DDI_DMA_RDWR);
+		if (ptr == NULL)
+			return (ENOMEM);
+		VMBUS_PCPU_GET(sc, event_flags, cpu) = ptr;
+	}
+
+	evtflags = (uint8_t *)hyperv_dmamem_alloc(sc->vmbus_dev, PAGE_SIZE, 0,
+	    PAGE_SIZE, &sc->vmbus_evtflags_dma, DDI_DMA_RDWR);
+	if (evtflags == NULL)
+		return (ENOMEM);
+	sc->vmbus_rx_evtflags = (ulong_t *)evtflags;
+	sc->vmbus_tx_evtflags = (ulong_t *)(evtflags + (PAGE_SIZE / 2));
+	sc->vmbus_evtflags = evtflags;
+
+	sc->vmbus_mnf1 = hyperv_dmamem_alloc(sc->vmbus_dev, PAGE_SIZE, 0,
+	    PAGE_SIZE, &sc->vmbus_mnf1_dma, DDI_DMA_RDWR);
+	if (sc->vmbus_mnf1 == NULL)
+		return (ENOMEM);
+
+	sc->vmbus_mnf2 = (struct vmbus_mnf *)hyperv_dmamem_alloc(sc->vmbus_dev,
+	    PAGE_SIZE, 0, sizeof (struct vmbus_mnf), &sc->vmbus_mnf2_dma,
+	    DDI_DMA_RDWR);
+	if (sc->vmbus_mnf2 == NULL)
+		return (ENOMEM);
+
+	return (0);
+}
+
+static void
+vmbus_dma_free(struct vmbus_softc *sc)
+{
+	int cpu;
+
+	if (sc->vmbus_evtflags != NULL) {
+		hyperv_dmamem_free(&sc->vmbus_evtflags_dma);
+		sc->vmbus_evtflags = NULL;
+		sc->vmbus_rx_evtflags = NULL;
+		sc->vmbus_tx_evtflags = NULL;
+	}
+	if (sc->vmbus_mnf1 != NULL) {
+		hyperv_dmamem_free(&sc->vmbus_mnf1_dma);
+		sc->vmbus_mnf1 = NULL;
+	}
+	if (sc->vmbus_mnf2 != NULL) {
+		hyperv_dmamem_free(&sc->vmbus_mnf2_dma);
+		sc->vmbus_mnf2 = NULL;
+	}
+
+	for (cpu = 0; cpu < ncpus; cpu++) {
+		if (VMBUS_PCPU_GET(sc, message, cpu) != NULL) {
+			hyperv_dmamem_free(
+			    VMBUS_PCPU_PTR(sc, message_dma, cpu));
+			VMBUS_PCPU_GET(sc, message, cpu) = NULL;
+		}
+		if (VMBUS_PCPU_GET(sc, event_flags, cpu) != NULL) {
+			hyperv_dmamem_free(
+			    VMBUS_PCPU_PTR(sc, event_flags_dma, cpu));
+			VMBUS_PCPU_GET(sc, event_flags, cpu) = NULL;
+		}
+	}
+}
+
+#define	IPL_VMBUS	0x1
+
+static int
+vmbus_intr_setup(struct vmbus_softc *sc)
+{
+	int cpu;
+
+	for (cpu = 0; cpu < ncpus; cpu++) {
+		char tq_name[MAXPATHLEN];
+
+		/* Allocate an interrupt counter for Hyper-V interrupt */
+		VMBUS_PCPU_GET(sc, intr_cnt, cpu) = 0;
+
+		/*
+		 * Setup taskq to handle events.  Task will be per-
+		 * channel.
+		 */
+		(void) snprintf(tq_name, sizeof (tq_name), "hyperv event[%d]",
+		    cpu);
+		*VMBUS_PCPU_PTR(sc, event_tq, cpu) = ddi_taskq_create(NULL,
+		    tq_name, 1, maxclsyspri, TASKQ_PREPOPULATE);
+
+		/*
+		 * Setup tasks and taskq to handle messages.
+		 */
+		(void) snprintf(tq_name, sizeof (tq_name), "hyperv msg[%d]",
+		    cpu);
+		*VMBUS_PCPU_PTR(sc, message_tq, cpu) = ddi_taskq_create(NULL,
+		    tq_name, 1, maxclsyspri, TASKQ_PREPOPULATE);
+	}
+
+	sc->vmbus_idtvec = psm_get_ipivect(IPL_VMBUS, -1);
+	if (add_avintr(NULL, IPL_VMBUS, (avfunc)vmbus_handle_intr,
+	    "Hyper-V vmbus", sc->vmbus_idtvec, (caddr_t)sc, NULL,
+	    NULL, NULL) == 0) {
+		dev_err(sc->vmbus_dev, CE_WARN,
+		    "cannot find free IDT (%d) vector", sc->vmbus_idtvec);
+		return (ENXIO);
+	}
+	dev_err(sc->vmbus_dev, CE_CONT, "?vmbus IDT vector %d\n",
+	    sc->vmbus_idtvec);
+	return (0);
+}
+
+static void
+vmbus_intr_teardown(struct vmbus_softc *sc)
+{
+	int cpu;
+
+	if (sc->vmbus_idtvec >= 0) {
+		rem_avintr(NULL, IPL_VMBUS, (avfunc)vmbus_handle_intr,
+		    sc->vmbus_idtvec);
+		sc->vmbus_idtvec = -1;
+	}
+
+	for (cpu = 0; cpu < ncpus; cpu++) {
+		if (VMBUS_PCPU_GET(sc, event_tq, cpu) != NULL) {
+			ddi_taskq_destroy(VMBUS_PCPU_GET(sc, event_tq, cpu));
+			VMBUS_PCPU_GET(sc, event_tq, cpu) = NULL;
+		}
+		if (VMBUS_PCPU_GET(sc, message_tq, cpu) != NULL) {
+			ddi_taskq_destroy(VMBUS_PCPU_GET(sc, message_tq, cpu));
+			VMBUS_PCPU_GET(sc, message_tq, cpu) = NULL;
+		}
+	}
+}
+
+typedef struct hv_vmbus_device {
+	char	*hv_name;
+	char	*hv_devname;
+	char	*hv_guid;
+} hv_vmbus_device_t;
+
+static hv_vmbus_device_t vmbus_devices[] = {
+	{
+	"Hyper-V Shutdown", "hv_shutdown",
+	"0e0b6031-5213-4934-818b-38d90ced39db"
+	},
+
+	{
+	"Hyper-V Timesync", "hv_timesync",
+	"9527e630-d0ae-497b-adce-e80ab0175caf"
+	},
+
+	{
+	"Hyper-V Heartbeat", "hv_heartbeat",
+	"57164f39-9115-4e78-ab55-382f3bd5422d"
+	},
+
+	{
+	"Hyper-V KVP", "hv_kvp",
+	"a9a0f4e7-5a45-4d96-b827-8a841e8c03e6"
+	},
+
+	{
+	"Hyper-V Network Interface", "hv_netvsc",
+	"f8615163-df3e-46c5-913f-f2d2f965ed0e"
+	},
+
+	{
+	"Hyper-V IDE Storage Interface", "blksvc",
+	"32412632-86cb-44a2-9b5c-50d1417354f5"
+	},
+
+	{
+	"Hyper-V SCSI Storage Interface", "hv_storvsc",
+	"ba6163d9-04a1-4d29-b605-72e2ffb1dc7f"
+	},
+
+	{
+	NULL,  NULL, NULL
+	}
+};
+
+void
+vmbus_walk_children(int (*walk_cb)(dev_info_t *, void *), void *arg)
+{
+	struct vmbus_softc *sc = vmbus_get_softc();
+	ddi_walk_devs(sc->vmbus_dev, walk_cb, arg);
+}
+
+int
+vmbus_add_child(struct vmbus_channel *chan)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	dev_info_t *parent = sc->vmbus_dev;
+	hv_vmbus_device_t *dev;
+	char *devname = NULL;
+
+	mutex_enter(&vmbus_lock);
+
+	char classid[HYPERV_GUID_STRLEN] = { 0 };
+	(void) hyperv_guid2str(&chan->ch_guid_type, classid, sizeof (classid));
+
+	/*
+	 * Find a device that matches the classid in the channel.
+	 */
+	for (dev = vmbus_devices; dev->hv_guid != NULL; dev++) {
+		if (strncmp(dev->hv_guid, classid, strlen(dev->hv_guid)) == 0) {
+			devname = dev->hv_devname;
+			break;
+		}
+	}
+
+	if (devname == NULL)
+		devname = "vmbus_child";
+
+	ndi_devi_alloc_sleep(parent, devname, DEVI_SID_NODEID, &chan->ch_dev);
+	if (chan->ch_dev == NULL) {
+		mutex_exit(&vmbus_lock);
+		dev_err(parent, CE_WARN, "device_add_child for chan%u failed",
+		    chan->ch_id);
+		return (ENXIO);
+	}
+	ddi_set_parent_data(chan->ch_dev, chan);
+	int err = ndi_devi_online(chan->ch_dev, 0);
+	if (err != NDI_SUCCESS) {
+		(void) ndi_devi_free(chan->ch_dev);
+		chan->ch_dev = NULL;
+		mutex_exit(&vmbus_lock);
+		dev_err(parent, CE_CONT, "?failed to online: classid %s, "
+		    "devname %s for chan%u, err %d\n", classid, devname,
+		    chan->ch_id, err);
+		return (DDI_FAILURE);
+	}
+
+	mutex_exit(&vmbus_lock);
+	return (DDI_SUCCESS);
+}
+
+int
+vmbus_delete_child(struct vmbus_channel *chan)
+{
+	int error = 0;
+
+	mutex_enter(&vmbus_lock);
+	if (chan->ch_dev != NULL) {
+		if (ddi_prop_update_string(DDI_DEV_T_NONE, chan->ch_dev,
+		    VMBUS_STATE, VMBUS_STATE_OFFLINE) != DDI_SUCCESS) {
+			dev_err(chan->ch_dev, CE_WARN, "Unable to set "
+			    "\"%s(%s)\" property", VMBUS_STATE,
+			    VMBUS_STATE_OFFLINE);
+			return (DDI_FAILURE);
+		}
+
+		if (ndi_devi_offline(chan->ch_dev, NDI_DEVI_REMOVE) !=
+		    DDI_SUCCESS) {
+			dev_err(chan->ch_dev, CE_WARN, "Unable to offline "
+			    "device");
+			return (DDI_FAILURE);
+		}
+		(void) ndi_devi_free(chan->ch_dev);
+		chan->ch_dev = NULL;
+	}
+	mutex_exit(&vmbus_lock);
+	return (error);
+}
+
+uint32_t
+vmbus_get_version(void)
+{
+	struct vmbus_softc *sc = vmbus_get_softc();
+
+	return (sc->vmbus_version);
+}
+
+int
+vmbus_probe_guid(dev_info_t *dev, const struct hyperv_guid *guid)
+{
+	const struct vmbus_channel *chan = vmbus_get_channel(dev);
+
+	if (memcmp(&chan->ch_guid_type, guid, sizeof (struct hyperv_guid)) == 0)
+		return (0);
+	return (ENXIO);
+}
+
+/*
+ * @brief Main vmbus driver initialization routine.
+ *
+ * Here, we
+ * - initialize the vmbus driver context
+ * - setup various driver entry points
+ * - invoke the vmbus hv main init routine
+ * - get the irq resource
+ * - invoke the vmbus to add the vmbus root device
+ * - setup the vmbus root device
+ * - retrieve the channel offers
+ */
+static int
+vmbus_doattach(struct vmbus_softc *sc)
+{
+	int ret;
+
+	if (sc->vmbus_flags & VMBUS_FLAG_ATTACHED)
+		return (DDI_SUCCESS);
+
+	sc->vmbus_gpadl = VMBUS_GPADL_START;
+	mutex_init(&sc->vmbus_prichan_lock, NULL, MUTEX_DEFAULT, NULL);
+	TAILQ_INIT(&sc->vmbus_prichans);
+	mutex_init(&sc->vmbus_chan_lock, NULL, MUTEX_DEFAULT, NULL);
+	TAILQ_INIT(&sc->vmbus_chans);
+	sc->vmbus_chmap = kmem_zalloc(
+	    sizeof (struct vmbus_channel *) * VMBUS_CHAN_MAX, KM_SLEEP);
+
+	/*
+	 * Create context for "post message" Hypercalls
+	 */
+	sc->vmbus_xc = vmbus_xact_ctx_create(sc->vmbus_dev,
+	    HYPERCALL_POSTMSGIN_SIZE, VMBUS_MSG_SIZE,
+	    sizeof (struct vmbus_msghc));
+	if (sc->vmbus_xc == NULL) {
+		ret = ENXIO;
+		goto cleanup;
+	}
+
+	/*
+	 * Allocate DMA stuffs.
+	 */
+	ret = vmbus_dma_alloc(sc);
+	if (ret != 0)
+		goto cleanup;
+
+	/*
+	 * Setup interrupt.
+	 */
+	ret = vmbus_intr_setup(sc);
+	if (ret != 0)
+		goto cleanup;
+
+	/*
+	 * Setup SynIC.
+	 */
+	vmbus_xcall(vmbus_synic_setup, sc);
+	sc->vmbus_flags |= VMBUS_FLAG_SYNIC;
+
+	/*
+	 * Initialize vmbus, e.g. connect to Hypervisor.
+	 */
+	ret = vmbus_init(sc);
+	if (ret != 0)
+		goto cleanup;
+
+	if (sc->vmbus_version == VMBUS_VERSION_WS2008 ||
+	    sc->vmbus_version == VMBUS_VERSION_WIN7)
+		sc->vmbus_event_proc = vmbus_event_proc_compat;
+	else
+		sc->vmbus_event_proc = vmbus_event_proc;
+
+	ret = vmbus_scan(sc);
+	if (ret != 0)
+		goto cleanup;
+
+	sc->vmbus_flags |= VMBUS_FLAG_ATTACHED;
+	return (DDI_SUCCESS);
+
+cleanup:
+	vmbus_scan_teardown(sc);
+	vmbus_intr_teardown(sc);
+	vmbus_dma_free(sc);
+	if (sc->vmbus_xc != NULL) {
+		vmbus_xact_ctx_destroy(sc->vmbus_xc);
+		sc->vmbus_xc = NULL;
+	}
+	kmem_free(sc->vmbus_chmap,
+	    sizeof (struct vmbus_channel *) * VMBUS_CHAN_MAX);
+	mutex_destroy(&sc->vmbus_prichan_lock);
+	mutex_destroy(&sc->vmbus_chan_lock);
+
+	return (DDI_FAILURE);
+}
+
+/* ARGSUSED */
+static void
+vmbus_event_proc_dummy(struct vmbus_softc *sc, int cpu)
+{
+}
+
+static int
+vmbus_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:
+		return (DDI_SUCCESS);
+	default:
+		return (DDI_FAILURE);
+	}
+
+	mutex_enter(&vmbus_lock);
+	int instance = ddi_get_instance(dip);
+	if (ddi_soft_state_zalloc(vmbus_state, instance) != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN, "ddi_soft_state_zalloc failed");
+		mutex_exit(&vmbus_lock);
+		return (DDI_FAILURE);
+	}
+	vmbus_sc = ddi_get_soft_state(vmbus_state, instance);
+	vmbus_sc->vmbus_dev = dip;
+	vmbus_sc->vmbus_idtvec = -1;
+
+	if (hypercall_create(vmbus_sc->vmbus_dev) != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN, "unable to create hypercall context");
+		return (DDI_FAILURE);
+	}
+
+	/*
+	 * Event processing logic will be configured:
+	 * - After the vmbus protocol version negotiation.
+	 * - Before we request channel offers.
+	 */
+	vmbus_sc->vmbus_event_proc = vmbus_event_proc_dummy;
+
+	int ret = vmbus_doattach(vmbus_sc);
+	if (vmbus_sc->vmbus_flags & VMBUS_FLAG_ATTACHED) {
+		(void) ddi_hold_driver(ddi_name_to_major("hyperv"));
+	}
+
+	ddi_report_dev(dip);
+	mutex_exit(&vmbus_lock);
+	return (ret);
+}
+
+static int
+vmbus_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	struct vmbus_softc *sc = NULL;
+
+	switch (cmd) {
+	case DDI_DETACH:
+		break;
+	case DDI_SUSPEND:
+		return (DDI_SUCCESS);
+	default:
+		return (DDI_FAILURE);
+	}
+
+	mutex_enter(&vmbus_lock);
+	int instance = ddi_get_instance(dip);
+	sc = ddi_get_soft_state(vmbus_state, instance);
+	if (sc == NULL) {
+		mutex_exit(&vmbus_lock);
+		return (DDI_FAILURE);
+	}
+
+	vmbus_chan_destroy_all(sc);
+
+	vmbus_scan_teardown(sc);
+
+	vmbus_disconnect(sc);
+
+	if (sc->vmbus_flags & VMBUS_FLAG_SYNIC) {
+		sc->vmbus_flags &= ~VMBUS_FLAG_SYNIC;
+		vmbus_xcall(vmbus_synic_teardown, NULL);
+	}
+
+	vmbus_intr_teardown(sc);
+	vmbus_dma_free(sc);
+
+	if (sc->vmbus_xc != NULL) {
+		vmbus_xact_ctx_destroy(sc->vmbus_xc);
+		sc->vmbus_xc = NULL;
+	}
+
+	kmem_free(sc->vmbus_chmap,
+	    sizeof (struct vmbus_channel *) * VMBUS_CHAN_MAX);
+	mutex_destroy(&sc->vmbus_prichan_lock);
+	mutex_destroy(&sc->vmbus_chan_lock);
+
+	hypercall_destroy();
+
+	if (sc->vmbus_flags & VMBUS_FLAG_ATTACHED) {
+		(void) ddi_rele_driver(ddi_name_to_major("hyperv"));
+		sc->vmbus_flags &= ~VMBUS_FLAG_ATTACHED;
+	}
+	ddi_soft_state_free(vmbus_state, instance);
+	mutex_exit(&vmbus_lock);
+	return (DDI_SUCCESS);
+}
+
+static int
+vmbus_sysinit(void)
+{
+	if ((get_hwenv() & HW_MICROSOFT) == 0)
+		return (-1);
+
+	int error = ddi_soft_state_init(&vmbus_state,
+	    sizeof (struct vmbus_softc), 0);
+	if (error != 0)
+		return (error);
+
+	return (0);
+}
+
+static void
+vmbus_xcall(vmbus_xcall_func_t func, void *arg)
+{
+	cpuset_t set;
+	CPUSET_ALL(set);
+	uint32_t spl = ddi_enter_critical();
+	xc_sync((xc_arg_t)arg, NULL, NULL, CPUSET2BV(set), (xc_func_t)func);
+	ddi_exit_critical(spl);
+}
+
+static int
+vmbus_initchild(dev_info_t *child)
+{
+	struct vmbus_softc *sc = vmbus_get_softc();
+	const struct vmbus_channel *chan = vmbus_get_channel(child);
+	char addr[80];
+
+	ASSERT3P(chan, !=, NULL);
+	ASSERT3P(chan->ch_dev, ==, child);
+
+	char classid[HYPERV_GUID_STRLEN] = { 0 };
+	(void) hyperv_guid2str(&chan->ch_guid_type, classid, sizeof (classid));
+	if (ddi_prop_update_string(DDI_DEV_T_NONE, child,
+	    VMBUS_CLASSID, classid) != DDI_SUCCESS) {
+		dev_err(chan->ch_dev, CE_WARN, "Unable to set \"%s(%s)\" "
+		    "property", VMBUS_CLASSID, classid);
+		return (DDI_FAILURE);
+	}
+
+	char deviceid[HYPERV_GUID_STRLEN] = { 0 };
+	(void) hyperv_guid2str(&chan->ch_guid_inst, deviceid,
+	    sizeof (deviceid));
+	if (ddi_prop_update_string(DDI_DEV_T_NONE, child,
+	    VMBUS_DEVICEID, deviceid) != DDI_SUCCESS) {
+		dev_err(chan->ch_dev, CE_WARN, "Unable to set \"%s(%s)\" "
+		    "property", VMBUS_DEVICEID, deviceid);
+		return (DDI_FAILURE);
+	}
+
+	if (ddi_prop_update_string(DDI_DEV_T_NONE, child,
+	    VMBUS_STATE, VMBUS_STATE_ONLINE) != DDI_SUCCESS) {
+		dev_err(chan->ch_dev, CE_WARN, "Unable to set "
+		    "\"%s(%s)\" property", VMBUS_STATE,
+		    VMBUS_STATE_ONLINE);
+		return (DDI_FAILURE);
+	}
+
+	dev_err(sc->vmbus_dev, CE_CONT,
+	    "?vmbus_initchild parent %p child %p (%s : %s)\n",
+	    (void *)sc->vmbus_dev, (void *)child, classid, deviceid);
+
+	(void) snprintf(addr, sizeof (addr), "%s", deviceid);
+	ddi_set_name_addr(child, addr);
+
+	return (DDI_SUCCESS);
+}
+
+static int
+vmbus_removechild(dev_info_t *dip)
+{
+	ddi_set_name_addr(dip, NULL);
+	return (DDI_SUCCESS);
+}
+
+/*ARGSUSED*/
+static int
+vmbus_ctlops(dev_info_t *dip, dev_info_t *rdip,
+    ddi_ctl_enum_t ctlop, void *arg, void *result)
+{
+	switch (ctlop) {
+	case DDI_CTLOPS_REPORTDEV:
+		if (rdip == (dev_info_t *)0)
+			return (DDI_FAILURE);
+		cmn_err(CE_CONT, "?%s@%s, %s%d\n", ddi_node_name(rdip),
+		    ddi_get_name_addr(rdip), ddi_driver_name(rdip),
+		    ddi_get_instance(rdip));
+		return (DDI_SUCCESS);
+
+	case DDI_CTLOPS_INITCHILD:
+		return (vmbus_initchild((dev_info_t *)arg));
+
+	case DDI_CTLOPS_UNINITCHILD:
+		return (vmbus_removechild((dev_info_t *)arg));
+
+	case DDI_CTLOPS_SIDDEV:
+		return (DDI_SUCCESS);
+
+	case DDI_CTLOPS_REGSIZE:
+	case DDI_CTLOPS_NREGS:
+		return (DDI_FAILURE);
+
+	case DDI_CTLOPS_POWER: {
+		return (ddi_ctlops(dip, rdip, ctlop, arg, result));
+	}
+
+	default:
+		return (ddi_ctlops(dip, rdip, ctlop, arg, result));
+	}
+
+	/* NOTREACHED */
+
+}
+
+static struct cb_ops vmbus_cb_ops = {
+	nulldev,	/* open */
+	nulldev,	/* close */
+	nodev,		/* strategy */
+	nodev,		/* print */
+	nodev,		/* dump */
+	nodev,		/* read */
+	nodev,		/* write */
+	nodev,		/* ioctl */
+	nodev,		/* devmap */
+	nodev,		/* mmap */
+	nodev,		/* segmap */
+	nochpoll,	/* chpoll */
+	ddi_prop_op,	/* prop_op */
+	NULL,		/* stream */
+	D_NEW | D_MP,	/* flag */
+	CB_REV,		/* rev */
+	nodev,		/* aread */
+	nodev		/* awrite */
+};
+
+static struct bus_ops vmbus_bus_ops = {
+	BUSO_REV,
+	i_ddi_bus_map,
+	NULL,   /* NO OP */
+	NULL,   /* NO OP */
+	NULL,   /* NO OP */
+	i_ddi_map_fault,
+	NULL,
+	ddi_dma_allochdl,
+	ddi_dma_freehdl,
+	ddi_dma_bindhdl,
+	ddi_dma_unbindhdl,
+	ddi_dma_flush,
+	ddi_dma_win,
+	ddi_dma_mctl,
+	vmbus_ctlops,
+	ddi_bus_prop_op,
+	NULL,		/* (*bus_get_eventcookie)();	*/
+	NULL,		/* (*bus_add_eventcall)();	*/
+	NULL,		/* (*bus_remove_eventcall)();	*/
+	NULL,		/* (*bus_post_event)();		*/
+	NULL,		/* (*bus_intr_ctl)();		*/
+	NULL,		/* (*bus_config)();		*/
+	NULL,		/* (*bus_unconfig)();		*/
+	NULL,		/* (*bus_fm_init)();		*/
+	NULL,		/* (*bus_fm_fini)();		*/
+	NULL,		/* (*bus_fm_access_enter)();    */
+	NULL,		/* (*bus_fm_access_fini)();	*/
+	NULL,		/* (*bus_power)();		*/
+	i_ddi_intr_ops	/* (*bus_intr_op)();		*/
+};
+
+static struct dev_ops vmbus_ops = {
+	DEVO_REV,	/* version */
+	0,		/* refcnt */
+	NULL,		/* info */
+	nulldev,	/* identify */
+	nulldev,	/* probe */
+	vmbus_attach,	/* attach */
+	vmbus_detach,	/* detach */
+	nodev,		/* reset */
+	&vmbus_cb_ops,	/* driver operations */
+	&vmbus_bus_ops,	/* no bus operations */
+	NULL,		/* power */
+	ddi_quiesce_not_needed,	/* quiesce */
+};
+
+static struct modldrv vmbus_modldrv = {
+	&mod_driverops,
+	"Hyper-V VMBus driver",
+	&vmbus_ops
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1,
+	&vmbus_modldrv,
+	NULL
+};
+
+int
+_init(void)
+{
+	mutex_init(&vmbus_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	if (vmbus_sysinit() != 0)
+		return (ENOTSUP);
+
+	int error = mod_install(&modlinkage);
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}
+
+int
+_fini(void)
+{
+	int error = mod_remove(&modlinkage);
+	if (error == 0) {
+		ddi_soft_state_fini(vmbus_state);
+		mutex_destroy(&vmbus_lock);
+	}
+	return (error);
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -989,6 +989,7 @@ vmbus_delete_child(struct vmbus_channel *chan)
 			dev_err(chan->ch_dev, CE_WARN, "Unable to set "
 			    "\"%s(%s)\" property", VMBUS_STATE,
 			    VMBUS_STATE_OFFLINE);
+			mutex_exit(&vmbus_lock);
 			return (DDI_FAILURE);
 		}
 
@@ -996,6 +997,7 @@ vmbus_delete_child(struct vmbus_channel *chan)
 		    DDI_SUCCESS) {
 			dev_err(chan->ch_dev, CE_WARN, "Unable to offline "
 			    "device");
+			mutex_exit(&vmbus_lock);
 			return (DDI_FAILURE);
 		}
 		(void) ndi_devi_free(chan->ch_dev);

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_br.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_br.c
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/param.h>
+#include <sys/mutex.h>
+#include <sys/atomic.h>
+#include <sys/cmn_err.h>
+#include "vmbus_reg.h"
+#include "vmbus_brvar.h"
+
+extern	void membar_sync(void);
+
+/* Amount of space available for write */
+#define	VMBUS_BR_WAVAIL(r, w, z)	\
+	(((w) >= (r)) ? ((z) - ((w) - (r))) : ((r) - (w)))
+
+/* Increase bufing index */
+#define	VMBUS_BR_IDXINC(idx, inc, sz)	(((idx) + (inc)) % (sz))
+
+static void	vmbus_br_setup(struct vmbus_br *, void *, int);
+
+void
+vmbus_rxbr_intr_mask(struct vmbus_rxbr *rbr)
+{
+	rbr->rxbr_imask = 1;
+	membar_sync();
+}
+
+static __inline uint32_t
+vmbus_rxbr_avail(const struct vmbus_rxbr *rbr)
+{
+	uint32_t rindex, windex;
+
+	/* Get snapshot */
+	rindex = rbr->rxbr_rindex;
+	windex = rbr->rxbr_windex;
+
+	return (rbr->rxbr_dsize -
+	    VMBUS_BR_WAVAIL(rindex, windex, rbr->rxbr_dsize));
+}
+
+uint32_t
+vmbus_rxbr_intr_unmask(struct vmbus_rxbr *rbr)
+{
+	rbr->rxbr_imask = 0;
+	membar_sync();
+
+	/*
+	 * Now check to see if the ring buffer is still empty.
+	 * If it is not, we raced and we need to process new
+	 * incoming channel packets.
+	 */
+	return (vmbus_rxbr_avail(rbr));
+}
+
+static void
+vmbus_br_setup(struct vmbus_br *br, void *buf, int blen)
+{
+	br->vbr = buf;
+	br->vbr_dsize = blen - sizeof (struct vmbus_bufring);
+}
+
+void
+vmbus_rxbr_init(struct vmbus_rxbr *rbr)
+{
+	mutex_init(&rbr->rxbr_lock, "vmbus_rxbr", MUTEX_DEFAULT, NULL);
+}
+
+void
+vmbus_rxbr_deinit(struct vmbus_rxbr *rbr)
+{
+	mutex_destroy(&rbr->rxbr_lock);
+}
+
+void
+vmbus_rxbr_setup(struct vmbus_rxbr *rbr, void *buf, int blen)
+{
+	vmbus_br_setup(&rbr->rxbr, buf, blen);
+}
+
+void
+vmbus_txbr_init(struct vmbus_txbr *tbr)
+{
+	mutex_init(&tbr->txbr_lock, "vmbus_txbr", MUTEX_DEFAULT, NULL);
+}
+
+void
+vmbus_txbr_deinit(struct vmbus_txbr *tbr)
+{
+	mutex_destroy(&tbr->txbr_lock);
+}
+
+void
+vmbus_txbr_setup(struct vmbus_txbr *tbr, void *buf, int blen)
+{
+	vmbus_br_setup(&tbr->txbr, buf, blen);
+}
+
+/*
+ * When we write to the ring buffer, check if the host needs to be
+ * signaled.
+ *
+ * The contract:
+ * - The host guarantees that while it is draining the TX bufring,
+ *   it will set the br_imask to indicate it does not need to be
+ *   interrupted when new data are added.
+ * - The host guarantees that it will completely drain the TX bufring
+ *   before exiting the read loop.  Further, once the TX bufring is
+ *   empty, it will clear the br_imask and re-check to see if new
+ *   data have arrived.
+ */
+static __inline boolean_t
+vmbus_txbr_need_signal(const struct vmbus_txbr *tbr, uint32_t old_windex)
+{
+	membar_sync();
+	if (tbr->txbr_imask)
+		return (B_FALSE);
+
+	__compiler_membar();
+
+	/*
+	 * This is the only case we need to signal when the
+	 * ring transitions from being empty to non-empty.
+	 */
+	if (old_windex == tbr->txbr_rindex)
+		return (B_TRUE);
+
+	return (B_FALSE);
+}
+
+static __inline uint32_t
+vmbus_txbr_avail(const struct vmbus_txbr *tbr)
+{
+	uint32_t rindex, windex;
+
+	/* Get snapshot */
+	rindex = tbr->txbr_rindex;
+	windex = tbr->txbr_windex;
+
+	return (VMBUS_BR_WAVAIL(rindex, windex, tbr->txbr_dsize));
+}
+
+static __inline uint32_t
+vmbus_txbr_copyto(const struct vmbus_txbr *tbr, uint32_t windex,
+    const void *src0, uint32_t cplen)
+{
+	const uint8_t *src = src0;
+	uint8_t *br_data = tbr->txbr_data;
+	uint32_t br_dsize = tbr->txbr_dsize;
+
+	if (cplen > br_dsize - windex) {
+		uint32_t fraglen = br_dsize - windex;
+
+		/* Wrap-around detected */
+		(void) memcpy(br_data + windex, src, fraglen);
+		(void) memcpy(br_data, src + fraglen, cplen - fraglen);
+	} else {
+		(void) memcpy(br_data + windex, src, cplen);
+	}
+	return (VMBUS_BR_IDXINC(windex, cplen, br_dsize));
+}
+
+/*
+ * Write scattered channel packet to TX bufring.
+ *
+ * The offset of this channel packet is written as a 64bits value
+ * immediately after this channel packet.
+ */
+int
+vmbus_txbr_write(struct vmbus_txbr *tbr, const struct iovec iov[], int iovlen,
+    boolean_t *need_sig)
+{
+	uint32_t old_windex, windex, total;
+	uint64_t save_windex;
+	int i;
+
+	total = 0;
+	for (i = 0; i < iovlen; i++)
+		total += iov[i].iov_len;
+	total += sizeof (save_windex);
+
+	mutex_enter(&tbr->txbr_lock);
+
+	/*
+	 * NOTE:
+	 * If this write is going to make br_windex same as br_rindex,
+	 * i.e. the available space for write is same as the write size,
+	 * we can't do it then, since br_windex == br_rindex means that
+	 * the bufring is empty.
+	 */
+	if (vmbus_txbr_avail(tbr) <= total) {
+		mutex_exit(&tbr->txbr_lock);
+		return (EAGAIN);
+	}
+
+	/* Save br_windex for later use */
+	old_windex = tbr->txbr_windex;
+
+	/*
+	 * Copy the scattered channel packet to the TX bufring.
+	 */
+	windex = old_windex;
+	for (i = 0; i < iovlen; i++) {
+		windex = vmbus_txbr_copyto(tbr, windex,
+		    iov[i].iov_base, iov[i].iov_len);
+	}
+
+	/*
+	 * Set the offset of the current channel packet.
+	 */
+	save_windex = ((uint64_t)old_windex) << 32;
+	windex = vmbus_txbr_copyto(tbr, windex, &save_windex,
+	    sizeof (save_windex));
+
+	/*
+	 * Update the write index _after_ the channel packet
+	 * is copied.
+	 */
+	__compiler_membar();
+	tbr->txbr_windex = windex;
+
+	mutex_exit(&tbr->txbr_lock);
+
+	*need_sig = vmbus_txbr_need_signal(tbr, old_windex);
+
+	return (0);
+}
+
+static __inline uint32_t
+vmbus_rxbr_copyfrom(const struct vmbus_rxbr *rbr, uint32_t rindex,
+    void *dst0, int cplen)
+{
+	uint8_t *dst = dst0;
+	const uint8_t *br_data = rbr->rxbr_data;
+	uint32_t br_dsize = rbr->rxbr_dsize;
+
+	if (cplen > br_dsize - rindex) {
+		uint32_t fraglen = br_dsize - rindex;
+
+		/* Wrap-around detected. */
+		(void) memcpy(dst, br_data + rindex, fraglen);
+		(void) memcpy(dst + fraglen, br_data, cplen - fraglen);
+	} else {
+		(void) memcpy(dst, br_data + rindex, cplen);
+	}
+	return (VMBUS_BR_IDXINC(rindex, cplen, br_dsize));
+}
+
+int
+vmbus_rxbr_peek(struct vmbus_rxbr *rbr, void *data, int dlen)
+{
+	mutex_enter(&rbr->rxbr_lock);
+
+	/*
+	 * The requested data and the 64bits channel packet
+	 * offset should be there at least.
+	 */
+	if (vmbus_rxbr_avail(rbr) < dlen + sizeof (uint64_t)) {
+		mutex_exit(&rbr->rxbr_lock);
+		return (EAGAIN);
+	}
+	(void) vmbus_rxbr_copyfrom(rbr, rbr->rxbr_rindex, data, dlen);
+
+	mutex_exit(&rbr->rxbr_lock);
+
+	return (0);
+}
+
+/*
+ * NOTE:
+ * We assume (dlen + skip) == sizeof(channel packet).
+ */
+int
+vmbus_rxbr_read(struct vmbus_rxbr *rbr, void *data, int dlen, uint32_t skip)
+{
+	uint32_t rindex, br_dsize = rbr->rxbr_dsize;
+
+	ASSERT(dlen + skip > 0);
+
+	mutex_enter(&rbr->rxbr_lock);
+
+	if (vmbus_rxbr_avail(rbr) < dlen + skip + sizeof (uint64_t)) {
+		mutex_exit(&rbr->rxbr_lock);
+		return (EAGAIN);
+	}
+
+	/*
+	 * Copy channel packet from RX bufring.
+	 */
+	rindex = VMBUS_BR_IDXINC(rbr->rxbr_rindex, skip, br_dsize);
+	rindex = vmbus_rxbr_copyfrom(rbr, rindex, data, dlen);
+
+	/*
+	 * Discard this channel packet's 64bits offset, which is useless to us.
+	 */
+	rindex = VMBUS_BR_IDXINC(rindex, sizeof (uint64_t), br_dsize);
+
+	/*
+	 * Update the read index _after_ the channel packet is fetched.
+	 */
+	__compiler_membar();
+	rbr->rxbr_rindex = rindex;
+
+	mutex_exit(&rbr->rxbr_lock);
+
+	return (0);
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_brvar.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_brvar.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_BRVAR_H_
+#define	_VMBUS_BRVAR_H_
+
+#include <sys/param.h>
+#include <sys/mutex.h>
+#include <sys/uio.h>
+
+
+struct vmbus_br {
+	struct vmbus_bufring	*vbr;
+	uint32_t		vbr_dsize;	/* total data size */
+};
+
+#define	vbr_windex		vbr->br_windex
+#define	vbr_rindex		vbr->br_rindex
+#define	vbr_imask		vbr->br_imask
+#define	vbr_data		vbr->br_data
+
+struct vmbus_rxbr {
+	kmutex_t		rxbr_lock;
+	struct vmbus_br		rxbr;
+};
+
+#define	rxbr_windex		rxbr.vbr_windex
+#define	rxbr_rindex		rxbr.vbr_rindex
+#define	rxbr_imask		rxbr.vbr_imask
+#define	rxbr_data		rxbr.vbr_data
+#define	rxbr_dsize		rxbr.vbr_dsize
+
+struct vmbus_txbr {
+	kmutex_t		txbr_lock;
+	struct vmbus_br		txbr;
+};
+
+#define	txbr_windex		txbr.vbr_windex
+#define	txbr_rindex		txbr.vbr_rindex
+#define	txbr_imask		txbr.vbr_imask
+#define	txbr_data		txbr.vbr_data
+#define	txbr_dsize		txbr.vbr_dsize
+
+
+inline int
+vmbus_txbr_maxpktsz(const struct vmbus_txbr *tbr)
+{
+
+	/*
+	 * - 64 bits for the trailing start index (- sizeof(uint64_t)).
+	 * - The rindex and windex can't be same (- 1).  See
+	 *   the comment near vmbus_bufring.br_{r,w}index.
+	 */
+	return (tbr->txbr_dsize - sizeof (uint64_t) - 1);
+}
+
+inline boolean_t
+vmbus_txbr_empty(const struct vmbus_txbr *tbr)
+{
+	return (tbr->txbr_windex == tbr->txbr_rindex ? B_TRUE : B_FALSE);
+}
+
+inline boolean_t
+vmbus_rxbr_empty(const struct vmbus_rxbr *rbr)
+{
+	return (rbr->rxbr_windex == rbr->rxbr_rindex ? B_TRUE : B_FALSE);
+}
+
+inline int
+vmbus_br_nelem(int br_size, int elem_size)
+{
+
+	/* Strip bufring header */
+	br_size -= sizeof (struct vmbus_bufring);
+	/* Add per-element trailing index */
+	elem_size += sizeof (uint64_t);
+	return (br_size / elem_size);
+}
+
+void		vmbus_rxbr_init(struct vmbus_rxbr *rbr);
+void		vmbus_rxbr_deinit(struct vmbus_rxbr *rbr);
+void		vmbus_rxbr_setup(struct vmbus_rxbr *rbr, void *buf, int blen);
+int		vmbus_rxbr_peek(struct vmbus_rxbr *rbr, void *data, int dlen);
+int		vmbus_rxbr_read(struct vmbus_rxbr *rbr, void *data, int dlen,
+		    uint32_t skip);
+void		vmbus_rxbr_intr_mask(struct vmbus_rxbr *rbr);
+uint32_t	vmbus_rxbr_intr_unmask(struct vmbus_rxbr *rbr);
+
+void		vmbus_txbr_init(struct vmbus_txbr *tbr);
+void		vmbus_txbr_deinit(struct vmbus_txbr *tbr);
+void		vmbus_txbr_setup(struct vmbus_txbr *tbr, void *buf, int blen);
+int		vmbus_txbr_write(struct vmbus_txbr *tbr,
+		    const struct iovec iov[], int iovlen, boolean_t *need_sig);
+
+#endif	/* !_VMBUS_BRVAR_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_chan.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_chan.c
@@ -1,0 +1,1918 @@
+/*
+ * Copyright (c) 2009-2012,2016 Microsoft Corp.
+ * Copyright (c) 2012 NetApp Inc.
+ * Copyright (c) 2012 Citrix Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/debug.h>
+#include <sys/param.h>
+#include <sys/bitmap.h>
+#include <sys/mutex.h>
+#include <sys/atomic.h>
+#include <sys/kmem.h>
+#include <sys/uio.h>
+#include <sys/taskq.h>
+#include <sys/cpuvar.h>
+#include <sys/reboot.h>
+
+#include <sys/hyperv_busdma.h>
+#include <sys/vmbus.h>
+#include <sys/vmbus_xact.h>
+#include "hyperv_var.h"
+#include "vmbus_reg.h"
+#include "vmbus_var.h"
+#include "vmbus_brvar.h"
+#include "vmbus_chanvar.h"
+
+static void			vmbus_chan_update_evtflagcnt(
+				    struct vmbus_softc *,
+				    const struct vmbus_channel *);
+static int			vmbus_chan_close_internal(
+				    struct vmbus_channel *);
+extern	void membar_sync(void);
+
+static struct vmbus_channel	*vmbus_chan_alloc(struct vmbus_softc *);
+static void			vmbus_chan_free(struct vmbus_channel *);
+static int			vmbus_chan_add(struct vmbus_channel *);
+static void			vmbus_chan_cpu_default(struct vmbus_channel *);
+static int			vmbus_chan_release(struct vmbus_channel *);
+static void			vmbus_chan_set_chmap(struct vmbus_channel *);
+static void			vmbus_chan_clear_chmap(struct vmbus_channel *);
+static void			vmbus_chan_detach(struct vmbus_channel *);
+static boolean_t		vmbus_chan_wait_revoke(
+				    const struct vmbus_channel *);
+
+static void			vmbus_chan_ins_prilist(struct vmbus_softc *,
+				    struct vmbus_channel *);
+static void			vmbus_chan_rem_prilist(struct vmbus_softc *,
+				    struct vmbus_channel *);
+static void			vmbus_chan_ins_list(struct vmbus_softc *,
+				    struct vmbus_channel *);
+static void			vmbus_chan_rem_list(struct vmbus_softc *,
+				    struct vmbus_channel *);
+static void			vmbus_chan_ins_sublist(struct vmbus_channel *,
+				    struct vmbus_channel *);
+static void			vmbus_chan_rem_sublist(struct vmbus_channel *,
+				    struct vmbus_channel *);
+
+static void			vmbus_chan_task(void *);
+static void			vmbus_chan_task_nobatch(void *);
+static void			vmbus_chan_clrchmap_task(void *);
+static void			vmbus_prichan_attach_task(void *);
+static void			vmbus_subchan_attach_task(void *);
+static void			vmbus_prichan_detach_task(void *);
+static void			vmbus_subchan_detach_task(void *);
+
+static void			vmbus_chan_msgproc_choffer(struct vmbus_softc *,
+				    const struct vmbus_message *);
+static void			vmbus_chan_msgproc_chrescind(
+				    struct vmbus_softc *,
+				    const struct vmbus_message *);
+
+#define	vmbus_chan_printf(chan, fmt...) \
+	dev_err(chan->ch_dev == NULL ? \
+	    chan->ch_vmbus->vmbus_dev : chan->ch_dev, CE_WARN, fmt)
+
+/*
+ * Vmbus channel message processing.
+ */
+static const vmbus_chanmsg_proc_t
+vmbus_chan_msgprocs[VMBUS_CHANMSG_TYPE_MAX] = {
+	VMBUS_CHANMSG_PROC(CHOFFER,	vmbus_chan_msgproc_choffer),
+	VMBUS_CHANMSG_PROC(CHRESCIND,	vmbus_chan_msgproc_chrescind),
+
+	VMBUS_CHANMSG_PROC_WAKEUP(CHOPEN_RESP),
+	VMBUS_CHANMSG_PROC_WAKEUP(GPADL_CONNRESP),
+	VMBUS_CHANMSG_PROC_WAKEUP(GPADL_DISCONNRESP)
+};
+
+/*
+ * Check to see if the bit is set or cleared
+ * Note: These routines don't return old value.
+ * It returns 0 when succeeds, or -1 when fails.
+ */
+#ifdef _LP64
+#define	test_and_set_bit(p, b) \
+	atomic_set_long_excl(((ulong_t *)(void *)p) + (b >> 6), (b & 0x3f))
+#define	test_and_clear_bit(p, b) \
+	atomic_clear_long_excl(((ulong_t *)(void *)(p)) + ((b) >> 6), \
+	((b) & 0x3f))
+#else
+#define	test_and_set_bit(p, b) \
+	atomic_set_long_excl(((ulong_t *)(void *)p) + (b >> 5), (b & 0x1f))
+#define	test_and_clear_bit(p, b) \
+	atomic_clear_long_excl(((ulong_t *)(void *)p) + (b >> 5), (b & 0x1f))
+#endif
+
+#define	atomic_cmpset_int(p, c, n) \
+	((c == atomic_cas_uint(p, c, n)) ? 1 : 0)
+
+
+
+/*
+ * Notify host that there are data pending on our TX bufring.
+ */
+static __inline void
+vmbus_chan_signal_tx(const struct vmbus_channel *chan)
+{
+	atomic_or_ulong(chan->ch_evtflag, chan->ch_evtflag_mask);
+	if (chan->ch_txflags & VMBUS_CHAN_TXF_HASMNF) {
+		atomic_or_uint(chan->ch_montrig, chan->ch_montrig_mask);
+	} else {
+		hv_status_t status =
+		    hypercall_signal_event(chan->ch_monprm_dma.hv_paddr);
+		if (status != HYPERCALL_STATUS_SUCCESS) {
+			vmbus_chan_printf(chan,
+			    "signal event failed ! status: 0x%x", status);
+		}
+	}
+}
+
+static void
+vmbus_chan_ins_prilist(struct vmbus_softc *sc, struct vmbus_channel *chan)
+{
+
+	ASSERT(MUTEX_HELD(&sc->vmbus_prichan_lock));
+	if (test_and_set_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_ONPRIL_SHIFT) == -1) {
+		panic("channel %u is already on the prilist", chan->ch_id);
+	}
+	TAILQ_INSERT_TAIL(&sc->vmbus_prichans, chan, ch_prilink);
+}
+
+static void
+vmbus_chan_rem_prilist(struct vmbus_softc *sc, struct vmbus_channel *chan)
+{
+
+	ASSERT(MUTEX_HELD(&sc->vmbus_prichan_lock));
+	if (test_and_clear_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_ONPRIL_SHIFT) == -1) {
+		panic("channel %u is not on the prilist", chan->ch_id);
+	}
+	TAILQ_REMOVE(&sc->vmbus_prichans, chan, ch_prilink);
+}
+
+static void
+vmbus_chan_ins_sublist(struct vmbus_channel *prichan,
+    struct vmbus_channel *chan)
+{
+
+	ASSERT(MUTEX_HELD(&prichan->ch_subchan_lock));
+
+	if (test_and_set_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_ONSUBL_SHIFT) == -1) {
+		panic("channel %u is already on the sublist %u",
+		    prichan->ch_id, chan->ch_id);
+	}
+	TAILQ_INSERT_TAIL(&prichan->ch_subchans, chan, ch_sublink);
+
+	/* Bump sub-channel count. */
+	prichan->ch_subchan_cnt++;
+}
+
+static void
+vmbus_chan_rem_sublist(struct vmbus_channel *prichan,
+    struct vmbus_channel *chan)
+{
+	ASSERT(chan->ch_vmbus != NULL);
+	ASSERT(MUTEX_HELD(&prichan->ch_subchan_lock));
+
+	ASSERT3U(prichan->ch_subchan_cnt, >, 0);
+	prichan->ch_subchan_cnt--;
+
+	if (test_and_clear_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_ONSUBL_SHIFT) == -1) {
+		panic("channel: %u is not on the sublist", chan->ch_id);
+	}
+	TAILQ_REMOVE(&prichan->ch_subchans, chan, ch_sublink);
+}
+
+static void
+vmbus_chan_ins_list(struct vmbus_softc *sc, struct vmbus_channel *chan)
+{
+
+	ASSERT(MUTEX_HELD(&sc->vmbus_chan_lock));
+	if (test_and_set_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_ONLIST_SHIFT) == -1) {
+		panic("channel %u is already on the list", chan->ch_id);
+	}
+	TAILQ_INSERT_TAIL(&sc->vmbus_chans, chan, ch_link);
+}
+
+static void
+vmbus_chan_rem_list(struct vmbus_softc *sc, struct vmbus_channel *chan)
+{
+
+	ASSERT(MUTEX_HELD(&sc->vmbus_chan_lock));
+	if (test_and_clear_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_ONLIST_SHIFT) == -1) {
+		panic("channel %u is not on the list", chan->ch_id);
+	}
+	TAILQ_REMOVE(&sc->vmbus_chans, chan, ch_link);
+}
+
+int
+vmbus_chan_open(struct vmbus_channel *chan, int txbr_size, int rxbr_size,
+    const void *udata, int udlen, vmbus_chan_callback_t cb, void *cbarg)
+{
+	struct vmbus_chan_br cbr;
+	int error;
+
+	/*
+	 * Allocate the TX+RX bufrings.
+	 */
+	if (chan->ch_bufring != NULL)
+		dev_err(chan->ch_dev, CE_WARN, "bufrings are allocated");
+	ASSERT(chan->ch_bufring == NULL);
+	chan->ch_bufring = hyperv_dmamem_alloc(chan->ch_dev,
+	    PAGE_SIZE, 0, txbr_size + rxbr_size, &chan->ch_bufring_dma,
+	    DDI_DMA_RDWR);
+	if (chan->ch_bufring == NULL) {
+		vmbus_chan_printf(chan, "bufring allocation failed");
+		return (ENOMEM);
+	}
+
+	cbr.cbr = chan->ch_bufring;
+	cbr.cbr_paddr = chan->ch_bufring_dma.hv_paddr;
+	cbr.cbr_txsz = txbr_size;
+	cbr.cbr_rxsz = rxbr_size;
+
+	error = vmbus_chan_open_br(chan, &cbr, udata, udlen, cb, cbarg);
+	if (error) {
+		if (error == EISCONN) {
+			/*
+			 * XXX
+			 * The bufring GPADL is still connected; abandon
+			 * this bufring, instead of having mysterious
+			 * crash or trashed data later on.
+			 */
+			vmbus_chan_printf(chan, "chan%u bufring GPADL "
+			    "is still connected upon channel open error; "
+			    "leak %d bytes memory", chan->ch_id,
+			    txbr_size + rxbr_size);
+		} else {
+			hyperv_dmamem_free(&chan->ch_bufring_dma);
+		}
+		chan->ch_bufring = NULL;
+	}
+	return (error);
+}
+
+int
+vmbus_chan_open_br(struct vmbus_channel *chan, const struct vmbus_chan_br *cbr,
+    const void *udata, int udlen, vmbus_chan_callback_t cb, void *cbarg)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	const struct vmbus_message *msg;
+	struct vmbus_chanmsg_chopen *req;
+	struct vmbus_msghc *mh;
+	uint32_t status;
+	int error, txbr_size, rxbr_size;
+	uint8_t *br;
+
+	if (udlen > VMBUS_CHANMSG_CHOPEN_UDATA_SIZE) {
+		vmbus_chan_printf(chan,
+		    "invalid udata len %d for chan%u", udlen, chan->ch_id);
+		return (EINVAL);
+	}
+
+	br = cbr->cbr;
+	txbr_size = cbr->cbr_txsz;
+	rxbr_size = cbr->cbr_rxsz;
+	ASSERT0((txbr_size & PAGEOFFSET));
+	ASSERT0((rxbr_size & PAGEOFFSET));
+	ASSERT0((cbr->cbr_paddr & PAGEOFFSET));
+
+	/*
+	 * Zero out the TX/RX bufrings, in case that they were used before.
+	 */
+	(void) memset(br, 0, txbr_size + rxbr_size);
+
+	if (test_and_set_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_OPENED_SHIFT) == -1) {
+		panic("double-open chan %u", chan->ch_id);
+	}
+
+	chan->ch_cb = cb;
+	chan->ch_cbarg = cbarg;
+
+	vmbus_chan_update_evtflagcnt(sc, chan);
+
+	chan->ch_tq = VMBUS_PCPU_GET(chan->ch_vmbus, event_tq, chan->ch_cpuid);
+	if (chan->ch_flags & VMBUS_CHAN_FLAG_BATCHREAD)
+		chan->ch_tqent_func =  vmbus_chan_task;
+	else
+		chan->ch_tqent_func =  vmbus_chan_task_nobatch;
+
+	/* TX bufring comes first */
+	vmbus_txbr_setup(&chan->ch_txbr, br, txbr_size);
+	/* RX bufring immediately follows TX bufring */
+	vmbus_rxbr_setup(&chan->ch_rxbr, (void *) (br + txbr_size), rxbr_size);
+
+	/*
+	 * Connect the bufrings, both RX and TX, to this channel.
+	 */
+	ASSERT0(chan->ch_bufring_gpadl);
+	error = vmbus_chan_gpadl_connect(chan, cbr->cbr_paddr,
+	    txbr_size + rxbr_size, &chan->ch_bufring_gpadl);
+	if (error) {
+		vmbus_chan_printf(chan,
+		    "failed to connect bufring GPADL to chan%u", chan->ch_id);
+		goto failed;
+	}
+
+	/*
+	 * Install this channel, before it is opened, but after everything
+	 * else has been setup.
+	 */
+	vmbus_chan_set_chmap(chan);
+
+	/*
+	 * Open channel w/ the bufring GPADL on the target CPU.
+	 */
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL) {
+		vmbus_chan_printf(chan,
+		    "can not get msg hypercall for chopen(chan%u)",
+		    chan->ch_id);
+		error = ENXIO;
+		goto failed;
+	}
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_CHOPEN;
+	req->chm_chanid = chan->ch_id;
+	req->chm_openid = chan->ch_id;
+	req->chm_gpadl = chan->ch_bufring_gpadl;
+	req->chm_vcpuid = chan->ch_vcpuid;
+	req->chm_txbr_pgcnt = txbr_size >> PAGESHIFT;
+	if (udlen > 0)
+		(void) memcpy(req->chm_udata, udata, udlen);
+
+	error = vmbus_msghc_exec(sc, mh);
+	if (error) {
+		vmbus_chan_printf(chan,
+		    "chopen(chan%u) msg hypercall exec failed: %d",
+		    chan->ch_id, error);
+		vmbus_msghc_put(sc, mh);
+		goto failed;
+	}
+
+	for (;;) {
+		msg = vmbus_msghc_poll_result(sc, mh);
+		if (msg != NULL)
+			break;
+		if (vmbus_chan_is_revoked(chan)) {
+			int i;
+
+			/*
+			 * NOTE:
+			 * Hypervisor does _not_ send response CHOPEN to
+			 * a revoked channel.
+			 */
+			vmbus_chan_printf(chan,
+			    "chan%u is revoked, when it is being opened",
+			    chan->ch_id);
+
+			/*
+			 * XXX
+			 * Add extra delay before cancel the hypercall
+			 * execution; mainly to close any possible
+			 * CHRESCIND and CHOPEN_RESP races on the
+			 * hypervisor side.
+			 */
+#define	REVOKE_LINGER	100
+			for (i = 0; i < REVOKE_LINGER; ++i) {
+				msg = vmbus_msghc_poll_result(sc, mh);
+				if (msg != NULL)
+					break;
+				drv_usecwait(1000);
+			}
+#undef REVOKE_LINGER
+			if (msg == NULL)
+				vmbus_msghc_exec_cancel(sc, mh);
+			break;
+		}
+		drv_usecwait(1000);
+	}
+	if (msg != NULL) {
+		status = ((const struct vmbus_chanmsg_chopen_resp *)
+		    msg->msg_data)->chm_status;
+	} else {
+		/* XXX any non-0 value is ok here. */
+		status = 0xff;
+	}
+
+	vmbus_msghc_put(sc, mh);
+
+	if (status == 0) {
+		if (boothowto & RB_VERBOSE)
+			vmbus_chan_printf(chan, "chan%u opened", chan->ch_id);
+		return (0);
+	}
+
+	dev_err(sc->vmbus_dev, CE_WARN, "failed to open chan%u", chan->ch_id);
+	error = ENXIO;
+
+failed:
+	vmbus_chan_clear_chmap(chan);
+	if (chan->ch_bufring_gpadl != 0) {
+		int error1;
+
+		error1 = vmbus_chan_gpadl_disconnect(chan,
+		    chan->ch_bufring_gpadl);
+		if (error1) {
+			/*
+			 * Give caller a hint that the bufring GPADL is still
+			 * connected.
+			 */
+			error = EISCONN;
+		}
+		chan->ch_bufring_gpadl = 0;
+	}
+	(void) test_and_clear_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_OPENED_SHIFT);
+	return (error);
+}
+
+int
+vmbus_chan_gpadl_connect(struct vmbus_channel *chan, paddr_t paddr,
+    int size, uint32_t *gpadl0)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	struct vmbus_msghc *mh;
+	struct vmbus_chanmsg_gpadl_conn *req;
+	const struct vmbus_message *msg;
+	size_t reqsz;
+	uint32_t gpadl, status;
+	int page_count, range_len, i, cnt, error;
+	uint64_t page_id;
+
+	ASSERT0(*gpadl0);
+
+	/*
+	 * Preliminary checks.
+	 */
+
+	ASSERT0((size & PAGEOFFSET));
+	page_count = size >> PAGESHIFT;
+
+	ASSERT0((paddr & PAGEOFFSET));
+	page_id = paddr >> PAGESHIFT;
+
+	range_len = offsetof(struct vmbus_gpa_range, gpa_page[page_count]);
+	/*
+	 * We don't support multiple GPA ranges.
+	 */
+	if (range_len > UINT16_MAX) {
+		vmbus_chan_printf(chan, "GPA too large, %d pages",
+		    page_count);
+		return (EOPNOTSUPP);
+	}
+
+	/*
+	 * Allocate GPADL id.
+	 */
+	gpadl = vmbus_gpadl_alloc(sc);
+
+	/*
+	 * Connect this GPADL to the target channel.
+	 *
+	 * NOTE:
+	 * Since each message can only hold small set of page
+	 * addresses, several messages may be required to
+	 * complete the connection.
+	 */
+	if (page_count > VMBUS_CHANMSG_GPADL_CONN_PGMAX)
+		cnt = VMBUS_CHANMSG_GPADL_CONN_PGMAX;
+	else
+		cnt = page_count;
+	page_count -= cnt;
+
+	reqsz = offsetof(struct vmbus_chanmsg_gpadl_conn,
+	    chm_range.gpa_page[cnt]);
+	mh = vmbus_msghc_get(sc, reqsz);
+	if (mh == NULL) {
+		vmbus_chan_printf(chan,
+		    "can not get msg hypercall for gpadl_conn(chan%u)",
+		    chan->ch_id);
+		return (EIO);
+	}
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_GPADL_CONN;
+	req->chm_chanid = chan->ch_id;
+	req->chm_gpadl = gpadl;
+	req->chm_range_len = range_len;
+	req->chm_range_cnt = 1;
+	req->chm_range.gpa_len = size;
+	req->chm_range.gpa_ofs = 0;
+	for (i = 0; i < cnt; ++i)
+		req->chm_range.gpa_page[i] = page_id++;
+
+	error = vmbus_msghc_exec(sc, mh);
+	if (error) {
+		vmbus_chan_printf(chan,
+		    "gpadl_conn(chan%u) msg hypercall exec failed: %d",
+		    chan->ch_id, error);
+		vmbus_msghc_put(sc, mh);
+		return (error);
+	}
+
+	while (page_count > 0) {
+		struct vmbus_chanmsg_gpadl_subconn *subreq;
+
+		if (page_count > VMBUS_CHANMSG_GPADL_SUBCONN_PGMAX)
+			cnt = VMBUS_CHANMSG_GPADL_SUBCONN_PGMAX;
+		else
+			cnt = page_count;
+		page_count -= cnt;
+
+		reqsz = offsetof(struct vmbus_chanmsg_gpadl_subconn,
+		    chm_gpa_page[cnt]);
+		vmbus_msghc_reset(mh, reqsz);
+
+		subreq = vmbus_msghc_dataptr(mh);
+		subreq->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_GPADL_SUBCONN;
+		subreq->chm_gpadl = gpadl;
+		for (i = 0; i < cnt; ++i)
+			subreq->chm_gpa_page[i] = page_id++;
+
+		(void) vmbus_msghc_exec_noresult(mh);
+	}
+
+	ASSERT0(page_count);
+
+	msg = vmbus_msghc_wait_result(sc, mh);
+
+	status = ((const struct vmbus_chanmsg_gpadl_connresp *)
+	    msg->msg_data)->chm_status;
+
+	vmbus_msghc_put(sc, mh);
+
+	if (status != 0) {
+		vmbus_chan_printf(chan, "gpadl_conn(chan%u) failed: %u",
+		    chan->ch_id, status);
+		return (EIO);
+	}
+
+	/* Done; commit the GPADL id. */
+	*gpadl0 = gpadl;
+	if (boothowto & RB_VERBOSE)
+		vmbus_chan_printf(chan, "gpadl_conn(chan%u) succeeded",
+		    chan->ch_id);
+	return (0);
+}
+
+static boolean_t
+vmbus_chan_wait_revoke(const struct vmbus_channel *chan)
+{
+#define	WAIT_COUNT	200	/* 200ms */
+
+	int i;
+
+	for (i = 0; i < WAIT_COUNT; ++i) {
+		if (vmbus_chan_is_revoked(chan))
+			return (B_TRUE);
+		/* Not sure about the context; use busy-wait. */
+		drv_usecwait(1000);
+	}
+	return (B_FALSE);
+
+#undef WAIT_COUNT
+}
+
+/*
+ * Disconnect the GPA from the target channel
+ */
+int
+vmbus_chan_gpadl_disconnect(struct vmbus_channel *chan, uint32_t gpadl)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	struct vmbus_msghc *mh;
+	struct vmbus_chanmsg_gpadl_disconn *req;
+	int error;
+
+	ASSERT3U(gpadl, !=, 0);
+
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL) {
+		vmbus_chan_printf(chan,
+		    "can not get msg hypercall for gpadl_disconn(chan%u)",
+		    chan->ch_id);
+		return (EBUSY);
+	}
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_GPADL_DISCONN;
+	req->chm_chanid = chan->ch_id;
+	req->chm_gpadl = gpadl;
+
+	error = vmbus_msghc_exec(sc, mh);
+	if (error != 0) {
+		vmbus_msghc_put(sc, mh);
+
+		if (vmbus_chan_wait_revoke(chan)) {
+			/*
+			 * Error is benign; this channel is revoked,
+			 * so this GPADL will not be touched anymore.
+			 */
+			vmbus_chan_printf(chan,
+			    "gpadl_disconn(revoked chan%u) msg hypercall "
+			    "exec failed: %d", chan->ch_id, error);
+			return (0);
+		}
+		vmbus_chan_printf(chan,
+		    "gpadl_disconn(chan%u) msg hypercall exec failed: %d",
+		    chan->ch_id, error);
+		return (error);
+	}
+
+	(void) vmbus_msghc_wait_result(sc, mh);
+	/* Discard result; no useful information */
+	vmbus_msghc_put(sc, mh);
+
+	return (0);
+}
+
+static void
+vmbus_chan_detach(struct vmbus_channel *chan)
+{
+	uint32_t refs;
+
+	ASSERT3U(chan->ch_refs, >, 0);
+	refs = atomic_dec_32_nv(&chan->ch_refs);
+	if (VMBUS_CHAN_ISPRIMARY(chan)) {
+		VERIFY0(refs);
+	}
+	if (refs == 0) {
+		/*
+		 * Detach the target channel.
+		 */
+		if (boothowto & RB_VERBOSE) {
+			vmbus_chan_printf(chan, "chan%u detached",
+			    chan->ch_id);
+		}
+		(void) ddi_taskq_dispatch(chan->ch_mgmt_tq,
+		    chan->ch_detach_task, chan, DDI_SLEEP);
+	}
+}
+
+static void
+vmbus_chan_clrchmap_task(void *xchan)
+{
+	struct vmbus_channel *chan = xchan;
+	/* Disable preemption */
+	kpreempt_disable();
+	chan->ch_vmbus->vmbus_chmap[chan->ch_id] = NULL;
+	/* Enable preemption */
+	kpreempt_enable();
+}
+
+static void
+vmbus_chan_clear_chmap(struct vmbus_channel *chan)
+{
+	vmbus_chan_run_task(chan, vmbus_chan_clrchmap_task);
+}
+
+static void
+vmbus_chan_set_chmap(struct vmbus_channel *chan)
+{
+	membar_sync();
+	chan->ch_vmbus->vmbus_chmap[chan->ch_id] = chan;
+}
+
+static int
+vmbus_chan_close_internal(struct vmbus_channel *chan)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	struct vmbus_msghc *mh;
+	struct vmbus_chanmsg_chclose *req;
+	uint32_t old_stflags;
+	int error;
+
+	/*
+	 * NOTE:
+	 * Sub-channels are closed upon their primary channel closing,
+	 * so they can be closed even before they are opened.
+	 */
+	for (;;) {
+		old_stflags = chan->ch_stflags;
+		if (atomic_cas_32(&chan->ch_stflags, old_stflags,
+		    old_stflags & ~VMBUS_CHAN_ST_OPENED) == old_stflags)
+			break;
+	}
+	if ((old_stflags & VMBUS_CHAN_ST_OPENED) == 0) {
+		/* Not opened yet; done */
+		if (boothowto & RB_VERBOSE) {
+			vmbus_chan_printf(chan, "chan%u not opened",
+			    chan->ch_id);
+		}
+		return (0);
+	}
+
+	/*
+	 * NOTE:
+	 * Order is critical.  This channel _must_ be uninstalled first,
+	 * else the channel task may be enqueued by the IDT after it has
+	 * been drained.
+	 */
+	vmbus_chan_clear_chmap(chan);
+	ddi_taskq_wait(chan->ch_tq); /* drain the queue first */
+	chan->ch_tq = NULL;
+
+	/*
+	 * Close this channel.
+	 */
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL) {
+		vmbus_chan_printf(chan,
+		    "can not get msg hypercall for chclose(chan%u)",
+		    chan->ch_id);
+		error = ENXIO;
+		goto disconnect;
+	}
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_CHCLOSE;
+	req->chm_chanid = chan->ch_id;
+
+	error = vmbus_msghc_exec_noresult(mh);
+	vmbus_msghc_put(sc, mh);
+
+	if (error) {
+		vmbus_chan_printf(chan,
+		    "chclose(chan%u) msg hypercall exec failed: %d",
+		    chan->ch_id, error);
+		goto disconnect;
+	}
+
+	if (boothowto & RB_VERBOSE)
+		vmbus_chan_printf(chan, "chan%u closed", chan->ch_id);
+
+disconnect:
+	/*
+	 * Disconnect the TX+RX bufrings from this channel.
+	 */
+	if (chan->ch_bufring_gpadl != 0) {
+		int error1;
+
+		error1 = vmbus_chan_gpadl_disconnect(chan,
+		    chan->ch_bufring_gpadl);
+		if (error1) {
+			/*
+			 * XXX
+			 * The bufring GPADL is still connected; abandon
+			 * this bufring, instead of having mysterious
+			 * crash or trashed data later on.
+			 */
+			vmbus_chan_printf(chan, "chan%u bufring GPADL "
+			    "is still connected after close", chan->ch_id);
+			chan->ch_bufring = NULL;
+			/*
+			 * Give caller a hint that the bufring GPADL is
+			 * still connected.
+			 */
+			error = EISCONN;
+		}
+		chan->ch_bufring_gpadl = 0;
+	}
+
+	/*
+	 * Destroy the TX+RX bufrings.
+	 */
+	if (chan->ch_bufring != NULL) {
+		hyperv_dmamem_free(&chan->ch_bufring_dma);
+		chan->ch_bufring = NULL;
+	}
+	return (error);
+}
+
+int
+vmbus_chan_close_direct(struct vmbus_channel *chan)
+{
+	int error;
+
+	if (VMBUS_CHAN_ISPRIMARY(chan)) {
+		struct vmbus_channel *subchan;
+
+		/*
+		 * All sub-channels _must_ have been closed, or are _not_
+		 * opened at all.
+		 */
+		mutex_enter(&chan->ch_subchan_lock);
+		TAILQ_FOREACH(subchan, &chan->ch_subchans, ch_sublink) {
+			VERIFY0(subchan->ch_stflags & VMBUS_CHAN_ST_OPENED);
+		}
+		mutex_exit(&chan->ch_subchan_lock);
+	}
+
+	error = vmbus_chan_close_internal(chan);
+	if (!VMBUS_CHAN_ISPRIMARY(chan)) {
+		/*
+		 * This sub-channel is referenced, when it is linked to
+		 * the primary channel; drop that reference now.
+		 */
+		vmbus_chan_detach(chan);
+	}
+	return (error);
+}
+
+/*
+ * Caller should make sure that all sub-channels have
+ * been added to 'chan' and all to-be-closed channels
+ * are not being opened.
+ */
+void
+vmbus_chan_close(struct vmbus_channel *chan)
+{
+	int subchan_cnt;
+
+	if (!VMBUS_CHAN_ISPRIMARY(chan)) {
+		/*
+		 * Sub-channel is closed when its primary channel
+		 * is closed; done.
+		 */
+		return;
+	}
+
+	/*
+	 * Close all sub-channels, if any.
+	 */
+	subchan_cnt = chan->ch_subchan_cnt;
+	if (subchan_cnt > 0) {
+		struct vmbus_channel **subchan;
+		int i;
+
+		subchan = vmbus_subchan_get(chan, subchan_cnt);
+		for (i = 0; i < subchan_cnt; ++i) {
+			(void) vmbus_chan_close_internal(subchan[i]);
+			/*
+			 * This sub-channel is referenced, when it is
+			 * linked to the primary channel; drop that
+			 * reference now.
+			 */
+			vmbus_chan_detach(subchan[i]);
+		}
+		vmbus_subchan_rel(subchan, subchan_cnt);
+	}
+
+	/* Then close the primary channel. */
+	(void) vmbus_chan_close_internal(chan);
+}
+
+void
+vmbus_chan_intr_drain(struct vmbus_channel *chan)
+{
+	ddi_taskq_wait(chan->ch_tq);
+}
+
+int
+vmbus_chan_send(struct vmbus_channel *chan, uint16_t type, uint16_t flags,
+    void *data, int dlen, uint64_t xactid)
+{
+	struct vmbus_chanpkt pkt;
+	int pktlen, pad_pktlen, hlen, error;
+	uint64_t pad = 0;
+	struct iovec iov[3];
+	boolean_t send_evt;
+
+	hlen = sizeof (pkt);
+	pktlen = hlen + dlen;
+	pad_pktlen = VMBUS_CHANPKT_TOTLEN(pktlen);
+	ASSERT3U(pad_pktlen, <=, vmbus_txbr_maxpktsz(&chan->ch_txbr));
+
+	pkt.cp_hdr.cph_type = type;
+	pkt.cp_hdr.cph_flags = flags;
+	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_hlen, hlen);
+	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_tlen, pad_pktlen);
+	pkt.cp_hdr.cph_xactid = xactid;
+
+	iov[0].iov_base = (void *)&pkt;
+	iov[0].iov_len = hlen;
+	iov[1].iov_base = data;
+	iov[1].iov_len = dlen;
+	iov[2].iov_base = (void *)&pad;
+	iov[2].iov_len = pad_pktlen - pktlen;
+
+	error = vmbus_txbr_write(&chan->ch_txbr, iov, 3, &send_evt);
+	if (!error && send_evt)
+		vmbus_chan_signal_tx(chan);
+	return (error);
+}
+
+int
+vmbus_chan_send_sglist(struct vmbus_channel *chan,
+    struct vmbus_gpa sg[], int sglen, void *data, int dlen, uint64_t xactid)
+{
+	struct vmbus_chanpkt_sglist pkt;
+	int pktlen, pad_pktlen, hlen, error;
+	struct iovec iov[4];
+	boolean_t send_evt;
+	uint64_t pad = 0;
+
+	hlen = offsetof(struct vmbus_chanpkt_sglist, cp_gpa[sglen]);
+	pktlen = hlen + dlen;
+	pad_pktlen = VMBUS_CHANPKT_TOTLEN(pktlen);
+	ASSERT3U(pad_pktlen, <=, vmbus_txbr_maxpktsz(&chan->ch_txbr));
+
+	pkt.cp_hdr.cph_type = VMBUS_CHANPKT_TYPE_GPA;
+	pkt.cp_hdr.cph_flags = VMBUS_CHANPKT_FLAG_RC;
+	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_hlen, hlen);
+	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_tlen, pad_pktlen);
+	pkt.cp_hdr.cph_xactid = xactid;
+	pkt.cp_rsvd = 0;
+	pkt.cp_gpa_cnt = sglen;
+
+	iov[0].iov_base = (void *)&pkt;
+	iov[0].iov_len = sizeof (pkt);
+	iov[1].iov_base = (void *)sg;
+	iov[1].iov_len = sizeof (struct vmbus_gpa) * sglen;
+	iov[2].iov_base = data;
+	iov[2].iov_len = dlen;
+	iov[3].iov_base = (void *)&pad;
+	iov[3].iov_len = pad_pktlen - pktlen;
+
+	error = vmbus_txbr_write(&chan->ch_txbr, iov, 4, &send_evt);
+	if (!error && send_evt)
+		vmbus_chan_signal_tx(chan);
+	return (error);
+}
+
+int
+vmbus_chan_send_prplist(struct vmbus_channel *chan,
+    struct vmbus_gpa_range *prp, int prp_cnt, void *data, int dlen,
+    uint64_t xactid)
+{
+	struct vmbus_chanpkt_prplist pkt;
+	int pktlen, pad_pktlen, hlen, error;
+	struct iovec iov[4];
+	boolean_t send_evt;
+	uint64_t pad = 0;
+
+	hlen = offsetof(struct vmbus_chanpkt_prplist,
+	    cp_range[0].gpa_page[prp_cnt]);
+	pktlen = hlen + dlen;
+	pad_pktlen = VMBUS_CHANPKT_TOTLEN(pktlen);
+	ASSERT3U(pad_pktlen, <=, vmbus_txbr_maxpktsz(&chan->ch_txbr));
+
+	pkt.cp_hdr.cph_type = VMBUS_CHANPKT_TYPE_GPA;
+	pkt.cp_hdr.cph_flags = VMBUS_CHANPKT_FLAG_RC;
+	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_hlen, hlen);
+	VMBUS_CHANPKT_SETLEN(pkt.cp_hdr.cph_tlen, pad_pktlen);
+	pkt.cp_hdr.cph_xactid = xactid;
+	pkt.cp_rsvd = 0;
+	pkt.cp_range_cnt = 1;
+
+	iov[0].iov_base = (void *)&pkt;
+	iov[0].iov_len = sizeof (pkt);
+	iov[1].iov_base = (void *)prp;
+	iov[1].iov_len = offsetof(struct vmbus_gpa_range, gpa_page[prp_cnt]);
+	iov[2].iov_base = data;
+	iov[2].iov_len = dlen;
+	iov[3].iov_base = (void *)&pad;
+	iov[3].iov_len = pad_pktlen - pktlen;
+
+	error = vmbus_txbr_write(&chan->ch_txbr, iov, 4, &send_evt);
+	if (!error && send_evt)
+		vmbus_chan_signal_tx(chan);
+	return (error);
+}
+
+int
+vmbus_chan_recv(struct vmbus_channel *chan, void *data, int *dlen0,
+    uint64_t *xactid)
+{
+	struct vmbus_chanpkt_hdr pkt;
+	int error, dlen, hlen;
+
+	error = vmbus_rxbr_peek(&chan->ch_rxbr, &pkt, sizeof (pkt));
+	if (error)
+		return (error);
+
+	if (__predict_false(pkt.cph_hlen < VMBUS_CHANPKT_HLEN_MIN)) {
+		vmbus_chan_printf(chan, "invalid hlen %u", pkt.cph_hlen);
+		/* XXX this channel is dead actually. */
+		return (EIO);
+	}
+	if (__predict_false(pkt.cph_hlen > pkt.cph_tlen)) {
+		vmbus_chan_printf(chan, "invalid hlen %u and tlen %u",
+		    pkt.cph_hlen, pkt.cph_tlen);
+		/* XXX this channel is dead actually. */
+		return (EIO);
+	}
+
+	hlen = VMBUS_CHANPKT_GETLEN(pkt.cph_hlen);
+	dlen = VMBUS_CHANPKT_GETLEN(pkt.cph_tlen) - hlen;
+
+	if (*dlen0 < dlen) {
+		/* Return the size of this packet's data. */
+		*dlen0 = dlen;
+		return (ENOBUFS);
+	}
+
+	*xactid = pkt.cph_xactid;
+	*dlen0 = dlen;
+
+	/* Skip packet header */
+	error = vmbus_rxbr_read(&chan->ch_rxbr, data, dlen, hlen);
+	ASSERT0(error);
+
+	return (0);
+}
+
+int
+vmbus_chan_recv_pkt(struct vmbus_channel *chan,
+    struct vmbus_chanpkt_hdr *pkt, int *pktlen0)
+{
+	int error, pktlen, pkt_hlen;
+
+	pkt_hlen = sizeof (*pkt);
+	error = vmbus_rxbr_peek(&chan->ch_rxbr, pkt, pkt_hlen);
+	if (error)
+		return (error);
+
+	if (__predict_false(pkt->cph_hlen < VMBUS_CHANPKT_HLEN_MIN)) {
+		vmbus_chan_printf(chan, "invalid hlen %u", pkt->cph_hlen);
+		/* XXX this channel is dead actually. */
+		return (EIO);
+	}
+	if (__predict_false(pkt->cph_hlen > pkt->cph_tlen)) {
+		vmbus_chan_printf(chan, "invalid hlen %u and tlen %u",
+		    pkt->cph_hlen, pkt->cph_tlen);
+		/* XXX this channel is dead actually. */
+		return (EIO);
+	}
+
+	pktlen = VMBUS_CHANPKT_GETLEN(pkt->cph_tlen);
+	if (*pktlen0 < pktlen) {
+		/* Return the size of this packet. */
+		*pktlen0 = pktlen;
+		return (ENOBUFS);
+	}
+	*pktlen0 = pktlen;
+
+	/*
+	 * Skip the fixed-size packet header, which has been filled
+	 * by the above vmbus_rxbr_peek().
+	 */
+	error = vmbus_rxbr_read(&chan->ch_rxbr, pkt + 1,
+	    pktlen - pkt_hlen, pkt_hlen);
+	ASSERT(!error);
+
+	return (0);
+}
+
+static void
+vmbus_chan_task(void *xchan)
+{
+	struct vmbus_channel *chan = xchan;
+	vmbus_chan_callback_t cb = chan->ch_cb;
+	void *cbarg = chan->ch_cbarg;
+
+	/*
+	 * Optimize host to guest signaling by ensuring:
+	 * 1. While reading the channel, we disable interrupts from
+	 *    host.
+	 * 2. Ensure that we process all posted messages from the host
+	 *    before returning from this callback.
+	 * 3. Once we return, enable signaling from the host. Once this
+	 *    state is set we check to see if additional packets are
+	 *    available to read. In this case we repeat the process.
+	 *
+	 * NOTE: Interrupt has been disabled in the ISR.
+	 */
+	for (;;) {
+		uint32_t left;
+
+		cb(chan, cbarg);
+
+		left = vmbus_rxbr_intr_unmask(&chan->ch_rxbr);
+		if (left == 0) {
+			/* No more data in RX bufring; done */
+			break;
+		}
+		vmbus_rxbr_intr_mask(&chan->ch_rxbr);
+	}
+}
+
+static void
+vmbus_chan_task_nobatch(void *xchan)
+{
+	struct vmbus_channel *chan = xchan;
+
+	chan->ch_cb(chan, chan->ch_cbarg);
+}
+
+static void /* __inline (really ?) */
+vmbus_event_flags_proc(struct vmbus_softc *sc, volatile ulong_t *event_flags,
+    int flag_cnt)
+{
+	int f;
+
+	for (f = 0; f < flag_cnt; ++f) {
+		uint32_t chid_base;
+		uint64_t flags;
+		int chid_ofs;
+
+		if (event_flags[f] == 0)
+			continue;
+
+		flags = atomic_swap_ulong(&event_flags[f], 0);
+		chid_base = f << VMBUS_EVTFLAG_SHIFT;
+
+		while ((chid_ofs = lowbit(flags)) != 0) {
+			struct vmbus_channel *chan;
+
+			--chid_ofs; /* NOTE: lowbit is 1-based */
+			flags &= ~(1UL << chid_ofs);
+
+			chan = sc->vmbus_chmap[chid_base + chid_ofs];
+			if (__predict_false(chan == NULL)) {
+				/* Channel is closed. */
+				continue;
+			}
+			__compiler_membar();
+
+			if (chan->ch_flags & VMBUS_CHAN_FLAG_BATCHREAD)
+				vmbus_rxbr_intr_mask(&chan->ch_rxbr);
+			if (ddi_taskq_dispatch(chan->ch_tq, chan->ch_tqent_func,
+			    chan, 0) != DDI_SUCCESS) {
+				vmbus_chan_printf(chan,
+				    "Failed to dispatch ch_task, flag: %d, "
+				    "flag_cnt: %d", f, flag_cnt);
+			}
+		}
+	}
+}
+
+void
+vmbus_event_proc(struct vmbus_softc *sc, int cpu)
+{
+	struct vmbus_evtflags *eventf;
+
+	/*
+	 * On Host with Win8 or above, the event page can be checked directly
+	 * to get the id of the channel that has the pending interrupt.
+	 */
+	eventf = VMBUS_PCPU_GET(sc, event_flags, cpu) + VMBUS_SINT_MESSAGE;
+	vmbus_event_flags_proc(sc, eventf->evt_flags,
+	    VMBUS_PCPU_GET(sc, event_flags_cnt, cpu));
+}
+
+void
+vmbus_event_proc_compat(struct vmbus_softc *sc, int cpu)
+{
+	struct vmbus_evtflags *eventf;
+
+	eventf = VMBUS_PCPU_GET(sc, event_flags, cpu) + VMBUS_SINT_MESSAGE;
+	if (atomic_clear_long_excl(&eventf->evt_flags[0], 0) == 0) {
+		vmbus_event_flags_proc(sc, sc->vmbus_rx_evtflags,
+		    VMBUS_CHAN_MAX_COMPAT >> VMBUS_EVTFLAG_SHIFT);
+	}
+}
+
+static void
+vmbus_chan_update_evtflagcnt(struct vmbus_softc *sc,
+    const struct vmbus_channel *chan)
+{
+	volatile uint_t *flag_cnt_ptr;
+	uint_t flag_cnt;
+
+	flag_cnt = (chan->ch_id / VMBUS_EVTFLAG_LEN) + 1;
+	flag_cnt_ptr = (uint_t *)VMBUS_PCPU_PTR(sc, event_flags_cnt,
+	    chan->ch_cpuid);
+
+	for (;;) {
+		uint_t old_flag_cnt;
+
+		old_flag_cnt = *flag_cnt_ptr;
+		if (old_flag_cnt >= flag_cnt)
+			break;
+		if (atomic_cmpset_int(flag_cnt_ptr, old_flag_cnt, flag_cnt)) {
+			if (boothowto & RB_VERBOSE) {
+				vmbus_chan_printf(chan,
+				    "chan%u update cpu%d flag_cnt to %d",
+				    chan->ch_id, chan->ch_cpuid, flag_cnt);
+			}
+			break;
+		}
+	}
+}
+
+static struct vmbus_channel *
+vmbus_chan_alloc(struct vmbus_softc *sc)
+{
+	struct vmbus_channel *chan;
+
+	chan = (struct vmbus_channel *)kmem_zalloc(sizeof (*chan), KM_SLEEP);
+
+	chan->ch_monprm = (struct hyperv_mon_param *)hyperv_dmamem_alloc(
+	    sc->vmbus_dev, (uint64_t)HYPERCALL_PARAM_ALIGN, 0,
+	    sizeof (struct hyperv_mon_param), &chan->ch_monprm_dma,
+	    DDI_DMA_RDWR);
+	if (chan->ch_monprm == NULL) {
+		dev_err(sc->vmbus_dev, CE_WARN, "monprm dma alloc failed");
+		kmem_free(chan, sizeof (*chan));
+		return (NULL);
+	}
+
+	chan->ch_refs = 1;
+	chan->ch_vmbus = sc;
+	mutex_init(&chan->ch_subchan_lock, "vmbus subchan", MUTEX_DRIVER, NULL);
+	mutex_init(&chan->ch_orphan_lock, "vmbus chorphan", MUTEX_DRIVER, NULL);
+	cv_init(&chan->ch_subchan_cv, NULL, CV_DEFAULT, NULL);
+	TAILQ_INIT(&chan->ch_subchans);
+	vmbus_rxbr_init(&chan->ch_rxbr);
+	vmbus_txbr_init(&chan->ch_txbr);
+
+	return (chan);
+}
+
+static void
+vmbus_chan_free(struct vmbus_channel *chan)
+{
+
+	ASSERT(TAILQ_EMPTY(&chan->ch_subchans) && chan->ch_subchan_cnt == 0);
+	    /* ("still owns sub-channels"); */
+	ASSERT((chan->ch_stflags &
+	    (VMBUS_CHAN_ST_OPENED |
+	    VMBUS_CHAN_ST_ONPRIL |
+	    VMBUS_CHAN_ST_ONSUBL |
+	    VMBUS_CHAN_ST_ONLIST)) == 0);
+	ASSERT3P(chan->ch_orphan_xact, ==, NULL);
+	ASSERT0(chan->ch_refs);
+
+	hyperv_dmamem_free(&chan->ch_monprm_dma);
+	mutex_destroy(&chan->ch_subchan_lock);
+	mutex_destroy(&chan->ch_orphan_lock);
+	cv_destroy(&chan->ch_subchan_cv);
+	vmbus_rxbr_deinit(&chan->ch_rxbr);
+	vmbus_txbr_deinit(&chan->ch_txbr);
+	kmem_free(chan, sizeof (*chan));
+}
+
+static int
+vmbus_chan_add(struct vmbus_channel *newchan)
+{
+	struct vmbus_softc *sc = newchan->ch_vmbus;
+	struct vmbus_channel *prichan;
+
+	if (newchan->ch_id == 0) {
+		/*
+		 * XXX
+		 * Chan0 will neither be processed nor should be offered;
+		 * skip it.
+		 */
+		dev_err(sc->vmbus_dev, CE_WARN, "got chan0 offer, discard");
+		return (EINVAL);
+	} else if (newchan->ch_id >= VMBUS_CHAN_MAX) {
+		dev_err(sc->vmbus_dev, CE_WARN, "invalid chan%u offer",
+		    newchan->ch_id);
+		return (EINVAL);
+	}
+
+	mutex_enter(&sc->vmbus_prichan_lock);
+	TAILQ_FOREACH(prichan, &sc->vmbus_prichans, ch_prilink) {
+		/*
+		 * Sub-channel will have the same type GUID and instance
+		 * GUID as its primary channel.
+		 */
+		if (memcmp(&prichan->ch_guid_type, &newchan->ch_guid_type,
+		    sizeof (struct hyperv_guid)) == 0 &&
+		    memcmp(&prichan->ch_guid_inst, &newchan->ch_guid_inst,
+		    sizeof (struct hyperv_guid)) == 0)
+			break;
+	}
+	if (VMBUS_CHAN_ISPRIMARY(newchan)) {
+		if (prichan == NULL) {
+			/* Install the new primary channel */
+			vmbus_chan_ins_prilist(sc, newchan);
+			mutex_exit(&sc->vmbus_prichan_lock);
+			goto done;
+		} else {
+			mutex_exit(&sc->vmbus_prichan_lock);
+			dev_err(sc->vmbus_dev, CE_WARN,
+			    "duplicated primary chan%u", newchan->ch_id);
+			return (EINVAL);
+		}
+	} else { /* Sub-channel */
+		if (prichan == NULL) {
+			mutex_exit(&sc->vmbus_prichan_lock);
+			dev_err(sc->vmbus_dev, CE_WARN,
+			    "no primary chan for chan%u", newchan->ch_id);
+			return (EINVAL);
+		}
+		/*
+		 * Found the primary channel for this sub-channel and
+		 * move on.
+		 *
+		 * XXX refcnt prichan
+		 */
+	}
+	mutex_exit(&sc->vmbus_prichan_lock);
+
+	/*
+	 * This is a sub-channel; link it with the primary channel.
+	 */
+	if (VMBUS_CHAN_ISPRIMARY(newchan)) {
+		dev_err(sc->vmbus_dev, CE_WARN,
+		    "new channel is not sub-channel");
+	}
+	ASSERT(!VMBUS_CHAN_ISPRIMARY(newchan));
+	if (prichan == NULL)
+		dev_err(sc->vmbus_dev, CE_WARN, "no primary channel");
+	ASSERT(prichan != NULL);
+
+	/*
+	 * Reference count this sub-channel; it will be dereferenced
+	 * when this sub-channel is closed.
+	 */
+	ASSERT3U(newchan->ch_refs, ==, 1);
+	atomic_inc_32(&newchan->ch_refs);
+
+	newchan->ch_prichan = prichan;
+	newchan->ch_dev = prichan->ch_dev;
+
+	mutex_enter(&prichan->ch_subchan_lock);
+	vmbus_chan_ins_sublist(prichan, newchan);
+	mutex_exit(&prichan->ch_subchan_lock);
+	/*
+	 * Notify anyone that is interested in this sub-channel,
+	 * after this sub-channel is setup.
+	 */
+	cv_broadcast(&prichan->ch_subchan_cv);
+done:
+	/*
+	 * Hook this channel up for later revocation.
+	 */
+	mutex_enter(&sc->vmbus_chan_lock);
+	vmbus_chan_ins_list(sc, newchan);
+	mutex_exit(&sc->vmbus_chan_lock);
+
+	if (boothowto & RB_VERBOSE) {
+		vmbus_chan_printf(newchan, "chan%u subidx%u offer",
+		    newchan->ch_id, newchan->ch_subidx);
+	}
+
+	/* Select default cpu for this channel. */
+	vmbus_chan_cpu_default(newchan);
+
+	return (0);
+}
+
+void
+vmbus_chan_cpu_set(struct vmbus_channel *chan, int cpu)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	/* ASSERT(cpu >= 0 && cpu < mp_ncpus);  ("invalid cpu %d", cpu)); */
+	ASSERT(cpu >= 0 && cpu < ncpus);
+
+	if (sc->vmbus_version == VMBUS_VERSION_WS2008 ||
+	    sc->vmbus_version == VMBUS_VERSION_WIN7) {
+		/* Only cpu0 is supported */
+		cpu = 0;
+	}
+
+	chan->ch_cpuid = cpu;
+	chan->ch_vcpuid = VMBUS_PCPU_GET(sc, vcpuid, cpu);
+
+	if (boothowto & RB_VERBOSE) {
+		vmbus_chan_printf(chan,
+		    "chan%u: assigned to cpu%u [vcpu%u]",
+		    chan->ch_id, chan->ch_cpuid, chan->ch_vcpuid);
+	}
+}
+
+void
+vmbus_chan_cpu_rr(struct vmbus_channel *chan)
+{
+	static uint32_t vmbus_chan_nextcpu;
+	int cpu;
+
+	/* cpu = atomic_fetchadd_int(&vmbus_chan_nextcpu, 1) % NCPU; */
+	cpu = (atomic_inc_32_nv(
+	    (volatile uint32_t *)&vmbus_chan_nextcpu) - 1) % ncpus_online;
+	vmbus_chan_cpu_set(chan, cpu);
+}
+
+static void
+vmbus_chan_cpu_default(struct vmbus_channel *chan)
+{
+	/*
+	 * By default, pin the channel to cpu0.  Devices having
+	 * special channel-cpu mapping requirement should call
+	 * vmbus_chan_cpu_{set,rr}().
+	 */
+	vmbus_chan_cpu_set(chan, 0);
+}
+
+static void
+vmbus_chan_msgproc_choffer(struct vmbus_softc *sc,
+    const struct vmbus_message *msg)
+{
+	const struct vmbus_chanmsg_choffer *offer;
+	struct vmbus_channel *chan;
+	task_func_t *detach_fn, *attach_fn;
+	int error;
+
+	offer = (const struct vmbus_chanmsg_choffer *)msg->msg_data;
+
+	chan = vmbus_chan_alloc(sc);
+	if (chan == NULL) {
+		dev_err(sc->vmbus_dev, CE_WARN, "allocate chan%u failed",
+		    offer->chm_chanid);
+		return;
+	}
+
+	chan->ch_id = offer->chm_chanid;
+	chan->ch_subidx = offer->chm_subidx;
+	chan->ch_guid_type = offer->chm_chtype;
+	chan->ch_guid_inst = offer->chm_chinst;
+
+	/* Batch reading is on by default */
+	chan->ch_flags |= VMBUS_CHAN_FLAG_BATCHREAD;
+
+	chan->ch_monprm->mp_connid = VMBUS_CONNID_EVENT;
+	if (sc->vmbus_version != VMBUS_VERSION_WS2008)
+		chan->ch_monprm->mp_connid = offer->chm_connid;
+
+	if (offer->chm_flags1 & VMBUS_CHOFFER_FLAG1_HASMNF) {
+		int trig_idx;
+
+		/*
+		 * Setup MNF stuffs.
+		 */
+		chan->ch_txflags |= VMBUS_CHAN_TXF_HASMNF;
+
+		trig_idx = offer->chm_montrig / VMBUS_MONTRIG_LEN;
+		if (trig_idx >= VMBUS_MONTRIGS_MAX)
+			panic("invalid monitor trigger %u", offer->chm_montrig);
+		chan->ch_montrig =
+		    &sc->vmbus_mnf2->mnf_trigs[trig_idx].mt_pending;
+
+		chan->ch_montrig_mask =
+		    1 << (offer->chm_montrig % VMBUS_MONTRIG_LEN);
+	}
+
+	/*
+	 * Setup event flag.
+	 */
+	chan->ch_evtflag =
+	    &sc->vmbus_tx_evtflags[chan->ch_id >> VMBUS_EVTFLAG_SHIFT];
+	chan->ch_evtflag_mask = 1UL << (chan->ch_id & VMBUS_EVTFLAG_MASK);
+
+	/*
+	 * Setup attach and detach tasks.
+	 */
+	if (VMBUS_CHAN_ISPRIMARY(chan)) {
+		chan->ch_mgmt_tq = sc->vmbus_devtq;
+		attach_fn = vmbus_prichan_attach_task;
+		detach_fn = vmbus_prichan_detach_task;
+	} else {
+		chan->ch_mgmt_tq = sc->vmbus_subchtq;
+		attach_fn = vmbus_subchan_attach_task;
+		detach_fn = vmbus_subchan_detach_task;
+	}
+	chan->ch_attach_task = attach_fn;
+	chan->ch_detach_task = detach_fn;
+
+	error = vmbus_chan_add(chan);
+	if (error) {
+		dev_err(sc->vmbus_dev, CE_WARN, "add chan%u failed: %d",
+		    chan->ch_id, error);
+		atomic_dec_32(&chan->ch_refs);
+		vmbus_chan_free(chan);
+		return;
+	}
+	(void) ddi_taskq_dispatch(chan->ch_mgmt_tq, chan->ch_attach_task,
+	    chan, 0);
+}
+
+static void
+vmbus_chan_msgproc_chrescind(struct vmbus_softc *sc,
+    const struct vmbus_message *msg)
+{
+	const struct vmbus_chanmsg_chrescind *note;
+	struct vmbus_channel *chan;
+
+	note = (const struct vmbus_chanmsg_chrescind *)msg->msg_data;
+	if (note->chm_chanid > VMBUS_CHAN_MAX) {
+		dev_err(sc->vmbus_dev, CE_WARN, "invalid revoked chan%u",
+		    note->chm_chanid);
+		return;
+	}
+
+	/*
+	 * Find and remove the target channel from the channel list.
+	 */
+	mutex_enter(&sc->vmbus_chan_lock);
+	TAILQ_FOREACH(chan, &sc->vmbus_chans, ch_link) {
+		if (chan->ch_id == note->chm_chanid)
+			break;
+	}
+	if (chan == NULL) {
+		mutex_exit(&sc->vmbus_chan_lock);
+		dev_err(sc->vmbus_dev, CE_WARN, "chan%u is not offered",
+		    note->chm_chanid);
+		return;
+	}
+	vmbus_chan_rem_list(sc, chan);
+	mutex_exit(&sc->vmbus_chan_lock);
+
+	if (VMBUS_CHAN_ISPRIMARY(chan)) {
+		/*
+		 * The target channel is a primary channel; remove the
+		 * target channel from the primary channel list now,
+		 * instead of later, so that it will not be found by
+		 * other sub-channel offers, which are processed in
+		 * this thread.
+		 */
+		mutex_enter(&sc->vmbus_prichan_lock);
+		vmbus_chan_rem_prilist(sc, chan);
+		mutex_exit(&sc->vmbus_prichan_lock);
+	}
+
+	/*
+	 * NOTE:
+	 * The following processing order is critical:
+	 * Set the REVOKED state flag before orphaning the installed xact.
+	 */
+
+	if (test_and_set_bit(&chan->ch_stflags,
+	    VMBUS_CHAN_ST_REVOKED_SHIFT) == -1)
+		panic("channel has already been revoked");
+
+	mutex_enter(&chan->ch_orphan_lock);
+	if (chan->ch_orphan_xact != NULL)
+		(void) vmbus_xact_ctx_orphan(chan->ch_orphan_xact);
+	mutex_exit(&chan->ch_orphan_lock);
+
+	if (boothowto & RB_VERBOSE)
+		vmbus_chan_printf(chan, "chan%u rescinded", note->chm_chanid);
+
+	vmbus_chan_detach(chan);
+}
+
+static int
+vmbus_chan_release(struct vmbus_channel *chan)
+{
+	struct vmbus_softc *sc = chan->ch_vmbus;
+	struct vmbus_chanmsg_chfree *req;
+	struct vmbus_msghc *mh;
+	int error;
+
+	mh = vmbus_msghc_get(sc, sizeof (*req));
+	if (mh == NULL) {
+		vmbus_chan_printf(chan,
+		    "can not get msg hypercall for chfree(chan%u)",
+		    chan->ch_id);
+		return (ENXIO);
+	}
+
+	req = vmbus_msghc_dataptr(mh);
+	req->chm_hdr.chm_type = VMBUS_CHANMSG_TYPE_CHFREE;
+	req->chm_chanid = chan->ch_id;
+
+	error = vmbus_msghc_exec_noresult(mh);
+	vmbus_msghc_put(sc, mh);
+
+	if (error) {
+		vmbus_chan_printf(chan,
+		    "chfree(chan%u) msg hypercall exec failed: %d",
+		    chan->ch_id, error);
+	} else {
+		if (boothowto & RB_VERBOSE)
+			vmbus_chan_printf(chan, "chan%u freed", chan->ch_id);
+	}
+	return (error);
+}
+
+static void
+vmbus_prichan_detach_task(void *xchan)
+{
+	struct vmbus_channel *chan = xchan;
+
+	ASSERT(VMBUS_CHAN_ISPRIMARY(chan));
+	    /* ("chan%u is not primary channel", chan->ch_id); */
+
+	/* Delete and detach the device associated with this channel. */
+	(void) vmbus_delete_child(chan);
+
+	/* Release this channel (back to vmbus). */
+	(void) vmbus_chan_release(chan);
+
+	/* Free this channel's resource. */
+	vmbus_chan_free(chan);
+}
+
+static void
+vmbus_subchan_detach_task(void *xchan)
+{
+	struct vmbus_channel *chan = xchan;
+	struct vmbus_channel *pri_chan = chan->ch_prichan;
+
+	ASSERT(!VMBUS_CHAN_ISPRIMARY(chan));
+	    /* ("chan%u is primary channel", chan->ch_id); */
+
+	/* Release this channel (back to vmbus). */
+	(void) vmbus_chan_release(chan);
+
+	/* Unlink from its primary channel's sub-channel list. */
+	mutex_enter(&pri_chan->ch_subchan_lock);
+	vmbus_chan_rem_sublist(pri_chan, chan);
+	mutex_exit(&pri_chan->ch_subchan_lock);
+	/* Notify anyone that is waiting for this sub-channel to vanish. */
+	cv_broadcast(&pri_chan->ch_subchan_cv);
+
+	/* Free this channel's resource. */
+	vmbus_chan_free(chan);
+}
+
+static void
+vmbus_prichan_attach_task(void *xchan)
+{
+
+	/*
+	 * Add device for this primary channel.
+	 */
+	(void) vmbus_add_child(xchan);
+}
+
+/* ARGSUSED */
+static void
+vmbus_subchan_attach_task(void *xchan)
+{
+}
+
+void
+vmbus_chan_destroy_all(struct vmbus_softc *sc)
+{
+
+	/*
+	 * Detach all devices and destroy the corresponding primary
+	 * channels.
+	 */
+	for (;;) {
+		struct vmbus_channel *chan;
+
+		mutex_enter(&sc->vmbus_chan_lock);
+		TAILQ_FOREACH(chan, &sc->vmbus_chans, ch_link) {
+			if (VMBUS_CHAN_ISPRIMARY(chan))
+				break;
+		}
+		if (chan == NULL) {
+			/* No more primary channels; done. */
+			mutex_exit(&sc->vmbus_chan_lock);
+			break;
+		}
+		vmbus_chan_rem_list(sc, chan);
+		mutex_exit(&sc->vmbus_chan_lock);
+
+		mutex_enter(&sc->vmbus_prichan_lock);
+		vmbus_chan_rem_prilist(sc, chan);
+		mutex_exit(&sc->vmbus_prichan_lock);
+
+		(void) ddi_taskq_dispatch(chan->ch_mgmt_tq,
+		    chan->ch_detach_task, chan, 0);
+	}
+}
+
+struct vmbus_channel **
+vmbus_subchan_get(struct vmbus_channel *pri_chan, int subchan_cnt)
+{
+	struct vmbus_channel **ret, *chan;
+	int i;
+
+	ASSERT(subchan_cnt > 0);
+	/* ("invalid sub-channel count %d", subchan_cnt); */
+
+	ret = kmem_alloc(subchan_cnt * sizeof (struct vmbus_channel *),
+	    KM_SLEEP);
+
+	mutex_enter(&pri_chan->ch_subchan_lock);
+
+	while (pri_chan->ch_subchan_cnt < subchan_cnt)
+		cv_wait(&pri_chan->ch_subchan_cv, &pri_chan->ch_subchan_lock);
+
+	i = 0;
+	TAILQ_FOREACH(chan, &pri_chan->ch_subchans, ch_sublink) {
+		/* TODO: refcnt chan */
+		ret[i] = chan;
+
+		++i;
+		if (i == subchan_cnt)
+			break;
+	}
+	ASSERT3U(i, ==, subchan_cnt);
+
+	mutex_exit(&pri_chan->ch_subchan_lock);
+
+	return (ret);
+}
+
+void
+vmbus_subchan_rel(struct vmbus_channel **subchan, int subchan_cnt)
+{
+	kmem_free(subchan, (subchan_cnt * sizeof (*subchan)));
+}
+
+void
+vmbus_subchan_drain(struct vmbus_channel *pri_chan)
+{
+	mutex_enter(&pri_chan->ch_subchan_lock);
+	while (pri_chan->ch_subchan_cnt > 0)
+		cv_wait(&pri_chan->ch_subchan_cv, &pri_chan->ch_subchan_lock);
+	mutex_exit(&pri_chan->ch_subchan_lock);
+}
+
+void
+vmbus_chan_msgproc(struct vmbus_softc *sc, const struct vmbus_message *msg)
+{
+	vmbus_chanmsg_proc_t msg_proc;
+	uint32_t msg_type;
+
+	msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;
+	ASSERT(msg_type < VMBUS_CHANMSG_TYPE_MAX);
+
+	msg_proc = vmbus_chan_msgprocs[msg_type];
+	if (msg_proc != NULL)
+		msg_proc(sc, msg);
+}
+
+void
+vmbus_chan_set_readbatch(struct vmbus_channel *chan, boolean_t on)
+{
+	if (!on)
+		chan->ch_flags &= ~VMBUS_CHAN_FLAG_BATCHREAD;
+	else
+		chan->ch_flags |= VMBUS_CHAN_FLAG_BATCHREAD;
+}
+
+uint32_t
+vmbus_chan_id(const struct vmbus_channel *chan)
+{
+	return (chan->ch_id);
+}
+
+uint32_t
+vmbus_chan_subidx(const struct vmbus_channel *chan)
+{
+	return (chan->ch_subidx);
+}
+
+boolean_t
+vmbus_chan_is_primary(const struct vmbus_channel *chan)
+{
+	if (VMBUS_CHAN_ISPRIMARY(chan))
+		return (B_TRUE);
+	else
+		return (B_FALSE);
+}
+
+const struct hyperv_guid *
+vmbus_chan_guid_inst(const struct vmbus_channel *chan)
+{
+	return (&chan->ch_guid_inst);
+}
+
+int
+vmbus_chan_prplist_nelem(int br_size, int prpcnt_max, int dlen_max)
+{
+	int elem_size;
+
+	elem_size = offsetof(struct vmbus_chanpkt_prplist,
+	    cp_range[0].gpa_page[prpcnt_max]);
+	elem_size += dlen_max;
+	elem_size = VMBUS_CHANPKT_TOTLEN(elem_size);
+
+	return (vmbus_br_nelem(br_size, elem_size));
+}
+
+boolean_t
+vmbus_chan_tx_empty(const struct vmbus_channel *chan)
+{
+	return (vmbus_txbr_empty(&chan->ch_txbr));
+}
+
+boolean_t
+vmbus_chan_rx_empty(const struct vmbus_channel *chan)
+{
+	return (vmbus_rxbr_empty(&chan->ch_rxbr));
+}
+
+void
+vmbus_chan_run_task(struct vmbus_channel *chan, task_func_t *task)
+{
+	if (ddi_taskq_dispatch(chan->ch_tq, task, chan, 0) != DDI_SUCCESS) {
+		dev_err(chan->ch_dev, CE_PANIC,
+		    "Failed to run task: %p", (void *)task);
+	} else {
+		ddi_taskq_wait(chan->ch_tq);
+	}
+}
+
+ddi_taskq_t *
+vmbus_chan_mgmt_tq(const struct vmbus_channel *chan)
+{
+
+	return (chan->ch_mgmt_tq);
+}
+
+boolean_t
+vmbus_chan_is_revoked(const struct vmbus_channel *chan)
+{
+
+	if (chan->ch_stflags & VMBUS_CHAN_ST_REVOKED)
+		return (B_TRUE);
+	return (B_FALSE);
+}
+
+void
+vmbus_chan_set_orphan(struct vmbus_channel *chan, struct vmbus_xact_ctx *xact)
+{
+
+	mutex_enter(&chan->ch_orphan_lock);
+	chan->ch_orphan_xact = xact;
+	mutex_exit(&chan->ch_orphan_lock);
+}
+
+void
+vmbus_chan_unset_orphan(struct vmbus_channel *chan)
+{
+
+	mutex_enter(&chan->ch_orphan_lock);
+	chan->ch_orphan_xact = NULL;
+	mutex_exit(&chan->ch_orphan_lock);
+}
+
+const void *
+vmbus_chan_xact_wait(const struct vmbus_channel *chan,
+    struct vmbus_xact *xact, size_t *resp_len, boolean_t can_sleep)
+{
+	const void *ret;
+
+	if (can_sleep)
+		ret = vmbus_xact_wait(xact, resp_len);
+	else
+		ret = vmbus_xact_busywait(xact, resp_len);
+	if (vmbus_chan_is_revoked(chan)) {
+		/*
+		 * This xact probably is interrupted, and the
+		 * interruption can race the reply reception,
+		 * so we have to make sure that there are nothing
+		 * left on the RX bufring, i.e. this xact will
+		 * not be touched, once this function returns.
+		 *
+		 * Since the hypervisor will not put more data
+		 * onto the RX bufring once the channel is revoked,
+		 * the following loop will be terminated, once all
+		 * data are drained by the driver's channel
+		 * callback.
+		 */
+		while (!vmbus_chan_rx_empty(chan)) {
+			if (can_sleep)
+				delay(1);
+			else
+				drv_usecwait(1000);
+		}
+	}
+	return (ret);
+}

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_chanvar.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_chanvar.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_CHANVAR_H_
+#define	_VMBUS_CHANVAR_H_
+
+#include <sys/param.h>
+#include <sys/mutex.h>
+#include <sys/queue.h>
+#include <sys/taskq.h>
+
+#include <sys/hyperv.h>
+#include <sys/hyperv_busdma.h>
+#include <sys/vmbus.h>
+#include "vmbus_brvar.h"
+
+
+struct vmbus_channel {
+	/*
+	 * NOTE:
+	 * Fields before ch_txbr are only accessed on this channel's
+	 * target CPU.
+	 */
+	uint32_t			ch_flags;	/* VMBUS_CHAN_FLAG_ */
+
+	/*
+	 * RX bufring; immediately following ch_txbr.
+	 */
+	struct vmbus_rxbr		ch_rxbr;
+
+	ddi_taskq_t			*ch_tq;
+	task_func_t			*ch_tqent_func;
+	/* taskq_ent_t			ch_task; */
+	vmbus_chan_callback_t		ch_cb;
+	void				*ch_cbarg;
+
+	/*
+	 * TX bufring; at the beginning of ch_bufring.
+	 *
+	 * NOTE:
+	 * Put TX bufring and the following MNF/evtflag to a new
+	 * cacheline, since they will be accessed on all CPUs by
+	 * locking ch_txbr first.
+	 *
+	 * XXX
+	 * TX bufring and following MNF/evtflags do _not_ fit in
+	 * one 64B cacheline.
+	 */
+	struct vmbus_txbr		ch_txbr __aligned(64);
+	uint32_t			ch_txflags;	/* VMBUS_CHAN_TXF_ */
+
+	/*
+	 * These are based on the vmbus_chanmsg_choffer.chm_montrig.
+	 * Save it here for easy access.
+	 */
+	uint32_t			ch_montrig_mask; /* MNF trig mask */
+	volatile uint32_t		*ch_montrig;	/* MNF trigger loc. */
+
+	/*
+	 * These are based on the vmbus_chanmsg_choffer.chm_chanid.
+	 * Save it here for easy access.
+	 */
+	ulong_t				ch_evtflag_mask; /* event flag */
+	volatile ulong_t		*ch_evtflag;	/* event flag loc. */
+
+	/*
+	 * Rarely used fields.
+	 */
+
+	struct hyperv_mon_param		*ch_monprm;
+	struct hyperv_dma		ch_monprm_dma;
+
+	uint32_t			ch_id;		/* channel id */
+	dev_info_t			*ch_dev;
+	struct vmbus_softc		*ch_vmbus;
+
+	int				ch_cpuid;	/* owner cpu */
+	/*
+	 * Virtual cpuid for ch_cpuid; it is used to communicate cpuid
+	 * related information w/ Hyper-V.  If MSR_HV_VP_INDEX does not
+	 * exist, ch_vcpuid will always be 0 for compatibility.
+	 */
+	uint32_t			ch_vcpuid;
+
+	/*
+	 * If this is a primary channel, ch_subchan* fields
+	 * contain sub-channels belonging to this primary
+	 * channel.
+	 */
+	kmutex_t			ch_subchan_lock;
+	kcondvar_t			ch_subchan_cv;
+	TAILQ_HEAD(, vmbus_channel)	ch_subchans;
+	int				ch_subchan_cnt;
+
+	/* If this is a sub-channel */
+	TAILQ_ENTRY(vmbus_channel)	ch_sublink;	/* sub-channel link */
+	struct vmbus_channel		*ch_prichan;	/* owner primary chan */
+
+	void				*ch_bufring;	/* TX+RX bufrings */
+	struct hyperv_dma		ch_bufring_dma;
+	uint32_t			ch_bufring_gpadl;
+
+	/* run in ch_mgmt_tq */
+	task_func_t			*ch_attach_task;
+	task_func_t			*ch_detach_task;
+	ddi_taskq_t			*ch_mgmt_tq;
+
+	/* If this is a primary channel */
+	TAILQ_ENTRY(vmbus_channel)	ch_prilink;	/* primary chan link */
+
+	TAILQ_ENTRY(vmbus_channel)	ch_link;	/* channel link */
+	uint32_t			ch_subidx;	/* subchan index */
+	volatile uint32_t		ch_stflags;	/* atomic-op */
+							/* VMBUS_CHAN_ST_ */
+	struct hyperv_guid		ch_guid_type;
+	struct hyperv_guid		ch_guid_inst;
+
+	kmutex_t			ch_orphan_lock;
+	struct vmbus_xact_ctx		*ch_orphan_xact;
+
+	uint32_t			ch_refs;
+
+} __aligned(64);
+
+#define	VMBUS_CHAN_ISPRIMARY(chan)	((chan)->ch_subidx == 0)
+
+/*
+ * If this flag is set, this channel's interrupt will be masked in ISR,
+ * and the RX bufring will be drained before this channel's interrupt is
+ * unmasked.
+ *
+ * This flag is turned on by default.  Drivers can turn it off according
+ * to their own requirement.
+ */
+#define	VMBUS_CHAN_FLAG_BATCHREAD	0x0002
+
+#define	VMBUS_CHAN_TXF_HASMNF		0x0001
+
+#define	VMBUS_CHAN_ST_OPENED_SHIFT	0
+#define	VMBUS_CHAN_ST_ONPRIL_SHIFT	1
+#define	VMBUS_CHAN_ST_ONSUBL_SHIFT	2
+#define	VMBUS_CHAN_ST_ONLIST_SHIFT	3
+#define	VMBUS_CHAN_ST_REVOKED_SHIFT	4	/* sticky */
+#define	VMBUS_CHAN_ST_OPENED		(1 << VMBUS_CHAN_ST_OPENED_SHIFT)
+#define	VMBUS_CHAN_ST_ONPRIL		(1 << VMBUS_CHAN_ST_ONPRIL_SHIFT)
+#define	VMBUS_CHAN_ST_ONSUBL		(1 << VMBUS_CHAN_ST_ONSUBL_SHIFT)
+#define	VMBUS_CHAN_ST_ONLIST		(1 << VMBUS_CHAN_ST_ONLIST_SHIFT)
+#define	VMBUS_CHAN_ST_REVOKED		(1 << VMBUS_CHAN_ST_REVOKED_SHIFT)
+
+struct vmbus_softc;
+struct vmbus_message;
+
+void		vmbus_event_proc(struct vmbus_softc *, int);
+void		vmbus_event_proc_compat(struct vmbus_softc *, int);
+void		vmbus_chan_msgproc(struct vmbus_softc *,
+		    const struct vmbus_message *);
+void		vmbus_chan_destroy_all(struct vmbus_softc *);
+
+#endif	/* !_VMBUS_CHANVAR_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_reg.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_reg.h
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_REG_H_
+#define	_VMBUS_REG_H_
+
+#include <sys/param.h>
+#include <sys/sysmacros.h>
+#include <sys/debug.h>
+
+#include <sys/hyperv_illumos.h> /* for __packed */
+#include <sys/hyperv.h>
+#include <sys/vmbus.h>
+#include <vmbus/hyperv_reg.h>
+
+
+/*
+ * Hyper-V SynIC message format.
+ */
+
+#define	VMBUS_MSG_DSIZE_MAX		240
+#define	VMBUS_MSG_SIZE			256
+
+struct vmbus_message {
+	uint32_t	msg_type;	/* HYPERV_MSGTYPE_ */
+	uint8_t		msg_dsize;	/* data size */
+	uint8_t		msg_flags;	/* VMBUS_MSGFLAG_ */
+	uint16_t	msg_rsvd;
+	uint64_t	msg_id;
+	uint8_t		msg_data[VMBUS_MSG_DSIZE_MAX];
+} __packed;
+CTASSERT(sizeof (struct vmbus_message) == VMBUS_MSG_SIZE);
+
+#define	VMBUS_MSGFLAG_PENDING		0x01
+
+/*
+ * Hyper-V SynIC event flags
+ */
+
+#ifdef __LP64__
+#define	VMBUS_EVTFLAGS_MAX	32
+#define	VMBUS_EVTFLAG_SHIFT	6
+#else
+#define	VMBUS_EVTFLAGS_MAX	64
+#define	VMBUS_EVTFLAG_SHIFT	5
+#endif
+#define	VMBUS_EVTFLAG_LEN	(1 << VMBUS_EVTFLAG_SHIFT)
+#define	VMBUS_EVTFLAG_MASK	(VMBUS_EVTFLAG_LEN - 1)
+#define	VMBUS_EVTFLAGS_SIZE	256
+
+struct vmbus_evtflags {
+	ulong_t		evt_flags[VMBUS_EVTFLAGS_MAX];
+} __packed;
+CTASSERT(sizeof (struct vmbus_evtflags) == VMBUS_EVTFLAGS_SIZE);
+
+/*
+ * Hyper-V Monitor Notification Facility
+ */
+
+struct vmbus_mon_trig {
+	uint32_t	mt_pending;
+	uint32_t	mt_armed;
+} __packed;
+
+#define	VMBUS_MONTRIGS_MAX	4
+#define	VMBUS_MONTRIG_LEN	32
+
+struct vmbus_mnf {
+	uint32_t	mnf_state;
+	uint32_t	mnf_rsvd1;
+
+	struct vmbus_mon_trig mnf_trigs[VMBUS_MONTRIGS_MAX];
+	uint8_t		mnf_rsvd2[536];
+
+	uint16_t	mnf_lat[VMBUS_MONTRIGS_MAX][VMBUS_MONTRIG_LEN];
+	uint8_t		mnf_rsvd3[256];
+
+	struct hyperv_mon_param
+			mnf_param[VMBUS_MONTRIGS_MAX][VMBUS_MONTRIG_LEN];
+	uint8_t		mnf_rsvd4[1984];
+} __packed;
+CTASSERT(sizeof (struct vmbus_mnf) == PAGE_SIZE);
+
+/*
+ * Buffer ring
+ */
+struct vmbus_bufring {
+	/*
+	 * If br_windex == br_rindex, this bufring is empty; this
+	 * means we can _not_ write data to the bufring, if the
+	 * write is going to make br_windex same as br_rindex.
+	 */
+	volatile uint32_t	br_windex;
+	volatile uint32_t	br_rindex;
+
+	/*
+	 * Interrupt mask {0,1}
+	 *
+	 * For TX bufring, host set this to 1, when it is processing
+	 * the TX bufring, so that we can safely skip the TX event
+	 * notification to host.
+	 *
+	 * For RX bufring, once this is set to 1 by us, host will not
+	 * further dispatch interrupts to us, even if there are data
+	 * pending on the RX bufring.  This effectively disables the
+	 * interrupt of the channel to which this RX bufring is attached.
+	 */
+	volatile uint32_t	br_imask;
+
+	uint8_t			br_rsvd[4084];
+	uint8_t			br_data[];
+} __packed;
+CTASSERT(sizeof (struct vmbus_bufring) == PAGE_SIZE);
+
+/*
+ * Channel
+ */
+
+#define	VMBUS_CHAN_MAX_COMPAT	256
+#define	VMBUS_CHAN_MAX		(VMBUS_EVTFLAG_LEN * VMBUS_EVTFLAGS_MAX)
+
+/*
+ * Channel packets
+ */
+
+#define	VMBUS_CHANPKT_SIZE_ALIGN	(1 << VMBUS_CHANPKT_SIZE_SHIFT)
+
+#define	VMBUS_CHANPKT_SETLEN(pktlen, len)		\
+do {							\
+	(pktlen) = (len) >> VMBUS_CHANPKT_SIZE_SHIFT;	\
+} while (0)
+
+#define	VMBUS_CHANPKT_TOTLEN(tlen)	\
+	P2ROUNDUP((tlen), VMBUS_CHANPKT_SIZE_ALIGN)
+
+#define	VMBUS_CHANPKT_HLEN_MIN		\
+	(sizeof (struct vmbus_chanpkt_hdr) >> VMBUS_CHANPKT_SIZE_SHIFT)
+
+struct vmbus_chanpkt {
+	struct vmbus_chanpkt_hdr cp_hdr;
+} __packed;
+
+struct vmbus_chanpkt_sglist {
+	struct vmbus_chanpkt_hdr cp_hdr;
+	uint32_t	cp_rsvd;
+	uint32_t	cp_gpa_cnt;
+	struct vmbus_gpa cp_gpa[];
+} __packed;
+
+struct vmbus_chanpkt_prplist {
+	struct vmbus_chanpkt_hdr cp_hdr;
+	uint32_t	cp_rsvd;
+	uint32_t	cp_range_cnt;
+	/* LINTED E_ARY_DERIVED_FROM_FLEX_MBR */
+	struct vmbus_gpa_range cp_range[];
+} __packed;
+
+/*
+ * Channel messages
+ * - Embedded in vmbus_message.msg_data, e.g. response and notification.
+ * - Embedded in hypercall_postmsg_in.hc_data, e.g. request.
+ */
+
+#define	VMBUS_CHANMSG_TYPE_CHOFFER		1	/* NOTE */
+#define	VMBUS_CHANMSG_TYPE_CHRESCIND		2	/* NOTE */
+#define	VMBUS_CHANMSG_TYPE_CHREQUEST		3	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_CHOFFER_DONE		4	/* NOTE */
+#define	VMBUS_CHANMSG_TYPE_CHOPEN		5	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_CHOPEN_RESP		6	/* RESP */
+#define	VMBUS_CHANMSG_TYPE_CHCLOSE		7	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_GPADL_CONN		8	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_GPADL_SUBCONN	9	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_GPADL_CONNRESP	10	/* RESP */
+#define	VMBUS_CHANMSG_TYPE_GPADL_DISCONN	11	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_GPADL_DISCONNRESP	12	/* RESP */
+#define	VMBUS_CHANMSG_TYPE_CHFREE		13	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_CONNECT		14	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_CONNECT_RESP		15	/* RESP */
+#define	VMBUS_CHANMSG_TYPE_DISCONNECT		16	/* REQ */
+#define	VMBUS_CHANMSG_TYPE_MAX			22
+
+struct vmbus_chanmsg_hdr {
+	uint32_t	chm_type;	/* VMBUS_CHANMSG_TYPE_ */
+	uint32_t	chm_rsvd;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CONNECT */
+struct vmbus_chanmsg_connect {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_ver;
+	uint32_t	chm_rsvd;
+	uint64_t	chm_evtflags;
+	uint64_t	chm_mnf1;
+	uint64_t	chm_mnf2;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CONNECT_RESP */
+struct vmbus_chanmsg_connect_resp {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint8_t		chm_done;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHREQUEST */
+struct vmbus_chanmsg_chrequest {
+	struct vmbus_chanmsg_hdr chm_hdr;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_DISCONNECT */
+struct vmbus_chanmsg_disconnect {
+	struct vmbus_chanmsg_hdr chm_hdr;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHOPEN */
+struct vmbus_chanmsg_chopen {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+	uint32_t	chm_openid;
+	uint32_t	chm_gpadl;
+	uint32_t	chm_vcpuid;
+	uint32_t	chm_txbr_pgcnt;
+#define	VMBUS_CHANMSG_CHOPEN_UDATA_SIZE	120
+	uint8_t		chm_udata[VMBUS_CHANMSG_CHOPEN_UDATA_SIZE];
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHOPEN_RESP */
+struct vmbus_chanmsg_chopen_resp {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+	uint32_t	chm_openid;
+	uint32_t	chm_status;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_GPADL_CONN */
+struct vmbus_chanmsg_gpadl_conn {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+	uint32_t	chm_gpadl;
+	uint16_t	chm_range_len;
+	uint16_t	chm_range_cnt;
+	/* LINTED E_STRUCT_DERIVED_FROM_FLEX_MBR */
+	struct vmbus_gpa_range chm_range;
+} __packed;
+
+#define	VMBUS_CHANMSG_GPADL_CONN_PGMAX		26
+CTASSERT(offsetof(struct vmbus_chanmsg_gpadl_conn,
+    chm_range.gpa_page[VMBUS_CHANMSG_GPADL_CONN_PGMAX]) <=
+    HYPERCALL_POSTMSGIN_DSIZE_MAX);
+
+/* VMBUS_CHANMSG_TYPE_GPADL_SUBCONN */
+struct vmbus_chanmsg_gpadl_subconn {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_msgno;
+	uint32_t	chm_gpadl;
+	uint64_t	chm_gpa_page[];
+} __packed;
+
+#define	VMBUS_CHANMSG_GPADL_SUBCONN_PGMAX	28
+CTASSERT(offsetof(struct vmbus_chanmsg_gpadl_subconn,
+    chm_gpa_page[VMBUS_CHANMSG_GPADL_SUBCONN_PGMAX]) <=
+    HYPERCALL_POSTMSGIN_DSIZE_MAX);
+
+/* VMBUS_CHANMSG_TYPE_GPADL_CONNRESP */
+struct vmbus_chanmsg_gpadl_connresp {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+	uint32_t	chm_gpadl;
+	uint32_t	chm_status;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHCLOSE */
+struct vmbus_chanmsg_chclose {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_GPADL_DISCONN */
+struct vmbus_chanmsg_gpadl_disconn {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+	uint32_t	chm_gpadl;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHFREE */
+struct vmbus_chanmsg_chfree {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHRESCIND */
+struct vmbus_chanmsg_chrescind {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	uint32_t	chm_chanid;
+} __packed;
+
+/* VMBUS_CHANMSG_TYPE_CHOFFER */
+struct vmbus_chanmsg_choffer {
+	struct vmbus_chanmsg_hdr chm_hdr;
+	struct hyperv_guid chm_chtype;
+	struct hyperv_guid chm_chinst;
+	uint64_t	chm_chlat;	/* unit: 100ns */
+	uint32_t	chm_chrev;
+	uint32_t	chm_svrctx_sz;
+	uint16_t	chm_chflags;
+	uint16_t	chm_mmio_sz;	/* unit: MB */
+	uint8_t		chm_udata[120];
+	uint16_t	chm_subidx;
+	uint16_t	chm_rsvd;
+	uint32_t	chm_chanid;
+	uint8_t		chm_montrig;
+	uint8_t		chm_flags1;	/* VMBUS_CHOFFER_FLAG1_ */
+	uint16_t	chm_flags2;
+	uint32_t	chm_connid;
+} __packed;
+CTASSERT(sizeof (struct vmbus_chanmsg_choffer) <= VMBUS_MSG_DSIZE_MAX);
+
+#define	VMBUS_CHOFFER_FLAG1_HASMNF	0x01
+
+
+#endif	/* !_VMBUS_REG_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_var.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_var.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#ifndef _VMBUS_VAR_H_
+#define	_VMBUS_VAR_H_
+
+#include <sys/param.h>
+#include <sys/sunddi.h>
+#include <sys/param.h>
+#include <sys/queue.h>
+
+#include <sys/hyperv_busdma.h>
+#include <sys/hyperv_illumos.h>
+
+/*
+ * NOTE: DO NOT CHANGE THIS.
+ */
+#define	VMBUS_SINT_MESSAGE	2
+/*
+ * NOTE:
+ * - DO NOT set it to the same value as VMBUS_SINT_MESSAGE.
+ * - DO NOT set it to 0.
+ */
+#define	VMBUS_SINT_TIMER	4
+
+/*
+ * NOTE: DO NOT CHANGE THESE
+ */
+#define	VMBUS_CONNID_MESSAGE		1
+#define	VMBUS_CONNID_EVENT		2
+
+struct vmbus_message;
+struct vmbus_softc;
+
+typedef void		(*vmbus_chanmsg_proc_t)(struct vmbus_softc *,
+			    const struct vmbus_message *);
+
+#define	VMBUS_CHANMSG_PROC(name, func)	\
+	[VMBUS_CHANMSG_TYPE_##name] = func
+#define	VMBUS_CHANMSG_PROC_WAKEUP(name)	\
+	VMBUS_CHANMSG_PROC(name, vmbus_msghc_wakeup)
+
+struct vmbus_pcpu_data {
+	uint64_t		intr_cnt;	/* Hyper-V interrupt counter */
+	struct vmbus_message	*message;	/* shared messages */
+	uint32_t		vcpuid;		/* virtual cpuid */
+	int			event_flags_cnt; /* # of event flags */
+	struct vmbus_evtflags	*event_flags;	/* event flags from host */
+
+	/* Rarely used fields */
+	struct hyperv_dma	message_dma;	/* busdma glue */
+	struct hyperv_dma	event_flags_dma; /* busdma glue */
+	ddi_taskq_t		*event_tq;	/* event taskq */
+	ddi_taskq_t		*message_tq;	/* message taskq */
+} __aligned(64);
+
+struct vmbus_softc {
+	void			(*vmbus_event_proc)(struct vmbus_softc *, int);
+	ulong_t			*vmbus_tx_evtflags;
+						/* event flags to host */
+	struct vmbus_mnf	*vmbus_mnf2;	/* monitored by host */
+
+	ulong_t			*vmbus_rx_evtflags;
+						/* compat evtflgs from host */
+	struct vmbus_channel	**vmbus_chmap;
+	struct vmbus_xact_ctx	*vmbus_xc;
+	struct vmbus_pcpu_data	vmbus_pcpu[256]; /* XXXX NCPU */
+
+	/*
+	 * Rarely used fields
+	 */
+
+	dev_info_t		*vmbus_dev;
+	int			vmbus_idtvec;
+	ddi_intr_handle_t	vmbus_htable;
+	uint32_t		vmbus_flags;	/* see VMBUS_FLAG_ */
+	uint32_t		vmbus_version;
+	uint32_t		vmbus_gpadl;
+
+	/* Shared memory for vmbus_{rx,tx}_evtflags */
+	void			*vmbus_evtflags;
+	struct hyperv_dma	vmbus_evtflags_dma;
+
+	void			*vmbus_mnf1;	/* monitored by VM, unused */
+	struct hyperv_dma	vmbus_mnf1_dma;
+	struct hyperv_dma	vmbus_mnf2_dma;
+
+	boolean_t		vmbus_scandone;
+	kcondvar_t		vmbus_scandone_cv;
+	struct task		vmbus_scandone_task;
+
+	ddi_taskq_t		*vmbus_devtq;	/* for dev attach/detach */
+	ddi_taskq_t		*vmbus_subchtq;	/* for sub-chan attach/detach */
+
+	/* Primary channels */
+	kmutex_t		vmbus_prichan_lock;
+	TAILQ_HEAD(, vmbus_channel) vmbus_prichans;
+
+	/* Complete channel list */
+	kmutex_t		vmbus_chan_lock;
+	TAILQ_HEAD(, vmbus_channel) vmbus_chans;
+};
+
+#define	VMBUS_FLAG_ATTACHED	0x0001	/* vmbus was attached */
+#define	VMBUS_FLAG_SYNIC	0x0002	/* SynIC was setup */
+
+#define	VMBUS_PCPU_GET(sc, field, cpu)	(sc)->vmbus_pcpu[(cpu)].field
+#define	VMBUS_PCPU_PTR(sc, field, cpu)	&(sc)->vmbus_pcpu[(cpu)].field
+
+struct vmbus_channel;
+struct trapframe;
+struct vmbus_message;
+struct vmbus_msghc;
+
+uint_t		vmbus_handle_intr(struct vmbus_softc *);
+int		vmbus_add_child(struct vmbus_channel *);
+int		vmbus_delete_child(struct vmbus_channel *);
+void		vmbus_et_intr(struct trapframe *);
+uint32_t	vmbus_gpadl_alloc(struct vmbus_softc *);
+
+struct vmbus_msghc *
+		vmbus_msghc_get(struct vmbus_softc *, size_t);
+void		vmbus_msghc_put(struct vmbus_softc *, struct vmbus_msghc *);
+void		*vmbus_msghc_dataptr(struct vmbus_msghc *);
+int		vmbus_msghc_exec_noresult(struct vmbus_msghc *);
+int		vmbus_msghc_exec(struct vmbus_softc *, struct vmbus_msghc *);
+void		vmbus_msghc_exec_cancel(struct vmbus_softc *,
+		    struct vmbus_msghc *);
+const struct vmbus_message *
+		vmbus_msghc_wait_result(struct vmbus_softc *,
+		    struct vmbus_msghc *);
+const struct vmbus_message *
+		vmbus_msghc_poll_result(struct vmbus_softc *,
+		    struct vmbus_msghc *);
+void		vmbus_msghc_wakeup(struct vmbus_softc *,
+		    const struct vmbus_message *);
+void		vmbus_msghc_reset(struct vmbus_msghc *, size_t);
+
+#endif	/* !_VMBUS_VAR_H_ */

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_xact.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_xact.c
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2016 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
+
+#include <sys/param.h>
+#include <sys/mutex.h>
+#include <sys/proc.h>
+
+#include <sys/hyperv_illumos.h>
+#include <sys/hyperv_busdma.h>
+#include <sys/vmbus_xact.h>
+
+struct vmbus_xact {
+	struct vmbus_xact_ctx		*x_ctx;
+	void				*x_priv;
+
+	void				*x_req;
+	hv_dma_t			x_req_dma;
+
+	const void			*x_resp;
+	size_t				x_resp_len;
+	void				*x_resp0;
+};
+
+struct vmbus_xact_ctx {
+	size_t				xc_req_size;
+	size_t				xc_resp_size;
+	size_t				xc_priv_size;
+
+	kmutex_t			xc_lock;
+	kcondvar_t			xc_cv;
+	/*
+	 * Protected by xc_lock.
+	 */
+	uint32_t			xc_flags;	/* VMBUS_XACT_CTXF_ */
+	struct vmbus_xact		*xc_free;
+
+	struct vmbus_xact		*xc_active;
+	struct vmbus_xact		*xc_orphan;
+};
+
+#define	VMBUS_XACT_CTXF_DESTROY		0x0001
+
+static struct vmbus_xact	*vmbus_xact_alloc(struct vmbus_xact_ctx *,
+				    dev_info_t *);
+static void			vmbus_xact_free(struct vmbus_xact *);
+static struct vmbus_xact	*vmbus_xact_get1(struct vmbus_xact_ctx *,
+				    uint32_t);
+static const void		*vmbus_xact_wait1(struct vmbus_xact *, size_t *,
+				    boolean_t);
+static const void		*vmbus_xact_return(struct vmbus_xact *,
+				    size_t *);
+static void			vmbus_xact_save_resp(struct vmbus_xact *,
+				    const void *, size_t);
+static void			vmbus_xact_ctx_free(struct vmbus_xact_ctx *);
+
+static struct vmbus_xact *
+vmbus_xact_alloc(struct vmbus_xact_ctx *ctx, dev_info_t *dip)
+{
+	struct vmbus_xact *xact;
+
+	xact = kmem_zalloc(sizeof (*xact), KM_SLEEP);
+	xact->x_ctx = ctx;
+
+	/* XXX assume that page aligned is enough */
+	xact->x_req = hyperv_dmamem_alloc(dip, PAGE_SIZE, 0,
+	    ctx->xc_req_size, &xact->x_req_dma, DDI_DMA_RDWR);
+	if (xact->x_req == NULL) {
+		kmem_free(xact, sizeof (*xact));
+		return (NULL);
+	}
+	if (ctx->xc_priv_size != 0)
+		xact->x_priv = kmem_alloc(ctx->xc_priv_size, KM_SLEEP);
+	xact->x_resp0 = kmem_alloc(ctx->xc_resp_size, KM_SLEEP);
+
+	return (xact);
+}
+
+static void
+vmbus_xact_free(struct vmbus_xact *xact)
+{
+
+	hyperv_dmamem_free(&xact->x_req_dma);
+	kmem_free(xact->x_resp0, xact->x_ctx->xc_resp_size);
+	if (xact->x_priv != NULL)
+		kmem_free(xact->x_priv, xact->x_ctx->xc_priv_size);
+	kmem_free(xact, sizeof (*xact));
+}
+
+static struct vmbus_xact *
+vmbus_xact_get1(struct vmbus_xact_ctx *ctx, uint32_t dtor_flag)
+{
+	struct vmbus_xact *xact;
+
+	mutex_enter(&ctx->xc_lock);
+
+	while ((ctx->xc_flags & dtor_flag) == 0 && ctx->xc_free == NULL)
+		cv_wait(&ctx->xc_cv, &ctx->xc_lock);
+	if (ctx->xc_flags & dtor_flag) {
+		/* Being destroyed */
+		xact = NULL;
+	} else {
+		xact = ctx->xc_free;
+		ASSERT3P(xact, !=, NULL);
+		ASSERT3P(xact->x_resp, ==, NULL);
+		ctx->xc_free = NULL;
+	}
+
+	mutex_exit(&ctx->xc_lock);
+
+	return (xact);
+}
+
+struct vmbus_xact_ctx *
+vmbus_xact_ctx_create(dev_info_t *dip, size_t req_size, size_t resp_size,
+    size_t priv_size)
+{
+	struct vmbus_xact_ctx *ctx;
+
+	ASSERT3U(req_size, >, 0);
+	ASSERT3U(resp_size, >, 0);
+
+	ctx = kmem_zalloc(sizeof (*ctx), KM_SLEEP);
+	ctx->xc_req_size = req_size;
+	ctx->xc_resp_size = resp_size;
+	ctx->xc_priv_size = priv_size;
+
+	ctx->xc_free = vmbus_xact_alloc(ctx, dip);
+	if (ctx->xc_free == NULL) {
+		kmem_free(ctx, sizeof (*ctx));
+		return (NULL);
+	}
+
+	mutex_init(&ctx->xc_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&ctx->xc_cv, NULL, CV_DEFAULT, NULL);
+
+	return (ctx);
+}
+
+boolean_t
+vmbus_xact_ctx_orphan(struct vmbus_xact_ctx *ctx)
+{
+	mutex_enter(&ctx->xc_lock);
+	if (ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY) {
+		mutex_exit(&ctx->xc_lock);
+		return (B_FALSE);
+	}
+	ctx->xc_flags |= VMBUS_XACT_CTXF_DESTROY;
+	cv_broadcast(&ctx->xc_cv);
+	mutex_exit(&ctx->xc_lock);
+
+	ctx->xc_orphan = vmbus_xact_get1(ctx, 0);
+	if (ctx->xc_orphan == NULL)
+		panic("can't get xact");
+	return (B_TRUE);
+}
+
+static void
+vmbus_xact_ctx_free(struct vmbus_xact_ctx *ctx)
+{
+	ASSERT(ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY);
+	ASSERT3P(ctx->xc_orphan, !=, NULL);
+
+	vmbus_xact_free(ctx->xc_orphan);
+	mutex_destroy(&ctx->xc_lock);
+	cv_destroy(&ctx->xc_cv);
+	kmem_free(ctx, sizeof (*ctx));
+}
+
+void
+vmbus_xact_ctx_destroy(struct vmbus_xact_ctx *ctx)
+{
+
+	(void) vmbus_xact_ctx_orphan(ctx);
+	vmbus_xact_ctx_free(ctx);
+}
+
+struct vmbus_xact *
+vmbus_xact_get(struct vmbus_xact_ctx *ctx, size_t req_len)
+{
+	struct vmbus_xact *xact;
+
+	if (req_len > ctx->xc_req_size)
+		panic("invalid request size %llu", (u_longlong_t)req_len);
+
+	xact = vmbus_xact_get1(ctx, VMBUS_XACT_CTXF_DESTROY);
+	if (xact == NULL)
+		return (NULL);
+
+	(void) memset(xact->x_req, 0, req_len);
+	return (xact);
+}
+
+void
+vmbus_xact_put(struct vmbus_xact *xact)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+
+	ASSERT3P(ctx->xc_active, ==, NULL);
+	xact->x_resp = NULL;
+
+	mutex_enter(&ctx->xc_lock);
+	ASSERT3P(ctx->xc_free, ==, NULL);
+	ctx->xc_free = xact;
+	cv_broadcast(&ctx->xc_cv);
+	mutex_exit(&ctx->xc_lock);
+}
+
+void *
+vmbus_xact_req_data(const struct vmbus_xact *xact)
+{
+
+	return (xact->x_req);
+}
+
+paddr_t
+vmbus_xact_req_paddr(const struct vmbus_xact *xact)
+{
+
+	return (xact->x_req_dma.hv_paddr);
+}
+
+void *
+vmbus_xact_priv(const struct vmbus_xact *xact, size_t priv_len)
+{
+
+	if (priv_len > xact->x_ctx->xc_priv_size)
+		panic("invalid priv size %llu", (u_longlong_t)priv_len);
+	return (xact->x_priv);
+}
+
+void
+vmbus_xact_activate(struct vmbus_xact *xact)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+
+	ASSERT3P(xact->x_resp, ==, NULL);
+
+	mutex_enter(&ctx->xc_lock);
+	ASSERT3P(ctx->xc_active, ==, NULL);
+	ctx->xc_active = xact;
+	mutex_exit(&ctx->xc_lock);
+}
+
+void
+vmbus_xact_deactivate(struct vmbus_xact *xact)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+
+	mutex_enter(&ctx->xc_lock);
+	ASSERT3P(ctx->xc_active, ==, xact);
+	ctx->xc_active = NULL;
+	mutex_exit(&ctx->xc_lock);
+}
+
+static const void *
+vmbus_xact_return(struct vmbus_xact *xact, size_t *resp_len)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+	const void *resp;
+
+	ASSERT(MUTEX_HELD(&ctx->xc_lock));
+	ASSERT3P(ctx->xc_active, ==, xact);
+
+	if ((ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY) && xact->x_resp == NULL) {
+		uint8_t b = 0;
+
+		/*
+		 * Orphaned and no response was received yet; fake up
+		 * an one byte response.
+		 */
+		printf("vmbus: xact ctx was orphaned w/ pending xact\n");
+		vmbus_xact_save_resp(ctx->xc_active, &b, sizeof (b));
+	}
+	ASSERT3P(xact->x_resp, !=, NULL);
+
+	ctx->xc_active = NULL;
+
+	resp = xact->x_resp;
+	*resp_len = xact->x_resp_len;
+
+	return (resp);
+}
+
+static const void *
+vmbus_xact_wait1(struct vmbus_xact *xact, size_t *resp_len,
+    boolean_t can_sleep)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+	const void *resp;
+
+	mutex_enter(&ctx->xc_lock);
+
+	ASSERT3P(ctx->xc_active, ==, xact);
+	while (xact->x_resp == NULL &&
+	    (ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY) == 0) {
+		if (can_sleep) {
+			cv_wait(&ctx->xc_cv, &ctx->xc_lock);
+		} else {
+			mutex_exit(&ctx->xc_lock);
+			drv_usecwait(1000);
+			mutex_enter(&ctx->xc_lock);
+		}
+	}
+	resp = vmbus_xact_return(xact, resp_len);
+
+	mutex_exit(&ctx->xc_lock);
+
+	return (resp);
+}
+
+const void *
+vmbus_xact_wait(struct vmbus_xact *xact, size_t *resp_len)
+{
+
+	return (vmbus_xact_wait1(xact, resp_len, B_TRUE /* can sleep */));
+}
+
+const void *
+vmbus_xact_busywait(struct vmbus_xact *xact, size_t *resp_len)
+{
+
+	return (vmbus_xact_wait1(xact, resp_len, B_FALSE /* can't sleep */));
+}
+
+const void *
+vmbus_xact_poll(struct vmbus_xact *xact, size_t *resp_len)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+	const void *resp;
+
+	mutex_enter(&ctx->xc_lock);
+
+	ASSERT3P(ctx->xc_active, ==, xact);
+	if (xact->x_resp == NULL &&
+	    (ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY) == 0) {
+		mutex_exit(&ctx->xc_lock);
+		*resp_len = 0;
+		return (NULL);
+	}
+	resp = vmbus_xact_return(xact, resp_len);
+
+	mutex_exit(&ctx->xc_lock);
+
+	return (resp);
+}
+
+static void
+vmbus_xact_save_resp(struct vmbus_xact *xact, const void *data, size_t dlen)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+	size_t cplen = dlen;
+
+	ASSERT(MUTEX_HELD(&ctx->xc_lock));
+
+	if (cplen > ctx->xc_resp_size) {
+		cmn_err(CE_NOTE, "vmbus: xact response truncated %llu -> "
+		    "%llu\n", (u_longlong_t)cplen,
+		    (u_longlong_t)ctx->xc_resp_size);
+		cplen = ctx->xc_resp_size;
+	}
+
+	ASSERT3P(ctx->xc_active, ==, xact);
+	(void) memcpy(xact->x_resp0, data, cplen);
+	xact->x_resp_len = cplen;
+	xact->x_resp = xact->x_resp0;
+}
+
+void
+vmbus_xact_wakeup(struct vmbus_xact *xact, const void *data, size_t dlen)
+{
+	struct vmbus_xact_ctx *ctx = xact->x_ctx;
+	int do_wakeup = 0;
+
+	mutex_enter(&ctx->xc_lock);
+	/*
+	 * NOTE:
+	 * xc_active could be NULL, if the ctx has been orphaned.
+	 */
+	if (ctx->xc_active != NULL) {
+		vmbus_xact_save_resp(xact, data, dlen);
+		do_wakeup = 1;
+	} else {
+		ASSERT(ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY);
+		printf("vmbus: drop xact response\n");
+	}
+
+	if (do_wakeup)
+		cv_broadcast(&ctx->xc_cv);
+	mutex_exit(&ctx->xc_lock);
+}
+
+void
+vmbus_xact_ctx_wakeup(struct vmbus_xact_ctx *ctx, const void *data, size_t dlen)
+{
+	int do_wakeup = 0;
+
+	mutex_enter(&ctx->xc_lock);
+	/*
+	 * NOTE:
+	 * xc_active could be NULL, if the ctx has been orphaned.
+	 */
+	if (ctx->xc_active != NULL) {
+		vmbus_xact_save_resp(ctx->xc_active, data, dlen);
+		do_wakeup = 1;
+	} else {
+		ASSERT(ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY);
+		printf("vmbus: drop xact response\n");
+	}
+
+	if (do_wakeup)
+		cv_broadcast(&ctx->xc_cv);
+	mutex_exit(&ctx->xc_lock);
+}


### PR DESCRIPTION
Hi, given Delphix moved from illumos to linux recently I had a quick look of things that might be of interest to import into omniosce. Given the strong boost in virtualization support recently I think it might make sense to import the HYPERV support from DeplhixOS so we have native support on Azure for network and storage analog to the virtio support on other hypervisors. I had a quick look and it seems we only need one commit from DelphixOS which contains the full hyperv stuff. I commited that with the original author and did two small additional patches one that makes things compile on illumos-omnios and one that updates the package manifests to no longer deliver 32 bits drivers as that landed in illumos after Delphix merged the HYPERV support.

The code has its origin in FreeBSD and was ported by Delphix an interesting presentation on the subject was done by George Wilson at BSDCAN 2017

https://www.bsdcan.org/2017/schedule/events/856.en.html

I compiled things and the drivers and daemon compile ok. Packaging looks ok too but have not created packages yet.