### PR TITLE
Backports to r151032

### DIFF
--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2019.09.27.1
+BOOT_VERSION = $(LOADER_VERSION)-2019.10.03.1

--- a/usr/src/boot/sys/boot/common/gfx_fb.c
+++ b/usr/src/boot/sys/boot/common/gfx_fb.c
@@ -1642,7 +1642,7 @@ insert_font(char *name)
 static int
 font_set(struct env_var *ev __unused, int flags __unused, const void *value)
 {
-	struct fontlist *fl, *tmp;
+	struct fontlist *fl;
 	char *eptr;
 	unsigned long x = 0, y = 0;
 
@@ -1662,9 +1662,9 @@ font_set(struct env_var *ev __unused, int flags __unused, const void *value)
 	}
 	if (fl != NULL) {
 		/* Reset any FONT_MANUAL flag. */
-		STAILQ_FOREACH(tmp, &fonts, font_next)
-			tmp->font_flags = FONT_AUTO;
+		reset_font_flags();
 
+		/* Mark this font manually loaded */
 		fl->font_flags = FONT_MANUAL;
 		/* Trigger tem update. */
 		tems.update_font = true;

--- a/usr/src/boot/sys/boot/efi/loader/framebuffer.c
+++ b/usr/src/boot/sys/boot/efi/loader/framebuffer.c
@@ -31,6 +31,7 @@
 #include <stand.h>
 #include <bootstrap.h>
 #include <sys/endian.h>
+#include <sys/font.h>
 #include <sys/consplat.h>
 
 #include <efi.h>
@@ -706,6 +707,7 @@ command_gop(int argc, char *argv[])
 		if (argc != 2)
 			goto usage;
 
+		reset_font_flags();
 		plat_cons_update_mode(EfiConsoleControlScreenText);
 		return (CMD_OK);
 	}
@@ -717,6 +719,7 @@ command_gop(int argc, char *argv[])
 		if (argc != 2)
 			goto usage;
 
+		reset_font_flags();
 		mode = gop_default_mode();
 		if (mode != gop->Mode->Mode)
 			efifb_set_mode(gop, mode);
@@ -749,6 +752,7 @@ command_gop(int argc, char *argv[])
 		if (mode == gop->Mode->MaxMode)
 			mode = gop->Mode->Mode;
 
+		reset_font_flags();
 		rv = efifb_set_mode(gop, mode);
 		plat_cons_update_mode(EfiConsoleControlScreenGraphics);
 		return (rv);

--- a/usr/src/boot/sys/boot/i386/libi386/i386_copy.c
+++ b/usr/src/boot/sys/boot/i386/libi386/i386_copy.c
@@ -34,11 +34,14 @@
 #include <stand.h>
 #include <sys/param.h>
 #include <sys/multiboot2.h>
+#include <sys/consplat.h>
 #include <machine/metadata.h>
 #include <machine/pc/bios.h>
 #include "libi386.h"
 #include "btxv86.h"
 #include "bootstrap.h"
+
+extern multiboot_tag_framebuffer_t gfx_fb;
 
 /*
  * Verify the address is not in use by existing modules.
@@ -52,7 +55,7 @@ addr_verify(struct preloaded_file *fp, vm_offset_t addr, size_t size)
 		f_addr = fp->f_addr;
 
 		if ((f_addr <= addr) &&
-		     (f_addr + fp->f_size >= addr)) {
+		    (f_addr + fp->f_size >= addr)) {
 			return (0);
 		}
 		if ((f_addr >= addr) && (f_addr <= addr + size)) {
@@ -100,7 +103,7 @@ smap_find(struct bios_smap *smap, int smaplen, vm_offset_t addr, size_t size)
  * aligned to page boundary and we have to fit into smap entry.
  */
 vm_offset_t
