### PR TITLE
Fix smatch warnings

### DIFF
--- a/usr/src/cmd/dlmgmtd/dlmgmt_door.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_door.c
@@ -1368,7 +1368,7 @@ dlmgmt_zonehalt(void *argp, void *retp, size_t *sz, zoneid_t zoneid,
 
 			while ((fd = open(ZONE_LOCK, O_WRONLY |
 			    O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)) < 0)
-			(void) sleep(1);
+				(void) sleep(1);
 			(void) write(fd, my_pid, sizeof (my_pid));
 			(void) close(fd);
 

--- a/usr/src/lib/brand/shared/zadump/zadump.c
+++ b/usr/src/lib/brand/shared/zadump/zadump.c
@@ -76,7 +76,7 @@ show_datalink(dladm_handle_t handle, datalink_id_t linkid,
 
 	if (dladm_datalink_id2info(handle, linkid, NULL, NULL, NULL,
 	    link, sizeof (link)) != DLADM_STATUS_OK)
-		strlcpy(link, "??", MAXLINKNAMELEN);
+		(void) strlcpy(link, "??", MAXLINKNAMELEN);
 	printf(LABEL "%d - %s\n", "Datalink", linkid, link);
 
 	bufsize = sizeof (buf);

--- a/usr/src/uts/common/io/comstar/port/qlt/qlt.c
+++ b/usr/src/uts/common/io/comstar/port/qlt/qlt.c
@@ -9488,7 +9488,11 @@ qlt_el_msg(qlt_state_t *qlt, const char *fn, int ce, ...)
 	bcopy((void *)&time, (void *)&entry->hs_time,
 	    sizeof (timespec_t));
 
-	(void) strcpy(entry->buf, fmt1);
+	/*
+	 * Here we know that fmt1 will fit within QL_LOG_LENGTH due to the
+	 * check above, but smatch identifies a potential problem.
+	 */
+	(void) strncpy(entry->buf, fmt1, rval);
 	entry->buf[rval] = 0;
 
 	TRACE_BUFFER_UNLOCK(qlt);


### PR DESCRIPTION
Fixing a few more smatch warnings for bits only in OmniOS.
We're almost smatch clean. The next upstream merge will fix most of the remaining ones then there are just a few for smb that will be fixed once SMB3 is complete.