### PR TITLE
Upstream merge joyent_merge/2019081201

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -830,13 +830,9 @@ usr/src/cmd/fs.d/tmpfs/mount
 usr/src/cmd/fs.d/udfs/fsck/fsck
 usr/src/cmd/fs.d/udfs/fsdb/fsdb
 usr/src/cmd/fs.d/udfs/fsdb/lex.yy.c
-usr/src/cmd/fs.d/udfs/fsdb/ud_lib.c
-usr/src/cmd/fs.d/udfs/fsdb/ud_lib.h
 usr/src/cmd/fs.d/udfs/fsdb/y.tab.c
 usr/src/cmd/fs.d/udfs/fsdb/y.tab.h
 usr/src/cmd/fs.d/udfs/labelit/labelit
-usr/src/cmd/fs.d/udfs/labelit/ud_lib.c
-usr/src/cmd/fs.d/udfs/labelit/ud_lib.h
 usr/src/cmd/fs.d/udfs/mkfs/mkfs
 usr/src/cmd/fs.d/udfs/mount/mount
 usr/src/cmd/fs.d/ufs/clri/clri
@@ -4198,7 +4194,6 @@ usr/src/test/zfs-tests/tests/functional/libzfs/many_fds
 usr/src/test/zfs-tests/tests/functional/threadsappend/threadsappend
 usr/src/tools/aw/aw
 usr/src/tools/btxld/btxld
-usr/src/tools/codereview/codereview
 usr/src/tools/codesign/findcrypto
 usr/src/tools/codesign/signit
 usr/src/tools/codesign/signproto

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 9e88ade90f654d7c2cdfcec90cface22eaa124c7
+Last illumos-joyent commit: 9cba20af356f81a5f469ca8aa89ed17ee827b6a6
 

--- a/usr/contrib/freebsd/dev/nvme/nvme.h
+++ b/usr/contrib/freebsd/dev/nvme/nvme.h
@@ -26,6 +26,8 @@
  * SUCH DAMAGE.
  *
  * $FreeBSD$
+ *
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef __NVME_H__
@@ -1076,7 +1078,10 @@ struct nvme_health_information_page {
 	uint8_t			reserved2[296];
 } __packed __aligned(4);
 
+/* Currently sparse/smatch incorrectly packs this struct in some situations. */
+#ifndef __CHECKER__
 _Static_assert(sizeof(struct nvme_health_information_page) == 512, "bad size for nvme_health_information_page");