-i386_loadaddr(u_int type, void *data, vm_offset_t addr)
+i386_loadaddr(uint_t type, void *data, vm_offset_t addr)
 {
 	struct stat st;
 	size_t size, smaplen;
@@ -141,7 +144,7 @@ i386_loadaddr(u_int type, void *data, vm_offset_t addr)
 		return (0);
 
 	smap = (struct bios_smap *)md->md_data;
-	smaplen = md->md_size / sizeof(struct bios_smap);
+	smaplen = md->md_size / sizeof (struct bios_smap);
 
 	/* Start from the end of the kernel. */
 	mfp = fp;
@@ -151,6 +154,24 @@ i386_loadaddr(u_int type, void *data, vm_offset_t addr)
 		} else {
 			off = roundup2(mfp->f_addr + mfp->f_size + 1,
 			    MULTIBOOT_MOD_ALIGN);
+		}
+		/* Avoid possible framebuffer memory */
+		if (plat_stdout_is_framebuffer()) {
+			vm_offset_t fb_addr;
+			size_t fb_size;
+
+			fb_addr = gfx_fb.framebuffer_common.framebuffer_addr;
+			fb_size = gfx_fb.framebuffer_common.framebuffer_height *
+			    gfx_fb.framebuffer_common.framebuffer_pitch;
+
+			if ((off >= fb_addr && off <= fb_addr + fb_size) ||
+			    (off + size >= fb_addr &&
+			    off + size <= fb_addr + fb_size)) {
+				printf("\nSkipping framebuffer memory %#x "
+				    "size %#x\n", fb_addr, fb_size);
+				off = roundup2(fb_addr + fb_size + 1,
+				    MULTIBOOT_MOD_ALIGN);
+			}
 		}
 		off = smap_find(smap, smaplen, off, size);
 		off = addr_verify(fp, off, size);

--- a/usr/src/boot/sys/boot/i386/libi386/vbe.c
+++ b/usr/src/boot/sys/boot/i386/libi386/vbe.c
@@ -38,6 +38,7 @@
 #include "libi386.h"
 #include "gfx_fb.h"	/* for EDID */
 #include "vbe.h"
+#include <sys/font.h>
 #include <sys/vgareg.h>
 #include <sys/vgasubr.h>
 
@@ -756,6 +757,7 @@ command_vesa(int argc, char *argv[])
 		if (vbestate.vbe_mode == 0)
 			return (CMD_OK);
 
+		reset_font_flags();
 		bios_set_text_mode(VGA_TEXT_MODE);
 		plat_cons_update_mode(0);
 		return (CMD_OK);
@@ -802,6 +804,7 @@ command_vesa(int argc, char *argv[])
 
 	if (modenum >= 0x100) {
 		if (vbestate.vbe_mode != modenum) {
+			reset_font_flags();
 			vbe_set_mode(modenum);
 			plat_cons_update_mode(1);
 		}

--- a/usr/src/cmd/boot/bootadm/bootadm_loader.c
+++ b/usr/src/cmd/boot/bootadm/bootadm_loader.c
@@ -26,7 +26,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
- * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -1135,9 +1135,9 @@ update_temp(struct menu_lst *menu, char *dummy, char *opt)
 
 		if (env != NULL) {
 			env = getenv("boot-args");
-			(void) fprintf(fp, "boot-args=\"%s %s\"\n", env, opt);
+			(void) fprintf(fp, "boot-args='%s %s'\n", env, opt);
 		} else
-			(void) fprintf(fp, "boot-args=\"%s\"\n", opt);
+			(void) fprintf(fp, "boot-args='%s'\n", opt);
 		(void) fclose(fp);
 		return (BAM_SUCCESS);
 	}
@@ -1154,7 +1154,7 @@ update_temp(struct menu_lst *menu, char *dummy, char *opt)
 		fp = fopen(path, "w");
 		if (fp == NULL)
 			return (BAM_ERROR);
-		(void) fprintf(fp, "bootfile=\"%s;unix\"\n", opt);
+		(void) fprintf(fp, "bootfile='%s;unix'\n", opt);
 		(void) fclose(fp);
 		return (BAM_SUCCESS);
 	}
@@ -1162,13 +1162,13 @@ update_temp(struct menu_lst *menu, char *dummy, char *opt)
 	fp = fopen(path, "w");
 	if (fp == NULL)
 		return (BAM_ERROR);
