### PR TITLE
12016 Use of GNU ld should explicitly specify the required output format

### DIFF
--- a/usr/src/boot/sys/boot/Makefile.inc
+++ b/usr/src/boot/sys/boot/Makefile.inc
@@ -12,6 +12,7 @@
 #
 # Copyright 2017 Toomas Soome <tsoome@me.com>
 # Copyright 2019 Joyent, Inc.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 # loader.help build needs better awk
@@ -20,6 +21,9 @@ LD=		$(GNU_ROOT)/bin/gld
 OBJCOPY=	$(GNU_ROOT)/bin/gobjcopy
 OBJDUMP=	$(GNU_ROOT)/bin/gobjdump
 GSTRIP=		$(GNU_ROOT)/bin/gstrip
+
+GLDTARGET=	-melf_i386_sol2
+LDFLAGS	+=	$(GLDTARGET)
 
 # Default Console font setup.
 # We want it to be the same as kernel.

--- a/usr/src/boot/sys/boot/i386/btx/btx/Makefile
+++ b/usr/src/boot/sys/boot/i386/btx/btx/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 include $(SRC)/Makefile.master
@@ -41,7 +42,7 @@ CPPFLAGS += -I./../../common
 
 ORG=	0x9000
 
-LDFLAGS=-e start -Ttext ${ORG} -N -S --oformat binary
+LDFLAGS=-e start -Ttext ${ORG} -N -S --oformat binary $(GLDTARGET)
 
 all install:	$(PROG)
 

--- a/usr/src/boot/sys/boot/i386/btx/btxldr/Makefile
+++ b/usr/src/boot/sys/boot/i386/btx/btxldr/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 include $(SRC)/Makefile.master
@@ -25,7 +26,7 @@ CPPFLAGS += -DLOADER_ADDRESS=${LOADER_ADDRESS}
 CPPFLAGS += -DBTXLDR_VERBOSE
 CPPFLAGS += -I./../../common
 
-LDFLAGS=-e start -Ttext ${LOADER_ADDRESS} -N -S --oformat binary
+LDFLAGS=-e start -Ttext ${LOADER_ADDRESS} -N -S --oformat binary $(GLDTARGET)
 
 all install:	$(PROG)
 

--- a/usr/src/boot/sys/boot/i386/btx/lib/Makefile
+++ b/usr/src/boot/sys/boot/i386/btx/lib/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 include $(SRC)/Makefile.master
@@ -23,7 +24,7 @@ PROG=	crt0.o
 SRCS=	btxcsu.S btxsys.s btxv86.s
 OBJS=	btxcsu.o btxsys.o btxv86.o
 
-LDFLAGS =-r
+LDFLAGS = -r $(GLDTARGET)
 
 all install: $(PROG)
 

--- a/usr/src/boot/sys/boot/i386/cdboot/Makefile
+++ b/usr/src/boot/sys/boot/i386/cdboot/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 include $(SRC)/Makefile.master
@@ -24,10 +25,9 @@ FILEMODE=0444
 SRCS=	${PROG}.S
 OBJS=	$(SRCS:%.S=%.o)
 
-
 ORG=	0x7c00
 
-LDFLAGS=-e start -Ttext $(ORG) -N -S --oformat binary
+LDFLAGS=-e start -Ttext $(ORG) -N -S --oformat binary $(GLDTARGET)
 
 all:	${PROG}
 

--- a/usr/src/boot/sys/boot/i386/pmbr/Makefile
+++ b/usr/src/boot/sys/boot/i386/pmbr/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -28,7 +29,7 @@ SRCS=	$(OBJS:%.o=%.s)
 
 ORG=	0x600
 
-LDFLAGS=-e start -Ttext ${ORG} -N -S --oformat binary
+LDFLAGS=-e start -Ttext ${ORG} -N -S --oformat binary $(GLDTARGET)
 
 all: $(PROG)
 

--- a/usr/src/grub/grub-0.97/Makefile.solaris.defs
+++ b/usr/src/grub/grub-0.97/Makefile.solaris.defs
@@ -2,6 +2,7 @@
 # Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 # Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 include $(SRC)/Makefile.master
 
@@ -70,6 +71,7 @@ CPPFLAGS	= $(DEFS) $(INCLUDES) $(WARNFLAGS) \
 		  $(t.ENVCPPFLAGS4:I,%=-nostdinc -isystem %)
 
 CCLD		= $(GNU_ROOT)/bin/gld
