### PR TITLE
Upstream merge joyent_merge/2019091801

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: c6dd2307128aa25ac346f7818440cd5cfd1f7221
+Last illumos-joyent commit: 8f77bed5b9e3f96e1fcf344bef8e85a338e9da6b
 


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019091801

## Backports

to r151030

## mail_msg

```

==== Nightly distributed build started:   Wed Sep 18 13:24:16 UTC 2019 ====
==== Nightly distributed build completed: Wed Sep 18 14:33:31 UTC 2019 ====

==== Total build time ====

real    1:09:15

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-7f6d3461785 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151031/7.4.0-il-3) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151031-20190219"

/usr/bin/openssl
OpenSSL 1.1.1c  28 May 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   74

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019091801-3ce2b2de37

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    33:42.9
user  4:43:07.3
sys   2:05:09.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:02.6
user  3:06:35.9
sys   1:00:48.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
