### PR TITLE
Backport to r151030:  DLPX-63519 ATA reads timeout after Azure update

### DIFF
--- a/usr/src/uts/intel/io/dktp/controller/ata/ata_common.c
+++ b/usr/src/uts/intel/io/dktp/controller/ata/ata_common.c
@@ -24,6 +24,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2018 RackTop Systems.
+ * Copyright (c) 2019 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -36,6 +37,7 @@
 #include <sys/uio.h>
 #include <sys/cred.h>
 #include <sys/cpu.h>
+#include <sys/x86_archext.h>
 #include "ata_common.h"
 #include "ata_disk.h"
 #include "atapi.h"
@@ -179,6 +181,11 @@ char *ata_dev_DMA_sel_msg;
  */
 static	struct bus_ops	 ata_bus_ops;
 static	struct bus_ops	*scsa_bus_ops_p;
+
+/*
+ * ATA workaround for Azure bug
+ */
+boolean_t ata_azure_workaround = B_FALSE;
 
 /* ARGSUSED */
 static int
@@ -390,6 +397,13 @@ _init(void)
 		ddi_soft_state_fini(&ata_state);
 		return (err);
 	}
+
+	/*
+	 * See comment in function ata_pciide_dma_start() of ata_dma.c for
+	 * more details.
+	 */
+	if (get_hwenv() & HW_MICROSOFT)
+		ata_azure_workaround = B_TRUE;
 
 	/* save pointer to SCSA provided bus_ops struct */
 	scsa_bus_ops_p = ata_ops.devo_bus_ops;

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
@@ -38,7 +38,7 @@
  */
 
 /*
- * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2017, 2019 by Delphix. All rights reserved.
  */
 
 /*
@@ -272,6 +272,13 @@ hyperv_identify(void)
 
 	cmn_err(CE_CONT, "?Hyper-V Version: %d.%d.%d [SP%d]\n",
 	    regs[1] >> 16, regs[1] & 0xffff, regs[0], regs[2]);
+	/*
+	 * Hyper-V version numbering is based on Linux source code, in
+	 * function ms_hyperv_init_platform().
+	 */
+	cmn_err(CE_CONT, "?Hyper-V Host Build: %d-%d.%d-%d-%d.%d\n",
+	    regs[0], regs[1] >> 16, regs[1] & 0xffff, regs[2],
+	    regs[3] >> 24, regs[3] & 0xffffff);
 
 	if (boothowto & RB_VERBOSE) {
 		printf("  Features=0x%b\n", hyperv_features,


### PR DESCRIPTION
This is merely a cherry-pick from master.  Unlike master, r151030 + DLPX-63519 HAS been actually tested on Azure.  (Thanks to @hadfl building VHDs.)

I understand this is a requires-reboot update, so time it at your discretion.