### PR TITLE
Fix-up hyperv manifests

### DIFF
--- a/usr/src/pkg/manifests/driver-hyperv-pv.mf
+++ b/usr/src/pkg/manifests/driver-hyperv-pv.mf
@@ -48,3 +48,4 @@ file path=kernel/drv/hv_netvsc.conf group=sys
 file path=kernel/drv/hv_vmbus.conf group=sys
 file path=kernel/misc/$(ARCH64)/hyperv group=sys mode=0755
 license lic_CDDL license=lic_CDDL
+depend fmri=system/hyperv/tools type=require

--- a/usr/src/pkg/manifests/system-hyperv-tools.mf
+++ b/usr/src/pkg/manifests/system-hyperv-tools.mf
@@ -38,4 +38,3 @@ file path=usr/lib/hyperv/hv_get_dhcp_info mode=0555
 file path=usr/lib/hyperv/hv_get_dns_info mode=0555
 file path=usr/lib/hyperv/hv_kvp_daemon mode=0555
 license lic_CDDL license=lic_CDDL
-depend fmri=driver/hyperv/pv type=require


### PR DESCRIPTION
### Reversing the package dependency

If the tools are not installed, the driver generates errors as it cannot communicate with the service. Installing the tools without the driver just means that they won't start. It feels better to make the driver dependent on the tools.
