### PR TITLE
Upstream merge joyent_merge/2019060501

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2012,6 +2012,7 @@ usr/src/cmd/smbsrv/fksmbd/fksmbd
 usr/src/cmd/smbsrv/smbadm/smbadm
 usr/src/cmd/smbsrv/smbd/smbd
 usr/src/cmd/smbsrv/smbstat/smbstat
+usr/src/cmd/smbsrv/test-msgbuf/test-msgbuf
 usr/src/cmd/smserverd/rpc.smserverd
 usr/src/cmd/smserverd/smed.h
 usr/src/cmd/smserverd/smed_svc.c
@@ -3185,6 +3186,7 @@ usr/src/lib/libldap5/i386/libldap.so.5
 usr/src/lib/libm/amd64/libm.so.2
 usr/src/lib/libm/i386/libm.so.2
 usr/src/lib/libmd/amd64/md5_amd64.s
+usr/src/lib/libmd/amd64/pics/
 usr/src/lib/libmd/amd64/sha1-x86_64.s
 usr/src/lib/libmd/amd64/sha256-x86_64.s
 usr/src/lib/libmd/amd64/sha512-x86_64.s
@@ -3380,6 +3382,7 @@ usr/src/lib/scsi/libscsi/common/scsi_errno.c
 usr/src/lib/scsi/libses/common/ses_errno.c
 usr/src/lib/scsi/libsmp/common/smp_errno.c
 usr/src/lib/scsi/plugins/ses/libses/common/libses_elemtype.c
+usr/src/lib/smbsrv/libfksmbsrv/common/fksmb_dt.h
 usr/src/lib/smbsrv/libmlsvc/amd64/dssetup_ndr.c
 usr/src/lib/smbsrv/libmlsvc/amd64/eventlog_ndr.c
 usr/src/lib/smbsrv/libmlsvc/amd64/lsarpc_ndr.c
@@ -3407,6 +3410,8 @@ usr/src/man/man1/dmake.1
 usr/src/man/man1/egrep.1
 usr/src/man/man1/fgrep.1
 usr/src/man/man1/mailq.1
+usr/src/man/man1/pauxv.1
+usr/src/man/man1/penv.1
 usr/src/man/man1/whatis.1
 usr/src/man/man1m/audlinks.1m
 usr/src/man/man1m/cdpd.1m
@@ -3995,6 +4000,8 @@ usr/src/test/libc-tests/tests/newlocale/newlocale_test.i386
 usr/src/test/libc-tests/tests/nl_langinfo/nl_langinfo_test
 usr/src/test/libc-tests/tests/nl_langinfo/nl_langinfo_test.amd64
 usr/src/test/libc-tests/tests/nl_langinfo/nl_langinfo_test.i386
+usr/src/test/libc-tests/tests/posix_memalign.32
+usr/src/test/libc-tests/tests/posix_memalign.64
 usr/src/test/libc-tests/tests/printf-6961.64
 usr/src/test/libc-tests/tests/printf-9511.32
 usr/src/test/libc-tests/tests/printf-9511.64
@@ -4339,6 +4346,8 @@ usr/src/uts/intel/core_pcbe/core_pcbe_wsm_ex.c
 usr/src/uts/intel/md5/md5_amd64.s
 usr/src/uts/intel/mwlfw/mw88W8363fw
 usr/src/uts/intel/mwlfw/mwlboot
+usr/src/uts/intel/opteron_pcbe/opteron_pcbe_cpcgen.h
+usr/src/uts/intel/opteron_pcbe/opteron_pcbe_f17h.c
 usr/src/uts/intel/os/priv_names
 usr/src/uts/intel/sha1/sha1-x86_64.s
 usr/src/uts/intel/sha2/sha256-x86_64.s

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 1205f1a47f18f403254c28de55875156744b9e0a
+Last illumos-joyent commit: 9240ea30ee29d2a499bcf3eed9e12dd9921f39f8
 

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -2811,8 +2811,22 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 			goto drop_hook;
 		}
 
-		if (dp != NULL)
+		if (dp != NULL) {
 			dp->d_ref--;
+
+			/*
+			 * It is possible that the hook(s) accepted the packet,
+			 * but as part of its processing, it issued a pull-up
+			 * which released all references to the desb.  In that
+			 * case, go back to acting like the packet is entirely
+			 * copied (which it is).
+			 */
+			if (dp->d_ref == 1) {
+				dp->d_cookie = 0;
+				dp->d_ref = 0;
+				dp = NULL;
+			}
+		}
 	}
 
 	/*

--- a/usr/src/uts/i86pc/io/viona/viona.c
+++ b/usr/src/uts/i86pc/io/viona/viona.c
@@ -402,7 +402,10 @@ typedef struct viona_vring {
 	uint16_t	vr_state_flags;
 	uint_t		vr_xfer_outstanding;
 	kthread_t	*vr_worker_thread;
-	viona_desb_t	*vr_desb;
+
+	/* ring-sized resources for TX activity */
+	viona_desb_t	*vr_txdesb;
+	struct iovec	*vr_txiov;
 
 	uint_t		vr_intr_enabled;
 	uint64_t	vr_msi_addr;
@@ -1234,16 +1237,24 @@ viona_ring_alloc(viona_link_t *link, viona_vring_t *ring)
 }
 
 static void
