### PR TITLE
SMB backports to r151032

### DIFF
--- a/usr/src/cmd/smbsrv/smbd/smbd_authsvc.c
+++ b/usr/src/cmd/smbsrv/smbd/smbd_authsvc.c
@@ -276,7 +276,7 @@ smbd_authsvc_listen(void *arg)
 			smbd_authsvc_thrcnt--;
 			(void) mutex_unlock(&smbd_authsvc_mutex);
 			(void) close(ns);
-			goto out;
+			continue;
 		}
 		ctx->ctx_socket = ns;
 
@@ -287,9 +287,8 @@ smbd_authsvc_listen(void *arg)
 			smbd_authsvc_thrcnt--;
 			(void) mutex_unlock(&smbd_authsvc_mutex);
 			smbd_authctx_destroy(ctx);
-			goto out;
 		}
-		ctx = NULL; /* given to the new thread */
+		ctx = NULL; /* given to the new thread or destroyed */
 	}
 
 out:

--- a/usr/src/lib/libmlrpc/common/ndr_process.c
+++ b/usr/src/lib/libmlrpc/common/ndr_process.c
@@ -21,8 +21,9 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
  * Copyright 2012 Milan Jurik. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -586,7 +587,7 @@ ndr_run_outer_queue(ndr_stream_t *nds)
 int
 ndr_outer(ndr_ref_t *outer_ref)
 {
-	ndr_stream_t 	*nds = outer_ref->stream;
+	ndr_stream_t	*nds = outer_ref->stream;
 	ndr_typeinfo_t	*ti = outer_ref->ti;
 	int	is_varlen = ti->pdu_size_variable_part;
 	int	is_union = NDR_IS_UNION(ti);
@@ -653,7 +654,7 @@ ndr_outer_fixed(ndr_ref_t *outer_ref)
 	ndr_stream_t	*nds = outer_ref->stream;
 	ndr_typeinfo_t	*ti = outer_ref->ti;
 	ndr_ref_t	myref;
-	char 		*valp = NULL;
+	char		*valp = NULL;
 	int		is_varlen = ti->pdu_size_variable_part;
 	int		is_union = NDR_IS_UNION(ti);
 	int		is_string = NDR_IS_STRING(ti);
@@ -743,7 +744,7 @@ ndr_outer_fixed_array(ndr_ref_t *outer_ref)
 	ndr_stream_t	*nds = outer_ref->stream;
 	ndr_typeinfo_t	*ti = outer_ref->ti;
 	ndr_ref_t	myref;
-	char 		*valp = NULL;
+	char		*valp = NULL;
 	int		is_varlen = ti->pdu_size_variable_part;
 	int		is_union = NDR_IS_UNION(ti);
 	int		is_string = NDR_IS_STRING(ti);
@@ -834,7 +835,7 @@ ndr_outer_conformant_array(ndr_ref_t *outer_ref)
 	ndr_stream_t	*nds = outer_ref->stream;
 	ndr_typeinfo_t	*ti = outer_ref->ti;
 	ndr_ref_t	myref;
-	char 		*valp = NULL;
+	char		*valp = NULL;
 	int		is_varlen = ti->pdu_size_variable_part;
 	int		is_union = NDR_IS_UNION(ti);
 	int		is_string = NDR_IS_STRING(ti);
@@ -962,7 +963,7 @@ ndr_outer_conformant_construct(ndr_ref_t *outer_ref)
 	ndr_stream_t	*nds = outer_ref->stream;
 	ndr_typeinfo_t	*ti = outer_ref->ti;
 	ndr_ref_t	myref;
-	char 		*valp = NULL;
+	char		*valp = NULL;
 	int		is_varlen = ti->pdu_size_variable_part;
 	int		is_union = NDR_IS_UNION(ti);
 	int		is_string = NDR_IS_STRING(ti);
@@ -1091,8 +1092,8 @@ ndr_outer_conformant_construct(ndr_ref_t *outer_ref)
 int
 ndr_size_is(ndr_ref_t *ref)
 {
-	ndr_stream_t 		*nds = ref->stream;
-	ndr_ref_t 		*outer_ref = nds->outer_current;
+	ndr_stream_t		*nds = ref->stream;
+	ndr_ref_t		*outer_ref = nds->outer_current;
 	ndr_typeinfo_t		*ti = outer_ref->ti;
 	unsigned long		size_is;
 	int			rc;
@@ -1161,9 +1162,9 @@ int
 ndr_outer_string(ndr_ref_t *outer_ref)
 {
 	ndr_stream_t	*nds = outer_ref->stream;
-	ndr_typeinfo_t 	*ti = outer_ref->ti;
+	ndr_typeinfo_t	*ti = outer_ref->ti;
 	ndr_ref_t	myref;
-	char 		*valp = NULL;
+	char		*valp = NULL;
 	unsigned	is_varlen = ti->pdu_size_variable_part;
 	int		is_union = NDR_IS_UNION(ti);
 	int		is_string = NDR_IS_STRING(ti);
@@ -1266,6 +1267,8 @@ ndr_outer_string(ndr_ref_t *outer_ref)
 			return (0);		/* error already set */
 
 		/*
+		 * Enforce bounds on: size_is, first_is, length_is
+		 *
 		 * In addition to the first_is check, we used to check that
 		 * size_is or size_is-1 was equal to length_is but Windows95
 		 * doesn't conform to this "rule" (see variable part below).
@@ -1280,8 +1283,16 @@ ndr_outer_string(ndr_ref_t *outer_ref)
 		 * size_is was the maximum path length rather than being
 		 * related to length_is.
 		 */
+		if (size_is > NDR_STRING_MAX) {
+			NDR_SET_ERROR(outer_ref, NDR_ERR_STRING_SIZING);
+			return (0);
+		}
 		if (first_is != 0) {
 			NDR_SET_ERROR(outer_ref, NDR_ERR_STRING_SIZING);
+			return (0);
+		}
+		if (length_is > size_is) {
+			NDR_SET_ERROR(outer_ref, NDR_ERR_STRLEN);
 			return (0);
 		}
 
@@ -1377,7 +1388,7 @@ int
 ndr_outer_peek_sizing(ndr_ref_t *outer_ref, unsigned offset,
     unsigned long *sizing_p)
 {
-	ndr_stream_t 	*nds = outer_ref->stream;
+	ndr_stream_t	*nds = outer_ref->stream;
 	unsigned long	pdu_offset;
 	int		rc;
 
@@ -1412,7 +1423,7 @@ int
 ndr_outer_poke_sizing(ndr_ref_t *outer_ref, unsigned offset,
     unsigned long *sizing_p)
 {
-	ndr_stream_t 	*nds = outer_ref->stream;
+	ndr_stream_t	*nds = outer_ref->stream;
 	unsigned long	pdu_offset;
 	int		rc;
 
@@ -1451,7 +1462,7 @@ ndr_outer_poke_sizing(ndr_ref_t *outer_ref, unsigned offset,
 int
 ndr_outer_align(ndr_ref_t *outer_ref)
 {
-	ndr_stream_t 	*nds = outer_ref->stream;
+	ndr_stream_t	*nds = outer_ref->stream;
 	int		rc;
 	unsigned	n_pad;
 	unsigned	align;
@@ -1493,7 +1504,7 @@ ndr_outer_align(ndr_ref_t *outer_ref)
 int
 ndr_outer_grow(ndr_ref_t *outer_ref, unsigned n_total)
 {
-	ndr_stream_t 	*nds = outer_ref->stream;
+	ndr_stream_t	*nds = outer_ref->stream;
 	unsigned long	pdu_want_size;
 	int		rc, is_ok = 0;
 
@@ -1549,7 +1560,7 @@ ndr_outer_grow(ndr_ref_t *outer_ref, unsigned n_total)
 int
 ndr_inner(ndr_ref_t *arg_ref)
 {
-	ndr_typeinfo_t 	*ti = arg_ref->ti;
+	ndr_typeinfo_t	*ti = arg_ref->ti;
 	int	is_varlen = ti->pdu_size_variable_part;
 	int	is_union = NDR_IS_UNION(ti);
 	int	error = NDR_ERR_INNER_PARAMS_BAD;
@@ -1623,8 +1634,8 @@ ndr_inner_pointer(ndr_ref_t *arg_ref)
 {
 	ndr_stream_t	*nds = arg_ref->stream;
 	/*LINTED E_BAD_PTR_CAST_ALIGN*/
-	char 		**valpp = (char **)arg_ref->datum;
-	ndr_ref_t 	*outer_ref;
+	char		**valpp = (char **)arg_ref->datum;
+	ndr_ref_t	*outer_ref;
 
 	if (!ndr__ulong(arg_ref))
 		return (0);	/* error */
@@ -1800,6 +1811,7 @@ ndr_inner_array(ndr_ref_t *encl_ref)
 int ndr_basic_integer(ndr_ref_t *, unsigned);
 int ndr_string_basic_integer(ndr_ref_t *, ndr_typeinfo_t *);
 
+/* BEGIN CSTYLED */
 /* Comments to be nice to those searching for these types. */
 MAKE_BASIC_TYPE(_char, 1)	/* ndt__char,  ndt_s_char */
 MAKE_BASIC_TYPE(_uchar, 1)	/* ndt__uchar, ndt_s_uchar */
@@ -1809,12 +1821,13 @@ MAKE_BASIC_TYPE(_long, 4)	/* ndt__long,  ndt_s_long */
 MAKE_BASIC_TYPE(_ulong, 4)	/* ndt__ulong, ndt_s_ulong */
 
 MAKE_BASIC_TYPE_BASE(_wchar, 2)	/* ndt__wchar, ndt_s_wchar */
+/* END CSTYLED */
 
 int
 ndr_basic_integer(ndr_ref_t *ref, unsigned size)
 {
 	ndr_stream_t	*nds = ref->stream;
-	char 		*valp = (char *)ref->datum;
+	char		*valp = (char *)ref->datum;
 	int		rc;
 
 	switch (nds->m_op) {

--- a/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 RackTop Systems.
  */
 
 
@@ -910,7 +911,7 @@ cmd_done:
 		cmn_err(CE_NOTE, "handler for %u returned 0x%x",
 		    sr->smb2_cmd_code, rc);
 #endif
-		sr->smb2_status = NT_STATUS_INTERNAL_ERROR;
+		smb2sr_put_error(sr, NT_STATUS_INTERNAL_ERROR);
 		break;
 	case SDRC_ERROR:
 		/*
@@ -921,6 +922,7 @@ cmd_done:
 		 */
 		if (sr->smb2_status == 0)
 			sr->smb2_status = NT_STATUS_INVALID_PARAMETER;
+		smb2sr_put_error(sr, sr->smb2_status);
 		break;
 	case SDRC_DROP_VC:
 		disconnect = B_TRUE;

--- a/usr/src/uts/common/fs/smbsrv/smb2_setinfo_file.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_setinfo_file.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -43,6 +43,21 @@ smb2_setinfo_file(smb_request_t *sr, smb_setinfo_t *si, int InfoClass)
 	uint32_t status;
 
 	si->si_node = of->f_node;
+
+	/* Most info levels need a disk file */
+	switch (of->f_ftype) {
+	case SMB_FTYPE_DISK:
+	case SMB_FTYPE_PRINTER:
+		break;
+	case SMB_FTYPE_BYTE_PIPE:
+	case SMB_FTYPE_MESG_PIPE:
+		if (InfoClass != FilePipeInformation)
+			return (NT_STATUS_INVALID_PARAMETER);
+		break;
+	default:
+		return (NT_STATUS_INTERNAL_ERROR);
+		break;
+	}
 
 	switch (InfoClass) {
 	case FileBasicInformation:		/* 4 */

--- a/usr/src/uts/common/fs/smbsrv/smb_ofile.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_ofile.c
@@ -22,7 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Syneto S.R.L. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
  */
 
 /*
@@ -954,6 +954,10 @@ smb_ofile_lookup_by_uniqid(smb_tree_t *tree, uint32_t uniqid)
 	return (NULL);
 }
 
+/*
+ * Durable ID (or persistent ID)
+ */
+
 static smb_ofile_t *
 smb_ofile_hold_cb(smb_ofile_t *of)
 {
@@ -1509,6 +1513,9 @@ smb_ofile_free(smb_ofile_t *of)
 	smb_tree_t	*tree = of->f_tree;
 
 	ASSERT(of->f_state == SMB_OFILE_STATE_ALLOC);
+
+	/* Make sure it's not in the persistid hash. */
+	ASSERT(of->f_persistid == 0);
 
 	if (tree != NULL) {
 		if (of->f_fid != 0)

--- a/usr/src/uts/common/fs/smbsrv/smb_server.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_server.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017 by Delphix. All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -1932,15 +1932,16 @@ smb_server_session_disconnect(smb_server_t *sv,
 		for (user = smb_llist_head(ulist);
 		    user != NULL;
 		    user = smb_llist_next(ulist, user)) {
-			SMB_USER_VALID(user);
-
-			if (*name != '\0' && !smb_user_namecmp(user, name))
-				continue;
 
 			if (smb_user_hold(user)) {
-				smb_user_logoff(user);
+
+				if (*name == '\0' ||
+				    smb_user_namecmp(user, name)) {
+					smb_user_logoff(user);
+					count++;
+				}
+
 				smb_user_release(user);
-				count++;
 			}
 		}
 

--- a/usr/src/uts/common/fs/smbsrv/smb_set_fileinfo.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_set_fileinfo.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -276,6 +276,9 @@ smb_set_by_path(smb_request_t *sr, smb_xa_t *xa, uint16_t infolev)
 		    ERRDOS, ERROR_ACCESS_DENIED);
 		return (-1);
 	}
+
+	if (STYPE_ISIPC(sr->tid_tree->t_res_type))
+		return (0);
 
 	pn = &sr->arg.dirop.fqi.fq_path;
 	smb_pathname_init(sr, pn, pn->pn_path);

--- a/usr/src/uts/common/fs/smbsrv/smb_tree_connect.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_tree_connect.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 #include <smbsrv/smb_kproto.h>
@@ -315,6 +315,7 @@ smb_com_tree_connect_andx(smb_request_t *sr)
 		if (tree != NULL) {
 			smb_tree_disconnect(tree, B_TRUE);
 			smb_session_cancel_requests(sr->session, tree, sr);
+			smb_tree_release(tree);
 		}
 	}
 

--- a/usr/src/uts/common/smbsrv/smb_kproto.h
+++ b/usr/src/uts/common/smbsrv/smb_kproto.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Syneto S.R.L.  All rights reserved.
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -56,6 +56,9 @@ extern "C" {
 #include <smbsrv/smb_ktypes.h>
 #include <smbsrv/smb_ioctl.h>
 
+/* For timeout(9F). Not in any system header, apparently. */
+typedef void (*tmo_func_t)(void *);
+
 extern	int smb_maxbufsize;
 extern	int smb_flush_required;
 extern	int smb_dirsymlink_enable;
@@ -69,6 +72,8 @@ extern	int smb_ssetup_timeout;
 extern	int smb_tcon_timeout;
 extern	int smb_opipe_timeout;
 extern	int smb_allow_advisory_locks;
+extern	int smb_session_auth_tmo;
+
 extern const uint32_t smb_vop_dosattr_settable;
 
 /* Thread priorities - see smb_init.c */

--- a/usr/src/uts/common/smbsrv/smb_ktypes.h
+++ b/usr/src/uts/common/smbsrv/smb_ktypes.h
@@ -964,6 +964,7 @@ typedef struct smb_session {
 	uint32_t		challenge_len;
 	unsigned char		challenge_key[SMB_CHALLENGE_SZ];
 	int64_t			activity_timestamp;
+	timeout_id_t		s_auth_tmo;
 
 	/*
 	 * Maximum negotiated buffer sizes between SMB client and server


### PR DESCRIPTION
SMB backports to r151032

## mail_msg

```

==== Nightly distributed build started:   Tue Oct 22 09:47:08 GMT 2019 ====
==== Nightly distributed build completed: Tue Oct 22 10:48:33 GMT 2019 ====

==== Total build time ====

real    1:01:24

==== Build environment ====

/usr/bin/uname
SunOS r151032 5.11 omnios-r151032-e8a22ce3b4 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151032/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151032/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151032-20190219"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   71

==== Nightly argument issues ====


==== Build version ====

omnios-smb_backport_r32-b0cad17ac7

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:59.6
user  3:30:46.9
sys   1:04:16.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:45.0
user  3:04:11.2
sys     59:19.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
