### PR TITLE
Backports for r151032

### DIFF
--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2019.09.20.1
+BOOT_VERSION = $(LOADER_VERSION)-2019.09.27.1

--- a/usr/src/boot/lib/libstand/stand.h
+++ b/usr/src/boot/lib/libstand/stand.h
@@ -252,12 +252,6 @@ static __inline int tolower(int c)
 extern void	setheap(void *base, void *top);
 extern char	*sbrk(int incr);
 
-/* Matt Dillon's zalloc/zmalloc */
-extern void	*malloc(size_t bytes);
-extern void	free(void *ptr);
-extern void	*calloc(size_t n1, size_t n2);
-extern void	*realloc(void *ptr, size_t size);
-extern void	*reallocf(void *ptr, size_t size);
 extern void	mallocstats(void);
 
 extern int	printf(const char *fmt, ...) __printflike(1, 2);
@@ -416,20 +410,26 @@ extern uint16_t		ntohs(uint16_t);
 #endif
 
 void *Malloc(size_t, const char *, int);
+void *Memalign(size_t, size_t, const char *, int);
 void *Calloc(size_t, size_t, const char *, int);
 void *Realloc(void *, size_t, const char *, int);
+void *Reallocf(void *, size_t, const char *, int);
 void Free(void *, const char *, int);
 
-#if 1
+#if DEBUG_MALLOC
 #define	malloc(x)	Malloc(x, __FILE__, __LINE__)
+#define	memalign(x, y)	Memalign(x, y, __FILE__, __LINE__)
 #define	calloc(x, y)	Calloc(x, y, __FILE__, __LINE__)
 #define	free(x)		Free(x, __FILE__, __LINE__)
 #define	realloc(x, y)	Realloc(x, y, __FILE__, __LINE__)
+#define	reallocf(x, y)	Reallocf(x, y, __FILE__, __LINE__)
 #else
 #define	malloc(x)	Malloc(x, NULL, 0)
+#define	memalign(x, y)	Memalign(x, y, NULL, 0)
 #define	calloc(x, y)	Calloc(x, y, NULL, 0)
 #define	free(x)		Free(x, NULL, 0)
 #define	realloc(x, y)	Realloc(x, y, NULL, 0)
+#define	reallocf(x, y)	Reallocf(x, y, NULL, 0)
 #endif
 
 #endif	/* STAND_H */

--- a/usr/src/boot/lib/libstand/zalloc.c
+++ b/usr/src/boot/lib/libstand/zalloc.c
@@ -28,6 +28,7 @@
  */
 
 #include <sys/cdefs.h>
+#include <sys/param.h>
 
 /*
  * LIB/MEMORY/ZALLOC.C	- self contained low-overhead memory pool/allocation
@@ -85,7 +86,7 @@ typedef char assert_align[(sizeof (struct MemNode) <= MALLOCALIGN) ? 1 : -1];
  */
 
 void *