+#endif
 
 struct nvme_firmware_page {
 

--- a/usr/src/boot/sys/boot/efi/libefi/i386/Makefile
+++ b/usr/src/boot/sys/boot/efi/libefi/i386/Makefile
@@ -12,6 +12,7 @@
 #
 # Copyright 2016 Toomas Soome <tsoome@me.com>
 # Copyright 2016 RackTop Systems.
+# Copyright 2019 Joyent, Inc.
 #
 
 MACHINE=	$(MACH)
@@ -22,6 +23,9 @@ SRCS=	time.c
 include ../Makefile.com
 
 CFLAGS +=	-m32
+
+# false positive only with a 64-bit smatch
+SMOFF += uninitialized
 
 CLEANFILES +=	machine x86
 

--- a/usr/src/boot/sys/boot/libstand/Makefile.com
+++ b/usr/src/boot/sys/boot/libstand/Makefile.com
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Toomas Soome <tsoome@me.com>
+# Copyright 2019 Joyent, Inc.
 #
 
 include $(SRC)/Makefile.master
@@ -26,6 +27,9 @@ include $(SASRC)/Makefile.inc
 include $(ZFSSRC)/Makefile.inc
 
 CPPFLAGS +=	-I$(SRC)/uts/common
+
+# 64-bit smatch false positive :/
+SMOFF += uninitialized
 
 clean: clobber
 clobber:

--- a/usr/src/cmd/mdb/common/mdb/mdb_cmds.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_cmds.c
@@ -26,7 +26,7 @@
 
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
- * Copyright (c) 2019 Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2013 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
  * Copyright (c) 2015, 2017 by Delphix. All rights reserved.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
@@ -2165,6 +2165,46 @@ cmd_dis(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	return (DCMD_OK);
 }
 
+static void
+dis_help(void)
+{
+	static const char dis_desc[] =
+"Disassembles instructions starting at the final argument or the current\n"
+"value of dot. If the address is the start of a function, the entire\n"
+"function is disassembled, or else a window of instructions before and after\n"
+"the disassembled address are displayed.\n"
+"\n";
+
+	static const char dis_opts[] =
+"  -a         Print instruction addresses as numeric values instead of \n"
+"             symbolic values.\n"
+"  -b         Print instruction addresses as both numeric and symbolic "
+"values.\n"
+"  -f         Read instructions from the target's object file instead of the \n"
+"             target's virtual address space.\n"
+"  -n instr   Display 'instr' instructions before and after the given "
+"address.\n"
+"  -w         Force window behavior, even at the start of a function.\n"
+"\n";
+
+	static const char dis_examples[] =
+"  ::dis\n"
+"  clock::dis\n"
+"  ::dis gethrtime\n"
+"  set_freemem+0x16::dis -n 4\n"
+"\n";
+
+	mdb_printf("%s", dis_desc);
+	(void) mdb_dec_indent(2);
+	mdb_printf("%<b>OPTIONS%</b>\n");
+	(void) mdb_inc_indent(2);
+	mdb_printf("%s", dis_opts);
+	(void) mdb_dec_indent(2);
+	mdb_printf("%<b>EXAMPLES%</b>\n");
+	(void) mdb_inc_indent(2);
+	(void) mdb_printf("%s", dis_examples);
+}
+
 /*ARGSUSED*/
 static int
 walk_step(uintptr_t addr, const void *data, void *private)
@@ -3105,7 +3145,8 @@ const mdb_dcmd_t mdb_dcmd_builtins[] = {
 	{ "dcmds", "[[-n] pattern]",
 	    "list available debugger commands", cmd_dcmds, cmd_dcmds_help },
 	{ "delete", "?[id|all]", "delete traced software events", cmd_delete },
-	{ "dis", "?[-abfw] [-n cnt] [addr]", "disassemble near addr", cmd_dis },
+	{ "dis", "?[-abfw] [-n cnt] [addr]", "disassemble near addr", cmd_dis,
+	    dis_help },
 	{ "disasms", NULL, "list available disassemblers", cmd_disasms },
 	{ "dismode", "[mode]", "get/set disassembly mode", cmd_dismode },
 	{ "dmods", "[-l] [mod]", "list loaded debugger modules", cmd_dmods },

--- a/usr/src/cmd/mdb/common/modules/genunix/genunix.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/genunix.c
@@ -352,6 +352,47 @@ ps(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	return (DCMD_OK);
 }
 
+static void
+ps_help(void)
+{
+	mdb_printf("Display processes.\n\n"
+	    "Options:\n"
+	    "    -f\tDisplay command arguments\n"
+	    "    -l\tDisplay LWPs\n"
+	    "    -T\tDisplay tasks\n"
+	    "    -P\tDisplay projects\n"
+	    "    -z\tDisplay zones\n"
+	    "    -t\tDisplay threads\n\n");
+
+	mdb_printf("The resulting output is a table of the processes on the "
+	    "system.  The\n"
+	    "columns in the output consist of a combination of the "
+	    "following fields:\n\n");
+	mdb_printf("S\tProcess state.  Possible states are:\n"
+	    "\tS\tSleeping (SSLEEP)\n"
+	    "\tR\tRunnable (SRUN)\n"
+	    "\tZ\tZombie (SZOMB)\n"
+	    "\tI\tIdle (SIDL)\n"
+	    "\tO\tOn Cpu (SONPROC)\n"
+	    "\tT\tStopped (SSTOP)\n"
+	    "\tW\tWaiting (SWAIT)\n");
+
+	mdb_printf("PID\tProcess id.\n");
+	mdb_printf("PPID\tParent process id.\n");
+	mdb_printf("PGID\tProcess group id.\n");
+	mdb_printf("SID\tProcess id of the session leader.\n");
+	mdb_printf("TASK\tThe task id of the process.\n");
+	mdb_printf("PROJ\tThe project id of the process.\n");
+	mdb_printf("ZONE\tThe zone id of the process.\n");
+	mdb_printf("UID\tThe user id of the process.\n");
+	mdb_printf("FLAGS\tThe process flags (see ::pflags).\n");
+	mdb_printf("ADDR\tThe kernel address of the proc_t structure of the "
+	    "process\n");
+	mdb_printf("NAME\tThe name (p_user.u_comm field) of the process.  If "
+	    "the -f flag\n"
+	    "\tis specified, the arguments of the process are displayed.\n");
+}
+
 #define	PG_NEWEST	0x0001
 #define	PG_OLDEST	0x0002
 #define	PG_PIPE_OUT	0x0004
@@ -4034,7 +4075,8 @@ static const mdb_dcmd_t dcmds[] = {
 	{ "panicinfo", NULL, "print panic information", panicinfo },
 	{ "pid2proc", "?", "convert PID to proc_t address", pid2proc },
 	{ "project", NULL, "display kernel project(s)", project },
-	{ "ps", "[-fltzTP]", "list processes (and associated thr,lwp)", ps },
+	{ "ps", "[-fltzTP]", "list processes (and associated thr,lwp)", ps,
+	    ps_help },
 	{ "pflags", NULL, "display various proc_t flags", pflags },
 	{ "pgrep", "[-x] [-n | -o] pattern",
 		"pattern match against all processes", pgrep },

--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
@@ -111,6 +111,9 @@ typedef struct lx_group_req32 {
 /* lxsad_flags */
 #define	LXSAD_FL_STRCRED	0x1
 #define	LXSAD_FL_EMULSEQPKT	0x2
+/* These two work together to implement Linux SO_REUSEADDR semantics. */
+#define	LXSAD_FL_EMULRUADDR	0x4
+#define	LXSAD_FL_EMULRUPORT	0x8
 
 static lx_socket_aux_data_t *lx_sad_acquire(vnode_t *);
 
@@ -3018,6 +3021,210 @@ lx_mcast_common(sonode_t *so, int level, int optname, void *optval,
 	return (error);
 }
 
+/*
+ * So in Linux, the SO_REUSEADDR includes, essentially, SO_REUSEPORT as part
+ * of its functionality.  Experiments on CentOS 7 with a 3.10-ish kernel show
+ * that querying on SO_REUSEPORT show it's "off" if SO_REUSEADDR gets set.
+ * This means we can't count on directly querying the native socket state. We
+ * munge things here in LX-land to essentially turn on both REUSEADDR and
+ * REUSEPORT in native conn_t state for LX processes that set SO_REUSEADDR.
+ *
+ * We also keep track if the wily Linux app sends BOTH REUSEADDR and REUSEPORT
+ * down. We can return that both are on, or if it uses just REUSEADDR, we
+ * don't return yes for a check of REUSEPORT.  This means our conn_t state may
+ * be different than what an LX process will see.  "REUSEPORT" for LX may be
+ * off, but internally it will be on.
+ *
+ * BEGIN CSTYLED
+ * State table for internal conn_reuse{addr,port}:
+ *
+ * LX ADDR,PORT  Int. ADDR,PORT  New ADDR  New LX    New Int.  LXchg?  Intchg?
+ * ============  ==============  ========  ======    ========  ======  =======
+ *
+ * off,off       off,off         off       off,off   off,off   NO      NO
+ *
+ * off,off       off,off         on        on,off    on,on     YES     YES(2)
+ *
+ * off,on        off,on          off       off,on    off,on    NO      NO
+ *
+ * off,on        off,on          on        on,on     on,on     YES     YES
+ *
+ * on,off        on,on           off       off,off   off,off   YES     YES(2)
+ *
+ * on,off        on,on           on        on,off    on,on     NO      NO
+ *
+ * on,on         on,on           off       off,on    off,on    YES     YES
+ *
+ * on,on         on,on           on        on,on     on,on     NO      NO
+ *
+ *
+ * LX ADDR,PORT  Int. ADDR,PORT  New PORT  New LX    New Int.  LXchg?  Intchg?
+ * ============  ==============  ========  ======    ========  ======  =======
+ *
+ * off,off       off,off         off       off,off   off,off   NO      NO
+ *
+ * off,off       off,off         on        off,on    off,on    YES     YES
+ *
+ * off,on        off,on          off       off,off   off,off   YES     YES
+ *
+ * off,on        off,on          on        off,on    off,on    NO      NO
+ *
+ * on,off        on,on           off       on,off    on,on     NO      NO
+ *
+ * on,off        on,on           on        on,on     on,on     YES     NO
+ *
+ * on,on         on,on           off       on,off    on,on     YES     NO
+ *
+ * on,on         on,on           on        on,on     on,on     NO      NO
+ *
+ * END CSTYLED
+ *
+ * For setting these options, we need to obey the state table above.
+ * For getting REUSEADDR, the native stack handles it already.
+ * For getting REUSEPORT, we'll have to track the auxiliary data's flags.
+ */
+static int
+lx_set_reuse_handler(sonode_t *so, int optname, void *optval, socklen_t optlen)
+{
+	lx_socket_aux_data_t *sad;
+	boolean_t enable;
+	int error;
+
+	if (optlen != sizeof (int))
+		return (EINVAL);
+	enable = (*((int *)optval) != 0);
+
+	ASSERT(optname == LX_SO_REUSEADDR || optname == LX_SO_REUSEPORT);
+	sad = lx_sad_acquire(SOTOV(so));
+
+	/*
+	 * lx_sad_acquire() holds its mutex for us.  This protects us
+	 * against racing option-setters on the same socket.
+	 */
+	if (optname == LX_SO_REUSEADDR) {
+		/* Check if already set to what we want! */
+		if (enable ==
+		    ((sad->lxsad_flags & LXSAD_FL_EMULRUADDR) != 0)) {
+			mutex_exit(&sad->lxsad_lock);
+			return (0);
+		}
+
+		/*
+		 * At this point, we know we need to change SO_REUSEADDR,
+		 * Linux-style.  We know these are supported options too,
+		 * so we don't bother with any lookup.
+		 */
+		error = socket_setsockopt(so, SOL_SOCKET, SO_REUSEADDR,
+		    optval, optlen, CRED());
+		if (error != 0) {
+			mutex_exit(&sad->lxsad_lock);
+			return (error);
+		}
+		if (enable)
+			sad->lxsad_flags |= LXSAD_FL_EMULRUADDR;
+		else
+			sad->lxsad_flags &= ~LXSAD_FL_EMULRUADDR;
+
+		/*
+		 * At THIS point, we need to figure out if we ALSO need to
+		 * toggle the native-side SO_REUSEPORT state because Linux's
+		 * SO_REUSEADDR ALSO include the moral equivalent of
+		 * SO_REUSEPORT.  There may be further subtleties, but for now
+		 * assume a Linux app that uses SO_REUSEADDR wants that
+		 * SO_REUSEPORT functionality thrown in for free.
+		 *
+		 * Check for SO_REUSEPORT already enabled first.
+		 */
+		if ((sad->lxsad_flags & LXSAD_FL_EMULRUPORT) != 0) {
+			/* Someone turned on REUSEPORT first, we're good. */
+			mutex_exit(&sad->lxsad_lock);
+			return (0);
+		}
+
+		/*
+		 * Fall through to REUSEPORT setting, it'll know it's a
+		 * supplement based on (optname == SO_REUSEADDR).
+		 */
+	} else if (enable ==
+	    ((sad->lxsad_flags & LXSAD_FL_EMULRUPORT) != 0)) {
+		/*
+		 * If we reach here, we're setting REUSEPORT to what it's
+		 * already set.
+		 */
+		ASSERT3U(optname, ==, LX_SO_REUSEPORT);
+		mutex_exit(&sad->lxsad_lock);
+		return (0);
+	}
+
+	if (optname == LX_SO_REUSEPORT &&
+	    ((sad->lxsad_flags & LXSAD_FL_EMULRUADDR) != 0)) {
+		/*
+		 * Corner case: REUSEPORT change *but* REUSEADDR is still
+		 * enabled.  We must not alter conn_t/native state here, as
+		 * REUSEADDR *needs* REUSEPORT enabled on conn_t/native state.
+		 * If we want to enable REUSEPORT, the setsockopt would be a
+		 * NOP.  If want to disable it, we MUST NOT turn off native
+		 * REUSEPORT lest we break Linux-like behavior, and instead
+		 * merely turn off the LXSAD_FL_EMULRUPORT flag.
+		 */
+		error = 0;
+	} else {
+		/*
+		 * At this point, we need to change REUSEPORT.  We may be
+		 * doing it for an actual REUSEPORT change, OR for Linux
+		 * REUSEADDR semantics.  As earlier, we know the option map
+		 * lookup is superfluous.
+		 */
+		error = socket_setsockopt(so, SOL_SOCKET, SO_REUSEPORT, optval,
+		    optlen, CRED());
+	}
+
+	if (error != 0 && optname == LX_SO_REUSEADDR) {
+		int addr_error, revert_to_optval;
+
+		ASSERT0(sad->lxsad_flags & LXSAD_FL_EMULRUPORT);
+		/*
+		 * We need more cleanup if the REUSEPORT change fails during
+		 * an actual REUSEADDR set.
+		 */
+		if (enable) {
+			sad->lxsad_flags &= ~LXSAD_FL_EMULRUADDR;
+			revert_to_optval = 0;
+		} else {
+			sad->lxsad_flags |= LXSAD_FL_EMULRUADDR;
+			revert_to_optval = 1;
+		}
+
+		/* Just hardwire it, we're in trouble! */
+		addr_error = socket_setsockopt(so, SOL_SOCKET, SO_REUSEADDR,
+		    &revert_to_optval, optlen, CRED());
+		if (addr_error != 0) {
+			/*
+			 * Well this sucks, we really shot ourselves in the
+			 * foot.  We should somehow signal a catastrophic
+			 * error. For now, just return the one we had earlier.
+			 */
+			DTRACE_PROBE1(lx__reuse__seconderr, int, addr_error);
+			mutex_exit(&sad->lxsad_lock);
+			return (error);
+		}
+		/*
+		 * Else we managed successfully to clean up and can fall
+		 * through the normal error path.
+		 */
+	} else if (error == 0 && optname == LX_SO_REUSEPORT) {
+		/* We successfully changed REUSEPORT explicitly. */
+		if (enable)
+			sad->lxsad_flags |= LXSAD_FL_EMULRUPORT;
+		else
+			sad->lxsad_flags &= ~LXSAD_FL_EMULRUPORT;
+	}
+	/* Else it's an error for an explicit REUSEPORT, just return. */
+
+	mutex_exit(&sad->lxsad_lock);
+	return (error);
+}
+
 static int
 lx_setsockopt_ip(sonode_t *so, int optname, void *optval, socklen_t optlen)
 {
@@ -3402,6 +3609,11 @@ lx_setsockopt_socket(sonode_t *so, int optname, void *optval, socklen_t optlen)
 		 */
 		return (0);
 
+	case LX_SO_REUSEADDR:
+	case LX_SO_REUSEPORT:
+		/* See the function called below for the oddness of REUSE*. */
+		return (lx_set_reuse_handler(so, optname, optval, optlen));
+
 	case LX_SO_PASSCRED:
 		/*
 		 * In many cases, the Linux SO_PASSCRED is mapped to the SunOS
@@ -3707,6 +3919,7 @@ lx_getsockopt_socket(sonode_t *so, int optname, void *optval,
 	int error = 0;
 	int *intval = (int *)optval;
 	lx_proto_opts_t sockopts_tbl = PROTO_SOCKOPTS(ltos_socket_sockopts);
+	lx_socket_aux_data_t *sad;
 
 	switch (optname) {
 	case LX_SO_TYPE:
@@ -3716,8 +3929,6 @@ lx_getsockopt_socket(sonode_t *so, int optname, void *optval,
 		 */
 		if (so->so_family == AF_UNIX &&
 		    (so->so_mode & SM_CONNREQUIRED) == 0) {
-			lx_socket_aux_data_t *sad;
-
 			if (*optlen < sizeof (int))
 				return (EINVAL);
 			sad = lx_sad_acquire(SOTOV(so));
@@ -3751,8 +3962,6 @@ lx_getsockopt_socket(sonode_t *so, int optname, void *optval,
 		 */
 		if (so->so_family == AF_UNIX &&
 		    (so->so_mode & SM_CONNREQUIRED) != 0) {
-			lx_socket_aux_data_t *sad;
-
 			if (*optlen < sizeof (int)) {
 				return (EINVAL);
 			}
@@ -3764,6 +3973,19 @@ lx_getsockopt_socket(sonode_t *so, int optname, void *optval,
 			return (0);
 		}
 		break;
+
+	case LX_SO_REUSEPORT:
+		/* See lx_set_reuse_handler() for the sordid details. */
+		if (so->so_family != AF_INET && so->so_family != AF_INET6)
+			break;
+		if (*optlen < sizeof (int))
+			return (EINVAL);
+		sad = lx_sad_acquire(SOTOV(so));
+		*optlen = sizeof (int);
+		*intval =
+		    (sad->lxsad_flags & LXSAD_FL_EMULRUPORT) == 0 ? 0 : 1;
+		mutex_exit(&sad->lxsad_lock);
+		return (0);
 
 	case LX_SO_PEERCRED:
 		if (*optlen < sizeof (struct lx_ucred)) {

--- a/usr/src/uts/common/io/mac/mac_client.c
+++ b/usr/src/uts/common/io/mac/mac_client.c
@@ -3619,7 +3619,7 @@ mac_tx(mac_client_handle_t mch, mblk_t *mp_chain, uintptr_t hint,
 
 			mp->b_next = NULL;
 
-			if (needed != 0) {
+			if ((needed & (HCK_TX_FLAGS | HW_LSO_FLAGS)) != 0) {
 				mac_emul_t emul = 0;
 
 				if (needed & HCK_IPV4_HDRCKSUM)

--- a/usr/src/uts/common/io/mac/mac_provider.c
+++ b/usr/src/uts/common/io/mac/mac_provider.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -980,12 +981,33 @@ mac_pdata_update(mac_handle_t mh, void *mac_pdata, size_t dsize)
 }
 
 /*
- * Invoked by driver as well as the framework to notify its capability change.
+ * The mac provider or mac frameowrk calls this function when it wants
+ * to notify upstream consumers that the capabilities have changed and
+ * that they should modify their own internal state accordingly.
+ *
+ * We currently have no regard for the fact that a provider could
+ * decide to drop capabilities which would invalidate pending traffic.
+ * For example, if one was to disable the Tx checksum offload while
+ * TCP/IP traffic was being sent by mac clients relying on that
+ * feature, then those packets would hit the write with missing or
+ * partial checksums. A proper solution involves not only providing
+ * notfication, but also performing client quiescing. That is, a capab
+ * change should be treated as an atomic transaction that forms a
+ * barrier between traffic relying on the current capabs and traffic
+ * relying on the new capabs. In practice, simnet is currently the
+ * only provider that could hit this, and it's an easily avoidable
+ * situation (and at worst it should only lead to some dropped
+ * packets). But if we ever want better on-the-fly capab change to
+ * actual hardware providers, then we should give this update
+ * mechanism a proper implementation.
  */
 void
 mac_capab_update(mac_handle_t mh)
 {
-	/* Send MAC_NOTE_CAPAB_CHG notification */
+	/*
+	 * Send a MAC_NOTE_CAPAB_CHG notification to alert upstream
+	 * clients to renegotiate capabilities.
+	 */
 	i_mac_notify((mac_impl_t *)mh, MAC_NOTE_CAPAB_CHG);
 }
 
@@ -1285,6 +1307,19 @@ i_mac_notify_thread(void *arg)
 				mip->mi_linkstate = newstate;
 				bits |= 1 << MAC_NOTE_LINK;
 			}
+		}
+
+		/*
+		 * Depending on which capabs have changed, the Tx
+		 * checksum flags may also need to be updated.
+		 */
+		if ((bits & (1 << MAC_NOTE_CAPAB_CHG)) != 0) {
+			mac_perim_handle_t mph;
+			mac_handle_t mh = (mac_handle_t)mip;
+
+			mac_perim_enter_by_mh(mh, &mph);
+			mip->mi_tx_cksum_flags = mac_features_to_flags(mh);
+			mac_perim_exit(mph);
 		}
 
 		/*

--- a/usr/src/uts/common/io/simnet/simnet.c
+++ b/usr/src/uts/common/io/simnet/simnet.c
@@ -1377,6 +1377,12 @@ simnet_m_setprop(void *arg, const char *name, mac_prop_id_t num,
 		break;
 	}
 
+	/*
+	 * We may have modified the configuration of hardware
+	 * offloads. Make sure to renegotiate capabilities with the
+	 * upstream clients.
+	 */
+	mac_capab_update(sdev->sd_mh);
 	return (err);
 }
 

--- a/usr/src/uts/common/sys/mac_impl.h
+++ b/usr/src/uts/common/sys/mac_impl.h
@@ -419,7 +419,7 @@ struct mac_impl_s {
 	mac_capab_led_t		mi_led;
 
 	/* Cache of the Tx DB_CKSUMFLAGS that this MAC supports. */
-	uint16_t		mi_tx_cksum_flags; /* WO */
+	uint16_t		mi_tx_cksum_flags; /* SL */
 
 	/*
 	 * MAC address list. SL protected.

--- a/usr/src/uts/common/sys/pattr.h
+++ b/usr/src/uts/common/sys/pattr.h
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _SYS_PATTR_H
@@ -98,6 +98,8 @@ typedef struct pattr_hcksum_s {
 
 #define	HCK_FLAGS		(HCK_IPV4_HDRCKSUM | HCK_PARTIALCKSUM |	\
 				HCK_FULLCKSUM | HCK_FULLCKSUM_OK)
+#define	HCK_TX_FLAGS		(HCK_IPV4_HDRCKSUM | HCK_PARTIALCKSUM | \
+				HCK_FULLCKSUM)
 /*
  * Extended hardware offloading flags that also use hcksum_flags
  */

--- a/usr/src/uts/intel/ia32/ml/lock_prim.s
+++ b/usr/src/uts/intel/ia32/ml/lock_prim.s
@@ -970,6 +970,7 @@ rw_exit(krwlock_t *lp)
 	jnz	rw_exit_wakeup
 .rw_read_exit_lockstat_patch_point:
 	ret
+	movq	%gs:CPU_THREAD, %rcx		/* rcx = thread ptr */
 	movq	%rdi, %rsi			/* rsi = lock ptr */
 	movl	$LS_RW_EXIT_RELEASE, %edi
 	movl	$RW_READER, %edx


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019081201

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019081201-ab5fa937ca i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Mon Aug 12 11:18:13 UTC 2019 ====
==== Nightly distributed build completed: Mon Aug 12 12:15:05 UTC 2019 ====

==== Total build time ====

real    0:56:52

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-398f96250b i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151031/7.4.0-il-2) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-3

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151031-20190219"

/usr/bin/openssl
OpenSSL 1.1.1c  28 May 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   71

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019081201-ab5fa937ca

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    23:26.3
user  3:37:47.2
sys     52:35.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    19:59.2
user  3:08:13.8
sys     47:16.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
