### PR TITLE
Upstream merge/2019112701

### DIFF
--- a/usr/src/boot/sys/boot/efi/libefi/efipart.c
+++ b/usr/src/boot/sys/boot/efi/libefi/efipart.c
@@ -299,11 +299,14 @@ efipart_floppy(EFI_DEVICE_PATH *node)
 static pdinfo_t *
 efipart_find_parent(pdinfo_list_t *pdi, EFI_DEVICE_PATH *devpath)
 {
-	pdinfo_t *pd;
+	pdinfo_t *pd, *part;
 
 	STAILQ_FOREACH(pd, pdi, pd_link) {
 		if (efi_devpath_is_prefix(pd->pd_devpath, devpath))
 			return (pd);
+		part = efipart_find_parent(&pd->pd_part, devpath);
+		if (part != NULL)
+			return (part);
 	}
 	return (NULL);
 }
@@ -486,21 +489,64 @@ efipart_initcd(void)
 	return (0);
 }
 
-static void
-efipart_hdinfo_add(pdinfo_t *hd, HARDDRIVE_DEVICE_PATH *node)
+static bool
+efipart_hdinfo_add_node(pdinfo_t *hd, EFI_DEVICE_PATH *node)
 {
-	pdinfo_t *pd, *last;
+	pdinfo_t *pd, *ptr;
 
+	if (node == NULL)
+		return (false);
+
+	/* Find our disk device. */
 	STAILQ_FOREACH(pd, &hdinfo, pd_link) {
-		if (efi_devpath_is_prefix(pd->pd_devpath, hd->pd_devpath)) {
-			/* Add the partition. */
-			hd->pd_unit = node->PartitionNumber;
-			hd->pd_parent = pd;
-			hd->pd_devsw = &efipart_hddev;
-			STAILQ_INSERT_TAIL(&pd->pd_part, hd, pd_link);
-			return;
-		}
+		if (efi_devpath_is_prefix(pd->pd_devpath, hd->pd_devpath))
+			break;
 	}
+	if (pd == NULL)
+		return (false);
+
+	/* If the node is not MEDIA_HARDDRIVE_DP, it is sub-partition. */
+	if (DevicePathSubType(node) != MEDIA_HARDDRIVE_DP) {
+		STAILQ_FOREACH(ptr, &pd->pd_part, pd_link) {
+			if (efi_devpath_is_prefix(ptr->pd_devpath,
+			    hd->pd_devpath))
+				break;
+		}
+		/*
+		 * If we don't find a pdinfo_t for this node, then that
+		 * means that the partition list we got from firmware isn't
+		 * properly ordered. We assume that firmware has ordered it.
+		 * In case we don't find anything, rather than blow up, we
+		 * add this node as another partition.
+		 */
+		if (ptr != NULL)
+			pd = ptr;
+
+		/* Add the partition. */
+		ptr = STAILQ_LAST(&pd->pd_part, pdinfo, pd_link);
+		if (ptr != NULL)
+			hd->pd_unit = ptr->pd_unit + 1;
+		else
+			hd->pd_unit = 0;
+	} else {
+		/* Add the partition. */
+		hd->pd_unit = ((HARDDRIVE_DEVICE_PATH *)node)->PartitionNumber;
+	}
+
+	hd->pd_parent = pd;
+	hd->pd_devsw = &efipart_hddev;
+
+	STAILQ_INSERT_TAIL(&pd->pd_part, hd, pd_link);
+	return (true);
+}
+
+static void
+efipart_hdinfo_add(pdinfo_t *hd, EFI_DEVICE_PATH *node)
+{
+	pdinfo_t *last;
+
+	if (efipart_hdinfo_add_node(hd, node))
+		return;
 
 	last = STAILQ_LAST(&hdinfo, pdinfo, pd_link);
 	if (last != NULL)
@@ -663,7 +709,7 @@ restart:
 			efipart_hdinfo_add(parent, NULL);
 		}
 
-		efipart_hdinfo_add(hd, (HARDDRIVE_DEVICE_PATH *)node);
+		efipart_hdinfo_add(hd, node);
 		goto restart;
 	}
 }

--- a/usr/src/cmd/format/io.c
+++ b/usr/src/cmd/format/io.c
@@ -38,6 +38,7 @@
 #include <sys/tty.h>
 #include <sys/termio.h>
 #include <sys/termios.h>
+#include <sys/efi_partition.h>
 
 #include "startup.h"
 #include "misc.h"
@@ -1556,8 +1557,11 @@ or g(gigabytes)\n");
 		 * either blocks/cyls/megabytes - a convenient fiction.
 		 */
 		if (strcmp(cleantoken, WILD_STRING) == 0) {
-			return (bounds->upper - EFI_MIN_RESV_SIZE -
-			    efi_deflt->start_sector);
+			uint64_t reserved;
+
+			reserved = efi_reserved_sectors(cur_parts->etoc);
+			return (bounds->upper - reserved -
+			    efi_deflt->start_sector + 1);
 		}
 
 		/*

--- a/usr/src/cmd/format/label.c
+++ b/usr/src/cmd/format/label.c
@@ -55,40 +55,22 @@
 #define	WD_NODE		7
 #endif
 
-#ifdef	__STDC__
-/*
- * Prototypes for ANSI C compilers
- */
 static int	do_geometry_sanity_check(void);
-static int	vtoc_to_label(struct dk_label *label, struct extvtoc *vtoc,
-		struct dk_geom *geom, struct dk_cinfo *cinfo);
+static int	vtoc_to_label(struct dk_label *, struct extvtoc *,
+		struct dk_geom *, struct dk_cinfo *);
 extern int	read_extvtoc(int, struct extvtoc *);
 extern int	write_extvtoc(int, struct extvtoc *);
 static int	vtoc64_to_label(struct efi_info *, struct dk_gpt *);
 
-#else	/* __STDC__ */
-
-/*
- * Prototypes for non-ANSI C compilers
- */
-static int	do_geometry_sanity_check();
-static int	vtoc_to_label();
-extern int	read_extvtoc();
-extern int	write_extvtoc();
-static int	vtoc64_to_label();
-
-#endif	/* __STDC__ */
-
 #ifdef	DEBUG
-static void dump_label(struct dk_label *label);
+static void dump_label(struct dk_label *);
 #endif
 
 /*
  * This routine checks the given label to see if it is valid.
  */
 int
-checklabel(label)
-	register struct dk_label *label;
+checklabel(struct dk_label *label)
 {
 
 	/*
@@ -109,12 +91,10 @@ checklabel(label)
  * the mode it is called in.
  */
 int
-checksum(label, mode)
-	struct	dk_label *label;
-	int	mode;
+checksum(struct	dk_label *label, int mode)
 {
-	register short *sp, sum = 0;
-	register short count = (sizeof (struct dk_label)) / (sizeof (short));
+	short *sp, sum = 0;
+	short count = (sizeof (struct dk_label)) / (sizeof (short));
 
 	/*
 	 * If we are generating a checksum, don't include the checksum
@@ -152,10 +132,9 @@ checksum(label, mode)
  * and truncate it there.
  */
 int
-trim_id(id)
-	char	*id;
+trim_id(char *id)
 {
-	register char *c;
+	char *c;
 
 	/*
 	 * Start at the end of the string.  When we match the word ' cyl',
@@ -167,7 +146,8 @@ trim_id(id)
 			 * Remove any white space.
 			 */
 			for (; (((*(c - 1) == ' ') || (*(c - 1) == '\t')) &&
-				(c >= id)); c--);
+			    (c >= id)); c--)
+				;
 			break;
 		}
 	}
@@ -222,13 +202,15 @@ int
 SMI_vtoc_to_EFI(int fd, struct dk_gpt **new_vtoc)
 {
 	int i;
-	struct dk_gpt	*efi;
+	struct dk_gpt *efi;
+	uint64_t reserved;
 
 	if (efi_alloc_and_init(fd, EFI_NUMPAR, new_vtoc) != 0) {
 		err_print("SMI vtoc to EFI failed\n");
 		return (-1);
 	}
 	efi = *new_vtoc;
+	reserved = efi_reserved_sectors(efi);
 
 	/*
 	 * create a clear EFI partition table:
@@ -239,7 +221,7 @@ SMI_vtoc_to_EFI(int fd, struct dk_gpt **new_vtoc)
 	efi->efi_parts[0].p_tag = V_USR;
 	efi->efi_parts[0].p_start = efi->efi_first_u_lba;
 	efi->efi_parts[0].p_size = efi->efi_last_u_lba - efi->efi_first_u_lba
-	    - EFI_MIN_RESV_SIZE + 1;
+	    - reserved + 1;
 
 	/*
 	 * s1-s6 are unassigned slices
@@ -255,8 +237,8 @@ SMI_vtoc_to_EFI(int fd, struct dk_gpt **new_vtoc)
 	 */
 	efi->efi_parts[efi->efi_nparts - 1].p_tag = V_RESERVED;
 	efi->efi_parts[efi->efi_nparts - 1].p_start =
-	    efi->efi_last_u_lba - EFI_MIN_RESV_SIZE + 1;
-	efi->efi_parts[efi->efi_nparts - 1].p_size = EFI_MIN_RESV_SIZE;
+	    efi->efi_last_u_lba - reserved + 1;
+	efi->efi_parts[efi->efi_nparts - 1].p_size = reserved;
 
 	return (0);
 }
@@ -1001,14 +983,16 @@ is_efi_type(int fd)
 void
 err_check(struct dk_gpt *vtoc)
 {
-	int			resv_part = -1;
-	int			i, j;
-	diskaddr_t		istart, jstart, isize, jsize, endsect;
-	int			overlap = 0;
+	int		resv_part = -1;
+	int		i, j;
+	diskaddr_t	istart, jstart, isize, jsize, endsect;
+	int		overlap = 0;
+	uint_t		reserved;
 
 	/*
 	 * make sure no partitions overlap
 	 */
+	reserved = efi_reserved_sectors(vtoc);
 	for (i = 0; i < vtoc->efi_nparts; i++) {
 		/* It can't be unassigned and have an actual size */
 		if ((vtoc->efi_parts[i].p_tag == V_UNASSIGNED) &&
@@ -1026,10 +1010,10 @@ err_check(struct dk_gpt *vtoc)
 "found duplicate reserved partition at %d\n", i);
 			}
 			resv_part = i;
-			if (vtoc->efi_parts[i].p_size != EFI_MIN_RESV_SIZE)
+			if (vtoc->efi_parts[i].p_size != reserved)
 				(void) fprintf(stderr,
-"Warning: reserved partition size must be %d sectors\n",
-				    EFI_MIN_RESV_SIZE);
+"Warning: reserved partition size must be %u sectors\n",
+				    reserved);
 		}
 		if ((vtoc->efi_parts[i].p_start < vtoc->efi_first_u_lba) ||
 		    (vtoc->efi_parts[i].p_start > vtoc->efi_last_u_lba)) {
@@ -1088,8 +1072,7 @@ err_check(struct dk_gpt *vtoc)
 
 #ifdef	DEBUG
 static void
-dump_label(label)
-	struct dk_label	*label;
+dump_label(struct dk_label *label)
 {
 	int		i;
 
@@ -1141,8 +1124,8 @@ dump_label(label)
 
 #if defined(_SUNOS_VTOC_8)
 		fmt_print("%c:        cyl=%d, blocks=%d", i+'a',
-			label->dkl_map[i].dkl_cylno,
-			label->dkl_map[i].dkl_nblk);
+		    label->dkl_map[i].dkl_cylno,
+		    label->dkl_map[i].dkl_nblk);
 
 #elif defined(_SUNOS_VTOC_16)
 		fmt_print("%c:        start=%u, blocks=%u", i+'a',
@@ -1153,8 +1136,8 @@ dump_label(label)
 #endif				/* defined(_SUNOS_VTOC_8) */
 
 		fmt_print(",  tag=%d,  flag=%d",
-			label->dkl_vtoc.v_part[i].p_tag,
-			label->dkl_vtoc.v_part[i].p_flag);
+		    label->dkl_vtoc.v_part[i].p_tag,
+		    label->dkl_vtoc.v_part[i].p_flag);
 		fmt_print("\n");
 	}
 

