### PR TITLE
Upstream merge joyent_merge/2019032801

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 52767bdcffaf8c9d0a1cbfac8fa46b8506ee88cd
+Last illumos-joyent commit: 6cf64ca03e24fc61dedf0e3705acd6716ce4145a
 

--- a/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
+++ b/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
@@ -82,6 +82,7 @@
  */
 
 #include <sys/note.h>
+#include <sys/debug.h>
 #include <sys/scsi/scsi.h>
 #include <sys/pci.h>
 #include <sys/disp.h>
@@ -10844,22 +10845,19 @@ static void
 ahci_em_quiesce(ahci_ctl_t *ahci_ctlp)
 {
 	ASSERT(ahci_ctlp->ahcictl_em_flags & AHCI_EM_PRESENT);
+	VERIFY(mutex_owned(&ahci_ctlp->ahcictl_mutex));
 
-	mutex_enter(&ahci_ctlp->ahcictl_mutex);
 	ahci_ctlp->ahcictl_em_flags |= AHCI_EM_QUIESCE;
-	mutex_exit(&ahci_ctlp->ahcictl_mutex);
-
 	ddi_taskq_wait(ahci_ctlp->ahcictl_em_taskq);
 }
 
 static void
 ahci_em_suspend(ahci_ctl_t *ahci_ctlp)
 {
-	ahci_em_quiesce(ahci_ctlp);
+	VERIFY(mutex_owned(&ahci_ctlp->ahcictl_mutex));
 
-	mutex_enter(&ahci_ctlp->ahcictl_mutex);
+	ahci_em_quiesce(ahci_ctlp);
 	ahci_ctlp->ahcictl_em_flags &= ~AHCI_EM_READY;
-	mutex_exit(&ahci_ctlp->ahcictl_mutex);
 }
 
 static void
@@ -10880,7 +10878,10 @@ ahci_em_fini(ahci_ctl_t *ahci_ctlp)
 		return;
 	}
 
+	mutex_enter(&ahci_ctlp->ahcictl_mutex);
 	ahci_em_quiesce(ahci_ctlp);
+	mutex_exit(&ahci_ctlp->ahcictl_mutex);
+
 	ddi_taskq_destroy(ahci_ctlp->ahcictl_em_taskq);
 	ahci_ctlp->ahcictl_em_taskq = NULL;
 }


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019032801

## Backports

None

## mail_msg

```

==== Nightly distributed build started:   Thu Mar 28 19:31:58 UTC 2019 ====
==== Nightly distributed build completed: Thu Mar 28 20:23:22 UTC 2019 ====

==== Total build time ====

real    0:51:24

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-fa6e4ea903 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151029-20190219"

/usr/bin/openssl
OpenSSL 1.1.1b  26 Feb 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1758 (illumos)

Build project:  default
Build taskid:   98

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019032801-43e68f61b0

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    20:54.3
user  3:07:16.4
sys     57:24.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:32.8
user  2:31:48.4
sys     46:10.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