-	(void) fprintf(fp, "bootfile=\"%s;unix\"\n", opt);
+	(void) fprintf(fp, "bootfile='%s;unix'\n", opt);
 
 	if (env != NULL) {
 		env = getenv("boot-args");
-		(void) fprintf(fp, "boot-args=\"%s %s\"\n", env, opt);
+		(void) fprintf(fp, "boot-args='%s %s'\n", env, o);
 	} else
-		(void) fprintf(fp, "boot-args=\"%s\"\n", o);
+		(void) fprintf(fp, "boot-args='%s'\n", o);
 
 	(void) fflush(fp);
 	(void) fclose(fp);

--- a/usr/src/cmd/smbsrv/smbd/server.xml
+++ b/usr/src/cmd/smbsrv/smbd/server.xml
@@ -24,6 +24,7 @@ CDDL HEADER END
 Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
 Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+Copyright 2019 RackTop Systems.
 
 NOTE:  This service manifest is not editable; its contents will
 be overwritten by package or patch operations, including
@@ -220,7 +221,7 @@ file.
 		<propval name='ipv6_enable' type='boolean'
 			value='false' override='true'/>
 		<propval name='sv_version' type='astring'
-			value='5.0' override='true'/>
+			value='6.1' override='true'/>
 		<propval name='dfs_stdroot_num' type='integer'
 			value='0' override='true'/>
 		<propval name='print_enable' type='boolean'

--- a/usr/src/cmd/svc/milestone/fs-usr
+++ b/usr/src/cmd/svc/milestone/fs-usr
@@ -25,6 +25,7 @@
 # Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T.
 # All rights reserved.
 # Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 . /lib/svc/share/smf_include.sh
@@ -53,7 +54,7 @@ dump_setup()
 
 	#
 	# If we have a dedicated dump device, then go ahead and configure it.
-	# 
+	#
 	if [ "x$special" != "x$DUMPADM_DEVICE" ]; then
 		if [ -x /usr/sbin/dumpadm -a -b $DUMPADM_DEVICE ]; then
 			/usr/sbin/dumpadm -u || exit $SMF_EXIT_ERR_CONFIG
@@ -146,34 +147,44 @@ if [ -f "${UPDATEFILE}" ]; then
 		cecho ""
 		cecho "WARNING: Automatic update of the boot archive failed."
 		cecho "Update the archives using 'bootadm update-archive'"
-		cecho "command and then reboot the system from the same device that"
-		cecho "was previously booted." 
+		cecho "command and then reboot the system from the same device"
+		cecho "that was previously booted."
 		cecho ""
 		exit $SMF_EXIT_ERR_FATAL
 	fi
 	rm -f $UPDATEFILE
+
+	cecho ""
+	cecho "WARNING: Reboot required."
+	cecho "The system has updated the cache of files (boot archive) that"
+	cecho "is used during the early boot sequence. To avoid booting and"
+	cecho "running the system with the previously out-of-sync version of"
+	cecho "these files, the system will be restarted."
+	cecho ""
+
 	bootcmd=`/usr/sbin/eeprom bootcmd | /usr/bin/sed -e 's#bootcmd=##g'`
 	if [ `uname -p` = "i386" ]; then
 		/usr/sbin/reboot -f dryrun
 		if [ $? = 0 ]; then
-			/usr/sbin/reboot -f -- "$bootcmd" 
+			/usr/sbin/reboot -f -- "$bootcmd"
 			exit $SMF_EXIT_OK
 		fi
-		boot_prop=`/usr/sbin/svccfg -s svc:/system/boot-config:default listprop config/auto-reboot-safe | \
-			/usr/bin/nawk '{ print $3}'`
-		if [ "$boot_prop" != "true" ]; then 
-			cecho ""
-			cecho "WARNING: Reboot required."
-			cecho "The system has updated the cache of files (boot archive) that is used"
-			cecho "during the early boot sequence. To avoid booting and running the system"
-			cecho "with the previously out-of-sync version of these files, reboot the"
-			cecho "system from the same device that was previously booted."
-			cecho ""
-			exit $SMF_EXIT_ERR_FATAL
-		else
-			/usr/sbin/reboot -p 
+		boot_prop=`/usr/sbin/svccfg -s svc:/system/boot-config:default \
+		    listprop config/auto-reboot-safe | \
+		    /usr/bin/nawk '{ print $3}'`
+		if [ "$boot_prop" = "true" ]; then
+			/usr/sbin/reboot -p
 			exit $SMF_EXIT_OK