+GLDTARGET	= -melf_i386_sol2
 LDFLAGS		= $(BASE_LDFLAGS)
 LINKFLAGS	= -g
 LINK		= $(CCLD) $(LINKFLAGS) $(LDFLAGS)

--- a/usr/src/grub/grub-0.97/stage1/Makefile.solaris
+++ b/usr/src/grub/grub-0.97/stage1/Makefile.solaris
@@ -2,7 +2,7 @@
 # Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 include ../../Makefile.grub
 include ../Makefile.solaris.defs
@@ -13,10 +13,9 @@ include ../Makefile.solaris.defs
 .exec:
 	$(OBJCOPY) -O binary $< $@
 
-
 INCLUDES	= -I. -I..
 CCASFLAGS	+= -O2 -fno-builtin -nostdinc
-LDFLAGS		+= -nostdlib -N -Ttext 7C00
+LDFLAGS		+= -nostdlib -N -Ttext 7C00 $(GLDTARGET)
 LIBS		=
 
 

--- a/usr/src/grub/grub-0.97/stage2/Makefile.solaris
+++ b/usr/src/grub/grub-0.97/stage2/Makefile.solaris
@@ -4,6 +4,7 @@
 # Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
 # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 include ../../Makefile.grub
 include ../Makefile.solaris.defs
@@ -43,12 +44,12 @@ STAGE2_CFLAGS	= -Os -fno-builtin -nostdinc \
 $(STAGE2_NETBOOT)STAGE2_CFLAGS	+= $(NETBOOT_CFLAGS)
 #STAGE2_CFLAGS	+= $(HERCULES_CFLAGS)
 
-NBLOADER_LINK	= -nostdlib -N -Ttext 0
-PRE_STAGE2_LINK	= -nostdlib -N -Ttext 8200
-PXELOADER_LINK	= -nostdlib -N -Ttext 7C00
-STAGE1_5_LINK	= -nostdlib -N -Ttext 2000
-START_ELTORITO_LINK = -nostdlib -N -Ttext 7C00
-START_LINK	= -nostdlib -N -Ttext 8000
+NBLOADER_LINK	= -nostdlib -N -Ttext 0 $(GLDTARGET)
+PRE_STAGE2_LINK	= -nostdlib -N -Ttext 8200 $(GLDTARGET)
+PXELOADER_LINK	= -nostdlib -N -Ttext 7C00 $(GLDTARGET)
+STAGE1_5_LINK	= -nostdlib -N -Ttext 2000 $(GLDTARGET)
+START_ELTORITO_LINK = -nostdlib -N -Ttext 7C00 $(GLDTARGET)
+START_LINK	= -nostdlib -N -Ttext 8000 $(GLDTARGET)
 
 LIBDRIVERS	= ../netboot/libdrivers.a
 
@@ -446,13 +447,13 @@ REISERFS_STAGE1_5_OBJS  = reiserfs_stage1_5_exec-bios.o \
 			  reiserfs_stage1_5_exec-fsys_reiserfs.o \
 			  reiserfs_stage1_5_exec-moddiv.o \
 			  reiserfs_stage1_5_exec-stage1_5.o
- 
+
 $(REISERFS_STAGE1_5_EXEC) := LDFLAGS = $(BASE_LDFLAGS) $(STAGE1_5_LINK)
- 
+
 $(REISERFS_STAGE1_5_ASMOBJS) := CCASFLAGS = $(BASE_CCASFLAGS) \
 				$(STAGE1_5_CFLAGS) \
 				-DFSYS_REISERFS=1 -DNO_BLOCK_FILES=1
- 
+
 $(REISERFS_STAGE1_5_OBJS) := CFLAGS = $(BASE_CFLAGS) $(STAGE1_5_CFLAGS)	\
 				-DFSYS_REISERFS=1 -DNO_BLOCK_FILES=1
 
@@ -678,7 +679,7 @@ $(LIBGRUB_OBJS): $$(@:libgrub_a-%.o=%.c)
 #
 # Diskless
 #
-$(DISKLESS_EXEC): $(DISKLESS_ASMOBJS) $(DISKLESS_OBJS) 
+$(DISKLESS_EXEC): $(DISKLESS_ASMOBJS) $(DISKLESS_OBJS)
 	$(RM) $@
 	$(LINK) -o $@ $(DISKLESS_ASMOBJS) $(DISKLESS_OBJS) $(LIBS)
 


### PR DESCRIPTION
Now that GNU binutils targets 64-bit by default, we need to specify 32-bit (elf_i386_sol2) output when we want it.