### PR TITLE
Various hyperv PV driver fixes

### DIFF
--- a/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
@@ -336,7 +336,8 @@ hn_getprop(struct hn_softc *sc, char *name, int min, int max, int def)
 	    DDI_PROP_DONTPASS, name, &props, &nprops) == DDI_PROP_SUCCESS) {
 		if (sc->hn_instance < nprops) {
 			ret = props[sc->hn_instance];
-			HN_NOTE(sc, "property %s configured to %d", name, ret);
+			dev_err(sc->hn_dev, CE_CONT,
+			    "?property %s configured to %d", name, ret);
 		} else {
 			HN_WARN(sc, "property %s not available for this "
 			    "device", name);

--- a/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
@@ -65,6 +65,7 @@
 
 /*
  * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/sysmacros.h>
@@ -219,7 +220,7 @@ static void			hn_link_taskfunc(void *);
 static void			hn_netchg_taskfunc(void *);
 static void			hn_link_status(struct hn_softc *);
 
-static int			hn_create_rx_data(struct hn_softc *);
+static int			hn_create_rx_data(struct hn_softc *, int);
 static void			hn_destroy_rx_data(struct hn_softc *);
 static void			hn_rss_ind_fixup(struct hn_softc *);
 static int			hn_rxpkt(struct hn_rx_ring *, const void *,
@@ -229,7 +230,7 @@ static uint32_t			hn_get_implied_hcksum(struct hn_rx_ring *,
 
 static int			hn_tx_ring_create(struct hn_softc *, int);
 static void			hn_tx_ring_destroy(struct hn_tx_ring *);
-static int			hn_create_tx_data(struct hn_softc *);
+static int			hn_create_tx_data(struct hn_softc *, int);
 static void			hn_fixup_tx_data(struct hn_softc *);
 static void			hn_destroy_tx_data(struct hn_softc *);
 static void			hn_txdesc_dmamap_destroy(struct hn_txdesc *);
@@ -352,45 +353,6 @@ hn_getprop(struct hn_softc *sc, char *name, int min, int max, int def)
 	HN_DEBUG(sc, 2, "hn_getprop(%s) -> %d", name, ret);
 
 	return (ret);
-}
-
-static void
-hn_init_properties(struct hn_softc *sc)
-{
-	/*
-	 * NOTE:
-	 * The # of RX rings to use is same as the # of channels to use.
-	 */
-	sc->hn_rx_ring_cnt = hn_getprop(sc, "rx_rings", 1, HN_RING_CNT_DEF_MAX,
-	    min(ncpus, HN_RING_CNT_DEF_MAX));
-
-	/*
-	 * # of TX rings is limited by the number of channels (i.e RX rings)
-	 */
-	sc->hn_tx_ring_cnt = hn_getprop(sc, "tx_rings", 1, sc->hn_rx_ring_cnt,
-	    sc->hn_rx_ring_cnt);
-
-	sc->hn_lso_enable = hn_getprop(sc, "lso", B_FALSE, B_TRUE,
-	    hn_lso_enable_default);
-
-	sc->hn_tx_hcksum_enable = hn_getprop(sc, "tx_cksum_offload", B_FALSE,
-	    B_TRUE, hn_tx_hcksum_enable_default);
-
-	/* TODO: find txdesc_cnt hard limit, or get it from host */
-	sc->hn_txdesc_cnt = hn_getprop(sc, "tx_desc_cnt", HN_TX_DESC_CNT_MIN,
-	    HN_TX_DESC_CNT_MAX, hn_txdesc_cnt_default);
-	if (!ISP2(sc->hn_txdesc_cnt)) {
-		HN_WARN(sc, "number of tx descriptors (%d) must be a power "
-		    "of 2, defaulting to %d", sc->hn_txdesc_cnt,
-		    HN_TX_DESC_CNT_DEFAULT);
-		sc->hn_txdesc_cnt = HN_TX_DESC_CNT_DEFAULT;
-	}
-
-	/*
-	 * Set the leader CPU for channels.
-	 */
-	sc->hn_cpu = (atomic_add_32_nv(&hn_cpu_index, sc->hn_rx_ring_cnt) -
-	    sc->hn_rx_ring_cnt) % ncpus;
 }
 
 int
@@ -709,7 +671,7 @@ static int
 hn_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
 	struct hn_softc *sc;
-	int error;
+	int error, rx_ring_cnt, tx_ring_cnt;
 
 	/*
 	 * We do not currently support DDI_RESUME
@@ -731,7 +693,39 @@ hn_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 	ddi_set_driver_private(dip, sc);
 
-	hn_init_properties(sc);
+	/*
+	 * NOTE:
+	 * The # of RX rings to use is same as the # of channels to use.
+	 */
+	rx_ring_cnt = hn_getprop(sc, "rx_rings", 1, HN_RING_CNT_DEF_MAX,
+	    min(ncpus, HN_RING_CNT_DEF_MAX));
+
+	/*
+	 * # of TX rings is limited by the number of channels (i.e RX rings)
+	 */
+	tx_ring_cnt = hn_getprop(sc, "tx_rings", 1, rx_ring_cnt, rx_ring_cnt);
+
+	sc->hn_lso_enable = hn_getprop(sc, "lso", B_FALSE, B_TRUE,
+	    hn_lso_enable_default);
+
+	sc->hn_tx_hcksum_enable = hn_getprop(sc, "tx_cksum_offload", B_FALSE,
+	    B_TRUE, hn_tx_hcksum_enable_default);
+
+	/* TODO: find txdesc_cnt hard limit, or get it from host */
+	sc->hn_txdesc_cnt = hn_getprop(sc, "tx_desc_cnt", HN_TX_DESC_CNT_MIN,
+	    HN_TX_DESC_CNT_MAX, hn_txdesc_cnt_default);
+	if (!ISP2(sc->hn_txdesc_cnt)) {
+		HN_WARN(sc, "number of tx descriptors (%d) must be a power "
+		    "of 2, defaulting to %d", sc->hn_txdesc_cnt,
+		    HN_TX_DESC_CNT_DEFAULT);
+		sc->hn_txdesc_cnt = HN_TX_DESC_CNT_DEFAULT;
+	}
+
+	/*
+	 * Set the leader CPU for channels.
+	 */
+	sc->hn_cpu = (atomic_add_32_nv(&hn_cpu_index, sc->hn_rx_ring_cnt) -
+	    sc->hn_rx_ring_cnt) % ncpus;
 
 	/*
 	 * Setup taskqueue for management tasks, e.g. link status.
@@ -743,10 +737,10 @@ hn_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * Create enough TX/RX rings, even if only limited number of
 	 * channels can be allocated.
 	 */
-	error = hn_create_tx_data(sc);
+	error = hn_create_tx_data(sc, tx_ring_cnt);
 	if (error != 0)
 		goto failed;
-	error = hn_create_rx_data(sc);
+	error = hn_create_rx_data(sc, rx_ring_cnt);
 	if (error != 0)
 		goto failed;
 
@@ -1690,7 +1684,7 @@ hn_get_implied_hcksum(struct hn_rx_ring *rxr, const mblk_t *mp)
 }
 
 static int
