### PR TITLE
OS-7600 Want exclusive hma registration

### DIFF
--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
@@ -12,6 +12,7 @@
 /*
  * Copyright 2015 Pluribus Networks Inc.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/types.h>
@@ -1205,17 +1206,28 @@ vmmdev_do_vm_create(char *name, cred_t *cr)
 	vmm_softc_t	*sc = NULL;
 	minor_t		minor;
 	int		error = ENOMEM;
+	hma_reg_t	*reg = NULL;
 
 	if (strnlen(name, VM_MAX_NAMELEN) >= VM_MAX_NAMELEN) {
 		return (EINVAL);
 	}
 
+	mutex_enter(&vmmdev_mtx);
 	mutex_enter(&vmm_mtx);
+
+	if (vmmdev_hma_reg == NULL) {
+		if ((reg = hma_register(vmmdev_hvm_name)) == NULL) {
+			cmn_err(CE_WARN, "%s HMA registration failed.",
+			    vmmdev_hvm_name);
+			error = ENXIO;
+			goto exit;
+		}
+	}
 
 	/* Look for duplicates names */
 	if (vmm_lookup(name) != NULL) {
-		mutex_exit(&vmm_mtx);
-		return (EEXIST);
+		error = EEXIST;
+		goto exit;
 	}
 
 	/* Allow only one instance per non-global zone. */
@@ -1223,8 +1235,8 @@ vmmdev_do_vm_create(char *name, cred_t *cr)
 		for (sc = list_head(&vmm_list); sc != NULL;
 		    sc = list_next(&vmm_list, sc)) {
 			if (sc->vmm_zone == curzone) {
-				mutex_exit(&vmm_mtx);
-				return (EINVAL);
+				error = EINVAL;
+				goto exit;
 			}
 		}
 	}
@@ -1256,7 +1268,12 @@ vmmdev_do_vm_create(char *name, cred_t *cr)
 		vmm_zsd_add_vm(sc);
 
 		list_insert_tail(&vmm_list, sc);
+		if (reg != NULL) {
+			VERIFY(vmmdev_hma_reg == NULL);
+			vmmdev_hma_reg = reg;
+		}
 		mutex_exit(&vmm_mtx);
+		mutex_exit(&vmmdev_mtx);
 		return (0);
 	}
 
@@ -1266,7 +1283,13 @@ fail:
 	if (sc != NULL) {
 		ddi_soft_state_free(vmm_statep, minor);
 	}
+exit:
+	if (reg != NULL) {
+		hma_unregister(reg);
+	}
+
 	mutex_exit(&vmm_mtx);
+	mutex_exit(&vmmdev_mtx);
 
 	return (error);
 }
@@ -1487,6 +1510,7 @@ vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd)
 	dev_info_t	*pdip = ddi_get_parent(vmmdev_dip);
 	minor_t		minor;
 
+	ASSERT(MUTEX_HELD(&vmmdev_mtx));
 	ASSERT(MUTEX_HELD(&vmm_mtx));
 
 	if (clean_zsd) {
@@ -1514,6 +1538,11 @@ vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd)
 	}
 	(void) devfs_clean(pdip, NULL, DV_CLEAN_FORCE);
 
+	if (list_is_empty(&vmm_list)) {
+		hma_unregister(vmmdev_hma_reg);
+		vmmdev_hma_reg = NULL;
+	}
+
 	return (0);
 }
 
@@ -1522,9 +1551,11 @@ vmm_do_vm_destroy(vmm_softc_t *sc, boolean_t clean_zsd)
 {
 	int		err;
 
+	mutex_enter(&vmmdev_mtx);
 	mutex_enter(&vmm_mtx);
 	err = vmm_do_vm_destroy_locked(sc, clean_zsd);
 	mutex_exit(&vmm_mtx);
+	mutex_exit(&vmmdev_mtx);
 
 	return (err);
 }
@@ -1539,26 +1570,29 @@ vmmdev_do_vm_destroy(const char *name, cred_t *cr)
 	if (crgetuid(cr) != 0)
 		return (EPERM);
 