-znalloc(MemPool *mp, uintptr_t bytes)
+znalloc(MemPool *mp, uintptr_t bytes, size_t align)
 {
 	MemNode **pmn;
 	MemNode *mn;
@@ -110,14 +111,41 @@ znalloc(MemPool *mp, uintptr_t bytes)
 
 	for (pmn = &mp->mp_First; (mn = *pmn) != NULL; pmn = &mn->mr_Next) {
 		char *ptr = (char *)mn;
+		uintptr_t dptr;
+		char *aligned;
+		size_t extra;
 
-		if (bytes > mn->mr_Bytes)
+		dptr = (uintptr_t)(ptr + MALLOCALIGN);	/* pointer to data */
+		aligned = (char *)(roundup2(dptr, align) - MALLOCALIGN);
+		extra = aligned - ptr;
+
+		if (bytes + extra > mn->mr_Bytes)
 			continue;
+
+		/*
+		 * Cut extra from head and create new memory node from
+		 * remainder.
+		 */
+
+		if (extra != 0) {
+			MemNode *new;
+
+			new = (MemNode *)aligned;
+			new->mr_Next = mn->mr_Next;
+			new->mr_Bytes = mn->mr_Bytes - extra;
+
+			/* And update current memory node */
+			mn->mr_Bytes = extra;
+			mn->mr_Next = new;
+			/* In next iteration, we will get our aligned address */
+			continue;
+		}
 
 		/*
 		 *  Cut a chunk of memory out of the beginning of this
 		 *  block and fixup the link appropriately.
 		 */
+
 		if (mn->mr_Bytes == bytes) {
 			*pmn = mn->mr_Next;
 		} else {

--- a/usr/src/boot/lib/libstand/zalloc_malloc.c
+++ b/usr/src/boot/lib/libstand/zalloc_malloc.c
@@ -49,8 +49,26 @@ void mallocstats(void);
 #undef free
 #endif
 
+static void *Malloc_align(size_t, size_t);
+
 void *
 Malloc(size_t bytes, const char *file, int line)
+{
+	return (Malloc_align(bytes, 1));
+}
+
+void *
+Memalign(size_t alignment, size_t bytes, const char *file __unused,
+    int line __unused)
+{
+	if (alignment == 0)
+		alignment = 1;
+
+	return (Malloc_align(bytes, alignment));
+}
+
+static void *
+Malloc_align(size_t bytes, size_t alignment)
 {
 	Guard *res;
 
@@ -60,7 +78,7 @@ Malloc(size_t bytes, const char *file, int line)
 	bytes += MALLOCALIGN;
 #endif
 
-	while ((res = znalloc(&MallocPool, bytes)) == NULL) {
+	while ((res = znalloc(&MallocPool, bytes, alignment)) == NULL) {
 		int incr = (bytes + BLKEXTENDMASK) & ~BLKEXTENDMASK;
 		char *base;
 
@@ -124,7 +142,6 @@ Free(void *ptr, const char *file, int line)
 #endif
 	}
 }
-
 
 void *
 Calloc(size_t n1, size_t n2, const char *file, int line)

--- a/usr/src/boot/lib/libstand/zalloc_protos.h
+++ b/usr/src/boot/lib/libstand/zalloc_protos.h
@@ -30,7 +30,7 @@
 #ifndef _ZALLOC_PROTOS_H
 #define	_ZALLOC_PROTOS_H
 
-Library void *znalloc(struct MemPool *mpool, uintptr_t bytes);
+Library void *znalloc(struct MemPool *mpool, uintptr_t bytes, size_t align);
 Library void zfree(struct MemPool *mpool, void *ptr, uintptr_t bytes);
 Library void zextendPool(MemPool *mp, void *base, uintptr_t bytes);
 Library void zallocstats(struct MemPool *mp);

--- a/usr/src/boot/sys/boot/common/module.c
+++ b/usr/src/boot/sys/boot/common/module.c
@@ -263,7 +263,7 @@ command_lsmod(int argc, char *argv[])
 				break;
 			if (strcmp(fp->f_type, "hash") == 0) {
 				pager_output("    contents: ");
-				strncpy(lbuf, PTOV(fp->f_addr), fp->f_size);
+				strlcpy(lbuf, PTOV(fp->f_addr), sizeof (lbuf));
 				if (pager_output(lbuf))
 					break;
 			}

--- a/usr/src/boot/sys/boot/efi/libefi/efipart.c
+++ b/usr/src/boot/sys/boot/efi/libefi/efipart.c
@@ -63,6 +63,9 @@ static int efipart_printhd(int);
 #define	PNP0700	0x700
 #define	PNP0701	0x701
 
+/* Bounce buffer max size */
+#define	BIO_BUFFER_SIZE	0x4000
+
 struct devsw efipart_fddev = {
 	.dv_name = "fd",
 	.dv_type = DEVT_FD,
@@ -249,6 +252,12 @@ efipart_inithandles(void)
 		if (blkio->Media->BlockSize < 512 ||
 		    blkio->Media->BlockSize > (1 << 16) ||
 		    !powerof2(blkio->Media->BlockSize)) {
+			continue;
+		}
+
+		/* Allowed values are 0, 1 and power of 2. */
+		if (blkio->Media->IoAlign > 1 &&
+		    !powerof2(blkio->Media->IoAlign)) {
 			continue;
 		}
 
@@ -965,8 +974,10 @@ efipart_realstrategy(void *devdata, int rw, daddr_t blk, size_t size,
 	EFI_BLOCK_IO *blkio;
 	uint64_t off, disk_blocks, d_offset = 0;
 	char *blkbuf;
-	size_t blkoff, blksz;
-	int error;
+	size_t blkoff, blksz, bio_size;
+	unsigned ioalign;
+	bool need_buf;
+	int rc;
 	uint64_t diskend, readstart;
 
 	if (dev == NULL || blk < 0)
@@ -1014,40 +1025,118 @@ efipart_realstrategy(void *devdata, int rw, daddr_t blk, size_t size,
 		size = size * blkio->Media->BlockSize;
 	}
 
-	if (rsize != NULL)
-		*rsize = size;
-
+	need_buf = true;
+	/* Do we need bounce buffer? */
 	if ((size % blkio->Media->BlockSize == 0) &&
 	    (off % blkio->Media->BlockSize == 0))
-		return (efipart_readwrite(blkio, rw,
-		    off / blkio->Media->BlockSize,
-		    size / blkio->Media->BlockSize, buf));
+		need_buf = false;
 
-	/*
-	 * The buffer size is not a multiple of the media block size.
-	 */
-	blkbuf = malloc(blkio->Media->BlockSize);
+	/* Do we have IO alignment requirement? */
+	ioalign = blkio->Media->IoAlign;
+	if (ioalign == 0)
+		ioalign++;
+
+	if (ioalign > 1 && (uintptr_t)buf != roundup2((uintptr_t)buf, ioalign))
+		need_buf = true;
+
+	if (need_buf) {
+		for (bio_size = BIO_BUFFER_SIZE; bio_size > 0;
+		    bio_size -= blkio->Media->BlockSize) {
+			blkbuf = memalign(ioalign, bio_size);
+			if (blkbuf != NULL)
+				break;
+		}
+	} else {
+		blkbuf = buf;
+		bio_size = size;
+	}
+
 	if (blkbuf == NULL)
 		return (ENOMEM);
 
-	error = 0;
+	if (rsize != NULL)
+		*rsize = size;
+
+	rc = 0;
 	blk = off / blkio->Media->BlockSize;
 	blkoff = off % blkio->Media->BlockSize;
-	blksz = blkio->Media->BlockSize - blkoff;
+
 	while (size > 0) {
-		error = efipart_readwrite(blkio, rw, blk, 1, blkbuf);
-		if (error)
+		size_t x = min(size, bio_size);
+
+		if (x < blkio->Media->BlockSize)
+			x = 1;
+		else
+			x /= blkio->Media->BlockSize;
+
+		switch (rw & F_MASK) {
+		case F_READ:
+			blksz = blkio->Media->BlockSize * x - blkoff;
+			if (size < blksz)
+				blksz = size;
+
+			rc = efipart_readwrite(blkio, rw, blk, x, blkbuf);
+			if (rc != 0)
+				goto error;
+
+			if (need_buf)
+				bcopy(blkbuf + blkoff, buf, blksz);
 			break;
-		if (size < blksz)
-			blksz = size;
-		bcopy(blkbuf + blkoff, buf, blksz);
+		case F_WRITE:
+			rc = 0;
+			if (blkoff != 0) {
+				/*
+				 * We got offset to sector, read 1 sector to
+				 * blkbuf.
+				 */
+				x = 1;
+				blksz = blkio->Media->BlockSize - blkoff;
+				blksz = min(blksz, size);
+				rc = efipart_readwrite(blkio, F_READ, blk, x,
+				    blkbuf);
+			} else if (size < blkio->Media->BlockSize) {
+				/*
+				 * The remaining block is not full
+				 * sector. Read 1 sector to blkbuf.
+				 */
+				x = 1;
+				blksz = size;
+				rc = efipart_readwrite(blkio, F_READ, blk, x,
+				    blkbuf);
+			} else {
+				/* We can write full sector(s). */
+				blksz = blkio->Media->BlockSize * x;
+			}
+
+			if (rc != 0)
+				goto error;
+			/*
+			 * Put your Data In, Put your Data out,
+			 * Put your Data In, and shake it all about
+			 */
+			if (need_buf)
+				bcopy(buf, blkbuf + blkoff, blksz);
+			rc = efipart_readwrite(blkio, F_WRITE, blk, x, blkbuf);
+			if (rc != 0)
+				goto error;
+			break;
+		default:
+			/* DO NOTHING */
+			rc = EROFS;
+			goto error;
+		}
+
+		blkoff = 0;
 		buf += blksz;
 		size -= blksz;
-		blk++;
-		blkoff = 0;
-		blksz = blkio->Media->BlockSize;
+		blk += x;
 	}
 
-	free(blkbuf);
-	return (error);
+error:
+	if (rsize != NULL)
+		*rsize -= size;
+
+	if (need_buf)
+		free(blkbuf);
+	return (rc);
 }

--- a/usr/src/uts/common/fs/nfs/nfs4_client_state.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_client_state.c
@@ -929,7 +929,7 @@ nfs4_end_open_seqid_sync(nfs4_open_owner_t *oop)
 	mutex_enter(&oop->oo_lock);
 	ASSERT(oop->oo_seqid_inuse);
 	oop->oo_seqid_inuse = 0;
-	cv_broadcast(&oop->oo_cv_seqid_sync);
+	cv_signal(&oop->oo_cv_seqid_sync);
 	mutex_exit(&oop->oo_lock);
 }
 
@@ -1294,7 +1294,7 @@ nfs4_end_lock_seqid_sync(nfs4_lock_owner_t *lop)
 	ASSERT(lop->lo_seqid_holder == curthread);
 	lop->lo_flags &= ~NFS4_LOCK_SEQID_INUSE;
 	lop->lo_seqid_holder = NULL;
-	cv_broadcast(&lop->lo_cv_seqid_sync);
+	cv_signal(&lop->lo_cv_seqid_sync);
 	mutex_exit(&lop->lo_lock);
 }
 
@@ -2036,7 +2036,7 @@ nfs4_resend_open_otw(vnode_t **vpp, nfs4_lost_rqst_t *resend_rqstp,
 	bool_t			retry_open = FALSE;
 	int			created_osp = 0;
 	hrtime_t		t;
-	char 			*failed_msg = "";
+	char			*failed_msg = "";
 	int			fh_different;
 	int			reopen = 0;
 

--- a/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 RackTop Systems.
  */
 
 /*
@@ -22,6 +23,7 @@
 
 static int smb2_negotiate_common(smb_request_t *, uint16_t);
 
+/* List of supported capabilities.  Can be patched for testing. */
 uint32_t smb2srv_capabilities =
 	SMB2_CAP_DFS |
 	SMB2_CAP_LEASING |
@@ -363,7 +365,10 @@ smb2_negotiate_common(smb_request_t *sr, uint16_t version)
 	 * One additional check: If KCF is missing something we
 	 * require for encryption, turn off that capability.
 	 */
-	if (s->dialect < SMB_VERS_3_0) {
+	if (s->dialect < SMB_VERS_2_1) {
+		/* SMB 2.002 */
+		s->srv_cap = smb2srv_capabilities & SMB2_CAP_DFS;
+	} else if (s->dialect < SMB_VERS_3_0) {
 		/* SMB 2.x */
 		s->srv_cap = smb2srv_capabilities & SMB_2X_CAPS;
 	} else {

--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -957,7 +957,7 @@ vdev_disk_io_start(zio_t *zio)
 		dkioc_free_list_t dfl;
 		dfl.dfl_flags = 0;
 		dfl.dfl_num_exts = 1;
-		dfl.dfl_offset = VDEV_LABEL_START_SIZE;
+		dfl.dfl_offset = 0;
 		dfl.dfl_exts[0].dfle_start = zio->io_offset;
 		dfl.dfl_exts[0].dfle_length = zio->io_size;
 

--- a/usr/src/uts/i86pc/io/viona/viona_impl.h
+++ b/usr/src/uts/i86pc/io/viona/viona_impl.h
@@ -70,6 +70,7 @@ enum viona_ring_state {
 	VRS_SETUP	= 0x1,	/* addrs setup and starting worker thread */
 	VRS_INIT	= 0x2,	/* worker thread started & waiting to run */
 	VRS_RUN		= 0x3,	/* running work routine */
+	VRS_STOP	= 0x4,	/* worker is exiting */
 };
 enum viona_ring_state_flags {
 	VRSF_REQ_START	= 0x1,	/* start running from INIT state */

--- a/usr/src/uts/i86pc/io/viona/viona_main.c
+++ b/usr/src/uts/i86pc/io/viona/viona_main.c
@@ -133,8 +133,14 @@
  *  +-----------+
  *        |						^
  *        |---* ioctl(VNA_IOC_RING_RESET) issued	|
- *        |	(or bhyve process begins exit)		|
- *        V						|
+ *        |	(or bhyve process begins exit)		^
+ *        |
+ *  +-----------+	The worker thread associated with the ring is in the
+ *  | VRS_STOP  |	process of exiting. All outstanding TX and RX
+ *  +-----------+	requests are allowed to complete, but new requests
+ *        |		must be ignored.
+ *        |						^
+ *        |						|
  *        +-------------------------------------------->+
  *
  *

--- a/usr/src/uts/i86pc/io/viona/viona_ring.c
+++ b/usr/src/uts/i86pc/io/viona/viona_ring.c
@@ -389,6 +389,8 @@ viona_worker(void *arg)
 		panic("unexpected ring: %p", (void *)ring);
 	}
 
+	VERIFY3U(ring->vr_state, ==, VRS_STOP);
+
 cleanup:
 	if (ring->vr_txdesb != NULL) {
 		/*

--- a/usr/src/uts/i86pc/io/viona/viona_tx.c
+++ b/usr/src/uts/i86pc/io/viona/viona_tx.c
@@ -283,6 +283,7 @@ viona_worker_tx(viona_vring_t *ring, viona_link_t *link)
 
 	ASSERT(MUTEX_HELD(&ring->vr_lock));
 
+	ring->vr_state = VRS_STOP;
 	viona_tx_wait_outstanding(ring);
 }
 


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Thu Oct  3 10:46:33 GMT 2019 ====
==== Nightly distributed build completed: Thu Oct  3 11:47:30 GMT 2019 ====

==== Total build time ====

real    1:00:57

==== Build environment ====

/usr/bin/uname
SunOS r151032 5.11 omnios-r151032-5297db41ff i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 12

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151032/7.4.0-il-3) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151032/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151032-20190219"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   95

==== Nightly argument issues ====


==== Build version ====

omnios-backportsr32-c3e50ecac9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:05.6
user  3:35:50.8
sys   1:09:50.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    22:03.7
user  3:07:20.5
sys   1:04:26.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
