### PR TITLE
Add state change hooks for lx zones

### DIFF
--- a/usr/src/lib/brand/lx/zone/config.xml
+++ b/usr/src/lib/brand/lx/zone/config.xml
@@ -45,6 +45,8 @@
 	<verify_adm></verify_adm>
 	<postclone></postclone>
 	<postinstall></postinstall>
+	<prestatechange>/usr/lib/brand/lx/prestate %z %R</prestatechange>
+	<poststatechange>/usr/lib/brand/lx/poststate %z %R</poststatechange>
 
 	<privilege set="default" name="contract_event" />
 	<privilege set="default" name="contract_identity" />


### PR DESCRIPTION
We're missing these hooks for the lx brand
(SmartOS has them, see https://github.com/joyent/smartos-live/blob/master/overlay/generic/usr/lib/brand/lx/config.xml#L49 )