--- a/usr/src/cmd/format/menu_command.c
+++ b/usr/src/cmd/format/menu_command.c
@@ -575,7 +575,9 @@ c_type()
 		new_partitiontable(tptr, oldtype);
 	} else if ((index == other_choice) && (cur_label == L_TYPE_EFI)) {
 		uint64_t start_lba = cur_parts->etoc->efi_first_u_lba;
+		uint64_t reserved;
 
+		reserved = efi_reserved_sectors(cur_parts->etoc);
 		maxLBA = get_mlba();
 		cur_parts->etoc->efi_last_lba = maxLBA;
 		cur_parts->etoc->efi_last_u_lba = maxLBA - start_lba;
@@ -585,8 +587,8 @@ c_type()
 			cur_parts->etoc->efi_parts[i].p_tag = V_UNASSIGNED;
 		}
 		cur_parts->etoc->efi_parts[8].p_start =
-		    maxLBA - start_lba - (1024 * 16);
-		cur_parts->etoc->efi_parts[8].p_size = (1024 * 16);
+		    maxLBA - start_lba - reserved;
+		cur_parts->etoc->efi_parts[8].p_size = reserved;
 		cur_parts->etoc->efi_parts[8].p_tag = V_RESERVED;
 		if (write_label()) {
 			err_print("Write label failed\n");

--- a/usr/src/cmd/format/menu_partition.c
+++ b/usr/src/cmd/format/menu_partition.c
@@ -380,7 +380,7 @@ p_name()
  * for all the partitions in the current partition map.
  */
 int
-p_print()
+p_print(void)
 {
 	/*
 	 * check if there exists a partition table for the disk.
@@ -411,13 +411,16 @@ p_print()
 		fmt_print("Total disk cylinders available: %d + %d "
 		    "(reserved cylinders)\n\n", ncyl, acyl);
 	} else if (cur_label == L_TYPE_EFI) {
+		unsigned reserved;
+
+		reserved = efi_reserved_sectors(cur_parts->etoc);
 		fmt_print("Current partition table (%s):\n",
 		    cur_parts->pinfo_name != NULL ?
 		    cur_parts->pinfo_name : "unnamed");
-		fmt_print("Total disk sectors available: %llu + %d "
+		fmt_print("Total disk sectors available: %llu + %u "
 		    "(reserved sectors)\n\n",
-		    cur_parts->etoc->efi_last_u_lba - EFI_MIN_RESV_SIZE -
-		    cur_parts->etoc->efi_first_u_lba + 1, EFI_MIN_RESV_SIZE);
+		    cur_parts->etoc->efi_last_u_lba - reserved -
+		    cur_parts->etoc->efi_first_u_lba + 1, reserved);
 	}
 
 

--- a/usr/src/cmd/format/modify_partition.c
+++ b/usr/src/cmd/format/modify_partition.c
@@ -560,53 +560,54 @@ get_user_map_efi(map, float_part)
 	char		tmpstr[80];
 	uint64_t	i64;
 	uint64_t	start_lba = map->efi_first_u_lba;
+	uint64_t	reserved;
 
+	reserved = efi_reserved_sectors(map);
 	for (i = 0; i < map->efi_nparts - 1; i++) {
-		if (i == float_part)
+		/* GPT partition 7 is whole disk device, minor node "wd" */
+		if (i == float_part || i == 7)
 			continue;
-		else {
-			ioparam.io_bounds.lower = start_lba;
-			ioparam.io_bounds.upper = map->efi_last_u_lba;
-			efi_deflt.start_sector = ioparam.io_bounds.lower;
-			efi_deflt.end_sector = map->efi_parts[i].p_size;
-			(void) sprintf(tmpstr,
-			    "Enter size of partition %d ", i);
-			i64 = input(FIO_EFI, tmpstr, ':',
-			    &ioparam, (int *)&efi_deflt, DATA_INPUT);
-			if (i64 == 0) {
-			    map->efi_parts[i].p_tag = V_UNASSIGNED;
-			} else if ((i64 != 0) && (map->efi_parts[i].p_tag ==
-				V_UNASSIGNED)) {
-			    map->efi_parts[i].p_tag = V_USR;
-			}
-			if (i64 == 0) {
-			    map->efi_parts[i].p_start = 0;
-			} else {
-			    map->efi_parts[i].p_start = start_lba;
-			}
-			map->efi_parts[i].p_size = i64;
-			start_lba += i64;
+
+		ioparam.io_bounds.lower = start_lba;
+		ioparam.io_bounds.upper = map->efi_last_u_lba;
+		efi_deflt.start_sector = ioparam.io_bounds.lower;
+		efi_deflt.end_sector = map->efi_parts[i].p_size;
+		(void) sprintf(tmpstr, "Enter size of partition %d ", i);
+		i64 = input(FIO_EFI, tmpstr, ':',
+		    &ioparam, (int *)&efi_deflt, DATA_INPUT);
+		if (i64 == 0) {
+			map->efi_parts[i].p_tag = V_UNASSIGNED;
+		} else if ((i64 != 0) && (map->efi_parts[i].p_tag ==
+		    V_UNASSIGNED)) {
+			map->efi_parts[i].p_tag = V_USR;
+		}
+		if (i64 == 0) {
+			map->efi_parts[i].p_start = 0;
+		} else {
+			map->efi_parts[i].p_start = start_lba;
+		}
+		map->efi_parts[i].p_size = i64;
+		start_lba += i64;
+	}
+	map->efi_parts[float_part].p_start = start_lba;
+	map->efi_parts[float_part].p_size = map->efi_last_u_lba + 1 -
+		start_lba - reserved;
+	map->efi_parts[float_part].p_tag = V_USR;
+	if (map->efi_parts[float_part].p_size == 0) {
+		map->efi_parts[float_part].p_size = 0;
+		map->efi_parts[float_part].p_start = 0;
+		map->efi_parts[float_part].p_tag = V_UNASSIGNED;
+		fmt_print("Warning: No space left for HOG\n");
+	}
+
+	for (i = 0; i < map->efi_nparts; i++) {
+		if (map->efi_parts[i].p_tag == V_RESERVED) {
+			map->efi_parts[i].p_start = map->efi_last_u_lba -
+			    reserved + 1;
+			map->efi_parts[i].p_size = reserved;
+			break;
 		}
 	}
-		map->efi_parts[float_part].p_start = start_lba;
-		map->efi_parts[float_part].p_size = map->efi_last_u_lba -
-			start_lba - (1024 * 16);
-		map->efi_parts[float_part].p_tag = V_USR;
-		if (map->efi_parts[float_part].p_size == UINT_MAX64) {
-			map->efi_parts[float_part].p_size = 0;
-			map->efi_parts[float_part].p_start = 0;
-			map->efi_parts[float_part].p_tag = V_UNASSIGNED;
-			fmt_print("Warning: No space left for HOG\n");
-		}
-
-		for (i = 0; i < map->efi_nparts; i++) {
-		    if (map->efi_parts[i].p_tag == V_RESERVED) {
-			map->efi_parts[i].p_start = map->efi_last_u_lba -
-			    (1024 * 16);
-			map->efi_parts[i].p_size = (1024 * 16);
-			break;
-		    }
-		}
 }
 
 

--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -448,7 +448,8 @@ dump_zap(objset_t *os, uint64_t object, void *data, size_t size)
 			    strcmp(attr.za_name,
 			    DSL_CRYPTO_KEY_HMAC_KEY) == 0 ||
 			    strcmp(attr.za_name, DSL_CRYPTO_KEY_IV) == 0 ||
-			    strcmp(attr.za_name, DSL_CRYPTO_KEY_MAC) == 0) {
+			    strcmp(attr.za_name, DSL_CRYPTO_KEY_MAC) == 0 ||
+			    strcmp(attr.za_name, DMU_POOL_CHECKSUM_SALT) == 0) {
 				uint8_t *u8 = prop;
 
 				for (i = 0; i < attr.za_num_integers; i++) {

--- a/usr/src/lib/fm/topo/libtopo/common/libtopo.h
+++ b/usr/src/lib/fm/topo/libtopo/common/libtopo.h
@@ -23,7 +23,7 @@
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _LIBTOPO_H
@@ -293,6 +293,7 @@ typedef enum topo_hdl_errno {
 
 extern const char *topo_strerror(int);
 extern void topo_hdl_strfree(topo_hdl_t *, char *);
+extern void topo_hdl_strfreev(topo_hdl_t *, char **, uint_t);
 extern void topo_debug_set(topo_hdl_t *, const char *, const char *);
 
 /*

--- a/usr/src/lib/fm/topo/libtopo/common/mapfile-vers
+++ b/usr/src/lib/fm/topo/libtopo/common/mapfile-vers
@@ -20,7 +20,7 @@
 #
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2019, Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 
 #
@@ -77,6 +77,7 @@ SYMBOL_VERSION SUNWprivate {
 	topo_hdl_prominfo;
 	topo_hdl_strdup;
 	topo_hdl_strfree;
+	topo_hdl_strfreev;
 	topo_hdl_zalloc;
 	topo_led_state_name;
 	topo_led_type_name;
@@ -125,6 +126,7 @@ SYMBOL_VERSION SUNWprivate {
 	topo_mod_str2nvl;
 	topo_mod_strdup;
 	topo_mod_strfree;
+	topo_mod_strfreev;
 	topo_mod_unload;
 	topo_mod_unregister;
 	topo_mod_walk_init;

--- a/usr/src/lib/fm/topo/libtopo/common/topo_2xml.c
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_2xml.c
@@ -318,10 +318,7 @@ txml_print_prop(topo_hdl_t *thp, FILE *fp, tnode_t *node, const char *pgname,
 				begin_end_element(fp, Propitem, Value, val[i],
 				    NULL);
 			}
-			for (uint_t i = 0; i < nelem; i++) {
-				topo_hdl_strfree(thp, val[i]);
-			}
-			topo_hdl_free(thp, val, nelem * sizeof (char *));
+			topo_hdl_strfreev(thp, val, nelem);
 
 			end_element(fp, Propval);
 			break;

--- a/usr/src/lib/fm/topo/libtopo/common/topo_mod.h
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_mod.h
@@ -23,7 +23,7 @@
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _TOPO_MOD_H
@@ -220,6 +220,7 @@ extern void *topo_mod_zalloc(topo_mod_t *, size_t);
 extern void topo_mod_free(topo_mod_t *, void *, size_t);
 extern char *topo_mod_strdup(topo_mod_t *, const char *);
 extern void topo_mod_strfree(topo_mod_t *, char *);
+extern void topo_mod_strfreev(topo_mod_t *, char **, uint_t);
 extern int topo_mod_nvalloc(topo_mod_t *, nvlist_t **, uint_t);
 extern int topo_mod_nvdup(topo_mod_t *, nvlist_t *, nvlist_t **);
 

--- a/usr/src/lib/fm/topo/libtopo/common/topo_mod.map
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_mod.map
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2019, Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 # CDDL HEADER START
 #
@@ -40,6 +40,7 @@ SYMBOL_SCOPE {
 	topo_mod_nvalloc		{ TYPE = FUNCTION; FLAGS = extern };
 	topo_mod_nvdup			{ TYPE = FUNCTION; FLAGS = extern };
 	topo_mod_strfree		{ TYPE = FUNCTION; FLAGS = extern };
+	topo_mod_strfreev		{ TYPE = FUNCTION; FLAGS = extern };
 	topo_mod_strdup			{ TYPE = FUNCTION; FLAGS = extern };
 
 	topo_mod_clrdebug		{ TYPE = FUNCTION; FLAGS = extern };

--- a/usr/src/lib/fm/topo/libtopo/common/topo_string.c
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_string.c
@@ -23,8 +23,9 @@
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
 
 #include <strings.h>
 #include <ctype.h>
@@ -55,6 +56,15 @@ topo_hdl_strfree(topo_hdl_t *thp, char *s)
 		topo_hdl_free(thp, s, strlen(s) + 1);
 }
 
+void
+topo_hdl_strfreev(topo_hdl_t *thp, char **strarr, uint_t nelem)
+{
+	for (uint_t i = 0; i < nelem; i++)
+		topo_hdl_strfree(thp, strarr[i]);
+
+	topo_hdl_free(thp, strarr, (nelem * sizeof (char *)));
+}
+
 char *
 topo_mod_strdup(topo_mod_t *mod, const char *s)
 {
@@ -65,6 +75,12 @@ void
 topo_mod_strfree(topo_mod_t *mod, char *s)
 {
 	topo_hdl_strfree(mod->tm_hdl, s);
+}
+
+void
+topo_mod_strfreev(topo_mod_t *mod, char **strarr, uint_t nelem)
+{
+	topo_hdl_strfreev(mod->tm_hdl, strarr, nelem);
 }
 
 const char *

--- a/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #include <libxml/parser.h>
@@ -54,16 +54,6 @@ static int fac_enum_process(topo_mod_t *, xmlNodePtr, tnode_t *);
 static int decorate_nodes(topo_mod_t *, tf_rdata_t *, xmlNodePtr, tnode_t *,
     tf_pad_t **);
 
-
-static void
-strarr_free(topo_mod_t *mod, char **arr, uint_t nelems)
-{
-	int i;
-
-	for (i = 0; i < nelems; i++)
-		topo_mod_strfree(mod, arr[i]);
-	topo_mod_free(mod, arr, (nelems * sizeof (char *)));
-}
 
 int
 xmlattr_to_stab(topo_mod_t *mp, xmlNodePtr n, const char *stabname,
@@ -388,7 +378,7 @@ xlate_common(topo_mod_t *mp, xmlNodePtr xn, topo_type_t ptype, nvlist_t *nvl,
 		}
 
 		rv = nvlist_add_string_array(nvl, name, strarrbuf, nelems);
-		strarr_free(mp, strarrbuf, nelems);
+		topo_mod_strfreev(mp, strarrbuf, nelems);
 		break;
 	case TOPO_TYPE_FMRI_ARRAY:
 		if ((nvlarrbuf = topo_mod_alloc(mp, (nelems *

--- a/usr/src/lib/fm/topo/modules/i86pc/chip/chip_serial.c
+++ b/usr/src/lib/fm/topo/modules/i86pc/chip/chip_serial.c
@@ -23,6 +23,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -144,7 +147,7 @@ ipmi_serial_lookup(topo_mod_t *mod, char *ipmi_tag, char *buf)
 	 * The components are:
 	 *
 	 * yyyy: JEDEC ID in hex (2 byte manufacture ID, 2 byte continuation
-	 * 		code).
+	 *	code).
 	 *
 	 * ll:   The memory module's manufacturing location.
 	 *
@@ -233,9 +236,7 @@ get_dimm_serial(topo_mod_t *mod, tnode_t *node, topo_version_t vers,
 		/* topo errno already set */
 		rv = -1;
 	}
-	for (i = 0; i < nelems; i++)
-		topo_mod_strfree(mod, entity_refs[i]);
-	topo_mod_free(mod, entity_refs, (nelems * sizeof (char *)));
+	topo_mod_strfreev(mod, entity_refs, nelems);
 
 	return (rv);
 }

--- a/usr/src/lib/fm/topo/modules/sun4v/platform-mem/mem.c
+++ b/usr/src/lib/fm/topo/modules/sun4v/platform-mem/mem.c
@@ -24,6 +24,9 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
 
 #include <strings.h>
 #include <umem.h>
@@ -207,18 +210,6 @@ mem_replaced(topo_mod_t *mod, tnode_t *node, topo_version_t vers,
 	}
 
 	return (0);
-}
-
-void
-mem_strarray_free(topo_mod_t *mod, char **arr, size_t dim)
-{
-	int i;
-
-	for (i = 0; i < dim; i++) {
-		if (arr[i] != NULL)
-			topo_mod_strfree(mod, arr[i]);
-	}
-	topo_mod_free(mod, arr, sizeof (char *) * dim);
 }
 
 /*

--- a/usr/src/man/man2/mmap.2
+++ b/usr/src/man/man2/mmap.2
@@ -45,12 +45,12 @@
 .\" Copyright (c) 2009, Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright 2013 OmniTI Computer Consulting, Inc. All Rights Reserved.
 .\" Copyright 2016 James S Blachly, MD. All Rights Reserved.
+.\" Copyright 2019 Joyent, Inc.
 .\"
-.TH MMAP 2 "August 29, 2016"
+.TH MMAP 2 "Nov 19, 2019"
 .SH NAME
 mmap \- map pages of memory
 .SH SYNOPSIS
-.LP
 .nf
 #include <sys/mman.h>
 
@@ -59,7 +59,6 @@ mmap \- map pages of memory
 .fi
 
 .SH DESCRIPTION
-.LP
 The \fBmmap()\fR function establishes a mapping between a process's address
 space and a file or shared memory object. The format of the call is as follows:
 .sp
@@ -71,7 +70,7 @@ space and a file or shared memory object. The format of the call is as follows:
 The \fBmmap()\fR function establishes a mapping between the address space of
 the process at an address \fIpa\fR for \fIlen\fR bytes to the memory object
 represented by the file descriptor \fIfildes\fR at offset \fIoff\fR for
-\fIlen\fR bytes. The value of \fIpa\fR is a function of the  \fIaddr\fR
+\fIlen\fR bytes. The value of \fIpa\fR is a function of the \fIaddr\fR
 argument and values of \fIflags\fR, further described below. A successful
 \fBmmap()\fR call returns \fIpa\fR as its result. The address range starting at
 \fIpa\fR and continuing for \fIlen\fR bytes will be legitimate for the possible
@@ -105,7 +104,7 @@ The \fBmmap()\fR function is supported for regular files and shared memory
 objects. Support for any other type of file is unspecified.
 .sp
 .LP
-The  \fIprot\fR argument determines whether read, write, execute, or some
+The \fIprot\fR argument determines whether read, write, execute, or some
 combination of accesses are permitted to the data being mapped. The \fIprot\fR
 argument should be either \fBPROT_NONE\fR or the bitwise inclusive \fBOR\fR of
 one or more of the other flags in the following table, defined in the header
@@ -165,7 +164,7 @@ descriptor \fIfildes\fR with write permission unless \fBMAP_PRIVATE\fR is
 specified in the \fIflags\fR argument as described below.
 .sp
 .LP
-The  \fIflags\fR argument provides other information about the handling of the
+The \fIflags\fR argument provides other information about the handling of the
 mapped data. The value of \fIflags\fR is the bitwise inclusive \fBOR\fR of
 these options, defined in <\fBsys/mman.h\fR>:
 .sp
@@ -304,7 +303,7 @@ data or stack "segments".
 When \fBMAP_ALIGN\fR is set, the system is informed that the alignment of
 \fIpa\fR must be the same as \fIaddr\fR. The alignment value in \fIaddr\fR must
 be 0 or some power of two multiple of page size as returned by
-\fBsysconf\fR(3C). If addr is 0, the system will choose a suitable  alignment.
+\fBsysconf\fR(3C). If addr is 0, the system will choose a suitable alignment.
 .sp
 .LP
 The \fBMAP_NORESERVE\fR option specifies that no swap space be reserved for a
@@ -312,11 +311,11 @@ mapping. Without this flag, the creation of a writable \fBMAP_PRIVATE\fR
 mapping reserves swap space equal to the size of the mapping; when the mapping
 is written into, the reserved space is employed to hold private copies of the
 data. A write into a \fBMAP_NORESERVE\fR mapping produces results which depend
-on the current availability of swap  space in the system.  If space is
-available, the write succeeds and a  private copy of the written page is
+on the current availability of swap space in the system.  If space is
+available, the write succeeds and a private copy of the written page is
 created; if space is not available, the write fails and a \fBSIGBUS\fR or
 \fBSIGSEGV\fR signal is delivered to the writing process.  \fBMAP_NORESERVE\fR
-mappings are inherited across  \fBfork()\fR; at the time of the \fBfork()\fR,
+mappings are inherited across \fBfork()\fR; at the time of the \fBfork()\fR,
 swap space is reserved in the child for all private pages that currently exist
 in the parent; thereafter the child's mapping behaves as described above.
 .sp
@@ -358,7 +357,7 @@ The \fIoff\fR argument is constrained to be aligned and sized according to the
 value returned by \fBsysconf()\fR when passed \fB_SC_PAGESIZE\fR or
 \fB_SC_PAGE_SIZE\fR. When \fBMAP_FIXED\fR is specified, the \fIaddr\fR argument
 must also meet these constraints. The system performs mapping operations over
-whole pages. Thus, while the  \fIlen\fR argument need not meet a size or
+whole pages. Thus, while the \fIlen\fR argument need not meet a size or
 alignment constraint, the system will include, in any mapping operation, any
 partial page specified by the range [\fIpa, pa + len\fR).
 .sp
@@ -712,7 +711,6 @@ application:
 .RE
 
 .SH RETURN VALUES
-.LP
 Upon successful completion, the \fBmmap()\fR function returns the address at
 which the mapping was placed (\fIpa\fR); otherwise, it returns a value of
 \fBMAP_FAILED\fR and sets \fBerrno\fR to indicate the error. The symbol
@@ -724,7 +722,6 @@ If \fBmmap()\fR fails for reasons other than \fBEBADF\fR, \fBEINVAL\fR or
 \fBENOTSUP\fR, some of the mappings in the address range starting at \fIaddr\fR
 and continuing for \fIlen\fR bytes may have been unmapped.
 .SH ERRORS
-.LP
 The \fBmmap()\fR function will fail if:
 .sp
 .ne 2
@@ -820,7 +817,7 @@ The mapping could not be locked in memory, if required by \fBmlockall\fR(3C),
 because it would require more space than the system is able to supply.
 .sp
 The composite size of \fIlen\fR plus the lengths obtained from all previous
-calls to \fBmmap()\fR exceeds \fBRLIMIT_VMEM\fR (see  \fBgetrlimit\fR(2)).
+calls to \fBmmap()\fR exceeds \fBRLIMIT_VMEM\fR (see \fBgetrlimit\fR(2)).
 .RE
 
 .sp
@@ -872,7 +869,6 @@ locking. See \fBfcntl\fR(2).
 .RE
 
 .SH USAGE
-.LP
 Use of \fBmmap()\fR may reduce the amount of memory available to other memory
 allocation functions.
 .sp
@@ -917,7 +913,7 @@ read(fildes, buf, len)
 
 .sp
 .LP
-The following is a rewrite using  \fBmmap()\fR:
+The following is a rewrite using \fBmmap()\fR:
 .sp
 .in +2
 .nf
@@ -929,7 +925,6 @@ address = mmap((caddr_t) 0, len, (PROT_READ | PROT_WRITE),
 .in -2
 
 .SH ATTRIBUTES
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -946,7 +941,6 @@ MT-Level	Async-Signal-Safe
 .TE
 
 .SH SEE ALSO
-.LP
 \fBclose\fR(2), \fBexec\fR(2), \fBfcntl\fR(2), \fBfork\fR(2),
 \fBgetrlimit\fR(2), \fBmemcntl\fR(2), \fBmmapobj\fR(2), \fBmprotect\fR(2),
 \fBmunmap\fR(2), \fBshmat\fR(2), \fBlockf\fR(3C), \fBmlockall\fR(3C),

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -53,6 +53,7 @@ dir path=opt/zfs-tests/tests/functional/cli_root/zfs_clone
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_copies
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_create
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_destroy
+dir path=opt/zfs-tests/tests/functional/cli_root/zfs_diff
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_get
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_inherit
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_load-key
@@ -891,6 +892,19 @@ file \
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib \
     mode=0444
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/cleanup mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/setup mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/socket mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_changes \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_encrypted \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_types \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_get/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_get/setup mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_get/zfs_get_001_pos \
@@ -2603,6 +2617,8 @@ file path=opt/zfs-tests/tests/functional/mmp/setup mode=0555
 file path=opt/zfs-tests/tests/functional/mount/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/mount/setup mode=0555
 file path=opt/zfs-tests/tests/functional/mount/umount_001 mode=0555
+file path=opt/zfs-tests/tests/functional/mount/umount_002 mode=0555
+file path=opt/zfs-tests/tests/functional/mount/umount_unlinked_drain mode=0555
 file path=opt/zfs-tests/tests/functional/mount/umountall_001 mode=0555
 file path=opt/zfs-tests/tests/functional/mv_files/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/mv_files/mv_files.cfg mode=0444

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -144,6 +144,11 @@ tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
     'zfs_destroy_016_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_diff]
+tests = ['zfs_diff_changes', 'zfs_diff_cliargs', 'zfs_diff_timestamp',
+    'zfs_diff_types', 'zfs_diff_encrypted']
+tags = ['functional', 'cli_root', 'zfs_diff']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_get]
 tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
     'zfs_get_004_pos', 'zfs_get_005_neg', 'zfs_get_006_neg', 'zfs_get_007_neg',
@@ -516,7 +521,7 @@ tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
     'mmp_on_zdb']
 
 [/opt/zfs-tests/tests/functional/mount]
-tests = ['umount_001', 'umountall_001']
+tests = ['umount_001', 'umount_002', 'umountall_001']
 
 [/opt/zfs-tests/tests/functional/mv_files]
 tests = ['mv_files_001_pos', 'mv_files_002_pos']

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -144,6 +144,11 @@ tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
     'zfs_destroy_016_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_diff]
+tests = ['zfs_diff_changes', 'zfs_diff_cliargs', 'zfs_diff_timestamp',
+    'zfs_diff_types', 'zfs_diff_encrypted']
+tags = ['functional', 'cli_root', 'zfs_diff']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_get]
 tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
     'zfs_get_004_pos', 'zfs_get_005_neg', 'zfs_get_006_neg', 'zfs_get_007_neg',
@@ -515,7 +520,7 @@ tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
     'mmp_on_zdb']
 
 [/opt/zfs-tests/tests/functional/mount]
-tests = ['umount_001', 'umountall_001']
+tests = ['umount_001', 'umount_002', 'umountall_001']
 
 [/opt/zfs-tests/tests/functional/mv_files]
 tests = ['mv_files_001_pos', 'mv_files_002_pos']

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -144,6 +144,11 @@ tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
     'zfs_destroy_016_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_diff]
+tests = ['zfs_diff_changes', 'zfs_diff_cliargs', 'zfs_diff_timestamp',
+    'zfs_diff_types', 'zfs_diff_encrypted']
+tags = ['functional', 'cli_root', 'zfs_diff']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_get]
 tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
     'zfs_get_004_pos', 'zfs_get_005_neg', 'zfs_get_006_neg', 'zfs_get_007_neg',
@@ -515,7 +520,7 @@ tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
     'mmp_on_zdb']
 
 [/opt/zfs-tests/tests/functional/mount]
-tests = ['umount_001', 'umountall_001']
+tests = ['umount_001', 'umount_002', 'umountall_001']
 
 [/opt/zfs-tests/tests/functional/mv_files]
 tests = ['mv_files_001_pos', 'mv_files_002_pos']

--- a/usr/src/test/zfs-tests/runfiles/smartos.run
+++ b/usr/src/test/zfs-tests/runfiles/smartos.run
@@ -106,6 +106,11 @@ tests = ['zfs_destroy_001_pos', 'zfs_destroy_002_pos', 'zfs_destroy_003_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
     'zfs_destroy_016_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_diff]
+tests = ['zfs_diff_changes', 'zfs_diff_cliargs', 'zfs_diff_timestamp',
+    'zfs_diff_types', 'zfs_diff_encrypted']
+tags = ['functional', 'cli_root', 'zfs_diff']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_get]
 tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
     'zfs_get_004_pos', 'zfs_get_005_neg', 'zfs_get_006_neg', 'zfs_get_007_neg',
@@ -447,7 +452,7 @@ tests = ['mmp_on_thread', 'mmp_on_off', 'mmp_interval',
     'mmp_on_zdb']
 
 [/opt/zfs-tests/tests/functional/mount]
-tests = ['umount_001', 'umountall_001']
+tests = ['umount_001', 'umount_002', 'umountall_001']
 
 [/opt/zfs-tests/tests/functional/mv_files]
 tests = ['mv_files_001_pos', 'mv_files_002_pos']

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Joyent, Inc.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/cli_root/zfs_diff
+
+PROG = socket
+OBJS = $(PROG:%=%.o)
+SRCS = $(OBJS:%.o=%.c)
+
+include $(SRC)/cmd/Makefile.cmd
+
+$(TARGETDIR)/$(PROG) :=	FILEMODE = 0555
+
+CPPFLAGS = -D__EXTENSIONS__
+LDLIBS = -lsocket
+
+$(PROG): $(OBJS)
+	$(LINK.c) $(OBJS) -o $@ $(LDLIBS)
+	$(POST_PROCESS)
+
+install: $(TARGETDIR)/$(PROG)
+
+clobber: clean
+	-$(RM) $(PROG)
+
+clean:
+	-$(RM) $(OBJS)
+
+$(TARGETDIR)/$(PROG): $(TARGETDIR)
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/cleanup.ksh
@@ -1,0 +1,19 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/setup.ksh
@@ -1,0 +1,21 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_volume_setup $DISK

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/socket.c
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/socket.c
@@ -1,0 +1,59 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <fcntl.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ARGSUSED */
+int
+main(int argc, char *argv[])
+{
+	struct sockaddr_un sock;
+	int fd;
+	char *path;
+	size_t size;
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s /path/to/socket\n", argv[0]);
+		exit(1);
+	}
+	path = argv[1];
+	size =  sizeof (sock.sun_path);
+	(void) strncpy(sock.sun_path, (char *)path, size - 1);
+	sock.sun_path[size - 1] = '\0';
+
+	sock.sun_family = AF_UNIX;
+	if ((fd = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
+		perror("socket");
+		return (1);
+	}
+	if (bind(fd, (struct sockaddr *)&sock, sizeof (struct sockaddr_un))) {
+		perror("bind");
+		return (1);
+	}
+	if (close(fd)) {
+		perror("close");
+		return (1);
+	}
+	return (0);
+}

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_changes.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_changes.ksh
@@ -1,0 +1,96 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff' should display changes correctly.
+#
+# STRATEGY:
+# 1. Create a filesystem with both files and directories, then snapshot it
+# 2. Generate different types of changes and verify 'zfs diff' displays them
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs destroy -r "$DATASET"
+	rm -f "$FILEDIFF"
+}
+
+#
+# Verify object $path has $change type
+# Valid types are:
+# * - (The path has been removed)
+# * + (The path has been created)
+# * M (The path has been modified)
+# * R (The path has been renamed)
+#
+function verify_object_change # <path> <change>
+{
+	path="$1"
+	change="$2"
+
+	log_must eval "zfs diff -F $TESTSNAP1 $TESTSNAP2 > $FILEDIFF"
+	diffchg="$(nawk -v path="$path" '$NF == path { print $1 }' < $FILEDIFF)"
+	if [[ "$diffchg" != "$change" ]]; then
+		log_fail "Unexpected change for $path ('$diffchg' != '$change')"
+	else
+		log_note "Object $path change is displayed correctly: '$change'"
+	fi
+}
+
+log_assert "'zfs diff' should display changes correctly."
+log_onexit cleanup
+
+DATASET="$TESTPOOL/$TESTFS/fs"
+TESTSNAP1="$DATASET@snap1"
+TESTSNAP2="$DATASET@snap2"
+FILEDIFF="$TESTDIR/zfs-diff.txt"
+
+# 1. Create a filesystem with both files and directories, then snapshot it
+log_must zfs create $DATASET
+MNTPOINT="$(get_prop mountpoint $DATASET)"
+log_must touch "$MNTPOINT/fremoved"
+log_must touch "$MNTPOINT/frenamed"
+log_must touch "$MNTPOINT/fmodified"
+log_must mkdir "$MNTPOINT/dremoved"
+log_must mkdir "$MNTPOINT/drenamed"
+log_must mkdir "$MNTPOINT/dmodified"
+log_must zfs snapshot "$TESTSNAP1"
+
+# 2. Generate different types of changes and verify 'zfs diff' displays them
+log_must rm -f "$MNTPOINT/fremoved"
+log_must mv "$MNTPOINT/frenamed" "$MNTPOINT/frenamed.new"
+log_must touch "$MNTPOINT/fmodified"
+log_must rmdir "$MNTPOINT/dremoved"
+log_must mv "$MNTPOINT/drenamed" "$MNTPOINT/drenamed.new"
+log_must touch "$MNTPOINT/dmodified/file"
+log_must touch "$MNTPOINT/fcreated"
+log_must mkdir "$MNTPOINT/dcreated"
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_change "$MNTPOINT/fremoved" "-"
+verify_object_change "$MNTPOINT/frenamed.new" "R"
+verify_object_change "$MNTPOINT/fmodified" "M"
+verify_object_change "$MNTPOINT/fcreated" "+"
+verify_object_change "$MNTPOINT/dremoved" "-"
+verify_object_change "$MNTPOINT/drenamed.new" "R"
+verify_object_change "$MNTPOINT/dmodified" "M"
+verify_object_change "$MNTPOINT/dcreated" "+"
+
+log_pass "'zfs diff' displays changes correctly."

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_cliargs.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff' should only work with supported options.
+#
+# STRATEGY:
+# 1. Create two snapshots
+# 2. Verify every supported option is accepted
+# 3. Verify supported options raise an error with unsupported arguments
+# 4. Verify other unsupported options raise an error
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	for snap in $TESTSNAP1 $TESTSNAP2; do
+		if snapexists "$snap"; then
+			log_must zfs destroy "$snap"
+		fi
+	done
+}
+
+log_assert "'zfs diff' should only work with supported options."
+log_onexit cleanup
+
+typeset goodopts=("" "-F" "-H" "-t" "-FH" "-Ft" "-Ht" "-FHt")
+typeset badopts=("-f" "-h" "-h" "-T" "-Fx" "-Ho" "-tT" "-")
+
+DATASET="$TESTPOOL/$TESTFS"
+TESTSNAP1="$DATASET@snap1"
+TESTSNAP2="$DATASET@snap2"
+
+# 1. Create two snapshots
+log_must zfs snapshot "$TESTSNAP1"
+log_must zfs snapshot "$TESTSNAP2"
+
+# 2. Verify every supported option is accepted
+for opt in ${goodopts[@]}
+do
+	log_must zfs diff $opt "$TESTSNAP1"
+	log_must zfs diff $opt "$TESTSNAP1" "$DATASET"
+	log_must zfs diff $opt "$TESTSNAP1" "$TESTSNAP2"
+done
+
+# 3. Verify supported options raise an error with unsupported arguments
+for opt in ${goodopts[@]}
+do
+	log_mustnot zfs diff $opt
+	log_mustnot zfs diff $opt "$DATASET"
+	log_mustnot zfs diff $opt "$DATASET@noexists"
+	log_mustnot zfs diff $opt "$DATASET" "$TESTSNAP1"
+	log_mustnot zfs diff $opt "$TESTSNAP2" "$TESTSNAP1"
+done
+
+# 4. Verify other unsupported options raise an error
+for opt in ${badopts[@]}
+do
+	log_mustnot zfs diff $opt "$TESTSNAP1" "$DATASET"
+	log_mustnot zfs diff $opt "$TESTSNAP1" "$TESTSNAP2"
+done
+
+log_pass "'zfs diff' only works with supported options."

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_encrypted.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_encrypted.ksh
@@ -1,0 +1,54 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018, Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff' should work with encrypted datasets
+#
+# STRATEGY:
+# 1. Create an encrypted dataset
+# 2. Create two snapshots of the dataset
+# 3. Perform 'zfs diff -Ft' and verify no errors occur
+# 4. Perform the same test on a dataset with large dnodes
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		log_must zfs destroy -r $TESTPOOL/$TESTFS1
+}
+
+log_assert "'zfs diff' should work with encrypted datasets"
+log_onexit cleanup
+
+# 1. Create an encrypted dataset
+log_must eval "echo 'password' | zfs create -o encryption=on \
+	-o keyformat=passphrase $TESTPOOL/$TESTFS1"
+MNTPOINT="$(get_prop mountpoint $TESTPOOL/$TESTFS1)"
+
+# 2. Create two snapshots of the dataset
+log_must zfs snapshot $TESTPOOL/$TESTFS1@snap1
+log_must touch "$MNTPOINT/file"
+log_must zfs snapshot $TESTPOOL/$TESTFS1@snap2
+
+# 3. Perform 'zfs diff' and verify no errors occur
+log_must zfs diff -Ft $TESTPOOL/$TESTFS1@snap1 $TESTPOOL/$TESTFS1@snap2
+
+log_pass "'zfs diff' works with encrypted datasets"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_timestamp.ksh
@@ -1,0 +1,100 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff -t' should display inode change time correctly.
+#
+# STRATEGY:
+# 1. Create a snapshot
+# 2. Create some files with a random delay and snapshot the filesystem again
+# 3. Verify 'zfs diff -t' correctly display timestamps
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	for snap in $TESTSNAP1 $TESTSNAP2; do
+		if snapexists "$snap"; then
+			log_must zfs destroy "$snap"
+		fi
+	done
+	find "$MNTPOINT" -type f -delete
+	rm -f "$FILEDIFF"
+}
+
+#
+# Creates $count files in $fspath. Waits a random delay between each file.
+#
+function create_random # <fspath> <count>
+{
+	fspath="$1"
+	typeset -i count="$2"
+	typeset -i i=0
+
+	while (( i < count )); do
+		log_must touch "$fspath/file$i"
+		sleep $(random 3)
+		(( i = i + 1 ))
+	done
+}
+
+log_assert "'zfs diff -t' should display inode change time correctly."
+log_onexit cleanup
+
+DATASET="$TESTPOOL/$TESTFS"
+TESTSNAP1="$DATASET@snap1"
+TESTSNAP2="$DATASET@snap2"
+MNTPOINT="$(get_prop mountpoint $DATASET)"
+FILEDIFF="$TESTDIR/zfs-diff.txt"
+FILENUM=5
+
+# 1. Create a snapshot
+log_must zfs snapshot "$TESTSNAP1"
+
+# 2. Create some files with a random delay and snapshot the filesystem again
+create_random "$MNTPOINT" $FILENUM
+log_must zfs snapshot "$TESTSNAP2"
+
+# 3. Verify 'zfs diff -t' correctly display timestamps
+typeset -i count=0
+log_must eval "zfs diff -t $TESTSNAP1 $TESTSNAP2 > $FILEDIFF"
+nawk '{print substr($1,1,index($1,".")-1)" "$NF}' < "$FILEDIFF" | while read line
+do
+	read ctime file <<< "$line"
+
+	# If path from 'zfs diff' is not a file (could be xattr object) skip it
+	if [[ ! -f "$file" ]]; then
+		continue;
+	fi
+
+	filetime="$(stat -c '%Z' $file)"
+	if [[ "$filetime" != "$ctime" ]]; then
+		log_fail "Unexpected ctime for file $file ($filetime != $ctime)"
+	else
+		log_note "Correct ctime read on $file: $ctime"
+	fi
+
+	(( i = i + 1 ))
+done
+if [[ $i != $FILENUM ]]; then
+	log_fail "Wrong number of files verified ($i != $FILENUM)"
+fi
+
+log_pass "'zfs diff -t' displays inode change time correctly."

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_types.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/zfs_diff_types.ksh
@@ -1,0 +1,126 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+# Copyright 2019 Joyent, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs diff -F' shows different object types correctly.
+#
+# STRATEGY:
+# 1. Prepare a dataset
+# 2. Create different objects and verify 'zfs diff -F' shows the correct type
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs destroy -r "$DATASET"
+	rm -f "$FILEDIFF"
+}
+
+#
+# Verify object at $path is of type $symbol using 'zfs diff -F'
+# Valid types are:
+# * B (Block device)
+# * C (Character device)
+# * / (Directory)
+# * > (Door)
+# * | (Named pipe)
+# * @ (Symbolic link)
+# * P (Event port)
+# * = (Socket)
+# * F (Regular file)
+#
+function verify_object_class # <path> <symbol>
+{
+	path="$1"
+	symbol="$2"
+
+	log_must eval "zfs diff -F $TESTSNAP1 $TESTSNAP2 > $FILEDIFF"
+	diffsym="$(nawk -v path="$path" '$NF == path { print $2 }' < $FILEDIFF)"
+	if [[ "$diffsym" != "$symbol" ]]; then
+		log_fail "Unexpected type for $path ('$diffsym' != '$symbol')"
+	else
+		log_note "Object $path type is correctly displayed as '$symbol'"
+	fi
+
+	log_must zfs destroy "$TESTSNAP1"
+	log_must zfs destroy "$TESTSNAP2"
+}
+
+log_assert "'zfs diff -F' should show different object types correctly."
+log_onexit cleanup
+
+DATASET="$TESTPOOL/$TESTFS/fs"
+TESTSNAP1="$DATASET@snap1"
+TESTSNAP2="$DATASET@snap2"
+FILEDIFF="$TESTDIR/zfs-diff.txt"
+MAJOR=$(stat -c %t /dev/null)
+MINOR=$(stat -c %T /dev/null)
+
+# 1. Prepare a dataset
+log_must zfs create $DATASET
+MNTPOINT="$(get_prop mountpoint $DATASET)"
+log_must zfs set devices=on $DATASET
+log_must zfs set xattr=on $DATASET
+
+# 2. Create different objects and verify 'zfs diff -F' shows the correct type
+# 2. F (Regular file)
+log_must zfs snapshot "$TESTSNAP1"
+log_must touch "$MNTPOINT/file"
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/file" "F"
+
+# 2. @ (Symbolic link)
+log_must zfs snapshot "$TESTSNAP1"
+log_must ln -s "$MNTPOINT/file" "$MNTPOINT/link"
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/link" "@"
+
+# 2. B (Block device)
+log_must zfs snapshot "$TESTSNAP1"
+log_must mknod "$MNTPOINT/bdev" b $MAJOR $MINOR
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/bdev" "B"
+
+# 2. C (Character device)
+log_must zfs snapshot "$TESTSNAP1"
+log_must mknod "$MNTPOINT/cdev" c $MAJOR $MINOR
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/cdev" "C"
+
+# 2. | (Named pipe)
+log_must zfs snapshot "$TESTSNAP1"
+log_must mknod "$MNTPOINT/fifo" p
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/fifo" "|"
+
+# 2. / (Directory)
+log_must zfs snapshot "$TESTSNAP1"
+log_must mkdir "$MNTPOINT/dir"
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/dir" "/"
+
+# 2. = (Socket)
+log_must zfs snapshot "$TESTSNAP1"
+log_must $STF_SUITE/tests/functional/cli_root/zfs_diff/socket "$MNTPOINT/sock"
+log_must zfs snapshot "$TESTSNAP2"
+verify_object_class "$MNTPOINT/sock" "="
+
+log_pass "'zfs diff -F' shows different object types correctly."