-viona_ring_desb_free(viona_vring_t *ring)
+viona_ring_misc_free(viona_vring_t *ring)
 {
-	viona_desb_t *dp = ring->vr_desb;
+	const uint_t cnt = ring->vr_size;
 
-	for (uint_t i = 0; i < ring->vr_size; i++, dp++) {
-		kmem_free(dp->d_headers, VIONA_MAX_HDRS_LEN);
+	if (ring->vr_txdesb != NULL) {
+		viona_desb_t *dp = ring->vr_txdesb;
+
+		for (uint_t i = 0; i < cnt; i++, dp++) {
+			kmem_free(dp->d_headers, VIONA_MAX_HDRS_LEN);
+		}
+		kmem_free(ring->vr_txdesb, sizeof (viona_desb_t) * cnt);
+		ring->vr_txdesb = NULL;
 	}
 
-	kmem_free(ring->vr_desb, sizeof (viona_desb_t) * ring->vr_size);
-	ring->vr_desb = NULL;
+	if (ring->vr_txiov != NULL) {
+		kmem_free(ring->vr_txiov, sizeof (struct iovec) * cnt);
+		ring->vr_txiov = NULL;
+	}
 }
 
 static void
@@ -1359,7 +1370,7 @@ viona_ioc_ring_init(viona_link_t *link, void *udata, int md)
 		viona_desb_t *dp;
 
 		dp = kmem_zalloc(sizeof (viona_desb_t) * cnt, KM_SLEEP);
-		ring->vr_desb = dp;
+		ring->vr_txdesb = dp;
 		for (uint_t i = 0; i < cnt; i++, dp++) {
 			dp->d_frtn.free_func = viona_desb_release;
 			dp->d_frtn.free_arg = (void *)dp;
@@ -1367,6 +1378,12 @@ viona_ioc_ring_init(viona_link_t *link, void *udata, int md)
 			dp->d_headers = kmem_zalloc(VIONA_MAX_HDRS_LEN,
 			    KM_SLEEP);
 		}
+	}
+
+	/* Allocate ring-sized iovec buffers for TX */
+	if (kri.ri_index == VIONA_VQ_TX) {
+		ring->vr_txiov = kmem_alloc(sizeof (struct iovec) * cnt,
+		    KM_SLEEP);
 	}
 
 	/* Zero out MSI-X configuration */
@@ -1388,9 +1405,7 @@ viona_ioc_ring_init(viona_link_t *link, void *udata, int md)
 	return (0);
 
 fail:
-	if (ring->vr_desb != NULL) {
-		viona_ring_desb_free(ring);
-	}
+	viona_ring_misc_free(ring);
 	ring->vr_size = 0;
 	ring->vr_mask = 0;
 	ring->vr_descr = NULL;
@@ -1629,11 +1644,6 @@ viona_worker_tx(viona_vring_t *ring, viona_link_t *link)
 		 */
 		cv_wait(&ring->vr_cv, &ring->vr_lock);
 	}
-
-	/* Free any desb resources before the ring is completely stopped */
-	if (ring->vr_desb != NULL) {
-		viona_ring_desb_free(ring);
-	}
 }
 
 static void
@@ -1677,11 +1687,14 @@ viona_worker(void *arg)
 	}
 
 cleanup:
-	/* Free any desb resources before the ring is completely stopped */
-	if (ring->vr_desb != NULL) {
+	if (ring->vr_txdesb != NULL) {
+		/*
+		 * Transmit activity must be entirely concluded before the
+		 * associated descriptors can be cleaned up.
+		 */
 		VERIFY(ring->vr_xfer_outstanding == 0);
-		viona_ring_desb_free(ring);
 	}
+	viona_ring_misc_free(ring);
 
 	ring->vr_cur_aidx = 0;
 	ring->vr_state = VRS_RESET;
@@ -2635,7 +2648,8 @@ viona_tx_csum(viona_vring_t *ring, const struct virtio_net_hdr *hdr,
 static void
 viona_tx(viona_link_t *link, viona_vring_t *ring)
 {
-	struct iovec		iov[VTNET_MAXSEGS];
+	struct iovec		*iov = ring->vr_txiov;
+	const uint_t		max_segs = ring->vr_size;
 	uint16_t		cookie;
 	int			i, n;
 	uint32_t		len, base_off = 0;
@@ -2647,10 +2661,19 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 
 	mp_head = mp_tail = NULL;
 
-	n = vq_popchain(ring, iov, VTNET_MAXSEGS, &cookie);
-	if (n <= 0) {
+	ASSERT(iov != NULL);
+
+	n = vq_popchain(ring, iov, max_segs, &cookie);
+	if (n == 0) {
 		VIONA_PROBE1(tx_absent, viona_vring_t *, ring);
 		VIONA_RING_STAT_INCR(ring, tx_absent);
+		return;
+	} else if (n < 0) {
+		/*
+		 * Any error encountered in vq_popchain has already resulted in
+		 * specific probe and statistic handling.  Further action here
+		 * is unnecessary.
+		 */
 		return;
 	}
 
@@ -2662,8 +2685,8 @@ viona_tx(viona_link_t *link, viona_vring_t *ring)
 	}
 
 	/* Make sure the packet headers are always in the first mblk. */
-	if (ring->vr_desb != NULL) {
-		dp = &ring->vr_desb[cookie];
+	if (ring->vr_txdesb != NULL) {
+		dp = &ring->vr_txdesb[cookie];
 
 		/*
 		 * If the guest driver is operating properly, each desb slot


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019060501

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019060501-d1cb068c02 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Wed Jun  5 10:48:22 UTC 2019 ====
==== Nightly distributed build completed: Wed Jun  5 11:41:38 UTC 2019 ====

==== Total build time ====

real    0:53:16

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-01c610f1f5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151031/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151031-20190219"

/usr/bin/openssl
OpenSSL 1.1.1c  28 May 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   100

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019060501-d1cb068c02

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    18:47.6
user  2:50:21.3
sys     46:00.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    20:20.4
user  3:03:14.7
sys     50:48.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
