### PR TITLE
Upstream merge joyent_merge/2019111801

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: e77e89c1413d1b43560c28ccc3aaeb3aa8f2fbe5
+Last illumos-joyent commit: 9fe633fd812f2df2354dc88fd3f7f50e94bd8eb3
 

--- a/usr/src/uts/common/inet/ip/ip6_input.c
+++ b/usr/src/uts/common/inet/ip/ip6_input.c
@@ -979,6 +979,9 @@ ire_recv_forward_v6(ire_t *ire, mblk_t *mp, void *iph_arg, ip_recv_attr_t *ira)
 		ira->ira_pktlen = ntohs(ip6h->ip6_plen) + IPV6_HDR_LEN;
 	}
 
+	/* Packet is being forwarded. Turning off hwcksum flag. */
+	DB_CKSUMFLAGS(mp) = 0;
+
 	/*
 	 * Per RFC 3513 section 2.5.2, we must not forward packets with
 	 * an unspecified source address.
@@ -1100,14 +1103,7 @@ ip_forward_xmit_v6(nce_t *nce, mblk_t *mp, ip6_t *ip6h, ip_recv_attr_t *ira,
 
 	BUMP_MIB(dst_ill->ill_ip_mib, ipIfStatsHCOutForwDatagrams);
 
-	/*
-	 * If the packet arrived via MAC-loopback then it might be an
-	 * LSO packet; in this case the MAC layer will take care to
-	 * segment it. Otherwise, we have a normal packet that is
-	 * being forwarded from a source interface with an MTU larger
-	 * than the destination's; in this case IP must fragment it.
-	 */
-	if (pkt_len > mtu && (DB_CKSUMFLAGS(mp) & HW_LSO) == 0) {
+	if (pkt_len > mtu) {
 		BUMP_MIB(dst_ill->ill_ip_mib, ipIfStatsOutFragFails);
 		ip_drop_output("ipIfStatsOutFragFails", mp, dst_ill);
 		if (iraflags & IRAF_SYSTEM_LABELED) {
@@ -1897,16 +1893,6 @@ ip_input_cksum_v6(iaflags_t iraflags, mblk_t *mp, ip6_t *ip6h,
 		return (B_TRUE);
 	}
 
-	hck_flags = DB_CKSUMFLAGS(mp);
-
-	if (hck_flags & HW_LOCAL_MAC) {
-		/*
-		 * The packet is from a same-machine sender in which
-		 * case we assume data integrity.
-		 */
-		return (B_TRUE);
-	}
-
 	/*
 	 * Revert to software checksum calculation if the interface
 	 * isn't capable of checksum offload.
@@ -1918,6 +1904,8 @@ ip_input_cksum_v6(iaflags_t iraflags, mblk_t *mp, ip6_t *ip6h,
 	    !dohwcksum) {
 		return (ip_input_sw_cksum_v6(mp, ip6h, ira));
 	}
+
+	hck_flags = DB_CKSUMFLAGS(mp);
 
 	/*
 	 * We apply this for all ULP protocols. Does the HW know to

--- a/usr/src/uts/common/inet/ip/ip_input.c
+++ b/usr/src/uts/common/inet/ip/ip_input.c
@@ -666,8 +666,7 @@ ill_input_short_v4(mblk_t *mp, void *iph_arg, void *nexthop_arg,
 	 * there is a good HW IP header checksum, we clear the need
 	 * look at the IP header checksum.
 	 */
-	if ((DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) ||
-	    ((DB_CKSUMFLAGS(mp) & HCK_IPV4_HDRCKSUM) &&
+	if (((DB_CKSUMFLAGS(mp) & HCK_IPV4_HDRCKSUM) &&
 	    ILL_HCKSUM_CAPABLE(ill) && dohwcksum)) {
 		/* Header checksum was ok. Clear the flag */
 		DB_CKSUMFLAGS(mp) &= ~HCK_IPV4_HDRCKSUM;
@@ -1005,26 +1004,8 @@ ire_recv_forward_v4(ire_t *ire, mblk_t *mp, void *iph_arg, ip_recv_attr_t *ira)
 		ira->ira_pktlen = ntohs(ipha->ipha_length);
 	}
 
-	/*
-	 * The packet came here via MAC-loopback so we must reinstate
-	 * its hardware IP header checksum request.
-	 *
-	 * IP input clears the HCK_IPV4_HDRCKSUM_OK flag. Since
-	 * HCK_IPV4_HDRCKSUM_OK and HCK_IPV4_HDRCKSUM use the same
-	 * value, we end up clearing the client's request to use
-	 * hardware IP header checksum offload. We check for
-	 * HW_LOCAL_MAC and an IP header checksum value of zero as an
-	 * indicator that this packet requires reinstatement of the
-	 * HCK_IPV4_HDRCKSUM flag. That said, zero is a valid
-	 * checksum, and given hardware that doesn't support IP header
-	 * checksum offload, this could result in the checksum being
-	 * computed twice. This is fine because the checksum value is
-	 * zero, and thus will retain its value on recalculation.
-	 */
-	if (((DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) != 0) &&
-	    ipha->ipha_hdr_checksum == 0) {
-		DB_CKSUMFLAGS(mp) |= HCK_IPV4_HDRCKSUM;
-	}
+	/* Packet is being forwarded. Turning off hwcksum flag. */
+	DB_CKSUMFLAGS(mp) = 0;
 
 	/*
 	 * Martian Address Filtering [RFC 1812, Section 5.3.7]
@@ -1166,15 +1147,6 @@ ip_forward_xmit_v4(nce_t *nce, ill_t *ill, mblk_t *mp, ipha_t *ipha,
 	sum = (int)ipha->ipha_hdr_checksum + IP_HDR_CSUM_TTL_ADJUST;
 	ipha->ipha_hdr_checksum = (uint16_t)(sum + (sum >> 16));
 
-	/*
-	 * Zero the IP header checksum if this is a mac-loopback
-	 * packet which has requested IP header checksum offload.
-	 */
-	if (((DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) != 0) &&
-	    (DB_CKSUMFLAGS(mp) & HCK_IPV4_HDRCKSUM) != 0) {
-		ipha->ipha_hdr_checksum = 0;
-	}
-
 	/* Check if there are options to update */
 	if (iraflags & IRAF_IPV4_OPTIONS) {
 		ASSERT(ipha->ipha_version_and_hdr_length !=
@@ -1208,14 +1180,7 @@ ip_forward_xmit_v4(nce_t *nce, ill_t *ill, mblk_t *mp, ipha_t *ipha,
 
 	ixaflags = IXAF_IS_IPV4 | IXAF_NO_DEV_FLOW_CTL;
 
-	/*
-	 * If the packet arrived via MAC-loopback, then it might be an
-	 * LSO packet; in this case the MAC layer will take care to
-	 * segment it. Otherwise, we have a normal packet that is
-	 * being forwarded from a source interface with an MTU larger
-	 * than the desination's; in this case IP must fragment it.
-	 */
-	if (pkt_len > mtu && (DB_CKSUMFLAGS(mp) & HW_LSO) == 0) {
+	if (pkt_len > mtu) {
 		/*
 		 * It needs fragging on its way out.  If we haven't
 		 * verified the header checksum yet we do it now since
@@ -2284,16 +2249,6 @@ ip_input_cksum_v4(iaflags_t iraflags, mblk_t *mp, ipha_t *ipha,
 		return (B_TRUE);
 	}
 
-	hck_flags = DB_CKSUMFLAGS(mp);
-
-	if (hck_flags & HW_LOCAL_MAC) {
-		/*
-		 * The packet is from a same-machine sender in which
-		 * case we assume data integrity.
-		 */
-		return (B_TRUE);
-	}
-
 	/*
 	 * Revert to software checksum calculation if the interface
 	 * isn't capable of checksum offload.
@@ -2305,6 +2260,8 @@ ip_input_cksum_v4(iaflags_t iraflags, mblk_t *mp, ipha_t *ipha,
 	    !dohwcksum) {
 		return (ip_input_sw_cksum_v4(mp, ipha, ira));
 	}
+
+	hck_flags = DB_CKSUMFLAGS(mp);
 
 	/*
 	 * We apply this for all ULP protocols. Does the HW know to

--- a/usr/src/uts/common/inet/ip_impl.h
+++ b/usr/src/uts/common/inet/ip_impl.h
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef	_INET_IP_IMPL_H
@@ -167,10 +167,7 @@ extern "C" {
  *
  * o The mblk is not a data message.
  *
- * o There is more than one outstanding reference to the mblk and it
- *   does not originate from a local MAC client. If the mblk does
- *   originate from a local MAC then allow it to pass through with
- *   more than one reference and leave the copying up to the consumer.
+ * o There is more than one outstanding reference to the mblk.
  *
  * o The IP header is not aligned (we assume alignment in the checksum
  *   routine).
@@ -179,7 +176,7 @@ extern "C" {
  */
 #define	MBLK_RX_FANOUT_SLOWPATH(mp, ipha)				\
 	(DB_TYPE(mp) != M_DATA ||					\
-	(DB_REF(mp) != 1 && ((DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) == 0)) || \
+	(DB_REF(mp) != 1) ||						\
 	!OK_32PTR(ipha) ||						\
 	(((uchar_t *)ipha + IP_SIMPLE_HDR_LENGTH) >= (mp)->b_wptr))
 

--- a/usr/src/uts/common/io/dls/dls_link.c
+++ b/usr/src/uts/common/io/dls/dls_link.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -30,7 +30,6 @@
 
 #include	<sys/sysmacros.h>
 #include	<sys/strsubr.h>
-#include	<sys/pattr.h>
 #include	<sys/strsun.h>
 #include	<sys/vlan.h>
 #include	<sys/dld_impl.h>
@@ -162,18 +161,6 @@ i_dls_link_subchain(dls_link_t *dlp, mblk_t *mp, const mac_header_info_t *mhip,
 		mac_header_info_t cmhi;
 		uint16_t cvid, cpri;
 		int err;
-
-		/*
-		 * If this message is from a same-machine sender, then
-		 * there may be HW checksum offloads to emulate.
-		 */
-		if (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) {
-			mblk_t *tmpnext = mp->b_next;
-
-			mp->b_next = NULL;
-			mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
-			mp->b_next = tmpnext;
-		}
 
 		DLS_PREPARE_PKT(dlp->dl_mh, mp, &cmhi, err);
 		if (err != 0)
@@ -369,22 +356,6 @@ i_dls_link_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 	int				err, rval;
 
 	/*
-	 * The mac_hw_emul() function, by design, doesn't predicate on
-	 * HW_LOCAL_MAC. But since we are in Rx context we know that
-	 * any LSO packet must also be from a same-machine sender. We
-	 * take advantage of that and forgoe writing a manual loop to
-	 * predicate on HW_LOCAL_MAC.
-	 *
-	 * But for checksum emulation we need to predicate on
-	 * HW_LOCAL_MAC to avoid calling mac_hw_emul() on packets that
-	 * don't need it (thanks to the fact that HCK_IPV4_HDRCKSUM
-	 * and HCK_IPV4_HDRCKSUM_OK use the same value). Therefore we
-	 * do the checksum emulation in the second loop and in
-	 * subchain matching.
-	 */
-	mac_hw_emul(&mp, NULL, NULL, MAC_LSO_EMUL);
-
-	/*
 	 * Walk the packet chain.
 	 */
 	for (; mp != NULL; mp = nextp) {
@@ -392,18 +363,6 @@ i_dls_link_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 		 * Wipe the accepted state.
 		 */
 		accepted = B_FALSE;
-
-		/*
-		 * If this message is from a same-machine sender, then
-		 * there may be HW checksum offloads to emulate.
-		 */
-		if (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) {
-			mblk_t *tmpnext = mp->b_next;
-
-			mp->b_next = NULL;
-			mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
-			mp->b_next = tmpnext;
-		}
 
 		DLS_PREPARE_PKT(dlp->dl_mh, mp, &mhi, err);
 		if (err != 0) {

--- a/usr/src/uts/common/io/mac/mac.c
+++ b/usr/src/uts/common/io/mac/mac.c
@@ -4459,6 +4459,32 @@ mac_bridge_tx(mac_impl_t *mip, mac_ring_handle_t rh, mblk_t *mp)
 	if (mh == NULL) {
 		mp = mac_ring_tx((mac_handle_t)mip, rh, mp);
 	} else {
+		/*
+		 * The bridge may place this mblk on a provider's Tx
+		 * path, a mac's Rx path, or both. Since we don't have
+		 * enough information at this point, we can't be sure
+		 * that the desination(s) are capable of handling the
+		 * hardware offloads requested by the mblk. We emulate
+		 * them here as it is the safest choice. In the
+		 * future, if bridge performance becomes a priority,
+		 * we can elide the emulation here and leave the
+		 * choice up to bridge.
+		 *
+		 * We don't clear the DB_CKSUMFLAGS here because
+		 * HCK_IPV4_HDRCKSUM (Tx) and HCK_IPV4_HDRCKSUM_OK
+		 * (Rx) still have the same value. If the bridge
+		 * receives a packet from a HCKSUM_IPHDRCKSUM NIC then
+		 * the mac(s) it is forwarded on may calculate the
+		 * checksum again, but incorrectly (because the
+		 * checksum field is not zero). Until the
+		 * HCK_IPV4_HDRCKSUM/HCK_IPV4_HDRCKSUM_OK issue is
+		 * resovled, we leave the flag clearing in bridge
+		 * itself.
+		 */
+		if ((DB_CKSUMFLAGS(mp) & (HCK_TX_FLAGS | HW_LSO_FLAGS)) != 0) {
+			mac_hw_emul(&mp, NULL, NULL, MAC_ALL_EMULS);
+		}
+
 		mp = mac_bridge_tx_cb(mh, rh, mp);
 		mac_bridge_ref_cb(mh, B_FALSE);
 	}
@@ -8380,7 +8406,7 @@ mac_provider_tx(mac_impl_t *mip, mac_ring_handle_t rh, mblk_t *mp,
 		rh = mip->mi_default_tx_ring;
 
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp, mcip);
+		mac_promisc_dispatch(mip, mp, mcip, B_FALSE);
 
 	if (mip->mi_bridge_link == NULL)
 		return (mac_ring_tx((mac_handle_t)mip, rh, mp));

--- a/usr/src/uts/common/io/mac/mac_client.c
+++ b/usr/src/uts/common/io/mac/mac_client.c
@@ -3565,12 +3565,6 @@ mac_tx(mac_client_handle_t mch, mblk_t *mp_chain, uintptr_t hint,
 		obytes = (mp_chain->b_cont == NULL ? MBLKL(mp_chain) :
 		    msgdsize(mp_chain));
 
-		/*
-		 * There's a chance this primary client might be part
-		 * of a bridge and the packet forwarded to a local
-		 * receiver -- mark the packet accordingly.
-		 */
-		DB_CKSUMFLAGS(mp_chain) |= HW_LOCAL_MAC;
 		mp_chain = mac_provider_tx(mip, srs_tx->st_arg2, mp_chain,
 		    mcip);
 
@@ -4055,10 +4049,9 @@ mac_client_get_effective_resources(mac_client_handle_t mch,
  */
 static void
 mac_promisc_dispatch_one(mac_promisc_impl_t *mpip, mblk_t *mp,
-    boolean_t loopback)
+    boolean_t loopback, boolean_t local)
 {
 	mblk_t *mp_next;
-	boolean_t local = (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) != 0;
 
 	if (!mpip->mpi_no_copy || mpip->mpi_strip_vlan_tag ||
 	    (mpip->mpi_do_fixups && local)) {
@@ -4151,7 +4144,7 @@ mac_is_mcast(mac_impl_t *mip, mblk_t *mp)
  */
 void
 mac_promisc_dispatch(mac_impl_t *mip, mblk_t *mp_chain,
-    mac_client_impl_t *sender)
+    mac_client_impl_t *sender, boolean_t local)
 {
 	mac_promisc_impl_t *mpip;
 	mac_cb_t *mcb;
@@ -4192,7 +4185,8 @@ mac_promisc_dispatch(mac_impl_t *mip, mblk_t *mp_chain,
 			if (is_sender ||
 			    mpip->mpi_type == MAC_CLIENT_PROMISC_ALL ||
 			    is_mcast) {
-				mac_promisc_dispatch_one(mpip, mp, is_sender);
+				mac_promisc_dispatch_one(mpip, mp, is_sender,
+					local);
 			}
 		}
 	}
@@ -4222,7 +4216,8 @@ mac_promisc_client_dispatch(mac_client_impl_t *mcip, mblk_t *mp_chain)
 			mpip = (mac_promisc_impl_t *)mcb->mcb_objp;
 			if (mpip->mpi_type == MAC_CLIENT_PROMISC_FILTERED &&
 			    !is_mcast) {
-				mac_promisc_dispatch_one(mpip, mp, B_FALSE);
+				mac_promisc_dispatch_one(mpip, mp, B_FALSE,
+					B_FALSE);
 			}
 		}
 	}

--- a/usr/src/uts/common/io/mac/mac_provider.c
+++ b/usr/src/uts/common/io/mac/mac_provider.c
@@ -719,7 +719,7 @@ mac_trill_snoop(mac_handle_t mh, mblk_t *mp)
 	mac_impl_t *mip = (mac_impl_t *)mh;
 
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp, NULL);
+		mac_promisc_dispatch(mip, mp, NULL, B_FALSE);
 }
 
 /*
@@ -740,7 +740,7 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 	 * this MAC, pass them a copy if appropriate.
 	 */
 	if (mip->mi_promisc_list != NULL)
-		mac_promisc_dispatch(mip, mp_chain, NULL);
+		mac_promisc_dispatch(mip, mp_chain, NULL, B_FALSE);
 
 	if (mr != NULL) {
 		/*

--- a/usr/src/uts/common/io/mac/mac_sched.c
+++ b/usr/src/uts/common/io/mac/mac_sched.c
@@ -2314,7 +2314,7 @@ check_again:
 				if (smcip->mci_mip->mi_promisc_list != NULL) {
 					mutex_exit(lock);
 					mac_promisc_dispatch(smcip->mci_mip,
-					    head, NULL);
+					    head, NULL, B_FALSE);
 					mutex_enter(lock);
 				}
 			}
@@ -4341,14 +4341,6 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 			obytes += (mp->b_cont == NULL ? MBLKL(mp) :
 			    msgdsize(mp));
 
-			/*
-			 * Mark all packets as local so that a
-			 * receiver can determine if a packet arrived
-			 * from a local source or from the network.
-			 * This allows some consumers to avoid
-			 * unecessary work like checksum computation.
-			 */
-			DB_CKSUMFLAGS(mp) |= HW_LOCAL_MAC;
 			CHECK_VID_AND_ADD_TAG(mp);
 			mp = mac_provider_tx(mip, ring, mp, src_mcip);
 
@@ -4388,14 +4380,6 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 		pkt_size = (mp->b_cont == NULL ? MBLKL(mp) : msgdsize(mp));
 		obytes += pkt_size;
 		CHECK_VID_AND_ADD_TAG(mp);
-
-		/*
-		 * Mark all packets as local so that a receiver can
-		 * determine if a packet arrived from a local source
-		 * or from the network. This allows some consumers to
-		 * avoid unecessary work like checksum computation.
-		 */
-		DB_CKSUMFLAGS(mp) |= HW_LOCAL_MAC;
 
 		/*
 		 * Find the destination.
@@ -4443,17 +4427,21 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 				 * macro.
 				 */
 				if (mip->mi_promisc_list != NULL) {
-					mac_promisc_dispatch(mip, mp, src_mcip);
+					mac_promisc_dispatch(mip, mp, src_mcip,
+					    B_TRUE);
 				}
 
 				do_switch = ((src_mcip->mci_state_flags &
 				    dst_mcip->mci_state_flags &
 				    MCIS_CLIENT_POLL_CAPABLE) != 0);
 
-				(dst_flow_ent->fe_cb_fn)(
-				    dst_flow_ent->fe_cb_arg1,
-				    dst_flow_ent->fe_cb_arg2,
-				    mp, do_switch);
+				mac_hw_emul(&mp, NULL, NULL, MAC_ALL_EMULS);
+				if (mp != NULL) {
+					(dst_flow_ent->fe_cb_fn)(
+						dst_flow_ent->fe_cb_arg1,
+						dst_flow_ent->fe_cb_arg2,
+						mp, do_switch);
+				}
 
 			}
 			FLOW_REFRELE(dst_flow_ent);

--- a/usr/src/uts/common/io/mac/mac_util.c
+++ b/usr/src/uts/common/io/mac/mac_util.c
@@ -384,10 +384,6 @@ mac_sw_cksum(mblk_t *mp, mac_emul_t emul)
 
 	mac_hcksum_get(mp, &start, &stuff, &end, &value, NULL);
 
-	/*
-	 * We use DB_CKSUMFLAGS (instead of mac_hcksum_get()) because
-	 * we don't want to mask-out the HW_LOCAL_MAC flag.
-	 */
 	flags = DB_CKSUMFLAGS(mp);
 
 	/* Why call this if checksum emulation isn't needed? */
@@ -1307,14 +1303,17 @@ fail:
  * nothing for the caller to free. In any event, the caller shouldn't
  * assume that '*mp_chain' is non-NULL on return.
  *
- * This function was written with two main use cases in mind.
+ * This function was written with three main use cases in mind.
  *
- * 1. A way for MAC clients to emulate hardware offloads when they
- *    can't directly handle LSO packets or packets without fully
- *    calculated checksums.
+ * 1. To emulate hardware offloads when traveling mac-loopback (two
+ *    clients on the same mac). This is wired up in mac_tx_send().
  *
- * 2. A way for MAC to offer hardware offloads when the underlying
- *    hardware can't or won't.
+ * 2. To provide hardware offloads to the client when the underlying
+ *    provider cannot. This is currently wired up in mac_tx() but we
+ *    still only negotiate offloads when the underlying provider
+ *    supports them.
+ *
+ * 3. To emulate real hardware in simnet.
  */
 void
 mac_hw_emul(mblk_t **mp_chain, mblk_t **otail, uint_t *ocount, mac_emul_t emul)
@@ -1569,10 +1568,10 @@ mac_strip_vlan_tag_chain(mblk_t *mp_chain)
  */
 /* ARGSUSED */
 void
-mac_rx_def(void *arg, mac_resource_handle_t resource, mblk_t *mp,
+mac_rx_def(void *arg, mac_resource_handle_t resource, mblk_t *mp_chain,
     boolean_t loopback)
 {
-	freemsgchain(mp);
+	freemsgchain(mp_chain);
 }
 
 /*

--- a/usr/src/uts/common/sys/mac.h
+++ b/usr/src/uts/common/sys/mac.h
@@ -642,6 +642,8 @@ typedef enum mac_emul {
 } mac_emul_t;
 
 #define	MAC_HWCKSUM_EMULS	(MAC_HWCKSUM_EMUL | MAC_IPCKSUM_EMUL)
+#define	MAC_ALL_EMULS		(MAC_HWCKSUM_EMUL | MAC_IPCKSUM_EMUL | \
+				MAC_LSO_EMUL)
 
 /*
  * Driver interface functions.

--- a/usr/src/uts/common/sys/mac_client_impl.h
+++ b/usr/src/uts/common/sys/mac_client_impl.h
@@ -338,7 +338,8 @@ extern	int	mac_tx_percpu_cnt;
 extern void mac_promisc_client_dispatch(mac_client_impl_t *, mblk_t *);
 extern void mac_client_init(void);
 extern void mac_client_fini(void);
-extern void mac_promisc_dispatch(mac_impl_t *, mblk_t *, mac_client_impl_t *);
+extern void mac_promisc_dispatch(mac_impl_t *, mblk_t *, mac_client_impl_t *,
+    boolean_t);
 
 extern int mac_validate_props(mac_impl_t *, mac_resource_props_t *);
 

--- a/usr/src/uts/common/sys/pattr.h
+++ b/usr/src/uts/common/sys/pattr.h
@@ -109,25 +109,6 @@ typedef struct pattr_hcksum_s {
 #define	HW_LSO_FLAGS		HW_LSO	/* All LSO flags, currently only one */
 
 /*
- * The packet originates from a MAC on the same machine as the
- * receiving MAC. There are two ways this can happen.
- *
- * 1. MAC loopback: When a packet is destined for a MAC client on the
- *                  same MAC as the sender. This datapath is taken in
- *                  max_tx_send().
- *
- * 2. Bridge Fwd: When a packet is destined for a MAC client on the
- *                same bridge as the sender. This datapath is taken in
- *                bridge_forward().
- *
- * Presented with this flag, a receiver can then decide whether or not
- * it needs to emulate some or all of the HW offloads that the NIC
- * would have performed otherwise -- or whether it should accept the
- * packet as-is.
- */
-#define	HW_LOCAL_MAC		0x100
-
-/*
  * Structure used for zerocopy attribute.
  */
 typedef struct pattr_zcopy_s {

--- a/usr/src/uts/i86pc/io/viona/viona_main.c
+++ b/usr/src/uts/i86pc/io/viona/viona_main.c
@@ -470,7 +470,7 @@ viona_open(dev_t *devp, int flag, int otype, cred_t *credp)
 	}
 
 	minor = id_alloc_nosleep(viona_minors);
-	if (minor == 0) {
+	if (minor == -1) {
 		/* All minors are busy */
 		return (EBUSY);
 	}

--- a/usr/src/uts/i86pc/io/viona/viona_rx.c
+++ b/usr/src/uts/i86pc/io/viona/viona_rx.c
@@ -459,10 +459,6 @@ viona_rx_common(viona_vring_t *ring, mblk_t *mp, boolean_t is_loopback)
 	mblk_t *mpdrop = NULL, **mpdrop_prevp = &mpdrop;
 	const boolean_t do_merge =
 	    ((link->l_features & VIRTIO_NET_F_MRG_RXBUF) != 0);
-	const boolean_t guest_csum =
-	    ((link->l_features & VIRTIO_NET_F_GUEST_CSUM) != 0);
-	const boolean_t guest_tso4 =
-	    ((link->l_features & VIRTIO_NET_F_GUEST_TSO4) != 0);
 
 	size_t nrx = 0, ndrop = 0;
 

--- a/usr/src/uts/i86pc/io/viona/viona_rx.c
+++ b/usr/src/uts/i86pc/io/viona/viona_rx.c
@@ -466,49 +466,13 @@ viona_rx_common(viona_vring_t *ring, mblk_t *mp, boolean_t is_loopback)
 
 	size_t nrx = 0, ndrop = 0;
 
-	/*
-	 * The mac_hw_emul() function, by design, doesn't predicate on
-	 * HW_LOCAL_MAC. Since we are in Rx context we know that any
-	 * LSO packet must also be from a same-machine sender. We take
-	 * advantage of that and forgoe writing a manual loop to
-	 * predicate on HW_LOCAL_MAC.
-	 *
-	 * For checksum emulation we need to predicate on HW_LOCAL_MAC
-	 * to avoid calling mac_hw_emul() on packets that don't need
-	 * it (thanks to the fact that HCK_IPV4_HDRCKSUM and
-	 * HCK_IPV4_HDRCKSUM_OK use the same value). Therefore, we do
-	 * the checksum emulation in the second loop.
-	 */
-	if (!guest_tso4)
-		mac_hw_emul(&mp, NULL, NULL, MAC_LSO_EMUL);
-
 	while (mp != NULL) {
-		mblk_t *next, *pad = NULL;
-		size_t size;
+		mblk_t *next = mp->b_next;
+		mblk_t *pad = NULL;
+		size_t size = msgsize(mp);
 		int err = 0;
 
-		next = mp->b_next;
 		mp->b_next = NULL;
-
-		if (DB_CKSUMFLAGS(mp) & HW_LOCAL_MAC) {
-			/*
-			 * The VIRTIO_NET_HDR_F_DATA_VALID flag only
-			 * covers the ULP checksum -- so we still have
-			 * to populate the IP header checksum.
-			 */
-			if (guest_csum) {
-				mac_hw_emul(&mp, NULL, NULL, MAC_IPCKSUM_EMUL);
-			} else {
-				mac_hw_emul(&mp, NULL, NULL, MAC_HWCKSUM_EMUL);
-			}
-
-			if (mp == NULL) {
-				mp = next;
-				continue;
-			}
-		}
-
-		size = msgsize(mp);
 
 		/*
 		 * We treat both a 'drop' response and errors the same here


### PR DESCRIPTION
Weekly upstream for joyent_merge/2019111801

## Backports

None

## onu

```
bloody# uname -a
SunOS bloody 5.11 omnios-joyent_merge-2019111801-a2ef021faf i86pc i386 i86pc

bloody# /opt/net-tests/bin/nettest
Test: /opt/net-tests/tests/forwarding/ip_fwd_001 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_002 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_003 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_004 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_005 (run as root)    [00:31] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_006 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_007 (run as root)    [00:29] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_008 (run as root)    [00:31] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_009 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_010 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_011 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_012 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_013 (run as root)    [00:31] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_014 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_015 (run as root)    [00:30] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_016 (run as root)    [00:31] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_017 (run as root)    [00:29] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_018 (run as root)    [00:28] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_019 (run as root)    [00:31] [PASS]
Test: /opt/net-tests/tests/forwarding/ip_fwd_020 (run as root)    [00:29] [PASS]

Results Summary
PASS      20

Running Time: 00:10:10
Percent passed: 100.0%
```
## mail_msg

```

==== Nightly distributed build started:   Mon Nov 18 14:52:23 UTC 2019 ====
==== Nightly distributed build completed: Mon Nov 18 16:21:17 UTC 2019 ====

==== Total build time ====

real    1:28:54

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-389c028148 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.5.1-il-6

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151033-20190219"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   207

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2019111801-a2ef021faf

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    37:47.6
user  6:04:21.2
sys   1:07:56.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    34:10.3
user  5:32:11.9
sys     58:58.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