-		fi 
+		fi
+		cecho ""
+		cecho "WARNING: Reboot required."
+		cecho "The system has updated the cache of files (boot archive)"
+		cecho "that is used during the early boot sequence. To avoid"
+		cecho "booting and running the system with the previously"
+		cecho "out-of-sync version of these files, reboot the system"
+		cecho "from the same device that was previously booted."
+		cecho ""
+		exit $SMF_EXIT_ERR_FATAL
 	fi
 	/usr/sbin/reboot -- "$bootcmd"
 fi

--- a/usr/src/common/font/font.c
+++ b/usr/src/common/font/font.c
@@ -164,6 +164,19 @@ rgb_color_map(const rgb_t *rgb, uint8_t index)
  */
 font_list_t fonts = STAILQ_HEAD_INITIALIZER(fonts);
 
+/*
+ * Reset font flags to FONT_AUTO.
+ */
+void
+reset_font_flags(void)
+{
+	struct fontlist *fl;
+
+	STAILQ_FOREACH(fl, &fonts, font_next) {
+		fl->font_flags = FONT_AUTO;
+	}
+}
+
 bitmap_data_t *
 set_font(short *rows, short *cols, short h, short w)
 {

--- a/usr/src/uts/common/fs/zfs/dsl_scan.c
+++ b/usr/src/uts/common/fs/zfs/dsl_scan.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
  * Copyright 2016 Gary Mills
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2017 Datto Inc.
  */
 
@@ -957,13 +957,15 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 		 * will find the drives that need to be resilvered
 		 * when the machine reboots and start the resilver then.
 		 */
-		boolean_t resilver_needed =
-		    dsl_scan_clear_deferred(spa->spa_root_vdev, tx);
-		if (resilver_needed) {
-			spa_history_log_internal(spa,
-			    "starting deferred resilver", tx,
-			    "errors=%llu", spa_get_errlog_size(spa));
-			spa_async_request(spa, SPA_ASYNC_RESILVER);
+		if (spa_feature_is_enabled(spa, SPA_FEATURE_RESILVER_DEFER)) {
+			boolean_t resilver_needed =
+			    dsl_scan_clear_deferred(spa->spa_root_vdev, tx);
+			if (resilver_needed) {
+				spa_history_log_internal(spa,
+				    "starting deferred resilver", tx,
+				    "errors=%llu", spa_get_errlog_size(spa));
+				spa_async_request(spa, SPA_ASYNC_RESILVER);
+			}
 		}
 	}
 

--- a/usr/src/uts/common/sys/font.h
+++ b/usr/src/uts/common/sys/font.h
@@ -123,6 +123,7 @@ extern bitmap_data_t font_data_8x16;
 #endif
 #define	BORDER_PIXELS		10	/* space from screen border */
 
+void reset_font_flags(void);
 bitmap_data_t *set_font(short *, short *, short, short);
 const uint8_t *font_lookup(const struct font *, uint32_t);
 void font_bit_to_pix4(struct font *, uint8_t *, uint32_t, uint8_t, uint8_t);


### PR DESCRIPTION
Backports to r151032
## mail_msg

```

==== Nightly distributed build started:   Wed Oct  9 20:56:40 GMT 2019 ====
==== Nightly distributed build completed: Wed Oct  9 21:58:45 GMT 2019 ====

==== Total build time ====

real    1:02:05

==== Build environment ====

/usr/bin/uname
SunOS r151032 5.11 omnios-r151032-5297db41ff i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151032/7.4.0-il-3) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151032/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151032-20190219"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   139

==== Nightly argument issues ====


==== Build version ====

omnios-backports-302b3dec83

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:39.4
user  3:34:55.6
sys   1:10:42.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    22:17.4
user  3:06:59.6
sys   1:03:06.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
