### PR TITLE
Upstream DelphixOS network fixes.

### DIFF
--- a/usr/src/lib/libipd/common/libipd.h
+++ b/usr/src/lib/libipd/common/libipd.h
@@ -13,11 +13,15 @@
  * Copyright (c) 2012 Joyent, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #ifndef	_LIBIPD_H
 #define	_LIBIPD_H
 
 #include <sys/types.h>
+#include <sys/ipd.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/usr/src/man/man1m/ipdadm.1m
+++ b/usr/src/man/man1m/ipdadm.1m
@@ -1,5 +1,6 @@
 '\" te
 .\" Copyright (c) 2012, Joyent, Inc. All Rights Reserved.
+.\" Copyright (c) 2017 by Delphix. All rights reserved.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License"). You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\" See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE. If applicable, add the following below this CDDL HEADER, with the
 .\" fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
@@ -13,7 +14,6 @@ ipdadm \- administer the Internet packet disturber
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 The ipdadm utility is used to administer the illumos facility for simulating
 pathological networks by induce packet drops, delays, and corruption.
@@ -23,7 +23,6 @@ networking stacks. If this is enabled for the global zone, any zone with a
 shared networking stack will be affected.
 
 .SH OPTIONS
-.sp
 .LP
 The following options are supported:
 .sp
@@ -38,7 +37,6 @@ zone is used. For the list subcommand, this option is not supported.
 .RE
 
 .SH SUBCOMMANDS
-.sp
 .LP
 The following subcommands are supported:
 
@@ -49,8 +47,8 @@ The following subcommands are supported:
 .ad
 .sp .6
 .RS 4n
-Sets the chance for packets to be corrupted to \fIpercent\fR which must be an
-integer between 0 and 100. Setting \fIpercent\fR to 0 disables packet corruption
+Sets the chance for packets to be corrupted to \fIpercent\fR which must be a
+decimal between 0 and 100. Setting \fIpercent\fR to 0 disables packet corruption
 and is equivalent to calling \fBremove\fR \fIcorrupt\fR. When enabled, a random
 byte will have a single bit flipped.
 .sp
@@ -77,7 +75,7 @@ each packet. Setting \fImicroseconds\fR to zero is equivalent to calling
 .sp .6
 .RS 4n
 Sets the chance for packets to be dropped to \fIpercent\fR. \fIpercent\fR must
-be an integer between 0 and 100. Setting \fIpercent\fR to zero is equivalent to
+be a decimal between 0 and 100. Setting \fIpercent\fR to zero is equivalent to
 calling \fBremove\fR \fIdrop\fR.
 .sp
 .RE
@@ -172,7 +170,6 @@ global zone.
 
 
 .SH EXIT STATUS
-.sp
 .LP
 The following exit values are returned:
 .sp
@@ -202,7 +199,6 @@ Invalid command line options or arguments were specified.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -218,6 +214,5 @@ Interface Stability	Evolving
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBzonename\fR(1), \fBzoneadm\fR(1M), \fBattributes\fR(5), \fBzones(5)\fR

--- a/usr/src/uts/common/sys/ipd.h
+++ b/usr/src/uts/common/sys/ipd.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -36,6 +37,12 @@ extern "C" {
 
 #define	IPD_DEV_PATH	"/dev/ipd"
 #define	IPD_MAX_DELAY	10000		/* 10 ms in us */
+
+/*
+ * Rates (e.g. ipii_corrupt and ipii_drop) are expressed as the integer
+ * numerator of a fraction whose denominator is IPD_RATE_PRECISION.
+ */
+#define	IPD_RATE_PRECISION	1000000
 
 typedef struct ipd_ioc_perturb {
 	zoneid_t	ipip_zoneid;


### PR DESCRIPTION
I left the bigger network fixes in delphix-os to Joyent who is already internally reviewing the bigger chunks. This contains one small patch that seems to make sense although I never used ipdadm and the daemon that allows you to inject errors and drops on network connections for testing purposes.