### PR TITLE
Add support for building with glib2 v2.62

### DIFF
--- a/usr/src/cmd/hal/Makefile.hal
+++ b/usr/src/cmd/hal/Makefile.hal
@@ -23,6 +23,7 @@
 # Use is subject to license terms.
 #
 # Copyright (c) 2018, Joyent, Inc.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 # Definitions common for HAL code and consumers
 #
@@ -73,6 +74,12 @@ CERRWARN +=		-_gcc=-Wno-extra
 CERRWARN +=		-_gcc=-Wno-parentheses
 CERRWARN +=		-_gcc=-Wno-address
 CERRWARN +=		-_gcc=-Wno-unused-function
+
+# glib2 >= 2.62 suppresses warnings about deprecated declarations in header
+# files using pragma "GCC diagnostic ignored \"-Wdeprecated-declarations\""
+# This is not supported before GCC 4.6 so just globally suppress these
+# warnings under the shadow compiler
+CERRWARN +=		-_gcc4=-Wno-deprecated-declarations
 
 # not linted
 SMATCH=off

--- a/usr/src/cmd/latencytop/Makefile.com
+++ b/usr/src/cmd/latencytop/Makefile.com
@@ -23,6 +23,7 @@
 # All Rights Reserved.
 #
 # Copyright (c) 2018, Joyent, Inc.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 PROG = latencytop
 OBJS = latencytop.o display.o dwrapper.o klog.o stat.o table.o util.o
@@ -35,20 +36,20 @@ CFLAGS64 += $(CCVERBOSE)
 
 CERRWARN += $(CNOWARN_UNINIT)
 
-SMOFF += all_func_returns
+# glib2 >= 2.62 suppresses warnings about deprecated declarations in header
+# files using pragma "GCC diagnostic ignored \"-Wdeprecated-declarations\""
+# This is not supported before GCC 4.6 so just globally suppress these
+# warnings under the shadow compiler
+CERRWARN +=	-_gcc4=-Wno-deprecated-declarations
+
+# smatch has problems parsing the glib header files
+SMATCH=off
 
 CPPFLAGS += -DEMBED_CONFIGS -I$(ADJUNCT_PROTO)/usr/include/glib-2.0 \
 	-I$(ADJUNCT_PROTO)/usr/lib/glib-2.0/include
 CSTD = $(CSTD_GNU99)
 LDLIBS += -lcurses -ldtrace
 all install	:= LDLIBS += -lglib-2.0
-
-LINTFLAGS += -erroff=E_NAME_USED_NOT_DEF2
-LINTFLAGS += -erroff=E_FUNC_RET_ALWAYS_IGNOR2
-LINTFLAGS += -erroff=E_FUNC_RET_MAYBE_IGNORED2
-LINTFLAGS64 += -erroff=E_NAME_USED_NOT_DEF2
-LINTFLAGS64 += -erroff=E_FUNC_RET_ALWAYS_IGNOR2
-LINTFLAGS64 += -erroff=E_FUNC_RET_MAYBE_IGNORED2
 
 FILEMODE = 0555
 
@@ -80,8 +81,6 @@ latencytop_trans:
 
 clean:
 	$(RM) $(CLEANFILES)
-
-lint:	lint_SRCS
 
 %.o: ../common/%.c
 	$(COMPILE.c) $<

--- a/usr/src/cmd/policykit/Makefile
+++ b/usr/src/cmd/policykit/Makefile
@@ -22,6 +22,8 @@
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+#
 
 PROG =	polkit-is-privileged
 
@@ -39,6 +41,15 @@ CSTD =	$(CSTD_GNU99)
 
 CERRWARN +=	-_gcc=-Wno-unused-variable
 CERRWARN +=	-_gcc=-Wno-unused-function
+
+# glib2 >= 2.62 suppresses warnings about deprecated declarations in header
+# files using pragma "GCC diagnostic ignored \"-Wdeprecated-declarations\""
+# This is not supported before GCC 4.6 so just globally suppress these
+# warnings under the shadow compiler
+CERRWARN +=	-_gcc4=-Wno-deprecated-declarations
+
+# smatch has problems parsing the glib header files
+SMATCH=off
 
 ROOTUSRSBINPROG =	$(PROG:%=$(ROOTUSRSBIN)/%)
 

--- a/usr/src/lib/policykit/libpolkit/Makefile.com
+++ b/usr/src/lib/policykit/libpolkit/Makefile.com
@@ -22,10 +22,7 @@
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
-#
-# usr/src/lib/policykit/libpolkit/Makefile.com
-#
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 LIBRARY =	libpolkit.a
 VERS =		.0.0.0
@@ -35,10 +32,9 @@ LIBPCSRC =	polkit.pc
 
 include ../../Makefile.com
 
-LIBS =		$(DYNLIB) $(LINTLIB)
+LIBS =		$(DYNLIB)
 LDLIBS +=	$(POLICYKIT_GLIB_LDLIBS)
 LDLIBS +=	-lc -lsecdb
-$(LINTLIB) := 	SRCS = $(SRCDIR)/$(LINTSRC)
 
 SRCDIR =	../common
 
@@ -47,11 +43,18 @@ CPPFLAGS +=	-DPACKAGE_LOCALE_DIR=\"/usr/lib/locale\"
 
 ROOTMAJLINK =	$(ROOTLIBDIR)/$(LIBRARY:.a=.so)$(VERS_MAJ)
 
+# glib2 >= 2.62 suppresses warnings about deprecated declarations in header
+# files using pragma "GCC diagnostic ignored \"-Wdeprecated-declarations\""
+# This is not supported before GCC 4.6 so just globally suppress these
+# warnings under the shadow compiler
+CERRWARN +=	-_gcc4=-Wno-deprecated-declarations
+
+# smatch has problems parsing the glib header files
+SMATCH=off
+
 .KEEP_STATE:
 
 all:		$(LIBS)
-
-lint:
 
 $(ROOTMAJLINK):
 	-$(RM) $@; $(SYMLINK) $(DYNLIB) $@


### PR DESCRIPTION
Since upgrading to glib2 version 2.62.0, it has not been possible to build illumos-omnios with shadow compilers enabled; here's the fix. It needs to go upstream too or it will not be possible to build illumos-gate on r151032 once it is released. It may be possible to be more specific with the smatch disable rules - that will be determined during the upstreaming process.

## mail_msg

```

==== Nightly distributed build started:   Sat Sep 14 15:15:39 UTC 2019 ====
==== Nightly distributed build completed: Sat Sep 14 16:15:01 UTC 2019 ====

==== Total build time ====

real    0:59:22

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-6c67d193c89 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151031/7.4.0-il-3) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151031-20190219"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   90

==== Nightly argument issues ====


==== Build version ====

omnios-glib2-08791f6ef6

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:09.0
user  3:31:19.6
sys   1:08:39.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:00.8
user  3:03:51.5
sys   1:01:48.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
