### PR TITLE
11856 chown can trigger vmdump when running recentish zfs

### DIFF
--- a/usr/src/uts/common/fs/zfs/zfs_vnops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vnops.c
@@ -2811,11 +2811,12 @@ zfs_setattr_dir(znode_t *dzp)
 	znode_t		*zp = NULL;
 	dmu_tx_t	*tx = NULL;
 	sa_bulk_attr_t	bulk[4];
-	int		count = 0;
+	int		count;
 	int		err;
 
 	zap_cursor_init(&zc, os, dzp->z_id);
 	while ((err = zap_cursor_retrieve(&zc, &zap)) == 0) {
+		count = 0;
 		if (zap.za_integer_length != 8 || zap.za_num_integers != 1) {
 			err = ENXIO;
 			break;


### PR DESCRIPTION
Avoid stack overwrite in zfs_setattr_dir()
