### PR TITLE
Joyent merge/2019052301

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 90e5050456387317c70dd8a3668940e0d9ab61f2
+Last illumos-joyent commit: ebe61a781b04a51e0700be7c93f60479ad63de01
 

--- a/usr/contrib/freebsd/x86/specialreg.h
+++ b/usr/contrib/freebsd/x86/specialreg.h
@@ -77,6 +77,7 @@
 #define	CR4_XSAVE 0x00040000	/* XSETBV/XGETBV */
 #define	CR4_SMEP 0x00100000	/* Supervisor-Mode Execution Prevention */
 #define	CR4_SMAP 0x00200000	/* Supervisor-Mode Access Prevention */
+#define	CR4_PKE	0x00400000	/* Protection Keys Enable */
 
 /*
  * Bits in AMD64 special registers.  EFER is 64 bits wide.
@@ -447,6 +448,8 @@
 /*
  * CPUID instruction 7 Structured Extended Features, leaf 0 edx info
  */
+#define	CPUID_STDEXT3_MD_CLEAR	0x00000400
+#define	CPUID_STDEXT3_TSXFA	0x00002000
 #define	CPUID_STDEXT3_IBPB	0x04000000
 #define	CPUID_STDEXT3_STIBP	0x08000000
 #define	CPUID_STDEXT3_L1D_FLUSH	0x10000000
@@ -460,6 +463,7 @@
 #define	IA32_ARCH_CAP_RSBA	0x00000004
 #define	IA32_ARCH_CAP_SKIP_L1DFL_VMENTRY	0x00000008
 #define	IA32_ARCH_CAP_SSB_NO	0x00000010
+#define	IA32_ARCH_CAP_MDS_NO	0x00000020
 
 /*
  * CPUID manufacturers identifiers
@@ -505,6 +509,7 @@
 #define	MSR_MTRRcap		0x0fe
 #define	MSR_IA32_ARCH_CAP	0x10a
 #define	MSR_IA32_FLUSH_CMD	0x10b
+#define	MSR_TSX_FORCE_ABORT	0x10f
 #define	MSR_BBL_CR_ADDR		0x116
 #define	MSR_BBL_CR_DECC		0x118
 #define	MSR_BBL_CR_CTL		0x119
@@ -1041,6 +1046,7 @@
 #define	MSR_FSBASE	0xc0000100	/* base address of the %fs "segment" */
 #define	MSR_GSBASE	0xc0000101	/* base address of the %gs "segment" */
 #define	MSR_KGSBASE	0xc0000102	/* base address of the kernel %gs */
+#define	MSR_TSC_AUX	0xc0000103
 #define	MSR_PERFEVSEL0	0xc0010000
 #define	MSR_PERFEVSEL1	0xc0010001
 #define	MSR_PERFEVSEL2	0xc0010002

--- a/usr/src/compat/freebsd/amd64/machine/specialreg.h
+++ b/usr/src/compat/freebsd/amd64/machine/specialreg.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _COMPAT_FREEBSD_AMD64_MACHINE_SPECIALREG_H_
@@ -37,6 +37,7 @@
 #undef	CR4_VMXE
 #undef	CR4_SMEP
 #undef	CR4_SMAP
+#undef	CR4_PKE
 #undef	CR4_FSGSBASE
 #undef	CR4_PCIDE
 #endif /* _SYS_CONTROLREGS_H */
@@ -48,6 +49,7 @@
 #undef	IA32_ARCH_CAP_RSBA
 #undef	IA32_ARCH_CAP_SKIP_L1DFL_VMENTRY
 #undef	IA32_ARCH_CAP_SSB_NO
+#undef	IA32_ARCH_CAP_MDS_NO
 #undef	IA32_SPEC_CTRL_IBRS
 #undef	IA32_SPEC_CTRL_STIBP
 #undef	IA32_SPEC_CTRL_SSBD

--- a/usr/src/uts/common/brand/lx/os/lx_pid.c
+++ b/usr/src/uts/common/brand/lx/os/lx_pid.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -366,7 +366,6 @@ retry:
 			goto retry;
 		} else {
 			p->p_proc_flag |= P_PR_LOCK;
-			THREAD_KPRI_REQUEST();
 		}
 	}
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_prsubr.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prsubr.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -350,7 +350,6 @@ lxpr_unlock(proc_t *p)
 	cv_signal(&pr_pid_cv[p->p_slot]);
 	p->p_proc_flag &= ~P_PR_LOCK;
 	mutex_exit(&p->p_lock);
-	THREAD_KPRI_RELEASE();
 }
 
 void

--- a/usr/src/uts/common/disp/sysdc.c
+++ b/usr/src/uts/common/disp/sysdc.c
@@ -193,32 +193,6 @@
  *	flag.  This flag currently has no effect, but marks threads which
  *	do bulk processing.
  *
- * - t_kpri_req
- *
- *	The TS and FSS scheduling classes pay attention to t_kpri_req,
- *	which provides a simple form of priority inheritance for
- *	synchronization primitives (such as rwlocks held as READER) which
- *	cannot be traced to a unique thread.  The SDC class does not honor
- *	t_kpri_req, for a few reasons:
- *
- *	1.  t_kpri_req is notoriously inaccurate.  A measure of its
- *	    inaccuracy is that it needs to be cleared every time a thread
- *	    returns to user mode, because it is frequently non-zero at that
- *	    point.  This can happen because "ownership" of synchronization
- *	    primitives that use t_kpri_req can be silently handed off,
- *	    leaving no opportunity to will the t_kpri_req inheritance.
- *
- *	2.  Unlike in TS and FSS, threads in SDC *will* eventually run at
- *	    kernel priority.  This means that even if an SDC thread
- *	    is holding a synchronization primitive and running at low
- *	    priority, its priority will eventually be raised above 60,
- *	    allowing it to drive on and release the resource.
- *
- *	3.  The first consumer of SDC uses the taskq subsystem, which holds
- *	    a reader lock for the duration of the task's execution.  This
- *	    would mean that SDC threads would never drop below kernel
- *	    priority in practice, which defeats one of the purposes of SDC.
- *
  * - Why not FSS?
  *
  *	It might seem that the existing FSS scheduling class could solve

--- a/usr/src/uts/common/fs/proc/prsubr.c
+++ b/usr/src/uts/common/fs/proc/prsubr.c
@@ -25,7 +25,7 @@
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 #include <sys/types.h>
 #include <sys/t_lock.h>
@@ -715,7 +715,6 @@ pr_p_lock(prnode_t *pnp)
 		mutex_enter(&p->p_lock);
 	}
 	p->p_proc_flag |= P_PR_LOCK;
-	THREAD_KPRI_REQUEST();
 	return (p);
 }
 
@@ -822,7 +821,6 @@ prunmark(proc_t *p)
 
 	cv_signal(&pr_pid_cv[p->p_slot]);
 	p->p_proc_flag &= ~P_PR_LOCK;
-	THREAD_KPRI_RELEASE();
 }
 
 void
@@ -2695,7 +2693,7 @@ prgetlwpsinfo32(kthread_t *t, lwpsinfo32_t *psp)
 #define	PR_COPY_TIMESPEC(s, d, field)				\
 	TIMESPEC_TO_TIMESPEC32(&d->field, &s->field);
 
-#define	PR_COPY_BUF(s, d, field)	 			\
+#define	PR_COPY_BUF(s, d, field)				\
 	bcopy(s->field, d->field, sizeof (d->field));
 
 #define	PR_IGNORE_FIELD(s, d, field)

--- a/usr/src/uts/common/os/bio.c
+++ b/usr/src/uts/common/os/bio.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2011 Joyent, Inc.  All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -1380,7 +1380,6 @@ pageio_setup(struct page *pp, size_t len, struct vnode *vp, int flags)
 
 	VN_HOLD(vp);
 	bp->b_vp = vp;
