### PR TITLE
Upstream merge/2019040401

### DIFF
--- a/exception_lists/packaging
+++ b/exception_lists/packaging
@@ -658,8 +658,8 @@ usr/lib/mdb/proc/libfknsmb.so
 usr/lib/mdb/proc/libfksmbfs.so
 usr/lib/mdb/proc/amd64/libfknsmb.so	i386
 usr/lib/mdb/proc/amd64/libfksmbfs.so	i386
-usr/lib/mdb/proc/sparc/libfknsmb.so	sparc
-usr/lib/mdb/proc/sparc/libfksmbfs.so	sparc
+usr/lib/mdb/proc/sparcv9/libfknsmb.so	sparc
+usr/lib/mdb/proc/sparcv9/libfksmbfs.so	sparc
 usr/lib/smbfs/amd64			i386
 usr/lib/smbfs/sparcv9			sparc
 usr/lib/smbfs/fksmbcl

--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2019.03.07.2
+BOOT_VERSION = $(LOADER_VERSION)-2019.03.30.1

--- a/usr/src/boot/sys/boot/common/bootstrap.h
+++ b/usr/src/boot/sys/boot/common/bootstrap.h
@@ -116,6 +116,8 @@ struct console
 	/* return nonzero if input is waiting */
 	int		(*c_ready)(struct console *);
 	int		(*c_ioctl)(struct console *, int, void *);
+	/* Print device info */
+	void		(*c_devinfo)(struct console *);
 	void		*c_private;	/* private data */
 };
 extern struct console	*consoles[];

--- a/usr/src/boot/sys/boot/common/console.c
+++ b/usr/src/boot/sys/boot/common/console.c
@@ -221,7 +221,12 @@ cons_check(const char *string)
 				printf("console %s is invalid!\n", curpos);
 				failed++;
 			} else {
-				found++;
+				if ((consoles[cons]->c_flags &
+				    (C_PRESENTIN | C_PRESENTOUT)) !=
+				    (C_PRESENTIN | C_PRESENTOUT)) {
+					failed++;
+				} else
+					found++;
 			}
 		}
 	}
@@ -233,12 +238,17 @@ cons_check(const char *string)
 
 	if (found == 0 || failed != 0) {
 		printf("Available consoles:\n");
-		for (cons = 0; consoles[cons] != NULL; cons++)
-			printf("    %s\n", consoles[cons]->c_name);
+		for (cons = 0; consoles[cons] != NULL; cons++) {
+			printf("    %s", consoles[cons]->c_name);
+			if (consoles[cons]->c_devinfo != NULL)
+				consoles[cons]->c_devinfo(consoles[cons]);
+			printf("\n");
+		}
 	}
 
 	return (found);
 }
+
 
 /*
  * Activate all the valid consoles listed in *string and disable all others.
@@ -266,8 +276,8 @@ cons_change(const char *string)
 			consoles[cons]->c_flags |= C_ACTIVEIN | C_ACTIVEOUT;
 			consoles[cons]->c_init(consoles[cons], 0);
 			if ((consoles[cons]->c_flags &
-			    (C_PRESENTIN | C_PRESENTOUT)) ==
-			    (C_PRESENTIN | C_PRESENTOUT)) {
+			    (C_ACTIVEIN | C_ACTIVEOUT)) ==
+			    (C_ACTIVEIN | C_ACTIVEOUT)) {
 				active++;
 				continue;
 			}
@@ -293,8 +303,8 @@ cons_change(const char *string)
 			consoles[cons]->c_flags |= C_ACTIVEIN | C_ACTIVEOUT;
 			consoles[cons]->c_init(consoles[cons], 0);
 			if ((consoles[cons]->c_flags &
-			    (C_PRESENTIN | C_PRESENTOUT)) ==
-			    (C_PRESENTIN | C_PRESENTOUT))
+			    (C_ACTIVEIN | C_ACTIVEOUT)) ==
+			    (C_ACTIVEIN | C_ACTIVEOUT))
 				active++;
 	}
 
@@ -326,6 +336,26 @@ twiddle_set(struct env_var *ev, int flags, const void *value)
 	}
 	twiddle_divisor((uint_t)tdiv);
 	env_setenv(ev->ev_name, flags | EV_NOHOOK, value, NULL, NULL);
+
+	return (CMD_OK);
+}
+
+COMMAND_SET(console, "console", "console info", command_console);
+
+static int
+command_console(int argc, char *argv[])
+{
+	if (argc > 1)
+		printf("%s: list info about available consoles\n", argv[0]);
+
+	printf("Current console: %s\n", getenv("console"));
+	printf("Available consoles:\n");
+	for (int cons = 0; consoles[cons] != NULL; cons++) {
+		printf("    %s", consoles[cons]->c_name);
+		if (consoles[cons]->c_devinfo != NULL)
+			consoles[cons]->c_devinfo(consoles[cons]);
+		printf("\n");
+	}
 
 	return (CMD_OK);
 }

--- a/usr/src/boot/sys/boot/common/help.common
+++ b/usr/src/boot/sys/boot/common/help.common
@@ -57,6 +57,14 @@
 	Displays statistics about disk cache usage.  For debugging only.
 
 ################################################################################
+# Tconsole DOutput information about console devices
+
+	console
+
+	Display the currently active console device(s) and show
+	information about available console devices.
+
+################################################################################
 # Tchain DChain load disk block
 
 	chain disk:

--- a/usr/src/boot/sys/boot/efi/loader/comconsole.c
+++ b/usr/src/boot/sys/boot/efi/loader/comconsole.c
@@ -62,6 +62,7 @@ static void	comc_putchar(struct console *, int);
 static int	comc_getchar(struct console *);
 static int	comc_ischar(struct console *);
 static int	comc_ioctl(struct console *, int, void *);
+static void	comc_devinfo(struct console *);
 static bool	comc_setup(struct console *);
 static char	*comc_asprint_mode(struct serial *);
 static int	comc_parse_mode(struct serial *, const char *);
@@ -79,6 +80,7 @@ struct console ttya = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -92,6 +94,7 @@ struct console ttyb = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -105,6 +108,7 @@ struct console ttyc = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -118,6 +122,7 @@ struct console ttyd = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -381,6 +386,32 @@ static int
 comc_ioctl(struct console *cp __unused, int cmd __unused, void *data __unused)
 {
 	return (ENOTTY);
+}
+
+static void
+comc_devinfo(struct console *cp)
+{
+	struct serial *port = cp->c_private;
+	EFI_HANDLE handle;
+	EFI_DEVICE_PATH *dp;
+	CHAR16 *text;
+
+	handle = efi_serial_get_handle(port->ioaddr);
+	if (handle == NULL) {
+		printf("\tdevice is not present");
+		return;
+	}
+
+	dp = efi_lookup_devpath(handle);
+	if (dp == NULL)
+		return;
+
+	text = efi_devpath_name(dp);
+	if (text == NULL)
+		return;
+
+	printf("\t%S", text);
+	efi_free_devpath_name(text);
 }
 
 static char *

--- a/usr/src/boot/sys/boot/efi/loader/framebuffer.c
+++ b/usr/src/boot/sys/boot/efi/loader/framebuffer.c
@@ -44,9 +44,9 @@
 #include "gfx_fb.h"
 #include "framebuffer.h"
 
-static EFI_GUID gop_guid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
+EFI_GUID gop_guid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
 static EFI_GUID pciio_guid = EFI_PCI_IO_PROTOCOL_GUID;
-static EFI_GUID uga_guid = EFI_UGA_DRAW_PROTOCOL_GUID;
+EFI_GUID uga_guid = EFI_UGA_DRAW_PROTOCOL_GUID;
 static EFI_GUID active_edid_guid = EFI_EDID_ACTIVE_PROTOCOL_GUID;
 static EFI_GUID discovered_edid_guid = EFI_EDID_DISCOVERED_PROTOCOL_GUID;
 

--- a/usr/src/boot/sys/boot/i386/libi386/comconsole.c
+++ b/usr/src/boot/sys/boot/i386/libi386/comconsole.c
@@ -84,6 +84,7 @@ static int	comc_parse_mode(struct serial *, const char *);
 static int	comc_mode_set(struct env_var *, int, const void *);
 static int	comc_cd_set(struct env_var *, int, const void *);
 static int	comc_rtsdtr_set(struct env_var *, int, const void *);
+static void	comc_devinfo(struct console *);
 
 struct console ttya = {
 	.c_name = "ttya",
@@ -95,6 +96,7 @@ struct console ttya = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -108,6 +110,7 @@ struct console ttyb = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -121,6 +124,7 @@ struct console ttyc = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
 
@@ -134,8 +138,20 @@ struct console ttyd = {
 	.c_in = comc_getchar,
 	.c_ready = comc_ischar,
 	.c_ioctl = comc_ioctl,
+	.c_devinfo = comc_devinfo,
 	.c_private = NULL
 };
+
+static void
+comc_devinfo(struct console *cp)
+{
+	struct serial *port = cp->c_private;
+
+	if (cp->c_flags != 0)
+		printf("\tport %#x", port->ioaddr);
+	else
+		printf("\tdevice is not present");
+}
 
 static void
 comc_probe(struct console *cp)

--- a/usr/src/boot/sys/boot/i386/libi386/nullconsole.c
+++ b/usr/src/boot/sys/boot/i386/libi386/nullconsole.c
@@ -45,6 +45,7 @@ static int	nullc_init(struct console *, int arg);
 static void	nullc_putchar(struct console *, int c);
 static int	nullc_getchar(struct console *);
 static int	nullc_ischar(struct console *);
+static void	nullc_devinfo(struct console *);
 
 struct console nullconsole = {
 	.c_name = "null",
@@ -56,8 +57,15 @@ struct console nullconsole = {
 	.c_in = nullc_getchar,
 	.c_ready = nullc_ischar,
 	.c_ioctl = NULL,
+	.c_devinfo = nullc_devinfo,
 	.c_private = NULL
 };
+
+static void
+nullc_devinfo(struct console *cp __unused)
+{
+	printf("\tsoftware device");
+}
 
 static void
 nullc_probe(struct console *cp)

--- a/usr/src/boot/sys/boot/i386/libi386/spinconsole.c
+++ b/usr/src/boot/sys/boot/i386/libi386/spinconsole.c
@@ -46,6 +46,7 @@ static int	spinc_init(struct console *cp, int arg);
 static void	spinc_putchar(struct console *cp, int c);
 static int	spinc_getchar(struct console *cp);
 static int	spinc_ischar(struct console *cp);
+static void	spinc_devinfo(struct console *cp);
 
 struct console spinconsole = {
 	.c_name = "spin",
@@ -57,8 +58,15 @@ struct console spinconsole = {
 	.c_in = spinc_getchar,
 	.c_ready = spinc_ischar,
 	.c_ioctl = NULL,
+	.c_devinfo = spinc_devinfo,
 	.c_private = NULL
 };
+
+static void
+spinc_devinfo(struct console *cp __unused)
+{
+	printf("\tsoftware device");
+}
 
 static void
 spinc_probe(struct console *cp)

--- a/usr/src/boot/sys/boot/i386/libi386/vidconsole.c
+++ b/usr/src/boot/sys/boot/i386/libi386/vidconsole.c
@@ -55,6 +55,7 @@ static int	vidc_getchar(struct console *cp);
 static int	vidc_ischar(struct console *cp);
 static int	vidc_ioctl(struct console *cp, int cmd, void *data);
 static void	vidc_biosputchar(int c);
+static void	vidc_devinfo(struct console *cp);
 
 static int vidc_vbe_devinit(struct vis_devinit *);
 static void vidc_cons_cursor(struct vis_conscursor *);
@@ -92,6 +93,7 @@ struct console text = {
 	.c_in = vidc_getchar,
 	.c_ready = vidc_ischar,
 	.c_ioctl = vidc_ioctl,
+	.c_devinfo = vidc_devinfo,
 	.c_private = NULL
 };
 
@@ -781,6 +783,20 @@ vidc_ischar(struct console *cp __unused)
 	v86.eax = 0x100;
 	v86int();
 	return (!V86_ZR(v86.efl));
+}
+
+static void
+vidc_devinfo(struct console *cp __unused)
+{
+	if (plat_stdout_is_framebuffer()) {
+		printf("\tVESA %ux%ux%u framebuffer mode %#x",
+		    gfx_fb.framebuffer_common.framebuffer_width,
+		    gfx_fb.framebuffer_common.framebuffer_height,
+		    gfx_fb.framebuffer_common.framebuffer_bpp,
+		    vbe_get_mode());
+	} else {
+		printf("\tVGA %ux%u text mode", TEXT_COLS, TEXT_ROWS);
+	}
 }
 
 #if KEYBOARD_PROBE

--- a/usr/src/cmd/mdb/sparc/v7/libfknsmb/Makefile
+++ b/usr/src/cmd/mdb/sparc/v7/libfknsmb/Makefile
@@ -1,0 +1,48 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+#
+
+MODULE = libfknsmb.so
+MDBTGT = proc
+
+MODSRCS = nsmb.c
+
+include ../../../../Makefile.cmd
+include ../../Makefile.sparcv7
+include ../../../Makefile.module
+
+MODSRCS_DIR = ../../../common/modules/nsmb
+
+# Note: need our sys includes _before_ ENVCPPFLAGS, proto etc.
+CPPFLAGS.first += -I$(SRC)/lib/smbclnt/libfknsmb/common
+CPPFLAGS.first += -I$(SRC)/lib/libfakekernel/common
+
+CPPFLAGS += -I$(SRC)/uts/common/fs/smbclnt/
+CPPFLAGS += -I$(SRC)/uts/common
+CPPFLAGS += -D_FAKE_KERNEL
+
+CSTD=		$(CSTD_GNU99)

--- a/usr/src/cmd/mdb/sparc/v7/libfksmbfs/Makefile
+++ b/usr/src/cmd/mdb/sparc/v7/libfksmbfs/Makefile
@@ -1,0 +1,55 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+#
+
+MODULE = libfksmbfs.so
+MDBTGT = proc
+
+MODSRCS = smbfs.c avl.c
+
+include ../../../../Makefile.cmd
+include ../../Makefile.sparcv7
+include ../../../Makefile.module
+
+MODSRCS_DIR = ../../../common/modules/smbfs
+GENUNIX_DIR = ../../../common/modules/genunix
+
+# Note: need our sys includes _before_ ENVCPPFLAGS, proto etc.
+CPPFLAGS.first += -I$(SRC)/lib/smbsrv/libfksmbsrv/common
+CPPFLAGS.first += -I$(SRC)/lib/libfakekernel/common
+
+CPPFLAGS += -I$(SRC)/uts/common/fs/smbclnt/
+CPPFLAGS += -I$(SRC)/uts/common
+
+CSTD=		$(CSTD_GNU99)
+
+dmod/%.o: $(GENUNIX_DIR)/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+dmod/%.ln: $(GENUNIX_DIR)/%.c
+	$(LINT.c) -c $<

--- a/usr/src/cmd/mdb/sparc/v9/libfknsmb/Makefile
+++ b/usr/src/cmd/mdb/sparc/v9/libfknsmb/Makefile
@@ -1,0 +1,49 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+#
+
+MODULE = libfknsmb.so
+MDBTGT = proc
+
+MODSRCS = nsmb.c
+
+include ../../../../Makefile.cmd
+include ../../../../Makefile.cmd.64
+include ../../Makefile.sparcv9
+include ../../../Makefile.module
+
+MODSRCS_DIR = ../../../common/modules/nsmb
+
+# Note: need our sys includes _before_ ENVCPPFLAGS, proto etc.
+CPPFLAGS.first += -I$(SRC)/lib/smbclnt/libfknsmb/common
+CPPFLAGS.first += -I$(SRC)/lib/libfakekernel/common
+
+CPPFLAGS += -I$(SRC)/uts/common/fs/smbclnt/
+CPPFLAGS += -I$(SRC)/uts/common
+CPPFLAGS += -D_FAKE_KERNEL
+
+CSTD=		$(CSTD_GNU99)

--- a/usr/src/cmd/mdb/sparc/v9/libfksmbfs/Makefile
+++ b/usr/src/cmd/mdb/sparc/v9/libfksmbfs/Makefile
@@ -1,0 +1,56 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+#
+
+MODULE = libfksmbfs.so
+MDBTGT = proc
+
+MODSRCS = smbfs.c avl.c
+
+include ../../../../Makefile.cmd
+include ../../../../Makefile.cmd.64
+include ../../Makefile.sparcv9
+include ../../../Makefile.module
+
+MODSRCS_DIR = ../../../common/modules/smbfs
+GENUNIX_DIR = ../../../common/modules/genunix
+
+# Note: need our sys includes _before_ ENVCPPFLAGS, proto etc.
+CPPFLAGS.first += -I$(SRC)/lib/smbsrv/libfksmbsrv/common
+CPPFLAGS.first += -I$(SRC)/lib/libfakekernel/common
+
+CPPFLAGS += -I$(SRC)/uts/common/fs/smbclnt/
+CPPFLAGS += -I$(SRC)/uts/common
+
+CSTD=		$(CSTD_GNU99)
+
+dmod/%.o: $(GENUNIX_DIR)/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+dmod/%.ln: $(GENUNIX_DIR)/%.c
+	$(LINT.c) -c $<

--- a/usr/src/cmd/picl/plugins/common/devtree/picldevtree.c
+++ b/usr/src/cmd/picl/plugins/common/devtree/picldevtree.c
@@ -24,6 +24,10 @@
  */
 
 /*
+ * Copyright (c) 2018, Joyent, Inc.
+ */
+
+/*
  * PICL plug-in that creates device tree nodes for all platforms
  */
 
@@ -1770,7 +1774,7 @@ static int
 is_snapshot_stale(di_node_t root)
 {
 	snapshot_stale = 0;
-	di_walk_node(root, DI_WALK_CLDFIRST, NULL, check_stale_node);
+	(void) di_walk_node(root, DI_WALK_CLDFIRST, NULL, check_stale_node);
 	return (snapshot_stale);
 }
 
@@ -2546,8 +2550,8 @@ get_asr_export_list(char **exportlist, int *exportlistlen)
 		return (0);
 	}
 	(void) memcpy(*exportlist, opp->oprom_array, opp->oprom_size);
-	free(opp);
 	*exportlistlen = opp->oprom_size;
+	free(opp);
 	(void) close(d);
 	return (1);
 }

--- a/usr/src/cmd/picl/plugins/common/memcfg/piclmemcfg_comm.c
+++ b/usr/src/cmd/picl/plugins/common/memcfg/piclmemcfg_comm.c
@@ -21,6 +21,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 /*
@@ -422,9 +424,9 @@ create_logical_tree(picl_nodehdl_t memh, int fd)
 		/*
 		 * Add property, Size to memory-segment node
 		 */
-		if ((ptree_init_propinfo(&propinfo, PTREE_PROPINFO_VERSION,
+		err = ptree_init_propinfo(&propinfo, PTREE_PROPINFO_VERSION,
 		    PICL_PTYPE_UNSIGNED_INT, PICL_READ, sizeof (mcseg->size),
-		    PICL_PROP_SIZE, NULL, NULL)) != PICL_SUCCESS)
+		    PICL_PROP_SIZE, NULL, NULL);
 		if (err != PICL_SUCCESS)
 			break;
 

--- a/usr/src/cmd/zdb/Makefile.com
+++ b/usr/src/cmd/zdb/Makefile.com
@@ -52,7 +52,6 @@ CPPFLAGS += -D_LARGEFILE64_SOURCE=1 -D_REENTRANT $(INCS) -DDEBUG
 # in Makefile.master
 CERRWARN += -_gcc=-Wmissing-braces
 CERRWARN += -_gcc=-Wsign-compare
-CERRWARN += -_gcc=-Wmissing-field-initializers
 
 SMOFF += 64bit_shift,all_func_returns
 

--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2017 Nexenta Systems, Inc.
+ * Copyright (c) 2017, 2018 Lawrence Livermore National Security, LLC.
  * Copyright 2017 RackTop Systems.
  */
 
@@ -2411,6 +2412,13 @@ dump_uberblock(uberblock_t *ub, const char *header, const char *footer)
 	(void) printf("\tguid_sum = %llu\n", (u_longlong_t)ub->ub_guid_sum);
 	(void) printf("\ttimestamp = %llu UTC = %s",
 	    (u_longlong_t)ub->ub_timestamp, asctime(localtime(&timestamp)));
+
+	(void) printf("\tmmp_magic = %016llx\n",
+	    (u_longlong_t)ub->ub_mmp_magic);
+	if (ub->ub_mmp_magic == MMP_MAGIC)
+		(void) printf("\tmmp_delay = %0llu\n",
+		    (u_longlong_t)ub->ub_mmp_delay);
+
 	if (dump_opt['u'] >= 3) {
 		char blkbuf[BP_SPRINTF_LEN];
 		snprintf_blkptr(blkbuf, sizeof (blkbuf), &ub->ub_rootbp);
@@ -2509,6 +2517,12 @@ dump_label_uberblocks(vdev_label_t *lbl, uint64_t ashift)
 
 		if (uberblock_verify(ub))
 			continue;
+
+		if ((dump_opt['u'] < 4) &&
+		    (ub->ub_mmp_magic == MMP_MAGIC) && ub->ub_mmp_delay &&
+		    (i >= VDEV_UBERBLOCK_COUNT(&vd) - MMP_BLOCKS_PER_LABEL))
+			continue;
+
 		(void) snprintf(header, ZDB_MAX_UB_HEADER_SIZE,
 		    "Uberblock[%d]\n", i);
 		dump_uberblock(ub, header, "");
@@ -4144,6 +4158,22 @@ verify_device_removal_feature_counts(spa_t *spa)
 	return (ret);
 }
 
+static void
+zdb_set_skip_mmp(char *target)
+{
+	spa_t *spa;
+
+	/*
+	 * Disable the activity check to allow examination of
+	 * active pools.
+	 */
+	mutex_enter(&spa_namespace_lock);
+	if ((spa = spa_lookup(target)) != NULL) {
+		spa->spa_import_flags |= ZFS_IMPORT_SKIP_MMP;
+	}
+	mutex_exit(&spa_namespace_lock);
+}
+
 #define	BOGUS_SUFFIX "_CHECKPOINTED_UNIVERSE"
 /*
  * Import the checkpointed state of the pool specified by the target
@@ -4178,6 +4208,7 @@ import_checkpointed_state(char *target, nvlist_t *cfg, char **new_path)
 	}
 
 	if (cfg == NULL) {
+		zdb_set_skip_mmp(poolname);
 		error = spa_get_stats(poolname, &cfg, NULL, 0);
 		if (error != 0) {
 			fatal("Tried to read config of pool \"%s\" but "
@@ -4190,7 +4221,8 @@ import_checkpointed_state(char *target, nvlist_t *cfg, char **new_path)
 	fnvlist_add_string(cfg, ZPOOL_CONFIG_POOL_NAME, bogus_name);
 
 	error = spa_import(bogus_name, cfg, NULL,
-	    ZFS_IMPORT_MISSING_LOG | ZFS_IMPORT_CHECKPOINT);
+	    ZFS_IMPORT_MISSING_LOG | ZFS_IMPORT_CHECKPOINT |
+	    ZFS_IMPORT_SKIP_MMP);
 	if (error != 0) {
 		fatal("Tried to import pool \"%s\" but spa_import() failed "
 		    "with error %d\n", bogus_name, error);
@@ -5190,90 +5222,6 @@ zdb_embedded_block(char *thing)
 	free(buf);
 }
 
-static boolean_t
-pool_match(nvlist_t *cfg, char *tgt)
-{
-	uint64_t v, guid = strtoull(tgt, NULL, 0);
-	char *s;
-
-	if (guid != 0) {
-		if (nvlist_lookup_uint64(cfg, ZPOOL_CONFIG_POOL_GUID, &v) == 0)
-			return (v == guid);
-	} else {
-		if (nvlist_lookup_string(cfg, ZPOOL_CONFIG_POOL_NAME, &s) == 0)
-			return (strcmp(s, tgt) == 0);
-	}
-	return (B_FALSE);
-}
-
-static char *
-find_zpool(char **target, nvlist_t **configp, int dirc, char **dirv)
-{
-	nvlist_t *pools;
-	nvlist_t *match = NULL;
-	char *name = NULL;
-	char *sepp = NULL;
-	char sep = '\0';
-	int count = 0;
-	importargs_t args;
-
-	bzero(&args, sizeof (args));
-	args.paths = dirc;
-	args.path = dirv;
-	args.can_be_active = B_TRUE;
-
-	if ((sepp = strpbrk(*target, "/@")) != NULL) {
-		sep = *sepp;
-		*sepp = '\0';
-	}
-
-	pools = zpool_search_import(g_zfs, &args);
-
-	if (pools != NULL) {
-		nvpair_t *elem = NULL;
-		while ((elem = nvlist_next_nvpair(pools, elem)) != NULL) {
-			verify(nvpair_value_nvlist(elem, configp) == 0);
-			if (pool_match(*configp, *target)) {
-				count++;
-				if (match != NULL) {
-					/* print previously found config */
-					if (name != NULL) {
-						(void) printf("%s\n", name);
-						dump_nvlist(match, 8);
-						name = NULL;
-					}
-					(void) printf("%s\n",
-					    nvpair_name(elem));
-					dump_nvlist(*configp, 8);
-				} else {
-					match = *configp;
-					name = nvpair_name(elem);
-				}
-			}
-		}
-	}
-	if (count > 1)
-		(void) fatal("\tMatched %d pools - use pool GUID "
-		    "instead of pool name or \n"
-		    "\tpool name part of a dataset name to select pool", count);
-
-	if (sepp)
-		*sepp = sep;
-	/*
-	 * If pool GUID was specified for pool id, replace it with pool name
-	 */
-	if (name && (strstr(*target, name) != *target)) {
-		int sz = 1 + strlen(name) + ((sepp) ? strlen(sepp) : 0);
-
-		*target = umem_alloc(sz, UMEM_NOFAIL);
-		(void) snprintf(*target, sz, "%s%s", name, sepp ? sepp : "");
-	}
-
-	*configp = name ? match : NULL;
-
-	return (name);
-}
-
 int
 main(int argc, char **argv)
 {
@@ -5286,7 +5234,7 @@ main(int argc, char **argv)
 	int error = 0;
 	char **searchdirs = NULL;
 	int nsearch = 0;
-	char *target;
+	char *target, *target_pool;
 	nvlist_t *policy = NULL;
 	uint64_t max_txg = UINT64_MAX;
 	int flags = ZFS_IMPORT_MISSING_LOG;
@@ -5493,22 +5441,48 @@ main(int argc, char **argv)
 	error = 0;
 	target = argv[0];
 
-	if (dump_opt['e']) {
-		char *name = find_zpool(&target, &cfg, nsearch, searchdirs);
+	if (strpbrk(target, "/@") != NULL) {
+		size_t targetlen;
 
-		error = ENOENT;
-		if (name) {
-			if (dump_opt['C'] > 1) {
-				(void) printf("\nConfiguration for import:\n");
-				dump_nvlist(cfg, 8);
-			}
+		target_pool = strdup(target);
+		*strpbrk(target_pool, "/@") = '\0';
+
+		target_is_spa = B_FALSE;
+		targetlen = strlen(target);
+		if (targetlen && target[targetlen - 1] == '/')
+			target[targetlen - 1] = '\0';
+	} else {
+		target_pool = target;
+	}
+
+	if (dump_opt['e']) {
+		importargs_t args = { 0 };
+
+		args.paths = nsearch;
+		args.path = searchdirs;
+		args.can_be_active = B_TRUE;
+
+		error = zpool_tryimport(g_zfs, target_pool, &cfg, &args);
+
+		if (error == 0) {
 
 			if (nvlist_add_nvlist(cfg,
 			    ZPOOL_LOAD_POLICY, policy) != 0) {
 				fatal("can't open '%s': %s",
 				    target, strerror(ENOMEM));
 			}
-			error = spa_import(name, cfg, NULL, flags);
+
+			if (dump_opt['C'] > 1) {
+				(void) printf("\nConfiguration for import:\n");
+				dump_nvlist(cfg, 8);
+			}
+
+			/*
+			 * Disable the activity check to allow examination of
+			 * active pools.
+			 */
+			error = spa_import(target_pool, cfg, NULL,
+			    flags | ZFS_IMPORT_SKIP_MMP);
 		}
 	}
 
@@ -5521,21 +5495,6 @@ main(int argc, char **argv)
 		if (checkpoint_target != NULL)
 			target = checkpoint_target;
 
-	}
-
-	if (strpbrk(target, "/@") != NULL) {
-		size_t targetlen;
-
-		target_is_spa = B_FALSE;
-		/*
-		 * Remove any trailing slash.  Later code would get confused
-		 * by it, but we want to allow it so that "pool/" can
-		 * indicate that we want to dump the topmost filesystem,
-		 * rather than the whole pool.
-		 */
-		targetlen = strlen(target);
-		if (targetlen != 0 && target[targetlen - 1] == '/')
-			target[targetlen - 1] = '\0';
 	}
 
 	if (error == 0) {
@@ -5551,6 +5510,7 @@ main(int argc, char **argv)
 			}
 
 		} else if (target_is_spa || dump_opt['R']) {
+			zdb_set_skip_mmp(target);
 			error = spa_open_rewind(target, &spa, FTAG, policy,
 			    NULL);
 			if (error) {
@@ -5573,6 +5533,7 @@ main(int argc, char **argv)
 				}
 			}
 		} else {
+			zdb_set_skip_mmp(target);
 			error = open_objset(target, DMU_OST_ANY, FTAG, &os);
 		}
 	}

