### PR TITLE
OS-7798 zfs_zone_zio_dequeue: count==0 console noise during boot

### DIFF
--- a/usr/src/uts/common/fs/zfs/vdev_queue.c
+++ b/usr/src/uts/common/fs/zfs/vdev_queue.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2013 Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -864,9 +864,11 @@ vdev_queue_change_io_priority(zio_t *zio, zio_priority_t priority)
 		spa_t *spa = zio->io_spa;
 		zio_priority_t oldpri = zio->io_priority;
 
+		zfs_zone_zio_dequeue(zio);
 		avl_remove(vdev_queue_class_tree(vq, zio->io_priority), zio);
 		zio->io_priority = priority;
 		avl_add(vdev_queue_class_tree(vq, zio->io_priority), zio);
+		zfs_zone_zio_enqueue(zio);
 
 		mutex_enter(&spa->spa_iokstat_lock);
 		ASSERT3U(spa->spa_queue_stats[oldpri].spa_queued, >, 0);


### PR DESCRIPTION
We are getting noise on the console during boot as follows. Joyent have a fix which will likely be upstreamed in time. I'm picking it now to fix this in bloody.

```
SunOS Release 5.11 Version omnios-master-95346d5fd9 64-bit
Copyright (c) 1983, 2010, Oracle and/or its affiliates. All rights reserved.
Copyright (c) 2017-2019 OmniOS Community Edition (OmniOSce) Association.
WARNING: zfs_zone_zio_dequeue: count==0
WARNING: zfs_zone_zio_dequeue: count==0
WARNING: zfs_zone_zio_dequeue: count==0
WARNING: zfs_zone_zio_dequeue: count==0
Hostname: bloody
WARNING: zfs_zone_zio_dequeue: count==0

bloody console login: May 29 10:24:56 bloody zfs: WARNING: zfs_zone_zio_dequeue: count==0

bloody console login: May 29 10:54:04 bloody zfs: WARNING: zfs_zone_zio_dequeue: count==0
```