-	THREAD_KPRI_RELEASE_N(btopr(len)); /* release kpri from page_locks */
 
 	/*
 	 * Caller sets dev & blkno and can adjust

--- a/usr/src/uts/common/os/condvar.c
+++ b/usr/src/uts/common/os/condvar.c
@@ -26,6 +26,7 @@
 
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/thread.h>
@@ -461,7 +462,7 @@ out:
 
 /*
  * Returns:
- * 	Function result in order of precedence:
+ *	Function result in order of precedence:
  *		 0 if a signal was received
  *		-1 if timeout occured
  *		>0 if awakened via cv_signal() or cv_broadcast().
@@ -552,7 +553,6 @@ cv_wait_sig_swap_core(kcondvar_t *cvp, kmutex_t *mp, int *sigret)
 	lwp->lwp_asleep = 1;
 	lwp->lwp_sysabort = 0;
 	thread_lock(t);
-	t->t_kpri_req = 0;	/* don't need kernel priority */
 	cv_block_sig(t, (condvar_impl_t *)cvp);
 	/* I can be swapped now */
 	curthread->t_schedflag &= ~TS_DONT_SWAP;
@@ -745,7 +745,7 @@ cv_wait_stop(kcondvar_t *cvp, kmutex_t *mp, int wakeup_time)
  * that a timeout occurred until the future time is passed.
  * If 'when' is a NULL pointer, no timeout will occur.
  * Returns:
- * 	Function result in order of precedence:
+ *	Function result in order of precedence:
  *		 0 if a signal was received
  *		-1 if timeout occured
  *	        >0 if awakened via cv_signal() or cv_broadcast()
@@ -763,8 +763,8 @@ cv_wait_stop(kcondvar_t *cvp, kmutex_t *mp, int wakeup_time)
  * does not need to deal with the time changing.
  */
 int
-cv_waituntil_sig(kcondvar_t *cvp, kmutex_t *mp,
-	timestruc_t *when, int timecheck)
+cv_waituntil_sig(kcondvar_t *cvp, kmutex_t *mp, timestruc_t *when,
+    int timecheck)
 {
 	timestruc_t now;
 	timestruc_t delta;

--- a/usr/src/uts/common/os/pid.c
+++ b/usr/src/uts/common/os/pid.c
@@ -21,11 +21,11 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -430,7 +430,6 @@ sprtrylock_proc(proc_t *p)
 		return (1);
 
 	p->p_proc_flag |= P_PR_LOCK;
-	THREAD_KPRI_REQUEST();
 
 	return (0);
 }
@@ -515,7 +514,6 @@ sprlock_proc(proc_t *p)
 	}
 
 	p->p_proc_flag |= P_PR_LOCK;
-	THREAD_KPRI_REQUEST();
 }
 
 void
@@ -532,7 +530,6 @@ sprunlock(proc_t *p)
 	cv_signal(&pr_pid_cv[p->p_slot]);
 	p->p_proc_flag &= ~P_PR_LOCK;
 	mutex_exit(&p->p_lock);
