### PR TITLE
Upstream merge joyent_merge/2019031301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,10 +326,8 @@ usr/src/cmd/cfgadm/cfgadm.dc
 usr/src/cmd/checkeq/checkeq
 usr/src/cmd/checknr/checknr
 usr/src/cmd/chgrp/chgrp
-usr/src/cmd/chgrp/chgrp.xpg4
 usr/src/cmd/chmod/chmod
 usr/src/cmd/chown/chown
-usr/src/cmd/chown/chown.xpg4
 usr/src/cmd/chroot/chroot
 usr/src/cmd/clear/clear
 usr/src/cmd/clinfo/clinfo
@@ -965,6 +963,9 @@ usr/src/cmd/hostid/hostid
 usr/src/cmd/hostname/hostname
 usr/src/cmd/hotplug/hotplug
 usr/src/cmd/hotplugd/hotplugd
+usr/src/cmd/hyperv/kvp/hv_kvp_daemon
+usr/src/cmd/hyperv/scripts/hv_get_dhcp_info
+usr/src/cmd/hyperv/scripts/hv_get_dns_info
 usr/src/cmd/ibd_upgrade/ibd_delete_link
 usr/src/cmd/ibd_upgrade/ibd_upgrade
 usr/src/cmd/iconv/iconv
@@ -3960,6 +3961,10 @@ usr/src/test/crypto-tests/tests/modes/aes/ecb/aes_ecb_kcf
 usr/src/test/crypto-tests/tests/modes/aes/ecb/aes_ecb_pkcs
 usr/src/test/crypto-tests/tests/modes/aes/gcm/aes_gcm_kcf
 usr/src/test/crypto-tests/tests/modes/aes/gcm/aes_gcm_pkcs
+usr/src/test/elf-tests/tests/assert-deflib/test-deflib
+usr/src/test/elf-tests/tests/tls/amd64/ie/amd64-ie-test
+usr/src/test/elf-tests/tests/tls/amd64/ld/amd64-ld-test
+usr/src/test/elf-tests/tests/tls/i386/ld/i386-ld-test
 usr/src/test/libc-tests/tests/aligned_alloc.32
 usr/src/test/libc-tests/tests/aligned_alloc.64
 usr/src/test/libc-tests/tests/c11_threads.32

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 422ca0551d119315cb50c98e8f94d2c0a5f435e8
+Last illumos-joyent commit: 0a83682c948d906938d974e41576c473991845ef
 

--- a/usr/src/lib/brand/lx/testing/Readme_ltp
+++ b/usr/src/lib/brand/lx/testing/Readme_ltp
@@ -19,6 +19,7 @@ Additional prerequisites are required activate some tests:
 As a normal user:
     git clone https://github.com/linux-test-project/ltp.git
     cd ltp
+    git checkout ed01f6a05c77f65cb5d1089474c9a0e2129c581a
     make autotools
     ./configure
     make all
@@ -50,7 +51,7 @@ which now work.
 As root:
     cd /opt/ltp
     /opt/ltp/runltp -f `cat /native/usr/lib/brand/lx/ltp_tests` \
-        -S /native/usr/lib/brand/lx/ltp_skiplist -p >/tmp/test.log
+        -S /native/usr/lib/brand/lx/ltp_skiplist -p >/tmp/test.log 2>&1
 
 When the test run has finished, the results will be logged in a date/time
 stamped file under /opt/ltp/results. The summary at the end of the log file

--- a/usr/src/uts/common/io/mac/mac_util.c
+++ b/usr/src/uts/common/io/mac/mac_util.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -1239,9 +1239,19 @@ mac_hw_emul(mblk_t **mp_chain, mblk_t **otail, uint_t *ocount, mac_emul_t emul)
 			 */
 			mac_sw_lso(mp, emul, &tmphead, &tmptail,
 			    &tmpcount);
+			if (tmphead == NULL) {
+				/* mac_sw_lso() freed the mp. */
+				mp = next;
+				continue;
+			}
 			count += tmpcount;
 		} else if ((flags & HCK_NEEDED) && (emul & MAC_HWCKSUM_EMULS)) {
 			tmp = mac_sw_cksum(mp, emul);
+			if (tmp == NULL) {
+				/* mac_sw_cksum() freed the mp. */
+				mp = next;
+				continue;
+			}
 			tmphead = tmp;
 			tmptail = tmp;
 			count++;


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019031301

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019031301-c4647a6bbf i86pc i386 i86pc

```
## mail_msg

```

==== Nightly distributed build started:   Wed Mar 13 11:18:06 UTC 2019 ====
==== Nightly distributed build completed: Wed Mar 13 12:22:10 UTC 2019 ====

==== Total build time ====

real    1:04:03

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-upstream_merge-2019031201-306641b65e i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.8.0_202-omnios-151029-20190219"

/usr/bin/openssl
OpenSSL 1.1.1b  26 Feb 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1758 (illumos)

Build project:  default
Build taskid:   71

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019031301-c4647a6bbf

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:54.4
user  3:20:34.3
sys   1:01:52.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    25:06.3
user  2:49:35.5
sys   1:15:46.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