+	mutex_enter(&vmmdev_mtx);
 	mutex_enter(&vmm_mtx);
 
 	if ((sc = vmm_lookup(name)) == NULL) {
-		mutex_exit(&vmm_mtx);
-		return (ENOENT);
+		err = ENOENT;
+		goto exit;
 	}
 	/*
 	 * We don't check this in vmm_lookup() since that function is also used
 	 * for validation during create and currently vmm names must be unique.
 	 */
 	if (!INGLOBALZONE(curproc) && sc->vmm_zone != curzone) {
-		mutex_exit(&vmm_mtx);
-		return (EPERM);
+		err = EPERM;
+		goto exit;
 	}
 	err = vmm_do_vm_destroy_locked(sc, B_TRUE);
+
+exit:
 	mutex_exit(&vmm_mtx);
+	mutex_exit(&vmmdev_mtx);
 
 	return (err);
 }
-
 
 static int
 vmm_open(dev_t *devp, int flag, int otyp, cred_t *credp)
@@ -1866,12 +1900,18 @@ vmm_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	vmm_sol_glue_init();
 	vmm_arena_init();
 
+	/*
+	 * Perform temporary HMA registration to determine if the hardware
+	 * is capable.
+	 */
 	if ((reg = hma_register(vmmdev_hvm_name)) == NULL) {
 		goto fail;
 	} else if (vmm_mod_load() != 0) {
 		goto fail;
 	}
 	vmm_loaded = B_TRUE;
+	hma_unregister(reg);
+	reg = NULL;
 
 	/* Create control node.  Other nodes will be created on demand. */
 	if (ddi_create_minor_node(dip, "ctl", S_IFCHR,
@@ -1885,7 +1925,6 @@ vmm_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	}
 
 	ddi_report_dev(dip);
-	vmmdev_hma_reg = reg;
 	vmmdev_sdev_hdl = sph;
 	vmmdev_dip = dip;
 	mutex_exit(&vmmdev_mtx);
@@ -1942,8 +1981,10 @@ vmm_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
 	vmmdev_dip = NULL;
 
 	VERIFY0(vmm_mod_unload());
-	hma_unregister(vmmdev_hma_reg);
-	vmmdev_hma_reg = NULL;
+	if (vmmdev_hma_reg != NULL) {
+		hma_unregister(vmmdev_hma_reg);
+		vmmdev_hma_reg = NULL;
+	}
 	vmm_arena_fini();
 	vmm_sol_glue_cleanup();
 

--- a/usr/src/uts/i86pc/os/hma.c
+++ b/usr/src/uts/i86pc/os/hma.c
@@ -32,6 +32,7 @@ struct hma_reg {
 
 static kmutex_t hma_lock;
 static list_t hma_registrations;
+static boolean_t hma_exclusive = B_FALSE;
 
 static boolean_t hma_vmx_ready = B_FALSE;
 static const char *hma_vmx_error = NULL;
@@ -77,18 +78,14 @@ hma_init(void)
 	}
 }
 