-hn_create_rx_data(struct hn_softc *sc)
+hn_create_rx_data(struct hn_softc *sc, int ring_cnt)
 {
 	/*
 	 * Create RXBUF for reception.
@@ -1708,6 +1702,7 @@ hn_create_rx_data(struct hn_softc *sc)
 		return (ENOMEM);
 	}
 
+	sc->hn_rx_ring_cnt = ring_cnt;
 	sc->hn_rx_ring_inuse = sc->hn_rx_ring_cnt;
 
 	sc->hn_rx_ring = kmem_zalloc(sizeof (struct hn_rx_ring) *
@@ -1995,7 +1990,7 @@ hn_tx_ring_destroy(struct hn_tx_ring *txr)
 }
 
 static int
-hn_create_tx_data(struct hn_softc *sc)
+hn_create_tx_data(struct hn_softc *sc, int ring_cnt)
 {
 	/*
 	 * Create TXBUF for chimney sending.
@@ -2010,6 +2005,7 @@ hn_create_tx_data(struct hn_softc *sc)
 		return (ENOMEM);
 	}
 
+	sc->hn_tx_ring_cnt = ring_cnt;
 	sc->hn_tx_ring_inuse = sc->hn_tx_ring_cnt;
 
 	sc->hn_tx_ring = kmem_zalloc(sizeof (struct hn_tx_ring) *

--- a/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
@@ -939,7 +939,7 @@ hv_kvp_detach(dev_info_t *dev, ddi_detach_cmd_t cmd)
 
 	error = vmbus_ic_detach(dev, &sc->util_sc);
 	if (error != 0) {
-		hv_kvp_log_error(sc, "detach failed, error: %d", error);
+		hv_kvp_log_info(sc, "detach failed, error: %d", error);
 		return (error);
 	}
 

--- a/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
@@ -908,7 +908,7 @@ hv_kvp_attach(dev_info_t *dev, ddi_attach_cmd_t cmd)
 	    NULL);
 	cv_init(&sc->pending_cv, "hv_kvp pending condvar", CV_DRIVER, NULL);
 
-	sc->requesttq = ddi_taskq_create(sc->dev, "kvp request", 1,
+	sc->requesttq = ddi_taskq_create(sc->dev, "kvp_request", 1,
 	    TASKQ_DEFAULTPRI, 0);
 
 	if (sc->requesttq == NULL) {

--- a/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/hv_kvp.c
@@ -939,7 +939,7 @@ hv_kvp_detach(dev_info_t *dev, ddi_detach_cmd_t cmd)
 
 	error = vmbus_ic_detach(dev, &sc->util_sc);
 	if (error != 0) {
-		hv_kvp_log_error(sc, "detatch failed, error: %d", error);
+		hv_kvp_log_error(sc, "detach failed, error: %d", error);
 		return (error);
 	}
 

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_icreg.h
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_icreg.h
@@ -139,7 +139,6 @@ struct vmbus_icmsg_timesync {
 struct vmbus_icmsg_timesync4 {
 	struct vmbus_icmsg_hdr	ic_hdr;
 	uint64_t		ic_hvtime;
-	uint64_t		ic_vmtime;
 	uint64_t		ic_sent_tc;
 	uint8_t			ic_tsflags;	/* VMBUS_ICMSG_TS_FLAG_ */
 	uint8_t			ic_rsvd[5];

--- a/usr/src/uts/intel/io/hyperv/utilities/vmbus_timesync.c
+++ b/usr/src/uts/intel/io/hyperv/utilities/vmbus_timesync.c
@@ -203,7 +203,7 @@ vmbus_timesync_cb(struct vmbus_channel *chan, void *xsc)
 		if (error)
 			return;
 		if (VMBUS_TIMESYNC_DORTT(sc))
-			dev_err(sc->ic_dev, CE_WARN, "RTT");
+			dev_err(sc->ic_dev, CE_CONT, "?RTT");
 		break;
 
 	case VMBUS_ICMSG_TYPE_TIMESYNC:

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
@@ -51,6 +51,8 @@
 #include <sys/types.h>
 #include <sys/inttypes.h>
 #include <sys/cmn_err.h>
+#include <sys/reboot.h>
+
 #include <sys/x86_archext.h>
 
 #include <sys/hyperv_illumos.h>
@@ -267,60 +269,69 @@ hyperv_identify(void)
 	hyperv_features3 = regs[3]; /* EDX */
 
 	do_cpuid(CPUID_LEAF_HV_IDENTITY, regs);
-	printf("Hyper-V Version: %d.%d.%d [SP%d]\n",
+
+	cmn_err(CE_CONT, "?Hyper-V Version: %d.%d.%d [SP%d]\n",
 	    regs[1] >> 16, regs[1] & 0xffff, regs[0], regs[2]);
 
-	printf("  Features=0x%b\n", hyperv_features,
-	    "\020"
-	    "\001VPRUNTIME"	/* MSR_HV_VP_RUNTIME */
-	    "\002TMREFCNT"	/* MSR_HV_TIME_REF_COUNT */
-	    "\003SYNIC"		/* MSRs for SynIC */
-	    "\004SYNTM"		/* MSRs for SynTimer */
-	    "\005APIC"		/* MSR_HV_{EOI,ICR,TPR} */
-	    "\006HYPERCALL"	/* MSR_HV_{GUEST_OS_ID,HYPERCALL} */
-	    "\007VPINDEX"	/* MSR_HV_VP_INDEX */
-	    "\010RESET"		/* MSR_HV_RESET */
-	    "\011STATS"		/* MSR_HV_STATS_ */
-	    "\012REFTSC"	/* MSR_HV_REFERENCE_TSC */
-	    "\013IDLE"		/* MSR_HV_GUEST_IDLE */
-	    "\014TMFREQ"	/* MSR_HV_{TSC,APIC}_FREQUENCY */
-	    "\015DEBUG");	/* MSR_HV_SYNTH_DEBUG_ */
-	printf("  Features1=0x%b\n", hyperv_features1,
-	    "\020"
-	    "\001CreatePartitions"
-	    "\002AccessPartitionId"
-	    "\003AccessMemoryPool"
-	    "\004AdjustMessageBuffers"
-	    "\005PostMessages"
-	    "\006SignalEvents"
-	    "\007CreatePort"
-	    "\008ConnectPort"
-	    "\009AccessStats"
-	    "\012Debugging"
-	    "\013CpuManagement"
-	    "\014ConfigureProfiler"
-	    "\015EnableExpandedStackwalking");
-	printf("  Features2(PM)=0x%b [C%u]\n",
-	    (hyperv_pm_features & ~CPUPM_HV_CSTATE_MASK),
-	    "\020"
-	    "\005C3HPET",	/* HPET is required for C3 state */
-	    CPUPM_HV_CSTATE(hyperv_pm_features));
-	printf("  Features3=0x%b\n", hyperv_features3,
-	    "\020"
-	    "\001MWAIT"		/* MWAIT */
-	    "\002DEBUG"		/* guest debug support */
-	    "\003PERFMON"	/* performance monitor */
-	    "\004PCPUDPE"	/* physical CPU dynamic partition event */
-	    "\005XMMHC"		/* hypercall input through XMM regs */
-	    "\006IDLE"		/* guest idle support */
-	    "\007SLEEP"		/* hypervisor sleep support */
-	    "\010NUMA"		/* NUMA distance query support */
-	    "\011TMFREQ"	/* timer frequency query (TSC, LAPIC) */
-	    "\012SYNCMC"	/* inject synthetic machine checks */
-	    "\013CRASH"		/* MSRs for guest crash */
-	    "\014DEBUGMSR"	/* MSRs for guest debug */
-	    "\015NPIEP"		/* NPIEP */
-	    "\016HVDIS");	/* disabling hypervisor */
+	if (boothowto & RB_VERBOSE) {
+		printf("  Features=0x%b\n", hyperv_features,
+		    "\020"
+		    "\001VPRUNTIME"	/* MSR_HV_VP_RUNTIME */
+		    "\002TMREFCNT"	/* MSR_HV_TIME_REF_COUNT */
+		    "\003SYNIC"		/* MSRs for SynIC */
+		    "\004SYNTM"		/* MSRs for SynTimer */
+		    "\005APIC"		/* MSR_HV_{EOI,ICR,TPR} */
+		    "\006HYPERCALL"	/* MSR_HV_{GUEST_OS_ID,HYPERCALL} */
+		    "\007VPINDEX"	/* MSR_HV_VP_INDEX */
+		    "\010RESET"		/* MSR_HV_RESET */
+		    "\011STATS"		/* MSR_HV_STATS_ */
+		    "\012REFTSC"	/* MSR_HV_REFERENCE_TSC */
+		    "\013IDLE"		/* MSR_HV_GUEST_IDLE */
+		    "\014TMFREQ"	/* MSR_HV_{TSC,APIC}_FREQUENCY */
+		    "\015DEBUG");	/* MSR_HV_SYNTH_DEBUG_ */
+		printf("  Features1=0x%b\n", hyperv_features1,
+		    "\020"
+		    "\001CreatePartitions"
+		    "\002AccessPartitionId"
+		    "\003AccessMemoryPool"
+		    "\004AdjustMessageBuffers"
+		    "\005PostMessages"
+		    "\006SignalEvents"
+		    "\007CreatePort"
+		    "\008ConnectPort"
+		    "\009AccessStats"
+		    "\012Debugging"
+		    "\013CpuManagement"
+		    "\014ConfigureProfiler"
+		    "\015EnableExpandedStackwalking");
+		printf("  Features2(PM)=0x%b [C%u]\n",
+		    (hyperv_pm_features & ~CPUPM_HV_CSTATE_MASK),
+		    "\020"
+		    "\005C3HPET",	/* HPET is required for C3 state */
+		    CPUPM_HV_CSTATE(hyperv_pm_features));
+		printf("  Features3=0x%b\n", hyperv_features3,
+		    "\020"
+		    "\001MWAIT"		/* MWAIT */
+		    "\002DEBUG"		/* guest debug support */
+		    "\003PERFMON"	/* performance monitor */
+		    "\004PCPUDPE"	/* phys CPU dynamic partition event */
+		    "\005XMMHC"		/* hypercall input through XMM regs */
+		    "\006IDLE"		/* guest idle support */
+		    "\007SLEEP"		/* hypervisor sleep support */
+		    "\010NUMA"		/* NUMA distance query support */
+		    "\011TMFREQ"	/* timer frequency query (TSC, LAPIC) */
+		    "\012SYNCMC"	/* inject synthetic machine checks */
+		    "\013CRASH"		/* MSRs for guest crash */
+		    "\014DEBUGMSR"	/* MSRs for guest debug */
+		    "\015NPIEP"		/* NPIEP */
+		    "\016HVDIS");	/* disabling hypervisor */
+	} else {
+		cmn_err(CE_CONT, "?Features=0x%x", hyperv_features);
+		cmn_err(CE_CONT, "?Features1=0x%x", hyperv_features1);
+		cmn_err(CE_CONT, "?Features2(PM)=0x%x",
+		    hyperv_pm_features & ~CPUPM_HV_CSTATE_MASK);
+		cmn_err(CE_CONT, "?Features3=0x%x", hyperv_features3);
+	}
 
 	do_cpuid(CPUID_LEAF_HV_RECOMMENDS, regs);
 	hyperv_recommends = regs[0];

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -419,7 +419,7 @@ vmbus_scan(struct vmbus_softc *sc)
 	 * for channel offer and rescind messages.
 	 */
 	sc->vmbus_devtq = ddi_taskq_create(sc->vmbus_dev,
-	    "vmbus dev", 1, maxclsyspri, TASKQ_PREPOPULATE);
+	    "vmbus_dev", 1, maxclsyspri, 0);
 
 	/*
 	 * This taskqueue handles sub-channel detach, so that vmbus
@@ -427,7 +427,7 @@ vmbus_scan(struct vmbus_softc *sc)
 	 * channels.
 	 */
 	sc->vmbus_subchtq = ddi_taskq_create(sc->vmbus_dev,
-	    "vmbus subch", 1, maxclsyspri, TASKQ_PREPOPULATE);
+	    "vmbus_subch", 1, maxclsyspri, 0);
 
 	/*
 	 * Start vmbus scanning.
@@ -824,18 +824,18 @@ vmbus_intr_setup(struct vmbus_softc *sc)
 		 * Setup taskq to handle events.  Task will be per-
 		 * channel.
 		 */
