### PR TITLE
Upstream DelphixOS comstar fixes

### DIFF
--- a/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd_impl.h
+++ b/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd_impl.h
@@ -22,6 +22,7 @@
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  *
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018 by Delphix. All rights reserved.
  */
 
 #ifndef	_SBD_IMPL_H
@@ -227,12 +228,13 @@ typedef struct sbd_cmd {
 #define	SBD_CMD_SCSI_PR_OUT	0x05
 
 typedef struct sbd_it_data {
-	struct sbd_it_data	*sbd_it_next;
-	uint64_t		sbd_it_session_id;
-	uint8_t			sbd_it_lun[8];
-	uint8_t			sbd_it_ua_conditions;
-	uint8_t			sbd_it_flags;
-	sbd_pgr_key_t		*pgr_key_ptr;
+	struct sbd_it_data		*sbd_it_next;
+	uint64_t			sbd_it_session_id;
+	uint8_t				sbd_it_lun[8];
+	uint8_t				sbd_it_ua_conditions;
+	uint8_t				sbd_it_flags;
+	sbd_pgr_key_t			*pgr_key_ptr;
+	struct stmf_scsi_session	*sbd_it_session;
 } sbd_it_data_t;
 
 typedef struct sbd_create_standby_lu {

--- a/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd_scsi.c
+++ b/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd_scsi.c
@@ -3049,12 +3049,14 @@ sbd_new_task(struct scsi_task *task, struct stmf_data_buf *initial_dbuf)
 			return;
 		}
 		it->sbd_it_session_id = task->task_session->ss_session_id;
+		it->sbd_it_session = task->task_session;
 		bcopy(task->task_lun_no, it->sbd_it_lun, 8);
 		it->sbd_it_next = sl->sl_it_list;
 		sl->sl_it_list = it;
 		mutex_exit(&sl->sl_lock);
 
-		DTRACE_PROBE1(itl__nexus__start, scsi_task *, task);
+		DTRACE_PROBE2(itl__nexus__start, scsi_task *, task,
+		    sbd_it_data_t *, it);
 
 		sbd_pgr_initialize_it(task, it);
 		if (stmf_register_itl_handle(task->task_lu, task->task_lun_no,
@@ -3547,6 +3549,8 @@ sbd_abort(struct stmf_lu *lu, int abort_cmd, void *arg, uint32_t flags)
 	if (abort_cmd == STMF_LU_ITL_HANDLE_REMOVED) {
 		sbd_check_and_clear_scsi2_reservation(sl, (sbd_it_data_t *)arg);
 		sbd_remove_it_handle(sl, (sbd_it_data_t *)arg);
+		DTRACE_PROBE3(itl__nexus__end__abort, sbd_lu_t *, sl,
+		    sbd_it_data_t *, (sbd_it_data_t *)arg, uint32_t, flags);
 		return (STMF_SUCCESS);
 	}
 

--- a/usr/src/uts/common/io/comstar/stmf/stmf.c
+++ b/usr/src/uts/common/io/comstar/stmf/stmf.c
@@ -23,7 +23,7 @@
  */
 /*
  * Copyright 2012, Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  */
 
@@ -4407,6 +4407,8 @@ stmf_task_free(scsi_task_t *task)
 	if (itask->itask_itl_datap) {
 		if (atomic_dec_32_nv(&itask->itask_itl_datap->itl_counter) ==
 		    0) {
+			itask->itask_itl_datap->itl_hdlrm_reason =
+			    STMF_ITL_REASON_TASK_FREE;
 			stmf_release_itl_handle(task->task_lu,
 			    itask->itask_itl_datap);
 		}
@@ -7802,7 +7804,8 @@ stmf_scsilib_tptid_validate(scsi_transport_id_t *tptid, uint32_t total_sz,
 }
 
 boolean_t
-stmf_scsilib_tptid_compare(scsi_transport_id_t *tpd1, scsi_transport_id_t *tpd2)
+stmf_scsilib_tptid_compare(scsi_transport_id_t *tpd1,
+				scsi_transport_id_t *tpd2)
 {
 	if ((tpd1->protocol_id != tpd2->protocol_id) ||
 	    (tpd1->format_code != tpd2->format_code))

--- a/usr/src/uts/common/sys/lpif.h
+++ b/usr/src/uts/common/sys/lpif.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
  */
 #ifndef	_LPIF_H
 #define	_LPIF_H
@@ -110,6 +110,7 @@ typedef struct stmf_lu {
 #define	STMF_ITL_REASON_DEREG_REQUEST	0x1
 #define	STMF_ITL_REASON_USER_REQUEST	0x2
 #define	STMF_ITL_REASON_IT_NEXUS_LOSS	0x3
+#define	STMF_ITL_REASON_TASK_FREE	0x4
 
 typedef struct stmf_lu_provider {
 	void			*lp_stmf_private;


### PR DESCRIPTION
This fixes a problem with SCSI-3 Persistent Reservation on the comstar target. I compared the build dir of both dephix-os and illumos-omnios and with this patch they are the same so there are not other fixes upstream in DelphixOS.