### PR TITLE
Upstream merge joyent_merge/2019032101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 0a83682c948d906938d974e41576c473991845ef
+Last illumos-joyent commit: 52767bdcffaf8c9d0a1cbfac8fa46b8506ee88cd
 

--- a/usr/src/uts/common/brand/sn1/sn1_brand.c
+++ b/usr/src/uts/common/brand/sn1/sn1_brand.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/errno.h>
@@ -58,7 +58,7 @@ void	sn1_forklwp(klwp_t *, klwp_t *);
 void	sn1_freelwp(klwp_t *);
 void	sn1_lwpexit(klwp_t *);
 int	sn1_elfexec(vnode_t *, execa_t *, uarg_t *, intpdata_t *, int,
-	long *, int, caddr_t, cred_t *, int *);
+	size_t *, int, caddr_t, cred_t *, int *);
 
 /* sn1 brand */
 struct brand_ops sn1_brops = {
@@ -255,7 +255,7 @@ sn1_init_brand_data(zone_t *zone, kmutex_t *zsl)
 
 int
 sn1_elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
-    int level, long *execsz, int setid, caddr_t exec_file, cred_t *cred,
+    int level, size_t *execsz, int setid, caddr_t exec_file, cred_t *cred,
     int *brand_action)
 {
 	return (brand_solaris_elfexec(vp, uap, args, idatap, level, execsz,

--- a/usr/src/uts/common/brand/solaris10/s10_brand.c
+++ b/usr/src/uts/common/brand/solaris10/s10_brand.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2013, OmniTI Computer Consulting, Inc. All rights reserved.
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2018, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/errno.h>
@@ -61,7 +61,7 @@ void	s10_forklwp(klwp_t *, klwp_t *);
 void	s10_freelwp(klwp_t *);
 void	s10_lwpexit(klwp_t *);
 int	s10_elfexec(vnode_t *, execa_t *, uarg_t *, intpdata_t *, int,
-	long *, int, caddr_t, cred_t *, int *);
+    size_t *, int, caddr_t, cred_t *, int *);
 void	s10_sigset_native_to_s10(sigset_t *);
 void	s10_sigset_s10_to_native(sigset_t *);
 
@@ -425,7 +425,7 @@ s10_init_brand_data(zone_t *zone, kmutex_t *zsl)
 
 int
 s10_elfexec(vnode_t *vp, execa_t *uap, uarg_t *args, intpdata_t *idatap,
-    int level, long *execsz, int setid, caddr_t exec_file, cred_t *cred,
+    int level, size_t *execsz, int setid, caddr_t exec_file, cred_t *cred,
     int *brand_action)
 {
 	return (brand_solaris_elfexec(vp, uap, args, idatap, level, execsz,

--- a/usr/src/uts/common/exec/elf/elf_impl.h
+++ b/usr/src/uts/common/exec/elf/elf_impl.h
@@ -22,11 +22,12 @@
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
 
 #ifndef _ELF_ELF_IMPL_H
 #define	_ELF_ELF_IMPL_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #ifdef	__cplusplus
 extern "C" {
@@ -71,6 +72,17 @@ typedef struct {
 	char	name[8];
 } Note;
 
+typedef struct {
+	vnode_t		*ecc_vp;
+	proc_t		*ecc_p;
+	cred_t		*ecc_credp;
+	rlim64_t	ecc_rlimit;
+	core_content_t	ecc_content;
+	u_offset_t	ecc_doffset;
+	void		*ecc_buf;
+	size_t		ecc_bufsz;
+} elf_core_ctx_t;
+
 #ifdef	_ELF32_COMPAT
 /*
  * These are defined only for the 32-bit compatibility
@@ -79,6 +91,7 @@ typedef struct {
 #define	elfexec	elf32exec
 #define	elfnote	elf32note
 #define	elfcore	elf32core
+#define	elfreadhdr		elf32readhdr
 #define	mapexec_brand		mapexec32_brand
 #define	setup_note_header	setup_note_header32
 #define	write_elfnotes		write_elfnotes32

--- a/usr/src/uts/common/exec/intp/intp.c
+++ b/usr/src/uts/common/exec/intp/intp.c
@@ -22,7 +22,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Milan Jurik. All rights reserved.
- * Copyright 2016, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*	Copyright (c) 1988 AT&T	*/
@@ -56,7 +56,7 @@
 #include <sys/modctl.h>
 
 extern int intpexec(struct vnode *, struct execa *, struct uarg *,
-    struct intpdata *, int, long *, int, caddr_t, struct cred *, int *);
+    struct intpdata *, int, size_t *, int, caddr_t, struct cred *, int *);
 
 static struct execsw esw = {
 	intpmagicstr,
@@ -196,7 +196,7 @@ intpexec(
 	struct uarg *args,
 	struct intpdata *idatap,
 	int level,
-	long *execsz,
+	size_t *execsz,
 	int setid,
 	caddr_t exec_file,
 	struct cred *cred,

--- a/usr/src/uts/common/exec/java/java.c
+++ b/usr/src/uts/common/exec/java/java.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2015, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -85,7 +85,7 @@ char *jexec_arg = "-jar";
 /*ARGSUSED3*/
 static int
 javaexec(vnode_t *vp, struct execa *uap, struct uarg *args,
-    struct intpdata *idatap, int level, long *execsz, int setid,
+    struct intpdata *idatap, int level, size_t *execsz, int setid,
     caddr_t execfile, cred_t *cred, int *brand_action)
 {
 	struct intpdata idata;

--- a/usr/src/uts/common/exec/shbin/shbin.c
+++ b/usr/src/uts/common/exec/shbin/shbin.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2015, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -55,7 +55,7 @@ shbinexec(
 	struct uarg *args,
 	struct intpdata *idatap,
 	int level,
-	long *execsz,
+	size_t *execsz,
 	int setid,
 	caddr_t exec_file,
 	struct cred *cred,
@@ -159,7 +159,7 @@ shbinexec(
 	struct uarg *args,
 	struct intpdata *idatap,
 	int level,
-	long *execsz,
+	size_t *execsz,
 	int setid,
 	caddr_t exec_file,
 	struct cred *cred,

--- a/usr/src/uts/common/fs/proc/prioctl.c
+++ b/usr/src/uts/common/fs/proc/prioctl.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -956,7 +956,7 @@ startover:
 
 	case PIOCNMAP:		/* get number of memory mappings */
 	{
-		int n;
+		uint_t n;
 		struct as *as = p->p_as;
 
 		if ((p->p_flag & SSYS) || as == &kas)
@@ -969,7 +969,7 @@ startover:
 			mutex_enter(&p->p_lock);
 		}
 		prunlock(pnp);
-		if (copyout(&n, cmaddr, sizeof (int)))
+		if (copyout(&n, cmaddr, sizeof (uint_t)))
 			error = EFAULT;
 		break;
 	}
@@ -2583,7 +2583,7 @@ startover:
 
 	case PIOCNMAP:		/* get number of memory mappings */
 	{
-		int n;
+		uint_t n;
 		struct as *as = p->p_as;
 
 		if ((p->p_flag & SSYS) || as == &kas)
@@ -2596,7 +2596,7 @@ startover:
 			mutex_enter(&p->p_lock);
 		}
 		prunlock(pnp);
-		if (copyout(&n, cmaddr, sizeof (int)))
+		if (copyout(&n, cmaddr, sizeof (uint_t)))
 			error = EFAULT;
 		break;
 	}

--- a/usr/src/uts/common/fs/proc/prsubr.c
+++ b/usr/src/uts/common/fs/proc/prsubr.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1382,10 +1382,10 @@ prgetaction32(proc_t *p, user_t *up, uint_t sig, struct sigaction32 *sp)
 /*
  * Count the number of segments in this process's address space.
  */
-int
+uint_t
 prnsegs(struct as *as, int reserved)
 {
-	int n = 0;
+	uint_t n = 0;
 	struct seg *seg;
 
 	ASSERT(as != &kas && AS_WRITE_HELD(as));
@@ -1402,8 +1402,21 @@ prnsegs(struct as *as, int reserved)
 		for (saddr = seg->s_base; saddr < eaddr; saddr = naddr) {
 			(void) pr_getprot(seg, reserved, &tmp,
 			    &saddr, &naddr, eaddr);
-			if (saddr != naddr)
+			if (saddr != naddr) {
 				n++;
+				/*
+				 * prnsegs() was formerly designated to return
+				 * an 'int' despite having no ability or use
+				 * for negative results.  As part of changing
+				 * it to 'uint_t', keep the old effective limit
+				 * of INT_MAX in place.
+				 */
+				if (n == INT_MAX) {
+					pr_getprot_done(&tmp);
+					ASSERT(tmp == NULL);
+					return (n);
+				}
+			}
 		}
 
 		ASSERT(tmp == NULL);

--- a/usr/src/uts/common/os/brand.c
+++ b/usr/src/uts/common/os/brand.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2016, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/kmem.h>
@@ -671,9 +671,9 @@ restoreexecenv(struct execenv *ep, stack_t *sp)
 /*ARGSUSED*/
 int
 brand_solaris_elfexec(vnode_t *vp, execa_t *uap, uarg_t *args,
-    intpdata_t *idatap, int level, long *execsz, int setid, caddr_t exec_file,
-    cred_t *cred, int *brand_action, struct brand *pbrand, char *bname,
-    char *brandlib, char *brandlib32)
+    intpdata_t *idatap, int level, size_t *execsz, int setid,
+    caddr_t exec_file, cred_t *cred, int *brand_action, struct brand *pbrand,
+    char *bname, char *brandlib, char *brandlib32)
 {
 
 	vnode_t		*nvp;

--- a/usr/src/uts/common/os/exec.c
+++ b/usr/src/uts/common/os/exec.c
@@ -26,7 +26,7 @@
 /*	Copyright (c) 1988 AT&T	*/
 /*	  All Rights Reserved  	*/
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -144,7 +144,7 @@ exec_common(const char *fname, const char **argp, const char **envp,
 	proc_t *p = ttoproc(curthread);
 	klwp_t *lwp = ttolwp(curthread);
 	struct user *up = PTOU(p);
-	long execsz;		/* temporary count of exec size */
+	size_t execsz;		/* temporary count of exec size */
 	int i;
 	int error;
 	char exec_file[MAXCOMLEN+1];
@@ -603,7 +603,7 @@ gexec(
 	struct uarg *args,
 	struct intpdata *idatap,
 	int level,
-	long *execsz,
+	size_t *execsz,
 	caddr_t exec_file,
 	struct cred *cred,
 	int *brand_action)
@@ -1491,7 +1491,7 @@ noexec(
     struct uarg *args,
     struct intpdata *idatap,
     int level,
-    long *execsz,
+    size_t *execsz,
     int setid,
     caddr_t exec_file,
     struct cred *cred)

--- a/usr/src/uts/common/sys/brand.h
+++ b/usr/src/uts/common/sys/brand.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _SYS_BRAND_H
@@ -172,10 +172,9 @@ struct brand_ops {
 	void	(*b_forklwp)(klwp_t *, klwp_t *);
 	void	(*b_freelwp)(klwp_t *);
 	void	(*b_lwpexit)(klwp_t *);
-	int	(*b_elfexec)(struct vnode *vp, struct execa *uap,
-	    struct uarg *args, struct intpdata *idata, int level,
-	    long *execsz, int setid, caddr_t exec_file,
-	    struct cred *cred, int *brand_action);
+	int	(*b_elfexec)(struct vnode *, struct execa *, struct uarg *,
+	    struct intpdata *, int, size_t *, int, caddr_t, struct cred *,
+	    int *);
 	void	(*b_sigset_native_to_brand)(sigset_t *);
 	void	(*b_sigset_brand_to_native)(sigset_t *);
 	void	(*b_sigfd_translate)(k_siginfo_t *);
@@ -258,7 +257,7 @@ extern int	brand_solaris_cmd(int, uintptr_t, uintptr_t, uintptr_t,
 extern void	brand_solaris_copy_procdata(proc_t *, proc_t *,
 		    struct brand *);
 extern int	brand_solaris_elfexec(vnode_t *, execa_t *, uarg_t *,
-		    intpdata_t *, int, long *, int, caddr_t, cred_t *, int *,
+		    intpdata_t *, int, size_t *, int, caddr_t, cred_t *, int *,
 		    struct brand *, char *, char *, char *);
 extern void	brand_solaris_exec(struct brand *);
 extern int	brand_solaris_fini(char **, struct modlinkage *,

--- a/usr/src/uts/common/sys/exec.h
+++ b/usr/src/uts/common/sys/exec.h
@@ -27,7 +27,7 @@
 /*	  All Rights Reserved	*/
 
 /*
- * Copyright 2016, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _SYS_EXEC_H
@@ -83,7 +83,7 @@ typedef struct uarg {
 	ssize_t arglen;
 	char	*fname;
 	char	*pathname;
-	ssize_t	auxsize;
+	size_t	auxsize;
 	caddr_t	stackend;
 	size_t	stk_align;
 	size_t	stk_size;
@@ -182,7 +182,7 @@ struct execsw {
 	int	exec_maglen;
 	int	(*exec_func)(struct vnode *vp, struct execa *uap,
 		    struct uarg *args, struct intpdata *idata, int level,
-		    long *execsz, int setid, caddr_t exec_file,
+		    size_t *execsz, int setid, caddr_t exec_file,
 		    struct cred *cred, int *brand_action);
 	int	(*exec_core)(struct vnode *vp, struct proc *p,
 		    struct cred *cred, rlim64_t rlimit, int sig,
@@ -220,7 +220,7 @@ extern int exece(const char *fname, const char **argp, const char **envp);
 extern int exec_common(const char *fname, const char **argp,
     const char **envp, int brand_action);
 extern int gexec(vnode_t **vp, struct execa *uap, struct uarg *args,
-    struct intpdata *idata, int level, long *execsz, caddr_t exec_file,
+    struct intpdata *idata, int level, size_t *execsz, caddr_t exec_file,
     struct cred *cred, int *brand_action);
 extern struct execsw *allocate_execsw(char *name, char *magic,
     size_t magic_size);
@@ -246,32 +246,32 @@ extern void exec_set_sp(size_t);
  * when compiling the 32-bit compatability elf code in the elfexec module.
  */
 extern int elfexec(vnode_t *, execa_t *, uarg_t *, intpdata_t *, int,
-    long *, int, caddr_t, cred_t *, int *);
+    size_t *, int, caddr_t, cred_t *, int *);
 extern int mapexec_brand(vnode_t *, uarg_t *, Ehdr *, Addr *,
     intptr_t *, caddr_t, char **, caddr_t *, caddr_t *, size_t *,
     uintptr_t *, uintptr_t *);
-extern int elfreadhdr(vnode_t *, cred_t *, Ehdr *, int *, caddr_t *,
-    ssize_t *);
+extern int elfreadhdr(vnode_t *, cred_t *, Ehdr *, uint_t *, caddr_t *,
+    size_t *);
 #endif /* !_ELF32_COMPAT */
 
 #if defined(_LP64)
 extern int elf32exec(vnode_t *, execa_t *, uarg_t *, intpdata_t *, int,
-    long *, int, caddr_t, cred_t *, int *);
+    size_t *, int, caddr_t, cred_t *, int *);
 extern int mapexec32_brand(vnode_t *, uarg_t *, Elf32_Ehdr *, Elf32_Addr *,
     intptr_t *, caddr_t, char **, caddr_t *, caddr_t *, size_t *,
     uintptr_t *, uintptr_t *);
-extern int elf32readhdr(vnode_t *, cred_t *, Elf32_Ehdr *, int *, caddr_t *,
-    ssize_t *);
+extern int elf32readhdr(vnode_t *, cred_t *, Elf32_Ehdr *, uint_t *, caddr_t *,
+    size_t *);
 #endif  /* _LP64 */
 
 /*
  * Utility functions for exec module core routines:
  */
-extern int core_seg(proc_t *, vnode_t *, offset_t, caddr_t,
-    size_t, rlim64_t, cred_t *);
+extern int core_seg(proc_t *, vnode_t *, u_offset_t, caddr_t, size_t,
+    rlim64_t, cred_t *);
 
-extern int core_write(vnode_t *, enum uio_seg, offset_t,
-    const void *, size_t, rlim64_t, cred_t *);
+extern int core_write(vnode_t *, enum uio_seg, u_offset_t, const void *,
+    size_t, rlim64_t, cred_t *);
 
 /* a.out stuff */
 

--- a/usr/src/uts/common/sys/prsystm.h
+++ b/usr/src/uts/common/sys/prsystm.h
@@ -28,7 +28,7 @@
 /*	  All Rights Reserved	*/
 
 /*
- * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _SYS_PRSYSTM_H
@@ -86,7 +86,7 @@ extern void prgetcred(proc_t *, struct prcred *);
 extern void prgetpriv(proc_t *, struct prpriv *);
 extern size_t prgetprivsize(void);
 extern void prgetsecflags(proc_t *, struct prsecflags *);
-extern int  prnsegs(struct as *, int);
+extern uint_t prnsegs(struct as *, int);
 extern void prexit(proc_t *);
 extern void prfree(proc_t *);
 extern void prlwpexit(kthread_t *);

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -279,6 +279,8 @@ VMM_OBJS += vmm.o \
 	vmm_sol_vm.o \
 	vmm_sol_glue.o \
 	vmm_sol_ept.o \
+	vmm_sol_rvi.o \
+	vmm_support.o \
 	vmm_zsd.o
 
 VIONA_OBJS += viona.o

--- a/usr/src/uts/i86pc/Makefile.rules
+++ b/usr/src/uts/i86pc/Makefile.rules
@@ -232,6 +232,9 @@ $(OBJS_DIR)/%.o:		$(UTSBASE)/i86pc/io/vmm/io/%.c
 	$(COMPILE.c) -o $@ $<
 	$(CTFCONVERT_O)
 
+$(OBJS_DIR)/%.o:		$(UTSBASE)/i86pc/io/vmm/%.s
+	$(COMPILE.s) -o $@ $<
+
 $(OBJS_DIR)/%.o:		$(UTSBASE)/i86pc/io/vmm/intel/%.s
 	$(COMPILE.s) -o $@ $<
 

--- a/usr/src/uts/i86pc/io/vmm/amd/svm_msr.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm_msr.c
@@ -54,6 +54,7 @@ enum {
 	HOST_MSR_NUM		/* must be the last enumeration */
 };
 
+#ifdef __FreeBSD__
 static uint64_t host_msrs[HOST_MSR_NUM];
 
 void
@@ -68,6 +69,19 @@ svm_msr_init(void)
 	host_msrs[IDX_MSR_STAR] = rdmsr(MSR_STAR);
 	host_msrs[IDX_MSR_SF_MASK] = rdmsr(MSR_SF_MASK);
 }
+#else
+
+CTASSERT(HOST_MSR_NUM == SVM_HOST_MSR_NUM);
+
+void
+svm_msr_init(void)
+{
+	/*
+	 * These MSRs do vary between CPUs on illumos, so saving system-wide
+	 * values for them serves no purpose.
+	 */
+}
+#endif /* __FreeBSD__ */
 
 void
 svm_msr_guest_init(struct svm_softc *sc, int vcpu)
@@ -89,11 +103,23 @@ svm_msr_guest_enter(struct svm_softc *sc, int vcpu)
 	/*
 	 * Save host MSRs (if any) and restore guest MSRs (if any).
 	 */
+#ifndef __FreeBSD__
+	uint64_t *host_msrs = sc->host_msrs[vcpu];
+
+	/* Save host MSRs */
+	host_msrs[IDX_MSR_LSTAR] = rdmsr(MSR_LSTAR);
+	host_msrs[IDX_MSR_CSTAR] = rdmsr(MSR_CSTAR);
+	host_msrs[IDX_MSR_STAR] = rdmsr(MSR_STAR);
+	host_msrs[IDX_MSR_SF_MASK] = rdmsr(MSR_SF_MASK);
+#endif /* __FreeBSD__ */
 }
 
 void
 svm_msr_guest_exit(struct svm_softc *sc, int vcpu)
 {
+#ifndef __FreeBSD__
+	uint64_t *host_msrs = sc->host_msrs[vcpu];
+#endif
 	/*
 	 * Save guest MSRs (if any) and restore host MSRs.
 	 */

--- a/usr/src/uts/i86pc/io/vmm/amd/svm_support.s
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm_support.s
@@ -25,36 +25,59 @@
  *
  * $FreeBSD$
  */
-#include <machine/asmacros.h>
 
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/asm_linkage.h>
+
+#include "svm_assym.h"
 
 /* Porting note: This is named 'svm_support.S' upstream. */
 
 #if defined(lint)
 
 struct svm_regctx;
-struct pcpu;
+struct cpu;
 
 /*ARGSUSED*/
 void
-svm_launch(unsigned long pa, struct svm_regctx *gctx, struct pcpu *pcpu)
+svm_launch(uint64_t pa, struct svm_regctx *gctx, struct cpu *cpu)
 {}
 
 #else /* lint */
 
-#include "svm_assym.h"
-
-/*
- * Be friendly to DTrace FBT's prologue/epilogue pattern matching.
- *
- * They are also responsible for saving/restoring the host %rbp across VMRUN.
- */
-#define	VENTER  push %rbp ; mov %rsp,%rbp
-#define	VLEAVE  pop %rbp
-
 #define	VMLOAD	.byte 0x0f, 0x01, 0xda
 #define	VMRUN	.byte 0x0f, 0x01, 0xd8
 #define	VMSAVE	.byte 0x0f, 0x01, 0xdb
+
+
+/*
+ * Flush scratch registers to avoid lingering guest state being used for
+ * Spectre v1 attacks when returning from guest entry.
+ */
+#define	SVM_GUEST_FLUSH_SCRATCH						\
+	xorl	%edi, %edi;						\
+	xorl	%esi, %esi;						\
+	xorl	%edx, %edx;						\
+	xorl	%ecx, %ecx;						\
+	xorl	%r8d, %r8d;						\
+	xorl	%r9d, %r9d;						\
+	xorl	%r10d, %r10d;						\
+	xorl	%r11d, %r11d;
+
+/* Stack layout (offset from %rsp) for svm_launch */
+#define	SVMSTK_R15	0x00	/* callee saved %r15			*/
+#define	SVMSTK_R14	0x08	/* callee saved %r14			*/
+#define	SVMSTK_R13	0x10	/* callee saved %r13			*/
+#define	SVMSTK_R12	0x18	/* callee saved %r12			*/
+#define	SVMSTK_RBX	0x20	/* callee saved %rbx			*/
+#define	SVMSTK_RDX	0x28	/* save-args %rdx (struct cpu *)	*/
+#define	SVMSTK_RSI	0x30	/* save-args %rsi (struct svm_regctx *)	*/
+#define	SVMSTK_RDI	0x38	/* save-args %rdi (uint64_t vmcb_pa)	*/
+#define	SVMSTK_FP	0x40	/* frame pointer %rbp			*/
+#define	SVMSTKSIZE	SVMSTK_FP
 
 /*
  * svm_launch(uint64_t vmcb, struct svm_regctx *gctx, struct pcpu *pcpu)
@@ -62,88 +85,80 @@ svm_launch(unsigned long pa, struct svm_regctx *gctx, struct pcpu *pcpu)
  * %rsi: pointer to guest context
  * %rdx: pointer to the pcpu data
  */
-ENTRY(svm_launch)
-	VENTER
+ENTRY_NP(svm_launch)
+	pushq	%rbp
+	movq	%rsp, %rbp
+	subq	$SVMSTKSIZE, %rsp
+	movq	%r15, SVMSTK_R15(%rsp)
+	movq	%r14, SVMSTK_R14(%rsp)
+	movq	%r13, SVMSTK_R13(%rsp)
+	movq	%r12, SVMSTK_R12(%rsp)
+	movq	%rbx, SVMSTK_RBX(%rsp)
+	movq	%rdx, SVMSTK_RDX(%rsp)
+	movq	%rsi, SVMSTK_RSI(%rsp)
+	movq	%rdi, SVMSTK_RDI(%rsp)
 
-	/* save pointer to the pcpu data */
-	push %rdx
+	/* VMLOAD and VMRUN expect the VMCB physaddr in %rax */
+	movq	%rdi, %rax
 
-	/*
-	 * Host register state saved across a VMRUN.
-	 *
-	 * All "callee saved registers" except:
-	 * %rsp: because it is preserved by the processor across VMRUN.
-	 * %rbp: because it is saved/restored by the function prologue/epilogue.
-	 */
-	push %rbx
-	push %r12
-	push %r13
-	push %r14
-	push %r15
-
-	/* Save the physical address of the VMCB in %rax */
-	movq %rdi, %rax
-
-	push %rsi		/* push guest context pointer on the stack */
-
-	/*
-	 * Restore guest state.
-	 */
-	movq SCTX_R8(%rsi), %r8
-	movq SCTX_R9(%rsi), %r9
-	movq SCTX_R10(%rsi), %r10
-	movq SCTX_R11(%rsi), %r11
-	movq SCTX_R12(%rsi), %r12
-	movq SCTX_R13(%rsi), %r13
-	movq SCTX_R14(%rsi), %r14
-	movq SCTX_R15(%rsi), %r15
-	movq SCTX_RBP(%rsi), %rbp
-	movq SCTX_RBX(%rsi), %rbx
-	movq SCTX_RCX(%rsi), %rcx
-	movq SCTX_RDX(%rsi), %rdx
-	movq SCTX_RDI(%rsi), %rdi
-	movq SCTX_RSI(%rsi), %rsi	/* %rsi must be restored last */
+	/* Restore guest state. */
+	movq	SCTX_R8(%rsi), %r8
+	movq	SCTX_R9(%rsi), %r9
+	movq	SCTX_R10(%rsi), %r10
+	movq	SCTX_R11(%rsi), %r11
+	movq	SCTX_R12(%rsi), %r12
+	movq	SCTX_R13(%rsi), %r13
+	movq	SCTX_R14(%rsi), %r14
+	movq	SCTX_R15(%rsi), %r15
+	movq	SCTX_RBP(%rsi), %rbp
+	movq	SCTX_RBX(%rsi), %rbx
+	movq	SCTX_RCX(%rsi), %rcx
+	movq	SCTX_RDX(%rsi), %rdx
+	movq	SCTX_RDI(%rsi), %rdi
+	movq	SCTX_RSI(%rsi), %rsi	/* %rsi must be restored last */
 
 	VMLOAD
 	VMRUN
 	VMSAVE
 
-	pop %rax		/* pop guest context pointer from the stack */
+	/* Grab the svm_regctx pointer */
+	movq	SVMSTK_RSI(%rsp), %rax
 
-	/*
-	 * Save guest state.
-	 */
-	movq %r8, SCTX_R8(%rax)
-	movq %r9, SCTX_R9(%rax)
-	movq %r10, SCTX_R10(%rax)
-	movq %r11, SCTX_R11(%rax)
-	movq %r12, SCTX_R12(%rax)
-	movq %r13, SCTX_R13(%rax)
-	movq %r14, SCTX_R14(%rax)
-	movq %r15, SCTX_R15(%rax)
-	movq %rbp, SCTX_RBP(%rax)
-	movq %rbx, SCTX_RBX(%rax)
-	movq %rcx, SCTX_RCX(%rax)
-	movq %rdx, SCTX_RDX(%rax)
-	movq %rdi, SCTX_RDI(%rax)
-	movq %rsi, SCTX_RSI(%rax)
+	/* Save guest state. */
+	movq	%r8, SCTX_R8(%rax)
+	movq	%r9, SCTX_R9(%rax)
+	movq	%r10, SCTX_R10(%rax)
+	movq	%r11, SCTX_R11(%rax)
+	movq	%r12, SCTX_R12(%rax)
+	movq	%r13, SCTX_R13(%rax)
+	movq	%r14, SCTX_R14(%rax)
+	movq	%r15, SCTX_R15(%rax)
+	movq	%rbp, SCTX_RBP(%rax)
+	movq	%rbx, SCTX_RBX(%rax)
+	movq	%rcx, SCTX_RCX(%rax)
+	movq	%rdx, SCTX_RDX(%rax)
+	movq	%rdi, SCTX_RDI(%rax)
+	movq	%rsi, SCTX_RSI(%rax)
 
-	/* Restore host state */
-	pop %r15
-	pop %r14
-	pop %r13
-	pop %r12
-	pop %rbx
+	/* Restore callee-saved registers */
+	movq	SVMSTK_R15(%rsp), %r15
+	movq	SVMSTK_R14(%rsp), %r14
+	movq	SVMSTK_R13(%rsp), %r13
+	movq	SVMSTK_R12(%rsp), %r12
+	movq	SVMSTK_RBX(%rsp), %rbx
 
-	/* Restore %GS.base to point to the host's pcpu data */
-	pop %rdx
-	mov %edx, %eax
-	shr $32, %rdx
-	mov $MSR_GSBASE, %ecx
+	/* Fix %gsbase to point back to the correct 'struct cpu *' */
+	movq	SVMSTK_RDX(%rsp), %rdx
+	movl	%edx, %eax
+	shrq	$32, %rdx
+	movl	$MSR_GSBASE, %ecx
 	wrmsr
 
-	VLEAVE
+	SVM_GUEST_FLUSH_SCRATCH
+
+	addq	$SVMSTKSIZE, %rsp
+	popq	%rbp
 	ret
-END(svm_launch)
+SET_SIZE(svm_launch)
 
 #endif /* lint */

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.c
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.c
@@ -2640,7 +2640,7 @@ vmx_exit_process(struct vmx *vmx, int vcpu, struct vm_exit *vmexit)
 #ifdef __FreeBSD__
 		__asm __volatile("int $18");
 #else
-		vmx_call_trap(T_MCE);
+		vmm_call_trap(T_MCE);
 #endif
 		return (1);
 	}
@@ -2929,7 +2929,7 @@ vmx_exit_process(struct vmx *vmx, int vcpu, struct vm_exit *vmexit)
 #ifdef __FreeBSD__
 			__asm __volatile("int $18");
 #else
-			vmx_call_trap(T_MCE);
+			vmm_call_trap(T_MCE);
 #endif
 			return (1);
 		}
@@ -3147,7 +3147,7 @@ vmx_exit_handle_nmi(struct vmx *vmx, int vcpuid, struct vm_exit *vmexit)
 #ifdef __FreeBSD__
 		__asm __volatile("int $2");
 #else
-		vmx_call_trap(T_NMIFLT);
+		vmm_call_trap(T_NMIFLT);
 #endif
 	}
 }

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.h
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.h
@@ -164,9 +164,6 @@ CTASSERT((offsetof(struct vmx, pir_desc[0]) & 63) == 0);
 #define	VMX_VMWRITE_ERROR	4
 int	vmx_enter_guest(struct vmxctx *ctx, struct vmx *vmx, int launched);
 void	vmx_call_isr(uintptr_t entry);
-#ifndef __FreeBSD__
-void	vmx_call_trap(uint64_t);
-#endif
 
 u_long	vmx_fix_cr0(u_long cr0);
 u_long	vmx_fix_cr4(u_long cr4);

--- a/usr/src/uts/i86pc/io/vmm/vm/vm_glue.h
+++ b/usr/src/uts/i86pc/io/vmm/vm/vm_glue.h
@@ -93,6 +93,7 @@ struct vmm_pt_ops {
 };
 
 extern struct vmm_pt_ops ept_ops;
+extern struct vmm_pt_ops rvi_ops;
 
 
 #endif /* _VM_GLUE_ */

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
@@ -1662,10 +1662,19 @@ vmm_is_supported(intptr_t arg)
 	int r;
 	const char *msg;
 
-	if (!vmm_is_intel())
-		return (ENXIO);
+	if (vmm_is_intel()) {
+		r = vmx_x86_supported(&msg);
+	} else if (vmm_is_amd()) {
+		/*
+		 * HMA already ensured that the features necessary for SVM
+		 * operation were present and online during vmm_attach().
+		 */
+		r = 0;
+	} else {
+		r = ENXIO;
+		msg = "Unsupported CPU vendor";
+	}
 
-	r = vmx_x86_supported(&msg);
 	if (r != 0 && arg != NULL) {
 		if (copyoutstr(msg, (char *)arg, strlen(msg) + 1, NULL) != 0)
 			return (EFAULT);

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_rvi.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_rvi.c
@@ -1,0 +1,297 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/kmem.h>
+#include <sys/machsystm.h>
+#include <sys/x86_archext.h>
+
+#include <sys/gipt.h>
+#include <vm/vm_glue.h>
+
+
+struct rvi_map {
+	gipt_map_t	rm_gipt;
+	uint64_t	rm_wired_page_count;
+};
+typedef struct rvi_map rvi_map_t;
+
+#define	RVI_LOCK(m)	(&(m)->rm_gipt.giptm_lock)
+
+#define	RVI_MAX_LEVELS	4
+
+CTASSERT(RVI_MAX_LEVELS <= GIPT_MAX_LEVELS);
+
+#define	RVI_PRESENT	PT_VALID
+#define	RVI_WRITABLE	PT_WRITABLE
+#define	RVI_ACCESSED	PT_REF
+#define	RVI_DIRTY	PT_MOD
+#define	RVI_LGPG	PT_PAGESIZE
+#define	RVI_NX		PT_NX
+#define	RVI_USER	PT_USER
+#define	RVI_PWT		PT_WRITETHRU
+#define	RVI_PCD		PT_NOCACHE
+
+#define	RVI_PA_MASK	PT_PADDR
+
+#define	RVI_PAT(attr)	rvi_attr_to_pat(attr)
+#define	RVI_PADDR(addr)	((addr) & RVI_PA_MASK)
+#define	RVI_PROT(prot)	\
+	((((prot) & PROT_WRITE) != 0 ? RVI_WRITABLE : 0) | \
+	(((prot) & PROT_EXEC) == 0 ? RVI_NX : 0))
+
+#define	RVI_IS_ABSENT(pte)	(((pte) & RVI_PRESENT) == 0)
+#define	RVI_PTE_PFN(pte)	mmu_btop(RVI_PADDR(pte))
+#define	RVI_MAPS_PAGE(pte, lvl)	\
+	(!RVI_IS_ABSENT(pte) && (((pte) & RVI_LGPG) != 0 || (lvl) == 0))
+#define	RVI_PTE_PROT(pte)	\
+	(RVI_IS_ABSENT(pte) ? 0 : (			\
+	PROT_READ |					\
+	(((pte) & RVI_NX) == 0 ? PROT_EXEC : 0) |	\
+	(((pte) & RVI_WRITABLE) != 0 ? PROT_WRITE : 0)))
+
+#define	RVI_PTE_ASSIGN_PAGE(lvl, pfn, prot, attr)	\
+	(RVI_PADDR(pfn_to_pa(pfn)) |			\
+	(((lvl) != 0) ? RVI_LGPG : 0) |			\
+	RVI_USER | RVI_ACCESSED | RVI_PRESENT |		\
+	RVI_PAT(attr) |					\
+	RVI_PROT(prot))
+
+#define	RVI_PTE_ASSIGN_TABLE(pfn)	\
+	(RVI_PADDR(pfn_to_pa(pfn)) |			\
+	RVI_USER | RVI_ACCESSED | RVI_PRESENT |		\
+	RVI_PAT(MTRR_TYPE_WB) |				\
+	RVI_PROT(PROT_READ | PROT_WRITE | PROT_EXEC))
+
+
+/* Make sure that PAT indexes line up as expected */
+CTASSERT((PAT_DEFAULT_ATTRIBUTE & 0xf) == MTRR_TYPE_WB);
+CTASSERT(((PAT_DEFAULT_ATTRIBUTE >> 24) & 0xf) == MTRR_TYPE_UC);
+
+static inline uint64_t
+rvi_attr_to_pat(const uint8_t attr)
+{
+	if (attr == MTRR_TYPE_UC) {
+		/* !PAT + PCD + PWT -> PAT3 -> MTRR_TYPE_UC */
+		return (RVI_PCD|RVI_PWT);
+	} else if (attr == MTRR_TYPE_WB) {
+		/* !PAT + !PCD + !PWT -> PAT0 -> MTRR_TYPE_WB */
+		return (0);
+	}
+
+	panic("unexpected memattr %x", attr);
+	return (0);
+}
+
+static gipt_pte_type_t
+rvi_pte_type(uint64_t pte, uint_t level)
+{
+	if (RVI_IS_ABSENT(pte)) {
+		return (PTET_EMPTY);
+	} else if (RVI_MAPS_PAGE(pte, level)) {
+		return (PTET_PAGE);
+	} else {
+		return (PTET_LINK);
+	}
+}
+
+static uint64_t
+rvi_pte_map(uint64_t pfn)
+{
+	return (RVI_PTE_ASSIGN_TABLE(pfn));
+}
+
+static void *
+rvi_create(uintptr_t *pml4_kaddr)
+{
+	rvi_map_t *rmap;
+	gipt_map_t *map;
+	gipt_t *root;
+	struct gipt_cbs cbs = {
+		.giptc_pte_type = rvi_pte_type,
+		.giptc_pte_map = rvi_pte_map,
+	};
+
+	rmap = kmem_zalloc(sizeof (*rmap), KM_SLEEP);
+	map = &rmap->rm_gipt;
+	root = gipt_alloc();
+	root->gipt_level = RVI_MAX_LEVELS - 1;
+	gipt_map_init(map, RVI_MAX_LEVELS, GIPT_HASH_SIZE_DEFAULT, &cbs, root);
+
+	*pml4_kaddr = (uintptr_t)root->gipt_kva;
+	return (rmap);
+}
+
+static void
+rvi_destroy(void *arg)
+{
+	rvi_map_t *rmap = arg;
+
+	if (rmap != NULL) {
+		gipt_map_t *map = &rmap->rm_gipt;
+
+		gipt_map_fini(map);
+		kmem_free(rmap, sizeof (*rmap));
+	}
+}
+
+static uint64_t
+rvi_wired_count(void *arg)
+{
+	rvi_map_t *rmap = arg;
+	uint64_t res;
+
+	mutex_enter(RVI_LOCK(rmap));
+	res = rmap->rm_wired_page_count;
+	mutex_exit(RVI_LOCK(rmap));
+
+	return (res);
+}
+
+static int
+rvi_is_wired(void *arg, uint64_t va, uint_t *protp)
+{
+	rvi_map_t *rmap = arg;
+	gipt_t *pt;
+	int rv = -1;
+
+	mutex_enter(RVI_LOCK(rmap));
+	pt = gipt_map_lookup_deepest(&rmap->rm_gipt, va);
+	if (pt != NULL) {
+		const uint64_t pte = GIPT_VA2PTE(pt, va);
+
+		if (RVI_MAPS_PAGE(pte, pt->gipt_level)) {
+			*protp = RVI_PTE_PROT(pte);
+			rv = 0;
+		}
+	}
+	mutex_exit(RVI_LOCK(rmap));
+
+	return (rv);
+}
+
+static int
+rvi_map(void *arg, uint64_t va, pfn_t pfn, uint_t lvl, uint_t prot,
+    uint8_t attr)
+{
+	rvi_map_t *rmap = arg;
+	gipt_map_t *map = &rmap->rm_gipt;
+	gipt_t *pt;
+	uint64_t *ptep, pte;
+
+	ASSERT((prot & PROT_READ) != 0);
+	ASSERT3U((prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC)), ==, 0);
+	ASSERT3U(lvl, <, RVI_MAX_LEVELS);
+
+	mutex_enter(RVI_LOCK(rmap));
+	pt = gipt_map_lookup(map, va, lvl);
+	if (pt == NULL) {
+		/*
+		 * A table at the appropriate VA/level that would house this
+		 * mapping does not currently exist.  Try to walk down to that
+		 * point, creating any necessary parent(s).
+		 */
+		pt = gipt_map_create_parents(map, va, lvl);
+
+		/*
+		 * There was a large page mapping in the way of creating the
+		 * necessary parent table(s).
+		 */
+		if (pt == NULL) {
+			panic("unexpected large page @ %08lx", va);
+		}
+	}
+	ptep = GIPT_VA2PTEP(pt, va);
+
+	pte = *ptep;
+	if (!RVI_IS_ABSENT(pte)) {
+		if (!RVI_MAPS_PAGE(pte, lvl)) {
+			panic("unexpected PT link @ %08lx in %p", va, pt);
+		} else {
+			panic("unexpected page mapped @ %08lx in %p", va, pt);
+		}
+	}
+
+	pte = RVI_PTE_ASSIGN_PAGE(lvl, pfn, prot, attr);
+	*ptep = pte;
+	pt->gipt_valid_cnt++;
+	rmap->rm_wired_page_count += gipt_level_count[lvl];
+
+	mutex_exit(RVI_LOCK(rmap));
+	return (0);
+}
+
+static uint64_t
+rvi_unmap(void *arg, uint64_t va, uint64_t end_va)
+{
+	rvi_map_t *rmap = arg;
+	gipt_map_t *map = &rmap->rm_gipt;
+	gipt_t *pt;
+	uint64_t cur_va = va;
+	uint64_t unmapped = 0;
+
+	mutex_enter(RVI_LOCK(rmap));
+
+	pt = gipt_map_lookup_deepest(map, cur_va);
+	if (pt == NULL) {
+		mutex_exit(RVI_LOCK(rmap));
+		return (0);
+	}
+	if (!RVI_MAPS_PAGE(GIPT_VA2PTE(pt, cur_va), pt->gipt_level)) {
+		cur_va = gipt_map_next_page(map, cur_va, end_va, &pt);
+		if (cur_va == 0) {
+			mutex_exit(RVI_LOCK(rmap));
+			return (0);
+		}
+	}
+
+	while (cur_va < end_va) {
+		uint64_t *ptep = GIPT_VA2PTEP(pt, cur_va);
+		const uint_t lvl = pt->gipt_level;
+
+		ASSERT(RVI_MAPS_PAGE(*ptep, lvl));
+		*ptep = 0;
+		pt->gipt_valid_cnt--;
+		unmapped += gipt_level_count[pt->gipt_level];
+
+		gipt_t *next_pt = pt;
+		uint64_t next_va;
+		next_va = gipt_map_next_page(map, cur_va, end_va, &next_pt);
+
+		if (pt->gipt_valid_cnt == 0) {
+			gipt_map_clean_parents(map, pt);
+		}
+		if (next_va == 0) {
+			break;
+		}
+		pt = next_pt;
+		cur_va = next_va;
+	}
+	rmap->rm_wired_page_count -= unmapped;
+
+	mutex_exit(RVI_LOCK(rmap));
+
+	return (unmapped);
+}
+
+struct vmm_pt_ops rvi_ops = {
+	.vpo_init	= rvi_create,
+	.vpo_free	= rvi_destroy,
+	.vpo_wired_cnt	= rvi_wired_count,
+	.vpo_is_wired	= rvi_is_wired,
+	.vpo_map	= rvi_map,
+	.vpo_unmap	= rvi_unmap,
+};

--- a/usr/src/uts/i86pc/io/vmm/vmm_support.s
+++ b/usr/src/uts/i86pc/io/vmm/vmm_support.s
@@ -1,0 +1,54 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/asm_linkage.h>
+#include <sys/segments.h>
+
+/*
+ * %rdi = trapno
+ *
+ * This variant is for any explicit exception injection that we need: in this
+ * case, we can't just, for example, do a direct "int $2", as that will then
+ * trash our %cr3 via tr_nmiint due to KPTI, so we have to fake a trap frame.
+ * Both NMIs and MCEs don't push an 'err' into the frame.
+ */
+ENTRY_NP(vmm_call_trap)
+	pushq	%rbp
+	movq	%rsp, %rbp
+	movq	%rsp, %r11
+	andq	$~0xf, %rsp	/* align stack */
+	pushq	$KDS_SEL	/* %ss */
+	pushq	%r11		/* %rsp */
+	pushfq			/* %rflags */
+	pushq	$KCS_SEL	/* %cs */
+	leaq	.trap_iret_dest(%rip), %rcx
+	pushq	%rcx		/* %rip */
+	cli
+	cmpq	$T_NMIFLT, %rdi
+	je	nmiint
+	cmpq	$T_MCE, %rdi
+	je	mcetrap
+
+	pushq	%rdi		/* save our bad trapno... */
+	leaq	__vmm_call_bad_trap(%rip), %rdi
+	xorl	%eax, %eax
+	call	panic
+	/*NOTREACHED*/
+
+.trap_iret_dest:
+	popq	%rbp
+	ret
+SET_SIZE(vmm_call_trap)
+
+__vmm_call_bad_trap:
+	.string	"bad trapno for vmm_call_trap()"

--- a/usr/src/uts/i86pc/io/vmm/x86.c
+++ b/usr/src/uts/i86pc/io/vmm/x86.c
@@ -198,6 +198,18 @@ x86_emulate_cpuid(struct vm *vm, int vcpu_id,
 			/* Hide mwaitx/monitorx capability from the guest */
 			regs[2] &= ~AMDID2_MWAITX;
 
+#ifndef __FreeBSD__
+			/*
+			 * Detection routines for TCE and FFXSR are missing
+			 * from our vm_cpuid_capability() detection logic
+			 * today.  Mask them out until that is remedied.
+			 * They do not appear to be in common usage, so their
+			 * absence should not cause undue trouble.
+			 */
+			regs[2] &= ~AMDID2_TCE;
+			regs[3] &= ~AMDID_FFXSR;
+#endif
+
 			/*
 			 * Hide rdtscp/ia32_tsc_aux until we know how
 			 * to deal with them.

--- a/usr/src/uts/i86pc/os/hma.c
+++ b/usr/src/uts/i86pc/os/hma.c
@@ -38,22 +38,32 @@ static boolean_t hma_vmx_ready = B_FALSE;
 static const char *hma_vmx_error = NULL;
 static id_space_t *hma_vmx_vpid;
 
-typedef enum vmx_cpu_state {
-	VCS_UNINITIALIZED = 0,
-	VCS_READY,
-	VCS_ERROR
-} vmx_cpu_state_t;
-
 /*
- * The bulk of VMX-related HMA state is protected by cpu_lock, rather than a
+ * The bulk of HMA state (VMX & SVM) is protected by cpu_lock, rather than a
  * mutex specific to the module.  It (cpu_lock) is already required for the
  * state needed to perform setup on all CPUs, so it was a natural fit to
  * protect this data too.
  */
+typedef enum hma_cpu_state {
+	HCS_UNINITIALIZED = 0,
+	HCS_READY,
+	HCS_ERROR
+} hma_cpu_state_t;
+static hma_cpu_state_t hma_cpu_status[NCPU];
+
 static void *hma_vmx_vmxon_page[NCPU];
 static uintptr_t hma_vmx_vmxon_pa[NCPU];
-static vmx_cpu_state_t hma_vmx_status[NCPU];
 static uint32_t hma_vmx_revision;
+
+static boolean_t hma_svm_ready = B_FALSE;
+static const char *hma_svm_error = NULL;
+static uint32_t hma_svm_features;
+static uint32_t hma_svm_max_asid;
+
+static void *hma_svm_hsave_page[NCPU];
+static uintptr_t hma_svm_hsave_pa[NCPU];
+
+static hma_svm_asid_t hma_svm_cpu_asid[NCPU];
 
 
 static int hma_vmx_init(void);
@@ -91,8 +101,7 @@ hma_register_backend(const char *name)
 		is_ready = hma_vmx_ready;
 		break;
 	case X86_VENDOR_AMD:
-		/* Punt on SVM support for now */
-		is_ready = B_FALSE;
+		is_ready = hma_svm_ready;
 		break;
 	default:
 		is_ready = B_FALSE;
@@ -191,9 +200,9 @@ hma_vmx_vpid_free(uint16_t vpid)
 
 extern int hma_vmx_vmxon(uintptr_t);
 
-/* ARGSUSED */
 static int
-hma_vmx_cpu_vmxon(xc_arg_t arg1, xc_arg_t arg2, xc_arg_t arg3)
+hma_vmx_cpu_vmxon(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
 {
 	uint64_t fctrl;
 	processorid_t id = CPU->cpu_seqid;
@@ -216,9 +225,9 @@ hma_vmx_cpu_vmxon(xc_arg_t arg1, xc_arg_t arg2, xc_arg_t arg3)
 	setcr4(getcr4() | CR4_VMXE);
 
 	if (hma_vmx_vmxon(vmxon_pa) == 0) {
-		hma_vmx_status[id] = VCS_READY;
+		hma_cpu_status[id] = HCS_READY;
 	} else {
-		hma_vmx_status[id] = VCS_ERROR;
+		hma_cpu_status[id] = HCS_ERROR;
 
 		/*
 		 * If VMX has already been marked active and available for the
@@ -233,9 +242,8 @@ hma_vmx_cpu_vmxon(xc_arg_t arg1, xc_arg_t arg2, xc_arg_t arg3)
 	return (0);
 }
 
-/* ARGSUSED2 */
 static int
-hma_vmx_cpu_setup(cpu_setup_t what, int id, void *arg)
+hma_vmx_cpu_setup(cpu_setup_t what, int id, void *arg __unused)
 {
 	ASSERT(MUTEX_HELD(&cpu_lock));
 	ASSERT(id >= 0 && id < NCPU);
@@ -258,8 +266,8 @@ hma_vmx_cpu_setup(cpu_setup_t what, int id, void *arg)
 	}
 
 	/* Perform initialization if it has not been previously attempted. */
-	if (hma_vmx_status[id] != VCS_UNINITIALIZED) {
-		return ((hma_vmx_status[id] == VCS_READY) ? 0 : -1);
+	if (hma_cpu_status[id] != HCS_UNINITIALIZED) {
+		return ((hma_cpu_status[id] == HCS_READY) ? 0 : -1);
 	}
 
 	/* Allocate the VMXON page for this CPU */
@@ -300,7 +308,7 @@ hma_vmx_cpu_setup(cpu_setup_t what, int id, void *arg)
 		xc_sync(0, 0, 0, CPUSET2BV(set), hma_vmx_cpu_vmxon);
 	}
 
-	return (hma_vmx_status[id] != VCS_READY);
+	return (hma_cpu_status[id] != HCS_READY);
 }
 
 static int
@@ -364,10 +372,233 @@ bail:
 	return (-1);
 }
 
+#define	VMCB_FLUSH_NOTHING	0x0
+#define	VMCB_FLUSH_ALL		0x1
+#define	VMCB_FLUSH_ASID		0x3
+
+void
+hma_svm_asid_init(hma_svm_asid_t *vcp)
+{
+	/*
+	 * Initialize the generation to 0, forcing an ASID allocation on first
+	 * entry.  Leave the ASID at 0, so if the host forgoes the call to
+	 * hma_svm_asid_update(), SVM will bail on the invalid vcpu state.
+	 */
+	vcp->hsa_gen = 0;
+	vcp->hsa_asid = 0;
+}
+
+uint8_t
+hma_svm_asid_update(hma_svm_asid_t *vcp, boolean_t flush_by_asid,
+    boolean_t npt_flush)
+{
+	hma_svm_asid_t *hcp = &hma_svm_cpu_asid[CPU->cpu_seqid];
+
+	ASSERT(curthread->t_preempt != 0);
+
+	/*
+	 * If NPT changes dictate a TLB flush and by-ASID flushing is not
+	 * supported/used, force a fresh ASID allocation.
+	 */
+	if (npt_flush && !flush_by_asid) {
+		vcp->hsa_gen = 0;
+	}
+
+	if (vcp->hsa_gen != hcp->hsa_gen) {
+		hcp->hsa_asid++;
+
+		if (hcp->hsa_asid >= hma_svm_max_asid) {
+			/* Keep the ASID properly constrained */
+			hcp->hsa_asid = 1;
+			hcp->hsa_gen++;
+			if (hcp->hsa_gen == 0) {
+				/*
+				 * Stay clear of the '0' sentinel value for
+				 * generation, if wrapping around.
+				 */
+				hcp->hsa_gen = 1;
+			}
+		}
+		vcp->hsa_gen = hcp->hsa_gen;
+		vcp->hsa_asid = hcp->hsa_asid;
+
+		ASSERT(vcp->hsa_asid != 0);
+		ASSERT3U(vcp->hsa_asid, <, hma_svm_max_asid);
+
+		if (flush_by_asid) {
+			return (VMCB_FLUSH_ASID);
+		}
+		return (VMCB_FLUSH_ALL);
+	} else if (npt_flush) {
+		ASSERT(flush_by_asid);
+		return (VMCB_FLUSH_ASID);
+	}
+	return (VMCB_FLUSH_NOTHING);
+}
+
+static int
+hma_svm_cpu_activate(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
+{
+	const processorid_t id = CPU->cpu_seqid;
+	const uintptr_t hsave_pa = hma_svm_hsave_pa[id];
+	uint64_t efer;
+
+	VERIFY(hsave_pa != 0);
+
+	/* Enable SVM via EFER */
+	efer = rdmsr(MSR_AMD_EFER);
+	efer |= AMD_EFER_SVME;
+	wrmsr(MSR_AMD_EFER, efer);
+
+	/* Setup hsave area */
+	wrmsr(MSR_AMD_VM_HSAVE_PA, hsave_pa);
+
+	hma_cpu_status[id] = HCS_READY;
+	return (0);
+}
+
+static int
+hma_svm_cpu_setup(cpu_setup_t what, int id, void *arg __unused)
+{
+	ASSERT(MUTEX_HELD(&cpu_lock));
+	ASSERT(id >= 0 && id < NCPU);
+
+	switch (what) {
+	case CPU_CONFIG:
+	case CPU_ON:
+	case CPU_INIT:
+		break;
+	default:
+		/*
+		 * Other events, such as CPU offlining, are of no interest.
+		 * Letting the SVM state linger should not cause any harm.
+		 *
+		 * This logic assumes that any offlining activity is strictly
+		 * administrative in nature and will not alter any existing
+		 * configuration (such as EFER bits previously set).
+		 */
+		return (0);
+	}
+
+	/* Perform initialization if it has not been previously attempted. */
+	if (hma_cpu_status[id] != HCS_UNINITIALIZED) {
+		return ((hma_cpu_status[id] == HCS_READY) ? 0 : -1);
+	}
+
+	/* Allocate the hsave page for this CPU */
+	if (hma_svm_hsave_page[id] == NULL) {
+		caddr_t va;
+		pfn_t pfn;
+
+		va = kmem_alloc(PAGESIZE, KM_SLEEP);
+		VERIFY0((uintptr_t)va & PAGEOFFSET);
+		hma_svm_hsave_page[id] = va;
+
+		/*
+		 * Cache the physical address of the hsave page rather than
+		 * looking it up later when the potential blocking of
+		 * hat_getpfnum would be less acceptable.
+		 */
+		pfn = hat_getpfnum(kas.a_hat, va);
+		hma_svm_hsave_pa[id] = (pfn << PAGESHIFT);
+	} else {
+		VERIFY(hma_svm_hsave_pa[id] != 0);
+	}
+
+	kpreempt_disable();
+	if (CPU->cpu_seqid == id) {
+		/* Perform svm setup directly if this CPU is the target */
+		(void) hma_svm_cpu_activate(0, 0, 0);
+		kpreempt_enable();
+	} else {
+		cpuset_t set;
+
+		/* Use a cross-call if a remote CPU is the target */
+		kpreempt_enable();
+		cpuset_zero(&set);
+		cpuset_add(&set, id);
+		xc_sync(0, 0, 0, CPUSET2BV(set), hma_svm_cpu_activate);
+	}
+
+	return (hma_cpu_status[id] != HCS_READY);
+}
 
 static int
 hma_svm_init(void)
 {
-	/* punt on AMD for now */
-	return (ENOTSUP);
+	uint64_t msr;
+	const char *msg = NULL;
+	struct cpuid_regs regs;
+	cpu_t *cp;
+
+	if (!is_x86_feature(x86_featureset, X86FSET_SVM)) {
+		msg = "CPU does not support SVM";
+		goto bail;
+	}
+
+	msr = rdmsr(MSR_AMD_VM_CR);
+	if ((msr & AMD_VM_CR_SVMDIS) != 0) {
+		msg = "SVM disabled by BIOS";
+		goto bail;
+	}
+
+	regs.cp_eax = 0x8000000a;
+	(void) cpuid_insn(NULL, &regs);
+	const uint32_t nasid = regs.cp_ebx;
+	const uint32_t feat = regs.cp_edx;
+
+	if (nasid == 0) {
+		msg = "Not enough ASIDs for guests";
+		goto bail;
+	}
+	if ((feat & CPUID_AMD_EDX_NESTED_PAGING) == 0) {
+		msg = "CPU does not support nested paging";
+		goto bail;
+	}
+	if ((feat & CPUID_AMD_EDX_NRIPS) == 0) {
+		msg = "CPU does not support NRIP save";
+		goto bail;
+	}
+
+	hma_svm_features = feat;
+	hma_svm_max_asid = nasid;
+
+	mutex_enter(&cpu_lock);
+	/* Perform SVM configuration for already-online CPUs. */
+	cp = cpu_active;
+	do {
+		int err = hma_svm_cpu_setup(CPU_ON, cp->cpu_seqid, NULL);
+		if (err != 0) {
+			msg = "failure during SVM setup";
+			mutex_exit(&cpu_lock);
+			goto bail;
+		}
+	} while ((cp = cp->cpu_next_onln) != cpu_active);
+
+	/*
+	 * Register callback for later-onlined CPUs and perform other remaining
+	 * resource allocation.
+	 */
+	register_cpu_setup_func(hma_svm_cpu_setup, NULL);
+	mutex_exit(&cpu_lock);
+
+	/* Initialize per-CPU ASID state. */
+	for (uint_t i = 0; i < NCPU; i++) {
+		/*
+		 * Skip past sentinel 0 value for generation.  Doing so for
+		 * ASID is unneeded, since it will be incremented during the
+		 * first allocation.
+		 */
+		hma_svm_cpu_asid[i].hsa_gen = 1;
+		hma_svm_cpu_asid[i].hsa_asid = 0;
+	}
+
+	hma_svm_ready = B_TRUE;
+	return (0);
+
+bail:
+	hma_svm_error = msg;
+	cmn_err(CE_NOTE, "hma_svm_init: %s", msg);
+	return (-1);
 }

--- a/usr/src/uts/i86pc/sys/hma.h
+++ b/usr/src/uts/i86pc/sys/hma.h
@@ -50,6 +50,15 @@ extern void hma_unregister(hma_reg_t *);
 extern uint16_t hma_vmx_vpid_alloc(void);
 extern void hma_vmx_vpid_free(uint16_t);
 
+struct hma_svm_asid {
+	uint64_t hsa_gen;
+	uint32_t hsa_asid;
+};
+typedef struct hma_svm_asid hma_svm_asid_t;
+
+extern void hma_svm_asid_init(hma_svm_asid_t *);
+extern uint8_t hma_svm_asid_update(hma_svm_asid_t *, boolean_t, boolean_t);
+
 /*
  * FPU related management. These functions provide a set of APIs to manage the
  * FPU state and switch between host and guest management of this state.

--- a/usr/src/uts/i86pc/sys/vmm.h
+++ b/usr/src/uts/i86pc/sys/vmm.h
@@ -38,7 +38,7 @@
  * http://www.illumos.org/license/CDDL.
  *
  * Copyright 2015 Pluribus Networks Inc.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _VMM_H_
@@ -740,6 +740,8 @@ void vmm_sol_glue_cleanup(void);
 
 int vmm_mod_load(void);
 int vmm_mod_unload(void);
+
+void vmm_call_trap(uint64_t);
 
 /*
  * Because of tangled headers, these are mirrored by vmm_drv.h to present the

--- a/usr/src/uts/intel/sys/controlregs.h
+++ b/usr/src/uts/intel/sys/controlregs.h
@@ -200,6 +200,18 @@ extern "C" {
 #define	MSR_AMD_KGSBASE	0xc0000102	/* swapgs swaps this with gsbase */
 #define	MSR_AMD_TSCAUX	0xc0000103	/* %ecx value on rdtscp insn */
 
+
+/* AMD's SVM MSRs */
+
+#define	MSR_AMD_VM_CR		0xc0010114 /* SVM global control */
+#define	MSR_AMD_VM_HSAVE_PA	0xc0010117 /* SVM host save area address */
+
+#define	AMD_VM_CR_DPD		(1 << 0)
+#define	AMD_VM_CR_R_INIT	(1 << 1)
+#define	AMD_VM_CR_DIS_A20M	(1 << 2)
+#define	AMD_VM_CR_LOCK		(1 << 3)
+#define	AMD_VM_CR_SVMDIS	(1 << 4)
+
 /* AMD's configuration MSRs, weakly documented in the revision guide */
 
 #define	MSR_AMD_DC_CFG	0xc0011022

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -210,6 +210,18 @@ extern "C" {
 #define	CPUID_AMD_EBX_SSB_NO		0x004000000 /* AMD: SSB Fixed */
 
 /*
+ * AMD SVM features (extended function 0x8000000A).
+ */
+#define	CPUID_AMD_EDX_NESTED_PAGING	0x000000001 /* AMD: SVM NP */
+#define	CPUID_AMD_EDX_LBR_VIRT		0x000000002 /* AMD: LBR virt. */
+#define	CPUID_AMD_EDX_SVML		0x000000004 /* AMD: SVM lock */
+#define	CPUID_AMD_EDX_NRIPS		0x000000008 /* AMD: NRIP save */
+#define	CPUID_AMD_EDX_TSC_RATE_MSR	0x000000010 /* AMD: MSR TSC ctrl */
+#define	CPUID_AMD_EDX_VMCB_CLEAN	0x000000020 /* AMD: VMCB clean bits */
+#define	CPUID_AMD_EDX_FLUSH_ASID	0x000000040 /* AMD: flush by ASID */
+#define	CPUID_AMD_EDX_DECODE_ASSISTS	0x000000080 /* AMD: decode assists */
+
+/*
  * Intel now seems to have claimed part of the "extended" function
  * space that we previously for non-Intel implementors to use.
  * More excitingly still, they've claimed bit 20 to mean LAHF/SAHF


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019032101

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019032101-7b7d0d5d99 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Mar 21 10:52:45 UTC 2019 ====
==== Nightly distributed build completed: Thu Mar 21 11:41:26 UTC 2019 ====

==== Total build time ====

real    0:48:40

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-upstream_merge-2019032101-3b034f56b1 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/java/bin/javac
openjdk full version "1.8.0_202-omnios-151029-20190219"

/usr/bin/openssl
OpenSSL 1.1.1b  26 Feb 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1758 (illumos)

Build project:  default
Build taskid:   70

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019032101-7b7d0d5d99

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:01.8
user  2:37:26.1
sys     20:00.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    16:52.2
user  2:14:36.0
sys     19:25.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