--- a/usr/src/cmd/zhack/zhack.c
+++ b/usr/src/cmd/zhack/zhack.c
@@ -121,16 +121,11 @@ space_delta_cb(dmu_object_type_t bonustype, void *data,
  * Target is the dataset whose pool we want to open.
  */
 static void
-import_pool(const char *target, boolean_t readonly)
+zhack_import(char *target, boolean_t readonly)
 {
 	nvlist_t *config;
-	nvlist_t *pools;
-	int error;
-	char *sepp;
-	spa_t *spa;
-	nvpair_t *elem;
 	nvlist_t *props;
-	const char *name;
+	int error;
 
 	kernel_init(readonly ? FREAD : (FREAD | FWRITE));
 	g_zfs = libzfs_init();
@@ -139,68 +134,40 @@ import_pool(const char *target, boolean_t readonly)
 	dmu_objset_register_type(DMU_OST_ZFS, space_delta_cb);
 
 	g_readonly = readonly;
-
-	/*
-	 * If we only want readonly access, it's OK if we find
-	 * a potentially-active (ie, imported into the kernel) pool from the
-	 * default cachefile.
-	 */
-	if (readonly && spa_open(target, &spa, FTAG) == 0) {
-		spa_close(spa, FTAG);
-		return;
-	}
-
 	g_importargs.unique = B_TRUE;
 	g_importargs.can_be_active = readonly;
 	g_pool = strdup(target);
-	if ((sepp = strpbrk(g_pool, "/@")) != NULL)
-		*sepp = '\0';
-	g_importargs.poolname = g_pool;
-	pools = zpool_search_import(g_zfs, &g_importargs);
 
-	if (nvlist_empty(pools)) {
-		if (!g_importargs.can_be_active) {
-			g_importargs.can_be_active = B_TRUE;
-			if (zpool_search_import(g_zfs, &g_importargs) != NULL ||
-			    spa_open(target, &spa, FTAG) == 0) {
-				fatal(spa, FTAG, "cannot import '%s': pool is "
-				    "active; run " "\"zpool export %s\" "
-				    "first\n", g_pool, g_pool);
-			}
-		}
-
-		fatal(NULL, FTAG, "cannot import '%s': no such pool "
-		    "available\n", g_pool);
-	}
-
-	elem = nvlist_next_nvpair(pools, NULL);
-	name = nvpair_name(elem);
-	verify(nvpair_value_nvlist(elem, &config) == 0);
+	error = zpool_tryimport(g_zfs, target, &config, &g_importargs);
+	if (error)
+		fatal(NULL, FTAG, "cannot import '%s': %s", target,
+		    libzfs_error_description(g_zfs));
 
 	props = NULL;
 	if (readonly) {
-		verify(nvlist_alloc(&props, NV_UNIQUE_NAME, 0) == 0);
-		verify(nvlist_add_uint64(props,
+		VERIFY(nvlist_alloc(&props, NV_UNIQUE_NAME, 0) == 0);
+		VERIFY(nvlist_add_uint64(props,
 		    zpool_prop_to_name(ZPOOL_PROP_READONLY), 1) == 0);
 	}
 
 	zfeature_checks_disable = B_TRUE;
-	error = spa_import(name, config, props, ZFS_IMPORT_NORMAL);
+	error = spa_import(target, config, props,
+	    (readonly ?  ZFS_IMPORT_SKIP_MMP : ZFS_IMPORT_NORMAL));
 	zfeature_checks_disable = B_FALSE;
 	if (error == EEXIST)
 		error = 0;
 
 	if (error)
-		fatal(NULL, FTAG, "can't import '%s': %s", name,
+		fatal(NULL, FTAG, "can't import '%s': %s", target,
 		    strerror(error));
 }
 
 static void
-zhack_spa_open(const char *target, boolean_t readonly, void *tag, spa_t **spa)
+zhack_spa_open(char *target, boolean_t readonly, void *tag, spa_t **spa)
 {
 	int err;
 
-	import_pool(target, readonly);
+	zhack_import(target, readonly);
 
 	zfeature_checks_disable = B_TRUE;
 	err = spa_open(target, spa, tag);

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -50,6 +50,7 @@
 #include <zfs_prop.h>
 #include <sys/fs/zfs.h>
 #include <sys/stat.h>
+#include <sys/debug.h>
 
 #include <libzfs.h>
 
@@ -1615,6 +1616,10 @@ print_status_config(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 			(void) printf(gettext("split into new pool"));
 			break;
 
+		case VDEV_AUX_ACTIVE:
+			(void) printf(gettext("currently in use"));
+			break;
+
 		case VDEV_AUX_CHILDREN_OFFLINE:
 			(void) printf(gettext("all children offline"));
 			break;
@@ -1743,6 +1748,10 @@ print_import_config(const char *name, nvlist_t *nv, int namewidth, int depth)
 			(void) printf(gettext("too many errors"));
 			break;
 
+		case VDEV_AUX_ACTIVE:
+			(void) printf(gettext("currently in use"));
+			break;
+
 		case VDEV_AUX_CHILDREN_OFFLINE:
 			(void) printf(gettext("all children offline"));
 			break;
@@ -1840,8 +1849,10 @@ show_import(nvlist_t *config)
 	vdev_stat_t *vs;
 	char *name;
 	uint64_t guid;
+	uint64_t hostid = 0;
 	char *msgid;
-	nvlist_t *nvroot;
+	char *hostname = "unknown";
+	nvlist_t *nvroot, *nvinfo;
 	int reason;
 	const char *health;
 	uint_t vsc;
@@ -1928,6 +1939,17 @@ show_import(nvlist_t *config)
 		zpool_print_unsup_feat(config);
 		break;
 
+	case ZPOOL_STATUS_HOSTID_ACTIVE:
+		(void) printf(gettext(" status: The pool is currently "
+		    "imported by another system.\n"));
+		break;
+
+	case ZPOOL_STATUS_HOSTID_REQUIRED:
+		(void) printf(gettext(" status: The pool has the "
+		    "multihost property on.  It cannot\n\tbe safely imported "
+		    "when the system hostid is not set.\n"));
+		break;
+
 	case ZPOOL_STATUS_HOSTID_MISMATCH:
 		(void) printf(gettext(" status: The pool was last accessed by "
 		    "another system.\n"));
@@ -2008,6 +2030,27 @@ show_import(nvlist_t *config)
 			    "imported. Attach the missing\n\tdevices and try "
 			    "again.\n"));
 			break;
+		case ZPOOL_STATUS_HOSTID_ACTIVE:
+			VERIFY0(nvlist_lookup_nvlist(config,
+			    ZPOOL_CONFIG_LOAD_INFO, &nvinfo));
+
+			if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_HOSTNAME))
+				hostname = fnvlist_lookup_string(nvinfo,
+				    ZPOOL_CONFIG_MMP_HOSTNAME);
+
+			if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_HOSTID))
+				hostid = fnvlist_lookup_uint64(nvinfo,
+				    ZPOOL_CONFIG_MMP_HOSTID);
+
+			(void) printf(gettext(" action: The pool must be "
+			    "exported from %s (hostid=%lx)\n\tbefore it "
+			    "can be safely imported.\n"), hostname,
+			    (unsigned long) hostid);
+			break;
+		case ZPOOL_STATUS_HOSTID_REQUIRED:
+			(void) printf(gettext(" action: Check the SMF "
+			    "svc:/system/hostid service.\n"));
+			break;
 		default:
 			(void) printf(gettext(" action: The pool cannot be "
 			    "imported due to damaged devices or data.\n"));
@@ -2055,6 +2098,31 @@ show_import(nvlist_t *config)
 	}
 }
 
+static boolean_t
+zfs_force_import_required(nvlist_t *config)
+{
+	uint64_t state;
+	uint64_t hostid = 0;
+	nvlist_t *nvinfo;
+
+	state = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_STATE);
+	(void) nvlist_lookup_uint64(config, ZPOOL_CONFIG_HOSTID, &hostid);
+
+	if (state != POOL_STATE_EXPORTED && hostid != get_system_hostid())
+		return (B_TRUE);
+
+	nvinfo = fnvlist_lookup_nvlist(config, ZPOOL_CONFIG_LOAD_INFO);
+	if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_STATE)) {
+		mmp_state_t mmp_state = fnvlist_lookup_uint64(nvinfo,
+		    ZPOOL_CONFIG_MMP_STATE);
+
+		if (mmp_state != MMP_STATE_INACTIVE)
+			return (B_TRUE);
+	}
+
+	return (B_FALSE);
+}
+
 /*
  * Perform the import for the given configuration.  This passes the heavy
  * lifting off to zpool_import_props(), and then mounts the datasets contained
@@ -2066,53 +2134,73 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 {
 	zpool_handle_t *zhp;
 	char *name;
-	uint64_t state;
 	uint64_t version;
 
-	verify(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
-	    &name) == 0);
+	name = fnvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME);
+	version = fnvlist_lookup_uint64(config, ZPOOL_CONFIG_VERSION);
 
-	verify(nvlist_lookup_uint64(config,
-	    ZPOOL_CONFIG_POOL_STATE, &state) == 0);
-	verify(nvlist_lookup_uint64(config,
-	    ZPOOL_CONFIG_VERSION, &version) == 0);
 	if (!SPA_VERSION_IS_SUPPORTED(version)) {
 		(void) fprintf(stderr, gettext("cannot import '%s': pool "
 		    "is formatted using an unsupported ZFS version\n"), name);
 		return (1);
-	} else if (state != POOL_STATE_EXPORTED &&
+	} else if (zfs_force_import_required(config) &&
 	    !(flags & ZFS_IMPORT_ANY_HOST)) {
-		uint64_t hostid;
+		mmp_state_t mmp_state = MMP_STATE_INACTIVE;
+		nvlist_t *nvinfo;
 
-		if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_HOSTID,
-		    &hostid) == 0) {
-			if ((unsigned long)hostid != gethostid()) {
-				char *hostname;
-				uint64_t timestamp;
-				time_t t;
+		nvinfo = fnvlist_lookup_nvlist(config, ZPOOL_CONFIG_LOAD_INFO);
+		if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_STATE))
+			mmp_state = fnvlist_lookup_uint64(nvinfo,
+			    ZPOOL_CONFIG_MMP_STATE);
 
-				verify(nvlist_lookup_string(config,
-				    ZPOOL_CONFIG_HOSTNAME, &hostname) == 0);
-				verify(nvlist_lookup_uint64(config,
-				    ZPOOL_CONFIG_TIMESTAMP, &timestamp) == 0);
-				t = timestamp;
-				(void) fprintf(stderr, gettext("cannot import "
-				    "'%s': pool may be in use from other "
-				    "system, it was last accessed by %s "
-				    "(hostid: 0x%lx) on %s"), name, hostname,
-				    (unsigned long)hostid,
-				    asctime(localtime(&t)));
-				(void) fprintf(stderr, gettext("use '-f' to "
-				    "import anyway\n"));
-				return (1);
-			}
-		} else {
+		if (mmp_state == MMP_STATE_ACTIVE) {
+			char *hostname = "<unknown>";
+			uint64_t hostid = 0;
+
+			if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_HOSTNAME))
+				hostname = fnvlist_lookup_string(nvinfo,
+				    ZPOOL_CONFIG_MMP_HOSTNAME);
+
+			if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_HOSTID))
+				hostid = fnvlist_lookup_uint64(nvinfo,
+				    ZPOOL_CONFIG_MMP_HOSTID);
+
 			(void) fprintf(stderr, gettext("cannot import '%s': "
-			    "pool may be in use from other system\n"), name);
-			(void) fprintf(stderr, gettext("use '-f' to import "
-			    "anyway\n"));
-			return (1);
+			    "pool is imported on %s (hostid: "
+			    "0x%lx)\nExport the pool on the other system, "
+			    "then run 'zpool import'.\n"),
+			    name, hostname, (unsigned long) hostid);
+		} else if (mmp_state == MMP_STATE_NO_HOSTID) {
+			(void) fprintf(stderr, gettext("Cannot import '%s': "
+			    "pool has the multihost property on and the\n"
+			    "system's hostid is not set.\n"), name);
+		} else {
+			char *hostname = "<unknown>";
+			uint64_t timestamp = 0;
+			uint64_t hostid = 0;
+
+			if (nvlist_exists(config, ZPOOL_CONFIG_HOSTNAME))
+				hostname = fnvlist_lookup_string(config,
+				    ZPOOL_CONFIG_HOSTNAME);
+
+			if (nvlist_exists(config, ZPOOL_CONFIG_TIMESTAMP))
+				timestamp = fnvlist_lookup_uint64(config,
+				    ZPOOL_CONFIG_TIMESTAMP);
+
+			if (nvlist_exists(config, ZPOOL_CONFIG_HOSTID))
+				hostid = fnvlist_lookup_uint64(config,
+				    ZPOOL_CONFIG_HOSTID);
+
+			(void) fprintf(stderr, gettext("cannot import '%s': "
+			    "pool was previously in use from another system.\n"
+			    "Last accessed by %s (hostid=%lx) at %s"
+			    "The pool can be imported, use 'zpool import -f' "
+			    "to import the pool.\n"), name, hostname,
+			    (unsigned long)hostid, ctime((time_t *)&timestamp));
+
 		}
+
+		return (1);
 	}
 
 	if (zpool_import_props(g_zfs, config, newname, props, flags) != 0)
@@ -5050,6 +5138,15 @@ status_callback(zpool_handle_t *zhp, void *data)
 		    "from a backup source.  Manually marking the device\n"
 		    "\trepaired using 'zpool clear' may allow some data "
 		    "to be recovered.\n"));
+		break;
+
+	case ZPOOL_STATUS_IO_FAILURE_MMP:
+		(void) printf(gettext("status: The pool is suspended because "
+		    "multihost writes failed or were delayed;\n\tanother "
+		    "system could import the pool undetected.\n"));
+		(void) printf(gettext("action: Make sure the pool's devices "
+		    "are connected, then reboot your system and\n\timport the "
+		    "pool.\n"));
 		break;
 
 	case ZPOOL_STATUS_IO_FAILURE_WAIT:

--- a/usr/src/cmd/ztest/Makefile.com
+++ b/usr/src/cmd/ztest/Makefile.com
@@ -22,7 +22,7 @@
 # Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2017 RackTop Systems.
-# Copyright (c) 2018, Joyent, Inc.
+# Copyright 2019, Joyent, Inc.
 
 PROG= ztest
 OBJS= $(PROG).o
@@ -36,7 +36,7 @@ INCS += -I../../../uts/common/fs/zfs
 INCS += -I../../../uts/common/fs/zfs/lua
 INCS += -I../../../common/zfs
 
-LDLIBS += -lumem -lzpool -lcmdutils -lm -lnvpair -lfakekernel
+LDLIBS += -lumem -lzpool -lcmdutils -lm -lnvpair -lfakekernel -lzfs
 
 CSTD= $(CSTD_GNU99)
 C99LMODE= -Xc99=%all

--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -126,6 +126,7 @@
 #include <math.h>
 #include <sys/fs/zfs.h>
 #include <libnvpair.h>
+#include <libzfs.h>
 #include <libcmdutils.h>
 
 static int ztest_fd_data = -1;
@@ -164,6 +165,7 @@ typedef struct ztest_shared_opts {
 	uint64_t zo_time;
 	uint64_t zo_maxloops;
 	uint64_t zo_metaslab_force_ganging;
+	int zo_mmp_test;
 } ztest_shared_opts_t;
 
 static const ztest_shared_opts_t ztest_opts_defaults = {
@@ -182,6 +184,7 @@ static const ztest_shared_opts_t ztest_opts_defaults = {
 	.zo_passtime = 60,		/* 60 seconds */
 	.zo_killrate = 70,		/* 70% kill rate */
 	.zo_verbose = 0,
+	.zo_mmp_test = 0,
 	.zo_init = 1,
 	.zo_time = 300,			/* 5 minutes */
 	.zo_maxloops = 50,		/* max loops during spa_freeze() */
@@ -341,6 +344,7 @@ ztest_func_t ztest_spa_create_destroy;
 ztest_func_t ztest_fault_inject;
 ztest_func_t ztest_ddt_repair;
 ztest_func_t ztest_dmu_snapshot_hold;
+ztest_func_t ztest_mmp_enable_disable;
 ztest_func_t ztest_scrub;
 ztest_func_t ztest_dsl_dataset_promote_busy;
 ztest_func_t ztest_vdev_attach_detach;
@@ -386,6 +390,7 @@ ztest_info_t ztest_info[] = {
 	{ ztest_fault_inject,			1,	&zopt_sometimes	},
 	{ ztest_ddt_repair,			1,	&zopt_sometimes	},
 	{ ztest_dmu_snapshot_hold,		1,	&zopt_sometimes	},
+	{ ztest_mmp_enable_disable,		1,	&zopt_sometimes	},
 	{ ztest_reguid,				1,	&zopt_rarely	},
 	{ ztest_scrub,				1,	&zopt_rarely	},
 	{ ztest_spa_upgrade,			1,	&zopt_rarely	},
@@ -599,6 +604,7 @@ usage(boolean_t requested)
 	    "\t[-k kill_percentage (default: %llu%%)]\n"
 	    "\t[-p pool_name (default: %s)]\n"
 	    "\t[-f dir (default: %s)] file directory for vdev files\n"
+	    "\t[-M] Multi-host simulate pool imported on remote host\n"
 	    "\t[-V] verbose (use multiple times for ever more blather)\n"
 	    "\t[-E] use existing pool instead of creating new one\n"
 	    "\t[-T time (default: %llu sec)] total run time\n"
@@ -642,7 +648,7 @@ process_options(int argc, char **argv)
 	bcopy(&ztest_opts_defaults, zo, sizeof (*zo));
 
 	while ((opt = getopt(argc, argv,
-	    "v:s:a:m:r:R:d:t:g:i:k:p:f:VET:P:hF:B:o:")) != EOF) {
+	    "v:s:a:m:r:R:d:t:g:i:k:p:f:MVET:P:hF:B:o:")) != EOF) {
 		value = 0;
 		switch (opt) {
 		case 'v':
@@ -710,6 +716,9 @@ process_options(int argc, char **argv)
 				(void) strlcpy(zo->zo_dir, path,
 				    sizeof (zo->zo_dir));
 			}
+			break;
+		case 'M':
+			zo->zo_mmp_test = 1;
 			break;
 		case 'V':
 			zo->zo_verbose++;
@@ -2478,6 +2487,9 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	spa_t *spa;
 	nvlist_t *nvroot;
 
+	if (zo->zo_mmp_test)
+		return;
+
 	/*
 	 * Attempt to create using a bad file.
 	 */
@@ -2509,6 +2521,56 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	rw_exit(&ztest_name_lock);
 }
 
+/*
+ * Start and then stop the MMP threads to ensure the startup and shutdown code
+ * works properly.  Actual protection and property-related code tested via ZTS.
+ */
+/* ARGSUSED */
+void
+ztest_mmp_enable_disable(ztest_ds_t *zd, uint64_t id)
+{
+	ztest_shared_opts_t *zo = &ztest_opts;
+	spa_t *spa = ztest_spa;
+
+	if (zo->zo_mmp_test)
+		return;
+
+	/*
+	 * Since enabling MMP involves setting a property, it could not be done
+	 * while the pool is suspended.
+	 */
+	if (spa_suspended(spa))
+		return;
+
+	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+	mutex_enter(&spa->spa_props_lock);
+
+	zfs_multihost_fail_intervals = 0;
+
+	if (!spa_multihost(spa)) {
+		spa->spa_multihost = B_TRUE;
+		mmp_thread_start(spa);
+	}
+
+	mutex_exit(&spa->spa_props_lock);
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
+
+	txg_wait_synced(spa_get_dsl(spa), 0);
+	mmp_signal_all_threads();
+	txg_wait_synced(spa_get_dsl(spa), 0);
+
+	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+	mutex_enter(&spa->spa_props_lock);
+
+	if (spa_multihost(spa)) {
+		mmp_thread_stop(spa);
+		spa->spa_multihost = B_FALSE;
+	}
+
+	mutex_exit(&spa->spa_props_lock);
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
+}
+
 /* ARGSUSED */
 void
 ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
@@ -2518,6 +2580,9 @@ ztest_spa_upgrade(ztest_ds_t *zd, uint64_t id)
 	uint64_t version, newversion;
 	nvlist_t *nvroot, *props;
 	char *name;
+
+	if (ztest_opts.zo_mmp_test)
+		return;
 
 	mutex_enter(&ztest_vdev_lock);
 	name = kmem_asprintf("%s_upgrade", ztest_opts.zo_pool);
@@ -2687,6 +2752,9 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	nvlist_t *nvroot;
 	int error;
 
+	if (ztest_opts.zo_mmp_test)
+		return;
+
 	mutex_enter(&ztest_vdev_lock);
 	leaves = MAX(zs->zs_mirrors + zs->zs_splits, 1) * ztest_opts.zo_raidz;
 
@@ -2768,6 +2836,9 @@ ztest_vdev_aux_add_remove(ztest_ds_t *zd, uint64_t id)
 	char *aux;
 	uint64_t guid = 0;
 	int error;