-	THREAD_KPRI_RELEASE();
 }
 
 /*
@@ -546,7 +543,6 @@ sprunprlock(proc_t *p)
 
 	cv_signal(&pr_pid_cv[p->p_slot]);
 	p->p_proc_flag &= ~P_PR_LOCK;
-	THREAD_KPRI_RELEASE();
 }
 
 void

--- a/usr/src/uts/common/sys/fss.h
+++ b/usr/src/uts/common/sys/fss.h
@@ -22,7 +22,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2012 Joyent, Inc.  All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef	_SYS_FSS_H
@@ -140,7 +140,7 @@ typedef struct fssproc {
  * than one cpu partition then it will have a few of these structures.
  */
 typedef struct fsszone {
-	struct zone 	*fssz_zone;	/* ptr to our zone structure	*/
+	struct zone	*fssz_zone;	/* ptr to our zone structure	*/
 	struct fsszone	*fssz_next;	/* next fsszone_t in fsspset_t	*/
 	struct fsszone	*fssz_prev;	/* prev fsszone_t in fsspset_t	*/
 	uint32_t	fssz_shares;	/* sum of all project shares	*/
@@ -160,7 +160,7 @@ typedef struct fsszone {
 /*
  * fss_flags
  */
-#define	FSSKPRI		0x01	/* the thread is in kernel mode	*/
+/* Formerly: FSSKPRI	0x01 - the thread is in kernel mode */
 #define	FSSBACKQ	0x02	/* thread should be placed at the back of */
 				/* the dispatch queue if preempted */
 #define	FSSRESTORE	0x04	/* thread was not preempted, due to schedctl */

--- a/usr/src/uts/common/sys/ia.h
+++ b/usr/src/uts/common/sys/ia.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1997-1998 by Sun Microsystems, Inc.
  * All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -85,7 +86,7 @@ typedef struct iaproc {
 
 
 /* flags */
-#define	IAKPRI	0x01	/* thread at kernel mode priority */
+/* Formerly: IAKPRI 0x01 - thread at kernel model priority */
 #define	IABACKQ	0x02	/* thread goes to back of disp q when preempted */
 #define	IASLEPT	0x04	/* thread had long-term suspend - give new slice */
 

--- a/usr/src/uts/common/sys/thread.h
+++ b/usr/src/uts/common/sys/thread.h
@@ -201,16 +201,15 @@ typedef struct _kthread {
 	 * it should be grabbed only by thread_lock().
 	 */
 	disp_lock_t	*t_lockp;	/* pointer to the dispatcher lock */
-	ushort_t 	t_oldspl;	/* spl level before dispatcher locked */
+	ushort_t	t_oldspl;	/* spl level before dispatcher locked */
 	volatile char	t_pre_sys;	/* pre-syscall work needed */
 	lock_t		t_lock_flush;	/* for lock_mutex_flush() impl */
 	struct _disp	*t_disp_queue;	/* run queue for chosen CPU */
 	clock_t		t_disp_time;	/* last time this thread was running */
-	uint_t		t_kpri_req;	/* kernel priority required */
 
 	/*
 	 * Post-syscall / post-trap flags.
-	 * 	No lock is required to set these.
+	 *	No lock is required to set these.
 	 *	These must be cleared only by the thread itself.
 	 *
 	 *	t_astflag indicates that some post-trap processing is required,
@@ -219,7 +218,7 @@ typedef struct _kthread {
 	 *	t_post_sys indicates that some unusualy post-system call
 	 *		handling is required, such as an error or tracing.
 	 *	t_sig_check indicates that some condition in ISSIG() must be
-	 * 		checked, but doesn't prevent returning to user.
+	 *		checked, but doesn't prevent returning to user.
 	 *	t_post_sys_ast is a way of checking whether any of these three
 	 *		flags are set.
 	 */
@@ -361,7 +360,7 @@ typedef struct _kthread {
 /*
  * Thread flag (t_flag) definitions.
  *	These flags must be changed only for the current thread,
- * 	and not during preemption code, since the code being
+ *	and not during preemption code, since the code being
  *	preempted could be modifying the flags.
  *
  *	For the most part these flags do not need locking.
@@ -520,10 +519,10 @@ typedef struct _kthread {
  *	convert a thread pointer to its proc pointer.
  *
  * ttoproj(x)
- * 	convert a thread pointer to its project pointer.
+ *	convert a thread pointer to its project pointer.
  *
  * ttozone(x)
- * 	convert a thread pointer to its zone pointer.
+ *	convert a thread pointer to its zone pointer.
  *
  * lwptot(x)
  *	convert a lwp pointer to its thread pointer.
@@ -617,20 +616,6 @@ extern int default_binding_mode;
 #define	THREAD_NAME_MAX	32	/* includes terminating NUL */
 
 /*
- * Macros to indicate that the thread holds resources that could be critical
- * to other kernel threads, so this thread needs to have kernel priority
- * if it blocks or is preempted.  Note that this is not necessary if the
- * resource is a mutex or a writer lock because of priority inheritance.
- *
- * The only way one thread may legally manipulate another thread's t_kpri_req
- * is to hold the target thread's thread lock while that thread is asleep.
- * (The rwlock code does this to implement direct handoff to waiting readers.)
- */
-#define	THREAD_KPRI_REQUEST()	(curthread->t_kpri_req++)
-#define	THREAD_KPRI_RELEASE()	(curthread->t_kpri_req--)
-#define	THREAD_KPRI_RELEASE_N(n) (curthread->t_kpri_req -= (n))
-
-/*
  * Macro to change a thread's priority.
  */
 #define	THREAD_CHANGE_PRI(t, pri) {					\
@@ -657,12 +642,12 @@ extern int default_binding_mode;
  * Point it at the transition lock, which is always held.
  * The previosly held lock is dropped.
  */
-#define	THREAD_TRANSITION(tp) 	thread_transition(tp);
+#define	THREAD_TRANSITION(tp)	thread_transition(tp);
 /*
  * Set the thread's lock to be the transition lock, without dropping
  * previosly held lock.
  */
-#define	THREAD_TRANSITION_NOLOCK(tp) 	((tp)->t_lockp = &transition_lock)
+#define	THREAD_TRANSITION_NOLOCK(tp)	((tp)->t_lockp = &transition_lock)
 
 /*
  * Put thread in run state, and set the lock pointer to the dispatcher queue

--- a/usr/src/uts/common/sys/ts.h
+++ b/usr/src/uts/common/sys/ts.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -78,7 +79,8 @@ typedef struct tsproc {
 } tsproc_t;
 
 /* flags */
-#define	TSKPRI		0x01	/* thread at kernel mode priority	*/
+
+/* Formerly: TSKPRI	0x01 - thread at kernel mode priority */
 #define	TSBACKQ		0x02	/* thread goes to back of dispq if preempted */
 #define	TSIA		0x04	/* thread is interactive		*/
 #define	TSIASET		0x08	/* interactive thread is "on"		*/

--- a/usr/src/uts/i86pc/io/vmm/x86.c
+++ b/usr/src/uts/i86pc/io/vmm/x86.c
@@ -455,7 +455,7 @@ x86_emulate_cpuid(struct vm *vm, int vcpu_id,
 				    CPUID_STDEXT_AVX512ER |
 				    CPUID_STDEXT_AVX512CD | CPUID_STDEXT_SHA);
 				regs[2] = 0;
-				regs[3] = 0;
+				regs[3] &= CPUID_STDEXT3_MD_CLEAR;
 
 				/* Advertise INVPCID if it is enabled. */
 				error = vm_get_capability(vm, vcpu_id,

--- a/usr/src/uts/i86pc/ml/offsets.in
+++ b/usr/src/uts/i86pc/ml/offsets.in
@@ -1,7 +1,7 @@
 \
 \ Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
 \ Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
-\ Copyright 2018 Joyent, Inc.
+\ Copyright 2019 Joyent, Inc.
 \
 \ CDDL HEADER START
 \
@@ -88,7 +88,6 @@ _kthread	THREAD_SIZE
 	t_lockstat
 	t_lockp
 	t_lock_flush
-	t_kpri_req
 	t_oldspl
 	t_pri
 	t_pil

--- a/usr/src/uts/intel/ia32/os/syscall.c
+++ b/usr/src/uts/intel/ia32/os/syscall.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/param.h>
@@ -1202,7 +1203,6 @@ loadable_syscall(
 	 * Try to autoload the system call if necessary
 	 */
 	module_lock = lock_syscall(se, code);
-	THREAD_KPRI_RELEASE();	/* drop priority given by rw_enter */
 
 	/*
 	 * we've locked either the loaded syscall or nosys
@@ -1234,7 +1234,6 @@ loadable_syscall(
 		}
 	}
 
-	THREAD_KPRI_REQUEST();	/* regain priority from read lock */
 	rw_exit(module_lock);
 	return (rval);
 }

--- a/usr/src/uts/sfmmu/vm/hat_sfmmu.c
+++ b/usr/src/uts/sfmmu/vm/hat_sfmmu.c
@@ -24,7 +24,7 @@
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 Gary Mills
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -112,35 +112,35 @@
 		ASSERT(_eaddr <= _rgnp->rgn_saddr + _rgnp->rgn_size);	\
 	}
 
-#define	SFMMU_VALIDATE_SHAREDHBLK(hmeblkp, srdp, rgnp, rid) 	 	 \
-{						 			 \
-		caddr_t _hsva;						 \
-		caddr_t _heva;						 \
-		caddr_t _rsva;					 	 \
-		caddr_t _reva;					 	 \
-		int	_ttesz = get_hblk_ttesz(hmeblkp);		 \
-		int	_flagtte;					 \
-		ASSERT((srdp)->srd_refcnt != 0);			 \
-		ASSERT((rid) < SFMMU_MAX_HME_REGIONS);			 \
-		ASSERT((rgnp)->rgn_id == rid);				 \
-		ASSERT(!((rgnp)->rgn_flags & SFMMU_REGION_FREE));	 \
-		ASSERT(((rgnp)->rgn_flags & SFMMU_REGION_TYPE_MASK) ==	 \
-		    SFMMU_REGION_HME);					 \
-		ASSERT(_ttesz <= (rgnp)->rgn_pgszc);			 \
-		_hsva = (caddr_t)get_hblk_base(hmeblkp);		 \
-		_heva = get_hblk_endaddr(hmeblkp);			 \
-		_rsva = (caddr_t)P2ALIGN(				 \
-		    (uintptr_t)(rgnp)->rgn_saddr, HBLK_MIN_BYTES);	 \
-		_reva = (caddr_t)P2ROUNDUP(				 \
-		    (uintptr_t)((rgnp)->rgn_saddr + (rgnp)->rgn_size),	 \
-		    HBLK_MIN_BYTES);					 \
-		ASSERT(_hsva >= _rsva);				 	 \
-		ASSERT(_hsva < _reva);				 	 \
-		ASSERT(_heva > _rsva);				 	 \
-		ASSERT(_heva <= _reva);				 	 \
-		_flagtte = (_ttesz < HBLK_MIN_TTESZ) ? HBLK_MIN_TTESZ :  \
-			_ttesz;						 \
-		ASSERT(rgnp->rgn_hmeflags & (0x1 << _flagtte));		 \
+#define	SFMMU_VALIDATE_SHAREDHBLK(hmeblkp, srdp, rgnp, rid)		\
+{									\
+		caddr_t _hsva;						\
+		caddr_t _heva;						\
+		caddr_t _rsva;						\
+		caddr_t _reva;						\
+		int	_ttesz = get_hblk_ttesz(hmeblkp);		\
+		int	_flagtte;					\
+		ASSERT((srdp)->srd_refcnt != 0);			\
+		ASSERT((rid) < SFMMU_MAX_HME_REGIONS);			\
+		ASSERT((rgnp)->rgn_id == rid);				\
+		ASSERT(!((rgnp)->rgn_flags & SFMMU_REGION_FREE));	\
+		ASSERT(((rgnp)->rgn_flags & SFMMU_REGION_TYPE_MASK) ==	\
+		    SFMMU_REGION_HME);					\
+		ASSERT(_ttesz <= (rgnp)->rgn_pgszc);			\
+		_hsva = (caddr_t)get_hblk_base(hmeblkp);		\
+		_heva = get_hblk_endaddr(hmeblkp);			\
+		_rsva = (caddr_t)P2ALIGN(				\
+		    (uintptr_t)(rgnp)->rgn_saddr, HBLK_MIN_BYTES);	\
+		_reva = (caddr_t)P2ROUNDUP(				\
+		    (uintptr_t)((rgnp)->rgn_saddr + (rgnp)->rgn_size),	\
+		    HBLK_MIN_BYTES);					\
+		ASSERT(_hsva >= _rsva);					\
+		ASSERT(_hsva < _reva);					\
+		ASSERT(_heva > _rsva);					\
+		ASSERT(_heva <= _reva);					\
+		_flagtte = (_ttesz < HBLK_MIN_TTESZ) ? HBLK_MIN_TTESZ : \
+			_ttesz;						\
+		ASSERT(rgnp->rgn_hmeflags & (0x1 << _flagtte));		\
 }
 
 #else /* DEBUG */
@@ -199,7 +199,7 @@ int	sfmmu_allow_nc_trans = 0;
 
 /*
  * Flag to disable large page support.
- * 	value of 1 => disable all large pages.
+ *	value of 1 => disable all large pages.
  *	bits 1, 2, and 3 are to disable 64K, 512K and 4M pages respectively.
  *
  * For example, use the value 0x4 to disable 512K pages.
@@ -247,7 +247,7 @@ static struct kmem_cache *sfmmu8_cache;
 static struct kmem_cache *sfmmu1_cache;
 static struct kmem_cache *pa_hment_cache;
 
-static kmutex_t 	ism_mlist_lock;	/* mutex for ism mapping list */
+static kmutex_t		ism_mlist_lock;	/* mutex for ism mapping list */
 /*
  * private data for ism
  */
@@ -393,7 +393,7 @@ int hat_check_vtop = 0;
  * Private sfmmu routines (prototypes)
  */
 static struct hme_blk *sfmmu_shadow_hcreate(sfmmu_t *, caddr_t, int, uint_t);
-static struct 	hme_blk *sfmmu_hblk_alloc(sfmmu_t *, caddr_t,
+static struct	hme_blk *sfmmu_hblk_alloc(sfmmu_t *, caddr_t,
 			struct hmehash_bucket *, uint_t, hmeblk_tag, uint_t,
 			uint_t);
 static caddr_t	sfmmu_hblk_unload(struct hat *, struct hme_blk *, caddr_t,
@@ -463,7 +463,7 @@ static void	sfmmu_tlb_range_demap(demap_range_t *);
 static void	sfmmu_invalidate_ctx(sfmmu_t *);
 static void	sfmmu_sync_mmustate(sfmmu_t *);
 
-static void 	sfmmu_tsbinfo_setup_phys(struct tsb_info *, pfn_t);
+static void	sfmmu_tsbinfo_setup_phys(struct tsb_info *, pfn_t);
 static int	sfmmu_tsbinfo_alloc(struct tsb_info **, int, int, uint_t,
 			sfmmu_t *);
 static void	sfmmu_tsb_free(struct tsb_info *);
@@ -561,8 +561,8 @@ struct hmehash_bucket *uhme_hash;	/* user hmeblk hash table */
 struct hmehash_bucket *khme_hash;	/* kernel hmeblk hash table */
 uint64_t	uhme_hash_pa;		/* PA of uhme_hash */
 uint64_t	khme_hash_pa;		/* PA of khme_hash */
-int 		uhmehash_num;		/* # of buckets in user hash table */
-int 		khmehash_num;		/* # of buckets in kernel hash table */
+int		uhmehash_num;		/* # of buckets in user hash table */
+int		khmehash_num;		/* # of buckets in kernel hash table */
 
 uint_t		max_mmu_ctxdoms = 0;	/* max context domains in the system */
 mmu_ctx_t	**mmu_ctxs_tbl;		/* global array of context domains */
@@ -705,7 +705,7 @@ struct sfmmu_tsbsize_stat sfmmu_tsbsize_stat;
 /*
  * Global data
  */
-sfmmu_t 	*ksfmmup;		/* kernel's hat id */
+sfmmu_t		*ksfmmup;		/* kernel's hat id */
 
 #ifdef DEBUG
 static void	chk_tte(tte_t *, tte_t *, tte_t *, struct hme_blk *);
@@ -857,7 +857,7 @@ sfmmu_vmem_xalloc_aligned_wrapper(vmem_t *vmp, size_t size, int vmflag)
 	if (ttesz == TTE8K || ttesz == TTE4M) {				\
 		sfmmu_unload_tsb(sfmmup, addr, ttesz);			\
 	} else {							\
-		caddr_t sva = ismhat ? addr : 				\
+		caddr_t sva = ismhat ? addr :				\
 		    (caddr_t)get_hblk_base(hmeblkp);			\
 		caddr_t eva = sva + get_hblk_span(hmeblkp);		\
 		ASSERT(addr >= sva && addr < eva);			\
@@ -1020,7 +1020,7 @@ static kphysm_setup_vector_t sfmmu_update_vec = {
 void
 hat_init_pagesizes()
 {
-	int 		i;
+	int		i;
 
 	mmu_exported_page_sizes = 0;
 	for (i = TTE8K; i < max_mmu_page_sizes; i++) {
@@ -1061,7 +1061,7 @@ hat_init_pagesizes()
 void
 hat_init(void)
 {
-	int 		i;
+	int		i;
 	uint_t		sz;
 	size_t		size;
 
@@ -2123,7 +2123,7 @@ hat_swapout(struct hat *sfmmup)
 /* ARGSUSED */
 int
 hat_dup(struct hat *hat, struct hat *newhat, caddr_t addr, size_t len,
-	uint_t flag)
+    uint_t flag)
 {
 	sf_srd_t *srdp;
 	sf_scd_t *scdp;
@@ -2188,7 +2188,7 @@ hat_dup(struct hat *hat, struct hat *newhat, caddr_t addr, size_t len,
 
 void
 hat_memload(struct hat *hat, caddr_t addr, struct page *pp,
-	uint_t attr, uint_t flags)
+    uint_t attr, uint_t flags)
 {
 	hat_do_memload(hat, addr, pp, attr, flags,
 	    SFMMU_INVALID_SHMERID);
@@ -2196,7 +2196,7 @@ hat_memload(struct hat *hat, caddr_t addr, struct page *pp,
 
 void
 hat_memload_region(struct hat *hat, caddr_t addr, struct page *pp,
-	uint_t attr, uint_t flags, hat_region_cookie_t rcookie)
+    uint_t attr, uint_t flags, hat_region_cookie_t rcookie)
 {
 	uint_t rid;
 	if (rcookie == HAT_INVALID_REGION_COOKIE) {
@@ -2216,7 +2216,7 @@ hat_memload_region(struct hat *hat, caddr_t addr, struct page *pp,
  */
 static void
 hat_do_memload(struct hat *hat, caddr_t addr, struct page *pp,
-	uint_t attr, uint_t flags, uint_t rid)
+    uint_t attr, uint_t flags, uint_t rid)
 {
 	tte_t tte;
 
@@ -2273,7 +2273,7 @@ hat_do_memload(struct hat *hat, caddr_t addr, struct page *pp,
  */
 void
 hat_devload(struct hat *hat, caddr_t addr, size_t len, pfn_t pfn,
-	uint_t attr, int flags)
+    uint_t attr, int flags)
 {
 	tte_t tte;
 	struct page *pp = NULL;
@@ -2414,7 +2414,7 @@ hat_devload(struct hat *hat, caddr_t addr, size_t len, pfn_t pfn,
 
 void
 hat_memload_array(struct hat *hat, caddr_t addr, size_t len,
-	struct page **pps, uint_t attr, uint_t flags)
+    struct page **pps, uint_t attr, uint_t flags)
 {
 	hat_do_memload_array(hat, addr, len, pps, attr, flags,
 	    SFMMU_INVALID_SHMERID);
@@ -2422,8 +2422,8 @@ hat_memload_array(struct hat *hat, caddr_t addr, size_t len,
 
 void
 hat_memload_array_region(struct hat *hat, caddr_t addr, size_t len,
-	struct page **pps, uint_t attr, uint_t flags,
-	hat_region_cookie_t rcookie)
+    struct page **pps, uint_t attr, uint_t flags,
+    hat_region_cookie_t rcookie)
 {
 	uint_t rid;
 	if (rcookie == HAT_INVALID_REGION_COOKIE) {
@@ -2449,7 +2449,7 @@ hat_memload_array_region(struct hat *hat, caddr_t addr, size_t len,
  */
 static void
 hat_do_memload_array(struct hat *hat, caddr_t addr, size_t len,
-	struct page **pps, uint_t attr, uint_t flags, uint_t rid)
+    struct page **pps, uint_t attr, uint_t flags, uint_t rid)
 {
 	int  ttesz;
 	size_t mapsz;
@@ -2559,7 +2559,7 @@ hat_do_memload_array(struct hat *hat, caddr_t addr, size_t len,
  */
 static void
 sfmmu_memload_batchsmall(struct hat *hat, caddr_t vaddr, page_t **pps,
-		    uint_t attr, uint_t flags, pgcnt_t npgs, uint_t rid)
+    uint_t attr, uint_t flags, pgcnt_t npgs, uint_t rid)
 {
 	tte_t	tte;
 	page_t *pp;
@@ -2675,7 +2675,7 @@ sfmmu_memtte(tte_t *ttep, pfn_t pfn, uint_t attr, int tte_sz)
  */
 void
 sfmmu_tteload(struct hat *sfmmup, tte_t *ttep, caddr_t vaddr, page_t *pp,
-	uint_t flags)
+    uint_t flags)
 {
 	ASSERT(sfmmup == ksfmmup);
 	(void) sfmmu_tteload_array(sfmmup, ttep, vaddr, &pp, flags,
@@ -2878,11 +2878,11 @@ sfmmu_select_tsb_szc(pgcnt_t pgcnt)
  */
 static int
 sfmmu_tteload_array(sfmmu_t *sfmmup, tte_t *ttep, caddr_t vaddr,
-	page_t **pps, uint_t flags, uint_t rid)
+    page_t **pps, uint_t flags, uint_t rid)
 {
 	struct hmehash_bucket *hmebp;
 	struct hme_blk *hmeblkp;
-	int 	ret;
+	int	ret;
 	uint_t	size;
 
 	/*
@@ -2947,7 +2947,7 @@ sfmmu_tteload_acquire_hashbucket(sfmmu_t *sfmmup, caddr_t vaddr, int size,
  */
 static struct hme_blk *
 sfmmu_tteload_find_hmeblk(sfmmu_t *sfmmup, struct hmehash_bucket *hmebp,
-	caddr_t vaddr, uint_t size, uint_t flags, uint_t rid)
+    caddr_t vaddr, uint_t size, uint_t flags, uint_t rid)
 {
 	hmeblk_tag hblktag;
 	int hmeshift;
@@ -3040,7 +3040,7 @@ ttearray_realloc:
  */
 static int
 sfmmu_tteload_addentry(sfmmu_t *sfmmup, struct hme_blk *hmeblkp, tte_t *ttep,
-	caddr_t vaddr, page_t **pps, uint_t flags, uint_t rid)
+    caddr_t vaddr, page_t **pps, uint_t flags, uint_t rid)
 {
 	page_t *pp = *pps;
 	int hmenum, size, remap;
@@ -3386,7 +3386,7 @@ sfmmu_tteload_release_hashbucket(struct hmehash_bucket *hmebp)
 static int
 sfmmu_pagearray_setup(caddr_t addr, page_t **pps, tte_t *ttep, int remap)
 {
-	int 	i, index, ttesz;
+	int	i, index, ttesz;
 	pfn_t	pfnum;
 	pgcnt_t	npgs;
 	page_t *pp, *pp1;
@@ -3670,7 +3670,7 @@ sfmmu_shadow_hcreate(sfmmu_t *sfmmup, caddr_t vaddr, int ttesz, uint_t flags)
  */
 static void
 sfmmu_shadow_hcleanup(sfmmu_t *sfmmup, struct hme_blk *hmeblkp,
-	struct hmehash_bucket *hmebp)
+    struct hmehash_bucket *hmebp)
 {
 	caddr_t addr, endaddr;
 	int hashno, size;
@@ -3698,7 +3698,7 @@ sfmmu_shadow_hcleanup(sfmmu_t *sfmmup, struct hme_blk *hmeblkp,
 
 static void
 sfmmu_free_hblks(sfmmu_t *sfmmup, caddr_t addr, caddr_t endaddr,
-	int hashno)
+    int hashno)
 {
 	int hmeshift, shadow = 0;
 	hmeblk_tag hblktag;
@@ -4212,10 +4212,10 @@ readtte:
  */
 id_t
 hat_register_callback(int key,
-	int (*prehandler)(caddr_t, uint_t, uint_t, void *),
-	int (*posthandler)(caddr_t, uint_t, uint_t, void *, pfn_t),
-	int (*errhandler)(caddr_t, uint_t, uint_t, void *),
-	int capture_cpus)
+    int (*prehandler)(caddr_t, uint_t, uint_t, void *),
+    int (*posthandler)(caddr_t, uint_t, uint_t, void *, pfn_t),
+    int (*errhandler)(caddr_t, uint_t, uint_t, void *),
+    int capture_cpus)
 {
 	id_t id;
 
@@ -4288,17 +4288,17 @@ hat_register_callback(int key,
  */
 int
 hat_add_callback(id_t callback_id, caddr_t vaddr, uint_t len, uint_t flags,
-	void *pvt, pfn_t *rpfn, void **cookiep)
+    void *pvt, pfn_t *rpfn, void **cookiep)
 {
-	struct 		hmehash_bucket *hmebp;
-	hmeblk_tag 	hblktag;
+	struct		hmehash_bucket *hmebp;
+	hmeblk_tag	hblktag;
 	struct hme_blk	*hmeblkp;
-	int 		hmeshift, hashno;
-	caddr_t 	saddr, eaddr, baseaddr;
+	int		hmeshift, hashno;
+	caddr_t		saddr, eaddr, baseaddr;
 	struct pa_hment *pahmep;
 	struct sf_hment *sfhmep, *osfhmep;
 	kmutex_t	*pml;
-	tte_t   	tte;
+	tte_t		tte;
 	page_t		*pp;
 	vnode_t		*vp;
 	u_offset_t	off;
@@ -4517,7 +4517,7 @@ rehash:
  */
 void
 hat_delete_callback(caddr_t vaddr, uint_t len, void *pvt, uint_t flags,
-	void *cookie)
+    void *cookie)
 {
 	struct		hmehash_bucket *hmebp;
 	hmeblk_tag	hblktag;
@@ -4835,7 +4835,7 @@ hat_clrattr(struct hat *hat, caddr_t addr, size_t len, uint_t attr)
  */
 static void
 sfmmu_chgattr(struct hat *sfmmup, caddr_t addr, size_t len, uint_t attr,
-	int mode)
+    int mode)
 {
 	struct hmehash_bucket *hmebp;
 	hmeblk_tag hblktag;
@@ -4931,7 +4931,7 @@ sfmmu_chgattr(struct hat *sfmmup, caddr_t addr, size_t len, uint_t attr,
  */
 static caddr_t
 sfmmu_hblk_chgattr(struct hat *sfmmup, struct hme_blk *hmeblkp, caddr_t addr,
-	caddr_t endaddr, demap_range_t *dmrp, uint_t attr, int mode)
+    caddr_t endaddr, demap_range_t *dmrp, uint_t attr, int mode)
 {
 	tte_t tte, tteattr, tteflags, ttemod;
 	struct sf_hment *sfhmep;
@@ -5259,7 +5259,7 @@ hat_chgprot(struct hat *sfmmup, caddr_t addr, size_t len, uint_t vprot)
  */
 static caddr_t
 sfmmu_hblk_chgprot(sfmmu_t *sfmmup, struct hme_blk *hmeblkp, caddr_t addr,
-	caddr_t endaddr, demap_range_t *dmrp, uint_t vprot)
+    caddr_t endaddr, demap_range_t *dmrp, uint_t vprot)
 {
 	uint_t pprot;
 	tte_t tte, ttemod;
@@ -5418,24 +5418,24 @@ sfmmu_vtop_prot(uint_t vprot, uint_t *tteflagsp)
 	case (PROT_EXEC):
 	case (PROT_EXEC | PROT_READ):
 		*tteflagsp = TTE_PRIV_INT | TTE_WRPRM_INT | TTE_HWWR_INT;
-		return (TTE_PRIV_INT); 		/* set prv and clr wrt */
+		return (TTE_PRIV_INT);		/* set prv and clr wrt */
 	case (PROT_WRITE):
 	case (PROT_WRITE | PROT_READ):
 	case (PROT_EXEC | PROT_WRITE):
 	case (PROT_EXEC | PROT_WRITE | PROT_READ):
 		*tteflagsp = TTE_PRIV_INT | TTE_WRPRM_INT;
-		return (TTE_PRIV_INT | TTE_WRPRM_INT); 	/* set prv and wrt */
+		return (TTE_PRIV_INT | TTE_WRPRM_INT);	/* set prv and wrt */
 	case (PROT_USER | PROT_READ):
 	case (PROT_USER | PROT_EXEC):
 	case (PROT_USER | PROT_EXEC | PROT_READ):
 		*tteflagsp = TTE_PRIV_INT | TTE_WRPRM_INT | TTE_HWWR_INT;
-		return (0); 			/* clr prv and wrt */
+		return (0);			/* clr prv and wrt */
 	case (PROT_USER | PROT_WRITE):
 	case (PROT_USER | PROT_WRITE | PROT_READ):
 	case (PROT_USER | PROT_EXEC | PROT_WRITE):
 	case (PROT_USER | PROT_EXEC | PROT_WRITE | PROT_READ):
 		*tteflagsp = TTE_PRIV_INT | TTE_WRPRM_INT;
-		return (TTE_WRPRM_INT); 	/* clr prv and set wrt */
+		return (TTE_WRPRM_INT);		/* clr prv and set wrt */
 	default:
 		panic("sfmmu_vtop_prot -- bad prot %x", vprot);
 	}
@@ -5449,12 +5449,8 @@ sfmmu_vtop_prot(uint_t vprot, uint_t *tteflagsp)
  * hash table to find and remove mappings.
  */
 static void
-hat_unload_large_virtual(
-	struct hat		*sfmmup,
-	caddr_t			startaddr,
-	size_t			len,
-	uint_t			flags,
-	hat_callback_t		*callback)
+hat_unload_large_virtual(struct hat *sfmmup, caddr_t startaddr, size_t len,
+    uint_t flags, hat_callback_t *callback)
 {
 	struct hmehash_bucket *hmebp;
 	struct hme_blk *hmeblkp;
@@ -5592,12 +5588,8 @@ segkmap->s_base <= (addr) && (addr) < (segkmap->s_base + segkmap->s_size))
 
 
 void
-hat_unload_callback(
-	struct hat *sfmmup,
-	caddr_t addr,
-	size_t len,
-	uint_t flags,
-	hat_callback_t *callback)
+hat_unload_callback(struct hat *sfmmup, caddr_t addr, size_t len, uint_t flags,
+    hat_callback_t *callback)
 {
 	struct hmehash_bucket *hmebp;
 	hmeblk_tag hblktag;
@@ -5920,7 +5912,7 @@ fnd_mapping_sz(page_t *pp)
  */
 static caddr_t
 sfmmu_hblk_unload(struct hat *sfmmup, struct hme_blk *hmeblkp, caddr_t addr,
-	caddr_t endaddr, demap_range_t *dmrp, uint_t flags)
+    caddr_t endaddr, demap_range_t *dmrp, uint_t flags)
 {
 	tte_t	tte, ttemod;
 	struct	sf_hment *sfhmep;
@@ -6304,7 +6296,7 @@ hat_sync(struct hat *sfmmup, caddr_t addr, size_t len, uint_t clearflag)
 
 static caddr_t
 sfmmu_hblk_sync(struct hat *sfmmup, struct hme_blk *hmeblkp, caddr_t addr,
-	caddr_t endaddr, int clearflag)
+    caddr_t endaddr, int clearflag)
 {
 	tte_t	tte, ttemod;
 	struct sf_hment *sfhmep;
@@ -6379,7 +6371,7 @@ static void
 sfmmu_ttesync(struct hat *sfmmup, caddr_t addr, tte_t *ttep, page_t *pp)
 {
 	uint_t rm = 0;
-	int   	sz;
+	int	sz;
 	pgcnt_t	npgs;
 
 	ASSERT(TTE_IS_VALID(ttep));
@@ -6744,7 +6736,7 @@ static kmutex_t prl_mutex;
  *
  * Input:
  *
- * target : 	constituent pages are SE_EXCL locked.
+ * target :	constituent pages are SE_EXCL locked.
  * replacement:	constituent pages are SE_EXCL locked.
  *
  * Output:
@@ -7492,7 +7484,7 @@ retry:
  */
 static cpuset_t
 sfmmu_pagesync(struct page *pp, struct sf_hment *sfhme,
-	uint_t clearflag)
+    uint_t clearflag)
 {
 	caddr_t addr;
 	tte_t tte, ttemod;
@@ -8359,7 +8351,7 @@ size_t
 hat_get_mapped_size(struct hat *hat)
 {
 	size_t		assize = 0;
-	int 		i;
+	int		i;
 
 	if (hat == NULL)
 		return (0);
@@ -8459,12 +8451,12 @@ iment_sub(struct ism_ment *iment, struct hat *ism_hat)
  * HATOP_SHARE()/UNSHARE() return 0
  */
 int
-hat_share(struct hat *sfmmup, caddr_t addr,
-	struct hat *ism_hatid, caddr_t sptaddr, size_t len, uint_t ismszc)
+hat_share(struct hat *sfmmup, caddr_t addr, struct hat *ism_hatid,
+    caddr_t sptaddr, size_t len, uint_t ismszc)
 {
 	ism_blk_t	*ism_blkp;
 	ism_blk_t	*new_iblk;
-	ism_map_t 	*ism_map;
+	ism_map_t	*ism_map;
 	ism_ment_t	*ism_ment;
 	int		i, added;
 	hatlock_t	*hatlockp;
@@ -8689,11 +8681,11 @@ hat_share(struct hat *sfmmup, caddr_t addr,
 void
 hat_unshare(struct hat *sfmmup, caddr_t addr, size_t len, uint_t ismszc)
 {
-	ism_map_t 	*ism_map;
+	ism_map_t	*ism_map;
 	ism_ment_t	*free_ment = NULL;
 	ism_blk_t	*ism_blkp;
 	struct hat	*ism_hatid;
-	int 		found, i;
+	int		found, i;
 	hatlock_t	*hatlockp;
 	struct tsb_info	*tsbinfo;
 	uint_t		ismshift = page_get_shift(ismszc);
@@ -9299,7 +9291,7 @@ tst_tnc(page_t *pp, pgcnt_t npages)
 	tte_t	tte;
 	caddr_t	vaddr;
 	int	clr_valid = 0;
-	int 	color, color1, bcolor;
+	int	color, color1, bcolor;
 	int	i, ncolors;
 
 	ASSERT(pp != NULL);
@@ -9369,7 +9361,7 @@ tst_tnc(page_t *pp, pgcnt_t npages)
 
 void
 sfmmu_page_cache_array(page_t *pp, int flags, int cache_flush_flag,
-	pgcnt_t npages)
+    pgcnt_t npages)
 {
 	kmutex_t *pmtx;
 	int i, ncolors, bcolor;
@@ -10168,7 +10160,7 @@ sfmmu_check_page_sizes(sfmmu_t *sfmmup, int growing)
 
 static void
 sfmmu_size_tsb(sfmmu_t *sfmmup, int growing, uint64_t tte8k_cnt,
-	uint64_t tte4m_cnt, int sectsb_thresh)
+    uint64_t tte4m_cnt, int sectsb_thresh)
 {
 	int tsb_bits;
 	uint_t tsb_szc;
@@ -10309,7 +10301,7 @@ sfmmu_free_sfmmu(sfmmu_t *sfmmup)
 	ism_blk_t	*blkp, *nx_blkp;
 #ifdef	DEBUG
 	ism_map_t	*map;
-	int 		i;
+	int		i;
 #endif
 
 	ASSERT(sfmmup->sfmmu_ttecnt[TTE8K] == 0);
@@ -10882,7 +10874,6 @@ sfmmu_ismhat_enter(sfmmu_t *sfmmup, int hatlock_held)
 {
 	hatlock_t *hatlockp;
 
-	THREAD_KPRI_REQUEST();
 	if (!hatlock_held)
 		hatlockp = sfmmu_hat_enter(sfmmup);
 	while (SFMMU_FLAGS_ISSET(sfmmup, HAT_ISMBUSY))
@@ -10904,7 +10895,6 @@ sfmmu_ismhat_exit(sfmmu_t *sfmmup, int hatlock_held)
 	cv_broadcast(&sfmmup->sfmmu_tsb_cv);
 	if (!hatlock_held)
 		sfmmu_hat_exit(hatlockp);
-	THREAD_KPRI_RELEASE();
 }
 
 /*
@@ -10916,7 +10906,7 @@ sfmmu_ismhat_exit(sfmmu_t *sfmmup, int hatlock_held)
  *
  * (2) if we are allocating an hblk for mapping a slab in sfmmu_cache,
  *
- * 		(a) try to return an hblk from reserve pool of free hblks;
+ *		(a) try to return an hblk from reserve pool of free hblks;
  *		(b) if the reserve pool is empty, acquire hblk_reserve_lock
  *		    and return hblk_reserve.
  *
@@ -10933,8 +10923,8 @@ sfmmu_ismhat_exit(sfmmu_t *sfmmup, int hatlock_held)
  */
 static struct hme_blk *
 sfmmu_hblk_alloc(sfmmu_t *sfmmup, caddr_t vaddr,
-	struct hmehash_bucket *hmebp, uint_t size, hmeblk_tag hblktag,
-	uint_t flags, uint_t rid)
+    struct hmehash_bucket *hmebp, uint_t size, hmeblk_tag hblktag,
+    uint_t flags, uint_t rid)
 {
 	struct hme_blk *hmeblkp = NULL;
 	struct hme_blk *newhblkp;
@@ -11441,7 +11431,7 @@ sfmmu_hblk_steal(int size)
  */
 static int
 sfmmu_steal_this_hblk(struct hmehash_bucket *hmebp, struct hme_blk *hmeblkp,
-	uint64_t hblkpa, struct hme_blk *pr_hblk)
+    uint64_t hblkpa, struct hme_blk *pr_hblk)
 {
 	int shw_size, vshift;
 	struct hme_blk *shw_hblkp;
@@ -12066,14 +12056,14 @@ find_ism_rid(sfmmu_t *sfmmup, sfmmu_t *ism_sfmmup, caddr_t va, uint_t *ism_rid)
 /* ARGSUSED */
 static void
 sfmmu_ismtlbcache_demap(caddr_t addr, sfmmu_t *ism_sfmmup,
-	struct hme_blk *hmeblkp, pfn_t pfnum, int cache_flush_flag)
+    struct hme_blk *hmeblkp, pfn_t pfnum, int cache_flush_flag)
 {
-	cpuset_t 	cpuset;
-	caddr_t 	va;
+	cpuset_t	cpuset;
+	caddr_t		va;
 	ism_ment_t	*ment;
 	sfmmu_t		*sfmmup;
 #ifdef VAC
-	int 		vcolor;
+	int		vcolor;
 #endif
 
 	sf_scd_t	*scdp;
@@ -12163,8 +12153,8 @@ sfmmu_ismtlbcache_demap(caddr_t addr, sfmmu_t *ism_sfmmup,
  */
 static void
 sfmmu_tlbcache_demap(caddr_t addr, sfmmu_t *sfmmup, struct hme_blk *hmeblkp,
-	pfn_t pfnum, int tlb_noflush, int cpu_flag, int cache_flush_flag,
-	int hat_lock_held)
+    pfn_t pfnum, int tlb_noflush, int cpu_flag, int cache_flush_flag,
+    int hat_lock_held)
 {
 #ifdef VAC
 	int vcolor;
@@ -12252,7 +12242,7 @@ sfmmu_tlbcache_demap(caddr_t addr, sfmmu_t *sfmmup, struct hme_blk *hmeblkp,
  */
 static void
 sfmmu_tlb_demap(caddr_t addr, sfmmu_t *sfmmup, struct hme_blk *hmeblkp,
-	int tlb_noflush, int hat_lock_held)
+    int tlb_noflush, int hat_lock_held)
 {
 	cpuset_t cpuset;
 	hatlock_t *hatlockp;
@@ -12449,7 +12439,7 @@ sfmmu_invalidate_ctx(sfmmu_t *sfmmup)
 	/* set HAT cnum invalid across all context domains. */
 	for (i = 0; i < max_mmu_ctxdoms; i++) {
 
-		cnum = 	sfmmup->sfmmu_ctxs[i].cnum;
+		cnum = sfmmup->sfmmu_ctxs[i].cnum;
 		if (cnum == INVALID_CONTEXT) {
 			continue;
 		}
@@ -12638,7 +12628,7 @@ sfmmu_tsb_inv_ctx(sfmmu_t *sfmmup)
 /* ARGSUSED */
 static int
 sfmmu_tsb_post_relocator(caddr_t va, uint_t tsbsz, uint_t flags,
-	void *tsbinfo, pfn_t newpfn)
+    void *tsbinfo, pfn_t newpfn)
 {
 	hatlock_t *hatlockp;
 	struct tsb_info *tsbinfop = (struct tsb_info *)tsbinfo;
@@ -12682,7 +12672,7 @@ sfmmu_tsb_post_relocator(caddr_t va, uint_t tsbsz, uint_t flags,
  */
 static int
 sfmmu_tsbinfo_alloc(struct tsb_info **tsbinfopp, int tsb_szc, int tte_sz_mask,
-	uint_t flags, sfmmu_t *sfmmup)
+    uint_t flags, sfmmu_t *sfmmup)
 {
 	int err;
 
@@ -13812,15 +13802,9 @@ sfmmu_srdcache_destructor(void *buf, void *cdrarg)
  * the ism_map structure for ism segments.
  */
 hat_region_cookie_t
-hat_join_region(struct hat *sfmmup,
-	caddr_t r_saddr,
-	size_t r_size,
-	void *r_obj,
-	u_offset_t r_objoff,
-	uchar_t r_perm,
-	uchar_t r_pgszc,
-	hat_rgn_cb_func_t r_cb_function,
-	uint_t flags)
+hat_join_region(struct hat *sfmmup, caddr_t r_saddr, size_t r_size,
+    void *r_obj, u_offset_t r_objoff, uchar_t r_perm, uchar_t r_pgszc,
+    hat_rgn_cb_func_t r_cb_function, uint_t flags)
 {
 	sf_srd_t *srdp = sfmmup->sfmmu_srdp;
 	uint_t rhash;
@@ -15384,7 +15368,7 @@ sfmmu_scdcache_destructor(void *buf, void *cdrarg)
  * We cross-call to make sure that there are no threads on other cpus accessing
  * these hmblks and then complete the process of freeing them under the
  * following conditions:
- * 	The total number of pending hmeblks is greater than the threshold
+ *	The total number of pending hmeblks is greater than the threshold
  *	The reserve list has fewer than HBLK_RESERVE_CNT hmeblks
  *	It is at least 1 second since the last time we cross-called
  *
@@ -15462,7 +15446,7 @@ sfmmu_hblks_list_purge(struct hme_blk **listp, int dontfree)
  */
 void
 sfmmu_hblk_hash_add(struct hmehash_bucket *hmebp, struct hme_blk *hmeblkp,
-	uint64_t hblkpa)
+    uint64_t hblkpa)
 {
 	ASSERT(SFMMU_HASH_LOCK_ISHELD(hmebp));
 #ifdef	DEBUG
@@ -15518,8 +15502,7 @@ sfmmu_hblk_hash_add(struct hmehash_bucket *hmebp, struct hme_blk *hmeblkp,
  */
 void
 sfmmu_hblk_hash_rm(struct hmehash_bucket *hmebp, struct hme_blk *hmeblkp,
-    struct hme_blk *pr_hblk, struct hme_blk **listp,
-    int free_now)
+    struct hme_blk *pr_hblk, struct hme_blk **listp, int free_now)
 {
 	int shw_size, vshift;
 	struct hme_blk *shw_hblkp;

--- a/usr/src/uts/sparc/os/syscall.c
+++ b/usr/src/uts/sparc/os/syscall.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/param.h>
@@ -191,7 +192,7 @@ get_syscall32_args(klwp_t *lwp, int *argp, int *nargsp)
 #endif
 
 /*
- * 	Save the system call arguments in a safe place.
+ *	Save the system call arguments in a safe place.
  *	lwp->lwp_ap normally points to the out regs in the reg structure.
  *	If the user is going to change the out registers, g1, or the stack,
  *	and might want to get the args (for /proc tracing), it must copy
@@ -1004,7 +1005,7 @@ lock_syscall(struct sysent *table, uint_t code)
 /*
  * Loadable syscall support.
  *	If needed, load the module, then reserve it by holding a read
- * 	lock for the duration of the call.
+ *	lock for the duration of the call.
  *	Later, if the syscall is not unloadable, it could patch the vector.
  */
 /*ARGSUSED*/
@@ -1026,7 +1027,6 @@ loadable_syscall(
 	 * Try to autoload the system call if necessary.
 	 */
 	module_lock = lock_syscall(se, code);
-	THREAD_KPRI_RELEASE();	/* drop priority given by rw_enter */
 
 	/*
 	 * we've locked either the loaded syscall or nosys
@@ -1040,7 +1040,6 @@ loadable_syscall(
 		rval = syscall_ap();
 	}
 
-	THREAD_KPRI_REQUEST();	/* regain priority from read lock */
 	rw_exit(module_lock);
 	return (rval);
 }
@@ -1070,7 +1069,7 @@ indir(int code, long a0, long a1, long a2, long a3, long a4)
 	 * Handle argument setup, unless already done in pre_syscall().
 	 */
 	if (callp->sy_narg > 5) {
-		if (save_syscall_args()) 	/* move args to LWP array */
+		if (save_syscall_args())	/* move args to LWP array */
 			return ((int64_t)set_errno(EFAULT));
 	} else if (!lwp->lwp_argsaved) {
 		long *ap;

--- a/usr/src/uts/sun4/ml/offsets.in
+++ b/usr/src/uts/sun4/ml/offsets.in
@@ -1,6 +1,7 @@
 \ offsets.in: input file to produce assym.h using the stabs program
 \ Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
 \ Copyright 2012 Garrett D'Amore <garett@damore.org>.  All rights reserved.
+\ Copyright 2019 Joyent, Inc.
 \
 \ CDDL HEADER START
 \
@@ -24,44 +25,44 @@
 \
 \
 \ Guidelines:
-\ 
+\
 \ A blank line is required between structure/union/intrinsic names.
-\ 
+\
 \ The general form is:
-\ 
+\
 \	name size_define [shift_define]
 \		member_name [offset_define]
 \	{blank line}
-\ 
+\
 \ If offset_define is not specified then the member_name is
 \ converted to all caps and used instead.  If the size of an item is
 \ a power of two then an optional shift count may be output using
 \ shift_define as the name but only if shift_define was specified.
-\ 
+\
 \ Arrays cause stabs to automatically output the per-array-item increment
 \ in addition to the base address:
-\ 
+\
 \	 foo FOO_SIZE
 \		array	FOO_ARRAY
-\ 
+\
 \ results in:
-\ 
+\
 \	#define	FOO_ARRAY	0x0
 \	#define	FOO_ARRAY_INCR	0x4
-\ 
+\
 \ which allows \#define's to be used to specify array items:
-\ 
+\
 \	#define	FOO_0	(FOO_ARRAY + (0 * FOO_ARRAY_INCR))
 \	#define	FOO_1	(FOO_ARRAY + (1 * FOO_ARRAY_INCR))
 \	...
 \	#define	FOO_n	(FOO_ARRAY + (n * FOO_ARRAY_INCR))
-\ 
+\
 \ There are several examples below (search for _INCR).
-\ 
+\
 \ There is currently no manner in which to identify "anonymous"
 \ structures or unions so if they are to be used in assembly code
 \ they must be given names.
-\ 
+\
 \ When specifying the offsets of nested structures/unions each nested
 \ structure or union must be listed separately then use the
 \ "\#define" escapes to add the offsets from the base structure/union
@@ -165,7 +166,6 @@ _kthread	THREAD_SIZE
 	_tu._ts._t_post_sys	T_POST_SYS
 	_tu._ts._t_trapret	T_TRAPRET
 	t_preempt_lk
-	t_kpri_req
 	t_lockstat
 	t_pil
 	t_intr_start
@@ -374,7 +374,7 @@ cpu	CPUSIZE
 	cpu_m.mpcb			CPU_MPCB
 	cpu_m.cpu_private		CPU_PRIVATE
 	cpu_m.cpu_mmu_idx		CPU_MMU_IDX
-	cpu_m.cpu_mmu_ctxp            	CPU_MMU_CTXP
+	cpu_m.cpu_mmu_ctxp		CPU_MMU_CTXP
 	cpu_m.ptl1_state		CPU_PTL1
 
 cpu_core_t	CPU_CORE_SIZE	CPU_CORE_SHIFT


### PR DESCRIPTION
Weekly upstream merge for illumos-joyent

## Backports

None (OS-7801 has already been backported to r30)

## onu

```
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-joyent_merge-2019052301-92f6114091 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu May 23 18:22:00 UTC 2019 ====
==== Nightly distributed build completed: Thu May 23 19:35:13 UTC 2019 ====

==== Total build time ====

real    1:13:12

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-5e514c8a6b1 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151031/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151031-20190219"

/usr/bin/openssl
OpenSSL 1.1.1b  26 Feb 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1761 (illumos)

Build project:  default
Build taskid:   67

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019052301-92f6114091

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    33:12.4
user  3:21:12.9
sys     31:41.1

==== Build noise differences (non-DEBUG) ====

124d123
< ln: /build/illumos-omnios/proto/root_i386-nd/usr/bin/pmadvise: File exists

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    29:01.5
user  2:51:49.6
sys     29:00.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```