--- a/usr/src/test/zfs-tests/tests/functional/mount/umount_002.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mount/umount_002.ksh
@@ -1,0 +1,52 @@
+#! /usr/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# zfs umount should not fail because flushing of DNLC
+# uses async implementation of zfs_inactive
+#
+# STRATEGY:
+# 1. Call zfs unmount/mount to be sure DNLC is empty
+# 2. Create a lot of files
+# 3. Call zfs unmount command
+# 4. Make sure the file systems were unmounted
+# 5. Mount them back
+#
+
+for fs in 1 2 3; do
+	log_must mounted $TESTDIR.$fs
+	log_must zfs umount $TESTPOOL/$TESTFS.$fs
+	log_must unmounted $TESTDIR.$fs
+	log_must zfs mount $TESTPOOL/$TESTFS.$fs
+	log_must mounted $TESTDIR.$fs
+
+	for fn in $(seq 1 8096); do
+		log_must dd if=/dev/urandom of=$TESTDIR.$fs/file$fn bs=1024 \
+		    count=1
+	done
+
+	log_must zfs umount $TESTPOOL/$TESTFS.$fs
+	log_must unmounted $TESTDIR.$fs
+	log_must zfs mount $TESTPOOL/$TESTFS.$fs
+	log_must mounted $TESTDIR.$fs
+	log_must rm -f $TESTDIR.$fs/file*
+done
+
+log_pass "All file systems are unmounted"