+
+	if (ztest_opts.zo_mmp_test)
+		return;
 
 	if (ztest_random(2) == 0) {
 		sav = &spa->spa_spares;
@@ -2863,6 +2934,9 @@ ztest_split_pool(ztest_ds_t *zd, uint64_t id)
 	nvlist_t *tree, **child, *config, *split, **schild;
 	uint_t c, children, schildren = 0, lastlogid = 0;
 	int error = 0;
+
+	if (ztest_opts.zo_mmp_test)
+		return;
 
 	mutex_enter(&ztest_vdev_lock);
 
@@ -2969,6 +3043,9 @@ ztest_vdev_attach_detach(ztest_ds_t *zd, uint64_t id)
 	int newvd_is_spare = B_FALSE;
 	int oldvd_is_log;
 	int error, expected_error;
+
+	if (ztest_opts.zo_mmp_test)
+		return;
 
 	mutex_enter(&ztest_vdev_lock);
 	leaves = MAX(zs->zs_mirrors, 1) * ztest_opts.zo_raidz;
@@ -5566,6 +5643,9 @@ ztest_reguid(ztest_ds_t *zd, uint64_t id)
 	uint64_t orig, load;
 	int error;
 
+	if (ztest_opts.zo_mmp_test)
+		return;
+
 	orig = spa_guid(spa);
 	load = spa_load_guid(spa);
 
@@ -6250,7 +6330,7 @@ ztest_run(ztest_shared_t *zs)
 	 * Verify that we can export the pool and reimport it under a
 	 * different name.
 	 */
-	if (ztest_random(2) == 0) {
+	if ((ztest_random(2) == 0) && !ztest_opts.zo_mmp_test) {
 		char name[ZFS_MAX_DATASET_NAME_LEN];
 		(void) snprintf(name, sizeof (name), "%s_import",
 		    ztest_opts.zo_pool);
@@ -6399,6 +6479,56 @@ make_random_props()
 }
 
 /*
+ * Import a storage pool with the given name.
+ */
+static void
+ztest_import(ztest_shared_t *zs)
+{
+	libzfs_handle_t *hdl;
+	importargs_t args = { 0 };
+	spa_t *spa;
+	nvlist_t *cfg = NULL;
+	int nsearch = 1;
+	char *searchdirs[nsearch];
+	char *name = ztest_opts.zo_pool;
+	int flags = ZFS_IMPORT_MISSING_LOG;
+	int error;
+
+	mutex_init(&ztest_vdev_lock, NULL, MUTEX_DEFAULT, NULL);
+	rw_init(&ztest_name_lock, NULL, USYNC_THREAD, NULL);
+
+	kernel_init(FREAD | FWRITE);
+	hdl = libzfs_init();
+
+	searchdirs[0] = ztest_opts.zo_dir;
+	args.paths = nsearch;
+	args.path = searchdirs;
+	args.can_be_active = B_FALSE;
+
+	error = zpool_tryimport(hdl, name, &cfg, &args);
+	if (error)
+		(void) fatal(0, "No pools found\n");
+
+	VERIFY0(spa_import(name, cfg, NULL, flags));
+	VERIFY0(spa_open(name, &spa, FTAG));
+	zs->zs_metaslab_sz =
+	    1ULL << spa->spa_root_vdev->vdev_child[0]->vdev_ms_shift;
+	spa_close(spa, FTAG);
+
+	libzfs_fini(hdl);
+	kernel_fini();
+
+	if (!ztest_opts.zo_mmp_test) {
+		ztest_run_zdb(ztest_opts.zo_pool);
+		ztest_freeze();
+		ztest_run_zdb(ztest_opts.zo_pool);
+	}
+
+	rw_destroy(&ztest_name_lock);
+	mutex_destroy(&ztest_vdev_lock);
+}
+
+/*
  * Create a storage pool with the given name and initial vdev size.
  * Then test spa_freeze() functionality.
  */
@@ -6442,11 +6572,11 @@ ztest_init(ztest_shared_t *zs)
 
 	kernel_fini();
 
-	ztest_run_zdb(ztest_opts.zo_pool);
-
-	ztest_freeze();
-
-	ztest_run_zdb(ztest_opts.zo_pool);
+	if (!ztest_opts.zo_mmp_test) {
+		ztest_run_zdb(ztest_opts.zo_pool);
+		ztest_freeze();
+		ztest_run_zdb(ztest_opts.zo_pool);
+	}
 
 	rw_destroy(&ztest_name_lock);
 	mutex_destroy(&ztest_vdev_lock);
@@ -6607,12 +6737,18 @@ ztest_run_init(void)
 {
 	ztest_shared_t *zs = ztest_shared;
 
-	ASSERT(ztest_opts.zo_init != 0);
-
 	/*
 	 * Blow away any existing copy of zpool.cache
 	 */
 	(void) remove(spa_config_path);
+
+	if (ztest_opts.zo_init == 0) {
+		if (ztest_opts.zo_verbose >= 1)
+			(void) printf("Importing pool %s\n",
+			    ztest_opts.zo_pool);
+		ztest_import(zs);
+		return;
+	}
 
 	/*
 	 * Create and initialize our storage pool.
@@ -6820,7 +6956,8 @@ main(int argc, char **argv)
 			(void) printf("\n");
 		}
 
-		ztest_run_zdb(ztest_opts.zo_pool);
+		if (!ztest_opts.zo_mmp_test)
+			ztest_run_zdb(ztest_opts.zo_pool);
 	}
 
 	if (ztest_opts.zo_verbose >= 1) {

--- a/usr/src/common/zfs/zfs_comutil.h
+++ b/usr/src/common/zfs/zfs_comutil.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef	_ZFS_COMUTIL_H
@@ -32,6 +33,9 @@
 #ifdef	__cplusplus
 extern "C" {
 #endif
+
+/* Needed for ZoL errno usage in MMP kernel and user code */
+#define	EREMOTEIO EREMOTE
 
 extern boolean_t zfs_allocatable_devs(nvlist_t *);
 extern void zpool_get_load_policy(nvlist_t *, zpool_load_policy_t *);

--- a/usr/src/common/zfs/zpool_prop.c
+++ b/usr/src/common/zfs/zpool_prop.c
@@ -125,6 +125,9 @@ zpool_prop_init(void)
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "EXPAND", boolean_table);
 	zprop_register_index(ZPOOL_PROP_READONLY, "readonly", 0,
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "RDONLY", boolean_table);
+	zprop_register_index(ZPOOL_PROP_MULTIHOST, "multihost", 0,
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "on | off", "MULTIHOST",
+	    boolean_table);
 
 	/* default index properties */
 	zprop_register_index(ZPOOL_PROP_FAILUREMODE, "failmode",

--- a/usr/src/lib/Makefile
+++ b/usr/src/lib/Makefile
@@ -22,7 +22,7 @@
 #
 # Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2012 by Delphix. All rights reserved.
-# Copyright 2018, Joyent, Inc.
+# Copyright 2019, Joyent, Inc.
 # Copyright (c) 2013 Gary Mills
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
 # Copyright (c) 2015 Gary Mills
@@ -689,7 +689,7 @@ libzfs_jni:	libdiskmgt libzfs
 libzonecfg:	libuuid libsysevent libsec libbrand libpool libscf libproc \
 		libuutil libbsm libsecdb
 libzonestat:	libcmdutils libumem
-libzpool:	libavl libumem libcmdutils libsysevent libfakekernel
+libzpool:	libavl libumem libcmdutils libsysevent libfakekernel libzfs
 madv:		libgen
 mpapi:		libpthread libdevinfo libsysevent
 mpss:		libgen

--- a/usr/src/lib/libfakekernel/common/cond.c
+++ b/usr/src/lib/libfakekernel/common/cond.c
@@ -12,6 +12,7 @@
 /*
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2017 RackTop Systems.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -117,6 +118,15 @@ cv_timedwait_sig(kcondvar_t *cv, kmutex_t *mp, clock_t abstime)
 
 	delta = abstime - ddi_get_lbolt();
 	return (cv__twait(cv, mp, delta, 1, 0));
+}
+
+int
+cv_timedwait_sig_hrtime(kcondvar_t *cv, kmutex_t *mp, hrtime_t tim)
+{
+	clock_t delta;
+
+	delta = tim;
+	return (cv__twait(cv, mp, delta, 1, 1));
 }
 
 /*ARGSUSED*/

--- a/usr/src/lib/libfakekernel/common/mapfile-vers
+++ b/usr/src/lib/libfakekernel/common/mapfile-vers
@@ -12,7 +12,7 @@
 #
 # Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2017 RackTop Systems.
-# Copyright 2018, Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 
 #
@@ -69,6 +69,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	cv_signal;
 	cv_timedwait;
 	cv_timedwait_sig;
+	cv_timedwait_sig_hrtime;
 	cv_timedwait_hires;
 	cv_wait;
 	cv_wait_sig;

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -23,7 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Pawel Jakub Dawidek. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
- * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Nexenta Systems, Inc.
@@ -130,6 +130,7 @@ typedef enum zfs_error {
 	EZFS_DIFFDATA,		/* bad zfs diff data */
 	EZFS_POOLREADONLY,	/* pool is in read-only mode */
 	EZFS_SCRUB_PAUSED,	/* scrub currently paused */
+	EZFS_ACTIVE_POOL,	/* pool is imported on a different system */
 	EZFS_NO_PENDING,	/* cannot cancel, no operation is pending */
 	EZFS_CHECKPOINT_EXISTS,	/* checkpoint exists */
 	EZFS_DISCARDING_CHECKPOINT,	/* currently discarding a checkpoint */
@@ -313,6 +314,8 @@ typedef enum {
 	/*
 	 * The following correspond to faults as defined in the (fault.fs.zfs.*)
 	 * event namespace.  Each is associated with a corresponding message ID.
+	 * This must be kept in sync with the zfs_msgid_table in
+	 * lib/libzfs/libzfs_status.c.
 	 */
 	ZPOOL_STATUS_CORRUPT_CACHE,	/* corrupt /kernel/drv/zpool.cache */
 	ZPOOL_STATUS_MISSING_DEV_R,	/* missing device with replicas */
@@ -325,8 +328,11 @@ typedef enum {
 	ZPOOL_STATUS_FAILING_DEV,	/* device experiencing errors */
 	ZPOOL_STATUS_VERSION_NEWER,	/* newer on-disk version */
 	ZPOOL_STATUS_HOSTID_MISMATCH,	/* last accessed by another system */
+	ZPOOL_STATUS_HOSTID_ACTIVE,	/* currently active on another system */
+	ZPOOL_STATUS_HOSTID_REQUIRED,	/* multihost=on and hostid=0 */
 	ZPOOL_STATUS_IO_FAILURE_WAIT,	/* failed I/O, failmode 'wait' */
 	ZPOOL_STATUS_IO_FAILURE_CONTINUE, /* failed I/O, failmode 'continue' */
+	ZPOOL_STATUS_IO_FAILURE_MMP,	/* failed MMP, failmode not 'panic' */
 	ZPOOL_STATUS_BAD_LOG,		/* cannot read log chain(s) */
 
 	/*
@@ -404,6 +410,8 @@ typedef struct importargs {
 } importargs_t;
 
 extern nvlist_t *zpool_search_import(libzfs_handle_t *, importargs_t *);
+extern int zpool_tryimport(libzfs_handle_t *hdl, char *target,
+    nvlist_t **configp, importargs_t *args);
 
 /* legacy pool search routines */
 extern nvlist_t *zpool_find_import(libzfs_handle_t *, int, char **);
@@ -723,6 +731,7 @@ extern boolean_t zfs_dataset_exists(libzfs_handle_t *, const char *,
     zfs_type_t);
 extern int zfs_spa_version(zfs_handle_t *, int *);
 extern boolean_t zfs_bookmark_exists(const char *path);
+extern ulong_t get_system_hostid(void);
 
 /*
  * Mount support functions.

--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -440,6 +440,8 @@ make_dataset_handle_common(zfs_handle_t *zhp, zfs_cmd_t *zc)
 		zhp->zfs_head_type = ZFS_TYPE_VOLUME;
 	else if (zhp->zfs_dmustats.dds_type == DMU_OST_ZFS)
 		zhp->zfs_head_type = ZFS_TYPE_FILESYSTEM;
+	else if (zhp->zfs_dmustats.dds_type == DMU_OST_OTHER)
+		return (-1);
 	else
 		abort();
 

--- a/usr/src/lib/libzfs/common/libzfs_impl.h
+++ b/usr/src/lib/libzfs/common/libzfs_impl.h
@@ -139,7 +139,7 @@ typedef enum {
 	SHARED_SMB = 0x4
 } zfs_share_type_t;
 
-#define	CONFIG_BUF_MINSIZE	65536
+#define	CONFIG_BUF_MINSIZE	262144
 
 int zfs_error(libzfs_handle_t *, int, const char *);
 int zfs_error_fmt(libzfs_handle_t *, int, const char *, ...);

--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -1438,16 +1438,87 @@ name_or_guid_exists(zpool_handle_t *zhp, void *data)
 nvlist_t *
 zpool_search_import(libzfs_handle_t *hdl, importargs_t *import)
 {
+	nvlist_t *pools = NULL;
+
 	verify(import->poolname == NULL || import->guid == 0);
 
 	if (import->unique)
 		import->exists = zpool_iter(hdl, name_or_guid_exists, import);
 
 	if (import->cachefile != NULL)
-		return (zpool_find_import_cached(hdl, import->cachefile,
-		    import->poolname, import->guid));
+		pools = zpool_find_import_cached(hdl, import->cachefile,
+		    import->poolname, import->guid);
+	else
+		pools = zpool_find_import_impl(hdl, import);
 
-	return (zpool_find_import_impl(hdl, import));
+	return (pools);
+}
+
+static boolean_t
+pool_match(nvlist_t *cfg, char *tgt)
+{
+	uint64_t v, guid = strtoull(tgt, NULL, 0);
+	char *s;
+
+	if (guid != 0) {
+		if (nvlist_lookup_uint64(cfg, ZPOOL_CONFIG_POOL_GUID, &v) == 0)
+			return (v == guid);
+	} else {
+		if (nvlist_lookup_string(cfg, ZPOOL_CONFIG_POOL_NAME, &s) == 0)
+			return (strcmp(s, tgt) == 0);
+	}
+	return (B_FALSE);
+}
+
+int
+zpool_tryimport(libzfs_handle_t *hdl, char *target, nvlist_t **configp,
+    importargs_t *args)
+{
+	nvlist_t *pools;
+	nvlist_t *match = NULL;
+	nvlist_t *config = NULL;
+	char *sepp = NULL;
+	int count = 0;
+	char *targetdup = strdup(target);
+
+	*configp = NULL;
+
+	if ((sepp = strpbrk(targetdup, "/@")) != NULL) {
+		*sepp = '\0';
+	}
+
+	pools = zpool_search_import(hdl, args);
+
+	if (pools != NULL) {
+		nvpair_t *elem = NULL;
+		while ((elem = nvlist_next_nvpair(pools, elem)) != NULL) {
+			VERIFY0(nvpair_value_nvlist(elem, &config));
+			if (pool_match(config, targetdup)) {
+				count++;
+				if (match != NULL) {
+					/* multiple matches found */
+					continue;
+				} else {
+					match = config;
+				}
+			}
+		}
+	}
+
+	if (count == 0) {
+		free(targetdup);
+		return (ENOENT);
+	}
+
+	if (count > 1) {
+		free(targetdup);
+		return (EINVAL);
+	}
+
+	*configp = match;
+	free(targetdup);
+
+	return (0);
 }
 
 boolean_t

--- a/usr/src/lib/libzfs/common/libzfs_pool.c
+++ b/usr/src/lib/libzfs/common/libzfs_pool.c
@@ -665,6 +665,15 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			}
 			break;
 
+		case ZPOOL_PROP_MULTIHOST:
+			if (get_system_hostid() == 0) {
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "requires a non-zero system hostid"));
+				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
+				goto error;
+			}
+			break;
+
 		default:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 			    "property '%s'(%d) not defined"), propname, prop);
@@ -1802,6 +1811,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 
 	if (error) {
 		char desc[1024];
+		char aux[256];
 
 		/*
 		 * Dry-run failed, but we print out what success
@@ -1845,6 +1855,46 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 			 * Unsupported version.
 			 */
 			(void) zfs_error(hdl, EZFS_BADVERSION, desc);
+			break;
+
+		case EREMOTEIO:
+			if (nv != NULL && nvlist_lookup_nvlist(nv,
+			    ZPOOL_CONFIG_LOAD_INFO, &nvinfo) == 0) {
+				char *hostname = "<unknown>";
+				uint64_t hostid = 0;
+				mmp_state_t mmp_state;
+
+				mmp_state = fnvlist_lookup_uint64(nvinfo,
+				    ZPOOL_CONFIG_MMP_STATE);
+
+				if (nvlist_exists(nvinfo,
+				    ZPOOL_CONFIG_MMP_HOSTNAME))
+					hostname = fnvlist_lookup_string(nvinfo,
+					    ZPOOL_CONFIG_MMP_HOSTNAME);
+
+				if (nvlist_exists(nvinfo,
+				    ZPOOL_CONFIG_MMP_HOSTID))
+					hostid = fnvlist_lookup_uint64(nvinfo,
+					    ZPOOL_CONFIG_MMP_HOSTID);
+
+				if (mmp_state == MMP_STATE_ACTIVE) {
+					(void) snprintf(aux, sizeof (aux),
+					    dgettext(TEXT_DOMAIN, "pool is imp"
+					    "orted on host '%s' (hostid=%lx).\n"
+					    "Export the pool on the other "
+					    "system, then run 'zpool import'."),
+					    hostname, (unsigned long) hostid);
+				} else if (mmp_state == MMP_STATE_NO_HOSTID) {
+					(void) snprintf(aux, sizeof (aux),
+					    dgettext(TEXT_DOMAIN, "pool has "
+					    "the multihost property on and "
+					    "the\nsystem's hostid is not "
+					    "set.\n"));
+				}
+
+				(void) zfs_error_aux(hdl, aux);
+			}
+			(void) zfs_error(hdl, EZFS_ACTIVE_POOL, desc);
 			break;
 
 		case EINVAL:
@@ -2387,7 +2437,7 @@ zpool_find_vdev(zpool_handle_t *zhp, const char *path, boolean_t *avail_spare,
 }
 
 static int
-vdev_online(nvlist_t *nv)
+vdev_is_online(nvlist_t *nv)
 {
 	uint64_t ival;
 
@@ -2455,7 +2505,7 @@ vdev_get_physpaths(nvlist_t *nv, char *physpath, size_t phypath_size,
 				return (EZFS_INVALCONFIG);
 		}
 
-		if (vdev_online(nv)) {
+		if (vdev_is_online(nv)) {
 			if ((ret = vdev_get_one_physpath(nv, physpath,
 			    phypath_size, rsz)) != 0)
 				return (ret);

--- a/usr/src/lib/libzfs/common/libzfs_status.c
+++ b/usr/src/lib/libzfs/common/libzfs_status.c
@@ -53,20 +53,36 @@
  * of this table, and hence have no associated message ID.
  */
 static char *zfs_msgid_table[] = {
-	"ZFS-8000-14",
-	"ZFS-8000-2Q",
-	"ZFS-8000-3C",
-	"ZFS-8000-4J",
-	"ZFS-8000-5E",
-	"ZFS-8000-6X",
-	"ZFS-8000-72",
-	"ZFS-8000-8A",
-	"ZFS-8000-9P",
-	"ZFS-8000-A5",
-	"ZFS-8000-EY",
-	"ZFS-8000-HC",
-	"ZFS-8000-JQ",
-	"ZFS-8000-K4",
+	"ZFS-8000-14", /* ZPOOL_STATUS_CORRUPT_CACHE */
+	"ZFS-8000-2Q", /* ZPOOL_STATUS_MISSING_DEV_R */
+	"ZFS-8000-3C", /* ZPOOL_STATUS_MISSING_DEV_NR */
+	"ZFS-8000-4J", /* ZPOOL_STATUS_CORRUPT_LABEL_R */
+	"ZFS-8000-5E", /* ZPOOL_STATUS_CORRUPT_LABEL_NR */
+	"ZFS-8000-6X", /* ZPOOL_STATUS_BAD_GUID_SUM */
+	"ZFS-8000-72", /* ZPOOL_STATUS_CORRUPT_POOL */
+	"ZFS-8000-8A", /* ZPOOL_STATUS_CORRUPT_DATA */
+	"ZFS-8000-9P", /* ZPOOL_STATUS_FAILING_DEV */
+	"ZFS-8000-A5", /* ZPOOL_STATUS_VERSION_NEWER */
+	"ZFS-8000-EY", /* ZPOOL_STATUS_HOSTID_MISMATCH */
+	"ZFS-8000-EY", /* ZPOOL_STATUS_HOSTID_ACTIVE */
+	"ZFS-8000-EY", /* ZPOOL_STATUS_HOSTID_REQUIRED */
+	"ZFS-8000-HC", /* ZPOOL_STATUS_IO_FAILURE_WAIT */
+	"ZFS-8000-JQ", /* ZPOOL_STATUS_IO_FAILURE_CONTINUE */
+	"ZFS-8000-MM", /* ZPOOL_STATUS_IO_FAILURE_MMP */
+	"ZFS-8000-K4", /* ZPOOL_STATUS_BAD_LOG */
+	/*
+	 * The following results have no message ID.
+	 *	ZPOOL_STATUS_UNSUP_FEAT_READ
+	 *	ZPOOL_STATUS_UNSUP_FEAT_WRITE
+	 *	ZPOOL_STATUS_FAULTED_DEV_R
+	 *	ZPOOL_STATUS_FAULTED_DEV_NR
+	 *	ZPOOL_STATUS_VERSION_OLDER
+	 *	ZPOOL_STATUS_FEAT_DISABLED
+	 *	ZPOOL_STATUS_RESILVERING
+	 *	ZPOOL_STATUS_OFFLINE_DEV
+	 *	ZPOOL_STATUS_REMOVED_DEV
+	 *	ZPOOL_STATUS_OK
+	 */
 };
 
 #define	NMSGID	(sizeof (zfs_msgid_table) / sizeof (zfs_msgid_table[0]))
@@ -193,6 +209,7 @@ check_status(nvlist_t *config, boolean_t isimport)
 	uint64_t stateval;
 	uint64_t suspended;
 	uint64_t hostid = 0;
+	unsigned long system_hostid = get_system_hostid();
 
 	verify(nvlist_lookup_uint64(config, ZPOOL_CONFIG_VERSION,
 	    &version) == 0);
@@ -213,10 +230,30 @@ check_status(nvlist_t *config, boolean_t isimport)
 		return (ZPOOL_STATUS_RESILVERING);
 
 	/*
+	 * The multihost property is set and the pool may be active.
+	 */
+	if (vs->vs_state == VDEV_STATE_CANT_OPEN &&
+	    vs->vs_aux == VDEV_AUX_ACTIVE) {
+		mmp_state_t mmp_state;
+		nvlist_t *nvinfo;
+
+		nvinfo = fnvlist_lookup_nvlist(config, ZPOOL_CONFIG_LOAD_INFO);
+		mmp_state = fnvlist_lookup_uint64(nvinfo,
+		    ZPOOL_CONFIG_MMP_STATE);
+
+		if (mmp_state == MMP_STATE_ACTIVE)
+			return (ZPOOL_STATUS_HOSTID_ACTIVE);
+		else if (mmp_state == MMP_STATE_NO_HOSTID)
+			return (ZPOOL_STATUS_HOSTID_REQUIRED);
+		else
+			return (ZPOOL_STATUS_HOSTID_MISMATCH);
+	}
+
+	/*
 	 * Pool last accessed by another system.
 	 */
 	(void) nvlist_lookup_uint64(config, ZPOOL_CONFIG_HOSTID, &hostid);
-	if (hostid != 0 && (unsigned long)hostid != gethostid() &&
+	if (hostid != 0 && (unsigned long)hostid != system_hostid &&
 	    stateval == POOL_STATE_ACTIVE)
 		return (ZPOOL_STATUS_HOSTID_MISMATCH);
 
@@ -249,10 +286,16 @@ check_status(nvlist_t *config, boolean_t isimport)
 		return (ZPOOL_STATUS_BAD_GUID_SUM);
 
 	/*
-	 * Check whether the pool has suspended due to failed I/O.
+	 * Check whether the pool has suspended.
 	 */
 	if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_SUSPENDED,
 	    &suspended) == 0) {
+		uint64_t reason;
+
+		if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_SUSPENDED_REASON,
+		    &reason) == 0 && reason == ZIO_SUSPEND_MMP)
+			return (ZPOOL_STATUS_IO_FAILURE_MMP);
+
 		if (suspended == ZIO_FAILURE_MODE_CONTINUE)
 			return (ZPOOL_STATUS_IO_FAILURE_CONTINUE);
 		return (ZPOOL_STATUS_IO_FAILURE_WAIT);
@@ -341,8 +384,9 @@ check_status(nvlist_t *config, boolean_t isimport)
 		if (isimport) {
 			feat = fnvlist_lookup_nvlist(config,
 			    ZPOOL_CONFIG_LOAD_INFO);
-			feat = fnvlist_lookup_nvlist(feat,
-			    ZPOOL_CONFIG_ENABLED_FEAT);
+			if (nvlist_exists(feat, ZPOOL_CONFIG_ENABLED_FEAT))
+				feat = fnvlist_lookup_nvlist(feat,
+				    ZPOOL_CONFIG_ENABLED_FEAT);
 		} else {
 			feat = fnvlist_lookup_nvlist(config,
 			    ZPOOL_CONFIG_FEATURE_STATS);

--- a/usr/src/lib/libzfs/common/libzfs_util.c
+++ b/usr/src/lib/libzfs/common/libzfs_util.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright (c) 2017 Datto Inc.
@@ -52,6 +52,7 @@
 
 #include "libzfs_impl.h"
 #include "zfs_prop.h"
+#include "zfs_comutil.h"
 #include "zfeature_common.h"
 
 int
@@ -249,6 +250,9 @@ libzfs_error_description(libzfs_handle_t *hdl)
 		return (dgettext(TEXT_DOMAIN, "device removal in progress"));
 	case EZFS_VDEV_TOO_BIG:
 		return (dgettext(TEXT_DOMAIN, "device exceeds supported size"));
+	case EZFS_ACTIVE_POOL:
+		return (dgettext(TEXT_DOMAIN, "pool is imported on a "
+		    "different host"));
 	case EZFS_TOOMANY:
 		return (dgettext(TEXT_DOMAIN, "argument list too long"));
 	case EZFS_INITIALIZING:
@@ -418,6 +422,9 @@ zfs_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 		    "pool I/O is currently suspended"));
 		zfs_verror(hdl, EZFS_POOLUNAVAIL, fmt, ap);
 		break;
+	case EREMOTEIO:
+		zfs_verror(hdl, EZFS_ACTIVE_POOL, fmt, ap);
+		break;
 	default:
 		zfs_error_aux(hdl, strerror(error));
 		zfs_verror(hdl, EZFS_UNKNOWN, fmt, ap);
@@ -504,6 +511,9 @@ zpool_standard_error_fmt(libzfs_handle_t *hdl, int error, const char *fmt, ...)
 	/* There is no pending operation to cancel */
 	case ENOTACTIVE:
 		zfs_verror(hdl, EZFS_NO_PENDING, fmt, ap);
+		break;
+	case EREMOTEIO:
+		zfs_verror(hdl, EZFS_ACTIVE_POOL, fmt, ap);
 		break;
 	case ZFS_ERR_CHECKPOINT_EXISTS:
 		zfs_verror(hdl, EZFS_CHECKPOINT_EXISTS, fmt, ap);
@@ -1595,4 +1605,21 @@ zfs_get_hole_count(const char *path, uint64_t *count, uint64_t *bs)
 		return (errno);
 	}
 	return (0);
+}
+
+ulong_t
+get_system_hostid(void)
+{
+	char *env;
+
+	/*
+	 * Allow the hostid to be subverted for testing.
+	 */
+	env = getenv("ZFS_HOSTID");
+	if (env) {
+		ulong_t hostid = strtoull(env, NULL, 16);
+		return (hostid & 0xFFFFFFFF);
+	}
+
+	return (gethostid());
 }

--- a/usr/src/lib/libzfs/common/mapfile-vers
+++ b/usr/src/lib/libzfs/common/mapfile-vers
@@ -49,6 +49,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	fletcher_4_byteswap;
 	fletcher_4_incremental_native;
 	fletcher_4_incremental_byteswap;
+	get_system_hostid;
 	libzfs_add_handle;
 	libzfs_errno;
 	libzfs_error_action;
@@ -245,6 +246,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	zpool_skip_pool;
 	zpool_state_to_name;
 	zpool_sync_one;
+	zpool_tryimport;
 	zpool_unmount_datasets;
 	zpool_upgrade;
 	zpool_vdev_attach;

--- a/usr/src/lib/libzpool/Makefile.com
+++ b/usr/src/lib/libzpool/Makefile.com
@@ -21,7 +21,7 @@
 #
 # Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
-# Copyright (c) 2018, Joyent, Inc.
+# Copyright 2019, Joyent, Inc.
 #
 
 LIBRARY= libzpool.a
@@ -69,7 +69,7 @@ C99LMODE=	-Xc99=%all
 CFLAGS +=	$(CCGDEBUG) $(CCVERBOSE) $(CNOGLOBAL)
 CFLAGS64 +=	$(CCGDEBUG) $(CCVERBOSE) $(CNOGLOBAL)
 LDLIBS +=	-lcmdutils -lumem -lavl -lnvpair -lz -lc -lsysevent -lmd \
-		-lfakekernel
+		-lfakekernel -lzfs
 CPPFLAGS.first =	-I$(SRC)/lib/libfakekernel/common
 CPPFLAGS +=	$(INCS)	-DDEBUG -D_FAKE_KERNEL
 

--- a/usr/src/lib/libzpool/common/kernel.c
+++ b/usr/src/lib/libzpool/common/kernel.c
@@ -41,6 +41,7 @@
 #include <sys/zmod.h>
 #include <sys/utsname.h>
 #include <sys/systeminfo.h>
+#include <libzfs.h>
 
 extern void system_taskq_init(void);
 extern void system_taskq_fini(void);
@@ -442,7 +443,7 @@ kernel_init(int mode)
 	    (double)physmem * sysconf(_SC_PAGE_SIZE) / (1ULL << 30));
 
 	(void) snprintf(hw_serial, sizeof (hw_serial), "%ld",
-	    (mode & FWRITE) ? gethostid() : 0);
+	    (mode & FWRITE) ? get_system_hostid() : 0);
 
 	system_taskq_init();
 

