### PR TITLE
Automatically maintain the whatis database

### DIFF
--- a/usr/src/cmd/man/Makefile
+++ b/usr/src/cmd/man/Makefile
@@ -12,6 +12,7 @@
 #
 # Copyright 2012 Nexenta Systems, Inc. All rights reserved.
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 PROG=		man
@@ -19,8 +20,12 @@ LINKS=		apropos whatis catman
 LIBLINKS =	makewhatis
 OBJS=		makewhatis.o man.o stringlist.o
 SRCS=		$(OBJS:%.o=%.c)
+MANIFEST=	rebuild-whatis.xml
+SVCMETHOD=	rebuild-whatis
 
 include		$(SRC)/cmd/Makefile.cmd
+
+ROOTMANIFESTDIR=	$(ROOTSVCSYSTEM)
 
 CFLAGS +=	$(CCVERBOSE)
 
@@ -33,9 +38,9 @@ all:		$(PROG)
 clean:
 		$(RM) $(OBJS)
 
-install:	all $(ROOTPROG) $(ROOTLINKS)
+install:	all $(ROOTPROG) $(ROOTLINKS) $(ROOTMANIFEST) $(ROOTSVCMETHOD)
 
-lint: 		lint_SRCS
+check:		$(CHKMANIFEST)
 
 $(PROG):	$(OBJS)
 		$(LINK.c) $(OBJS) -o $@ $(LDLIBS)

--- a/usr/src/cmd/man/rebuild-whatis
+++ b/usr/src/cmd/man/rebuild-whatis
@@ -1,0 +1,35 @@
+#!/bin/ksh
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+#
+
+[ -f /lib/svc/share/smf_include.sh ] || exit 1
+
+. /lib/svc/share/smf_include.sh
+
+_path=`grep '^PATH=' /etc/default/login | sed -n '
+    s/PATH=//
+    p
+    q
+    '`
+
+[ -z "$_path" ] && _path=/usr/sbin:/usr/bin
+
+# Man -w uses the PATH to determine where to look for man pages.
+export PATH=$_path
+/usr/bin/man -w
+
+exit 0

--- a/usr/src/cmd/man/rebuild-whatis.xml
+++ b/usr/src/cmd/man/rebuild-whatis.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+ CDDL HEADER START
+
+ This file and its contents are supplied under the terms of the
+ Common Development and Distribution License ("CDDL"), version 1.0.
+ You may only use this file in accordance with the terms of version
+ 1.0 of the CDDL.
+
+ A full copy of the text of the CDDL should have accompanied this
+ source. A copy of the CDDL is also available via the Internet at
+ http://www.illumos.org/license/CDDL.
+
+ CDDL HEADER END
+
+ Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+-->
+
+<service_bundle type='manifest' name='SUNWcsr:whatis'>
+
+<service
+	name='system/rebuild-whatis'
+	type='service'
+	version='1'>
+
+	<create_default_instance enabled='true' />
+
+	<single_instance/>
+
+	<dependency
+		name='fs-local'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/system/filesystem/local' />
+	</dependency>
+
+	<exec_method
+		type='method'
+		name='start'
+		exec='/lib/svc/method/rebuild-whatis'
+		timeout_seconds='300' />
+
+	<exec_method
+		type='method'
+		name='stop'
+		exec=':true'
+		timeout_seconds='3' />
+
+	<property_group name='startd' type='framework'>
+		<propval name='duration' type='astring' value='transient' />
+	</property_group>
+
+	<stability value='Unstable' />
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'>
+				whatis database updater
+			</loctext>
+		</common_name>
+		<documentation>
+			<manpage title='man' section='1'
+				manpath='/usr/share/man' />
+		</documentation>
+	</template>
+</service>
+
+</service_bundle>

--- a/usr/src/pkg/manifests/system-man.mf
+++ b/usr/src/pkg/manifests/system-man.mf
@@ -21,12 +21,18 @@ set name=pkg.summary value="Reference Manual Pages Tools"
 set name=info.classification \
     value="org.opensolaris.category.2008:System/Text Tools"
 set name=variant.arch value=$(ARCH)
+dir path=lib/svc
+dir path=lib/svc/manifest group=sys
+dir path=lib/svc/manifest/system group=sys
+dir path=lib/svc/method
 dir path=usr/bin
 dir path=usr/share
 dir path=usr/share/man
 dir path=usr/share/man/man1
 dir path=usr/share/man/man1m
 dir path=usr/share/man/man5
