### PR TITLE
Panic if Hyper-V cannot create interrupt handler

### DIFF
--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -841,7 +841,7 @@ vmbus_intr_setup(struct vmbus_softc *sc)
 	}
 
 	if (psm_get_ipivect == NULL)
-		return (0);
+		panic("Hyper-V vmbus cannot get IDT vector (no PSM support)");
 
 	sc->vmbus_idtvec = psm_get_ipivect(IPL_VMBUS, -1);
 	if (add_avintr(NULL, IPL_VMBUS, (avfunc)vmbus_handle_intr,


### PR DESCRIPTION
Currently if OmniOS is booted under Hyper-V with a single vCPU, it hangs. It should panic instead until PSM is fixed (see #483 )