--- a/usr/src/lib/udapl/libdat/common/dat_dictionary.c
+++ b/usr/src/lib/udapl/libdat/common/dat_dictionary.c
@@ -28,7 +28,9 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
+/*
+ * Copyright (c) 2018, Joyent, Inc.
+ */
 
 /*
  *
@@ -144,8 +146,6 @@ dat_dictionary_create(
 bail:
 	if (DAT_SUCCESS != status) {
 		if (NULL != p_dictionary) {
-			dat_os_free(p_dictionary, sizeof (DAT_DICTIONARY));
-
 			if (NULL != p_dictionary->head) {
 				dat_os_free(p_dictionary->head,
 				    sizeof (DAT_DICTIONARY_NODE));
@@ -155,7 +155,10 @@ bail:
 				dat_os_free(p_dictionary->tail,
 				    sizeof (DAT_DICTIONARY_NODE));
 			}
+
+			dat_os_free(p_dictionary, sizeof (DAT_DICTIONARY));
 		}
+
 	}
 
 	return (status);

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -409,6 +409,11 @@ If a pool has a shared spare that is currently being used, the pool can not be
 exported since other pools may use this shared spare, which may lead to
 potential data corruption.
 .Pp
+Shared spares add some risk.
+If the pools are imported on different hosts, and both pools suffer a device
+failure at the same time, both could attempt to use the spare at the same time.
+This may not be detected, resulting in data corruption.
+.Pp
 An in-progress spare replacement can be cancelled by detaching the hot spare.
 If the original faulted device is detached, then the hot spare assumes its
 place in the configuration, and is removed from the spare list of all active
@@ -731,6 +736,31 @@ The default value is
 .Sy off .
 This property can also be referred to by its shortened name,
 .Sy listsnaps .
+.It Sy multihost Ns = Ns Sy on Ns | Ns Sy off
+Controls whether a pool activity check should be performed during
+.Nm zpool Cm import .
+When a pool is determined to be active it cannot be imported, even with the
+.Fl f
+option.
+This property is intended to be used in failover configurations
+where multiple hosts have access to a pool on shared storage.
+.sp
+Multihost provides protection on import only.
+It does not protect against an
+individual device being used in multiple pools, regardless of the type of vdev.
+See the discussion under
+.Sy zpool create.
+.sp
+When this property is on, periodic writes to storage occur to show the pool is
+in use.
+See
+.Sy zfs_multihost_interval
+in the
+.Xr zfs-module-parameters 5
+man page.
+In order to enable this property each host must set a unique hostid.
+The default value is
+.Sy off .
 .It Sy version Ns = Ns Ar version
 The current on-disk version of the pool.
 This can be increased, but never decreased.
@@ -862,6 +892,10 @@ Clears device errors in a pool.
 If no arguments are specified, all device errors within the pool are cleared.
 If one or more devices is specified, only those errors associated with the
 specified device or devices are cleared.
+If multihost is enabled, and the pool has been suspended, this will not
+resume I/O.
+While the pool was suspended, it may have been imported on
+another host, and resuming I/O could result in pool damage.
 .It Xo
 .Nm
 .Cm create
@@ -897,8 +931,24 @@ specification is described in the
 .Sx Virtual Devices
 section.
 .Pp
-The command verifies that each device specified is accessible and not currently
-in use by another subsystem.
+The command attempts to verify that each device specified is accessible and not
+currently in use by another subsystem.
+However this check is not robust enough
+to detect simultaneous attempts to use a new device in different pools, even if
+.Sy multihost
+is
+.Sy enabled.
+The
+administrator must ensure that simultaneous invocations of any combination of
+.Sy zpool replace ,
+.Sy zpool create ,
+.Sy zpool add ,
+or
+.Sy zpool labelclear ,
+do not refer to the same device.
+Using the same device in two pools will
+result in pool corruption.
+.sp
 There are some uses, such as being currently mounted, or specified as the
 dedicated dump device, that prevents a device from ever being used by ZFS.
 Other uses, such as having a preexisting UFS file system, can be overridden with

--- a/usr/src/pkg/manifests/driver-serial-usbftdi.mf
+++ b/usr/src/pkg/manifests/driver-serial-usbftdi.mf
@@ -41,6 +41,7 @@ dir path=usr/share/man
 dir path=usr/share/man/man7d
 driver name=usbftdi perms="* 0666 root sys" \
     alias=usb403,6001 \
+    alias=usb403,6015 \
     alias=usb403,cc48 \
     alias=usb403,cc49 \
     alias=usb403,cc4a \

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -120,6 +120,7 @@ dir path=opt/zfs-tests/tests/functional/link_count
 dir path=opt/zfs-tests/tests/functional/mdb
 dir path=opt/zfs-tests/tests/functional/migration
 dir path=opt/zfs-tests/tests/functional/mmap
+dir path=opt/zfs-tests/tests/functional/mmp
 dir path=opt/zfs-tests/tests/functional/mount
 dir path=opt/zfs-tests/tests/functional/mv_files
 dir path=opt/zfs-tests/tests/functional/nestedfs
@@ -188,6 +189,7 @@ file path=opt/zfs-tests/bin/rename_dir mode=0555
 file path=opt/zfs-tests/bin/rm_lnkcnt_zero_file mode=0555
 file path=opt/zfs-tests/bin/zfstest mode=0555
 file path=opt/zfs-tests/callbacks/zfs_dbgmsg mode=0555
+file path=opt/zfs-tests/callbacks/zfs_mmp mode=0555
 file path=opt/zfs-tests/include/commands.cfg mode=0444
 file path=opt/zfs-tests/include/default.cfg mode=0444
 file path=opt/zfs-tests/include/libtest.shlib mode=0444
@@ -2270,6 +2272,22 @@ file path=opt/zfs-tests/tests/functional/mmap/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/mmap/mmap_read_001_pos mode=0555
 file path=opt/zfs-tests/tests/functional/mmap/mmap_write_001_pos mode=0555
 file path=opt/zfs-tests/tests/functional/mmap/setup mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/cleanup mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp.cfg mode=0444
+file path=opt/zfs-tests/tests/functional/mmp/mmp.kshlib mode=0444
+file path=opt/zfs-tests/tests/functional/mmp/mmp_active_import mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_exported_import mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_inactive_import mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_interval mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_on_off mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_on_thread mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_on_uberblocks mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_on_zdb mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_reset_interval mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_write_distribution mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/mmp_write_uberblocks mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/multihost_history mode=0555
+file path=opt/zfs-tests/tests/functional/mmp/setup mode=0555
 file path=opt/zfs-tests/tests/functional/mount/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/mount/setup mode=0555
 file path=opt/zfs-tests/tests/functional/mount/umount_001 mode=0555

--- a/usr/src/test/zfs-tests/callbacks/zfs_mmp.ksh
+++ b/usr/src/test/zfs-tests/callbacks/zfs_mmp.ksh
@@ -1,0 +1,37 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security.
+# All rights reserved.
+#
+
+# $1: number of lines to output (default: 40)
+typeset lines=${1:-40}
+typeset history=$(cat /sys/module/zfs/parameters/zfs_multihost_history)
+
+if [ $history -eq 0 ]; then
+	exit
+fi
+
+for f in /proc/spl/kstat/zfs/*/multihost; do
+	echo "================================================================="
+	echo " Last $lines lines of $f"
+	echo "================================================================="
+
+	sudo tail -n $lines $f
+done
+
+echo "================================================================="
+echo " End of zfs multihost log"
+echo "================================================================="

--- a/usr/src/test/zfs-tests/include/commands.cfg
+++ b/usr/src/test/zfs-tests/include/commands.cfg
@@ -56,6 +56,7 @@ export USR_BIN_FILES='awk
     getent
     grep
     head
+    hostid
     hostname
     id
     iostat

--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -2703,3 +2703,89 @@ function mdb_ctf_set_int
 
 	return 0
 }
+
+#
+# Set a global system tunable (64-bit value)
+#
+# $1 tunable name
+# $2 tunable values
+#
+function set_tunable64
+{
+	set_tunable_impl "$1" "$2" Z
+}
+
+#
+# Set a global system tunable (32-bit value)
+#
+# $1 tunable name
+# $2 tunable values
+#
+function set_tunable32
+{
+	set_tunable_impl "$1" "$2" W
+}
+
+function set_tunable_impl
+{
+	typeset tunable="$1"
+	typeset value="$2"
+	typeset mdb_cmd="$3"
+	typeset module="${4:-zfs}"
+
+	[[ -z "$tunable" ]] && return 1
+	[[ -z "$value" ]] && return 1
+	[[ -z "$mdb_cmd" ]] && return 1
+
+	case "$(uname)" in
+	Linux)
+		typeset zfs_tunables="/sys/module/$module/parameters"
+		[[ -w "$zfs_tunables/$tunable" ]] || return 1
+		echo -n "$value" > "$zfs_tunables/$tunable"
+		return "$?"
+		;;
+	SunOS)
+		[[ "$module" -eq "zfs" ]] || return 1
+		echo "${tunable}/${mdb_cmd}0t${value}" | mdb -kw
+		return "$?"
+		;;
+	esac
+}
+
+#
+# Get a global system tunable
+#
+# $1 tunable name
+#
+function get_tunable
+{
+	get_tunable_impl "$1"
+}
+
+function get_tunable_impl
+{
+	typeset tunable="$1"
+	typeset module="${2:-zfs}"
+
+	[[ -z "$tunable" ]] && return 1
+
+	case "$(uname)" in
+	Linux)
+		typeset zfs_tunables="/sys/module/$module/parameters"
+		[[ -f "$zfs_tunables/$tunable" ]] || return 1
+		cat $zfs_tunables/$tunable
+		return "$?"
+		;;
+	SunOS)
+		typeset value=$(mdb -k -e "$tunable/X | ::eval .=U")
+		if [[ $? -ne 0 ]]; then
+			log_fail "Failed to get value of '$tunable' from mdb."
+			return 1
+		fi
+		echo $value
+		return 0
+		;;
+	esac
+
+	return 1
+}

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -462,6 +462,12 @@ tests = ['migration_001_pos', 'migration_002_pos', 'migration_003_pos',
 [/opt/zfs-tests/tests/functional/mmap]
 tests = ['mmap_read_001_pos', 'mmap_write_001_pos']
 
+[/opt/zfs-tests/tests/functional/mmp]
+tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
+    'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
+    'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
+    'mmp_on_zdb', 'mmp_write_distribution']
+
 [/opt/zfs-tests/tests/functional/mount]
 tests = ['umount_001', 'umountall_001']
 

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -431,6 +431,12 @@ tests = ['migration_001_pos', 'migration_002_pos', 'migration_003_pos',
 [/opt/zfs-tests/tests/functional/mmap]
 tests = ['mmap_read_001_pos', 'mmap_write_001_pos']
 
+[/opt/zfs-tests/tests/functional/mmp]
+tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
+    'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
+    'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
+    'mmp_on_zdb', 'mmp_write_distribution']
+
 [/opt/zfs-tests/tests/functional/mount]
 tests = ['umount_001', 'umountall_001']
 

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -431,6 +431,12 @@ tests = ['migration_001_pos', 'migration_002_pos', 'migration_003_pos',
 [/opt/zfs-tests/tests/functional/mmap]
 tests = ['mmap_read_001_pos', 'mmap_write_001_pos']
 
+[/opt/zfs-tests/tests/functional/mmp]
+tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
+    'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
+    'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
+    'mmp_on_zdb', 'mmp_write_distribution']
+
 [/opt/zfs-tests/tests/functional/mount]
 tests = ['umount_001', 'umountall_001']
 

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -56,6 +56,7 @@ typeset -a properties=(
     "leaked"
     "bootsize"
     "checkpoint"
+    "multihost"
     "feature@async_destroy"
     "feature@empty_bpobj"
     "feature@lz4_compress"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Joyent, Inc.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/mmp
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/mmp/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/cleanup.ksh
@@ -1,0 +1,36 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "global"
+
+case "$(uname)" in
+SunOS)	h=$(cat /var/tmp/zfs_test_hostid.txt)
+	mmp_set_hostid $h
+	rm /var/tmp/zfs_test_hostid.txt
+	;;
+esac
+log_must set_tunable64 zfs_multihost_history 0
+
+log_pass "mmp cleanup passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp.cfg
@@ -1,0 +1,40 @@
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+export PREV_UBER="$TEST_BASE_DIR/mmp-uber-prev.txt"
+export CURR_UBER="$TEST_BASE_DIR/mmp-uber-curr.txt"
+export DISK=${DISKS%% *}
+
+export HOSTID_FILE="/etc/hostid"
+export HOSTID1=01234567
+export HOSTID2=89abcdef
+
+export TXG_TIMEOUT_LONG=5000
+export TXG_TIMEOUT_DEFAULT=5
+
+export MMP_POOL=mmppool
+export MMP_DIR=$TEST_BASE_DIR/mmp
+export MMP_CACHE=$MMP_DIR/zpool.cache
+export MMP_ZTEST_LOG=$MMP_DIR/ztest.log
+export MMP_HISTORY=100
+export MMP_HISTORY_OFF=0
+
+export MMP_INTERVAL_HOUR=$((60*60*1000))
+export MMP_INTERVAL_DEFAULT=1000
+export MMP_INTERVAL_MIN=100

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -1,0 +1,292 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Use is subject to license terms.
+# Copyright 2019 Joyent, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+
+
+function check_pool_import # pool opts token keyword
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset opts=$2
+	typeset token=$3
+	typeset keyword=$4
+
+	zpool import $opts 2>&1 | \
+	    nawk -v token="$token:" '($1==token) {print $0}' | \
+	    grep -i "$keyword" > /dev/null 2>&1
+
+	return $?
+}
+
+function is_pool_imported # pool opts
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset opts=$2
+
+	check_pool_import "$pool" "$opts" "status" \
+	    "The pool is currently imported"
+	return $?
+}
+
+function wait_pool_imported # pool opts
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset opts=$2
+
+	while is_pool_imported "$pool" "$opts"; do
+		log_must sleep 5
+	done
+
+	return 0
+}
+
+function try_pool_import # pool opts message
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset opts=$2
+	typeset msg=$3
+
+	zpool import $opts $pool 2>&1 | grep -i "$msg"
+
+	return $?
+}
+
+function chr2ascii
+{
+	case "$1" in
+	0)	asc="30";;
+	1)	asc="31";;
+	2)	asc="32";;
+	3)	asc="33";;
+	4)	asc="34";;
+	5)	asc="35";;
+	6)	asc="36";;
+	7)	asc="37";;
+	8)	asc="38";;
+	9)	asc="39";;
+	a)	asc="61";;
+	b)	asc="62";;
+	c)	asc="63";;
+	d)	asc="64";;
+	e)	asc="65";;
+	f)	asc="66";;
+	esac
+}
+
+function mmp_set_hostid
+{
+        typeset hostid=$1
+
+	case "$(uname)" in
+	Linux)
+	        a=${hostid:6:2}
+		b=${hostid:4:2}
+		c=${hostid:2:2}
+		d=${hostid:0:2}
+
+		printf "\\x$a\\x$b\\x$c\\x$d" >$HOSTID_FILE
+
+		if [ $(hostid) != "$hostid" ]; then
+			return 1
+		fi
+		;;
+	SunOS)
+		#
+		# Given a hostid in hex, we have to convert to decimal, then
+		# save the ascii string representation in the kernel. The
+		# 'hostid' command will get the decimal SI_HW_SERIAL value via
+		# sysinfo, then print that as an 8 digit hex number.
+		#
+		typeset dec=$(mdb -e "$hostid=E" | sed -e 's/ *//g')
+		typeset len=$(echo $dec | awk '{print length($0)}')
+		if [[ $len -lt 0 || $len -gt 10 ]]; then
+			return
+		fi
+		typeset pos=0
+		while [[ $pos -lt $len ]]; do
+			chr2ascii ${dec:$pos:1}
+			echo "hw_serial+${pos}/v $asc" | mdb -kw >/dev/null 2>&1
+			pos=$(($pos + 1))
+		done
+		echo "hw_serial+${pos}/v 0" | mdb -kw >/dev/null 2>&1
+		;;
+	esac
+
+        return 0
+}
+
+function mmp_clear_hostid
+{
+	case "$(uname)" in
+	Linux)	rm -f $HOSTID_FILE;;
+	SunOS)	mmp_set_hostid "00000000";;
+	esac
+}
+
+function mmp_pool_create_simple # pool dir
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset dir=${2:-$MMP_DIR}
+
+	log_must mkdir -p $dir
+	log_must rm -f $dir/*
+	log_must truncate -s $MINVDEVSIZE $dir/vdev1 $dir/vdev2
+
+	log_must mmp_set_hostid $HOSTID1
+	log_must zpool create -f -o cachefile=$MMP_CACHE $pool \
+	    mirror $dir/vdev1 $dir/vdev2
+	log_must zpool set multihost=on $pool
+}
+
+function mmp_pool_create # pool dir
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset dir=${2:-$MMP_DIR}
+	typeset opts="-VVVVV -T120 -M -k0 -f $dir -E -p $pool"
+
+	mmp_pool_create_simple $pool $dir
+
+	log_must mv $MMP_CACHE ${MMP_CACHE}.stale
+	log_must zpool export $pool
+	log_must mmp_set_hostid $HOSTID2
+
+	log_note "Starting ztest in the background as hostid $HOSTID1"
+	log_must eval "ZFS_HOSTID=$HOSTID1 /usr/bin/ztest $opts >$MMP_ZTEST_LOG 2>&1 &"
+
+	while ! is_pool_imported "$pool" "-d $dir"; do
+		log_must pgrep ztest
+		log_must sleep 5
+	done
+}
+
+function mmp_pool_destroy # pool dir
+{
+	typeset pool=${1:-$MMP_POOL}
+	typeset dir=${2:-$MMP_DIR}
+
+	ZTESTPID=$(pgrep ztest)
+	if [ -n "$ZTESTPID" ]; then
+		log_must kill $ZTESTPID
+		wait $ZTESTPID
+	fi
+
+	if poolexists $pool; then
+		destroy_pool $pool
+        fi
+
+	log_must rm -f $dir/*
+	mmp_clear_hostid
+}
+
+function mmp_pool_set_hostid # pool hostid
+{
+	typeset pool=$1
+	typeset hostid=$2
+
+	log_must mmp_set_hostid $hostid
+	log_must zpool export $pool
+	log_must zpool import $pool
+
+	return 0
+}
+
+# Return the number of seconds the activity check portion of the import process
+# will take.  Does not include the time to find devices and assemble the
+# preliminary pool configuration passed into the kernel.
+function seconds_mmp_waits_for_activity
+{
+	typeset import_intervals=$(get_tunable zfs_multihost_import_intervals)
+	typeset interval=$(get_tunable zfs_multihost_interval)
+	typeset seconds=$((interval*import_intervals/1000))
+
+	echo $seconds
+}
+
+function import_no_activity_check # pool opts
+{
+	typeset pool=$1
+	typeset opts=$2
+
+	typeset max_duration=$(seconds_mmp_waits_for_activity)
+
+	SECONDS=0
+	zpool import $opts $pool
+	typeset rc=$?
+
+	if [[ $SECONDS -gt $max_duration ]]; then
+		log_fail "unexpected activity check (${SECONDS}s gt \
+$max_duration)"
+	fi
+
+	return $rc
+}
+
+function import_activity_check # pool opts
+{
+	typeset pool=$1
+	typeset opts=$2
+
+	typeset min_duration=$(seconds_mmp_waits_for_activity)
+
+	SECONDS=0
+	zpool import $opts $pool
+	typeset rc=$?
+
+	if [[ $SECONDS -le $min_duration ]]; then
+		log_fail "expected activity check (${SECONDS}s le \
+$min_duration)"
+	fi
+
+	return $rc
+}
+
+function clear_mmp_history
+{
+	log_must set_tunable64 zfs_multihost_history $MMP_HISTORY_OFF
+	log_must set_tunable64 zfs_multihost_history $MMP_HISTORY
+}
+
+function count_skipped_mmp_writes # pool duration
+{
+	typeset pool=$1
+	typeset -i duration=$2
+	typeset hist_path="/proc/spl/kstat/zfs/$pool/multihost"
+
+	sleep $duration
+	awk 'BEGIN {count=0}; $NF == "-" {count++}; END {print count};' "$hist_path"
+}
+
+function count_mmp_writes # pool duration
+{
+	typeset pool=$1
+	typeset -i duration=$2
+	typeset hist_path="/proc/spl/kstat/zfs/$pool/multihost"
+
+	log_must sleep $duration
+	awk 'BEGIN {count=0}; $NF != "-" {count++}; END {print count};' "$hist_path"
+}

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_active_import.ksh
@@ -1,0 +1,119 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+# DESCRIPTION:
+#	Under no circumstances when multihost is active, should an active pool
+#	with one hostid be importable by a host with a different hostid.
+#
+# STRATEGY:
+#	 1. Simulate an active pool on another host with ztest.
+#	 2. Verify 'zpool import' reports an active pool.
+#	 3. Verify 'zpool import [-f] $MMP_POOL' cannot import the pool.
+#	 4. Kill ztest to make pool eligible for import.
+#	 5. Verify 'zpool import' fails with the expected error message.
+#	 6. Verify 'zpool import $MMP_POOL' fails with the expected message.
+#	 7. Verify 'zpool import -f $MMP_POOL' can now import the pool.
+#	 8. Verify pool may be exported/imported without -f argument.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
+	log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+	log_must mmp_clear_hostid
+}
+
+log_assert "multihost=on|off active pool activity checks"
+log_onexit cleanup
+
+# 1. Simulate an active pool on another host with ztest.
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+mmp_pool_create $MMP_POOL $MMP_DIR
+
+# 2. Verify 'zpool import' reports an active pool.
+log_must mmp_set_hostid $HOSTID2
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_MIN
+log_must is_pool_imported $MMP_POOL "-d $MMP_DIR"
+
+# 3. Verify 'zpool import [-f] $MMP_POOL' cannot import the pool.
+MMP_IMPORTED_MSG="Cannot import '$MMP_POOL': pool is imported"
+
+log_must try_pool_import $MMP_POOL "-d $MMP_DIR" "$MMP_IMPORTED_MSG"
+for i in {1..10}; do
+	log_must try_pool_import $MMP_POOL "-f -d $MMP_DIR" "$MMP_IMPORTED_MSG"
+done
+
+log_must try_pool_import $MMP_POOL "-c ${MMP_CACHE}.stale" "$MMP_IMPORTED_MSG"
+
+for i in {1..10}; do
+	log_must try_pool_import $MMP_POOL "-f -c ${MMP_CACHE}.stale" \
+	    "$MMP_IMPORTED_MSG"
+done
+
+# 4. Kill ztest to make pool eligible for import.  Poll with 'zpool status'.
+ZTESTPID=$(pgrep ztest)
+if [ -n "$ZTESTPID" ]; then
+	log_must kill -9 $ZTESTPID
+fi
+log_must wait_pool_imported $MMP_POOL "-d $MMP_DIR"
+
+# 5. Verify 'zpool import' fails with the expected error message, when
+#    - hostid=0:        - configuration error
+#    - hostid=matches   - safe to import the pool
+#    - hostid=different - previously imported on a different system
+#
+log_must mmp_clear_hostid
+case "$(uname)" in
+Linux)  MMP_IMPORTED_MSG="Set a unique system hostid";;
+SunOS)  MMP_IMPORTED_MSG="Check the SMF svc:/system/hostid service.";;
+esac
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" "$MMP_IMPORTED_MSG"
+
+log_must mmp_set_hostid $HOSTID1
+MMP_IMPORTED_MSG="The pool can be imported"
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" "$MMP_IMPORTED_MSG"
+
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID2
+MMP_IMPORTED_MSG="The pool was last accessed by another system."
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "status" "$MMP_IMPORTED_MSG"
+
+# 6. Verify 'zpool import $MMP_POOL' fails with the expected message.
+MMP_IMPORTED_MSG="pool was previously in use from another system."
+log_must try_pool_import $MMP_POOL "-d $MMP_DIR" "$MMP_IMPORTED_MSG"
+
+# 7. Verify 'zpool import -f $MMP_POOL' can now import the pool.
+# Default interval results in minimum activity test 10s which
+# makes detection of the activity test reliable.
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+log_must import_activity_check $MMP_POOL "-f -d $MMP_DIR"
+
+# 8 Verify pool may be exported/imported without -f argument.
+log_must zpool export $MMP_POOL
+log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR"
+
+log_pass "multihost=on|off active pool activity checks passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
@@ -1,0 +1,110 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+# DESCRIPTION:
+#	Verify import behavior for exported pool (no activity check)
+#
+# STRATEGY:
+#	1. Create a zpool
+#	2. Verify multihost=off and hostids match (no activity check)
+#	3. Verify multihost=off and hostids differ (no activity check)
+#	4. Verify multihost=off and hostid zero allowed (no activity check)
+#	5. Verify multihost=on and hostids match (no activity check)
+#	6. Verify multihost=on and hostids differ (no activity check)
+#	7. Verify multihost=on and hostid zero fails (no activity check)
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must mmp_clear_hostid
+}
+
+log_assert "multihost=on|off activity checks exported pool"
+log_onexit cleanup
+
+# 1. Create a zpool
+log_must mmp_set_hostid $HOSTID1
+default_setup_noexit $DISK
+
+# 2. Verify multihost=off and hostids match (no activity check)
+log_must zpool set multihost=off $TESTPOOL
+
+for opt in "" "-f"; do
+	log_must zpool export $TESTPOOL
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 3. Verify multihost=off and hostids differ (no activity check)
+for opt in "" "-f"; do
+	log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
+	log_must zpool export $TESTPOOL
+	log_must mmp_clear_hostid
+	log_must mmp_set_hostid $HOSTID2
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 4. Verify multihost=off and hostid zero allowed (no activity check)
+log_must mmp_clear_hostid
+
+for opt in "" "-f"; do
+	log_must zpool export $TESTPOOL
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 5. Verify multihost=on and hostids match (no activity check)
+log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
+log_must zpool set multihost=on $TESTPOOL
+
+for opt in "" "-f"; do
+	log_must zpool export $TESTPOOL
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 6. Verify multihost=on and hostids differ (no activity check)
+for opt in "" "-f"; do
+	log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
+	log_must zpool export $TESTPOOL
+	log_must mmp_clear_hostid
+	log_must mmp_set_hostid $HOSTID2
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 7. Verify multihost=on and hostid zero fails (no activity check)
+log_must zpool export $TESTPOOL
+log_must mmp_clear_hostid
+
+for opt in "" "-f"; do
+	case "$(uname)" in
+	Linux)  MMP_IMPORTED_MSG="Set a unique system hostid";;
+	SunOS)  MMP_IMPORTED_MSG="Check the SMF svc:/system/hostid service.";;
+	esac
+	log_must check_pool_import $TESTPOOL "" "action" "$MMP_IMPORTED_MSG"
+	log_mustnot import_no_activity_check $TESTPOOL $opt
+done
+
+log_pass "multihost=on|off exported pool activity checks passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
@@ -1,0 +1,101 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+# DESCRIPTION:
+#	Verify import behavior for inactive, but not exported, pools
+#
+# STRATEGY:
+#	1. Create a zpool
+#	2. Verify multihost=off and hostids match (no activity check)
+#	3. Verify multihost=off and hostids differ (no activity check)
+#	4. Verify multihost=off and hostid allowed (no activity check)
+#	5. Verify multihost=on and hostids match (no activity check)
+#	6. Verify multihost=on and hostids differ (activity check)
+#	7. Verify multihost=on and hostid zero fails (no activity check)
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must mmp_clear_hostid
+}
+
+log_assert "multihost=on|off inactive pool activity checks"
+log_onexit cleanup
+
+# 1. Create a zpool
+log_must mmp_set_hostid $HOSTID1
+default_setup_noexit $DISK
+
+# 2. Verify multihost=off and hostids match (no activity check)
+log_must zpool set multihost=off $TESTPOOL
+
+for opt in "" "-f"; do
+	log_must zpool export -F $TESTPOOL
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 3. Verify multihost=off and hostids differ (no activity check)
+log_must zpool export -F $TESTPOOL
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID2
+log_mustnot import_no_activity_check $TESTPOOL ""
+log_must import_no_activity_check $TESTPOOL "-f"
+
+# 4. Verify multihost=off and hostid zero allowed (no activity check)
+log_must zpool export -F $TESTPOOL
+log_must mmp_clear_hostid
+log_mustnot import_no_activity_check $TESTPOOL ""
+log_must import_no_activity_check $TESTPOOL "-f"
+
+# 5. Verify multihost=on and hostids match (no activity check)
+log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
+log_must zpool set multihost=on $TESTPOOL
+
+for opt in "" "-f"; do
+	log_must zpool export -F $TESTPOOL
+	log_must import_no_activity_check $TESTPOOL $opt
+done
+
+# 6. Verify multihost=on and hostids differ (activity check)
+log_must zpool export -F $TESTPOOL
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID2
+log_mustnot import_activity_check $TESTPOOL ""
+log_must import_activity_check $TESTPOOL "-f"
+
+# 7. Verify multihost=on and hostid zero fails (no activity check)
+log_must zpool export -F $TESTPOOL
+log_must mmp_clear_hostid
+case "$(uname)" in
+Linux)	MMP_IMPORTED_MSG="Set a unique system hostid";;
+SunOS)	MMP_IMPORTED_MSG="Check the SMF svc:/system/hostid service.";;
+esac
+log_must check_pool_import $TESTPOOL "-f" "action" "$MMP_IMPORTED_MSG"
+log_mustnot import_no_activity_check $TESTPOOL "-f"
+
+log_pass "multihost=on|off inactive pool activity checks passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_interval.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_interval.ksh
@@ -1,0 +1,50 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+# DESCRIPTION:
+#	zfs_multihost_interval should only accept valid values.
+#
+# STRATEGY:
+#	1. Set zfs_multihost_interval to invalid values (negative).
+#	2. Set zfs_multihost_interval to valid values.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+}
+
+log_assert "zfs_multihost_interval cannot be set to an invalid value"
+log_onexit cleanup
+
+if [[ $(uname) == "Linux" ]]; then
+	log_mustnot set_tunable64 zfs_multihost_interval -1
+fi
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_MIN
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+
+log_pass "zfs_multihost_interval cannot be set to an invalid value"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_off.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_off.ksh
@@ -1,0 +1,79 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+# DESCRIPTION:
+#	When multihost=off ensure that leaf vdev uberblocks are not updated.
+#
+# STRATEGY:
+#	1. Set multihost=off (disables mmp)
+#	2. Set zfs_txg_timeout to large value
+#	3. Create a zpool
+#	4. Find the current "best" uberblock
+#	5. Sleep for enough time for uberblocks to change
+#	6. Find the current "best" uberblock
+#	7. If the uberblock changed, fail
+#	8. Set multihost=on
+#	9. Sleep for enough time for uberblocks to change
+#	10. Find the current "best" uberblock
+#	11. If uberblocks didn't change, fail
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_DEFAULT
+	log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+	log_must rm -f $PREV_UBER $CURR_UBER
+	log_must mmp_clear_hostid
+}
+
+log_assert "mmp thread won't write uberblocks with multihost=off"
+log_onexit cleanup
+
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_MIN
+log_must set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_LONG
+log_must mmp_set_hostid $HOSTID1
+
+default_setup_noexit $DISK
+log_must zpool set multihost=off $TESTPOOL
+
+log_must zdb -u $TESTPOOL > $PREV_UBER
+log_must sleep 5
+log_must zdb -u $TESTPOOL > $CURR_UBER
+
+if ! diff "$CURR_UBER" "$PREV_UBER"; then
+	log_fail "mmp thread has updated an uberblock"
+fi
+
+log_must zpool set multihost=on $TESTPOOL
+log_must sleep 5
+log_must zdb -u $TESTPOOL > $CURR_UBER
+
+if diff "$CURR_UBER" "$PREV_UBER"; then
+	log_fail "mmp failed to update uberblocks"
+fi
+
+log_pass "mmp thread won't write uberblocks with multihost=off passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_thread.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_thread.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+# DESCRIPTION:
+#	Ensure that the MMP thread is writing uberblocks.
+#
+# STRATEGY:
+#	1. Set zfs_txg_timeout to large value
+#	2. Create a zpool
+#	3. Find the current "best" uberblock
+#	4. Sleep for enough time for a potential uberblock update
+#	5. Find the current "best" uberblock
+#	6. If the uberblock never changed, fail
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_DEFAULT
+	log_must rm -f $PREV_UBER $CURR_UBER
+	log_must mmp_clear_hostid
+}
+
+log_assert "mmp thread writes uberblocks (MMP)"
+log_onexit cleanup
+
+log_must set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_LONG
+log_must mmp_set_hostid $HOSTID1
+
+default_setup_noexit $DISK
+log_must zpool set multihost=on $TESTPOOL
+
+log_must zdb -u $TESTPOOL > $PREV_UBER
+log_must sleep 5
+log_must zdb -u $TESTPOOL > $CURR_UBER
+
+if diff -u "$CURR_UBER" "$PREV_UBER"; then
+	log_fail "mmp failed to update uberblocks"
+fi
+
+log_pass "mmp thread writes uberblocks (MMP) passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
@@ -1,0 +1,73 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+# DESCRIPTION:
+#	Ensure that MMP updates uberblocks at the expected intervals.
+#
+# STRATEGY:
+#	1. Set zfs_txg_timeout to large value
+#	2. Create a zpool
+#	3. Clear multihost history
+#	4. Sleep, then collect count of uberblocks written
+#	5. If number of changes seen is less than min threshold, then fail
+#	6. If number of changes seen is more than max threshold, then fail
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+UBER_CHANGES=0
+EXPECTED=$(($(echo $DISKS | wc -w) * 10))
+FUDGE=$((EXPECTED * 20 / 100))
+MIN=$((EXPECTED - FUDGE))
+MAX=$((EXPECTED + FUDGE))
+
+function cleanup
+{
+	default_cleanup_noexit
+	set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_DEFAULT
+	log_must mmp_clear_hostid
+}
+
+log_assert "Ensure MMP uberblocks update at the correct interval"
+log_onexit cleanup
+
+log_must set_tunable64 zfs_txg_timeout $TXG_TIMEOUT_LONG
+log_must mmp_set_hostid $HOSTID1
+
+default_setup_noexit "$DISKS"
+log_must zpool set multihost=on $TESTPOOL
+clear_mmp_history
+UBER_CHANGES=$(count_mmp_writes $TESTPOOL 10)
+
+log_note "Uberblock changed $UBER_CHANGES times"
+
+if [ $UBER_CHANGES -lt $MIN ]; then
+	log_fail "Fewer uberblock writes occured than expected ($EXPECTED)"
+fi
+
+if [ $UBER_CHANGES -gt $MAX ]; then
+	log_fail "More uberblock writes occured than expected ($EXPECTED)"
+fi
+
+log_pass "Ensure MMP uberblocks update at the correct interval passed"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_zdb.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_on_zdb.ksh
@@ -1,0 +1,81 @@
+#!/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 Lawrence Livermore National Security, LLC.
+# Copyright (c) 2018 by Nutanix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+#
+# Description:
+# zdb will work while multihost is enabled.
+#
+# Strategy:
+# 1. Create a pool
+# 2. Enable multihost
+# 3. Run zdb -d with pool and dataset arguments.
+# 4. Create a checkpoint
+# 5. Run zdb -kd with pool and dataset arguments.
+# 6. Discard the checkpoint
+# 7. Export the pool
+# 8. Run zdb -ed with pool and dataset arguments.
+#
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	for DISK in $DISKS; do
+		zpool labelclear -f $DEV_RDSKDIR/$DISK
+	done
+	log_must mmp_clear_hostid
+}
+
+log_assert "Verify zdb -d works while multihost is enabled"
+log_onexit cleanup
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+default_mirror_setup_noexit $DISKS
+log_must mmp_set_hostid $HOSTID1
+log_must zpool set multihost=on $TESTPOOL
+log_must zfs snap $TESTPOOL/$TESTFS@snap
+
+log_must zdb -d $TESTPOOL
+log_must zdb -d $TESTPOOL/
+log_must zdb -d $TESTPOOL/$TESTFS
+log_must zdb -d $TESTPOOL/$TESTFS@snap
+
+log_must zpool checkpoint $TESTPOOL
+log_must zdb -kd $TESTPOOL
+log_must zdb -kd $TESTPOOL/
+log_must zdb -kd $TESTPOOL/$TESTFS
+log_must zdb -kd $TESTPOOL/$TESTFS@snap
+log_must zpool checkpoint -d $TESTPOOL
+
+log_must zpool export $TESTPOOL
+
+log_must zdb -ed $TESTPOOL
+log_must zdb -ed $TESTPOOL/
+log_must zdb -ed $TESTPOOL/$TESTFS
+log_must zdb -ed $TESTPOOL/$TESTFS@snap
+
+log_must zpool import $TESTPOOL
+
+cleanup
+
+log_pass "zdb -d works while multihost is enabled"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+# DESCRIPTION:
+#	Ensure that the MMP thread is notified when zfs_multihost_interval is
+#	reduced.
+#
+# STRATEGY:
+#	1. Set zfs_multihost_interval to much longer than the test duration
+#	2. Create a zpool and enable multihost
+#	3. Verify no MMP writes occurred
+#	4. Set zfs_multihost_interval to 1 second
+#	5. Sleep briefly
+#	6. Verify MMP writes began
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	default_cleanup_noexit
+	log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+	log_must mmp_clear_hostid
+}
+
+log_assert "mmp threads notified when zfs_multihost_interval reduced"
+log_onexit cleanup
+
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_HOUR
+log_must mmp_set_hostid $HOSTID1
+
+default_setup_noexit $DISK
+log_must zpool set multihost=on $TESTPOOL
+
+clear_mmp_history
+log_must set_tunable64 zfs_multihost_interval $MMP_INTERVAL_DEFAULT
+uber_count=$(count_mmp_writes $TESTPOOL 1)
+
+if [ $uber_count -eq 0 ]; then
+	log_fail "mmp writes did not start when zfs_multihost_interval reduced"
+fi
+
+log_pass "mmp threads notified when zfs_multihost_interval reduced"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_write_distribution.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_write_distribution.ksh
@@ -1,0 +1,92 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+# DESCRIPTION:
+#	Verify MMP writes are distributed evenly among leaves
+#
+# STRATEGY:
+#	1. Create an asymmetric mirrored pool
+#	2. Enable multihost and multihost_history
+#	3. Delay for MMP writes to occur
+#	4. Verify the MMP writes are distributed evenly across leaf vdevs
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zpool destroy $MMP_POOL
+	log_must rm $MMP_DIR/file.{0,1,2,3,4,5,6,7}
+	log_must rm $MMP_HISTORY_TMP
+	log_must rmdir $MMP_DIR
+	log_must mmp_clear_hostid
+}
+
+log_assert "mmp writes are evenly distributed across leaf vdevs"
+log_onexit cleanup
+
+MMP_HISTORY_TMP=$MMP_DIR/history
+MMP_HISTORY=/proc/spl/kstat/zfs/$MMP_POOL/multihost
+
+# Step 1
+log_must mkdir -p $MMP_DIR
+log_must truncate -s 128M $MMP_DIR/file.{0,1,2,3,4,5,6,7}
+log_must zpool create -f $MMP_POOL mirror $MMP_DIR/file.{0,1} mirror $MMP_DIR/file.{2,3,4,5,6,7}
+
+# Step 2
+log_must mmp_set_hostid $HOSTID1
+log_must zpool set multihost=on $MMP_POOL
+set_tunable64 zfs_multihost_history 0
+set_tunable64 zfs_multihost_history 40
+
+# Step 3
+# default settings, every leaf written once/second
+sleep 4
+
+# Step 4
+typeset -i min_writes=999
+typeset -i max_writes=0
+typeset -i write_count
+# copy to get as close to a consistent view as possible
+cat $MMP_HISTORY > $MMP_HISTORY_TMP
+for x in $(seq 0 7); do
+	write_count=$(grep -c file.${x} $MMP_HISTORY_TMP)
+	if [ $write_count -lt $min_writes ]; then
+		min_writes=$write_count
+	fi
+	if [ $write_count -gt $max_writes ]; then
+		max_writes=$write_count
+	fi
+done
+log_note "mmp min_writes $min_writes max_writes $max_writes"
+
+if [ $min_writes -lt 1 ]; then
+	log_fail "mmp writes were not counted correctly"
+fi
+
+if [ $((max_writes - min_writes)) -gt 1 ]; then
+	log_fail "mmp writes were not evenly distributed across leaf vdevs"
+fi
+
+log_pass "mmp writes were evenly distributed across leaf vdevs"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
@@ -1,0 +1,59 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+# DESCRIPTION:
+#	Verify MMP behaves correctly when failing to write uberblocks.
+#
+# STRATEGY:
+#	1. Create a mirrored pool and enable multihost
+#	2. Inject a 50% failure rate when writing uberblocks to a device
+#	3. Delay briefly for additional MMP writes to complete
+#	4. Verify the failed uberblock writes did not prevent MMP updates
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	zinject -c all
+	default_cleanup_noexit
+	log_must mmp_clear_hostid
+}
+
+log_assert "mmp behaves correctly when failing to write uberblocks."
+log_onexit cleanup
+
+log_must mmp_set_hostid $HOSTID1
+default_mirror_setup_noexit $DISKS
+log_must zpool set multihost=on $TESTPOOL
+log_must zinject -d ${DISK[0]} -e io -T write -f 50 -L uber $TESTPOOL
+clear_mmp_history
+uber_count=$(count_mmp_writes $TESTPOOL 3)
+
+if [ $uber_count -eq 0 ]; then
+	log_fail "mmp writes did not occur when uberblock IO errors injected"
+fi
+
+log_pass "mmp correctly wrote uberblocks when IO errors injected"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/multihost_history.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/multihost_history.ksh
@@ -1,0 +1,67 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+#
+
+# DESCRIPTION:
+#	zfs_multihost_history should report both writes issued and gaps
+#
+# STRATEGY:
+#	1. Create a 2-vdev pool with mmp enabled
+#	2. Delay writes by 2*MMP_INTERVAL_DEFAULT
+#	3. Check multihost_history for both issued writes, and for gaps where
+#	no write could be issued because all vdevs are busy
+#
+# During the first MMP_INTERVAL period 2 MMP writes will be issued - one to
+# each vdev.  At the third scheduled attempt to write, at time t0+MMP_INTERVAL,
+# both vdevs will still have outstanding writes, so a skipped write entry will
+# be recorded in the multihost_history.
+
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zinject -c all
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
+	log_must mmp_clear_hostid
+}
+
+log_assert "zfs_multihost_history records writes and skipped writes"
+log_onexit cleanup
+
+mmp_pool_create_simple $MMP_POOL $MMP_DIR
+log_must zinject -d $MMP_DIR/vdev1 -D$((2*MMP_INTERVAL_DEFAULT)):10 $MMP_POOL
+log_must zinject -d $MMP_DIR/vdev2 -D$((2*MMP_INTERVAL_DEFAULT)):10 $MMP_POOL
+
+mmp_writes=$(count_mmp_writes $MMP_POOL $((MMP_INTERVAL_DEFAULT/1000)))
+mmp_skips=$(count_skipped_mmp_writes $MMP_POOL $((MMP_INTERVAL_DEFAULT/1000)))
+
+if [ $mmp_writes -lt 1 ]; then
+	log_fail "mmp writes entries missing when delays injected"
+fi
+
+if [ $mmp_skips -lt 1 ]; then
+	log_fail "mmp skipped write entries missing when delays injected"
+fi
+
+log_pass "zfs_multihost_history records writes and skipped writes"

--- a/usr/src/test/zfs-tests/tests/functional/mmp/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mmp/setup.ksh
@@ -1,0 +1,38 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+# Copyright 2019 Joyent, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+
+verify_runnable "global"
+
+case "$(uname)" in
+Linux)	if [ -e $HOSTID_FILE ]; then
+		log_unsupported "System has existing $HOSTID_FILE file"
+	fi
+	log_must set_tunable64 zfs_multihost_history $MMP_HISTORY
+	;;
+
+SunOS)	hostid >/var/tmp/zfs_test_hostid.txt
+	;;
+esac
+
+log_pass "mmp setup pass"

--- a/usr/src/uts/common/Makefile.files
+++ b/usr/src/uts/common/Makefile.files
@@ -1375,6 +1375,7 @@ ZFS_COMMON_OBJS +=		\
 	lz4.o			\
 	lzjb.o			\
 	metaslab.o		\
+	mmp.o			\
 	multilist.o		\
 	range_tree.o		\
 	refcount.o		\
@@ -1641,10 +1642,14 @@ CONSCONFIG_DACF_OBJS  += consconfig_dacf.o consplat.o
 TEM_OBJS += tem.o tem_safe.o
 
 #
-#	Font data for generated 8x16 font
+#	Font data for generated console fonts
 #
-FONT	= 8x16
-FONT_SRC= ter-u16n
+i386_FONT	= 8x16
+i386_FONT_SRC= ter-u16n
+sparc_FONT	= 12x22
+sparc_FONT_SRC= Gallant19
+FONT=$($(MACH)_FONT)
+FONT_SRC=$($(MACH)_FONT_SRC)
 FONT_DIR= $(SRC)/data/consfonts
 FONT_OBJS += font.o $(FONT).o
 

--- a/usr/src/uts/common/fs/zfs/dsl_pool.c
+++ b/usr/src/uts/common/fs/zfs/dsl_pool.c
@@ -50,6 +50,7 @@
 #include <sys/zfeature.h>
 #include <sys/zil_impl.h>
 #include <sys/dsl_userhold.h>
+#include <sys/mmp.h>
 
 /*
  * ZFS Write Throttle
@@ -192,6 +193,7 @@ dsl_pool_open_impl(spa_t *spa, uint64_t txg)
 	dp->dp_meta_rootbp = *bp;
 	rrw_init(&dp->dp_config_rwlock, B_TRUE);
 	txg_init(dp, txg);
+	mmp_init(spa);
 
 	txg_list_create(&dp->dp_dirty_datasets, spa,
 	    offsetof(dsl_dataset_t, ds_dirty_link));
@@ -393,6 +395,7 @@ dsl_pool_close(dsl_pool_t *dp)
 	 */
 	arc_flush(dp->dp_spa, FALSE);
 