--- a/usr/src/test/zfs-tests/tests/functional/mount/umount_unlinked_drain.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mount/umount_unlinked_drain.ksh
@@ -1,0 +1,119 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Test async unlinked drain to ensure mounting is not held up when there are
+# entries in the unlinked set. We also try to test that the list is able to be
+# filled up and drained at the same time.
+#
+# STRATEGY:
+# 1. Use zfs_unlink_suspend_progress tunable to disable freeing to build up
+#    the unlinked set
+# 2. Make sure mount happens even when there are entries in the unlinked set
+# 3. Drain and build up the unlinked list at the same time to test for races
+#
+
+function cleanup
+{
+	log_must set_tunable32 zfs_unlink_suspend_progress $default_unlink_sp
+	for fs in $(seq 1 3); do
+		mounted $TESTDIR.$fs || zfs mount $TESTPOOL/$TESTFS.$fs
+		rm -f $TESTDIR.$fs/file-*
+		zfs set xattr=on $TESTPOOL/$TESTFS.$fs
+	done
+}
+
+function unlinked_size_is
+{
+	MAX_ITERS=5 # iteration to do before we consider reported number stable
+	iters=0
+	last_usize=0
+	while [[ $iters -le $MAX_ITERS ]]; do
+		kstat_file=$(grep -nrwl /proc/spl/kstat/zfs/$2/objset-0x* -e $3)
+		nunlinks=`cat $kstat_file | grep nunlinks | awk '{print $3}'`
+		nunlinked=`cat $kstat_file | grep nunlinked | awk '{print $3}'`
+		usize=$(($nunlinks - $nunlinked))
+		if [[ $iters == $MAX_ITERS && $usize == $1 ]]; then
+			return 0
+		fi
+		if [[ $usize == $last_usize ]]; then
+			(( iters++ ))
+		else
+			iters=0
+		fi
+		last_usize=$usize
+	done
+
+	log_note "Unexpected unlinked set size: $last_usize, expected $1"
+	return 1
+}
+
+
+UNLINK_SP_PARAM=/sys/module/zfs/parameters/zfs_unlink_suspend_progress
+default_unlink_sp=$(get_tunable zfs_unlink_suspend_progress)
+
+log_onexit cleanup
+
+log_assert "Unlinked list drain does not hold up mounting of fs"
+
+for fs in 1 2 3; do
+	set -A xattrs on sa off
+	for xa in ${xattrs[@]}; do
+		# setup fs and ensure all deleted files got into unliked set
+		log_must mounted $TESTDIR.$fs
+
+		log_must zfs set xattr=$xa $TESTPOOL/$TESTFS.$fs
+
+		if [[ $xa == off ]]; then
+			for fn in $(seq 1 175); do
+				log_must mkfile 128k $TESTDIR.$fs/file-$fn
+			done
+		else
+			log_must xattrtest -f 175 -x 3 -r -k -p $TESTDIR.$fs
+		fi
+
+		log_must set_tunable32 zfs_unlink_suspend_progress 1
+		log_must unlinked_size_is 0 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+
+		# build up unlinked set
+		for fn in $(seq 1 100); do
+			log_must eval "rm $TESTDIR.$fs/file-$fn &"
+		done
+		log_must unlinked_size_is 100 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+
+		# test that we can mount fs without emptying the unlinked list
+		log_must zfs umount $TESTPOOL/$TESTFS.$fs
+		log_must unmounted $TESTDIR.$fs
+		log_must zfs mount $TESTPOOL/$TESTFS.$fs
+		log_must mounted $TESTDIR.$fs
+		log_must unlinked_size_is 100 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+
+		# confirm we can drain and add to unlinked set at the same time
+		log_must set_tunable32 zfs_unlink_suspend_progress 0
+		log_must zfs umount $TESTPOOL/$TESTFS.$fs
+		log_must zfs mount $TESTPOOL/$TESTFS.$fs
+		for fn in $(seq 101 175); do
+			log_must eval "rm $TESTDIR.$fs/file-$fn &"
+		done
+		log_must unlinked_size_is 0 $TESTPOOL $TESTPOOL/$TESTFS.$fs
+	done
+done
+
+log_pass "Confirmed unlinked list drain does not hold up mounting of fs"