-		(void) snprintf(tq_name, sizeof (tq_name), "hyperv event[%d]",
+		(void) snprintf(tq_name, sizeof (tq_name), "hyperv_event_%d",
 		    cpu);
 		*VMBUS_PCPU_PTR(sc, event_tq, cpu) = ddi_taskq_create(NULL,
-		    tq_name, 1, maxclsyspri, TASKQ_PREPOPULATE);
+		    tq_name, 1, maxclsyspri, 0);
 
 		/*
 		 * Setup tasks and taskq to handle messages.
 		 */
-		(void) snprintf(tq_name, sizeof (tq_name), "hyperv msg[%d]",
+		(void) snprintf(tq_name, sizeof (tq_name), "hyperv_msg_%d",
 		    cpu);
 		*VMBUS_PCPU_PTR(sc, message_tq, cpu) = ddi_taskq_create(NULL,
-		    tq_name, 1, maxclsyspri, TASKQ_PREPOPULATE);
+		    tq_name, 1, maxclsyspri, 0);
 	}
 
 	sc->vmbus_idtvec = psm_get_ipivect(IPL_VMBUS, -1);

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -329,7 +329,7 @@ vmbus_init(struct vmbus_softc *sc)
 			(void) snprintf(version, sizeof (version),
 			    "%u.%u", VMBUS_VERSION_MAJOR(sc->vmbus_version),
 			    VMBUS_VERSION_MINOR(sc->vmbus_version));
-			dev_err(sc->vmbus_dev, CE_NOTE, "version %s",
+			dev_err(sc->vmbus_dev, CE_CONT, "?version %s",
 			    version);
 			(void) ddi_prop_update_string(DDI_DEV_T_NONE,
 			    sc->vmbus_dev, VMBUS_VERSION, version);

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -1005,7 +1005,6 @@ vmbus_delete_child(struct vmbus_channel *chan)
 			mutex_exit(&vmbus_lock);
 			return (DDI_FAILURE);
 		}
-		(void) ndi_devi_free(chan->ch_dev);
 		chan->ch_dev = NULL;
 	}
 	mutex_exit(&vmbus_lock);


### PR DESCRIPTION
These fix a number of crash bugs in the new hyperv drivers.
With these fixes, installing OmniOS on a HyperV first generation machine works well, using the PV drivers for disk and network interface.
Running as a guest with a single CPU is still not supported, but at least it no longer causes a system panic.
Second generation HyperV machines will require more work.