+	mmp_fini(dp->dp_spa);
 	txg_fini(dp);
 	dsl_scan_fini(dp);
 	dmu_buf_user_evict_wait();

--- a/usr/src/uts/common/fs/zfs/mmp.c
+++ b/usr/src/uts/common/fs/zfs/mmp.c
@@ -1,0 +1,582 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2017 by Lawrence Livermore National Security, LLC.
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/abd.h>
+#include <sys/mmp.h>
+#include <sys/spa.h>
+#include <sys/spa_impl.h>
+#include <sys/time.h>
+#include <sys/vdev.h>
+#include <sys/vdev_impl.h>
+#include <sys/zfs_context.h>
+#include <sys/callb.h>
+
+/*
+ * Multi-Modifier Protection (MMP) attempts to prevent a user from importing
+ * or opening a pool on more than one host at a time.  In particular, it
+ * prevents "zpool import -f" on a host from succeeding while the pool is
+ * already imported on another host.  There are many other ways in which a
+ * device could be used by two hosts for different purposes at the same time
+ * resulting in pool damage.  This implementation does not attempt to detect
+ * those cases.
+ *
+ * MMP operates by ensuring there are frequent visible changes on disk (a
+ * "heartbeat") at all times.  And by altering the import process to check
+ * for these changes and failing the import when they are detected.  This
+ * functionality is enabled by setting the 'multihost' pool property to on.
+ *
+ * Uberblocks written by the txg_sync thread always go into the first
+ * (N-MMP_BLOCKS_PER_LABEL) slots, the remaining slots are reserved for MMP.
+ * They are used to hold uberblocks which are exactly the same as the last
+ * synced uberblock except that the ub_timestamp is frequently updated.
+ * Like all other uberblocks, the slot is written with an embedded checksum,
+ * and slots with invalid checksums are ignored.  This provides the
+ * "heartbeat", with no risk of overwriting good uberblocks that must be
+ * preserved, e.g. previous txgs and associated block pointers.
+ *
+ * Two optional fields are added to uberblock structure: ub_mmp_magic and
+ * ub_mmp_delay.  The magic field allows zfs to tell whether ub_mmp_delay is
+ * valid.  The delay field is a decaying average of the amount of time between
+ * completion of successive MMP writes, in nanoseconds.  It is used to predict
+ * how long the import must wait to detect activity in the pool, before
+ * concluding it is not in use.
+ *
+ * During import an activity test may now be performed to determine if
+ * the pool is in use.  The activity test is typically required if the
+ * ZPOOL_CONFIG_HOSTID does not match the system hostid, the pool state is
+ * POOL_STATE_ACTIVE, and the pool is not a root pool.
+ *
+ * The activity test finds the "best" uberblock (highest txg & timestamp),
+ * waits some time, and then finds the "best" uberblock again.  If the txg
+ * and timestamp in both "best" uberblocks do not match, the pool is in use
+ * by another host and the import fails.  Since the granularity of the
+ * timestamp is in seconds this activity test must take a bare minimum of one
+ * second.  In order to assure the accuracy of the activity test, the default
+ * values result in an activity test duration of 10x the mmp write interval.
+ *
+ * The "zpool import"  activity test can be expected to take a minimum time of
+ * zfs_multihost_import_intervals * zfs_multihost_interval milliseconds.  If the
+ * "best" uberblock has a valid ub_mmp_delay field, then the duration of the
+ * test may take longer if MMP writes were occurring less frequently than
+ * expected.  Additionally, the duration is then extended by a random 25% to
+ * attempt to to detect simultaneous imports.  For example, if both partner
+ * hosts are rebooted at the same time and automatically attempt to import the
+ * pool.
+ */
+
+/*
+ * Used to control the frequency of mmp writes which are performed when the
+ * 'multihost' pool property is on.  This is one factor used to determine the
+ * length of the activity check during import.
+ *
+ * The mmp write period is zfs_multihost_interval / leaf-vdevs milliseconds.
+ * This means that on average an mmp write will be issued for each leaf vdev
+ * every zfs_multihost_interval milliseconds.  In practice, the observed period
+ * can vary with the I/O load and this observed value is the delay which is
+ * stored in the uberblock.  The minimum allowed value is 100 ms.
+ */
+ulong_t zfs_multihost_interval = MMP_DEFAULT_INTERVAL;
+
+/*
+ * Used to control the duration of the activity test on import.  Smaller values
+ * of zfs_multihost_import_intervals will reduce the import time but increase
+ * the risk of failing to detect an active pool.  The total activity check time
+ * is never allowed to drop below one second.  A value of 0 is ignored and
+ * treated as if it was set to 1.
+ */
+uint_t zfs_multihost_import_intervals = MMP_DEFAULT_IMPORT_INTERVALS;
+
+/*
+ * Controls the behavior of the pool when mmp write failures are detected.
+ *
+ * When zfs_multihost_fail_intervals = 0 then mmp write failures are ignored.
+ * The failures will still be reported to the ZED which depending on its
+ * configuration may take action such as suspending the pool or taking a
+ * device offline.
+ *
+ * When zfs_multihost_fail_intervals > 0 then sequential mmp write failures will
+ * cause the pool to be suspended.  This occurs when
+ * zfs_multihost_fail_intervals * zfs_multihost_interval milliseconds have
+ * passed since the last successful mmp write.  This guarantees the activity
+ * test will see mmp writes if the
+ * pool is imported.
+ */
+uint_t zfs_multihost_fail_intervals = MMP_DEFAULT_FAIL_INTERVALS;
+
+char *mmp_tag = "mmp_write_uberblock";
+static void mmp_thread(void *arg);
+
+void
+mmp_init(spa_t *spa)
+{
+	mmp_thread_t *mmp = &spa->spa_mmp;
+
+	mutex_init(&mmp->mmp_thread_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&mmp->mmp_thread_cv, NULL, CV_DEFAULT, NULL);
+	mutex_init(&mmp->mmp_io_lock, NULL, MUTEX_DEFAULT, NULL);
+	mmp->mmp_kstat_id = 1;
+}
+
+void
+mmp_fini(spa_t *spa)
+{
+	mmp_thread_t *mmp = &spa->spa_mmp;
+
+	mutex_destroy(&mmp->mmp_thread_lock);
+	cv_destroy(&mmp->mmp_thread_cv);
+	mutex_destroy(&mmp->mmp_io_lock);
+}
+
+static void
+mmp_thread_enter(mmp_thread_t *mmp, callb_cpr_t *cpr)
+{
+	CALLB_CPR_INIT(cpr, &mmp->mmp_thread_lock, callb_generic_cpr, FTAG);
+	mutex_enter(&mmp->mmp_thread_lock);
+}
+
+static void
+mmp_thread_exit(mmp_thread_t *mmp, kthread_t **mpp, callb_cpr_t *cpr)
+{
+	ASSERT(*mpp != NULL);
+	*mpp = NULL;
+	cv_broadcast(&mmp->mmp_thread_cv);
+	CALLB_CPR_EXIT(cpr);		/* drops &mmp->mmp_thread_lock */
+	thread_exit();
+}
+
+void
+mmp_thread_start(spa_t *spa)
+{
+	mmp_thread_t *mmp = &spa->spa_mmp;
+
+	if (spa_writeable(spa)) {
+		mutex_enter(&mmp->mmp_thread_lock);
+		if (!mmp->mmp_thread) {
+			dprintf("mmp_thread_start pool %s\n",
+			    spa->spa_name);
+			mmp->mmp_thread = thread_create(NULL, 0, mmp_thread,
+			    spa, 0, &p0, TS_RUN, minclsyspri);
+		}
+		mutex_exit(&mmp->mmp_thread_lock);
+	}
+}
+
+void
+mmp_thread_stop(spa_t *spa)
+{
+	mmp_thread_t *mmp = &spa->spa_mmp;
+
+	mutex_enter(&mmp->mmp_thread_lock);
+	mmp->mmp_thread_exiting = 1;
+	cv_broadcast(&mmp->mmp_thread_cv);
+
+	while (mmp->mmp_thread) {
+		cv_wait(&mmp->mmp_thread_cv, &mmp->mmp_thread_lock);
+	}
+	mutex_exit(&mmp->mmp_thread_lock);
+
+	ASSERT(mmp->mmp_thread == NULL);
+	mmp->mmp_thread_exiting = 0;
+}
+
+typedef enum mmp_vdev_state_flag {
+	MMP_FAIL_NOT_WRITABLE	= (1 << 0),
+	MMP_FAIL_WRITE_PENDING	= (1 << 1),
+} mmp_vdev_state_flag_t;
+
+/*
+ * Find a leaf vdev to write an MMP block to.  It must not have an outstanding
+ * mmp write (if so a new write will also likely block).  If there is no usable
+ * leaf, a nonzero error value is returned. The error value returned is a bit
+ * field.
+ *
+ * MMP_FAIL_WRITE_PENDING   One or more leaf vdevs are writeable, but have an
+ *                          outstanding MMP write.
+ * MMP_FAIL_NOT_WRITABLE    One or more leaf vdevs are not writeable.
+ */
+
+static int
+mmp_next_leaf(spa_t *spa)
+{
+	vdev_t *leaf;
+	vdev_t *starting_leaf;
+	int fail_mask = 0;
+
+	ASSERT(MUTEX_HELD(&spa->spa_mmp.mmp_io_lock));
+	ASSERT(spa_config_held(spa, SCL_STATE, RW_READER));
+	ASSERT(list_link_active(&spa->spa_leaf_list.list_head) == B_TRUE);
+	ASSERT(!list_is_empty(&spa->spa_leaf_list));
+
+	if (spa->spa_mmp.mmp_leaf_last_gen != spa->spa_leaf_list_gen) {
+		spa->spa_mmp.mmp_last_leaf = list_head(&spa->spa_leaf_list);
+		spa->spa_mmp.mmp_leaf_last_gen = spa->spa_leaf_list_gen;
+	}
+
+	leaf = spa->spa_mmp.mmp_last_leaf;
+	if (leaf == NULL)
+		leaf = list_head(&spa->spa_leaf_list);
+	starting_leaf = leaf;
+
+	do {
+		leaf = list_next(&spa->spa_leaf_list, leaf);
+		if (leaf == NULL)
+			leaf = list_head(&spa->spa_leaf_list);
+
+		if (!vdev_writeable(leaf)) {
+			fail_mask |= MMP_FAIL_NOT_WRITABLE;
+		} else if (leaf->vdev_mmp_pending != 0) {
+			fail_mask |= MMP_FAIL_WRITE_PENDING;
+		} else {
+			spa->spa_mmp.mmp_last_leaf = leaf;
+			return (0);
+		}
+	} while (leaf != starting_leaf);
+
+	ASSERT(fail_mask);
+
+	return (fail_mask);
+}
+
+/*
+ * MMP writes are issued on a fixed schedule, but may complete at variable,
+ * much longer, intervals.  The mmp_delay captures long periods between
+ * successful writes for any reason, including disk latency, scheduling delays,
+ * etc.
+ *
+ * The mmp_delay is usually calculated as a decaying average, but if the latest
+ * delay is higher we do not average it, so that we do not hide sudden spikes
+ * which the importing host must wait for.
+ *
+ * If writes are occurring frequently, such as due to a high rate of txg syncs,
+ * the mmp_delay could become very small.  Since those short delays depend on
+ * activity we cannot count on, we never allow mmp_delay to get lower than rate
+ * expected if only mmp_thread writes occur.
+ *
+ * If an mmp write was skipped or fails, and we have already waited longer than
+ * mmp_delay, we need to update it so the next write reflects the longer delay.
+ *
+ * Do not set mmp_delay if the multihost property is not on, so as not to
+ * trigger an activity check on import.
+ */
+static void
+mmp_delay_update(spa_t *spa, boolean_t write_completed)
+{
+	mmp_thread_t *mts = &spa->spa_mmp;
+	hrtime_t delay = gethrtime() - mts->mmp_last_write;
+
+	ASSERT(MUTEX_HELD(&mts->mmp_io_lock));
+
+	if (spa_multihost(spa) == B_FALSE) {
+		mts->mmp_delay = 0;
+		return;
+	}
+
+	if (delay > mts->mmp_delay)
+		mts->mmp_delay = delay;
+
+	if (write_completed == B_FALSE)
+		return;
+
+	mts->mmp_last_write = gethrtime();
+
+	/*
+	 * strictly less than, in case delay was changed above.
+	 */
+	if (delay < mts->mmp_delay) {
+		hrtime_t min_delay = MSEC2NSEC(zfs_multihost_interval) /
+		    MAX(1, vdev_count_leaves(spa));
+		mts->mmp_delay = MAX(((delay + mts->mmp_delay * 127) / 128),
+		    min_delay);
+	}
+}
+
+static void
+mmp_write_done(zio_t *zio)
+{
+	spa_t *spa = zio->io_spa;
+	vdev_t *vd = zio->io_vd;
+	mmp_thread_t *mts = zio->io_private;
+
+	mutex_enter(&mts->mmp_io_lock);
+	uint64_t mmp_kstat_id = vd->vdev_mmp_kstat_id;
+	hrtime_t mmp_write_duration = gethrtime() - vd->vdev_mmp_pending;
+
+	mmp_delay_update(spa, (zio->io_error == 0));
+
+	vd->vdev_mmp_pending = 0;
+	vd->vdev_mmp_kstat_id = 0;
+
+	mutex_exit(&mts->mmp_io_lock);
+	spa_config_exit(spa, SCL_STATE, mmp_tag);
+
+	abd_free(zio->io_abd);
+}
+
+/*
+ * When the uberblock on-disk is updated by a spa_sync,
+ * creating a new "best" uberblock, update the one stored
+ * in the mmp thread state, used for mmp writes.
+ */
+void
+mmp_update_uberblock(spa_t *spa, uberblock_t *ub)
+{
+	mmp_thread_t *mmp = &spa->spa_mmp;
+
+	mutex_enter(&mmp->mmp_io_lock);
+	mmp->mmp_ub = *ub;
+	mmp->mmp_ub.ub_timestamp = gethrestime_sec();
+	mmp_delay_update(spa, B_TRUE);
+	mutex_exit(&mmp->mmp_io_lock);
+}
+
+/*
+ * Choose a random vdev, label, and MMP block, and write over it
+ * with a copy of the last-synced uberblock, whose timestamp
+ * has been updated to reflect that the pool is in use.
+ */
+static void
+mmp_write_uberblock(spa_t *spa)
+{
+	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL;
+	mmp_thread_t *mmp = &spa->spa_mmp;
+	uberblock_t *ub;
+	vdev_t *vd = NULL;
+	int label, error;
+	uint64_t offset;
+
+	hrtime_t lock_acquire_time = gethrtime();
+	spa_config_enter(spa, SCL_STATE, mmp_tag, RW_READER);
+	lock_acquire_time = gethrtime() - lock_acquire_time;
+	if (lock_acquire_time > (MSEC2NSEC(MMP_MIN_INTERVAL) / 10))
+		zfs_dbgmsg("SCL_STATE acquisition took %llu ns\n",
+		    (u_longlong_t)lock_acquire_time);
+
+	mutex_enter(&mmp->mmp_io_lock);
+
+	error = mmp_next_leaf(spa);
+
+	/*
+	 * spa_mmp_history has two types of entries:
+	 * Issued MMP write: records time issued, error status, etc.
+	 * Skipped MMP write: an MMP write could not be issued because no
+	 * suitable leaf vdev was available.  See comment above struct
+	 * spa_mmp_history for details.
+	 */
+
+	if (error) {
+		mmp_delay_update(spa, B_FALSE);
+		if (mmp->mmp_skip_error == error) {
+			/*
+			 * ZoL porting note: the following is TBD
+			 * spa_mmp_history_set_skip(spa, mmp->mmp_kstat_id - 1);
+			 */
+		} else {
+			mmp->mmp_skip_error = error;
+			/*
+			 * ZoL porting note: the following is TBD
+			 * spa_mmp_history_add(spa, mmp->mmp_ub.ub_txg,
+			 * gethrestime_sec(), mmp->mmp_delay, NULL, 0,
+			 * mmp->mmp_kstat_id++, error);
+			 */
+		}
+		mutex_exit(&mmp->mmp_io_lock);
+		spa_config_exit(spa, SCL_STATE, mmp_tag);
+		return;
+	}
+
+	vd = spa->spa_mmp.mmp_last_leaf;
+	mmp->mmp_skip_error = 0;
+
+	if (mmp->mmp_zio_root == NULL)
+		mmp->mmp_zio_root = zio_root(spa, NULL, NULL,
+		    flags | ZIO_FLAG_GODFATHER);
+
+	ub = &mmp->mmp_ub;
+	ub->ub_timestamp = gethrestime_sec();
+	ub->ub_mmp_magic = MMP_MAGIC;
+	ub->ub_mmp_delay = mmp->mmp_delay;
+	vd->vdev_mmp_pending = gethrtime();
+	vd->vdev_mmp_kstat_id = mmp->mmp_kstat_id;
+
+	zio_t *zio  = zio_null(mmp->mmp_zio_root, spa, NULL, NULL, NULL, flags);
+	abd_t *ub_abd = abd_alloc_for_io(VDEV_UBERBLOCK_SIZE(vd), B_TRUE);
+	abd_zero(ub_abd, VDEV_UBERBLOCK_SIZE(vd));
+	abd_copy_from_buf(ub_abd, ub, sizeof (uberblock_t));
+
+	mmp->mmp_kstat_id++;
+	mutex_exit(&mmp->mmp_io_lock);
+
+	offset = VDEV_UBERBLOCK_OFFSET(vd, VDEV_UBERBLOCK_COUNT(vd) -
+	    MMP_BLOCKS_PER_LABEL + spa_get_random(MMP_BLOCKS_PER_LABEL));
+
+	label = spa_get_random(VDEV_LABELS);
+	vdev_label_write(zio, vd, label, ub_abd, offset,
+	    VDEV_UBERBLOCK_SIZE(vd), mmp_write_done, mmp,
+	    flags | ZIO_FLAG_DONT_PROPAGATE);
+
+	/*
+	 * ZoL porting note: the following is TBD
+	 * (void) spa_mmp_history_add(spa, ub->ub_txg, ub->ub_timestamp,
+	 * ub->ub_mmp_delay, vd, label, vd->vdev_mmp_kstat_id, 0);
+	 */
+
+	zio_nowait(zio);
+}
+
+static void
+mmp_thread(void *arg)
+{
+	spa_t *spa = (spa_t *)arg;
+	mmp_thread_t *mmp = &spa->spa_mmp;
+	boolean_t last_spa_suspended = spa_suspended(spa);
+	boolean_t last_spa_multihost = spa_multihost(spa);
+	callb_cpr_t cpr;
+	hrtime_t max_fail_ns = zfs_multihost_fail_intervals *
+	    MSEC2NSEC(MAX(zfs_multihost_interval, MMP_MIN_INTERVAL));
+
+	mmp_thread_enter(mmp, &cpr);
+
+	/*
+	 * The mmp_write_done() function calculates mmp_delay based on the
+	 * prior value of mmp_delay and the elapsed time since the last write.
+	 * For the first mmp write, there is no "last write", so we start
+	 * with fake, but reasonable, default non-zero values.
+	 */
+	mmp->mmp_delay = MSEC2NSEC(MAX(zfs_multihost_interval,
+	    MMP_MIN_INTERVAL)) / MAX(vdev_count_leaves(spa), 1);
+	mmp->mmp_last_write = gethrtime() - mmp->mmp_delay;
+
+	while (!mmp->mmp_thread_exiting) {
+		uint64_t mmp_fail_intervals = zfs_multihost_fail_intervals;
+		uint64_t mmp_interval = MSEC2NSEC(
+		    MAX(zfs_multihost_interval, MMP_MIN_INTERVAL));
+		boolean_t suspended = spa_suspended(spa);
+		boolean_t multihost = spa_multihost(spa);
+		hrtime_t next_time;
+
+		if (multihost)
+			next_time = gethrtime() + mmp_interval /
+			    MAX(vdev_count_leaves(spa), 1);
+		else
+			next_time = gethrtime() +
+			    MSEC2NSEC(MMP_DEFAULT_INTERVAL);
+
+		/*
+		 * MMP off => on, or suspended => !suspended:
+		 * No writes occurred recently.  Update mmp_last_write to give
+		 * us some time to try.
+		 */
+		if ((!last_spa_multihost && multihost) ||
+		    (last_spa_suspended && !suspended)) {
+			mutex_enter(&mmp->mmp_io_lock);
+			mmp->mmp_last_write = gethrtime();
+			mutex_exit(&mmp->mmp_io_lock);
+		}
+
+		/*
+		 * MMP on => off:
+		 * mmp_delay == 0 tells importing node to skip activity check.
+		 */
+		if (last_spa_multihost && !multihost) {
+			mutex_enter(&mmp->mmp_io_lock);
+			mmp->mmp_delay = 0;
+			mutex_exit(&mmp->mmp_io_lock);
+		}
+		last_spa_multihost = multihost;
+		last_spa_suspended = suspended;
+
+		/*
+		 * Smooth max_fail_ns when its factors are decreased, because
+		 * making (max_fail_ns < mmp_interval) results in the pool being
+		 * immediately suspended before writes can occur at the new
+		 * higher frequency.
+		 */
+		if ((mmp_interval * mmp_fail_intervals) < max_fail_ns) {
+			max_fail_ns = ((31 * max_fail_ns) + (mmp_interval *
+			    mmp_fail_intervals)) / 32;
+		} else {
+			max_fail_ns = mmp_interval * mmp_fail_intervals;
+		}
+
+		/*
+		 * Suspend the pool if no MMP write has succeeded in over
+		 * mmp_interval * mmp_fail_intervals nanoseconds.
+		 */
+		if (!suspended && mmp_fail_intervals && multihost &&
+		    (gethrtime() - mmp->mmp_last_write) > max_fail_ns) {
+			cmn_err(CE_WARN, "MMP writes to pool '%s' have not "
+			    "succeeded in over %llus; suspending pool",
+			    spa_name(spa),
+			    NSEC2SEC(gethrtime() - mmp->mmp_last_write));
+			zio_suspend(spa, NULL, ZIO_SUSPEND_MMP);
+		}
+
+		if (multihost && !suspended)
+			mmp_write_uberblock(spa);
+
+		CALLB_CPR_SAFE_BEGIN(&cpr);
+		(void) cv_timedwait_sig_hrtime(&mmp->mmp_thread_cv,
+		    &mmp->mmp_thread_lock, next_time);
+		CALLB_CPR_SAFE_END(&cpr, &mmp->mmp_thread_lock);
+	}
+
+	/* Outstanding writes are allowed to complete. */
+	if (mmp->mmp_zio_root)
+		zio_wait(mmp->mmp_zio_root);
+
+	mmp->mmp_zio_root = NULL;
+	mmp_thread_exit(mmp, &mmp->mmp_thread, &cpr);
+}
+
+/*
+ * Signal the MMP thread to wake it, when it is sleeping on
+ * its cv.  Used when some module parameter has changed and
+ * we want the thread to know about it.
+ * Only signal if the pool is active and mmp thread is
+ * running, otherwise there is no thread to wake.
+ */
+static void
+mmp_signal_thread(spa_t *spa)
+{
+	mmp_thread_t *mmp = &spa->spa_mmp;
+
+	mutex_enter(&mmp->mmp_thread_lock);
+	if (mmp->mmp_thread)
+		cv_broadcast(&mmp->mmp_thread_cv);
+	mutex_exit(&mmp->mmp_thread_lock);
+}
+
+void
+mmp_signal_all_threads(void)
+{
+	spa_t *spa = NULL;
+
+	mutex_enter(&spa_namespace_lock);
+	while ((spa = spa_next(spa))) {
+		if (spa->spa_state == POOL_STATE_ACTIVE)
+			mmp_signal_thread(spa);
+	}
+	mutex_exit(&spa_namespace_lock);
+}

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -57,6 +57,7 @@
 #include <sys/vdev_initialize.h>
 #include <sys/metaslab.h>
 #include <sys/metaslab_impl.h>