--- a/usr/src/tools/smatch/Makefile
+++ b/usr/src/tools/smatch/Makefile
@@ -20,7 +20,7 @@
 #
 
 PROG = smatch
-SPARSE_VERSION = 0.6.1-rc1-il-1
+SPARSE_VERSION = 0.6.1-rc1-il-2
 
 include ../Makefile.tools
 

--- a/usr/src/tools/smatch/src/Makefile
+++ b/usr/src/tools/smatch/src/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.1-rc1-il-1
+VERSION=0.6.1-rc1-il-2
 
 ########################################################################
 # The following variables can be overwritten from the command line
@@ -9,7 +9,7 @@ CC ?= gcc
 LD = $(CC)
 AR = ar
 
-CFLAGS ?= -O2 -g
+CFLAGS ?= -g
 
 DESTDIR ?=
 PREFIX ?= $(HOME)

--- a/usr/src/tools/smatch/src/check_arm64_tagged.c
+++ b/usr/src/tools/smatch/src/check_arm64_tagged.c
@@ -154,8 +154,13 @@ int rl_range_has_min_value(struct range_list *rl, sval_t sval)
 
 static bool rl_is_tagged(struct range_list *rl)
 {
-	sval_t invalid = { .type = &ullong_ctype, .value = (1ULL << 56) };
-	sval_t invalid_kernel = { .type = &ullong_ctype, .value = (0xff8ULL << 52) };
+	sval_t invalid;
+	sval_t invalid_kernel;
+
+	invalid.type = &ullong_ctype;
+	invalid.value = 1ULL << 56;
+	invalid_kernel.type = &ullong_ctype;
+	invalid_kernel.value = 0xff8ULL << 52;
 
 	/*
 	 * We only care for tagged addresses, thus ignore anything where the

--- a/usr/src/tools/smatch/src/ident-list.h
+++ b/usr/src/tools/smatch/src/ident-list.h
@@ -31,7 +31,7 @@ IDENT(static);
 /* C99 keywords */
 IDENT(restrict); IDENT(__restrict); IDENT(__restrict__);
 IDENT(_Bool);
-IDENT(_Complex);
+IDENT_RESERVED(_Complex);
 IDENT_RESERVED(_Imaginary);
 
 /* C11 keywords */

--- a/usr/src/tools/smatch/src/smatch_data/illumos_kernel.skipped_functions
+++ b/usr/src/tools/smatch/src/smatch_data/illumos_kernel.skipped_functions
@@ -3,6 +3,7 @@ ECDSA_VerifyDigest
 dtrace_disx86
 elf32exec
 elfexec
+emlxs_sli4_process_unsol_rcv
 iscsi_ioctl
 lm_idle_chk
 ld64_sym_validate

--- a/usr/src/tools/smatch/src/smatch_data/illumos_user.skipped_functions
+++ b/usr/src/tools/smatch/src/smatch_data/illumos_user.skipped_functions
@@ -1,8 +1,6 @@
 /*
- * The below functions cause smatch to fail with "turning off implications after
- * 60 seconds" or similar, generally because they're too large for it to handle.
- *
- * This will disable analysis altogether.
+ * These are specific functions that are generally too complex for smatch to
+ * reasonably handle.
  */
 
 /* libast */

--- a/usr/src/tools/smatch/src/smatch_kernel_user_data.c
+++ b/usr/src/tools/smatch/src/smatch_kernel_user_data.c
@@ -681,9 +681,14 @@ static void handle_eq_noteq(struct expression *expr)
 static struct range_list *strip_negatives(struct range_list *rl)
 {
 	sval_t min = rl_min(rl);
-	sval_t minus_one = { .type = rl_type(rl), .value = -1 };
-	sval_t over = { .type = rl_type(rl), .value = INT_MAX + 1ULL };
+	sval_t minus_one;
+	sval_t over;
 	sval_t max = sval_type_max(rl_type(rl));
+
+	minus_one.type = rl_type(rl);
+	minus_one.value = -1;
+	over.type = rl_type(rl);
+	over.value = INT_MAX + 1ULL;
 
 	if (!rl)
 		return NULL;

--- a/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
@@ -93,6 +93,7 @@ typedef struct dsl_pool {
 	struct dsl_dataset *dp_origin_snap;
 	uint64_t dp_root_dir_obj;
 	taskq_t *dp_vnrele_taskq;
+	struct taskq *dp_unlinked_drain_taskq;
 
 	/* No lock needed - sync context only */
 	blkptr_t dp_meta_rootbp;
@@ -173,6 +174,7 @@ boolean_t dsl_pool_config_held_writer(dsl_pool_t *dp);
 boolean_t dsl_pool_need_dirty_delay(dsl_pool_t *dp);
 
 taskq_t *dsl_pool_vnrele_taskq(dsl_pool_t *dp);
+taskq_t *dsl_pool_unlinked_drain_taskq(dsl_pool_t *dp);
 
 int dsl_pool_user_hold(dsl_pool_t *dp, uint64_t dsobj,
     const char *tag, uint64_t now, dmu_tx_t *tx);

--- a/usr/src/uts/common/fs/zfs/sys/zfs_dir.h
+++ b/usr/src/uts/common/fs/zfs/sys/zfs_dir.h
@@ -63,6 +63,7 @@ extern void zfs_dl_name_switch(zfs_dirlock_t *dl, char *new, char **old);
 extern boolean_t zfs_dirempty(znode_t *);
 extern void zfs_unlinked_add(znode_t *, dmu_tx_t *);
 extern void zfs_unlinked_drain(zfsvfs_t *zfsvfs);
+extern void zfs_unlinked_drain_stop_wait(zfsvfs_t *zfsvfs);
 extern int zfs_sticky_remove_access(znode_t *, znode_t *, cred_t *cr);
 extern int zfs_get_xattrdir(znode_t *, vnode_t **, cred_t *, int);
 extern int zfs_make_xattrdir(znode_t *, vattr_t *, vnode_t **, cred_t *);

--- a/usr/src/uts/common/fs/zfs/sys/zfs_vfsops.h
+++ b/usr/src/uts/common/fs/zfs/sys/zfs_vfsops.h
@@ -75,6 +75,8 @@ struct zfsvfs {
 	boolean_t	z_use_fuids;	/* version allows fuids */
 	boolean_t	z_replay;	/* set during ZIL replay */
 	boolean_t	z_use_sa;	/* version allow system attributes */
+	boolean_t	z_draining;	/* is true when drain is active */
+	boolean_t	z_drain_cancel; /* signal the unlinked drain to stop */
 	uint64_t	z_version;	/* ZPL version */
 	uint64_t	z_shares_dir;	/* hidden shares dir */
 	kmutex_t	z_lock;
@@ -88,6 +90,7 @@ struct zfsvfs {
 	sa_attr_type_t	*z_attr_table;	/* SA attr mapping->id */
 #define	ZFS_OBJ_MTX_SZ	64
 	kmutex_t	z_hold_mtx[ZFS_OBJ_MTX_SZ];	/* znode hold locks */
+	taskqid_t	z_drain_task;	/* task id for the unlink drain task */
 };
 
 /*

--- a/usr/src/uts/common/fs/zfs/zfs_dir.c
+++ b/usr/src/uts/common/fs/zfs/zfs_dir.c
@@ -480,20 +480,23 @@ zfs_unlinked_add(znode_t *zp, dmu_tx_t *tx)
  * Clean up any znodes that had no links when we either crashed or
  * (force) umounted the file system.
  */
-void
-zfs_unlinked_drain(zfsvfs_t *zfsvfs)
+static void
+zfs_unlinked_drain_task(void *arg)
 {
+	zfsvfs_t *zfsvfs = arg;
 	zap_cursor_t	zc;
 	zap_attribute_t zap;
 	dmu_object_info_t doi;
 	znode_t		*zp;
 	int		error;
 
+	ASSERT3B(zfsvfs->z_draining, ==, B_TRUE);
+
 	/*
 	 * Interate over the contents of the unlinked set.
 	 */
 	for (zap_cursor_init(&zc, zfsvfs->z_os, zfsvfs->z_unlinkedobj);
-	    zap_cursor_retrieve(&zc, &zap) == 0;
+	    zap_cursor_retrieve(&zc, &zap) == 0 && !zfsvfs->z_drain_cancel;
 	    zap_cursor_advance(&zc)) {
 
 		/*
@@ -523,9 +526,52 @@ zfs_unlinked_drain(zfsvfs_t *zfsvfs)
 			continue;
 
 		zp->z_unlinked = B_TRUE;
+
 		VN_RELE(ZTOV(zp));
+		ASSERT3B(zfsvfs->z_unmounted, ==, B_FALSE);
 	}
 	zap_cursor_fini(&zc);
+
+	zfsvfs->z_draining = B_FALSE;
+	zfsvfs->z_drain_task = TASKQID_INVALID;
+}
+
+/*
+ * Sets z_draining then tries to dispatch async unlinked drain.
+ * If that fails executes synchronous unlinked drain.
+ */
+void
+zfs_unlinked_drain(zfsvfs_t *zfsvfs)
+{
+	ASSERT3B(zfsvfs->z_unmounted, ==, B_FALSE);
+	ASSERT3B(zfsvfs->z_draining, ==, B_FALSE);
+
+	zfsvfs->z_draining = B_TRUE;
+	zfsvfs->z_drain_cancel = B_FALSE;
+
+	zfsvfs->z_drain_task = taskq_dispatch(
+	    dsl_pool_unlinked_drain_taskq(dmu_objset_pool(zfsvfs->z_os)),
+	    zfs_unlinked_drain_task, zfsvfs, TQ_SLEEP);
+	if (zfsvfs->z_drain_task == TASKQID_INVALID) {
+		zfs_dbgmsg("async zfs_unlinked_drain dispatch failed");
+		zfs_unlinked_drain_task(zfsvfs);
+	}
+}
+
+/*
+ * Wait for the unlinked drain taskq task to stop. This will interrupt the
+ * unlinked set processing if it is in progress.
+ */
+void
+zfs_unlinked_drain_stop_wait(zfsvfs_t *zfsvfs)
+{
+	ASSERT3B(zfsvfs->z_unmounted, ==, B_FALSE);
+
+	while (zfsvfs->z_draining) {
+		zfsvfs->z_drain_cancel = B_TRUE;
+		taskq_wait(dsl_pool_unlinked_drain_taskq(
+		    dmu_objset_pool(zfsvfs->z_os)));
+	}
 }
 
 /*
@@ -1109,7 +1155,7 @@ top:
 int
 zfs_sticky_remove_access(znode_t *zdp, znode_t *zp, cred_t *cr)
 {
-	uid_t  		uid;
+	uid_t		uid;
 	uid_t		downer;
 	uid_t		fowner;
 	zfsvfs_t	*zfsvfs = zdp->z_zfsvfs;

--- a/usr/src/uts/common/io/vioif/vioif.c
+++ b/usr/src/uts/common/io/vioif/vioif.c
@@ -13,6 +13,7 @@
  * Copyright 2013 Nexenta Inc.  All rights reserved.
  * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2019 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 /* Based on the NetBSD virtio driver by Minoura Makoto. */
@@ -62,6 +63,7 @@
 #include <sys/ethernet.h>
 #include <sys/vlan.h>
 #include <sys/sysmacros.h>
+#include <sys/smbios.h>
 
 #include <sys/dlpi.h>
 #include <sys/taskq.h>
@@ -178,6 +180,13 @@ static const uchar_t vioif_broadcast[ETHERADDRL] = {
  * Interval for the periodic TX reclaim.
  */
 uint_t vioif_reclaim_ms = 200;
+
+/*
+ * Allow the operator to override the kinds of interrupts we'll use for
+ * vioif.  This value defaults to -1 so that it can be overridden to 0 in
+ * /etc/system.
+ */
+int vioif_allowed_int_types = -1;
 
 /*
  * DMA attribute template for transmit and receive buffers.  The SGL entry
@@ -1576,6 +1585,45 @@ vioif_check_features(vioif_t *vif)
 }
 
 static int
+vioif_select_interrupt_types(void)
+{
+	id_t id;
+	smbios_system_t sys;
+	smbios_info_t info;
+
+	if (vioif_allowed_int_types != -1) {
+		/*
+		 * If this value was tuned via /etc/system or the debugger,
+		 * use the provided value directly.
+		 */
+		return (vioif_allowed_int_types);
+	}
+
+	if ((id = smbios_info_system(ksmbios, &sys)) == SMB_ERR ||
+	    smbios_info_common(ksmbios, id, &info) == SMB_ERR) {
+		/*
+		 * The system may not have valid SMBIOS data, so ignore a
+		 * failure here.
+		 */
+		return (0);
+	}
+
+	if (strcmp(info.smbi_manufacturer, "Google") == 0 &&
+	    strcmp(info.smbi_product, "Google Compute Engine") == 0) {
+		/*
+		 * An undiagnosed issue with the Google Compute Engine (GCE)
+		 * hypervisor exists.  In this environment, no RX interrupts
+		 * are received if MSI-X handlers are installed.  This does not
+		 * appear to be true for the Virtio SCSI driver.  Fixed
+		 * interrupts do appear to work, so we fall back for now:
+		 */
+		return (DDI_INTR_TYPE_FIXED);
+	}
+
+	return (0);
+}
+
+static int
 vioif_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
 	int ret;
@@ -1605,7 +1653,8 @@ vioif_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		goto fail;
 	}
 
-	if (virtio_init_complete(vio, 0) != DDI_SUCCESS) {
+	if (virtio_init_complete(vio, vioif_select_interrupt_types()) !=
+	    DDI_SUCCESS) {
 		dev_err(dip, CE_WARN, "failed to complete Virtio init");
 		goto fail;
 	}

--- a/usr/src/uts/common/io/virtio/virtio_impl.h
+++ b/usr/src/uts/common/io/virtio/virtio_impl.h
@@ -258,7 +258,7 @@ struct virtio_vq_elem {
 /*
  * This structure is variously known as the "used" ring, or the device-owned
  * portion of the queue structure.  It is used by the device to return
- * completed descriptor chains to the device.
+ * completed descriptor chains to the driver.
  */
 struct virtio_vq_device {
 	uint16_t			vqde_flags;

--- a/usr/src/uts/common/io/virtio/virtio_main.c
+++ b/usr/src/uts/common/io/virtio/virtio_main.c
@@ -323,7 +323,9 @@ virtio_init(dev_info_t *dip, uint64_t driver_features, boolean_t allow_indirect)
 
 /*
  * This function must be called by the driver once it has completed early setup
- * calls.
+ * calls.  The value of "allowed_interrupt_types" is a mask of interrupt types
+ * (DDI_INTR_TYPE_MSIX, etc) that we'll try to use when installing handlers, or
+ * the special value 0 to allow the system to use any available type.
  */
 int
 virtio_init_complete(virtio_t *vio, int allowed_interrupt_types)

--- a/usr/src/uts/common/os/cap_util.c
+++ b/usr/src/uts/common/os/cap_util.c
@@ -1298,7 +1298,7 @@ static void
 cu_cpu_kstat_create(pghw_t *pg, cu_cntr_info_t *cntr_info)
 {
 	kstat_t		*ks;
-	char 		*sharing = pghw_type_string(pg->pghw_hw);
+	char		*sharing = pghw_type_string(pg->pghw_hw);
 	char		name[KSTAT_STRLEN + 1];
 
 	/*
@@ -1417,7 +1417,7 @@ cu_cpu_run(cpu_t *cp, cu_cpu_func_t func, uintptr_t arg)
 	 * cpu_call() will call func on the CPU specified with given argument
 	 * and return func's return value in last argument
 	 */
-	cpu_call(cp, (cpu_call_func_t)func, arg, (uintptr_t)&error);
+	cpu_call(cp, (cpu_call_func_t)(uintptr_t)func, arg, (uintptr_t)&error);
 	return (error);
 }
 
@@ -1471,7 +1471,7 @@ cu_cpu_update(struct cpu *cp, boolean_t move_to)
 	 */
 	retval = 0;
 	if (move_to)
-		(void) cu_cpu_run(cp, (cu_cpu_func_t)kcpc_read,
+		(void) cu_cpu_run(cp, (cu_cpu_func_t)(uintptr_t)kcpc_read,
 		    (uintptr_t)cu_cpu_update_stats);
 	else {
 		retval = kcpc_read((kcpc_update_func_t)cu_cpu_update_stats);

--- a/usr/src/uts/common/vm/seg_kmem.c
+++ b/usr/src/uts/common/vm/seg_kmem.c
@@ -440,7 +440,7 @@ segkmem_badop()
 	panic("segkmem_badop");
 }
 
-#define	SEGKMEM_BADOP(t)	(t(*)())segkmem_badop
+#define	SEGKMEM_BADOP(t)	(t(*)())(uintptr_t)segkmem_badop
 
 /*ARGSUSED*/
 static faultcode_t
@@ -1224,7 +1224,7 @@ static void
 segkmem_free_one_lp(caddr_t addr, size_t size)
 {
 	page_t		*pp, *rootpp = NULL;
-	pgcnt_t 	pgs_left = btopr(size);
+	pgcnt_t		pgs_left = btopr(size);
 
 	ASSERT(size == segkmem_lpsize);
 
@@ -1424,7 +1424,7 @@ segkmem_free_lpi(vmem_t *vmp, void *inaddr, size_t size)
 	pgcnt_t		nlpages = size >> segkmem_lpshift;
 	size_t		lpsize = segkmem_lpsize;
 	caddr_t		addr = inaddr;
-	pgcnt_t 	npages = btopr(size);
+	pgcnt_t		npages = btopr(size);
 	int		i;
 
 	ASSERT(vmp == heap_lp_arena);

--- a/usr/src/uts/i86pc/io/apix/apix.c
+++ b/usr/src/uts/i86pc/io/apix/apix.c
@@ -612,7 +612,7 @@ apix_picinit(void)
 	/* add nmi handler - least priority nmi handler */
 	LOCK_INIT_CLEAR(&apic_nmi_lock);
 
-	if (!psm_add_nmintr(0, (avfunc) apic_nmi_intr,
+	if (!psm_add_nmintr(0, apic_nmi_intr,
 	    "apix NMI handler", (caddr_t)NULL))
 		cmn_err(CE_WARN, "apix: Unable to add nmi handler");
 

--- a/usr/src/uts/i86pc/io/cbe.c
+++ b/usr/src/uts/i86pc/io/cbe.c
@@ -68,15 +68,15 @@ extern int tsc_gethrtime_enable;
 
 void cbe_hres_tick(void);
 
-int
-cbe_softclock(void)
+uint_t
+cbe_softclock(caddr_t arg1 __unused, caddr_t arg2 __unused)
 {
 	cyclic_softint(CPU, CY_LOCK_LEVEL);
 	return (1);
 }
 
-int
-cbe_low_level(void)
+uint_t
+cbe_low_level(caddr_t arg1 __unused, caddr_t arg2 __unused)
 {
 	cpu_t *cpu = CPU;
 
@@ -90,8 +90,8 @@ cbe_low_level(void)
  * spurious calls, it would not matter if we called cyclic_fire() in both
  * cases.
  */
-int
-cbe_fire(void)
+uint_t
+cbe_fire(caddr_t arg1 __unused, caddr_t arg2 __unused)
 {
 	cpu_t *cpu = CPU;
 	processorid_t me = cpu->cpu_id, i;
@@ -346,21 +346,21 @@ cbe_init(void)
 	cyclic_init(&cbe, cbe_timer_resolution);
 	mutex_exit(&cpu_lock);
 
-	(void) add_avintr(NULL, CBE_HIGH_PIL, (avfunc)cbe_fire,
+	(void) add_avintr(NULL, CBE_HIGH_PIL, cbe_fire,
 	    "cbe_fire_master", cbe_vector, 0, NULL, NULL, NULL);
 
 	if (psm_get_ipivect != NULL) {
-		(void) add_avintr(NULL, CBE_HIGH_PIL, (avfunc)cbe_fire,
+		(void) add_avintr(NULL, CBE_HIGH_PIL, cbe_fire,
 		    "cbe_fire_slave",
 		    (*psm_get_ipivect)(CBE_HIGH_PIL, PSM_INTR_IPI_HI),
 		    0, NULL, NULL, NULL);
 	}
 
 	(void) add_avsoftintr((void *)&cbe_clock_hdl, CBE_LOCK_PIL,
-	    (avfunc)cbe_softclock, "softclock", NULL, NULL);
+	    cbe_softclock, "softclock", NULL, NULL);
 
 	(void) add_avsoftintr((void *)&cbe_low_hdl, CBE_LOW_PIL,
-	    (avfunc)cbe_low_level, "low level", NULL, NULL);
+	    cbe_low_level, "low level", NULL, NULL);
 
 	mutex_enter(&cpu_lock);
 

--- a/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
+++ b/usr/src/uts/i86pc/io/pcplusmp/apic_common.c
@@ -364,17 +364,17 @@ apic_cpcovf_mask_clear(void)
 	    (apic_reg_ops->apic_read(APIC_PCINT_VECT) & ~APIC_LVT_MASK));
 }
 
-/*ARGSUSED*/
 static int
-apic_cmci_enable(xc_arg_t arg1, xc_arg_t arg2, xc_arg_t arg3)
+apic_cmci_enable(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
 {
 	apic_reg_ops->apic_write(APIC_CMCI_VECT, apic_cmci_vect);
 	return (0);
 }
 
-/*ARGSUSED*/
 static int
-apic_cmci_disable(xc_arg_t arg1, xc_arg_t arg2, xc_arg_t arg3)
+apic_cmci_disable(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
 {
 	apic_reg_ops->apic_write(APIC_CMCI_VECT, apic_cmci_vect | AV_MASK);
 	return (0);
@@ -498,7 +498,7 @@ apic_cpu_send_SIPI(processorid_t cpun, boolean_t start)
 
 /*ARGSUSED1*/
 int
-apic_cpu_start(processorid_t cpun, caddr_t arg)
+apic_cpu_start(processorid_t cpun, caddr_t arg __unused)
 {
 	ASSERT(MUTEX_HELD(&cpu_lock));
 
@@ -524,7 +524,7 @@ apic_cpu_start(processorid_t cpun, caddr_t arg)
  */
 /*ARGSUSED1*/
 int
-apic_cpu_stop(processorid_t cpun, caddr_t arg)
+apic_cpu_stop(processorid_t cpun, caddr_t arg __unused)
 {
 	int		rc;
 	cpu_t		*cp;
@@ -645,15 +645,13 @@ apic_get_pir_ipivect(void)
 	return (apic_pir_vect);
 }
 
-/*ARGSUSED*/
 void
-apic_set_idlecpu(processorid_t cpun)
+apic_set_idlecpu(processorid_t cpun __unused)
 {
 }
 
-/*ARGSUSED*/
 void
-apic_unset_idlecpu(processorid_t cpun)
+apic_unset_idlecpu(processorid_t cpun __unused)
 {
 }
 
@@ -806,21 +804,20 @@ gethrtime_again:
 }
 
 /* apic NMI handler */
-/*ARGSUSED*/
-void
-apic_nmi_intr(caddr_t arg, struct regs *rp)
+uint_t
+apic_nmi_intr(caddr_t arg __unused, caddr_t arg1 __unused)
 {
 	nmi_action_t action = nmi_action;
 
 	if (apic_shutdown_processors) {
 		apic_disable_local_apic();
-		return;
+		return (DDI_INTR_CLAIMED);
 	}
 
 	apic_error |= APIC_ERR_NMI;
 
 	if (!lock_try(&apic_nmi_lock))
-		return;
+		return (DDI_INTR_CLAIMED);
 	apic_num_nmis++;
 
 	/*
@@ -861,6 +858,7 @@ apic_nmi_intr(caddr_t arg, struct regs *rp)
 	}
 
 	lock_clear(&apic_nmi_lock);
+	return (DDI_INTR_CLAIMED);
 }
 
 processorid_t
@@ -1286,7 +1284,7 @@ apic_clkinit(int hertz)
  * after filesystems are all unmounted.
  */
 void
-apic_preshutdown(int cmd, int fcn)
+apic_preshutdown(int cmd __unused, int fcn __unused)
 {
 	APIC_VERBOSE_POWEROFF(("apic_preshutdown(%d,%d); m=%d a=%d\n",
 	    cmd, fcn, apic_poweroff_method, apic_enable_acpi));
@@ -1640,16 +1638,14 @@ apic_intrmap_init(int apic_mode)
 	}
 }
 
-/*ARGSUSED*/
 static void
-apic_record_ioapic_rdt(void *intrmap_private, ioapic_rdt_t *irdt)
+apic_record_ioapic_rdt(void *intrmap_private __unused, ioapic_rdt_t *irdt)
 {
 	irdt->ir_hi <<= APIC_ID_BIT_OFFSET;
 }
 
-/*ARGSUSED*/
 static void
-apic_record_msi(void *intrmap_private, msi_regs_t *mregs)
+apic_record_msi(void *intrmap_private __unused, msi_regs_t *mregs)
 {
 	mregs->mr_addr = MSI_ADDR_HDR |
 	    (MSI_ADDR_RH_FIXED << MSI_ADDR_RH_SHIFT) |

--- a/usr/src/uts/i86pc/os/cpupm/pwrnow.c
+++ b/usr/src/uts/i86pc/os/cpupm/pwrnow.c
@@ -110,9 +110,11 @@ write_ctrl(cpu_acpi_handle_t handle, uint32_t ctrl)
 /*
  * Transition the current processor to the requested state.
  */
-static void
-pwrnow_pstate_transition(uint32_t req_state)
+static int
+pwrnow_pstate_transition(xc_arg_t arg1, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
 {
+	uint32_t req_state = (uint32_t)arg1;
 	cpupm_mach_state_t *mach_state =
 	    (cpupm_mach_state_t *)CPU->cpu_m.mcpu_pm_mach_state;
 	cpu_acpi_handle_t handle = mach_state->ms_acpi_handle;
@@ -137,6 +139,7 @@ pwrnow_pstate_transition(uint32_t req_state)
 
 	mach_state->ms_pstate.cma_state.pstate = req_state;
 	cpu_set_curr_clock((uint64_t)CPU_ACPI_FREQ(req_pstate) * 1000000);
+	return (0);
 }
 
 static void
@@ -149,12 +152,12 @@ pwrnow_power(cpuset_t set, uint32_t req_state)
 	 */
 	kpreempt_disable();
 	if (CPU_IN_SET(set, CPU->cpu_id)) {
-		pwrnow_pstate_transition(req_state);
+		(void) pwrnow_pstate_transition(req_state, 0, 0);
 		CPUSET_DEL(set, CPU->cpu_id);
 	}
 	if (!CPUSET_ISNULL(set)) {
 		xc_call((xc_arg_t)req_state, 0, 0,
-		    CPUSET2BV(set), (xc_func_t)pwrnow_pstate_transition);
+		    CPUSET2BV(set), pwrnow_pstate_transition);
 	}
 	kpreempt_enable();
 }

--- a/usr/src/uts/i86pc/os/dtrace_subr.c
+++ b/usr/src/uts/i86pc/os/dtrace_subr.c
@@ -134,9 +134,10 @@ dtrace_toxic_ranges(void (*func)(uintptr_t base, uintptr_t limit))
 }
 
 static int
-dtrace_xcall_func(dtrace_xcall_t func, void *arg)
+dtrace_xcall_func(xc_arg_t arg1, xc_arg_t arg2, xc_arg_t arg3 __unused)
 {
-	(*func)(arg);
+	dtrace_xcall_t func = (dtrace_xcall_t)arg1;
+	(*func)((void*)arg2);
 
 	return (0);
 }
@@ -157,7 +158,7 @@ dtrace_xcall(processorid_t cpu, dtrace_xcall_t func, void *arg)
 
 	kpreempt_disable();
 	xc_sync((xc_arg_t)func, (xc_arg_t)arg, 0, CPUSET2BV(set),
-	    (xc_func_t)dtrace_xcall_func);
+	    dtrace_xcall_func);
 	kpreempt_enable();
 }
 

--- a/usr/src/uts/i86pc/os/fastboot.c
+++ b/usr/src/uts/i86pc/os/fastboot.c
@@ -1293,8 +1293,9 @@ err_out:
 
 /* ARGSUSED */
 static int
-fastboot_xc_func(fastboot_info_t *nk, xc_arg_t unused2, xc_arg_t unused3)
+fastboot_xc_func(xc_arg_t arg1, xc_arg_t arg2 __unused, xc_arg_t arg3 __unused)
 {
+	fastboot_info_t *nk = (fastboot_info_t *)arg1;
 	void (*fastboot_func)(fastboot_info_t *);
 	fastboot_file_t	*fb = &nk->fi_files[FASTBOOT_SWTCH];
 	fastboot_func = (void (*)())(fb->fb_va);
@@ -1372,11 +1373,11 @@ fast_reboot()
 		CPUSET_ZERO(cpuset);
 		CPUSET_ADD(cpuset, bootcpuid);
 		xc_priority((xc_arg_t)&newkernel, 0, 0, CPUSET2BV(cpuset),
-		    (xc_func_t)fastboot_xc_func);
+		    fastboot_xc_func);
 
 		panic_idle();
 	} else
-		(void) fastboot_xc_func(&newkernel, 0, 0);
+		(void) fastboot_xc_func((xc_arg_t)&newkernel, 0, 0);
 }
 
 

--- a/usr/src/uts/i86pc/os/machdep.c
+++ b/usr/src/uts/i86pc/os/machdep.c
@@ -403,7 +403,7 @@ stop_other_cpus(void)
 	cpuset_t xcset;
 
 	CPUSET_ALL_BUT(xcset, CPU->cpu_id);
-	xc_priority(0, 0, 0, CPUSET2BV(xcset), (xc_func_t)mach_cpu_halt);
+	xc_priority(0, 0, 0, CPUSET2BV(xcset), mach_cpu_halt);
 	restore_int_flag(s);
 }
 

--- a/usr/src/uts/i86pc/os/mp_call.c
+++ b/usr/src/uts/i86pc/os/mp_call.c
@@ -37,7 +37,7 @@
 
 /*
  * Interrupt another CPU.
- * 	This is useful to make the other CPU go through a trap so that
+ *	This is useful to make the other CPU go through a trap so that
  *	it recognizes an address space trap (AST) for preempting a thread.
  *
  *	It is possible to be preempted here and be resumed on the CPU
@@ -87,7 +87,7 @@ cpu_call(cpu_t *cp, cpu_call_func_t func, uintptr_t arg1, uintptr_t arg2)
 	} else {
 		CPUSET_ONLY(set, cp->cpu_id);
 		xc_call((xc_arg_t)arg1, (xc_arg_t)arg2, 0, CPUSET2BV(set),
-		    (xc_func_t)func);
+		    (xc_func_t)(uintptr_t)func);
 	}
 	kpreempt_enable();
 }

--- a/usr/src/uts/i86pc/os/mp_pc.c
+++ b/usr/src/uts/i86pc/os/mp_pc.c
@@ -440,15 +440,18 @@ mach_cpucontext_free(struct cpu *cp, void *arg, int err)
 /*
  * "Enter monitor."  Called via cross-call from stop_other_cpus().
  */
-void
-mach_cpu_halt(char *msg)
+int
+mach_cpu_halt(xc_arg_t arg1, xc_arg_t arg2 __unused, xc_arg_t arg3 __unused)
 {
+	char *msg = (char *)arg1;
+
 	if (msg)
 		prom_printf("%s\n", msg);
 
 	/*CONSTANTCONDITION*/
 	while (1)
 		;
+	return (0);
 }
 
 void

--- a/usr/src/uts/i86pc/os/startup.c
+++ b/usr/src/uts/i86pc/os/startup.c
@@ -2320,7 +2320,7 @@ startup_end(void)
 	 */
 	for (i = DDI_IPL_1; i <= DDI_IPL_10; i++) {
 		(void) add_avsoftintr((void *)&softlevel_hdl[i-1], i,
-		    (avfunc)ddi_periodic_softintr, "ddi_periodic",
+		    (avfunc)(uintptr_t)ddi_periodic_softintr, "ddi_periodic",
 		    (caddr_t)(uintptr_t)i, NULL);
 	}
 

--- a/usr/src/uts/i86pc/sys/apic_common.h
+++ b/usr/src/uts/i86pc/sys/apic_common.h
@@ -167,7 +167,7 @@ extern int	apic_stretch_ISR;	/* IPL of 3 matches nothing now */
 
 extern cyclic_id_t apic_cyclic_id;
 
-extern void apic_nmi_intr(caddr_t arg, struct regs *rp);
+extern uint_t apic_nmi_intr(caddr_t arg, caddr_t);
 extern int	apic_clkinit();
 extern hrtime_t apic_gettime();
 extern hrtime_t apic_gethrtime();

--- a/usr/src/uts/i86pc/sys/machsystm.h
+++ b/usr/src/uts/i86pc/sys/machsystm.h
@@ -71,7 +71,7 @@ typedef struct mach_cpu_add_arg {
 } mach_cpu_add_arg_t;
 
 extern void mach_cpu_idle(void);
-extern void mach_cpu_halt(char *);
+extern int mach_cpu_halt(xc_arg_t, xc_arg_t, xc_arg_t);
 extern int mach_cpu_start(cpu_t *, void *);
 extern int mach_cpuid_start(processorid_t, void *);
 extern int mach_cpu_stop(cpu_t *, void *);
@@ -107,8 +107,8 @@ struct memconf {
 
 struct system_hardware {
 	int		hd_nodes;		/* number of nodes */
-	int		hd_cpus_per_node; 	/* max cpus in a node */
-	struct memconf 	hd_mem[MAXNODES];
+	int		hd_cpus_per_node;	/* max cpus in a node */
+	struct memconf	hd_mem[MAXNODES];
 						/*
 						 * memory layout for each
 						 * node.

--- a/usr/src/uts/i86xpv/os/mp_xen.c
+++ b/usr/src/uts/i86xpv/os/mp_xen.c
@@ -558,12 +558,15 @@ mach_cpu_pause(volatile char *safe)
 	}
 }
 
-void
-mach_cpu_halt(char *msg)
+int
+mach_cpu_halt(xc_arg_t arg1, xc_arg_t arg2 __unused, xc_arg_t arg3 __unused)
 {
+	char *msg = (char *)arg1;
+
 	if (msg)
 		prom_printf("%s\n", msg);
 	(void) xen_vcpu_down(CPU->cpu_id);
+	return (0);
 }
 
 /*ARGSUSED*/

--- a/usr/src/uts/intel/ia32/os/desctbls.c
+++ b/usr/src/uts/intel/ia32/os/desctbls.c
@@ -103,7 +103,7 @@ user_desc_t	*gdt0;
 desctbr_t	gdt0_default_r;
 #endif
 
-gate_desc_t	*idt0; 		/* interrupt descriptor table */
+gate_desc_t	*idt0;		/* interrupt descriptor table */
 #if defined(__i386)
 desctbr_t	idt0_default_r;		/* describes idt0 in IDTR format */
 #endif
@@ -147,10 +147,10 @@ void (*(fasttable[]))(void) = {
 	fast_null,			/* T_FNULL routine */
 	fast_null,			/* T_FGETFP routine (initially null) */
 	fast_null,			/* T_FSETFP routine (initially null) */
-	(void (*)())get_hrtime,		/* T_GETHRTIME */
-	(void (*)())gethrvtime,		/* T_GETHRVTIME */
-	(void (*)())get_hrestime,	/* T_GETHRESTIME */
-	(void (*)())getlgrp		/* T_GETLGRP */
+	(void (*)())(uintptr_t)get_hrtime,	/* T_GETHRTIME */
+	(void (*)())(uintptr_t)gethrvtime,	/* T_GETHRVTIME */
+	(void (*)())(uintptr_t)get_hrestime,	/* T_GETHRESTIME */
+	(void (*)())(uintptr_t)getlgrp		/* T_GETLGRP */
 };
 
 /*
@@ -1356,7 +1356,7 @@ void
 brand_interpositioning_enable(void)
 {
 	gate_desc_t	*idt = CPU->cpu_idt;
-	int 		i;
+	int		i;
 
 	ASSERT(curthread->t_preempt != 0 || getpil() >= DISP_LEVEL);
 

--- a/usr/src/uts/intel/kdi/kdi_idt.c
+++ b/usr/src/uts/intel/kdi/kdi_idt.c
@@ -298,7 +298,8 @@ kdi_cpu_init(void)
  * loaded at boot.
  */
 static int
-kdi_cpu_activate(void)
+kdi_cpu_activate(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
 {
 	kdi_idt_gates_install(KCS_SEL, KDI_IDT_SAVE);
 	return (0);
@@ -346,13 +347,13 @@ kdi_activate(kdi_main_t main, kdi_cpusave_t *cpusave, uint_t ncpusave)
 	if (boothowto & RB_KMDB) {
 		kdi_idt_gates_install(KMDBCODE_SEL, KDI_IDT_NOSAVE);
 	} else {
-		xc_call(0, 0, 0, CPUSET2BV(cpuset),
-		    (xc_func_t)kdi_cpu_activate);
+		xc_call(0, 0, 0, CPUSET2BV(cpuset), kdi_cpu_activate);
 	}
 }
 
 static int
-kdi_cpu_deactivate(void)
+kdi_cpu_deactivate(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
+    xc_arg_t arg3 __unused)
 {
 	kdi_idt_gates_restore();
 	return (0);
@@ -364,7 +365,7 @@ kdi_deactivate(void)
 	cpuset_t cpuset;
 	CPUSET_ALL(cpuset);
 
-	xc_call(0, 0, 0, CPUSET2BV(cpuset), (xc_func_t)kdi_cpu_deactivate);
+	xc_call(0, 0, 0, CPUSET2BV(cpuset), kdi_cpu_deactivate);
 	kdi_nmemranges = 0;
 }
 


### PR DESCRIPTION
Weekly illumos-gate upstream merge

## Backports

* none

## onu

```
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2019112701-d881ae6daf i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Wed Nov 27 18:42:19 CET 2019 ====
==== Nightly distributed build completed: Wed Nov 27 20:02:22 CET 2019 ====

==== Total build time ====

real    1:20:02

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-f278973e33 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-2

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_202-omnios-151033-20190219"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   79

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2019112701-d881ae6daf

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    35:47.8
user  3:20:16.1
sys     39:38.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    32:08.8
user  2:58:49.1
sys     35:41.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====

```