### PR TITLE
12041 tem: x86 needs to use tems.ts_color_map() for 8-bit colors (r151032)

### DIFF
--- a/usr/src/uts/common/io/tem_safe.c
+++ b/usr/src/uts/common/io/tem_safe.c
@@ -2213,9 +2213,17 @@ tem_safe_pix_cursor(struct tem_vt_state *tem, short action,
 
 	switch (tems.ts_pdepth) {
 	case 4:
-	case 8:
 		ca.fg_color.mono = fg;
 		ca.bg_color.mono = bg;
+		break;
+	case 8:
+#ifdef _HAVE_TEM_FIRMWARE
+		ca.fg_color.mono = fg;
+		ca.bg_color.mono = bg;
+#else
+		ca.fg_color.mono = tems.ts_color_map(fg);
+		ca.bg_color.mono = tems.ts_color_map(bg);
+#endif
 		break;
 	case 15:
 	case 16:
@@ -2256,8 +2264,8 @@ tem_safe_pix_cursor(struct tem_vt_state *tem, short action,
 		ca.bg_color.twentyfour[0] = (color >> 16) & 0xFF;
 		ca.bg_color.twentyfour[1] = (color >> 8) & 0xFF;
 		ca.bg_color.twentyfour[2] = color & 0xFF;
-		break;
 #endif
+		break;
 	}
 
 	ca.action = action;
@@ -2292,6 +2300,11 @@ bit_to_pix8(struct tem_vt_state *tem, tem_char_t c, text_color_t fg_color,
     text_color_t bg_color)
 {
 	uint8_t *dest = (uint8_t *)tem->tvs_pix_data;
+
+#ifndef _HAVE_TEM_FIRMWARE
+	fg_color = (text_color_t)tems.ts_color_map(fg_color);
+	bg_color = (text_color_t)tems.ts_color_map(bg_color);
+#endif
 	font_bit_to_pix8(&tems.ts_font, dest, c, fg_color, bg_color);
 }
 


### PR DESCRIPTION
This helps 8-bit colour modes work properly on the console after boot.