+#include <sys/mmp.h>
 #include <sys/uberblock_impl.h>
 #include <sys/txg.h>
 #include <sys/avl.h>
@@ -544,6 +545,16 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 			error = nvpair_value_uint64(elem, &intval);
 			if (!error && intval > 1)
 				error = SET_ERROR(EINVAL);
+			break;
+
+		case ZPOOL_PROP_MULTIHOST:
+			error = nvpair_value_uint64(elem, &intval);
+			if (!error && intval > 1)
+				error = SET_ERROR(EINVAL);
+
+			if (!error && !spa_get_hostid())
+				error = SET_ERROR(ENOTSUP);
+
 			break;
 
 		case ZPOOL_PROP_BOOTFS:
@@ -1352,6 +1363,9 @@ spa_unload(spa_t *spa)
 			vdev_metaslab_fini(spa->spa_root_vdev->vdev_child[c]);
 		spa_config_exit(spa, SCL_ALL, spa);
 	}
+
+	if (spa->spa_mmp.mmp_thread)
+		mmp_thread_stop(spa);
 
 	/*
 	 * Wait for any outstanding async I/O to complete.
@@ -2305,6 +2319,205 @@ vdev_count_verify_zaps(vdev_t *vd)
 	return (total);
 }
 
+/*
+ * Determine whether the activity check is required.
+ */
+static boolean_t
+spa_activity_check_required(spa_t *spa, uberblock_t *ub, nvlist_t *label,
+    nvlist_t *config)
+{
+	uint64_t state = 0;
+	uint64_t hostid = 0;
+	uint64_t tryconfig_txg = 0;
+	uint64_t tryconfig_timestamp = 0;
+	nvlist_t *nvinfo;
+
+	if (nvlist_exists(config, ZPOOL_CONFIG_LOAD_INFO)) {
+		nvinfo = fnvlist_lookup_nvlist(config, ZPOOL_CONFIG_LOAD_INFO);
+		(void) nvlist_lookup_uint64(nvinfo, ZPOOL_CONFIG_MMP_TXG,
+		    &tryconfig_txg);
+		(void) nvlist_lookup_uint64(config, ZPOOL_CONFIG_TIMESTAMP,
+		    &tryconfig_timestamp);
+	}
+
+	(void) nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_STATE, &state);
+
+	/*
+	 * Disable the MMP activity check - This is used by zdb which
+	 * is intended to be used on potentially active pools.
+	 */
+	if (spa->spa_import_flags & ZFS_IMPORT_SKIP_MMP)
+		return (B_FALSE);
+
+	/*
+	 * Skip the activity check when the MMP feature is disabled.
+	 */
+	if (ub->ub_mmp_magic == MMP_MAGIC && ub->ub_mmp_delay == 0)
+		return (B_FALSE);
+	/*
+	 * If the tryconfig_* values are nonzero, they are the results of an
+	 * earlier tryimport.  If they match the uberblock we just found, then
+	 * the pool has not changed and we return false so we do not test a
+	 * second time.
+	 */
+	if (tryconfig_txg && tryconfig_txg == ub->ub_txg &&
+	    tryconfig_timestamp && tryconfig_timestamp == ub->ub_timestamp)
+		return (B_FALSE);
+
+	/*
+	 * Allow the activity check to be skipped when importing the pool
+	 * on the same host which last imported it.  Since the hostid from
+	 * configuration may be stale use the one read from the label.
+	 */
+	if (nvlist_exists(label, ZPOOL_CONFIG_HOSTID))
+		hostid = fnvlist_lookup_uint64(label, ZPOOL_CONFIG_HOSTID);
+
+	if (hostid == spa_get_hostid())
+		return (B_FALSE);
+
+	/*
+	 * Skip the activity test when the pool was cleanly exported.
+	 */
+	if (state != POOL_STATE_ACTIVE)
+		return (B_FALSE);
+
+	return (B_TRUE);
+}
+
+/*
+ * Perform the import activity check.  If the user canceled the import or
+ * we detected activity then fail.
+ */
+static int
+spa_activity_check(spa_t *spa, uberblock_t *ub, nvlist_t *config)
+{
+	uint64_t import_intervals = MAX(zfs_multihost_import_intervals, 1);
+	uint64_t txg = ub->ub_txg;
+	uint64_t timestamp = ub->ub_timestamp;
+	uint64_t import_delay = NANOSEC;
+	hrtime_t import_expire;
+	nvlist_t *mmp_label = NULL;
+	vdev_t *rvd = spa->spa_root_vdev;
+	kcondvar_t cv;
+	kmutex_t mtx;
+	int error = 0;
+
+	cv_init(&cv, NULL, CV_DEFAULT, NULL);
+	mutex_init(&mtx, NULL, MUTEX_DEFAULT, NULL);
+	mutex_enter(&mtx);
+
+	/*
+	 * If ZPOOL_CONFIG_MMP_TXG is present an activity check was performed
+	 * during the earlier tryimport.  If the txg recorded there is 0 then
+	 * the pool is known to be active on another host.
+	 *
+	 * Otherwise, the pool might be in use on another node.  Check for
+	 * changes in the uberblocks on disk if necessary.
+	 */
+	if (nvlist_exists(config, ZPOOL_CONFIG_LOAD_INFO)) {
+		nvlist_t *nvinfo = fnvlist_lookup_nvlist(config,
+		    ZPOOL_CONFIG_LOAD_INFO);
+
+		if (nvlist_exists(nvinfo, ZPOOL_CONFIG_MMP_TXG) &&
+		    fnvlist_lookup_uint64(nvinfo, ZPOOL_CONFIG_MMP_TXG) == 0) {
+			vdev_uberblock_load(rvd, ub, &mmp_label);
+			error = SET_ERROR(EREMOTEIO);
+			goto out;
+		}
+	}
+
+	/*
+	 * Preferentially use the zfs_multihost_interval from the node which
+	 * last imported the pool.  This value is stored in an MMP uberblock as.
+	 *
+	 * ub_mmp_delay * vdev_count_leaves() == zfs_multihost_interval
+	 */
+	if (ub->ub_mmp_magic == MMP_MAGIC && ub->ub_mmp_delay)
+		import_delay = MAX(import_delay, import_intervals *
+		    ub->ub_mmp_delay * MAX(vdev_count_leaves(spa), 1));
+
+	/* Apply a floor using the local default values. */
+	import_delay = MAX(import_delay, import_intervals *
+	    MSEC2NSEC(MAX(zfs_multihost_interval, MMP_MIN_INTERVAL)));
+
+	zfs_dbgmsg("import_delay=%llu ub_mmp_delay=%llu import_intervals=%u "
+	    "leaves=%u", import_delay, ub->ub_mmp_delay, import_intervals,
+	    vdev_count_leaves(spa));
+
+	/* Add a small random factor in case of simultaneous imports (0-25%) */
+	import_expire = gethrtime() + import_delay +
+	    (import_delay * spa_get_random(250) / 1000);
+
+	while (gethrtime() < import_expire) {
+		vdev_uberblock_load(rvd, ub, &mmp_label);
+
+		if (txg != ub->ub_txg || timestamp != ub->ub_timestamp) {
+			error = SET_ERROR(EREMOTEIO);
+			break;
+		}
+
+		if (mmp_label) {
+			nvlist_free(mmp_label);
+			mmp_label = NULL;
+		}
+
+		error = cv_timedwait_sig(&cv, &mtx, ddi_get_lbolt() + hz);
+		if (error != -1) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+		error = 0;
+	}
+
+out:
+	mutex_exit(&mtx);
+	mutex_destroy(&mtx);
+	cv_destroy(&cv);
+
+	/*
+	 * If the pool is determined to be active store the status in the
+	 * spa->spa_load_info nvlist.  If the remote hostname or hostid are
+	 * available from configuration read from disk store them as well.
+	 * This allows 'zpool import' to generate a more useful message.
+	 *
+	 * ZPOOL_CONFIG_MMP_STATE    - observed pool status (mandatory)
+	 * ZPOOL_CONFIG_MMP_HOSTNAME - hostname from the active pool
+	 * ZPOOL_CONFIG_MMP_HOSTID   - hostid from the active pool
+	 */
+	if (error == EREMOTEIO) {
+		char *hostname = "<unknown>";
+		uint64_t hostid = 0;
+
+		if (mmp_label) {
+			if (nvlist_exists(mmp_label, ZPOOL_CONFIG_HOSTNAME)) {
+				hostname = fnvlist_lookup_string(mmp_label,
+				    ZPOOL_CONFIG_HOSTNAME);
+				fnvlist_add_string(spa->spa_load_info,
+				    ZPOOL_CONFIG_MMP_HOSTNAME, hostname);
+			}
+
+			if (nvlist_exists(mmp_label, ZPOOL_CONFIG_HOSTID)) {
+				hostid = fnvlist_lookup_uint64(mmp_label,
+				    ZPOOL_CONFIG_HOSTID);
+				fnvlist_add_uint64(spa->spa_load_info,
+				    ZPOOL_CONFIG_MMP_HOSTID, hostid);
+			}
+		}
+
+		fnvlist_add_uint64(spa->spa_load_info,
+		    ZPOOL_CONFIG_MMP_STATE, MMP_STATE_ACTIVE);
+		fnvlist_add_uint64(spa->spa_load_info,
+		    ZPOOL_CONFIG_MMP_TXG, 0);
+
+		error = spa_vdev_err(rvd, VDEV_AUX_ACTIVE, EREMOTEIO);
+	}
+
+	if (mmp_label)
+		nvlist_free(mmp_label);
+
+	return (error);
+}
+
 static int
 spa_verify_host(spa_t *spa, nvlist_t *mos_config)
 {
@@ -2555,6 +2768,7 @@ spa_ld_select_uberblock(spa_t *spa, spa_import_type_t type)
 	vdev_t *rvd = spa->spa_root_vdev;
 	nvlist_t *label;
 	uberblock_t *ub = &spa->spa_uberblock;
+	boolean_t activity_check = B_FALSE;
 
 	/*
 	 * If we are opening the checkpointed state of the pool by
@@ -2595,6 +2809,34 @@ spa_ld_select_uberblock(spa_t *spa, spa_import_type_t type)
 
 	spa_load_note(spa, "using uberblock with txg=%llu",
 	    (u_longlong_t)ub->ub_txg);
+
+	/*
+	 * For pools which have the multihost property on determine if the
+	 * pool is truly inactive and can be safely imported.  Prevent
+	 * hosts which don't have a hostid set from importing the pool.
+	 */
+	activity_check = spa_activity_check_required(spa, ub, label,
+	    spa->spa_config);
+	if (activity_check) {
+		if (ub->ub_mmp_magic == MMP_MAGIC && ub->ub_mmp_delay &&
+		    spa_get_hostid() == 0) {
+			nvlist_free(label);
+			fnvlist_add_uint64(spa->spa_load_info,
+			    ZPOOL_CONFIG_MMP_STATE, MMP_STATE_NO_HOSTID);
+			return (spa_vdev_err(rvd, VDEV_AUX_ACTIVE, EREMOTEIO));
+		}
+
+		int error = spa_activity_check(spa, ub, spa->spa_config);
+		if (error) {
+			nvlist_free(label);
+			return (error);
+		}
+
+		fnvlist_add_uint64(spa->spa_load_info,
+		    ZPOOL_CONFIG_MMP_STATE, MMP_STATE_INACTIVE);
+		fnvlist_add_uint64(spa->spa_load_info,
+		    ZPOOL_CONFIG_MMP_TXG, ub->ub_txg);
+	}
 
 	/*
 	 * If the pool has an unsupported version we can't open it.
@@ -3151,6 +3393,7 @@ spa_ld_get_props(spa_t *spa)
 		spa_prop_find(spa, ZPOOL_PROP_DELEGATION, &spa->spa_delegation);
 		spa_prop_find(spa, ZPOOL_PROP_FAILUREMODE, &spa->spa_failmode);
 		spa_prop_find(spa, ZPOOL_PROP_AUTOEXPAND, &spa->spa_autoexpand);
+		spa_prop_find(spa, ZPOOL_PROP_MULTIHOST, &spa->spa_multihost);
 		spa_prop_find(spa, ZPOOL_PROP_DEDUPDITTO,
 		    &spa->spa_dedup_ditto);
 
@@ -3237,6 +3480,18 @@ spa_ld_load_vdev_metadata(spa_t *spa)
 {
 	int error = 0;
 	vdev_t *rvd = spa->spa_root_vdev;
+
+	/*
+	 * If the 'multihost' property is set, then never allow a pool to
+	 * be imported when the system hostid is zero.  The exception to
+	 * this rule is zdb which is always allowed to access pools.
+	 */
+	if (spa_multihost(spa) && spa_get_hostid() == 0 &&
+	    (spa->spa_import_flags & ZFS_IMPORT_SKIP_MMP) == 0) {
+		fnvlist_add_uint64(spa->spa_load_info,
+		    ZPOOL_CONFIG_MMP_STATE, MMP_STATE_NO_HOSTID);
+		return (spa_vdev_err(rvd, VDEV_AUX_ACTIVE, EREMOTEIO));
+	}
 
 	/*
 	 * If the 'autoreplace' property is set, then post a resource notifying
@@ -3838,6 +4093,7 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, char **ereport)
 		 */
 		spa->spa_sync_on = B_TRUE;
 		txg_sync_start(spa->spa_dsl_pool);
+		mmp_thread_start(spa);
 
 		/*
 		 * Wait for all claims to sync.  We sync up to the highest
@@ -4361,10 +4617,14 @@ spa_get_stats(const char *name, nvlist_t **config,
 			    ZPOOL_CONFIG_ERRCOUNT,
 			    spa_get_errlog_size(spa)) == 0);
 
-			if (spa_suspended(spa))
+			if (spa_suspended(spa)) {
 				VERIFY(nvlist_add_uint64(*config,
 				    ZPOOL_CONFIG_SUSPENDED,
 				    spa->spa_failmode) == 0);
+				VERIFY(nvlist_add_uint64(*config,
+				    ZPOOL_CONFIG_SUSPENDED_REASON,
+				    spa->spa_suspended) == 0);
+			}
 
 			spa_add_spares(spa, *config);
 			spa_add_l2cache(spa, *config);
@@ -4451,18 +4711,6 @@ spa_validate_aux_devs(spa_t *spa, nvlist_t *nvroot, uint64_t crtxg, int mode,
 			goto out;
 		}
 
-		/*
-		 * The L2ARC currently only supports disk devices in
-		 * kernel context.  For user-level testing, we allow it.
-		 */
-#ifdef _KERNEL
-		if ((strcmp(config, ZPOOL_CONFIG_L2CACHE) == 0) &&
-		    strcmp(vd->vdev_ops->vdev_op_type, VDEV_TYPE_DISK) != 0) {
-			error = SET_ERROR(ENOTBLK);
-			vdev_free(vd);
-			goto out;
-		}
-#endif
 		vd->vdev_top = vd;
 
 		if ((error = vdev_open(vd)) == 0 &&
@@ -4807,6 +5055,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	spa->spa_delegation = zpool_prop_default_numeric(ZPOOL_PROP_DELEGATION);
 	spa->spa_failmode = zpool_prop_default_numeric(ZPOOL_PROP_FAILUREMODE);
 	spa->spa_autoexpand = zpool_prop_default_numeric(ZPOOL_PROP_AUTOEXPAND);
+	spa->spa_multihost = zpool_prop_default_numeric(ZPOOL_PROP_MULTIHOST);
 
 	if (props != NULL) {
 		spa_configfile_set(spa, props, B_FALSE);
@@ -4817,6 +5066,7 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 
 	spa->spa_sync_on = B_TRUE;
 	txg_sync_start(spa->spa_dsl_pool);
+	mmp_thread_start(spa);
 
 	/*
 	 * We explicitly wait for the first transaction to complete so that our
@@ -7403,6 +7653,9 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 					spa_async_request(spa,
 					    SPA_ASYNC_AUTOEXPAND);
 				break;
+			case ZPOOL_PROP_MULTIHOST:
+				spa->spa_multihost = intval;
+				break;
 			case ZPOOL_PROP_DEDUPDITTO:
 				spa->spa_dedup_ditto = intval;
 				break;
@@ -7804,7 +8057,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 
 		if (error == 0)
 			break;
-		zio_suspend(spa, NULL);
+		zio_suspend(spa, NULL, ZIO_SUSPEND_IOERR);
 		zio_resume_wait(spa);
 	}
 	dmu_tx_commit(tx);

--- a/usr/src/uts/common/fs/zfs/spa_config.c
+++ b/usr/src/uts/common/fs/zfs/spa_config.c
@@ -413,8 +413,7 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 		    spa->spa_comment);
 	}
 
-	hostid = zone_get_hostid(NULL);
-
+	hostid = spa_get_hostid();
 	if (hostid != 0) {
 		fnvlist_add_uint64(config, ZPOOL_CONFIG_HOSTID, hostid);
 	}

--- a/usr/src/uts/common/fs/zfs/spa_misc.c
+++ b/usr/src/uts/common/fs/zfs/spa_misc.c
@@ -718,6 +718,9 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 		spa->spa_feat_refcount_cache[i] = SPA_FEATURE_DISABLED;
 	}
 
+	list_create(&spa->spa_leaf_list, sizeof (vdev_t),
+	    offsetof(vdev_t, vdev_leaf_node));
+
 	return (spa);
 }
 
@@ -762,6 +765,7 @@ spa_remove(spa_t *spa)
 	    sizeof (avl_tree_t));
 
 	list_destroy(&spa->spa_config_list);
+	list_destroy(&spa->spa_leaf_list);
 
 	nvlist_free(spa->spa_label_features);
 	nvlist_free(spa->spa_load_info);
@@ -1407,6 +1411,9 @@ spa_get_random(uint64_t range)
 
 	ASSERT(range != 0);
 
+	if (range == 1)
+		return (0);
+
 	(void) random_get_pseudo_bytes((void *)&r, sizeof (uint64_t));
 
 	return (r % range);
@@ -1736,7 +1743,7 @@ spa_get_failmode(spa_t *spa)
 boolean_t
 spa_suspended(spa_t *spa)
 {
-	return (spa->spa_suspended);
+	return (spa->spa_suspended != ZIO_SUSPEND_NONE);
 }
 
 uint64_t
@@ -2112,6 +2119,30 @@ spa_maxdnodesize(spa_t *spa)
 		return (DNODE_MAX_SIZE);
 	else
 		return (DNODE_MIN_SIZE);
+}
+
+boolean_t
+spa_multihost(spa_t *spa)
+{
+	return (spa->spa_multihost ? B_TRUE : B_FALSE);
+}
+
+unsigned long
+spa_get_hostid(void)
+{
+	unsigned long myhostid;
+
+#ifdef	_KERNEL
+	myhostid = zone_get_hostid(NULL);
+#else	/* _KERNEL */
+	/*
+	 * We're emulating the system's hostid in userland, so
+	 * we can't use zone_get_hostid().
+	 */
+	(void) ddi_strtoul(hw_serial, NULL, 10, &myhostid);
+#endif	/* _KERNEL */
+
+	return (myhostid);
 }
 
 /*

--- a/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
@@ -39,6 +39,7 @@
 #include <sys/bptree.h>
 #include <sys/rrwlock.h>
 #include <sys/dsl_synctask.h>
+#include <sys/mmp.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/usr/src/uts/common/fs/zfs/sys/mmp.h
+++ b/usr/src/uts/common/fs/zfs/sys/mmp.h
@@ -1,0 +1,68 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (C) 2017 by Lawrence Livermore National Security, LLC.
+ */
+
+#ifndef _SYS_MMP_H
+#define	_SYS_MMP_H
+
+#include <sys/spa.h>
+#include <sys/zfs_context.h>
+#include <sys/uberblock_impl.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#define	MMP_MIN_INTERVAL		100	/* ms */
+#define	MMP_DEFAULT_INTERVAL		1000	/* ms */
+#define	MMP_DEFAULT_IMPORT_INTERVALS	10
+#define	MMP_DEFAULT_FAIL_INTERVALS	5
+
+typedef struct mmp_thread {
+	kmutex_t	mmp_thread_lock; /* protect thread mgmt fields */
+	kcondvar_t	mmp_thread_cv;
+	kthread_t	*mmp_thread;
+	uint8_t		mmp_thread_exiting;
+	kmutex_t	mmp_io_lock;	/* protect below */
+	hrtime_t	mmp_last_write;	/* last successful MMP write */
+	uint64_t	mmp_delay;	/* decaying avg ns between MMP writes */
+	uberblock_t	mmp_ub;		/* last ub written by sync */
+	zio_t		*mmp_zio_root;	/* root of mmp write zios */
+	uint64_t	mmp_kstat_id;	/* unique id for next MMP write kstat */
+	int		mmp_skip_error; /* reason for last skipped write */
+	vdev_t		*mmp_last_leaf;	/* last mmp write sent here */
+	uint64_t	mmp_leaf_last_gen;	/* last mmp write sent here */
+} mmp_thread_t;
+
+
+extern void mmp_init(struct spa *spa);
+extern void mmp_fini(struct spa *spa);
+extern void mmp_thread_start(struct spa *spa);
+extern void mmp_thread_stop(struct spa *spa);
+extern void mmp_update_uberblock(struct spa *spa, struct uberblock *ub);
+extern void mmp_signal_all_threads(void);
+
+/* Global tuning */
+extern ulong_t zfs_multihost_interval;
+extern uint_t zfs_multihost_fail_intervals;
+extern uint_t zfs_multihost_import_intervals;
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_MMP_H */

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -844,6 +844,8 @@ extern boolean_t spa_writeable(spa_t *spa);
 extern boolean_t spa_has_pending_synctask(spa_t *spa);
 extern int spa_maxblocksize(spa_t *spa);
 extern int spa_maxdnodesize(spa_t *spa);
+extern boolean_t spa_multihost(spa_t *spa);
+extern unsigned long spa_get_hostid(void);
 extern boolean_t spa_has_checkpoint(spa_t *spa);
 extern boolean_t spa_importing_readonly_checkpoint(spa_t *spa);
 extern boolean_t spa_suspend_async_destroy(spa_t *spa);

--- a/usr/src/uts/common/fs/zfs/sys/spa_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa_impl.h
@@ -326,7 +326,7 @@ struct spa {
 	zio_t		*spa_txg_zio[TXG_SIZE]; /* spa_sync() waits for this */
 	kmutex_t	spa_suspend_lock;	/* protects suspend_zio_root */
 	kcondvar_t	spa_suspend_cv;		/* notification of resume */
-	uint8_t		spa_suspended;		/* pool is suspended */
+	zio_suspend_reason_t	spa_suspended;	/* pool is suspended */
 	uint8_t		spa_claiming;		/* pool is doing zil_claim() */
 	boolean_t	spa_is_root;		/* pool is root */
 	int		spa_minref;		/* num refs when first opened */
@@ -378,6 +378,11 @@ struct spa {
 	uint64_t	spa_lowmem_last_txg;	/* txg window start */
 
 	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
+
+	uint64_t	spa_multihost;		/* multihost aware (mmp) */
+	mmp_thread_t	spa_mmp;		/* multihost mmp thread */
+	list_t		spa_leaf_list;		/* list of leaf vdevs */
+	uint64_t	spa_leaf_list_gen;	/* track leaf_list changes */
 
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements

--- a/usr/src/uts/common/fs/zfs/sys/uberblock.h
+++ b/usr/src/uts/common/fs/zfs/sys/uberblock.h
@@ -40,7 +40,8 @@ extern "C" {
 typedef struct uberblock uberblock_t;
 
 extern int uberblock_verify(uberblock_t *);
-extern boolean_t uberblock_update(uberblock_t *, vdev_t *, uint64_t);
+extern boolean_t uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg,
+    uint64_t mmp_delay);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/fs/zfs/sys/uberblock_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/uberblock_impl.h
@@ -44,6 +44,7 @@ extern "C" {
  */
 #define	UBERBLOCK_MAGIC		0x00bab10c		/* oo-ba-bloc!	*/
 #define	UBERBLOCK_SHIFT		10			/* up to 1K	*/
+#define	MMP_MAGIC		0xa11cea11		/* all-see-all  */
 
 struct uberblock {
 	uint64_t	ub_magic;	/* UBERBLOCK_MAGIC		*/
@@ -56,7 +57,7 @@ struct uberblock {
 	/* highest SPA_VERSION supported by software that wrote this txg */
 	uint64_t	ub_software_version;
 
-	/* These fields are reserved for features that are under development: */
+	/* Maybe missing in uberblocks we read, but always written */
 	uint64_t	ub_mmp_magic;
 	uint64_t	ub_mmp_delay;
 	uint64_t	ub_mmp_seq;

--- a/usr/src/uts/common/fs/zfs/sys/vdev.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev.h
@@ -161,6 +161,8 @@ extern uint64_t vdev_label_offset(uint64_t psize, int l, uint64_t offset);
 extern int vdev_label_number(uint64_t psise, uint64_t offset);
 extern nvlist_t *vdev_label_read_config(vdev_t *vd, uint64_t txg);
 extern void vdev_uberblock_load(vdev_t *, struct uberblock *, nvlist_t **);
+extern void vdev_label_write(zio_t *zio, vdev_t *vd, int l, abd_t *buf, uint64_t
+    offset, uint64_t size, zio_done_func_t *done, void *private, int flags);
 
 typedef enum {
 	VDEV_LABEL_CREATE,	/* create/add a new device */

--- a/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
@@ -244,7 +244,7 @@ struct vdev {
 
 	/* pool checkpoint related */
 	space_map_t	*vdev_checkpoint_sm;	/* contains reserved blocks */
-	
+
 	boolean_t	vdev_initialize_exit_wanted;
 	vdev_initializing_state_t	vdev_initialize_state;
 	kthread_t	*vdev_initialize_thread;
@@ -345,6 +345,9 @@ struct vdev {
 	zio_t		*vdev_probe_zio; /* root of current probe	*/
 	vdev_aux_t	vdev_label_aux;	/* on-disk aux state		*/
 	uint64_t	vdev_leaf_zap;
+	hrtime_t	vdev_mmp_pending; /* 0 if write finished	*/
+	uint64_t	vdev_mmp_kstat_id;	/* to find kstat entry */
+	list_node_t	vdev_leaf_node;		/* leaf vdev list */
 
 	/*
 	 * For DTrace to work in userland (libzpool) context, these fields must
@@ -365,6 +368,12 @@ struct vdev {
 #define	VDEV_SKIP_SIZE		VDEV_PAD_SIZE * 2
 #define	VDEV_PHYS_SIZE		(112 << 10)
 #define	VDEV_UBERBLOCK_RING	(128 << 10)
+
+/*
+ * MMP blocks occupy the last MMP_BLOCKS_PER_LABEL slots in the uberblock
+ * ring when MMP is enabled.
+ */
+#define	MMP_BLOCKS_PER_LABEL	1
 
 /* The largest uberblock we support is 8k. */
 #define	MAX_UBERBLOCK_SHIFT (13)

--- a/usr/src/uts/common/fs/zfs/sys/zio.h
+++ b/usr/src/uts/common/fs/zfs/sys/zio.h
@@ -138,6 +138,12 @@ enum zio_checksum {
 #define	ZIO_FAILURE_MODE_CONTINUE	1
 #define	ZIO_FAILURE_MODE_PANIC		2
 
+typedef enum zio_suspend_reason {
+	ZIO_SUSPEND_NONE = 0,
+	ZIO_SUSPEND_IOERR,
+	ZIO_SUSPEND_MMP,
+} zio_suspend_reason_t;
+
 enum zio_flag {
 	/*
 	 * Flags inherited by gang, ddt, and vdev children,
@@ -224,7 +230,7 @@ enum zio_child {
 #define	ZIO_CHILD_DDT_BIT		ZIO_CHILD_BIT(ZIO_CHILD_DDT)
 #define	ZIO_CHILD_LOGICAL_BIT		ZIO_CHILD_BIT(ZIO_CHILD_LOGICAL)
 #define	ZIO_CHILD_ALL_BITS					\
-	(ZIO_CHILD_VDEV_BIT | ZIO_CHILD_GANG_BIT | 		\
+	(ZIO_CHILD_VDEV_BIT | ZIO_CHILD_GANG_BIT |		\
 	ZIO_CHILD_DDT_BIT | ZIO_CHILD_LOGICAL_BIT)
 
 enum zio_wait_type {
@@ -436,7 +442,7 @@ struct zio {
 	avl_node_t	io_queue_node;
 	avl_node_t	io_offset_node;
 	avl_node_t	io_alloc_node;
-	zio_alloc_list_t 	io_alloc_list;
+	zio_alloc_list_t	io_alloc_list;
 
 	/* Internal pipeline state */
 	enum zio_flag	io_flags;
@@ -569,7 +575,7 @@ extern enum zio_checksum zio_checksum_dedup_select(spa_t *spa,
 extern enum zio_compress zio_compress_select(spa_t *spa,
     enum zio_compress child, enum zio_compress parent);
 
-extern void zio_suspend(spa_t *spa, zio_t *zio);
+extern void zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t);
 extern int zio_resume(spa_t *spa);
 extern void zio_resume_wait(spa_t *spa);
 

--- a/usr/src/uts/common/fs/zfs/uberblock.c
+++ b/usr/src/uts/common/fs/zfs/uberblock.c
@@ -44,7 +44,7 @@ uberblock_verify(uberblock_t *ub)
  * transaction group.
  */
 boolean_t
-uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg)
+uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg, uint64_t mmp_delay)
 {
 	ASSERT(ub->ub_txg < txg);
 
@@ -57,6 +57,9 @@ uberblock_update(uberblock_t *ub, vdev_t *rvd, uint64_t txg)
 	ub->ub_guid_sum = rvd->vdev_guid_sum;
 	ub->ub_timestamp = gethrestime_sec();
 	ub->ub_software_version = SPA_VERSION;
+	ub->ub_mmp_magic = MMP_MAGIC;
+	ub->ub_mmp_delay = spa_multihost(rvd->vdev_spa) ? mmp_delay : 0;
+	ub->ub_mmp_seq = 0;
 	ub->ub_checkpoint_txg = 0;
 
 	return (ub->ub_rootbp.blk_birth == txg);

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -353,6 +353,11 @@ vdev_add_child(vdev_t *pvd, vdev_t *cvd)
 	 */
 	for (; pvd != NULL; pvd = pvd->vdev_parent)
 		pvd->vdev_guid_sum += cvd->vdev_guid_sum;
+
+	if (cvd->vdev_ops->vdev_op_leaf) {
+		list_insert_head(&cvd->vdev_spa->spa_leaf_list, cvd);
+		cvd->vdev_spa->spa_leaf_list_gen++;
+	}
 }
 
 void
@@ -380,6 +385,12 @@ vdev_remove_child(vdev_t *pvd, vdev_t *cvd)
 		kmem_free(pvd->vdev_child, c * sizeof (vdev_t *));
 		pvd->vdev_child = NULL;
 		pvd->vdev_children = 0;
+	}
+
+	if (cvd->vdev_ops->vdev_op_leaf) {
+		spa_t *spa = cvd->vdev_spa;
+		list_remove(&spa->spa_leaf_list, cvd);
+		spa->spa_leaf_list_gen++;
 	}
 
 	/*
@@ -466,6 +477,7 @@ vdev_alloc_common(spa_t *spa, uint_t id, uint64_t guid, vdev_ops_t *ops)
 	mutex_init(&vd->vdev_obsolete_lock, NULL, MUTEX_DEFAULT, NULL);
 	vd->vdev_obsolete_segments = range_tree_create(NULL, NULL);
 
+	list_link_init(&vd->vdev_leaf_node);
 	mutex_init(&vd->vdev_dtl_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&vd->vdev_stat_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&vd->vdev_probe_lock, NULL, MUTEX_DEFAULT, NULL);
@@ -786,6 +798,7 @@ vdev_free(vdev_t *vd)
 	vdev_remove_child(vd->vdev_parent, vd);
 
 	ASSERT(vd->vdev_parent == NULL);
+	ASSERT(!list_link_active(&vd->vdev_leaf_node));
 
 	/*
 	 * Clean up vdev structure.

--- a/usr/src/uts/common/fs/zfs/vdev_label.c
+++ b/usr/src/uts/common/fs/zfs/vdev_label.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -193,14 +194,21 @@ vdev_label_read(zio_t *zio, vdev_t *vd, int l, abd_t *buf, uint64_t offset,
 	    ZIO_PRIORITY_SYNC_READ, flags, B_TRUE));
 }
 
-static void
+void
 vdev_label_write(zio_t *zio, vdev_t *vd, int l, abd_t *buf, uint64_t offset,
     uint64_t size, zio_done_func_t *done, void *private, int flags)
 {
+#ifdef _KERNEL
+	/*
+	 * This assert is invalid in the user-level ztest MMP code because
+	 * the ztest thread is not in dsl_pool_sync_context. ZoL does not
+	 * build the user-level code with DEBUG so this is not an issue there.
+	 */
 	ASSERT(spa_config_held(zio->io_spa, SCL_ALL, RW_WRITER) == SCL_ALL ||
 	    (spa_config_held(zio->io_spa, SCL_CONFIG | SCL_STATE, RW_READER) ==
 	    (SCL_CONFIG | SCL_STATE) &&
 	    dsl_pool_sync_context(spa_get_dsl(zio->io_spa))));
+#endif
 	ASSERT(flags & ZIO_FLAG_CONFIG_WRITER);
 
 	zio_nowait(zio_write_phys(zio, vd,
@@ -1142,7 +1150,8 @@ vdev_uberblock_sync(zio_t *zio, uint64_t *good_writes,
 	if (!vdev_writeable(vd))
 		return;
 
-	int n = ub->ub_txg & (VDEV_UBERBLOCK_COUNT(vd) - 1);
+	int m = spa_multihost(vd->vdev_spa) ? MMP_BLOCKS_PER_LABEL : 0;
+	int n = ub->ub_txg % (VDEV_UBERBLOCK_COUNT(vd) - m);
 
 	/* Copy the uberblock_t into the ABD */
 	abd_t *ub_abd = abd_alloc_for_io(VDEV_UBERBLOCK_SIZE(vd), B_TRUE);
@@ -1360,10 +1369,13 @@ retry:
 	 * and the vdev configuration hasn't changed,
 	 * then there's nothing to do.
 	 */
-	if (ub->ub_txg < txg &&
-	    uberblock_update(ub, spa->spa_root_vdev, txg) == B_FALSE &&
-	    list_is_empty(&spa->spa_config_dirty_list))
-		return (0);
+	if (ub->ub_txg < txg) {
+		boolean_t changed = uberblock_update(ub, spa->spa_root_vdev,
+		    txg, spa->spa_mmp.mmp_delay);
+
+		if (!changed && list_is_empty(&spa->spa_config_dirty_list))
+			return (0);
+	}
 
 	if (txg > spa_freeze_txg(spa))
 		return (0);
@@ -1425,6 +1437,9 @@ retry:
 		}
 		goto retry;
 	}
+
+	if (spa_multihost(spa))
+		mmp_update_uberblock(spa, ub);
 
 	/*
 	 * Sync out odd labels for every dirty vdev.  If the system dies

--- a/usr/src/uts/common/fs/zfs/zfs_ioctl.c
+++ b/usr/src/uts/common/fs/zfs/zfs_ioctl.c
@@ -4847,6 +4847,13 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 	if (error != 0)
 		return (error);
 
+	/*
+	 * If multihost is enabled, resuming I/O is unsafe as another
+	 * host may have imported the pool.
+	 */
+	if (spa_multihost(spa) && spa_suspended(spa))
+		return (SET_ERROR(EINVAL));
+
 	spa_vdev_state_enter(spa, SCL_NONE);
 
 	if (zc->zc_guid == 0) {

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -1783,7 +1783,7 @@ zio_reexecute(zio_t *pio)
 }
 
 void
-zio_suspend(spa_t *spa, zio_t *zio)
+zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 {
 	if (spa_get_failmode(spa) == ZIO_FAILURE_MODE_PANIC)
 		fm_panic("Pool '%s' has encountered an uncorrectable I/O "
@@ -1799,7 +1799,7 @@ zio_suspend(spa_t *spa, zio_t *zio)
 		    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE |
 		    ZIO_FLAG_GODFATHER);
 
-	spa->spa_suspended = B_TRUE;
+	spa->spa_suspended = reason;
 
 	if (zio != NULL) {
 		ASSERT(!(zio->io_flags & ZIO_FLAG_GODFATHER));
@@ -1822,7 +1822,7 @@ zio_resume(spa_t *spa)
 	 * Reexecute all previously suspended i/o.
 	 */
 	mutex_enter(&spa->spa_suspend_lock);
-	spa->spa_suspended = B_FALSE;
+	spa->spa_suspended = ZIO_SUSPEND_NONE;
 	cv_broadcast(&spa->spa_suspend_cv);
 	pio = spa->spa_suspend_zio_root;
 	spa->spa_suspend_zio_root = NULL;
@@ -3888,7 +3888,7 @@ zio_done(zio_t *zio)
 			 * We'd fail again if we reexecuted now, so suspend
 			 * until conditions improve (e.g. device comes online).
 			 */
-			zio_suspend(spa, zio);
+			zio_suspend(zio->io_spa, zio, ZIO_SUSPEND_IOERR);
 		} else {
 			/*
 			 * Reexecution is potentially a huge amount of work.

--- a/usr/src/uts/common/io/kstat.c
+++ b/usr/src/uts/common/io/kstat.c
@@ -689,7 +689,7 @@ kstat_ioctl(dev_t dev, int cmd, intptr_t data, int flag, cred_t *cr, int *rvalp)
 /* ARGSUSED */
 static int
 kstat_info(dev_info_t *dip, ddi_info_cmd_t infocmd, void *arg,
-	void **result)
+    void **result)
 {
 	switch (infocmd) {
 	case DDI_INFO_DEVT2DEVINFO:
@@ -709,7 +709,7 @@ kstat_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 		return (DDI_FAILURE);
 
 	if (ddi_create_minor_node(devi, "kstat", S_IFCHR,
-	    0, DDI_PSEUDO, NULL) == DDI_FAILURE) {
+	    0, DDI_PSEUDO, 0) == DDI_FAILURE) {
 		ddi_remove_minor_node(devi, NULL);
 		return (DDI_FAILURE);
 	}

--- a/usr/src/uts/common/io/ksyms.c
+++ b/usr/src/uts/common/io/ksyms.c
@@ -61,7 +61,7 @@ typedef struct ksyms_buflist {
 } ksyms_buflist_t;
 
 typedef struct ksyms_buflist_hdr {
-	list_t 	blist;
+	list_t	blist;
 	int	nchunks;
 	ksyms_buflist_t *cur;
 	size_t	curbuf_off;
@@ -392,7 +392,7 @@ ksyms_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 {
 	if (cmd != DDI_ATTACH)
 		return (DDI_FAILURE);
-	if (ddi_create_minor_node(devi, "ksyms", S_IFCHR, 0, DDI_PSEUDO, NULL)
+	if (ddi_create_minor_node(devi, "ksyms", S_IFCHR, 0, DDI_PSEUDO, 0)
 	    == DDI_FAILURE) {
 		ddi_remove_minor_node(devi, NULL);
 		return (DDI_FAILURE);

--- a/usr/src/uts/common/io/llc1.c
+++ b/usr/src/uts/common/io/llc1.c
@@ -1291,7 +1291,7 @@ llc1_inforeq(queue_t *q, mblk_t *mp)
 			    lld->llc_mac_info->llcp_addrlen);
 		} else {
 			dlp->dl_addr_length = 0; /* not attached yet */
-			dlp->dl_addr_offset = NULL;
+			dlp->dl_addr_offset = 0;
 			dlp->dl_sap_length = 0; /* 1 bytes on end */
 		}
 		dlp->dl_version = DL_VERSION_2;
@@ -2831,9 +2831,8 @@ llc1remque(void *arg)
 
 /* VARARGS */
 static void
-llc1error(dip, fmt, a1, a2, a3, a4, a5, a6)
-	dev_info_t *dip;
-	char   *fmt, *a1, *a2, *a3, *a4, *a5, *a6;
+llc1error(dev_info_t *dip, char *fmt, char *a1, char *a2, char *a3,
+    char *a4, char *a5, char *a6)
 {
 	static long last;
 	static char *lastfmt;
@@ -2849,7 +2848,7 @@ llc1error(dip, fmt, a1, a2, a3, a4, a5, a6)
 	lastfmt = fmt;
 
 	cmn_err(CE_CONT, "%s%d:  ",
-		ddi_get_name(dip), ddi_get_instance(dip));
+	    ddi_get_name(dip), ddi_get_instance(dip));
 	cmn_err(CE_CONT, fmt, a1, a2, a3, a4, a5, a6);
 	cmn_err(CE_CONT, "\n");
 }

--- a/usr/src/uts/common/io/log.c
+++ b/usr/src/uts/common/io/log.c
@@ -73,9 +73,9 @@ static int
 log_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 {
 	if (ddi_create_minor_node(devi, "conslog", S_IFCHR,
-	    LOG_CONSMIN, DDI_PSEUDO, NULL) == DDI_FAILURE ||
+	    LOG_CONSMIN, DDI_PSEUDO, 0) == DDI_FAILURE ||
 	    ddi_create_minor_node(devi, "log", S_IFCHR,
-	    LOG_LOGMIN, DDI_PSEUDO, NULL) == DDI_FAILURE) {
+	    LOG_LOGMIN, DDI_PSEUDO, 0) == DDI_FAILURE) {
 		ddi_remove_minor_node(devi, NULL);
 		return (DDI_FAILURE);
 	}
@@ -307,8 +307,8 @@ static struct qinit logwinit =
 static struct streamtab loginfo = { &logrinit, &logwinit, NULL, NULL };
 
 DDI_DEFINE_STREAM_OPS(log_ops, nulldev, nulldev, log_attach, nodev,
-	nodev, log_info, D_NEW | D_MP | D_MTPERMOD, &loginfo,
-	ddi_quiesce_not_needed);
+    nodev, log_info, D_NEW | D_MP | D_MTPERMOD, &loginfo,
+    ddi_quiesce_not_needed);
 
 static struct modldrv modldrv =
 	{ &mod_driverops, "streams log driver", &log_ops };

--- a/usr/src/uts/common/io/mouse8042.c
+++ b/usr/src/uts/common/io/mouse8042.c
@@ -20,7 +20,7 @@
  */
 /*	Copyright (c) 1990, 1991 UNIX System Laboratories, Inc.	*/
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989, 1990 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
@@ -319,11 +319,11 @@ mouse8042_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * transparent.
 	 *
 	 * So we change minor node numbering scheme to be:
-	 * 	external node minor num == instance * 2
+	 *	external node minor num == instance * 2
 	 *	internal node minor num == instance * 2 + 1
 	 */
 	rc = ddi_create_minor_node(dip, "mouse", S_IFCHR, instance * 2,
-	    DDI_NT_MOUSE, NULL);
+	    DDI_NT_MOUSE, 0);
 	if (rc != DDI_SUCCESS) {
 		goto fail_1;
 	}
@@ -922,7 +922,7 @@ mouse8042_reset_fsm(mouse8042_reset_state_e reset_state, uint8_t mdata)
 			return (MSE_RESET_AA);
 		break;
 
-	case MSE_RESET_AA: 	/* 0xAA received; now we expect 0x00 */
+	case MSE_RESET_AA:	/* 0xAA received; now we expect 0x00 */
 		if (mdata == MSE_00)
 			return (MSE_RESET_IDLE);
 		break;

--- a/usr/src/uts/common/io/openprom.c
+++ b/usr/src/uts/common/io/openprom.c
@@ -221,7 +221,7 @@ opattach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		opdip = dip;
 
 		if (ddi_create_minor_node(dip, "openprom", S_IFCHR,
-		    0, DDI_PSEUDO, NULL) == DDI_FAILURE) {
+		    0, DDI_PSEUDO, 0) == DDI_FAILURE) {
 			return (DDI_FAILURE);
 		}
 

--- a/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas.c
+++ b/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas.c
@@ -4196,7 +4196,7 @@ mptsas_cache_frames_destructor(void *buf, void *cdrarg)
 		(void) ddi_dma_unbind_handle(p->m_dma_hdl);
 		(void) ddi_dma_mem_free(&p->m_acc_hdl);
 		ddi_dma_free_handle(&p->m_dma_hdl);
-		p->m_phys_addr = NULL;
+		p->m_phys_addr = 0;
 		p->m_frames_addr = NULL;
 		p->m_dma_hdl = NULL;
 		p->m_acc_hdl = NULL;
@@ -6147,7 +6147,8 @@ mptsas_free_devhdl(mptsas_t *mpt, uint16_t devhdl)
 	req.DevHandle = LE_16(devhdl);
 
 	ret = mptsas_do_passthru(mpt, (uint8_t *)&req, (uint8_t *)&rep, NULL,
-	    sizeof (req), sizeof (rep), NULL, 0, NULL, 0, 60, FKIOCTL);
+	    sizeof (req), sizeof (rep), 0, MPTSAS_PASS_THRU_DIRECTION_NONE,
+	    NULL, 0, 60, FKIOCTL);
 	if (ret != 0) {
 		cmn_err(CE_WARN, "mptsas_free_devhdl: passthru SAS IO Unit "
 		    "Control error %d", ret);
@@ -6184,7 +6185,7 @@ mptsas_update_sata_bridge(mptsas_t *mpt, dev_info_t *parent,
 	uint32_t		page_address;
 	uint16_t		bay_num, enclosure, io_flags;
 	uint32_t		dev_info;
-	char 			uabuf[SCSI_WWN_BUFLEN];
+	char			uabuf[SCSI_WWN_BUFLEN];
 	dev_info_t		*dip;
 	mdi_pathinfo_t		*pip;
 
@@ -10676,7 +10677,7 @@ mptsas_start_passthru(mptsas_t *mpt, mptsas_cmd_t *cmd)
 	 */
 	(void) ddi_dma_sync(dma_hdl, 0, 0, DDI_DMA_SYNC_FORDEV);
 	request_desc |= (SMID << 16) + desc_type;
-	cmd->cmd_rfm = NULL;
+	cmd->cmd_rfm = 0;
 	MPTSAS_START_CMD(mpt, request_desc);
 	if ((mptsas_check_dma_handle(dma_hdl) != DDI_SUCCESS) ||
 	    (mptsas_check_acc_handle(acc_hdl) != DDI_SUCCESS)) {
@@ -11543,7 +11544,7 @@ mptsas_start_diag(mptsas_t *mpt, mptsas_cmd_t *cmd)
 	    DDI_DMA_SYNC_FORDEV);
 	request_desc = (cmd->cmd_slot << 16) +
 	    MPI2_REQ_DESCRIPT_FLAGS_DEFAULT_TYPE;
-	cmd->cmd_rfm = NULL;
+	cmd->cmd_rfm = 0;
 	MPTSAS_START_CMD(mpt, request_desc);
 	if ((mptsas_check_dma_handle(mpt->m_dma_req_frame_hdl) !=
 	    DDI_SUCCESS) ||
@@ -13857,7 +13858,7 @@ mptsas_get_target_device_info(mptsas_t *mpt, uint32_t page_address,
 
 	if ((dev_info & (MPI2_SAS_DEVICE_INFO_SSP_TARGET |
 	    MPI2_SAS_DEVICE_INFO_SATA_DEVICE |
-	    MPI2_SAS_DEVICE_INFO_ATAPI_DEVICE)) == NULL) {
+	    MPI2_SAS_DEVICE_INFO_ATAPI_DEVICE)) == 0) {
 		rval = DEV_INFO_WRONG_DEVICE_TYPE;
 		return (rval);
 	}
@@ -16848,7 +16849,7 @@ mptsas_send_sep(mptsas_t *mpt, mptsas_enclosure_t *mep, uint16_t idx,
 	Mpi2SepRequest_t	req;
 	Mpi2SepReply_t		rep;
 	int			ret;
-	uint16_t 		enctype;
+	uint16_t		enctype;
 	uint16_t		slot;
 
 	ASSERT(mutex_owned(&mpt->m_mutex));
@@ -16878,7 +16879,8 @@ mptsas_send_sep(mptsas_t *mpt, mptsas_enclosure_t *mep, uint16_t idx,
 		req.SlotStatus = LE_32(*status);
 	}
 	ret = mptsas_do_passthru(mpt, (uint8_t *)&req, (uint8_t *)&rep, NULL,
-	    sizeof (req), sizeof (rep), NULL, 0, NULL, 0, 60, FKIOCTL);
+	    sizeof (req), sizeof (rep), 0, MPTSAS_PASS_THRU_DIRECTION_NONE,
+	    NULL, 0, 60, FKIOCTL);
 	if (ret != 0) {
 		mptsas_log(mpt, CE_NOTE, "mptsas_send_sep: passthru SEP "
 		    "Processor Request message error %d", ret);

--- a/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas_impl.c
+++ b/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas_impl.c
@@ -281,7 +281,7 @@ mptsas_start_config_page_access(mptsas_t *mpt, mptsas_cmd_t *cmd)
 	    DDI_DMA_SYNC_FORDEV);
 	request_desc = (cmd->cmd_slot << 16) +
 	    MPI2_REQ_DESCRIPT_FLAGS_DEFAULT_TYPE;
-	cmd->cmd_rfm = NULL;
+	cmd->cmd_rfm = 0;
 	MPTSAS_START_CMD(mpt, request_desc);
 	if ((mptsas_check_dma_handle(mpt->m_dma_req_frame_hdl) !=
 	    DDI_SUCCESS) ||
@@ -1399,7 +1399,7 @@ mptsas_update_flash(mptsas_t *mpt, caddr_t ptrbuffer, uint32_t size,
 	    DDI_DMA_SYNC_FORDEV);
 	request_desc = (cmd->cmd_slot << 16) +
 	    MPI2_REQ_DESCRIPT_FLAGS_DEFAULT_TYPE;
-	cmd->cmd_rfm = NULL;
+	cmd->cmd_rfm = 0;
 	MPTSAS_START_CMD(mpt, request_desc);
 
 	rvalue = 0;
@@ -2864,7 +2864,7 @@ mptsas_enclosurepage_0_cb(mptsas_t *mpt, caddr_t page_memp,
     ddi_acc_handle_t accessp, uint16_t iocstatus, uint32_t iocloginfo,
     va_list ap)
 {
-	uint32_t 			page_address;
+	uint32_t			page_address;
 	pMpi2SasEnclosurePage0_t	encpage, encout;
 
 	if ((iocstatus != MPI2_IOCSTATUS_SUCCESS) &&

--- a/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas_init.c
+++ b/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas_init.c
@@ -178,7 +178,7 @@ mptsas_ioc_get_facts(mptsas_t *mpt)
 	/*
 	 * Send get facts messages
 	 */
-	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_FACTS_REQUEST), NULL,
+	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_FACTS_REQUEST), 0,
 	    mptsas_ioc_do_get_facts)) {
 		return (DDI_FAILURE);
 	}
@@ -186,7 +186,7 @@ mptsas_ioc_get_facts(mptsas_t *mpt)
 	/*
 	 * Get facts reply messages
 	 */
-	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_FACTS_REPLY), NULL,
+	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_FACTS_REPLY), 0,
 	    mptsas_ioc_do_get_facts_reply)) {
 		return (DDI_FAILURE);
 	}
@@ -560,7 +560,7 @@ mptsas_ioc_enable_event_notification(mptsas_t *mpt)
 	/*
 	 * Send enable event notification message
 	 */
-	if (mptsas_do_dma(mpt, sizeof (MPI2_EVENT_NOTIFICATION_REQUEST), NULL,
+	if (mptsas_do_dma(mpt, sizeof (MPI2_EVENT_NOTIFICATION_REQUEST), 0,
 	    mptsas_ioc_do_enable_event_notification)) {
 		return (DDI_FAILURE);
 	}
@@ -568,7 +568,7 @@ mptsas_ioc_enable_event_notification(mptsas_t *mpt)
 	/*
 	 * Get enable event reply message
 	 */
-	if (mptsas_do_dma(mpt, sizeof (MPI2_EVENT_NOTIFICATION_REPLY), NULL,
+	if (mptsas_do_dma(mpt, sizeof (MPI2_EVENT_NOTIFICATION_REPLY), 0,
 	    mptsas_ioc_do_enable_event_notification_reply)) {
 		return (DDI_FAILURE);
 	}
@@ -641,7 +641,7 @@ mptsas_ioc_init(mptsas_t *mpt)
 	/*
 	 * Send ioc init message
 	 */
-	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_INIT_REQUEST), NULL,
+	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_INIT_REQUEST), 0,
 	    mptsas_do_ioc_init)) {
 		return (DDI_FAILURE);
 	}
@@ -649,7 +649,7 @@ mptsas_ioc_init(mptsas_t *mpt)
 	/*
 	 * Get ioc init reply message
 	 */
-	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_INIT_REPLY), NULL,
+	if (mptsas_do_dma(mpt, sizeof (MPI2_IOC_INIT_REPLY), 0,
 	    mptsas_do_ioc_init_reply)) {
 		return (DDI_FAILURE);
 	}

--- a/usr/src/uts/common/io/usb/clients/usbser/usbftdi/uftdi_dsd.c
+++ b/usr/src/uts/common/io/usb/clients/usbser/usbftdi/uftdi_dsd.c
@@ -245,6 +245,7 @@ uftdi_attach(ds_attach_info_t *aip)
 		case USB_PRODUCT_FTDI_EMCU2D:
 		case USB_PRODUCT_FTDI_PCMSFU:
 		case USB_PRODUCT_FTDI_EMCU2H:
+		case USB_PRODUCT_FTDI_232EX:
 			break;
 		default:
 			recognized = B_FALSE;

--- a/usr/src/uts/common/sys/fs/zfs.h
+++ b/usr/src/uts/common/sys/fs/zfs.h
@@ -213,6 +213,7 @@ typedef enum {
 	ZPOOL_PROP_CHECKPOINT,
 	ZPOOL_PROP_TNAME,
 	ZPOOL_PROP_MAXDNODESIZE,
+	ZPOOL_PROP_MULTIHOST,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -580,6 +581,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_RESILVER_TXG	"resilver_txg"
 #define	ZPOOL_CONFIG_COMMENT		"comment"
 #define	ZPOOL_CONFIG_SUSPENDED		"suspended"	/* not stored on disk */
+#define	ZPOOL_CONFIG_SUSPENDED_REASON	"suspended_reason"	/* not stored */
 #define	ZPOOL_CONFIG_TIMESTAMP		"timestamp"	/* not stored on disk */
 #define	ZPOOL_CONFIG_BOOTFS		"bootfs"	/* not stored on disk */
 #define	ZPOOL_CONFIG_MISSING_DEVICES	"missing_vdevs"	/* not stored on disk */
@@ -594,6 +596,10 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_VDEV_LEAF_ZAP	"com.delphix:vdev_zap_leaf"
 #define	ZPOOL_CONFIG_HAS_PER_VDEV_ZAPS	"com.delphix:has_per_vdev_zaps"
 #define	ZPOOL_CONFIG_CACHEFILE		"cachefile"	/* not stored on disk */
+#define	ZPOOL_CONFIG_MMP_STATE		"mmp_state"	/* not stored on disk */
+#define	ZPOOL_CONFIG_MMP_TXG		"mmp_txg"	/* not stored on disk */
+#define	ZPOOL_CONFIG_MMP_HOSTNAME	"mmp_hostname"	/* not stored on disk */
+#define	ZPOOL_CONFIG_MMP_HOSTID		"mmp_hostid"	/* not stored on disk */
 /*
  * The persistent vdev state is stored as separate values rather than a single
  * 'vdev_state' entry.  This is because a device can be in multiple states, such
@@ -704,6 +710,7 @@ typedef enum vdev_aux {
 	VDEV_AUX_BAD_LOG,	/* cannot read log chain(s)		*/
 	VDEV_AUX_EXTERNAL,	/* external diagnosis			*/
 	VDEV_AUX_SPLIT_POOL,	/* vdev was split off into another pool	*/
+	VDEV_AUX_ACTIVE,	/* vdev active on a different host	*/
 	VDEV_AUX_CHILDREN_OFFLINE /* all children are offline		*/
 } vdev_aux_t;
 
@@ -723,6 +730,16 @@ typedef enum pool_state {
 	POOL_STATE_UNAVAIL,		/* Internal libzfs state	*/
 	POOL_STATE_POTENTIALLY_ACTIVE	/* Internal libzfs state	*/
 } pool_state_t;
+
+/*
+ * mmp state. The following states provide additional detail describing
+ * why a pool couldn't be safely imported.
+ */
+typedef enum mmp_state {
+	MMP_STATE_ACTIVE = 0,		/* In active use		*/
+	MMP_STATE_INACTIVE,		/* Inactive and safe to import	*/
+	MMP_STATE_NO_HOSTID		/* System hostid is not set	*/
+} mmp_state_t;
 
 /*
  * Scan Functions.
@@ -1076,6 +1093,7 @@ typedef enum {
 #define	ZFS_IMPORT_ONLY		0x8
 #define	ZFS_IMPORT_CHECKPOINT	0x10
 #define	ZFS_IMPORT_TEMP_NAME	0x20
+#define	ZFS_IMPORT_SKIP_MMP	0x40
 
 /*
  * Channel program argument/return nvlist keys and defaults.

--- a/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
+ * Copyright 2019, Joyent, Inc.
  * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  * Copyright 2018 Joyent, Inc.
  */
@@ -808,6 +809,8 @@ gethrtime_again:
 void
 apic_nmi_intr(caddr_t arg, struct regs *rp)
 {
+	nmi_action_t action = nmi_action;
+
 	if (apic_shutdown_processors) {
 		apic_disable_local_apic();
 		return;
@@ -819,18 +822,41 @@ apic_nmi_intr(caddr_t arg, struct regs *rp)
 		return;
 	apic_num_nmis++;
 
-	if (apic_kmdb_on_nmi && psm_debugger()) {
-		debug_enter("NMI received: entering kmdb\n");
-	} else if (apic_panic_on_nmi) {
-		/* Keep panic from entering kmdb. */
-		nopanicdebug = 1;
-		panic("NMI received\n");
-	} else {
+	/*
+	 * "nmi_action" always over-rides the older way of doing this, unless we
+	 * can't actually drop into kmdb when requested.
+	 */
+	if (action == NMI_ACTION_KMDB && !psm_debugger())
+		action = NMI_ACTION_UNSET;
+
+	if (action == NMI_ACTION_UNSET) {
+		if (apic_kmdb_on_nmi && psm_debugger())
+			action = NMI_ACTION_KMDB;
+		else if (apic_panic_on_nmi)
+			action = NMI_ACTION_PANIC;
+		else
+			action = NMI_ACTION_IGNORE;
+	}
+
+	switch (action) {
+	case NMI_ACTION_IGNORE:
 		/*
 		 * prom_printf is the best shot we have of something which is
 		 * problem free from high level/NMI type of interrupts
 		 */
 		prom_printf("NMI received\n");
+		break;
+
+	case NMI_ACTION_PANIC:
+		/* Keep panic from entering kmdb. */
+		nopanicdebug = 1;
+		panic("NMI received\n");
+		break;
+
+	case NMI_ACTION_KMDB:
+	default:
+		debug_enter("NMI received: entering kmdb\n");
+		break;
 	}
 
 	lock_clear(&apic_nmi_lock);

--- a/usr/src/uts/i86pc/os/fakebop.c
+++ b/usr/src/uts/i86pc/os/fakebop.c
@@ -2915,10 +2915,8 @@ boot_compinfo(int fd, struct compinfo *cbp)
 	return (0);
 }
 
-#define	BP_MAX_STRLEN	32
-
 /*
- * Get value for given boot property
+ * Get an integer value for given boot property
  */
 int
 bootprop_getval(const char *prop_name, u_longlong_t *prop_value)
@@ -2928,13 +2926,25 @@ bootprop_getval(const char *prop_name, u_longlong_t *prop_value)
 	u_longlong_t	value;
 
 	boot_prop_len = BOP_GETPROPLEN(bootops, prop_name);
-	if (boot_prop_len < 0 || boot_prop_len > sizeof (str) ||
+	if (boot_prop_len < 0 || boot_prop_len >= sizeof (str) ||
 	    BOP_GETPROP(bootops, prop_name, str) < 0 ||
 	    kobj_getvalue(str, &value) == -1)
 		return (-1);
 
 	if (prop_value)
 		*prop_value = value;
+
+	return (0);
+}
+
+int
+bootprop_getstr(const char *prop_name, char *buf, size_t buflen)
+{
+	int boot_prop_len = BOP_GETPROPLEN(bootops, prop_name);
+
+	if (boot_prop_len < 0 || boot_prop_len >= buflen ||
+	    BOP_GETPROP(bootops, prop_name, buf) < 0)
+		return (-1);
 
 	return (0);
 }

--- a/usr/src/uts/i86pc/os/mlsetup.c
+++ b/usr/src/uts/i86pc/os/mlsetup.c
@@ -23,7 +23,7 @@
  *
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 by Delphix. All rights reserved.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019, Joyent, Inc.
  */
 /*
  * Copyright (c) 2010, Intel Corporation.
@@ -61,6 +61,8 @@
 #include <sys/archsystm.h>
 #include <sys/promif.h>
 #include <sys/pci_cfgspace.h>
+#include <sys/apic.h>
+#include <sys/apic_common.h>
 #include <sys/bootvfs.h>
 #include <sys/tsc.h>
 #ifdef __xpv
@@ -78,6 +80,8 @@ extern uint32_t cpuid_feature_ecx_include;
 extern uint32_t cpuid_feature_ecx_exclude;
 extern uint32_t cpuid_feature_edx_include;
 extern uint32_t cpuid_feature_edx_exclude;
+
+nmi_action_t nmi_action = NMI_ACTION_UNSET;
 
 /*
  * Set console mode
@@ -103,6 +107,7 @@ void
 mlsetup(struct regs *rp)
 {
 	u_longlong_t prop_value;
+	char prop_str[BP_MAX_STRLEN];
 	extern struct classfuncs sys_classfuncs;
 	extern disp_t cpu0_disp;
 	extern char t0stack[];
@@ -149,6 +154,19 @@ mlsetup(struct regs *rp)
 		cpuid_feature_edx_exclude = (uint32_t)prop_value;
 
 #if !defined(__xpv)
+	if (bootprop_getstr("nmi", prop_str, sizeof (prop_str)) == 0) {
+		if (strcmp(prop_str, "ignore") == 0) {
+			nmi_action = NMI_ACTION_IGNORE;
+		} else if (strcmp(prop_str, "panic") == 0) {
+			nmi_action = NMI_ACTION_PANIC;
+		} else if (strcmp(prop_str, "kmdb") == 0) {
+			nmi_action = NMI_ACTION_KMDB;
+		} else {
+			prom_printf("unix: ignoring unknown nmi=%s\n",
+			    prop_str);
+		}
+	}
+
 	/*
 	 * Check to see if KPTI has been explicitly enabled or disabled.
 	 * We have to check this before init_desctbls().

--- a/usr/src/uts/i86pc/sys/apic_common.h
+++ b/usr/src/uts/i86pc/sys/apic_common.h
@@ -23,7 +23,7 @@
  * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 /*
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019, Joyent, Inc.
  */
 
 #ifndef _SYS_APIC_COMMON_H
@@ -155,7 +155,6 @@ extern lock_t	apic_nmi_lock;
 extern lock_t	apic_error_lock;
 
 /* Patchable global variables. */
-extern int	apic_kmdb_on_nmi;	/* 0 - no, 1 - yes enter kmdb */
 extern uint32_t	apic_divide_reg_init;	/* 0 - divide by 2 */
 
 extern apic_intrmap_ops_t *apic_vt_ops;
@@ -201,6 +200,15 @@ extern int	apic_msix_enable;
 
 extern uint32_t apic_get_localapicid(uint32_t cpuid);
 extern uchar_t apic_get_ioapicid(uchar_t ioapicindex);
+
+typedef enum nmi_action {
+	NMI_ACTION_UNSET,
+	NMI_ACTION_PANIC,
+	NMI_ACTION_IGNORE,
+	NMI_ACTION_KMDB
+} nmi_action_t;
+
+extern nmi_action_t nmi_action;
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/intel/sys/bootconf.h
+++ b/usr/src/uts/intel/sys/bootconf.h
@@ -23,6 +23,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2019, Joyent, Inc.
  */
 
 #ifndef	_SYS_BOOTCONF_H
@@ -45,6 +46,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define	BP_MAX_STRLEN	32
 
 /*
  * Boot property names
@@ -243,6 +246,7 @@ extern void bop_panic(const char *, ...)
 extern void boot_prop_finish(void);
 
 extern int bootprop_getval(const char *, u_longlong_t *);
+extern int bootprop_getstr(const char *, char *, size_t);
 
 /*
  * Back door to fakebop.c to get physical memory allocated.


### PR DESCRIPTION
Weekly illumos-gate upstream merge

## Backports

None

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2019040401-9f14f3c760 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu Apr  4 20:45:26 CEST 2019 ====
==== Nightly distributed build completed: Thu Apr  4 21:59:56 CEST 2019 ====

==== Total build time ====

real    1:14:30

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-fa6e4ea903 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151029/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151029-20190219"

/usr/bin/openssl
OpenSSL 1.1.1b  26 Feb 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1758 (illumos)

Build project:  default
Build taskid:   72

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2019040401-9f14f3c760

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    35:04.2
user  2:14:22.8
sys     24:36.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    28:11.0
user  1:59:56.0
sys     24:48.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```