### PR TITLE
Fewer messages to console during boot

### DIFF
--- a/usr/src/uts/i86pc/os/hma.c
+++ b/usr/src/uts/i86pc/os/hma.c
@@ -325,7 +325,7 @@ hma_vmx_init(void)
 
 bail:
 	hma_vmx_error = msg;
-	cmn_err(CE_NOTE, "hma_vmx_init: %s", msg);
+	cmn_err(CE_CONT, "?hma_vmx_init: %s", msg);
 	return (-1);
 }
 

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
@@ -225,8 +225,8 @@ hyperv_identify(void)
 	unsigned int maxleaf;
 
 	if ((get_hwenv() & HW_MICROSOFT) == 0) {
-		cmn_err(CE_WARN,
-		    "hyperv_identify: NOT Hyper-V environment: 0x%x",
+		cmn_err(CE_CONT,
+		    "?hyperv_identify: NOT Hyper-V environment: 0x%x",
 		    get_hwenv());
 		return (B_FALSE);
 	}
@@ -347,8 +347,8 @@ hyperv_init(void)
 {
 	cmn_err(CE_CONT, "?hyperv_init: Checking Hyper-V support...\n");
 	if (!hyperv_identify()) {
-		cmn_err(CE_WARN,
-		    "hyperv_init: Hyper-V not supported on this environment");
+		cmn_err(CE_CONT,
+		    "?hyperv_init: Hyper-V not supported on this environment");
 		return (-1);
 	}
 
@@ -458,16 +458,16 @@ hypercall_destroy()
 	if (hypercall_context.hc_addr == NULL)
 		return;
 
-	cmn_err(CE_NOTE,
-	    "hypercall_destroy: Disabling Hypercall interface...");
+	cmn_err(CE_CONT,
+	    "?hypercall_destroy: Disabling Hypercall interface...");
 
 	/* Disable Hypercall */
 	hc = rdmsr(MSR_HV_HYPERCALL);
 	wrmsr(MSR_HV_HYPERCALL, (hc & MSR_HV_HYPERCALL_RSVD_MASK));
 	hypercall_memfree();
 
-	cmn_err(CE_NOTE,
-	    "hypercall_destroy: Disabling Hypercall interface - done.");
+	cmn_err(CE_CONT,
+	    "?hypercall_destroy: Disabling Hypercall interface - done.");
 }
 
 static struct modldrv hyperv_modldrv = {


### PR DESCRIPTION
These changes make the messages go to the system log by default and only to the console if booted in verbose mode.