+file path=lib/svc/manifest/system/rebuild-whatis.xml group=sys mode=0444
+file path=lib/svc/method/rebuild-whatis mode=0555
 file path=usr/bin/man mode=0555
 file path=usr/bin/mandoc mode=0555
 file path=usr/share/man/man1/apropos.1

--- a/usr/src/pkg/transforms/restart_fmri
+++ b/usr/src/pkg/transforms/restart_fmri
@@ -21,11 +21,18 @@
 
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
-<transform file path=var/svc/manifest/.*\.xml -> add restart_fmri svc:/system/manifest-import:default>
-<transform file path=lib/svc/manifest/.*\.xml -> add restart_fmri svc:/system/manifest-import:default>
-<transform file path=etc/security/[^/]+_attr.d/.+ -> add restart_fmri svc:/system/rbac:default>
-<transform file path=etc/user_attr.d/.+ -> add restart_fmri svc:/system/rbac:default>
+<transform file path=var/svc/manifest/.*\.xml -> \
+    add restart_fmri svc:/system/manifest-import:default>
+<transform file path=lib/svc/manifest/.*\.xml -> \
+    add restart_fmri svc:/system/manifest-import:default>
+<transform file path=etc/security/[^/]+_attr.d/.+ -> \
+    add restart_fmri svc:/system/rbac:default>
+<transform file path=etc/user_attr.d/.+ -> \
+    add restart_fmri svc:/system/rbac:default>
 <transform file path=usr/share/applications/.*\.desktop -> \
-	add restart_fmri svc:/application/desktop-cache/desktop-mime-cache:default>
+    add restart_fmri svc:/application/desktop-cache/desktop-mime-cache:default>
+<transform file link path=usr/(share|has)/man/.*\.\d[a-z]*$ -> \
+    add restart_fmri svc:/system/rebuild-whatis:default>


### PR DESCRIPTION
Fixes https://github.com/omniosorg/illumos-omnios/issues/494

Packages now get their man pages tagged with a restart_fmri action:
```
% pkg contents -mg packages/i386/nightly-nd/repo.redist fss | grep man
dir group=bin mode=0755 owner=root path=usr/share/man
dir facet.doc.man=true group=bin mode=0755 owner=root path=usr/share/man/man7
file feda492d099cc87d4674fbbb3e859ef2af35fb3d chash=4dcc635a03b98b051a1243be45771d2327910cf2 facet.doc.man=true group=bin mode=0444 owner=root path=usr/share/man/man7/FSS.7 pkg.content-hash=file:sha512t_256:4284e5c4e44a8b7692b147780a9c0c36c3a20569e8f8e33c23e39b01af380329 pkg.content-hash=gzip:sha512t_256:d4d943badc489cf3d1981f377027bff7ce16c0b227b311261cb0b2b346887f4a pkg.csize=3293 pkg.size=8128 restart_fmri=svc:/system/rebuild-whatis:default
```

Installing a new package which delivers a man page causes a database rebuild, and `apropos` works for the new page:

```
bloody% apropos pppd
bloody% tail -f `svcs -L rebuild-whatis` &
[1] 671
bloody% [ Jun 12 13:14:15 Enabled. ]
[ Jun 12 13:14:17 Executing start method ("/usr/bin/man -w"). ]
man: /usr/share/man/man3ssl/bio.3: No such file or directory
[ Jun 12 13:14:31 Method "start" exited with status 0. ]

bloody%
bloody% pfexec pkg install ppp
           Packages to install:  1
            Services to change:  1
       Create boot environment: No
Create backup boot environment: No

Planning linked: 0/1 done; 1 working: zone:test
Linked image 'zone:test' output:
|
`
Planning linked: 1/1 done
DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1         25/25      0.3/0.3      --

Downloading linked: 0/1 done; 1 working: zone:test
Downloading linked: 1/1 done
PHASE                                          ITEMS
Installing new actions                         66/66
Updating package state database                 Done
Updating package cache                           0/0
Updating image state                            Done
[ Jun 12 13:15:00 Stopping because service restarting. ]
[ Jun 12 13:15:00 Executing stop method (null). ]
[ Jun 12 13:15:00 Executing start method ("/usr/bin/man -w"). ]
man: /usr/share/man/man3ssl/bio.3: No such file or directory
[ Jun 12 13:15:00 Method "start" exited with status 0. ]
Creating fast lookup database                   Done
Reading search index                            Done
Updating search index                            1/1
Executing linked: 0/1 done; 1 working: zone:test
Executing linked: 1/1 done

bloody% apropos pppd
pppd(1m)                 - point to point protocol daemon
```