-hma_reg_t *
-hma_register(const char *name)
+static hma_reg_t *
+hma_register_backend(const char *name)
 {
 	struct hma_reg *reg;
 	boolean_t is_ready;
 
-	VERIFY(name != NULL);
+	ASSERT(MUTEX_HELD(&hma_lock));
 
-	reg = kmem_zalloc(sizeof (*reg), KM_SLEEP);
-	reg->hr_name = name;
-
-	mutex_enter(&hma_lock);
 	switch (cpuid_getvendor(CPU)) {
 	case X86_VENDOR_Intel:
 		is_ready = hma_vmx_ready;
@@ -102,12 +99,48 @@ hma_register(const char *name)
 		break;
 	}
 
-	if (!is_ready) {
-		kmem_free(reg, sizeof (*reg));
-		reg = NULL;
-	} else {
-		list_insert_tail(&hma_registrations, reg);
+	if (!is_ready)
+		return (NULL);
+
+	reg = kmem_zalloc(sizeof (*reg), KM_SLEEP);
+	reg->hr_name = name;
+	list_insert_tail(&hma_registrations, reg);
+
+	return (reg);
+}
+
+hma_reg_t *
+hma_register(const char *name)
+{
+	struct hma_reg *reg = NULL;
+
+	VERIFY(name != NULL);
+
+	mutex_enter(&hma_lock);
+
+	if (!hma_exclusive)
+		reg = hma_register_backend(name);
+
+	mutex_exit(&hma_lock);
+
+	return (reg);
+}
+
+hma_reg_t *
+hma_register_exclusive(const char *name)
+{
+	struct hma_reg *reg = NULL;
+
+	VERIFY(name != NULL);
+
+	mutex_enter(&hma_lock);
+
+	if (list_is_empty(&hma_registrations)) {
+		reg = hma_register_backend(name);
+		if (reg != NULL)
+			hma_exclusive = B_TRUE;
 	}
+
 	mutex_exit(&hma_lock);
 
 	return (reg);
@@ -121,6 +154,8 @@ hma_unregister(hma_reg_t *reg)
 
 	mutex_enter(&hma_lock);
 	list_remove(&hma_registrations, reg);
+	if (hma_exclusive && list_is_empty(&hma_registrations))
+		hma_exclusive = B_FALSE;
 	mutex_exit(&hma_lock);
 	kmem_free(reg, sizeof (*reg));
 }

--- a/usr/src/uts/i86pc/sys/hma.h
+++ b/usr/src/uts/i86pc/sys/hma.h
@@ -38,6 +38,7 @@ extern "C" {
  */
 typedef struct hma_reg hma_reg_t;
 extern hma_reg_t *hma_register(const char *);
+extern hma_reg_t *hma_register_exclusive(const char *);
 extern void hma_unregister(hma_reg_t *);
 
 /*


### PR DESCRIPTION
This completes the changes needed to ensure that one cannot shoot oneself in the foot with respect to running incompatible hypervisors concurrently.

```
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
theeo# zoneadm -z bloody boot
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
const char *hr_name = 0xfffffffff83e590a "bhyve"
theeo# VBoxHeadless -s test
Oracle VM VirtualBox Headless Interface 5.2.26
(C) 2008-2019 Oracle Corporation
All rights reserved.

19/03/2019 12:54:28 Listening for VNC connections on TCP port 5900
19/03/2019 12:54:28 Listening for VNC connections on TCP6 port 5900
VRDE server is listening on port 5900.
Error: failed to start machine. Error message: VT-x is being used by another hypervisor (VERR_VMX_IN_VMX_ROOT_MODE).
VirtualBox can't operate in VMX root mode. Please close all other virtualization programs. (VERR_VMX_IN_VMX_ROOT_MODE)
19/03/2019 12:54:28 listenerRun: error in select: Bad file number

theeo# zoneadm -z bloody halt
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
theeo# VBoxHeadless -s test &
Oracle VM VirtualBox Headless Interface 5.2.26
(C) 2008-2019 Oracle Corporation
All rights reserved.

19/03/2019 12:55:57 Listening for VNC connections on TCP port 5900
19/03/2019 12:55:57 Listening for VNC connections on TCP6 port 5900
VRDE server is listening on port 5900.
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
const char *hr_name = 0xfffffffff7fb2abe "VirtualBox HostDrv"

theeo# zoneadm -z bloody boot
theeo# zoneadm list -vc
  ID NAME             STATUS     PATH                           BRAND    IP
   0 global           running    /                              ipkg     shared
   - bloody           installed  /data/zone/bloody              bhyve    excl
theeo# dmesg | tail | grep HMA
Mar 19 12:56:31 theeo vmm: [ID 799464 kern.warning] WARNING: bhyve HMA registration failed.

theeo# cat /data/zone/bloody/root/tmp/init.log
INFO:root:Zone UUID: 4d17cdc5-e409-4cb4-a70a-8ed866c19551
INFO:root:/usr/sbin/bhyve -U 4d17cdc5-e409-4cb4-a70a-8ed866c19551 -A -H -B 1,product=OmniOS HVM -c 2 -m 1G -l bootrom,/usr/share/bhyve/firmware/BHYVE_CSM.fd -s 0,hostbridge,model=i440fx -s 1,lpc -l com1,/dev/zconsole -s 4:0,virtio-blk,/dev/zvol/rdsk/data/hdd-bloody -s 6:0,virtio-net-viona,bloody0 bloody
INFO:root:Starting bhyve
INFO:root:Bhyve exited 4
ERROR:root:Error b'vm_create: No such device or address\n'
DEBUG:root:Output b''

theeo# fg
[1]  + running    VBoxHeadless -s test
^C
theeo#
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
theeo# zoneadm -z bloody boot
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
const char *hr_name = 0xfffffffff83e590a "bhyve"
```

```
theeo# zoneadm -z kbloody boot
theeo# mdb -ke 'hma_registrations::walk list | ::print -t hma_reg_t hr_name'
const char *hr_name = 0xfffffffff83e590a "bhyve"
const char *hr_name = 0xfffffffff7d0d361 "SmartOS KVM"
```