### PR TITLE
Squish zero-length KM_SLEEP allocations

### DIFF
--- a/usr/src/uts/common/fs/nfs/nfs4_callback.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_callback.c
@@ -560,13 +560,17 @@ cb_compound(CB_COMPOUND4args *args, CB_COMPOUND4res *resp, struct svc_req *req,
 	cs.cont = TRUE;
 
 	/*
-	 * Form a reply tag by copying over the reqeuest tag.
+	 * Form a reply tag by copying over the request tag.
 	 */
 	resp->tag.utf8string_len = args->tag.utf8string_len;
-	resp->tag.utf8string_val = kmem_alloc(resp->tag.utf8string_len,
-	    KM_SLEEP);
-	bcopy(args->tag.utf8string_val, resp->tag.utf8string_val,
-	    args->tag.utf8string_len);
+	if (args->tag.utf8string_len != 0) {
+		resp->tag.utf8string_val =
+		    kmem_alloc(resp->tag.utf8string_len, KM_SLEEP);
+		bcopy(args->tag.utf8string_val, resp->tag.utf8string_val,
+		    args->tag.utf8string_len);
+	} else {
+		resp->tag.utf8string_val = NULL;
+	}
 
 	/*
 	 * XXX for now, minorversion should be zero

--- a/usr/src/uts/common/fs/nfs/nfs4_dispatch.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_dispatch.c
@@ -545,13 +545,17 @@ rfs4_minorvers_mismatch(struct svc_req *req, SVCXPRT *xprt, void *args)
 	resp = &res_buf;
 
 	/*
-	 * Form a reply tag by copying over the reqeuest tag.
+	 * Form a reply tag by copying over the request tag.
 	 */
-	resp->tag.utf8string_val =
-	    kmem_alloc(argsp->tag.utf8string_len, KM_SLEEP);
 	resp->tag.utf8string_len = argsp->tag.utf8string_len;
-	bcopy(argsp->tag.utf8string_val, resp->tag.utf8string_val,
-	    resp->tag.utf8string_len);
+	if (argsp->tag.utf8string_len != 0) {
+		resp->tag.utf8string_val =
+		    kmem_alloc(argsp->tag.utf8string_len, KM_SLEEP);
+		bcopy(argsp->tag.utf8string_val, resp->tag.utf8string_val,
+		    resp->tag.utf8string_len);
+	} else {
+		resp->tag.utf8string_val = NULL;
+	}
 	resp->array_len = 0;
 	resp->array = NULL;
 	resp->status = NFS4ERR_MINOR_VERS_MISMATCH;
@@ -576,11 +580,15 @@ rfs4_resource_err(struct svc_req *req, COMPOUND4args *argsp)
 	/*
 	 * Form a reply tag by copying over the request tag.
 	 */
-	rbp->tag.utf8string_val =
-	    kmem_alloc(argsp->tag.utf8string_len, KM_SLEEP);
 	rbp->tag.utf8string_len = argsp->tag.utf8string_len;
-	bcopy(argsp->tag.utf8string_val, rbp->tag.utf8string_val,
-	    rbp->tag.utf8string_len);
+	if (argsp->tag.utf8string_len != 0) {
+		rbp->tag.utf8string_val =
+		    kmem_alloc(argsp->tag.utf8string_len, KM_SLEEP);
+		bcopy(argsp->tag.utf8string_val, rbp->tag.utf8string_val,
+		    rbp->tag.utf8string_len);
+	} else {
+		rbp->tag.utf8string_val = NULL;
+	}
 
 	rbp->array_len = 1;
 	rbp->array = kmem_zalloc(rbp->array_len * sizeof (nfs_resop4),

--- a/usr/src/uts/common/fs/nfs/nfs4_srv.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_srv.c
@@ -5801,13 +5801,17 @@ rfs4_compound(COMPOUND4args *args, COMPOUND4res *resp, struct exportinfo *exi,
 		*rv = 0;
 	rfs4_init_compound_state(&cs);
 	/*
-	 * Form a reply tag by copying over the reqeuest tag.
+	 * Form a reply tag by copying over the request tag.
 	 */
-	resp->tag.utf8string_val =
-	    kmem_alloc(args->tag.utf8string_len, KM_SLEEP);
 	resp->tag.utf8string_len = args->tag.utf8string_len;
-	bcopy(args->tag.utf8string_val, resp->tag.utf8string_val,
-	    resp->tag.utf8string_len);
+	if (args->tag.utf8string_len != 0) {
+		resp->tag.utf8string_val =
+		    kmem_alloc(args->tag.utf8string_len, KM_SLEEP);
+		bcopy(args->tag.utf8string_val, resp->tag.utf8string_val,
+		    resp->tag.utf8string_len);
+	} else {
+		resp->tag.utf8string_val = NULL;
+	}
 
 	cs.statusp = &resp->status;
 	cs.req = req;

--- a/usr/src/uts/common/fs/nfs/nfs_auth.c
+++ b/usr/src/uts/common/fs/nfs/nfs_auth.c
@@ -899,8 +899,12 @@ nfsauth_cache_get(struct exportinfo *exi, struct svc_req *req, int flavor,
 
 	claddr = svc_getrpccaller(req->rq_xprt);
 	addr = *claddr;
-	addr.buf = kmem_alloc(addr.maxlen, KM_SLEEP);
-	bcopy(claddr->buf, addr.buf, claddr->len);
+	if (claddr->len != 0) {
+		addr.buf = kmem_alloc(addr.maxlen, KM_SLEEP);
+		bcopy(claddr->buf, addr.buf, claddr->len);
+	} else {
+		addr.buf = NULL;
+	}
 
 	SVC_GETADDRMASK(req->rq_xprt, SVC_TATTR_ADDRMASK, (void **)&taddrmask);
 	ASSERT(taddrmask != NULL);


### PR DESCRIPTION
Subject says it all.  Tested on SmartOS, not yet tested on OmniOSce per se BUT  first round of testing had identical problems as SmartOS did.  Just happen to have faster SmartOS boxes (for now... hopefully my new work desktop will support a 8-16GB OmniOSce VM or two).