### PR TITLE
Provide psm_get_ipivect even on single CPU systems

### DIFF
--- a/usr/src/uts/i86pc/os/mp_machdep.c
+++ b/usr/src/uts/i86pc/os/mp_machdep.c
@@ -1134,6 +1134,14 @@ mach_smpinit(void)
 	if (pops->psm_enable_intr)
 		psm_enable_intr  = pops->psm_enable_intr;
 
+	/*
+	 * Set this vector so it can be used by vmbus (for Hyper-V)
+	 * Need this even for single-CPU systems.  This works for
+	 * "pcplusmp" and "apix" platforms, but not "uppc" (because
+	 * "Uni-processor PC" does not provide a _get_ipivect).
+	 */
+	psm_get_ipivect = pops->psm_get_ipivect;
+
 	/* check for multiple CPUs */
 	if (cnt < 2 && plat_dr_support_cpu() == B_FALSE)
 		return;
@@ -1156,7 +1164,6 @@ mach_smpinit(void)
 #endif
 	}
 
-	psm_get_ipivect = pops->psm_get_ipivect;
 	psm_get_pir_ipivect = pops->psm_get_pir_ipivect;
 	psm_send_pir_ipi = pops->psm_send_pir_ipi;
 	psm_cmci_setup = pops->psm_cmci_setup;


### PR DESCRIPTION
This is what I'm testing on my system.  No full build yet, so just dropping in a new "unix" in an existing r151030 build for now.  I'll open another PR against master once this tests out OK.

https://github.com/omniosorg/illumos-omnios/issues/482