### PR TITLE
Add configurable screen resolution variables to loader

### DIFF
--- a/usr/src/boot/sys/boot/forth/loader.4th
+++ b/usr/src/boot/sys/boot/forth/loader.4th
@@ -40,6 +40,7 @@ s" arch-i386" environment? [if] [if]
 [then] [then]
 
 include /boot/forth/support.4th
+include /boot/forth/screen.4th
 include /boot/forth/color.4th
 include /boot/forth/delay.4th
 include /boot/forth/check-password.4th
@@ -55,6 +56,7 @@ only forth definitions
   ." Booting..."
   if me then
   clear
+  s" boot_resolution" set_resolution
 ;
 
 : try-menu-unset

--- a/usr/src/boot/sys/boot/forth/loader.conf
+++ b/usr/src/boot/sys/boot/forth/loader.conf
@@ -59,6 +59,8 @@ beastie_disable="NO"		# Turn the beastie boot menu on and off
 loader_logo="omnios"		# Desired logo
 loader_brand="omnios"		# brand name
 loader_menu_title="Welcome to OmniOS"
+loader_resolution="800x600"	# The resolution of the loader menu screen
+boot_resolution="1024x768"	# The resolution set before booting the system
 loader_menu_y="11"		# Row position of the boot menu
 loader_menu_timeout_y="24"	# Row position of autoboot counter
 

--- a/usr/src/boot/sys/boot/forth/logo-omnios.4th
+++ b/usr/src/boot/sys/boot/forth/logo-omnios.4th
@@ -77,20 +77,16 @@ variable PNGLogo
 
 : logo ( x y -- )
 	framebuffer? if
-		s" framebuffer set 800x600" evaluate
 		s" loadfont /boot/fonts/10x18.fnt" evaluate
-		\ Check that the screen height is now 600
-		s" screen-height" getenv s" 600" compare invert if
-			clear
-			at-bl
-			ooce if
-				dragon drop
-				illumos_png drop
-				1 PNGLogo !
-				13 menupos
-				2drop
-				exit
-			then
+		clear
+		at-bl
+		ooce if
+			dragon drop
+			illumos_png drop
+			1 PNGLogo !
+			13 menupos
+			2drop
+			exit
 		then
 	then
 

--- a/usr/src/boot/sys/boot/forth/menu-commands.4th
+++ b/usr/src/boot/sys/boot/forth/menu-commands.4th
@@ -553,6 +553,7 @@ also menu-namespace also menu-command-helpers
 
 : be_draw_screen
 	clear		\ Clear the screen (in screen.4th)
+	s" loader_resolution" set_resolution
 	print_version	\ print version string (bottom-right; see version.4th)
 	draw-beastie	\ Draw FreeBSD logo at right (in beastie.4th)
 	draw-brand	\ Draw brand.4th logo at top (in brand.4th)

--- a/usr/src/boot/sys/boot/forth/menu.rc
+++ b/usr/src/boot/sys/boot/forth/menu.rc
@@ -9,6 +9,7 @@ include /boot/forth/shortcuts.4th
 
 \ Screen prep
 clear         \ clear the screen (see `screen.4th')
+s" loader_resolution" set_resolution
 print_version \ print version string (bottom-right; see `version.4th')
 draw-beastie  \ draw freebsd mascot (on right; see `beastie.4th')
 draw-brand    \ draw the FreeBSD title (top-left; see `brand.4th')

--- a/usr/src/boot/sys/boot/forth/shortcuts.4th
+++ b/usr/src/boot/sys/boot/forth/shortcuts.4th
@@ -42,6 +42,7 @@ marker task-shortcuts.4th
 \ 
 : menu ( -- )
 	clear           \ Clear the screen (in screen.4th)
+	s" loader_resolution" set_resolution
 	print_version   \ print version string (bottom-right; see version.4th)
 	draw-beastie    \ Draw FreeBSD logo at right (in beastie.4th)
 	draw-brand      \ Draw FIS logo at top (in brand.4th)

--- a/usr/src/boot/sys/boot/forth/support.4th
+++ b/usr/src/boot/sys/boot/forth/support.4th
@@ -232,6 +232,20 @@ create last_module_option sizeof module.next allot 0 last_module_option !
 	s" screen-height" getenv?
 ;
 
+\ Set the screen resolution based on an environment variable.
+\ If the framebuffer is not active or the variable is not set, do nothing
+: set_resolution ( varname -- )
+	framebuffer? if
+		getenv dup -1 = if
+			\ variable not set
+			drop
+		else
+			s" framebuffer set "
+			2swap strcat evaluate
+		then
+	else drop then
+;
+
 \ determine if a word appears in a string, case-insensitive
 : contains? ( addr1 len1 addr2 len2 -- 0 | -1 )
 	2 pick 0= if 2drop 2drop true exit then


### PR DESCRIPTION
This adds two new loader configuration variables - `loader_resolution` and `boot_resolution`
The first specifies the screen resolution of the framebuffer-based loader screen, and defaults to 800x600.
The second specifies the screen resolution that is selected just before booting the kernel and defaults to 1024x768.

Both of these can be overridden via a file in `/boot/conf.d/` if desired.

@v-a-b 