### PR TITLE
Upstream merge upstream_merge/2019121901

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3545,6 +3545,7 @@ usr/src/man/man3c/wctomb_l.3c
 usr/src/man/man3c/wctrans_l.3c
 usr/src/man/man3c/wctype_l.3c
 usr/src/man/man3c/wcwidth_l.3c
+usr/src/man/man3ext/efi_reserved_sectors.3ext
 usr/src/man/man3head/LIST_CLASS_ENTRY.3head
 usr/src/man/man3head/LIST_CLASS_HEAD.3head
 usr/src/man/man3head/LIST_CONCAT.3head
@@ -4360,6 +4361,7 @@ usr/src/test/zfs-tests/tests/functional/checksum/sha2/amd64/sha2_test
 usr/src/test/zfs-tests/tests/functional/checksum/sha2/i386/sha2_test
 usr/src/test/zfs-tests/tests/functional/checksum/skein/amd64/skein_test
 usr/src/test/zfs-tests/tests/functional/checksum/skein/i386/skein_test
+usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/socket
 usr/src/test/zfs-tests/tests/functional/ctime/ctime_001_pos
 usr/src/test/zfs-tests/tests/functional/exec/mmap_exec
 usr/src/test/zfs-tests/tests/functional/libzfs/many_fds
@@ -4397,14 +4399,8 @@ usr/src/tools/ndrgen/ndrgen
 usr/src/tools/ndrgen/ndrgen1
 usr/src/tools/ndrgen/y.tab.c
 usr/src/tools/ndrgen/y.tab.h
-usr/src/tools/onbld/Checks/py2/python2.7/
-usr/src/tools/onbld/Checks/py3/python3.5/
 usr/src/tools/onbld/Checks/py3/python3.7/
-usr/src/tools/onbld/Scm/py2/python2.7/
-usr/src/tools/onbld/Scm/py3/python3.5/
 usr/src/tools/onbld/Scm/py3/python3.7/
-usr/src/tools/onbld/py2/python2.7/
-usr/src/tools/onbld/py3/python3.5/
 usr/src/tools/onbld/py3/python3.7/
 usr/src/tools/proto/
 usr/src/tools/protocmp/protocmp

--- a/exception_lists/copyright
+++ b/exception_lists/copyright
@@ -379,8 +379,10 @@ usr/src/lib/krb5/ss/mit-sipb-copyright.h
 usr/src/lib/krb5/ss/options.c
 usr/src/lib/krb5/ss/std_rqs.c
 usr/src/lib/krb5/ss/utils.c
+usr/src/lib/libast/common/tm/tvsleep.c
 usr/src/lib/librstp/common/*.[ch]
 usr/src/lib/librstp/common/[CRT]*
+usr/src/lib/libshell/common/bltins/sleep.c
 # these have copyrights that the nit checker doesn't grok
 usr/src/lib/libsmbfs/netsmb/spnego.h
 usr/src/lib/libsmbfs/smb/derparse.[ch]

--- a/exception_lists/cstyle
+++ b/exception_lists/cstyle
@@ -644,6 +644,7 @@ usr/src/lib/krb5/ss/ss_internal.h
 usr/src/lib/krb5/ss/ss.h
 usr/src/lib/krb5/ss/std_rqs.c
 usr/src/lib/krb5/ss/utils.c
+usr/src/lib/libast/common/tm/tvsleep.c
 usr/src/lib/libgss/g_glue.c
 usr/src/lib/libresolv2/common
 usr/src/lib/librstp/common/base.h
@@ -685,6 +686,7 @@ usr/src/lib/librstp/common/transmit.h
 usr/src/lib/librstp/common/uid_stp.h
 usr/src/lib/librstp/common/vector.c
 usr/src/lib/librstp/common/vector.h
+usr/src/lib/libshell/common/bltins/sleep.c
 usr/src/lib/libsmbfs/smb/derparse.c
 usr/src/lib/libsmbfs/smb/derparse.h
 usr/src/lib/libsmbfs/smb/spnego.c

--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2019.12.05.1
+BOOT_VERSION = $(LOADER_VERSION)-2019.12.18.2

--- a/usr/src/boot/lib/libstand/cd9660.c
+++ b/usr/src/boot/lib/libstand/cd9660.c
@@ -286,7 +286,7 @@ cd9660_open(const char *path, struct open_file *f)
 	struct file *fp = NULL;
 	void *buf;
 	struct iso_primary_descriptor *vd;
-	size_t buf_size, read, dsize, off;
+	size_t read, dsize, off;
 	daddr_t bno, boff;
 	struct iso_directory_record rec;
 	struct iso_directory_record *dp = NULL;
@@ -294,7 +294,8 @@ cd9660_open(const char *path, struct open_file *f)
 	bool isdir = false;
 
 	/* First find the volume descriptor */
-	buf = malloc(buf_size = ISO_DEFAULT_BLOCK_SIZE);
+	buf = malloc(MAX(ISO_DEFAULT_BLOCK_SIZE,
+	    sizeof (struct iso_primary_descriptor)));
 	vd = buf;
 	for (bno = 16; ; bno++) {
 		twiddle(1);
@@ -438,8 +439,7 @@ cd9660_open(const char *path, struct open_file *f)
 	return (0);
 
 out:
-	if (fp)
-		free(fp);
+	free(fp);
 	free(buf);
 
 	return (rc);

--- a/usr/src/boot/lib/libstand/zfs/zfsimpl.c
+++ b/usr/src/boot/lib/libstand/zfs/zfsimpl.c
@@ -103,7 +103,7 @@ typedef struct indirect_vsd {
  */
 static vdev_list_t zfs_vdevs;
 
- /*
+/*
  * List of ZFS features supported for read
  */
 static const char *features_for_read[] = {
@@ -140,7 +140,7 @@ static char *dnode_cache_buf;
 static char *zap_scratch;
 static char *zfs_temp_buf, *zfs_temp_end, *zfs_temp_ptr;
 
-#define TEMP_SIZE	(1024 * 1024)
+#define	TEMP_SIZE	(1024 * 1024)
 
 static int zio_read(const spa_t *spa, const blkptr_t *bp, void *buf);
 static int zfs_get_root(const spa_t *spa, uint64_t *objid);
@@ -205,7 +205,7 @@ xdr_int(const unsigned char **xdr, int *ip)
 }
 
 static int
-xdr_u_int(const unsigned char **xdr, u_int *ip)
+xdr_u_int(const unsigned char **xdr, uint_t *ip)
 {
 	*ip = be32dec(*xdr);
 	(*xdr) += 4;
@@ -215,17 +215,17 @@ xdr_u_int(const unsigned char **xdr, u_int *ip)
 static int
 xdr_uint64_t(const unsigned char **xdr, uint64_t *lp)
 {
-	u_int hi, lo;
+	uint_t hi, lo;
 
 	xdr_u_int(xdr, &hi);
 	xdr_u_int(xdr, &lo);
-	*lp = (((uint64_t) hi) << 32) | lo;
+	*lp = (((uint64_t)hi) << 32) | lo;
 	return (0);
 }
 
 static int
 nvlist_find(const unsigned char *nvlist, const char *name, int type,
-	    int *elementsp, void *valuep)
+    int *elementsp, void *valuep)
 {
 	const unsigned char *p, *pair;
 	int junk;
@@ -243,33 +243,34 @@ nvlist_find(const unsigned char *nvlist, const char *name, int type,
 		const char *pairname;
 
 		xdr_int(&p, &namelen);
-		pairname = (const char*) p;
+		pairname = (const char *)p;
 		p += roundup(namelen, 4);
 		xdr_int(&p, &pairtype);
 
-		if (!memcmp(name, pairname, namelen) && type == pairtype) {
+		if (memcmp(name, pairname, namelen) == 0 && type == pairtype) {
 			xdr_int(&p, &elements);
 			if (elementsp)
 				*elementsp = elements;
 			if (type == DATA_TYPE_UINT64) {
-				xdr_uint64_t(&p, (uint64_t *) valuep);
+				xdr_uint64_t(&p, (uint64_t *)valuep);
 				return (0);
 			} else if (type == DATA_TYPE_STRING) {
 				int len;
 				xdr_int(&p, &len);
-				(*(const char**) valuep) = (const char*) p;
+				(*(const char **)valuep) = (const char *)p;
 				return (0);
-			} else if (type == DATA_TYPE_NVLIST
-				   || type == DATA_TYPE_NVLIST_ARRAY) {
-				(*(const unsigned char**) valuep) =
-					 (const unsigned char*) p;
+			} else if (type == DATA_TYPE_NVLIST ||
+			    type == DATA_TYPE_NVLIST_ARRAY) {
+				(*(const unsigned char **)valuep) =
+				    (const unsigned char *)p;
 				return (0);
 			} else {
 				return (EIO);
 			}
 		} else {
 			/*
-			 * Not the pair we are looking for, skip to the next one.
+			 * Not the pair we are looking for, skip to the
+			 * next one.
 			 */
 			p = pair + encoded_size;
 		}
@@ -307,12 +308,13 @@ nvlist_check_features_for_read(const unsigned char *nvlist)
 		found = 0;
 
 		xdr_int(&p, &namelen);
-		pairname = (const char*) p;
+		pairname = (const char *)p;
 		p += roundup(namelen, 4);
 		xdr_int(&p, &pairtype);
 
 		for (i = 0; features_for_read[i] != NULL; i++) {
-			if (!memcmp(pairname, features_for_read[i], namelen)) {
+			if (memcmp(pairname, features_for_read[i],
+			    namelen) == 0) {
 				found = 1;
 				break;
 			}
@@ -358,7 +360,7 @@ nvlist_next(const unsigned char *nvlist)
 		xdr_int(&p, &decoded_size);
 	}
 
-	return p;
+	return (p);
 }
 
 #ifdef TEST
@@ -366,7 +368,7 @@ nvlist_next(const unsigned char *nvlist)
 static const unsigned char *
 nvlist_print(const unsigned char *nvlist, unsigned int indent)
 {
-	static const char* typenames[] = {
+	static const char *typenames[] = {
 		"DATA_TYPE_UNKNOWN",
 		"DATA_TYPE_BOOLEAN",
 		"DATA_TYPE_BYTE",
@@ -413,7 +415,7 @@ nvlist_print(const unsigned char *nvlist, unsigned int indent)
 		const char *pairname;
 
 		xdr_int(&p, &namelen);
-		pairname = (const char*) p;
+		pairname = (const char *)p;
 		p += roundup(namelen, 4);
 		xdr_int(&p, &pairtype);
 
@@ -449,7 +451,8 @@ nvlist_print(const unsigned char *nvlist, unsigned int indent)
 				if (j != elements - 1) {
 					for (i = 0; i < indent; i++)
 						printf(" ");
-					printf("%s %s", typenames[pairtype], pairname);
+					printf("%s %s", typenames[pairtype],
+					    pairname);
 				}
 			}
 			break;
@@ -465,7 +468,7 @@ nvlist_print(const unsigned char *nvlist, unsigned int indent)
 		xdr_int(&p, &decoded_size);
 	}
 
-	return p;
+	return (p);
 }
 
 #endif
@@ -486,7 +489,6 @@ vdev_read_phys(vdev_t *vdev, const blkptr_t *bp, void *buf,
 		psize = size;
 	}
 
-	/*printf("ZFS: reading %zu bytes at 0x%jx to %p\n", psize, (uintmax_t)offset, buf);*/
 	rc = vdev->v_phys_read(vdev, vdev->v_read_priv, offset, buf, psize);
 	if (rc)
 		return (rc);
@@ -848,7 +850,7 @@ vdev_indirect_remap(vdev_t *vd, uint64_t offset, uint64_t asize, void *arg)
 		printf("vdev_indirect_remap: out of memory.\n");
 		zio->io_error = ENOMEM;
 	}
-	for ( ; rs != NULL; rs = list_remove_head(&stack)) {
+	for (; rs != NULL; rs = list_remove_head(&stack)) {
 		vdev_t *v = rs->rs_vd;
 		uint64_t num_entries = 0;
 		/* vdev_indirect_mapping_t *vim = v->v_mapping; */
@@ -1018,7 +1020,7 @@ vdev_disk_read(vdev_t *vdev, const blkptr_t *bp, void *buf,
 {
 
 	return (vdev_read_phys(vdev, bp, buf,
-		offset + VDEV_LABEL_START_SIZE, bytes));
+	    offset + VDEV_LABEL_START_SIZE, bytes));
 }
 
 
@@ -1080,8 +1082,8 @@ vdev_create(uint64_t guid, vdev_read_t *vdev_read)
 	vdev_t *vdev;
 	vdev_indirect_config_t *vic;
 
-	vdev = malloc(sizeof(vdev_t));
-	memset(vdev, 0, sizeof(vdev_t));
+	vdev = malloc(sizeof (vdev_t));
+	memset(vdev, 0, sizeof (vdev_t));
 	STAILQ_INIT(&vdev->v_children);
 	vdev->v_guid = guid;
 	vdev->v_state = VDEV_STATE_OFFLINE;
@@ -1117,15 +1119,16 @@ vdev_init_from_nvlist(const unsigned char *nvlist, vdev_t *pvdev,
 		return (ENOENT);
 	}
 
-	if (strcmp(type, VDEV_TYPE_MIRROR)
-	    && strcmp(type, VDEV_TYPE_DISK)
+	if (strcmp(type, VDEV_TYPE_MIRROR) != 0 &&
+	    strcmp(type, VDEV_TYPE_DISK) != 0 &&
 #ifdef ZFS_TEST
-	    && strcmp(type, VDEV_TYPE_FILE)
+	    strcmp(type, VDEV_TYPE_FILE) != 0 &&
 #endif
-	    && strcmp(type, VDEV_TYPE_RAIDZ)
-	    && strcmp(type, VDEV_TYPE_INDIRECT)
-	    && strcmp(type, VDEV_TYPE_REPLACING)) {
-		printf("ZFS: can only boot from disk, mirror, raidz1, raidz2 and raidz3 vdevs\n");
+	    strcmp(type, VDEV_TYPE_RAIDZ) != 0 &&
+	    strcmp(type, VDEV_TYPE_INDIRECT) != 0 &&
+	    strcmp(type, VDEV_TYPE_REPLACING) != 0) {
+		printf("ZFS: can only boot from disk, mirror, raidz1, "
+		    "raidz2 and raidz3 vdevs\n");
 		return (EIO);
 	}
 
@@ -1149,13 +1152,13 @@ vdev_init_from_nvlist(const unsigned char *nvlist, vdev_t *pvdev,
 	if (!vdev) {
 		is_new = 1;
 
-		if (!strcmp(type, VDEV_TYPE_MIRROR))
+		if (strcmp(type, VDEV_TYPE_MIRROR) == 0)
 			vdev = vdev_create(guid, vdev_mirror_read);
-		else if (!strcmp(type, VDEV_TYPE_RAIDZ))
+		else if (strcmp(type, VDEV_TYPE_RAIDZ) == 0)
 			vdev = vdev_create(guid, vdev_raidz_read);
-		else if (!strcmp(type, VDEV_TYPE_REPLACING))
+		else if (strcmp(type, VDEV_TYPE_REPLACING) == 0)
 			vdev = vdev_create(guid, vdev_replacing_read);
-		else if (!strcmp(type, VDEV_TYPE_INDIRECT)) {
+		else if (strcmp(type, VDEV_TYPE_INDIRECT) == 0) {
 			vdev_indirect_config_t *vic;
 
 			vdev = vdev_create(guid, vdev_indirect_read);
@@ -1213,7 +1216,7 @@ vdev_init_from_nvlist(const unsigned char *nvlist, vdev_t *pvdev,
 		} else {
 			char *name;
 
-			if (!strcmp(type, "raidz")) {
+			if (strcmp(type, "raidz") == 0) {
 				if (vdev->v_nparity < 1 ||
 				    vdev->v_nparity > 3) {
 					printf("ZFS: can only boot from disk, "
@@ -1221,12 +1224,12 @@ vdev_init_from_nvlist(const unsigned char *nvlist, vdev_t *pvdev,
 					    "vdevs\n");
 					return (EIO);
 				}
-				asprintf(&name, "%s%d-%" PRIu64, type,
+				rc = asprintf(&name, "%s%d-%" PRIu64, type,
 				    vdev->v_nparity, id);
 			} else {
-				asprintf(&name, "%s-%" PRIu64, type, id);
+				rc = asprintf(&name, "%s-%" PRIu64, type, id);
 			}
-			if (name == NULL)
+			if (rc < 0)
 				return (ENOMEM);
 			vdev->v_name = name;
 		}
@@ -1266,7 +1269,7 @@ vdev_init_from_nvlist(const unsigned char *nvlist, vdev_t *pvdev,
 				return (rc);
 			if (is_new)
 				STAILQ_INSERT_TAIL(&vdev->v_children, kid,
-						   v_childlink);
+				    v_childlink);
 			kids = nvlist_next(kids);
 		}
 	} else {
@@ -1328,7 +1331,7 @@ spa_find_by_guid(uint64_t guid)
 		if (spa->spa_guid == guid)
 			return (spa);
 
-	return (0);
+	return (NULL);
 }
 
 static spa_t *
@@ -1337,10 +1340,10 @@ spa_find_by_name(const char *name)
 	spa_t *spa;
 
 	STAILQ_FOREACH(spa, &zfs_pools, spa_link)
-		if (!strcmp(spa->spa_name, name))
+		if (strcmp(spa->spa_name, name) == 0)
 			return (spa);
 
-	return (0);
+	return (NULL);
 }
 
 spa_t *
@@ -1363,7 +1366,7 @@ spa_get_primary_vdev(const spa_t *spa)
 	if (vdev == NULL)
 		return (NULL);
 	for (kid = STAILQ_FIRST(&vdev->v_children); kid != NULL;
-	     kid = STAILQ_FIRST(&vdev->v_children))
+	    kid = STAILQ_FIRST(&vdev->v_children))
 		vdev = kid;
 	return (vdev);
 }
@@ -1389,7 +1392,7 @@ spa_create(uint64_t guid, const char *name)
 static const char *
 state_name(vdev_state_t state)
 {
-	static const char* names[] = {
+	static const char *names[] = {
 		"UNKNOWN",
 		"CLOSED",
 		"OFFLINE",
@@ -1399,7 +1402,7 @@ state_name(vdev_state_t state)
 		"DEGRADED",
 		"ONLINE"
 	};
-	return names[state];
+	return (names[state]);
 }
 
 static int
@@ -1414,7 +1417,7 @@ pager_printf(const char *fmt, ...)
 	return (pager_output(line));
 }
 
-#define STATUS_FORMAT	"        %s %s\n"
+#define	STATUS_FORMAT	"        %s %s\n"
 
 static int
 print_state(int indent, const char *name, vdev_state_t state)
@@ -1436,7 +1439,7 @@ vdev_status(vdev_t *vdev, int indent)
 	int ret;
 
 	if (vdev->v_islog) {
-		(void)pager_output("        logs\n");
+		(void) pager_output("        logs\n");
 		indent++;
 	}
 
@@ -1731,7 +1734,7 @@ vdev_probe(vdev_phys_read_t *phys_read, void *read_priv, spa_t **spap)
 
 	if (!SPA_VERSION_IS_SUPPORTED(val)) {
 		printf("ZFS: unsupported ZFS version %u (should be %u)\n",
-		    (unsigned) val, (unsigned) SPA_VERSION);
+		    (unsigned)val, (unsigned)SPA_VERSION);
 		free(nvlist);
 		return (EIO);
 	}
@@ -1876,8 +1879,8 @@ ilog2(int n)
 
 	for (v = 0; v < 32; v++)
 		if (n == (1 << v))
-			return v;
-	return -1;
+			return (v);
+	return (-1);
 }
 
 static int
@@ -1948,8 +1951,8 @@ zio_read(const spa_t *spa, const blkptr_t *bp, void *buf)
 			zfs_free(pbuf, size);
 		}
 		if (error != 0)
-			printf("ZFS: i/o error - unable to decompress block pointer data, error %d\n",
-			    error);
+			printf("ZFS: i/o error - unable to decompress "
+			    "block pointer data, error %d\n", error);
 		return (error);
 	}
 
@@ -2006,7 +2009,8 @@ zio_read(const spa_t *spa, const blkptr_t *bp, void *buf)
 }
 
 static int
-dnode_read(const spa_t *spa, const dnode_phys_t *dnode, off_t offset, void *buf, size_t buflen)
+dnode_read(const spa_t *spa, const dnode_phys_t *dnode, off_t offset,
+    void *buf, size_t buflen)
 {
 	int ibshift = dnode->dn_indblkshift - SPA_BLKPTRSHIFT;
 	int bsize = dnode->dn_datablkszsec << SPA_MINBLOCKSHIFT;
@@ -2073,7 +2077,7 @@ dnode_read(const spa_t *spa, const dnode_phys_t *dnode, off_t offset, void *buf,
 		i = bsize - boff;
 		if (i > buflen) i = buflen;
 		memcpy(buf, &dnode_cache_buf[boff], i);
-		buf = ((char*) buf) + i;
+		buf = ((char *)buf) + i;
 		offset += i;
 		buflen -= i;
 	}
@@ -2104,7 +2108,7 @@ mzap_lookup(const dnode_phys_t *dnode, const char *name, uint64_t *value)
 
 	for (i = 0; i < chunks; i++) {
 		mze = &mz->mz_chunk[i];
-		if (!strcmp(mze->mze_name, name)) {
+		if (strcmp(mze->mze_name, name) == 0) {
 			*value = mze->mze_value;
 			return (0);
 		}
@@ -2118,7 +2122,8 @@ mzap_lookup(const dnode_phys_t *dnode, const char *name, uint64_t *value)
  * matches.
  */
 static int
-fzap_name_equal(const zap_leaf_t *zl, const zap_leaf_chunk_t *zc, const char *name)
+fzap_name_equal(const zap_leaf_t *zl, const zap_leaf_chunk_t *zc,
+    const char *name)
 {
 	size_t namelen;
 	const zap_leaf_chunk_t *nc;
@@ -2130,6 +2135,7 @@ fzap_name_equal(const zap_leaf_t *zl, const zap_leaf_chunk_t *zc, const char *na
 	p = name;
 	while (namelen > 0) {
 		size_t len;
+
 		len = namelen;
 		if (len > ZAP_LEAF_ARRAY_BYTES)
 			len = ZAP_LEAF_ARRAY_BYTES;
@@ -2140,7 +2146,7 @@ fzap_name_equal(const zap_leaf_t *zl, const zap_leaf_chunk_t *zc, const char *na
 		nc = &ZAP_LEAF_CHUNK(zl, nc->l_array.la_next);
 	}
 
-	return 1;
+	return (1);
 }
 
 /*
@@ -2159,7 +2165,7 @@ fzap_leaf_value(const zap_leaf_t *zl, const zap_leaf_chunk_t *zc)
 		value = (value << 8) | p[i];
 	}
 
-	return value;
+	return (value);
 }
 
 static void
@@ -2251,7 +2257,7 @@ fzap_lookup(const spa_t *spa, const dnode_phys_t *dnode, const char *name,
     uint64_t integer_size, uint64_t num_integers, void *value)
 {
 	int bsize = dnode->dn_datablkszsec << SPA_MINBLOCKSHIFT;
-	zap_phys_t zh = *(zap_phys_t *) zap_scratch;
+	zap_phys_t zh = *(zap_phys_t *)zap_scratch;
 	fat_zap_t z;
 	uint64_t *ptrtbl;
 	uint64_t hash;
@@ -2264,17 +2270,17 @@ fzap_lookup(const spa_t *spa, const dnode_phys_t *dnode, const char *name,
 		return (rc);
 
 	z.zap_block_shift = ilog2(bsize);
-	z.zap_phys = (zap_phys_t *) zap_scratch;
+	z.zap_phys = (zap_phys_t *)zap_scratch;
 
 	/*
 	 * Figure out where the pointer table is and read it in if necessary.
 	 */
 	if (zh.zap_ptrtbl.zt_blk) {
 		rc = dnode_read(spa, dnode, zh.zap_ptrtbl.zt_blk * bsize,
-			       zap_scratch, bsize);
+		    zap_scratch, bsize);
 		if (rc)
 			return (rc);
-		ptrtbl = (uint64_t *) zap_scratch;
+		ptrtbl = (uint64_t *)zap_scratch;
 	} else {
 		ptrtbl = &ZAP_EMBEDDED_PTRTBL_ENT(&z, 0);
 	}
@@ -2291,20 +2297,21 @@ fzap_lookup(const spa_t *spa, const dnode_phys_t *dnode, const char *name,
 	if (rc)
 		return (rc);
 
-	zl.l_phys = (zap_leaf_phys_t *) zap_scratch;
+	zl.l_phys = (zap_leaf_phys_t *)zap_scratch;
 
 	/*
 	 * Make sure this chunk matches our hash.
 	 */
-	if (zl.l_phys->l_hdr.lh_prefix_len > 0
-	    && zl.l_phys->l_hdr.lh_prefix
-	    != hash >> (64 - zl.l_phys->l_hdr.lh_prefix_len))
+	if (zl.l_phys->l_hdr.lh_prefix_len > 0 &&
+	    zl.l_phys->l_hdr.lh_prefix !=
+	    hash >> (64 - zl.l_phys->l_hdr.lh_prefix_len))
 		return (ENOENT);
 
 	/*
 	 * Hash within the chunk to find our entry.
 	 */
-	int shift = (64 - ZAP_LEAF_HASH_SHIFT(&zl) - zl.l_phys->l_hdr.lh_prefix_len);
+	int shift = (64 - ZAP_LEAF_HASH_SHIFT(&zl) -
+	    zl.l_phys->l_hdr.lh_prefix_len);
 	int h = (hash >> shift) & ((1 << ZAP_LEAF_HASH_SHIFT(&zl)) - 1);
 	h = zl.l_phys->l_hash[h];
 	if (h == 0xffff)
@@ -2343,12 +2350,12 @@ zap_lookup(const spa_t *spa, const dnode_phys_t *dnode, const char *name,
 	if (rc)
 		return (rc);
 
-	zap_type = *(uint64_t *) zap_scratch;
+	zap_type = *(uint64_t *)zap_scratch;
 	if (zap_type == ZBT_MICRO)
-		return mzap_lookup(dnode, name, value);
+		return (mzap_lookup(dnode, name, value));
 	else if (zap_type == ZBT_HEADER) {
-		return fzap_lookup(spa, dnode, name, integer_size,
-		    num_integers, value);
+		return (fzap_lookup(spa, dnode, name, integer_size,
+		    num_integers, value));
 	}
 	printf("ZFS: invalid zap_type=%d\n", (int)zap_type);
 	return (EIO);
@@ -2391,10 +2398,11 @@ mzap_list(const dnode_phys_t *dnode, int (*callback)(const char *, uint64_t))
  * the directory header.
  */
 static int
-fzap_list(const spa_t *spa, const dnode_phys_t *dnode, int (*callback)(const char *, uint64_t))
+fzap_list(const spa_t *spa, const dnode_phys_t *dnode,
+    int (*callback)(const char *, uint64_t))
 {
 	int bsize = dnode->dn_datablkszsec << SPA_MINBLOCKSHIFT;
-	zap_phys_t zh = *(zap_phys_t *) zap_scratch;
+	zap_phys_t zh = *(zap_phys_t *)zap_scratch;
 	fat_zap_t z;
 	int i, j, rc;
 
@@ -2402,7 +2410,7 @@ fzap_list(const spa_t *spa, const dnode_phys_t *dnode, int (*callback)(const cha
 		return (EIO);
 
 	z.zap_block_shift = ilog2(bsize);
-	z.zap_phys = (zap_phys_t *) zap_scratch;
+	z.zap_phys = (zap_phys_t *)zap_scratch;
 
 	/*
 	 * This assumes that the leaf blocks start at block 1. The
@@ -2418,7 +2426,7 @@ fzap_list(const spa_t *spa, const dnode_phys_t *dnode, int (*callback)(const cha
 		if (dnode_read(spa, dnode, off, zap_scratch, bsize))
 			return (EIO);
 
-		zl.l_phys = (zap_leaf_phys_t *) zap_scratch;
+		zl.l_phys = (zap_leaf_phys_t *)zap_scratch;
 
 		for (j = 0; j < ZAP_LEAF_NUMCHUNKS(&zl); j++) {
 			zap_leaf_chunk_t *zc, *nc;
@@ -2428,8 +2436,8 @@ fzap_list(const spa_t *spa, const dnode_phys_t *dnode, int (*callback)(const cha
 			if (zc->l_entry.le_type != ZAP_CHUNK_ENTRY)
 				continue;
 			namelen = zc->l_entry.le_name_numints;
-			if (namelen > sizeof(name))
-				namelen = sizeof(name);
+			if (namelen > sizeof (name))
+				namelen = sizeof (name);
 
 			/*
 			 * Paste the name back together.
@@ -2453,7 +2461,7 @@ fzap_list(const spa_t *spa, const dnode_phys_t *dnode, int (*callback)(const cha
 			 */
 			value = fzap_leaf_value(&zl, zc);
 
-			//printf("%s 0x%jx\n", name, (uintmax_t)value);
+			/* printf("%s 0x%jx\n", name, (uintmax_t)value); */
 			rc = callback((const char *)name, value);
 			if (rc != 0)
 				return (rc);
@@ -2483,21 +2491,22 @@ zap_list(const spa_t *spa, const dnode_phys_t *dnode)
 	if (dnode_read(spa, dnode, 0, zap_scratch, size))
 		return (EIO);
 
-	zap_type = *(uint64_t *) zap_scratch;
+	zap_type = *(uint64_t *)zap_scratch;
 	if (zap_type == ZBT_MICRO)
-		return mzap_list(dnode, zfs_printf);
+		return (mzap_list(dnode, zfs_printf));
 	else
-		return fzap_list(spa, dnode, zfs_printf);
+		return (fzap_list(spa, dnode, zfs_printf));
 }
 
 static int
-objset_get_dnode(const spa_t *spa, const objset_phys_t *os, uint64_t objnum, dnode_phys_t *dnode)
+objset_get_dnode(const spa_t *spa, const objset_phys_t *os, uint64_t objnum,
+    dnode_phys_t *dnode)
 {
 	off_t offset;
 
-	offset = objnum * sizeof(dnode_phys_t);
-	return dnode_read(spa, &os->os_meta_dnode, offset,
-		dnode, sizeof(dnode_phys_t));
+	offset = objnum * sizeof (dnode_phys_t);
+	return (dnode_read(spa, &os->os_meta_dnode, offset,
+	    dnode, sizeof (dnode_phys_t)));
 }
 
 static int
@@ -2515,7 +2524,7 @@ mzap_rlookup(const spa_t *spa __unused, const dnode_phys_t *dnode, char *name,
 	 */
 	size = dnode->dn_datablkszsec * 512;
 
-	mz = (const mzap_phys_t *) zap_scratch;
+	mz = (const mzap_phys_t *)zap_scratch;
 	chunks = size / MZAP_ENT_LEN - 1;
 
 	for (i = 0; i < chunks; i++) {
@@ -2555,10 +2564,11 @@ fzap_name_copy(const zap_leaf_t *zl, const zap_leaf_chunk_t *zc, char *name)
 }
 
 static int
-fzap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name, uint64_t value)
+fzap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name,
+    uint64_t value)
 {
 	int bsize = dnode->dn_datablkszsec << SPA_MINBLOCKSHIFT;
-	zap_phys_t zh = *(zap_phys_t *) zap_scratch;
+	zap_phys_t zh = *(zap_phys_t *)zap_scratch;
 	fat_zap_t z;
 	int i, j;
 
@@ -2566,7 +2576,7 @@ fzap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name, uint64_t v
 		return (EIO);
 
 	z.zap_block_shift = ilog2(bsize);
-	z.zap_phys = (zap_phys_t *) zap_scratch;
+	z.zap_phys = (zap_phys_t *)zap_scratch;
 
 	/*
 	 * This assumes that the leaf blocks start at block 1. The
@@ -2580,7 +2590,7 @@ fzap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name, uint64_t v
 		if (dnode_read(spa, dnode, off, zap_scratch, bsize))
 			return (EIO);
 
-		zl.l_phys = (zap_leaf_phys_t *) zap_scratch;
+		zl.l_phys = (zap_leaf_phys_t *)zap_scratch;
 
 		for (j = 0; j < ZAP_LEAF_NUMCHUNKS(&zl); j++) {
 			zap_leaf_chunk_t *zc;
@@ -2603,7 +2613,8 @@ fzap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name, uint64_t v
 }
 
 static int
-zap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name, uint64_t value)
+zap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name,
+    uint64_t value)
 {
 	int rc;
 	uint64_t zap_type;
@@ -2613,11 +2624,11 @@ zap_rlookup(const spa_t *spa, const dnode_phys_t *dnode, char *name, uint64_t va
 	if (rc)
 		return (rc);
 
-	zap_type = *(uint64_t *) zap_scratch;
+	zap_type = *(uint64_t *)zap_scratch;
 	if (zap_type == ZBT_MICRO)
-		return mzap_rlookup(spa, dnode, name, value);
+		return (mzap_rlookup(spa, dnode, name, value));
 	else
-		return fzap_rlookup(spa, dnode, name, value);
+		return (fzap_rlookup(spa, dnode, name, value));
 }
 
 static int
@@ -2632,7 +2643,7 @@ zfs_rlookup(const spa_t *spa, uint64_t objnum, char *result)
 	char *p;
 	int len;
 
-	p = &name[sizeof(name) - 1];
+	p = &name[sizeof (name) - 1];
 	*p = '\0';
 
 	if (objset_get_dnode(spa, &spa->spa_mos, objnum, &dataset)) {
@@ -2648,15 +2659,17 @@ zfs_rlookup(const spa_t *spa, uint64_t objnum, char *result)
 		dd = (dsl_dir_phys_t *)&dir.dn_bonus;
 
 		/* Actual loop condition. */
-		parent_obj  = dd->dd_parent_obj;
+		parent_obj = dd->dd_parent_obj;
 		if (parent_obj == 0)
 			break;
 
-		if (objset_get_dnode(spa, &spa->spa_mos, parent_obj, &parent) != 0)
+		if (objset_get_dnode(spa, &spa->spa_mos, parent_obj,
+		    &parent) != 0)
 			return (EIO);
 		dd = (dsl_dir_phys_t *)&parent.dn_bonus;
 		child_dir_zapobj = dd->dd_child_dir_zapobj;
-		if (objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj, &child_dir_zap) != 0)
+		if (objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj,
+		    &child_dir_zap) != 0)
 			return (EIO);
 		if (zap_rlookup(spa, &child_dir_zap, component, dir_obj) != 0)
 			return (EIO);
@@ -2687,7 +2700,8 @@ zfs_lookup_dataset(const spa_t *spa, const char *name, uint64_t *objnum)
 	dsl_dir_phys_t *dd;
 	const char *p, *q;
 
-	if (objset_get_dnode(spa, &spa->spa_mos, DMU_POOL_DIRECTORY_OBJECT, &dir))
+	if (objset_get_dnode(spa, &spa->spa_mos,
+	    DMU_POOL_DIRECTORY_OBJECT, &dir))
 		return (EIO);
 	if (zap_lookup(spa, &dir, DMU_POOL_ROOT_DATASET, sizeof (dir_obj),
 	    1, &dir_obj))
@@ -2716,7 +2730,8 @@ zfs_lookup_dataset(const spa_t *spa, const char *name, uint64_t *objnum)
 		}
 
 		child_dir_zapobj = dd->dd_child_dir_zapobj;
-		if (objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj, &child_dir_zap) != 0)
+		if (objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj,
+		    &child_dir_zap) != 0)
 			return (EIO);
 
 		/* Actual loop condition #2. */
@@ -2731,7 +2746,7 @@ zfs_lookup_dataset(const spa_t *spa, const char *name, uint64_t *objnum)
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 static int
-zfs_list_dataset(const spa_t *spa, uint64_t objnum/*, int pos, char *entry*/)
+zfs_list_dataset(const spa_t *spa, uint64_t objnum)
 {
 	uint64_t dir_obj, child_dir_zapobj;
 	dnode_phys_t child_dir_zap, dir, dataset;
@@ -2742,7 +2757,7 @@ zfs_list_dataset(const spa_t *spa, uint64_t objnum/*, int pos, char *entry*/)
 		printf("ZFS: can't find dataset %ju\n", (uintmax_t)objnum);
 		return (EIO);
 	}
-	ds = (dsl_dataset_phys_t *) &dataset.dn_bonus;
+	ds = (dsl_dataset_phys_t *)&dataset.dn_bonus;
 	dir_obj = ds->ds_dir_obj;
 
 	if (objset_get_dnode(spa, &spa->spa_mos, dir_obj, &dir)) {
@@ -2752,7 +2767,8 @@ zfs_list_dataset(const spa_t *spa, uint64_t objnum/*, int pos, char *entry*/)
 	dd = (dsl_dir_phys_t *)&dir.dn_bonus;
 
 	child_dir_zapobj = dd->dd_child_dir_zapobj;
-	if (objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj, &child_dir_zap) != 0) {
+	if (objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj,
+	    &child_dir_zap) != 0) {
 		printf("ZFS: can't find child zap %ju\n", (uintmax_t)dir_obj);
 		return (EIO);
 	}
@@ -2761,7 +2777,8 @@ zfs_list_dataset(const spa_t *spa, uint64_t objnum/*, int pos, char *entry*/)
 }
 
 int
-zfs_callback_dataset(const spa_t *spa, uint64_t objnum, int (*callback)(const char *, uint64_t))
+zfs_callback_dataset(const spa_t *spa, uint64_t objnum,
+    int (*callback)(const char *, uint64_t))
 {
 	uint64_t dir_obj, child_dir_zapobj, zap_type;
 	dnode_phys_t child_dir_zap, dir, dataset;
@@ -2774,7 +2791,7 @@ zfs_callback_dataset(const spa_t *spa, uint64_t objnum, int (*callback)(const ch
 		printf("ZFS: can't find dataset %ju\n", (uintmax_t)objnum);
 		return (err);
 	}
-	ds = (dsl_dataset_phys_t *) &dataset.dn_bonus;
+	ds = (dsl_dataset_phys_t *)&dataset.dn_bonus;
 	dir_obj = ds->ds_dir_obj;
 
 	err = objset_get_dnode(spa, &spa->spa_mos, dir_obj, &dir);
@@ -2785,21 +2802,23 @@ zfs_callback_dataset(const spa_t *spa, uint64_t objnum, int (*callback)(const ch
 	dd = (dsl_dir_phys_t *)&dir.dn_bonus;
 
 	child_dir_zapobj = dd->dd_child_dir_zapobj;
-	err = objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj, &child_dir_zap);
+	err = objset_get_dnode(spa, &spa->spa_mos, child_dir_zapobj,
+	    &child_dir_zap);
 	if (err != 0) {
 		printf("ZFS: can't find child zap %ju\n", (uintmax_t)dir_obj);
 		return (err);
 	}
 
-	err = dnode_read(spa, &child_dir_zap, 0, zap_scratch, child_dir_zap.dn_datablkszsec * 512);
+	err = dnode_read(spa, &child_dir_zap, 0, zap_scratch,
+	    child_dir_zap.dn_datablkszsec * 512);
 	if (err != 0)
 		return (err);
 
-	zap_type = *(uint64_t *) zap_scratch;
+	zap_type = *(uint64_t *)zap_scratch;
 	if (zap_type == ZBT_MICRO)
-		return mzap_list(&child_dir_zap, callback);
+		return (mzap_list(&child_dir_zap, callback));
 	else
-		return fzap_list(spa, &child_dir_zap, callback);
+		return (fzap_list(spa, &child_dir_zap, callback));
 }
 
 /*
@@ -2817,7 +2836,7 @@ zfs_mount_dataset(const spa_t *spa, uint64_t objnum, objset_phys_t *objset)
 		return (EIO);
 	}
 
-	ds = (dsl_dataset_phys_t *) &dataset.dn_bonus;
+	ds = (dsl_dataset_phys_t *)&dataset.dn_bonus;
 	if (zio_read(spa, &ds->ds_bp, objset)) {
 		printf("ZFS: can't read object set for dataset %ju\n",
 		    (uintmax_t)objnum);
@@ -2842,7 +2861,8 @@ zfs_get_root(const spa_t *spa, uint64_t *objid)
 	/*
 	 * Start with the MOS directory object.
 	 */
-	if (objset_get_dnode(spa, &spa->spa_mos, DMU_POOL_DIRECTORY_OBJECT, &dir)) {
+	if (objset_get_dnode(spa, &spa->spa_mos,
+	    DMU_POOL_DIRECTORY_OBJECT, &dir)) {
 		printf("ZFS: can't read MOS object directory\n");
 		return (EIO);
 	}
@@ -2850,19 +2870,20 @@ zfs_get_root(const spa_t *spa, uint64_t *objid)
 	/*
 	 * Lookup the pool_props and see if we can find a bootfs.
 	 */
-	if (zap_lookup(spa, &dir, DMU_POOL_PROPS, sizeof (props), 1, &props) == 0
-	     && objset_get_dnode(spa, &spa->spa_mos, props, &propdir) == 0
-	     && zap_lookup(spa, &propdir, "bootfs", sizeof (bootfs), 1, &bootfs) == 0
-	     && bootfs != 0)
-	{
+	if (zap_lookup(spa, &dir, DMU_POOL_PROPS,
+	    sizeof (props), 1, &props) == 0 &&
+	    objset_get_dnode(spa, &spa->spa_mos, props, &propdir) == 0 &&
+	    zap_lookup(spa, &propdir, "bootfs",
+	    sizeof (bootfs), 1, &bootfs) == 0 && bootfs != 0) {
 		*objid = bootfs;
 		return (0);
 	}
 	/*
 	 * Lookup the root dataset directory
 	 */
-	if (zap_lookup(spa, &dir, DMU_POOL_ROOT_DATASET, sizeof (root), 1, &root)
-	    || objset_get_dnode(spa, &spa->spa_mos, root, &dir)) {
+	if (zap_lookup(spa, &dir, DMU_POOL_ROOT_DATASET,
+	    sizeof (root), 1, &root) ||
+	    objset_get_dnode(spa, &spa->spa_mos, root, &dir)) {
 		printf("ZFS: can't find root dsl_dir\n");
 		return (EIO);
 	}
@@ -2871,7 +2892,7 @@ zfs_get_root(const spa_t *spa, uint64_t *objid)
 	 * Use the information from the dataset directory's bonus buffer
 	 * to find the dataset object and from that the object set itself.
 	 */
-	dsl_dir_phys_t *dd = (dsl_dir_phys_t *) &dir.dn_bonus;
+	dsl_dir_phys_t *dd = (dsl_dir_phys_t *)&dir.dn_bonus;
 	*objid = dd->dd_head_dataset_obj;
 	return (0);
 }
@@ -2956,7 +2977,7 @@ check_mos_features(const spa_t *spa)
 	if (dnode_read(spa, &dir, 0, zap_scratch, size))
 		return (EIO);
 
-	zap_type = *(uint64_t *) zap_scratch;
+	zap_type = *(uint64_t *)zap_scratch;
 	if (zap_type == ZBT_MICRO)
 		rc = mzap_list(&dir, check_feature);
 	else
@@ -3052,8 +3073,7 @@ zfs_spa_init(spa_t *spa)
 		goto done;
 	}
 
-	if (nvlist_find(nv, ZPOOL_CONFIG_TYPE, DATA_TYPE_STRING,
-            NULL, &type)) {
+	if (nvlist_find(nv, ZPOOL_CONFIG_TYPE, DATA_TYPE_STRING, NULL, &type)) {
 		printf("ZFS: can't find vdev details\n");
 		rc = ENOENT;
 		goto done;
@@ -3064,7 +3084,7 @@ zfs_spa_init(spa_t *spa)
 	}
 
 	rc = nvlist_find(nv, ZPOOL_CONFIG_CHILDREN, DATA_TYPE_NVLIST_ARRAY,
-            &nkids, &nv);
+	    &nkids, &nv);
 	if (rc != 0)
 		goto done;
 
@@ -3199,9 +3219,9 @@ zfs_dnode_readlink(const spa_t *spa, dnode_phys_t *dn, char *path, size_t psize)
 	 * Second test is purely to silence bogus compiler
 	 * warning about accessing past the end of dn_bonus.
 	 */
-	if (psize + sizeof(znode_phys_t) <= dn->dn_bonuslen &&
-	    sizeof(znode_phys_t) <= sizeof(dn->dn_bonus)) {
-		memcpy(path, &dn->dn_bonus[sizeof(znode_phys_t)], psize);
+	if (psize + sizeof (znode_phys_t) <= dn->dn_bonuslen &&
+	    sizeof (znode_phys_t) <= sizeof (dn->dn_bonus)) {
+		memcpy(path, &dn->dn_bonus[sizeof (znode_phys_t)], psize);
 	} else {
 		rc = dnode_read(spa, dn, 0, path, psize);
 	}
@@ -3238,7 +3258,7 @@ zfs_lookup(const struct zfsmount *mnt, const char *upath, dnode_phys_t *dnode)
 		return (EIO);
 	}
 
-	if ((entry = malloc(sizeof(struct obj_list))) == NULL)
+	if ((entry = malloc(sizeof (struct obj_list))) == NULL)
 		return (ENOMEM);
 
 	/*
@@ -3250,7 +3270,7 @@ zfs_lookup(const struct zfsmount *mnt, const char *upath, dnode_phys_t *dnode)
 		return (rc);
 	}
 
-	rc = zap_lookup(spa, &dn, ZFS_ROOT_OBJ, sizeof(objnum), 1, &objnum);
+	rc = zap_lookup(spa, &dn, ZFS_ROOT_OBJ, sizeof (objnum), 1, &objnum);
 	if (rc) {
 		free(entry);
 		return (rc);
@@ -3295,7 +3315,7 @@ zfs_lookup(const struct zfsmount *mnt, const char *upath, dnode_phys_t *dnode)
 			objnum = (STAILQ_FIRST(&on_cache))->objnum;
 			continue;
 		}
-		if (q - p + 1 > sizeof(element)) {
+		if (q - p + 1 > sizeof (element)) {
 			rc = ENAMETOOLONG;
 			goto done;
 		}
@@ -3310,12 +3330,12 @@ zfs_lookup(const struct zfsmount *mnt, const char *upath, dnode_phys_t *dnode)
 			goto done;
 		}
 
-		rc = zap_lookup(spa, &dn, element, sizeof(objnum), 1, &objnum);
+		rc = zap_lookup(spa, &dn, element, sizeof (objnum), 1, &objnum);
 		if (rc)
 			goto done;
 		objnum = ZFS_DIRENT_OBJ(objnum);
 
-		if ((entry = malloc(sizeof(struct obj_list))) == NULL) {
+		if ((entry = malloc(sizeof (struct obj_list))) == NULL) {
 			rc = ENOMEM;
 			goto done;
 		}
@@ -3342,7 +3362,7 @@ zfs_lookup(const struct zfsmount *mnt, const char *upath, dnode_phys_t *dnode)
 			 * Read the link value and copy the tail of our
 			 * current path onto the end.
 			 */
-			if (sb.st_size + strlen(p) + 1 > sizeof(path)) {
+			if (sb.st_size + strlen(p) + 1 > sizeof (path)) {
 				rc = ENAMETOOLONG;
 				goto done;
 			}

--- a/usr/src/boot/sys/boot/common/devopen.c
+++ b/usr/src/boot/sys/boot/common/devopen.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 1998 Michael Smith <msmith@freebsd.org>
  * All rights reserved.
  *
@@ -25,7 +25,6 @@
  */
 
 #include <sys/cdefs.h>
-__FBSDID("$FreeBSD$");
 
 #include <stand.h>
 #include <string.h>
@@ -33,7 +32,7 @@ __FBSDID("$FreeBSD$");
 #include "bootstrap.h"
 
 int
-devopen(struct open_file *f, const char *fname, const char **file) 
+devopen(struct open_file *f, const char *fname, const char **file)
 {
 	struct devdesc *dev;
 	int result;
@@ -43,25 +42,22 @@ devopen(struct open_file *f, const char *fname, const char **file)
 		return (result);
 
 	/* point to device-specific data so that device open can use it */
+	f->f_dev = dev->d_dev;
 	f->f_devdata = dev;
 	result = dev->d_dev->dv_open(f, dev);
 	if (result != 0) {
 		f->f_devdata = NULL;
+		f->f_dev = NULL;
 		free(dev);
-		return (result);
 	}
 
-	/* reference the devsw entry from the open_file structure */
-	f->f_dev = dev->d_dev;
-	return (0);
+	return (result);
 }
 
 int
 devclose(struct open_file *f)
 {
 
-	if (f->f_devdata != NULL) {
-		free(f->f_devdata);
-	}
+	free(f->f_devdata);
 	return (0);
 }

--- a/usr/src/boot/sys/boot/common/vdisk.c
+++ b/usr/src/boot/sys/boot/common/vdisk.c
@@ -228,10 +228,10 @@ command_unmapvd(int argc, char *argv[])
 	}
 
 	STAILQ_REMOVE(&vdisk_list, vd, vdisk_info, vdisk_link);
-	close(vd->vdisk_fd);
+	(void) close(vd->vdisk_fd);
+	printf("%s (%s) unmapped\n", argv[1], vd->vdisk_path);
 	free(vd->vdisk_path);
 	free(vd);
-	printf("%s (%s) unmapped\n", argv[1], vd->vdisk_path);
 
 	return (CMD_OK);
 }

--- a/usr/src/boot/sys/boot/efi/libefi/efi_console.c
+++ b/usr/src/boot/sys/boot/efi/libefi/efi_console.c
@@ -674,11 +674,15 @@ efi_readkey_ex(EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *coninex)
 					kp->UnicodeChar++;
 				}
 			}
-			if (kp->ScanCode == 0 && kp->UnicodeChar == 0)
-				return (false);
-			keybuf_inschar(kp);
-			return (true);
 		}
+		/*
+		 * The shift state and/or toggle state may not be valid,
+		 * but we still can have ScanCode or UnicodeChar.
+		 */
+		if (kp->ScanCode == 0 && kp->UnicodeChar == 0)
+			return (false);
+		keybuf_inschar(kp);
+		return (true);
 	}
 	return (false);
 }

--- a/usr/src/boot/sys/boot/i386/common/edd.h
+++ b/usr/src/boot/sys/boot/i386/common/edd.h
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 2011 Hudson River Trading LLC
  * Written by: John H. Baldwin <jhb@FreeBSD.org>
  * All rights reserved.
@@ -23,8 +23,6 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * $FreeBSD$
  */
 
 #ifndef	_EDD_H_
@@ -106,5 +104,8 @@ struct edd_params_v4 {
 #define	EDD_FLAGS_NO_MEDIA_PRESENT		0x0020
 
 #define	EDD_DEVICE_PATH_KEY	0xbedd
+
+#define	EDD_QUERY_MAGIC		0x55aa
+#define	EDD_INSTALLED		0xaa55
 
 #endif /* !_EDD_H_ */

--- a/usr/src/boot/sys/boot/i386/isoboot/cd9660read.c
+++ b/usr/src/boot/sys/boot/i386/isoboot/cd9660read.c
@@ -33,6 +33,7 @@
 /*	$NetBSD: cd9660.c,v 1.5 1997/06/26 19:11:33 drochner Exp $	*/
 
 #include <sys/cdefs.h>
+#include <sys/param.h>
 
 #include <fs/cd9660/iso.h>
 #include <fs/cd9660/cd9660_rrip.h>
@@ -222,7 +223,8 @@ dirmatch(const char *path, struct iso_directory_record *dp, int use_rrip,
 static uint64_t
 cd9660_lookup(const char *path)
 {
-	static char blkbuf[ISO_DEFAULT_BLOCK_SIZE];
+	static char blkbuf[MAX(ISO_DEFAULT_BLOCK_SIZE,
+	    sizeof (struct iso_primary_descriptor))];
 	struct iso_primary_descriptor *vd;
 	struct iso_directory_record rec;
 	struct iso_directory_record *dp = NULL;

--- a/usr/src/boot/sys/boot/i386/libi386/biosdisk.c
+++ b/usr/src/boot/sys/boot/i386/libi386/biosdisk.c
@@ -63,6 +63,22 @@
 #define	ACDMAJOR	117
 #define	CDMAJOR		15
 
+/*
+ * INT13 commands
+ */
+#define	CMD_RESET	0x0000
+#define	CMD_READ_CHS	0x0200
+#define	CMD_WRITE_CHS	0x0300
+#define	CMD_READ_PARAM	0x0800
+#define	CMD_DRIVE_TYPE	0x1500
+#define	CMD_CHECK_EDD	0x4100
+#define	CMD_READ_LBA	0x4200
+#define	CMD_WRITE_LBA	0x4300
+#define	CMD_EXT_PARAM	0x4800
+#define	CMD_CD_GET_STATUS 0x4b01
+
+#define	DISK_BIOS	0x13
+
 #ifdef DISK_DEBUG
 #define	DPRINTF(fmt, args...)	printf("%s: " fmt "\n", __func__, ## args)
 #else
@@ -264,8 +280,8 @@ fd_count(void)
 
 	for (drive = 0; drive < MAXBDDEV; drive++) {
 		v86.ctl = V86_FLAGS;
-		v86.addr = 0x13;
-		v86.eax = 0x1500;
+		v86.addr = DISK_BIOS;
+		v86.eax = CMD_DRIVE_TYPE;
 		v86.edx = drive;
 		v86int();
 
@@ -362,8 +378,8 @@ bc_add(int biosdev)
 		return (-1);
 
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0x4b01;
+	v86.addr = DISK_BIOS;
+	v86.eax = CMD_CD_GET_STATUS;
 	v86.edx = biosdev;
 	v86.ds = VTOPSEG(&bc_sp);
 	v86.esi = VTOPOFF(&bc_sp);
@@ -417,14 +433,14 @@ bd_check_extensions(int unit)
 
 	/* Determine if we can use EDD with this device. */
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0x4100;
+	v86.addr = DISK_BIOS;
+	v86.eax = CMD_CHECK_EDD;
 	v86.edx = unit;
-	v86.ebx = 0x55aa;
+	v86.ebx = EDD_QUERY_MAGIC;
 	v86int();
 
 	if (V86_CY(v86.efl) ||			/* carry set */
-	    (v86.ebx & 0xffff) != 0xaa55)	/* signature */
+	    (v86.ebx & 0xffff) != EDD_INSTALLED) /* signature */
 		return (0);
 
 	/* extended disk access functions (AH=42h-44h,47h,48h) supported */
@@ -439,8 +455,8 @@ bd_reset_disk(int unit)
 {
 	/* reset disk */
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0;
+	v86.addr = DISK_BIOS;
+	v86.eax = CMD_RESET;
 	v86.edx = unit;
 	v86int();
 }
@@ -453,8 +469,8 @@ bd_get_diskinfo_std(struct bdinfo *bd)
 {
 	bzero(&v86, sizeof (v86));
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0x800;
+	v86.addr = DISK_BIOS;
+	v86.eax = CMD_READ_PARAM;
 	v86.edx = bd->bd_unit;
 	v86int();
 
@@ -488,8 +504,8 @@ bd_get_diskinfo_ext(struct bdinfo *bd)
 	bzero(&params, sizeof (params));
 	params.len = sizeof (params);
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0x4800;
+	v86.addr = DISK_BIOS;
+	v86.eax = CMD_EXT_PARAM;
 	v86.edx = bd->bd_unit;
 	v86.ds = VTOPSEG(&params);
 	v86.esi = VTOPOFF(&params);
@@ -555,8 +571,8 @@ bd_int13probe(bdinfo_t *bd)
 
 		/* Get disk type */
 		v86.ctl = V86_FLAGS;
-		v86.addr = 0x13;
-		v86.eax = 0x1500;
+		v86.addr = DISK_BIOS;
+		v86.eax = CMD_DRIVE_TYPE;
 		v86.edx = bd->bd_unit;
 		v86int();
 		if (V86_CY(v86.efl) || (v86.eax & 0x300) == 0)
@@ -1070,12 +1086,11 @@ bd_edd_io(bdinfo_t *bd, daddr_t dblk, int blks, caddr_t dest,
 	packet.seg = VTOPSEG(dest);
 	packet.lba = dblk;
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	/* Should we Write with verify ?? 0x4302 ? */
+	v86.addr = DISK_BIOS;
 	if (dowrite == BD_WR)
-		v86.eax = 0x4300;
+		v86.eax = CMD_WRITE_LBA; /* maybe Write with verify 0x4302? */
 	else
-		v86.eax = 0x4200;
+		v86.eax = CMD_READ_LBA;
 	v86.edx = bd->bd_unit;
 	v86.ds = VTOPSEG(&packet);
 	v86.esi = VTOPOFF(&packet);
@@ -1107,11 +1122,11 @@ bd_chs_io(bdinfo_t *bd, daddr_t dblk, int blks, caddr_t dest,
 	}
 
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
+	v86.addr = DISK_BIOS;
 	if (dowrite == BD_WR)
-		v86.eax = 0x300 | blks;
+		v86.eax = CMD_WRITE_CHS | blks;
 	else
-		v86.eax = 0x200 | blks;
+		v86.eax = CMD_READ_CHS | blks;
 	v86.ecx = ((cyl & 0xff) << 8) | ((cyl & 0x300) >> 2) | sec;
 	v86.edx = (hd << 8) | bd->bd_unit;
 	v86.es = VTOPSEG(dest);
@@ -1216,8 +1231,8 @@ bd_getbigeom(int bunit)
 {
 
 	v86.ctl = V86_FLAGS;
-	v86.addr = 0x13;
-	v86.eax = 0x800;
+	v86.addr = DISK_BIOS;
+	v86.eax = CMD_READ_PARAM;
 	v86.edx = 0x80 + bunit;
 	v86int();
 	if (V86_CY(v86.efl))

--- a/usr/src/cmd/acpi/iasl/Makefile
+++ b/usr/src/cmd/acpi/iasl/Makefile
@@ -126,6 +126,8 @@ $(LEX_C_FILES) := LEXFILE = $(LY_BASE).l
 $(LEX_C_FILES) := LEXFILE = $(LY_BASE).l
 $(YACC_FILES) := YTABC = $(LY_BASE)parse.c
 
+$(YACC_C_FILES:.c=.o) := CERRWARN += -_gcc=-Wno-char-subscripts
+
 OBJS += $(LEX_C_FILES:.c=.o) $(YACC_C_FILES:.c=.o)
 
 GM4FLAGS = -P
@@ -161,7 +163,5 @@ install: all $(ROOTUSRSBINPROG)
 clean:
 	$(RM) $(OBJS) $(INTERMEDIATES) $(PROG)
 	$(RM) -r AslCompiler.?????? DtParser.?????? PrParser.??????
-
-lint:	lint_SRCS
 
 include ../../Makefile.targ

--- a/usr/src/cmd/mdb/common/mdb/mdb_modapi.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_modapi.c
@@ -1020,6 +1020,13 @@ mdb_dump_aux_partial(void *buf, size_t nbyte, uint64_t offset, void *arg)
 	return (result);
 }
 
+/* Default callback for mdb_dumpptr() is calling mdb_vread(). */
+static ssize_t
+mdb_dumpptr_cb(void *buf, size_t nbytes, uintptr_t addr, void *arg __unused)
+{
+	return (mdb_vread(buf, nbytes, addr));
+}
+
 int
 mdb_dumpptr(uintptr_t addr, size_t len, uint_t flags, mdb_dumpptr_cb_t fp,
     void *arg)
@@ -1027,7 +1034,10 @@ mdb_dumpptr(uintptr_t addr, size_t len, uint_t flags, mdb_dumpptr_cb_t fp,
 	dptrdat_t dat;
 	d64dat_t dat64;
 
-	dat.func = fp;
+	if (fp == NULL)
+		dat.func = mdb_dumpptr_cb;
+	else
+		dat.func = fp;
 	dat.arg = arg;
 	dat64.func = mdb_dump_aux_ptr;
 	dat64.arg = &dat;

--- a/usr/src/cmd/mdb/common/modules/idm/idm.c
+++ b/usr/src/cmd/mdb/common/modules/idm/idm.c
@@ -2352,8 +2352,7 @@ iscsi_print_iscsit_task_data(idm_task_t *idt)
 		if (mdb_dumpptr((uintptr_t)scsi_task.task_cdb,
 		    scsi_task.task_cdb_length,
 		    MDB_DUMP_RELATIVE | MDB_DUMP_TRIM |
-		    MDB_DUMP_GROUP(1),
-		    (mdb_dumpptr_cb_t)mdb_vread, NULL)) {
+		    MDB_DUMP_GROUP(1), NULL, NULL)) {
 			mdb_printf("** Invalid CDB addr (%p)\n",
 			    scsi_task.task_cdb);
 		}

--- a/usr/src/cmd/mdb/common/modules/ipc/ipc.c
+++ b/usr/src/cmd/mdb/common/modules/ipc/ipc.c
@@ -127,8 +127,7 @@ ipcperm(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 #define	MSG_SND_SIZE 0x1
 static int
 msgq_check_for_waiters(list_t *walk_this, int min, int max,
-	int copy_wait, uintptr_t addr, int flag)
-
+    int copy_wait, uintptr_t addr, int flag)
 {
 	int found = 0;
 	int ii;
@@ -686,8 +685,7 @@ msgprint(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 			    (uintptr_t)message.msg_addr, message.msg_size,
 			    MDB_DUMP_RELATIVE | MDB_DUMP_TRIM |
 			    MDB_DUMP_ASCII | MDB_DUMP_HEADER |
-			    MDB_DUMP_GROUP(4),
-			    (mdb_dumpptr_cb_t)mdb_vread, NULL)) {
+			    MDB_DUMP_GROUP(4), NULL, NULL)) {
 				mdb_dec_indent(CMN_INDENT);
 				return (DCMD_ERR);
 			}

--- a/usr/src/cmd/mdb/common/modules/smbsrv/smbsrv.c
+++ b/usr/src/cmd/mdb/common/modules/smbsrv/smbsrv.c
@@ -3258,8 +3258,7 @@ smb_mbuf_dump_dcmd(uintptr_t addr, uint_t flags, int argc,
 	    addr, mdata, mh.mh_len);
 
 	dumpptr_flags = MDB_DUMP_RELATIVE | MDB_DUMP_ASCII | MDB_DUMP_HEADER;
-	if (mdb_dumpptr(mdata, len, dumpptr_flags,
-	    (mdb_dumpptr_cb_t)mdb_vread, NULL) < 0)
+	if (mdb_dumpptr(mdata, len, dumpptr_flags, NULL, NULL) < 0)
 		return (DCMD_ERR);
 
 	return (DCMD_OK);

--- a/usr/src/cmd/mdb/sun4v/modules/mdesc/mdesc.c
+++ b/usr/src/cmd/mdb/sun4v/modules/mdesc/mdesc.c
@@ -23,8 +23,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/sysmacros.h>
@@ -221,8 +219,7 @@ mdformat(uintptr_t addr, int size, int indent)
 	mdb_inc_indent(indent);
 	if (mdb_dumpptr((uintptr_t)addr, size,
 	    MDB_DUMP_RELATIVE | MDB_DUMP_TRIM | MDB_DUMP_ASCII |
-	    MDB_DUMP_HEADER | MDB_DUMP_GROUP(4),
-	    (mdb_dumpptr_cb_t)mdb_vread, NULL)) {
+	    MDB_DUMP_HEADER | MDB_DUMP_GROUP(4), NULL, NULL)) {
 		mdb_dec_indent(indent);
 		return (DCMD_ERR);
 	}

--- a/usr/src/cmd/svc/milestone/global.xml
+++ b/usr/src/cmd/svc/milestone/global.xml
@@ -3,6 +3,7 @@
 <!--
  Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+ Copyright 2019 Joyent, Inc.
 
  CDDL HEADER START
 
@@ -102,7 +103,7 @@ The restarter responsible for managing this service instance.  If the property i
 			    required='false'>
 				<description>
 					<loctext xml:lang='C'>
-Only one instance of this service may be run.  This property is currently unenforced, but will be at some point in the future.
+Only one instance of this service may be run.  This behavior is unimplemented, and obsolete.
 					</loctext>
 				</description>
 				<cardinality min='1' max='1'/>

--- a/usr/src/cmd/svc/milestone/network-physical.xml
+++ b/usr/src/cmd/svc/milestone/network-physical.xml
@@ -4,6 +4,8 @@
  Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  Use is subject to license terms.
 
+ Copyright 2019 Joyent, Inc.
+
  CDDL HEADER START
 
  The contents of this file are subject to the terms of the
@@ -50,8 +52,7 @@
 	<!--
 		physical:default and physical:nwam are mutually exclusive.
 		Use a one-way dependency for now since two-way exclude_all
-		does not work; enforcement of single_instance in the future
-		will fix this.
+		does not work.
 	-->
 	<dependency
 		name='physical_nwam'

--- a/usr/src/cmd/svc/svccfg/svccfg_libscf.c
+++ b/usr/src/cmd/svc/svccfg/svccfg_libscf.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  * Copyright 2012 Milan Jurik. All rights reserved.
  * Copyright 2017 RackTop Systems.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
@@ -9743,6 +9743,10 @@ export_svc_general(scf_propertygroup_t *pg, struct entity_elts *selts)
 			scfdie();
 
 		if (strcmp(exp_str, SCF_PROPERTY_SINGLE_INSTANCE) == 0) {
+			/*
+			 * Unimplemented and obsolete, but we still process it
+			 * for compatibility purposes.
+			 */
 			if (prop_check_type(exp_prop, SCF_TYPE_BOOLEAN) == 0 &&
 			    prop_get_val(exp_prop, exp_val) == 0) {
 				uint8_t b;

--- a/usr/src/cmd/svc/svccfg/svccfg_xml.c
+++ b/usr/src/cmd/svc/svccfg/svccfg_xml.c
@@ -23,6 +23,7 @@
  */
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 
@@ -3317,9 +3318,12 @@ lxml_get_instance(entity_t *service, xmlNodePtr inst, bundle_type_t bt,
 	return (0);
 }
 
-/* ARGSUSED1 */
+/*
+ * Unimplemented and obsolete, but we still process it for compatibility
+ * purposes.
+ */
 static int
-lxml_get_single_instance(entity_t *entity, xmlNodePtr si)
+lxml_get_single_instance(entity_t *entity, xmlNodePtr si __unused)
 {
 	pgroup_t *pg;
 	property_t *p;

--- a/usr/src/cmd/zlogin/zlogin.c
+++ b/usr/src/cmd/zlogin/zlogin.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2014 Gary Mills
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -125,6 +126,8 @@ static int pollerr = 0;
 
 static const char *pname;
 static char *username;
+
+extern int __xpg4;	/* 0 if not an xpg4/6-compiled program */
 
 /*
  * When forced_login is true, the user is not prompted
@@ -832,8 +835,16 @@ process_output(int in_fd, int out_fd)
 	cc = read(in_fd, ibuf, ZLOGIN_BUFSIZ);
 	if (cc == -1 && (errno != EINTR || dead))
 		return (-1);
-	if (cc == 0)	/* EOF */
-		return (-1);
+	if (cc == 0) {
+		/*
+		 * A return value of 0 when calling read() on a terminal
+		 * indicates end-of-file pre-XPG4 and no data available
+		 * for XPG4 and above.
+		 */
+		if (__xpg4 == 0)
+			return (-1);
+		return (0);
+	}
 	if (cc == -1)	/* The read was interrupted. */
 		return (0);
 
@@ -853,10 +864,10 @@ process_output(int in_fd, int out_fd)
 /*
  * This is the main I/O loop, and is shared across all zlogin modes.
  * Parameters:
- * 	stdin_fd:  The fd representing 'stdin' for the slave side; input to
+ *	stdin_fd:  The fd representing 'stdin' for the slave side; input to
  *		   the zone will be written here.
  *
- * 	appin_fd:  The fd representing the other end of the 'stdin' pipe (when
+ *	appin_fd:  The fd representing the other end of the 'stdin' pipe (when
  *		   we're running non-interactive); used in process_raw_input
  *		   to ensure we don't fill up the application's stdin pipe.
  *

--- a/usr/src/cmd/zonecfg/zonecfg.c
+++ b/usr/src/cmd/zonecfg/zonecfg.c
@@ -1879,14 +1879,16 @@ quoteit(char *instr)
 static void
 export_prop(FILE *of, int prop_num, char *prop_id)
 {
-	char *quote_str;
-
 	if (strlen(prop_id) == 0)
 		return;
-	quote_str = quoteit(prop_id);
-	(void) fprintf(of, "%s %s=%s\n", cmd_to_str(CMD_SET),
-	    pt_to_str(prop_num), quote_str);
-	free(quote_str);
+	/*
+	 * We're going to explicitly quote all strings on export.
+	 * This should be fine since it seems that no amount of escaping
+	 * will coerce zonecfg to properly parse a double quote as
+	 * part of the string value.
+	 */
+	(void) fprintf(of, "%s %s=\"%s\"\n", cmd_to_str(CMD_SET),
+	    pt_to_str(prop_num), prop_id);
 }
 
 void

--- a/usr/src/lib/auditd_plugins/remote/transport.c
+++ b/usr/src/lib/auditd_plugins/remote/transport.c
@@ -51,10 +51,10 @@
 #include "audit_remote.h"
 
 
-static int 		sockfd = -1;
+static int		sockfd = -1;
 static struct hostent	*current_host;
 static gss_OID		*current_mech_oid;
-static in_port_t 	current_port;
+static in_port_t	current_port;
 static boolean_t	flush_transq;
 
 static char		*ver_str = "01";	/* supported protocol version */
@@ -100,11 +100,11 @@ static boolean_t	transq_enqueue(transq_node_t **, gss_buffer_t,
 static int		transq_retransmit(void);
 
 static boolean_t	init_poll(int);
-static void 		do_reset(int *, struct pollfd *, boolean_t);
-static void 		do_cleanup(int *, struct pollfd *, boolean_t);
+static void		do_reset(int *, struct pollfd *, boolean_t);
+static void		do_cleanup(int *, struct pollfd *, boolean_t);
 
 static void		init_recv_record(void);
-static void		recv_record();
+static void		*recv_record(void *);
 static int		connect_timeout(int, struct sockaddr *, int);
 static int		send_timeout(int, const char *, size_t);
 static int		recv_timeout(int, char *, size_t);
@@ -933,8 +933,7 @@ static void
 init_recv_record()
 {
 	DPRINT((dfile, "Initiating the recv thread\n"));
-	(void) pthread_create(&recv_tid, NULL, (void *(*)(void *))recv_record,
-	    (void *)NULL);
+	(void) pthread_create(&recv_tid, NULL, recv_record, NULL);
 
 }
 
@@ -942,8 +941,8 @@ init_recv_record()
 /*
  * recv_record() - the receiver thread routine
  */
-static void
-recv_record()
+static void *
+recv_record(void *arg __unused)
 {
 	OM_uint32		maj_stat, min_stat;
 	gss_qop_t		qop_state;
@@ -1170,7 +1169,7 @@ recv_record()
 					break;
 				} /* switch (maj_stat) */
 
-			} else { 	/* the failure case */
+			} else {	/* the failure case */
 				report_gss_err(
 				    gettext("signature verification of the "
 				    "received token failed"),

--- a/usr/src/lib/fm/topo/libtopo/common/mapfile-vers
+++ b/usr/src/lib/fm/topo/libtopo/common/mapfile-vers
@@ -82,6 +82,7 @@ SYMBOL_VERSION SUNWprivate {
 	topo_led_state_name;
 	topo_led_type_name;
 	topo_list_append;
+	topo_list_deepcopy;
 	topo_list_delete;
 	topo_method_invoke;
 	topo_method_register;

--- a/usr/src/lib/fm/topo/libtopo/common/topo_list.h
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_list.h
@@ -22,11 +22,12 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
 
 #ifndef	_TOPO_LIST_H
 #define	_TOPO_LIST_H
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #include <fm/libtopo.h>
 
@@ -42,6 +43,8 @@ extern void topo_list_prepend(topo_list_t *, void *);
 extern void topo_list_insert_before(topo_list_t *, void *, void *);
 extern void topo_list_insert_after(topo_list_t *, void *, void *);
 extern void topo_list_delete(topo_list_t *, void *);
+extern int topo_list_deepcopy(topo_hdl_t *, topo_list_t *, topo_list_t *,
+    size_t);
 
 /* Helpers for child/sibling lists */
 extern tnode_t *topo_child_first(tnode_t *);

--- a/usr/src/lib/libast/common/tm/tvsleep.c
+++ b/usr/src/lib/libast/common/tm/tvsleep.c
@@ -1,144 +1,48 @@
 /***********************************************************************
-*                                                                      *
-*               This software is part of the ast package               *
-*          Copyright (c) 1985-2010 AT&T Intellectual Property          *
-*                      and is licensed under the                       *
-*                  Common Public License, Version 1.0                  *
-*                    by AT&T Intellectual Property                     *
-*                                                                      *
-*                A copy of the License is available at                 *
-*            http://www.opensource.org/licenses/cpl1.0.txt             *
-*         (with md5 checksum 059e8cd6165cb4c31e351f2b69388fd9)         *
-*                                                                      *
-*              Information and Software Systems Research               *
-*                            AT&T Research                             *
-*                           Florham Park NJ                            *
-*                                                                      *
-*                 Glenn Fowler <gsf@research.att.com>                  *
-*                  David Korn <dgk@research.att.com>                   *
-*                   Phong Vo <kpv@research.att.com>                    *
-*                                                                      *
-***********************************************************************/
-#pragma prototyped
+ *                                                                      *
+ *               This software is part of the ast package               *
+ *          Copyright (c) 1985-2013 AT&T Intellectual Property          *
+ *                      and is licensed under the                       *
+ *                 Eclipse Public License, Version 1.0                  *
+ *                    by AT&T Intellectual Property                     *
+ *                                                                      *
+ *                A copy of the License is available at                 *
+ *          http://www.eclipse.org/org/documents/epl-v10.html           *
+ *         (with md5 checksum b35adb5213ca9657e911e9befb180842)         *
+ *                                                                      *
+ *              Information and Software Systems Research               *
+ *                            AT&T Research                             *
+ *                           Florham Park NJ                            *
+ *                                                                      *
+ *               Glenn Fowler <glenn.s.fowler@gmail.com>                *
+ *                    David Korn <dgkorn@gmail.com>                     *
+ *                     Phong Vo <phongvo@gmail.com>                     *
+ *                                                                      *
+ ***********************************************************************/
 
-#include <tv.h>
-#include <tm.h>
+#include <errno.h>
+#include <time.h>
 
-#include "FEATURE/tvlib"
-
-#if !_lib_nanosleep
-# if _lib_select
-#  if _sys_select
-#   include <sys/select.h>
-#  else
-#   include <sys/socket.h>
-#  endif
-# else
-#  if !_lib_usleep
-#   if _lib_poll_notimer
-#    undef _lib_poll
-#   endif
-#   if _lib_poll
-#    include <poll.h>
-#   endif
-#  endif
-# endif
-#endif
+#include "tv.h"
 
 /*
  * sleep for tv
  * non-zero exit if sleep did not complete
  * with remaining time in rv
+ *
+ * NOTE: some systems hide nanosleep() ouside of -lc -- puleeze
  */
 
-int
-tvsleep(register const Tv_t* tv, register Tv_t* rv)
-{
+int tvsleep(const Tv_t *tv, Tv_t *rv) {
+    struct timespec stv;
+    struct timespec srv;
+    int r;
 
-#if _lib_nanosleep
-
-	struct timespec	stv;
-	struct timespec	srv;
-	int		r;
-
-	stv.tv_sec = tv->tv_sec;
-	stv.tv_nsec = tv->tv_nsec;
-	if ((r = nanosleep(&stv, &srv)) && rv)
-	{
-		rv->tv_sec = srv.tv_sec;
-		rv->tv_nsec = srv.tv_nsec;
-	}
-	return r;
-
-#else
-
-#if _lib_select
-
-	struct timeval	stv;
-
-	stv.tv_sec = tv->tv_sec;
-	stv.tv_usec = tv->tv_nsec / 1000;
-	if (select(0, NiL, NiL, NiL, &stv) < 0)
-	{
-		if (rv)
-			*rv = *tv;
-		return -1;
-	}
-	if (rv)
-	{
-		rv->tv_sec = stv.tv_sec;
-		rv->tv_nsec = stv.tv_usec * 1000;
-	}
-	return 0;
-
-#else
-
-	unsigned int		s = tv->tv_sec;
-	uint32_t		n = tv->tv_nsec;
-
-#if _lib_usleep
-
-
-	unsigned long		t;
-
-	if (t = (n + 999L) / 1000L)
-	{
-		usleep(t);
-		s -= t / 1000000L;
-		n = 0;
-	}
-
-#else
-
-#if _lib_poll
-
-	struct pollfd		pfd;
-	int			t;
-
-	if ((t = (n + 999999L) / 1000000L) > 0)
-	{
-		poll(&pfd, 0, t);
-		s -= t / 1000L;
-		n = 0;
-	}
-
-#endif
-
-#endif
-
-	if ((s += (n + 999999999L) / 1000000000L) && (s = sleep(s)))
-	{
-		if (rv)
-		{
-			rv->tv_sec = s;
-			rv->tv_nsec = 0;
-		}
-		return -1;
-	}
-	return 0;
-
-#endif
-
-#endif
-
+    stv.tv_sec = tv->tv_sec;
+    stv.tv_nsec = tv->tv_nsec;
+    if ((r = nanosleep(&stv, &srv)) && errno == EINTR && rv) {
+        rv->tv_sec = srv.tv_sec;
+        rv->tv_nsec = srv.tv_nsec;
+    }
+    return r;
 }

--- a/usr/src/lib/libc_db/common/thread_db.c
+++ b/usr/src/lib/libc_db/common/thread_db.c
@@ -2893,14 +2893,13 @@ out:
  */
 #pragma weak td_sync_setstate = __td_sync_setstate
 td_err_e
-__td_sync_setstate(const td_synchandle_t *sh_p, long lvalue)
+__td_sync_setstate(const td_synchandle_t *sh_p, int value)
 {
 	struct ps_prochandle *ph_p;
 	int		trunc = 0;
 	td_err_e	return_val;
 	td_so_un_t	generic_so;
 	uint32_t	*rwstate;
-	int		value = (int)lvalue;
 
 	if ((ph_p = ph_lock_sh(sh_p, &return_val)) == NULL)
 		return (return_val);

--- a/usr/src/lib/libldap5/sources/ldap/common/open.c
+++ b/usr/src/lib/libldap5/sources/ldap/common/open.c
@@ -34,7 +34,7 @@
  */
 
 #if 0
-#ifndef lint 
+#ifndef lint
 static char copyright[] = "@(#) Copyright (c) 1995 Regents of the University of Michigan.\nAll rights reserved.\n";
 #endif
 #endif
@@ -82,7 +82,7 @@ struct nsldapi_ldap_error {
 #else
 __declspec ( thread ) int	nsldapi_gldaperrno;
 __declspec ( thread ) char	*nsldapi_gmatched = NULL;
-__declspec ( thread ) char	*nsldapi_gldaperror = NULL; 
+__declspec ( thread ) char	*nsldapi_gldaperror = NULL;
 #endif /* _WINDOWS */
 
 #ifdef _WINDOWS
@@ -245,18 +245,18 @@ get_ld_error( char **matched, char **errmsg, void *dummy )
 
         le = pthread_getspecific( nsldapi_key );
 	if (le != NULL) {
-        	if ( matched != NULL ) {
-                	*matched = le->le_matched;
-        	}
-        	if ( errmsg != NULL ) {
-                	*errmsg = le->le_errmsg;
-        	}
-        	return( le->le_errno );
+		if ( matched != NULL ) {
+			*matched = le->le_matched;
+		}
+		if ( errmsg != NULL ) {
+			*errmsg = le->le_errmsg;
+		}
+		return( le->le_errno );
 	} else {
-        	if ( matched != NULL )
-                	*matched = NULL;
-        	if ( errmsg != NULL )
-                	*errmsg = NULL;
+		if ( matched != NULL )
+			*matched = NULL;
+		if ( errmsg != NULL )
+			*errmsg = NULL;
 	}
 	return (LDAP_SUCCESS);
 }
@@ -292,7 +292,7 @@ static struct ldap_extra_thread_fns
 #ifdef _WINDOWS
 		0
 #else
-		(void *(*)(void))pthread_self
+		(void *(*)(void))(uintptr_t)pthread_self
 #endif /* _WINDOWS */
 		};
 
@@ -393,8 +393,8 @@ ldap_version( LDAPVersion *ver )
 		ver->sdk_version = (int)(VI_PRODUCTVERSION * 100);
 		ver->protocol_version = LDAP_VERSION_MAX * 100;
 		ver->SSL_version = SSL_VERSION * 100;
-		/* 
-		 * set security to none by default 
+		/*
+		 * set security to none by default
 		 */
 
 		ver->security_level = LDAP_SECURITY_NONE;
@@ -710,7 +710,7 @@ ldap_x_hostlist_next( char **hostp, int *portp,
 		status->lhs_nexthost = NULL;
 	}
 
-	/* 
+	/*
 	 * Look for closing ']' and skip past it before looking for port.
 	 */
 	if ( squarebrackets && NULL != ( q = strchr( *hostp, ']' ))) {

--- a/usr/src/lib/libpctx/common/libpctx.c
+++ b/usr/src/lib/libpctx/common/libpctx.c
@@ -301,21 +301,23 @@ pctx_set_events(pctx_t *pctx, ...)
 		return (error);
 
 	if (pctx->exec == NULL)
-		pctx->exec = (pctx_sysc_execfn_t *)default_int;
+		pctx->exec = (pctx_sysc_execfn_t *)(uintptr_t)default_int;
 	if (pctx->fork == NULL)
-		pctx->fork = (pctx_sysc_forkfn_t *)default_void;
+		pctx->fork = (pctx_sysc_forkfn_t *)(uintptr_t)default_void;
 	if (pctx->exit == NULL)
-		pctx->exit = (pctx_sysc_exitfn_t *)default_void;
+		pctx->exit = (pctx_sysc_exitfn_t *)(uintptr_t)default_void;
 	if (pctx->lwp_create == NULL)
-		pctx->lwp_create = (pctx_sysc_lwp_createfn_t *)default_int;
+		pctx->lwp_create = (pctx_sysc_lwp_createfn_t *)
+		    (uintptr_t)default_int;
 	if (pctx->init_lwp == NULL)
-		pctx->init_lwp = (pctx_init_lwpfn_t *)default_int;
+		pctx->init_lwp = (pctx_init_lwpfn_t *)(uintptr_t)default_int;
 	if (pctx->fini_lwp == NULL)
-		pctx->fini_lwp = (pctx_fini_lwpfn_t *)default_int;
+		pctx->fini_lwp = (pctx_fini_lwpfn_t *)(uintptr_t)default_int;
 	if (pctx->lwp_exit == NULL)
-		pctx->lwp_exit = (pctx_sysc_lwp_exitfn_t *)default_int;
+		pctx->lwp_exit = (pctx_sysc_lwp_exitfn_t *)
+		    (uintptr_t)default_int;
 
-	if (pctx->fork != (pctx_sysc_forkfn_t *)default_void) {
+	if ((uintptr_t)pctx->fork != (uintptr_t)default_void) {
 		(void) Psysexit(pctx->Pr, SYS_vfork, 1);
 		(void) Psysexit(pctx->Pr, SYS_forksys, 1);
 		if (Psetflags(pctx->Pr, PR_FORK) == -1)
@@ -331,9 +333,9 @@ pctx_set_events(pctx_t *pctx, ...)
 	 * exec causes termination of all but the exec-ing lwp,
 	 * and resets the lwpid to one in the new address space.
 	 */
-	if (pctx->exec != (pctx_sysc_execfn_t *)default_int ||
-	    pctx->fini_lwp != (pctx_fini_lwpfn_t *)default_int ||
-	    pctx->init_lwp != (pctx_init_lwpfn_t *)default_int) {
+	if ((uintptr_t)pctx->exec != (uintptr_t)default_int ||
+	    (uintptr_t)pctx->fini_lwp != (uintptr_t)default_int ||
+	    (uintptr_t)pctx->init_lwp != (uintptr_t)default_int) {
 		(void) Psysexit(pctx->Pr, SYS_execve, 1);
 		(void) Psysentry(pctx->Pr, SYS_execve, 1);
 	} else {
@@ -342,12 +344,12 @@ pctx_set_events(pctx_t *pctx, ...)
 	}
 
 	(void) Psysexit(pctx->Pr, SYS_lwp_create,
-	    pctx->lwp_create != (pctx_sysc_lwp_createfn_t *)default_int ||
-	    pctx->init_lwp != (pctx_init_lwpfn_t *)default_int);
+	    (uintptr_t)pctx->lwp_create != (uintptr_t)default_int ||
+	    (uintptr_t)pctx->init_lwp != (uintptr_t)default_int);
 
 	(void) Psysentry(pctx->Pr, SYS_lwp_exit,
-	    pctx->lwp_exit != (pctx_sysc_lwp_exitfn_t *)default_int ||
-	    pctx->fini_lwp != (pctx_fini_lwpfn_t *)default_int);
+	    (uintptr_t)pctx->lwp_exit != (uintptr_t)default_int ||
+	    (uintptr_t)pctx->fini_lwp != (uintptr_t)default_int);
 
 	return (0);
 }
@@ -407,7 +409,7 @@ pctx_lwpiterate(pctx_t *pctx, int (*action)(pctx_t *, pid_t, id_t, void *))
 	int fd, nlwp;
 	int ret = 0;
 
-	if (action == (int (*)(pctx_t *, pid_t, id_t, void *))default_int)
+	if ((uintptr_t)action == (uintptr_t)default_int)
 		return (0);
 
 	pstatus = Pstatus(pctx->Pr);
@@ -722,8 +724,8 @@ checkstate:
 						running = -1;
 					break;
 				}
-				if (pctx->exec == (pctx_sysc_execfn_t *)
-				    default_int) {
+				if ((uintptr_t)pctx->exec ==
+				    (uintptr_t)default_int) {
 					running = 0;
 					break;
 				}

--- a/usr/src/lib/libsocket/socket/weaks.c
+++ b/usr/src/lib/libsocket/socket/weaks.c
@@ -79,7 +79,7 @@ extern int _so_getsockname();
  * already bound socket.
  */
 int
-_bind(int sock, struct sockaddr *addr, int addrlen)
+_bind(int sock, struct sockaddr *addr, socklen_t addrlen)
 {
 	return (_so_bind(sock, addr, addrlen, SOV_SOCKBSD));
 }
@@ -103,7 +103,7 @@ _accept4(int sock, struct sockaddr *addr, int *addrlen, int flags)
 }
 
 int
-_connect(int sock, struct sockaddr *addr, int addrlen)
+_connect(int sock, struct sockaddr *addr, socklen_t addrlen)
 {
 	return (_so_connect(sock, addr, addrlen, SOV_DEFAULT));
 }
@@ -114,41 +114,41 @@ _shutdown(int sock, int how)
 	return (_so_shutdown(sock, how, SOV_DEFAULT));
 }
 
-int
-_recv(int sock, char *buf, int len, int flags)
+ssize_t
+_recv(int sock, void *buf, size_t len, int flags)
 {
 	return (_so_recv(sock, buf, len, flags & ~MSG_XPG4_2));
 }
 
-int
-_recvfrom(int sock, char *buf, int len, int flags,
-	struct sockaddr *addr, int *addrlen)
+ssize_t
+_recvfrom(int sock, void *_RESTRICT_KYWD buf, size_t len, int flags,
+    struct sockaddr *_RESTRICT_KYWD addr, void *addrlen)
 {
 	return (_so_recvfrom(sock, buf, len, flags & ~MSG_XPG4_2,
 	    addr, addrlen));
 }
 
-int
+ssize_t
 _recvmsg(int sock, struct msghdr *msg, int flags)
 {
 	return (_so_recvmsg(sock, msg, flags & ~MSG_XPG4_2));
 }
 
-int
-_send(int sock, char *buf, int len, int flags)
+ssize_t
+_send(int sock, const void *buf, size_t len, int flags)
 {
 	return (_so_send(sock, buf, len, flags & ~MSG_XPG4_2));
 }
 
-int
-_sendmsg(int sock, struct msghdr *msg, int flags)
+ssize_t
+_sendmsg(int sock, const struct msghdr *msg, int flags)
 {
 	return (_so_sendmsg(sock, msg, flags & ~MSG_XPG4_2));
 }
 
-int
-_sendto(int sock, char *buf, int len, int flags,
-	struct sockaddr *addr, int *addrlen)
+ssize_t
+_sendto(int sock, const void *buf, size_t len, int flags,
+    const struct sockaddr *addr, socklen_t addrlen)
 {
 	return (_so_sendto(sock, buf, len, flags & ~MSG_XPG4_2,
 	    addr, addrlen));
@@ -211,7 +211,7 @@ _getsockopt(int sock, int level, int optname, char *optval, int *optlen)
 }
 
 int
-_setsockopt(int sock, int level, int optname, char *optval, int optlen)
+_setsockopt(int sock, int level, int optname, char *optval, socklen_t optlen)
 {
 	return (_so_setsockopt(sock, level, optname, optval, optlen,
 	    SOV_DEFAULT));
@@ -250,7 +250,7 @@ __xnet_sendmsg(int sock, const struct msghdr *msg, int flags)
 
 int
 __xnet_sendto(int sock, const void *buf, size_t len, int flags,
-	const struct sockaddr *addr, socklen_t addrlen)
+    const struct sockaddr *addr, socklen_t addrlen)
 {
 	return (_so_sendto(sock, buf, len, flags | MSG_XPG4_2,
 	    addr, addrlen));
@@ -258,7 +258,7 @@ __xnet_sendto(int sock, const void *buf, size_t len, int flags,
 
 int
 __xnet_getsockopt(int sock, int level, int option_name,
-	void *option_value, socklen_t *option_lenp)
+    void *option_value, socklen_t *option_lenp)
 {
 	if (level == IPPROTO_SCTP) {
 		return (_getsockopt(sock, level, option_name, option_value,

--- a/usr/src/man/man1/svcprop.1
+++ b/usr/src/man/man1/svcprop.1
@@ -1,13 +1,13 @@
 '\" te
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved
+.\" Copyright 2019 Joyent, Inc.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SVCPROP 1 "April 9, 2016"
+.TH SVCPROP 1 "Dec 11, 2019"
 .SH NAME
 svcprop \- retrieve values of service configuration properties
 .SH SYNOPSIS
-.LP
 .nf
 \fBsvcprop\fR [\fB-fqtv\fR] [\fB-C\fR | \fB-c\fR | \fB-s\fR \fIsnapshot\fR]
      [\fB-z\fR \fIzone\fR] [\fB-p\fR [\fIname\fR/]\fIname\fR]...
@@ -20,7 +20,6 @@ svcprop \- retrieve values of service configuration properties
 .fi
 
 .SH DESCRIPTION
-.LP
 The \fBsvcprop\fR utility prints values of properties in the service
 configuration repository. Properties are selected by \fB-p\fR options and the
 operands.
@@ -35,7 +34,6 @@ instance's directly attached properties. See \fBsmf\fR(5) for an explanation of
 property composition. If the \fBrunning\fR snapshot does not exist then the
 instance's directly attached properties are used instead.
 .SS "Output Format"
-.LP
 By default, when a single property is selected, the values for each are printed
 on separate lines. Empty \fBASCII\fR string values are represented by a pair of
 double quotes (\fB""\fR). Bourne shell metacharacters ('\fB;\fR', '\fB&\fR\&',
@@ -62,7 +60,6 @@ due to access controls, an error results.
 .LP
 Error messages are printed to the standard error stream.
 .SH OPTIONS
-.LP
 The following options are supported:
 .sp
 .ne 2
@@ -174,7 +171,6 @@ Uses properties from the service or instance in the specified \fIzone\fR.
 This option is only applicable from the global zone, see \fBzones\fR(5).
 
 .SH OPERANDS
-.LP
 The following operands are supported:
 .sp
 .ne 2
@@ -236,7 +232,6 @@ instances, \fBsvcprop\fR acts on each service or instance.
 .RE
 
 .SH EXAMPLES
-.LP
 \fBExample 1 \fRDisplaying the Value of a Single Property
 .sp
 .LP
@@ -284,7 +279,6 @@ example% svcprop -p general ntp
 general/package astring SUNWntpr
 general/enabled boolean true
 general/entity_stability astring Unstable
-general/single_instance boolean true
 .fi
 .in -2
 .sp
@@ -367,7 +361,6 @@ svcprop -p $1 $2 | (
 .sp
 
 .SH EXIT STATUS
-.LP
 The following exit values are returned:
 .sp
 .ne 2
@@ -397,7 +390,6 @@ Invalid command line options were specified.
 .RE
 
 .SH SEE ALSO
-.LP
 \fBsvcs\fR(1), \fBinetd\fR(1M), \fBsvcadm\fR(1M), \fBsvccfg\fR(1M),
 \fBsvc.startd\fR(1M), \fBservice_bundle\fR(4), \fBattributes\fR(5),
 \fBfnmatch\fR(5), \fBsmf\fR(5), \fBsmf_method\fR(5), \fBsmf_security\fR(5),

--- a/usr/src/man/man1m/svc.startd.1m
+++ b/usr/src/man/man1m/svc.startd.1m
@@ -1,14 +1,13 @@
 '\" te
 .\" Copyright (c) 2008, Sun Microsystems, Inc. All Rights Reserved.
-.\" Copyright 2012, Joyent, Inc. All Rights Reserved.
+.\" Copyright 2019 Joyent, Inc.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SVC.STARTD 1M "Mar 18, 2011"
+.TH SVC.STARTD 1M "Dec 11, 2019"
 .SH NAME
 svc.startd \- Service Management Facility master restarter
 .SH SYNOPSIS
-.LP
 .nf
 \fB/lib/svc/bin/svc.startd\fR
 .fi
@@ -19,8 +18,6 @@ svc.startd \- Service Management Facility master restarter
 .fi
 
 .SH DESCRIPTION
-.sp
-.LP
 \fBsvc.startd\fR is the master restarter daemon for Service Management Facility
 (SMF) and the default restarter for all services. \fBsvc.startd\fR starts,
 stops, and restarts services based on administrative requests, system failures,
@@ -44,8 +41,6 @@ to all restarters.
 Configuration Facility. \fBsvcadm\fR(1M) allows manipulation of service
 instances with respect to the service's restarter.
 .SS "Environment Variables"
-.sp
-.LP
 Environment variables with the "SMF_" prefix are reserved and may be
 overwritten.
 .sp
@@ -59,8 +54,6 @@ default. By default, all other environment variables supplied to
 Duplicate entries are reduced to a single entry. The value used is undefined.
 Environment entries that are not prefixed with "<\fIname\fR>=" are ignored.
 .SS "Restarter Options"
-.sp
-.LP
 \fBsvc.startd\fR is not configured by command line options. Instead,
 configuration is read from the service configuration repository. You can use
 \fBsvccfg\fR(1M) to set all options and properties.
@@ -159,13 +152,9 @@ administrator.
 Configuration errors, such as disabling \fBsvc.startd\fR are logged by
 \fBsyslog\fR, but ignored.
 .SS "SERVICE STATES"
-.sp
-.LP
 Services managed by \fBsvc.startd\fR can appear in any of the states described
 in \fBsmf\fR(5). The state definitions are unmodified by this restarter.
 .SS "SERVICE REPORTING"
-.sp
-.LP
 In addition to any logging done by the managed service, \fBsvc.startd\fR
 provides a common set of service reporting and logging mechanisms.
 .sp
@@ -249,8 +238,6 @@ descriptors to \fB/var/svc/log/\fIservice\fR:\fIinstance\fR.log\fR. The level
 of logging to system global locations like \fB/var/svc/log/svc.startd.log\fR
 and \fBsyslog\fR is controlled by the \fBoptions/logging\fR property.
 .SS "SERVICE DEFINITION"
-.sp
-.LP
 When developing or configuring a service managed by \fBsvc.startd\fR, a common
 set of properties are used to affect the interaction between the service
 instance and the restarter.
@@ -351,8 +338,10 @@ available) for managing the service.
 .ad
 .sp .6
 .RS 4n
-If \fBsingle_instance\fR is set to true, \fBsvc.startd\fR only allows one
-instance of this service to transition to online or degraded at any time.
+This was originally supposed to ensure that only one service instance could be
+in online or degraded state at once; however, it was never implemented, and is
+often incorrectly specified in multi-instance manifests. As such, it should be
+considered obsolete and not specified in new manifests.
 .RE
 
 .sp
@@ -426,8 +415,6 @@ create a \fButmpx\fR entry.
 .RE
 
 .SS "SERVICE FAILURE"
-.sp
-.LP
 \fBsvc.startd\fR assumes that a method has failed if it returns a non-zero exit
 code or if fails to complete before the timeout specified expires. If
 \fB$SMF_EXIT_ERR_CONFIG\fR or \fB$SMF_EXIT_ERR_FATAL\fR is returned,
@@ -492,8 +479,6 @@ transition to maintenance state. However, a wait service which is repeatedly
 exiting with an error that exceeds the default rate (5 failures/second) will be
 throttled back so that the service only restarts once per second.
 .SS "LEGACY SERVICES"
-.sp
-.LP
 \fBsvc.startd\fR continues to provide support for services invoked during the
 startup run level transitions. Each \fB/etc/rc?.d\fR directory is processed
 after all managed services which constitute the equivalent run level milestone
@@ -542,7 +527,6 @@ in the \fBLEGACY-RUN\fR state, cannot be modified, and can not be specified as
 dependencies of other services. The initial start time of the legacy service is
 captured as a convenience for the administrator.
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/var/svc/log\fR\fR
@@ -562,7 +546,6 @@ before \fB/var\fR is mounted read-write.
 .RE
 
 .SH EXAMPLE
-.LP
 \fBExample 1 \fRTurning on Verbose Logging
 .sp
 .LP
@@ -585,8 +568,6 @@ svc:/system/svc/restarter:default> exit
 This request will take effect on the next restart of \fBsvc.startd\fR.
 
 .SH SEE ALSO
-.sp
-.LP
 \fBsvcs\fR(1), \fBsvcprop\fR(1), \fBkernel\fR(1M), \fBinit\fR(1M),
 \fBsvcadm\fR(1M), \fBsvccfg\fR(1M), \fBsvc.configd\fR(1M), \fBsetsid\fR(2),
 \fBsyslog\fR(3C), \fBlibscf\fR(3LIB), \fBscf_value_is_type\fR(3SCF),

--- a/usr/src/man/man3c_db/td_sync_get_info.3c_db
+++ b/usr/src/man/man3c_db/td_sync_get_info.3c_db
@@ -3,7 +3,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH TD_SYNC_GET_INFO 3C_DB "Jun 5, 2007"
+.TH TD_SYNC_GET_INFO 3C_DB "Nov 22, 2018"
 .SH NAME
 td_sync_get_info, td_ta_sync_tracking_enable, td_sync_get_stats,
 td_sync_setstate, td_sync_waiters \- operations on a synchronization object in
@@ -30,7 +30,7 @@ cc [ \fIflag\fR... ] \fIfile\fR... -lc_db [ \fIlibrary\fR... ]
 
 .LP
 .nf
-\fBtd_err_e\fR \fBtd_sync_setstate\fR(\fBconst td_synchandle_t *\fR\fIsh_p\fR);
+\fBtd_err_e\fR \fBtd_sync_setstate\fR(\fBconst td_synchandle_t *\fR\fIsh_p\fR, \fBint\fR \fIvalue\fR);
 .fi
 
 .LP
@@ -243,16 +243,16 @@ structure, depending on the type of the synchronization object.
 .LP
 The \fBtd_sync_setstate\fR function modifies the state of synchronization
 object \fIsi_p\fR, depending on the synchronization object type. For mutexes,
-\fBtd_sync_setstate\fR is unlocked if the value is  \fB0\fR. Otherwise it is
-locked. For semaphores, the semaphore's count is set to the value. For
-reader-writer locks, the reader count set to the value if value is \fB>0\fR.
-The count is set to write-locked if value is \fB-1\fR\&. It is set to unlocked
-if the value is  \fB0\fR. Setting the state of a synchronization object from a
-\fBlibc_db\fR interface may cause the synchronization object's semantics to be
-violated from the point of view of the threads in the target process. For
-example, if a thread holds a mutex, and \fBtd_sync_setstate\fR is used to set
-the mutex to unlocked, then a different thread  will also be able to
-subsequently acquire the same mutex.
+\fBtd_sync_setstate\fR is unlocked if the \fIvalue\fR is \fB0\fR. Otherwise it
+is locked. For semaphores, the semaphore's count is set to the \fIvalue\fR. For
+reader-writer locks, the reader count set to the \fIvalue\fR if \fIvalue\fR is
+\fB>0\fR. The count is set to write-locked if \fIvalue\fR is \fB-1\fR\&.
+It is set to unlocked if the \fIvalue\fR is \fB0\fR. Setting the state of a
+synchronization object from a \fBlibc_db\fR interface may cause the
+synchronization object's semantics to be violated from the point of view of
+the threads in the target process. For example, if a thread holds a mutex,
+and \fBtd_sync_setstate\fR is used to set the mutex to unlocked, then a
+different thread  will also be able to subsequently acquire the same mutex.
 .sp
 .LP
 The \fBtd_sync_waiters\fR function iterates over the set of thread handles of

--- a/usr/src/man/man5/smf_restarter.5
+++ b/usr/src/man/man5/smf_restarter.5
@@ -1,14 +1,13 @@
 '\" te
 .\" Copyright (c) 2008, Sun Microsystems, Inc. All Rights Reserved.
+.\" Copyright 2019 Joyent, Inc.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SMF_RESTARTER 5 "May 23, 2008"
+.TH SMF_RESTARTER 5 "Dec 11, 2019"
 .SH NAME
 smf_restarter \- service management facility conventions for restarters
 .SH DESCRIPTION
-.sp
-.LP
 All service instances in the service management facility must be managed by a
 restarter. This manual page describes configuration, functionality, and
 reporting characteristics that are common to all restarters in the framework.
@@ -21,8 +20,6 @@ service instance to determine configuration. The restarter manages a set of
 property groups to communicate the current disposition of a service with
 display tools such as \fBsvcs\fR(1).
 .SS "Service Configuration"
-.sp
-.LP
 The common restarter configuration for all services is captured in the
 \fBgeneral\fR property group. This group includes the following required and
 optional property settings.
@@ -54,12 +51,11 @@ absent, the restarter defaults to \fBsvc.startd\fR(1M).
 .ad
 .RS 19n
 This is an optional property. When set, only one instance of the service is
-allowed to transition to an online or degraded status at any time.
+allowed to transition to an online or degraded status at any time. Note that no
+known implementation honours this setting, and it should be considered obsolete.
 .RE
 
 .SS "Service Reporting"
-.sp
-.LP
 All restarters report status using the \fBrestarter\fR property group, which
 includes the following properties:
 .sp
@@ -106,7 +102,5 @@ executing.
 .RE
 
 .SH SEE ALSO
-.sp
-.LP
 \fBsvcs\fR(1), \fBsvc.startd\fR(1M), \fBservice_bundle\fR(4), \fBsmf\fR(5),
 \fBsmf_method\fR(5)

--- a/usr/src/man/man9s/Intro.9s
+++ b/usr/src/man/man9s/Intro.9s
@@ -1,189 +1,130 @@
-'\" te
+.\" Copyright 2018, Joyent Inc.
 .\" Copyright 2014 Garrett D'Amore <garrett@damore.org>
 .\" Copyright (c) 2001, Sun Microsystems, Inc.,  All Rights Reserved.
 .\" Copyright 1989 AT&T
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH INTRO 9S "May 24, 2014"
-.SH NAME
-Intro, intro \- introduction to kernel data structures and properties
-.SH DESCRIPTION
-.sp
-.LP
-Section 9P describes kernel properties used by device drivers. Section 9S
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt INTRO 9S
+.Os
+.Sh NAME
+.Nm Intro ,
+.Nm intro
+.Nd introduction to kernel data structures and properties
+.Sh DESCRIPTION
+Section 9P describes kernel properties used by device drivers.
+Section 9S
 describes the data structures used by drivers to share information between the
-driver and the kernel. See \fBIntro\fR(9E) for an overview of device driver
+driver and the kernel.
+See
+.Xr Intro 9E
+for an overview of device driver
 interfaces.
-.sp
-.LP
+.Pp
 In Section 9S, reference pages contain the following headings:
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fBNAME\fR summarizes the purpose of the structure or property.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fBSYNOPSIS\fR lists the include file that defines the structure or property.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fBINTERFACE\fR \fBLEVEL\fR describes any architecture dependencies.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fBDESCRIPTION\fR provides general information about the structure or property.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fBSTRUCTURE\fR \fBMEMBERS\fR lists all accessible structure members (for
-Section 9S).
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-\fBSEE\fR \fBALSO\fR gives sources for further information.
-.RE
-.sp
-.LP
-Of the preceding headings, Section 9P reference pages contain the \fBNAME\fR,
-\fBDESCRIPTION\fR, and \fBSEE\fR \fBALSO\fR fields.
-.sp
-.LP
-Every driver MUST include <\fBsys/ddi.h\fR> and <\fBsys/sunddi.h\fR>, in that
-order, and as final entries.
-.sp
-.LP
+.Bl -bullet -offset indent
+.It
+.Sy NAME
+summarizes the purpose of the structure or property.
+.It
+.Sy SYNOPSIS
+lists the include file that defines the structure or property.
+.It
+.Sy "INTERFACE LEVEL"
+describes any architecture dependencies.
+.It
+.Sy DESCRIPTION
+provides general information about the structure or property.
+.It
+.Sy "STRUCTURE MEMBERS"
+lists all accessible structure members (for Section 9S).
+.It
+.Sy "SEE ALSO"
+gives sources for further information.
+.El
+.Pp
+Of the preceding headings, Section 9P reference pages contain the
+.Sy NAME ,
+.Sy DESCRIPTION ,
+and
+.Sy "SEE ALSO"
+fields.
+.Pp
+Every driver MUST include
+.In sys/ddi.h
+and
+.In sys/sunddi.h ,
+in that order, and as final entries.
+.Pp
 The following table summarizes the STREAMS structures described in Section 9S.
-.sp
-
-.sp
-.TS
-box;
-c | c
-l | l .
-Structure	Type
-_
-\fBcopyreq\fR	DDI/DKI
-_
-\fBcopyresp\fR	DDI/DKI
-_
-\fBdatab\fR	DDI/DKI
-_
-\fBfmodsw\fR	Solaris DDI
-_
-\fBfree_rtn\fR	DDI/DKI
-_
-\fBiocblk\fR	DDI/DKI
-_
-\fBlinkblk\fR	DDI/DKI
-_
-\fBmodule_info\fR	DDI/DKI
-_
-\fBmsgb\fR	DDI/DKI
-_
-\fBqband\fR	DDI/DKI
-_
-\fBqinit\fR	DDI/DKI
-_
-\fBqueclass\fR	Solaris DDI
-_
-\fBqueue\fR	DDI/DKI
-_
-\fBstreamtab\fR	DDI/DKI
-_
-\fBstroptions\fR	DDI/DKI
-.TE
-
-.sp
-.LP
+.Bl -column "module_info" "Solaris DDI" -offset indent
+.It Structure Ta Type
+.It Vt copyreq Ta DDI/DKI
+.It Vt copyresp Ta DDI/DKI
+.It Vt datab Ta DDI/DKI
+.It Vt fmodsw Ta Solaris DDI
+.It Vt free_rtn Ta DDI/DKI
+.It Vt iocblk Ta DDI/DKI
+.It Vt linkblk Ta DDI/DKI
+.It Vt module_info Ta DDI/DKI
+.It Vt msgb Ta DDI/DKI
+.It Vt qband Ta DDI/DKI
+.It Vt qinit Ta DDI/DKI
+.It Vt queclass Ta Solaris DDI
+.It Vt queue Ta DDI/DKI
+.It Vt streamtab Ta DDI/DKI
+.It Vt stroptions Ta DDI/DKI
+.El
+.Pp
 The following table summarizes structures that are not specific to STREAMS I/O.
-.sp
-
-.sp
-.TS
-box;
-c | c
-l | l .
-Structure	Type
-_
-\fBaio_req\fR	Solaris DDI
-_
-\fBbuf\fR	DDI/DKI
-_
-\fBcb_ops\fR	Solaris DDI
-_
-\fBddi_device_acc_attr\fR	Solaris DDI
-_
-\fBddi_dma_attr\fR	Solaris DDI
-_
-\fBddi_dma_cookie\fR	Solaris DDI
-_
-\fBddi_dmae_req\fR	Solaris x86 DDI
-_
-\fBddi_idevice_cookie\fR	Solaris DDI
-_
-\fBddi_mapdev_ctl\fR	Solaris DDI
-_
-\fBdevmap_callback_ctl\fR	Solaris DDI
-_
-\fBdev_ops\fR	Solaris DDI
-_
-\fBiovec\fR	DDI/DKI
-_
-\fBkstat\fR	Solaris DDI
-_
-\fBkstat_intr\fR	Solaris DDI
-_
-\fBkstat_io\fR	Solaris DDI
-_
-\fBkstat_named\fR	Solaris DDI
-_
-\fBmap\fR	DDI/DKI
-_
-\fBmodldrv\fR	Solaris DDI
-_
-\fBmodlinkage\fR	Solaris DDI
-_
-\fBmodlstrmod\fR	Solaris DDI
-_
-\fBscsi_address\fR	Solaris DDI
-_
-\fBscsi_arq_status\fR	Solaris DDI
-_
-\fBscsi_device\fR	Solaris DDI
-_
-\fBscsi_extended_sense\fR	Solaris DDI
-_
-\fBscsi_hba_tran\fR	Solaris DDI
-_
-\fBscsi_inquiry\fR	Solaris DDI
-_
-\fBscsi_pkt\fR	Solaris DDI
-_
-\fBscsi_status\fR	Solaris DDI
-_
-\fBuio\fR	DDI/DKI
-.TE
-
-.SH SEE ALSO
-.sp
-.LP
-\fBIntro\fR(9E)
-.SH NOTES
-.sp
-.LP
+.Bl -column "ddi_device_acc_attr" "Solaris x86 DDI" -offset indent
+.It Structure	Type
+.It Vt aio_req Ta Solaris DDI
+.It Vt buf Ta DDI/DKI
+.It Vt cb_ops Ta Solaris DDI
+.It Vt ddi_device_acc_attr Ta Solaris DDI
+.It Vt ddi_dma_attr Ta Solaris DDI
+.It Vt ddi_dma_cookie Ta Solaris DDI
+.It Vt ddi_dmae_req Ta Solaris x86 DDI
+.It Vt ddi_idevice_cookie Ta Solaris DDI
+.It Vt ddi_mapdev_ctl Ta Solaris DDI
+.It Vt devmap_callback_ctl Ta Solaris DDI
+.It Vt dev_ops Ta Solaris DDI
+.It Vt iovec Ta DDI/DKI
+.It Vt kstat Ta Solaris DDI
+.It Vt kstat_intr Ta Solaris DDI
+.It Vt kstat_io Ta Solaris DDI
+.It Vt kstat_named Ta Solaris DDI
+.It Vt map Ta DDI/DKI
+.It Vt modldrv Ta Solaris DDI
+.It Vt modlinkage Ta Solaris DDI
+.It Vt modlstrmod Ta Solaris DDI
+.It Vt scsi_address Ta Solaris DDI
+.It Vt scsi_arq_status Ta Solaris DDI
+.It Vt scsi_device Ta Solaris DDI
+.It Vt scsi_extended_sense Ta Solaris DDI
+.It Vt scsi_hba_tran Ta Solaris DDI
+.It Vt scsi_inquiry Ta Solaris DDI
+.It Vt scsi_pkt Ta Solaris DDI
+.It Vt scsi_status Ta Solaris DDI
+.It Vt uio Ta DDI/DKI
+.El
+.Sh SEE ALSO
+.Xr Intro 9E
+.Sh NOTES
 Do not declare arrays of structures as the size of the structures can change
-between releases. Rely only on the structure members listed in this chapter and
+between releases.
+Rely only on the structure members listed in this chapter and
 not on unlisted members or the position of a member in a structure.

--- a/usr/src/man/man9s/aio_req.9s
+++ b/usr/src/man/man9s/aio_req.9s
@@ -1,42 +1,54 @@
-'\" te
+.\"  Copyright 2018, Joyent, Inc.
 .\"  Copyright 1989 AT&T
 .\"  Copyright (c) 1997, Sun Microsystems, Inc.  All Rights Reserved
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH AIO_REQ 9S "Mar 28, 1997"
-.SH NAME
-aio_req \- asynchronous I/O request structure
-.SH SYNOPSIS
-.LP
-.nf
-#include <sys/uio.h>
-#include <sys/aio_req.h>
-#include <sys/ddi.h>
-#include <sys/sunddi.h>
-.fi
-
-.SH INTERFACE LEVEL
-.sp
-.LP
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt AIO_REQ 9S
+.Os
+.Sh NAME
+.Nm aio_req
+.Nd asynchronous I/O request structure
+.Sh SYNOPSIS
+.In sys/uio.h
+.In sys/aio_req.h
+.In sys/ddi.h
+.In sys/sunddi.h
+.Sh INTERFACE LEVEL
 Solaris DDI specific (Solaris DDI)
-.SH DESCRIPTION
-.sp
-.LP
-An  \fBaio_req\fR structure describes an asynchronous \fBI/O \fRrequest.
-.SH STRUCTURE MEMBERS
-.sp
-.in +2
-.nf
-struct uio*aio_uio;   /* uio structure describing the I/O request */
-.fi
-.in -2
-
-.sp
-.LP
-The \fBaio_uio\fR member is a pointer to a \fBuio\fR(9S) structure, describing
-the \fBI/O \fRtransfer request.
-.SH SEE ALSO
-.sp
-.LP
-\fBaread\fR(9E), \fBawrite\fR(9E), \fBaphysio\fR(9F), \fBuio\fR(9S)
+.Sh DESCRIPTION
+An
+.Vt aio_req
+structure describes an asynchronous
+.Sy I/O
+request.
+.Sh STRUCTURE MEMBERS
+.Bd -literal -offset 2n
+struct uio *aio_uio;   /* uio structure describing the I/O request */
+.Ed
+.Pp
+The
+.Fa aio_uio
+member is a pointer to a
+.Xr uio 9S
+structure, describing
+the
+.Sy I/O
+transfer request.
+.Sh SEE ALSO
+.Xr aread 9E ,
+.Xr awrite 9E ,
+.Xr aphysio 9F ,
+.Xr uio 9S

--- a/usr/src/man/man9s/buf.9s
+++ b/usr/src/man/man9s/buf.9s
@@ -1,228 +1,264 @@
-'\" te
 .\" Copyright (c) 2002 Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 1989 AT&T
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH BUF 9S "Sep 19, 2002"
-.SH NAME
-buf \- block I/O data transfer structure
-.SH SYNOPSIS
-.LP
-.nf
-#include <sys/ddi.h>
-#include <sys/sunddi.h>
-.fi
-
-.SH INTERFACE LEVEL
-.sp
-.LP
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt BUF 9S
+.Os
+.Sh NAME
+.Nm buf
+.Nd block I/O data transfer structure
+.Sh SYNOPSIS
+.In sys/ddi.h
+.In sys/sunddi.h
+.Sh INTERFACE LEVEL
 Architecture independent level 1 (DDI/DKI)
-.SH DESCRIPTION
-.sp
-.LP
-The \fBbuf\fR structure is the basic data structure for block \fBI/O\fR
-transfers. Each block \fBI/O\fR transfer has an associated buffer header. The
-header contains all the buffer control and status information. For drivers, the
-buffer header pointer is the sole argument to a block driver \fBstrategy\fR(9E)
-routine. Do not depend on the size of the \fBbuf\fR structure when writing a
-driver.
-.sp
-.LP
-A buffer header can be linked in multiple lists simultaneously. Because of
+.Sh DESCRIPTION
+The
+.Vt buf
+structure is the basic data structure for block
+.Sy I/O
+transfers.
+Each block
+.Sy I/O
+transfer has an associated buffer header.
+The header contains all the buffer control and status information.
+For drivers, the buffer header pointer is the sole argument to a block driver
+.Xr strategy 9E
+routine.
+Do not depend on the size of the
+.Vt buf
+structure when writing a driver.
+.Pp
+A buffer header can be linked in multiple lists simultaneously.
+Because of
 this, most of the members in the buffer header cannot be changed by the driver,
 even when the buffer header is in one of the driver's work lists.
-.sp
-.LP
-Buffer headers are also used by the system for unbuffered or physical \fBI/O\fR
-for block drivers. In this case, the buffer describes a portion of user data
+.Pp
+Buffer headers are also used by the system for unbuffered or physical
+.Sy I/O
+for block drivers.
+In this case, the buffer describes a portion of user data
 space that is locked into memory.
-.sp
-.LP
+.Pp
 Block drivers often chain block requests so that overall throughput for the
-device is maximized. The \fBav_forw\fR and the \fBav_back\fR members of the
-\fBbuf\fR structure can serve as link pointers for chaining block requests.
-.SH STRUCTURE MEMBERS
-.sp
-.in +2
-.nf
+device is maximized.
+The
+.Fa av_forw
+and the
+.Fa av_back
+members of the
+.Vt buf
+structure can serve as link pointers for chaining block requests.
+.Sh STRUCTURE MEMBERS
+.Bd -literal -offset 2n
 int           b_flags;           /* Buffer status */
 struct buf    *av_forw;          /* Driver work list link */
 struct buf    *av_back;          /* Driver work list link */
 size_t        b_bcount;          /* # of bytes to transfer */
 union {
-     caddr_t  b_addr;            /* Buffer's virtual address */
+    caddr_t  b_addr;            /* Buffer's virtual address */
 } b_un;
 daddr_t       b_blkno;           /* Block number on device */
-diskaddr_t    b_lblkno;          /* Expanded block number on dev. */
+diskaddr_t    b_lblkno;          /* Expanded block number on dev.  */
 size_t        b_resid;           /* # of bytes not xferred */
 size_t        b_bufsize;         /* size of alloc. buffer */
 int           (*b_iodone)(struct buf *); /* function called */
-	                                        /* by biodone */
+                                         /* by biodone */
 int           b_error;           /* expanded error field */
 void          *b_private;        /* "opaque" driver private area */
 dev_t         b_edev;            /* expanded dev field */
-\fI\fR
-.fi
-.in -2
-
-.sp
-.LP
+.Ed
+.Pp
 The members of the buffer header available to test or set by a driver are as
 follows:
-.sp
-.LP
-\fBb_flags\fR stores the buffer status and indicates to the driver whether to
-read or write to the device. The driver must never clear the \fBb_flags\fR
-member. If this is done, unpredictable results can occur including loss of disk
+.Pp
+.Fa b_flags
+stores the buffer status and indicates to the driver whether to
+read or write to the device.
+The driver must never clear the
+.Fa b_flags
+member.
+If this is done, unpredictable results can occur including loss of disk
 sanity and the possible failure of other kernel processes.
-.sp
-.LP
-All \fBb_flags\fR bit values not otherwise specified above are reserved by the
+.Pp
+All
+.Fa b_flags
+bit values not otherwise specified above are reserved by the
 kernel and may not be used.
-.sp
-.LP
+.Pp
 Valid flags are as follows:
-.sp
-.ne 2
-.na
-\fB\fBB_BUSY\fR \fR
-.ad
-.RS 13n
-Indicates the buffer is in use. The driver must not change this flag unless it
-allocated the buffer with \fBgetrbuf\fR(9F) and no \fBI/O\fR operation is in
-progress.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBB_DONE\fR \fR
-.ad
-.RS 13n
-Indicates the data transfer has completed. This flag is read-only.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBB_ERROR\fR \fR
-.ad
-.RS 13n
-Indicates an \fBI/O\fR transfer error. It is set in conjunction with the
-\fBb_error\fR field. \fBbioerror\fR(9F) should be used in preference to setting
-the \fBB_ERROR\fR bit.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBB_PAGEIO\fR \fR
-.ad
-.RS 13n
-Indicates the buffer is being used in a paged \fBI/O\fR request. See the
-description of the \fBb_un.b_addr\fR field for more information. This flag is
-read-only.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBB_PHYS\fR \fR
-.ad
-.RS 13n
-indicates the buffer header is being used for physical (direct) \fBI/O\fR to a
-user data area. See the description of the \fBb_un.b_addr\fR field for more
-information. This flag is read-only.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBB_READ\fR \fR
-.ad
-.RS 13n
+.Bl -tag -width "B_PAGEIO"
+.It Dv B_BUSY
+Indicates the buffer is in use.
+The driver must not change this flag unless it allocated the buffer with
+.Xr getrbuf 9F
+and no
+.Sy I/O
+operation is in progress.
+.It Dv B_DONE
+Indicates the data transfer has completed.
+This flag is read-only.
+.It Dv B_ERROR
+Indicates an
+.Sy I/O
+transfer error.
+It is set in conjunction with the
+.Fa b_error
+field.
+.Xr bioerror 9F
+should be used in preference to setting the
+.Dv B_ERROR
+bit.
+.It Dv B_PAGEIO
+Indicates the buffer is being used in a paged
+.Sy I/O
+request.
+See the description of the
+.Fa b_un.b_addr
+field for more information.
+This flag is read-only.
+.It Dv B_PHYS
+indicates the buffer header is being used for physical (direct)
+.Sy I/O
+to a user data area.
+See the description of the
+.Fa b_un.b_addr
+field for more information.
+This flag is read-only.
+.It Dv B_READ
 Indicates that data is to be read from the peripheral device into main memory.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBB_WRITE\fR \fR
-.ad
-.RS 13n
+.It Dv B_WRITE
 Indicates that the data is to be transferred from main memory to the peripheral
-device. \fBB_WRITE\fR is a pseudo flag and cannot be directly tested; it is
-only detected as the NOT form of \fBB_READ\fR.
-.RE
-
-.sp
-.LP
-\fBav_forw\fR and \fBav_back\fR can be used by the driver to link the buffer
-into driver work lists.
-.sp
-.LP
-\fBb_bcount\fR specifies the number of bytes to be transferred in both a paged
-and a non-paged \fBI/O\fR request.
-.sp
-.LP
-\fBb_un.b_addr\fR is the virtual address of the \fBI/O\fR request, unless
-\fBB_PAGEIO\fR is set. The address is a kernel virtual address, unless
-\fBB_PHYS\fR is set, in which case it is a user virtual address. If
-\fBB_PAGEIO\fR is set, \fBb_un.b_addr\fR contains kernel private data. Note
-that either one of \fBB_PHYS\fR and \fBB_PAGEIO\fR, or neither, can be set, but
+device.
+.Dv B_WRITE
+is a pseudo flag and cannot be directly tested; it is
+only detected as the NOT form of
+.Dv B_READ .
+.El
+.Pp
+.Fa av_forw
+and
+.Fa av_back
+can be used by the driver to link the buffer into driver work lists.
+.Pp
+.Fa b_bcount
+specifies the number of bytes to be transferred in both a paged and a non-paged
+.Sy I/O
+request.
+.Pp
+.Fa b_un.b_addr
+is the virtual address of the
+.Sy I/O
+request, unless
+.Dv B_PAGEIO
+is set.
+The address is a kernel virtual address, unless
+.Dv B_PHYS
+is set, in which case it is a user virtual address.
+If
+.Dv B_PAGEIO
+is set,
+.Fa b_un.b_addr
+contains kernel private data.
+Note that either one of
+.Dv B_PHYS
+and
+.Dv B_PAGEIO ,
+or neither, can be set, but
 not both.
-.sp
-.LP
-\fBb_blkno\fR identifies which logical block on the device (the device is
-defined by the device number) is to be accessed. The driver might have to
+.Pp
+.Fa b_blkno
+identifies which logical block on the device (the device is
+defined by the device number) is to be accessed.
+The driver might have to
 convert this logical block number to a physical location such as a cylinder,
-track, and sector of a disk. This is a 32-bit value. The driver should use
-\fBb_blkno\fR or \fBb_lblkno\fR, but not both.
-.sp
-.LP
-\fBb_lblkno\fR identifies which logical block on the device (the device is
-defined by the device number) is to be accessed. The driver might have to
+track, and sector of a disk.
+This is a 32-bit value.
+The driver should use
+.Fa b_blkno
+or
+.Fa b_lblkno ,
+but not both.
+.Pp
+.Fa b_lblkno
+identifies which logical block on the device (the device is
+defined by the device number) is to be accessed.
+The driver might have to
 convert this logical block number to a physical location such as a cylinder,
-track, and sector of a disk. This is a 64-bit value. The driver should use
-\fBb_lblkno\fR or \fBb_blkno\fR, but not both.
-.sp
-.LP
-\fBb_resid\fR should be set to the number of bytes not transferred because of
-an error.
-.sp
-.LP
-\fBb_bufsize\fR contains the size of the allocated buffer.
-.sp
-.LP
-\fBb_iodone\fR identifies a specific \fBbiodone\fR routine to be called by the
-driver when the \fBI/O\fR is complete.
-.sp
-.LP
-\fBb_error\fR can hold an error code that should be passed as a return code
-from the driver. \fBb_error\fR is set in conjunction with the \fBB_ERROR\fR bit
-set in the \fBb_flags\fR member. \fBbioerror\fR(9F) should be used in
-preference to setting the \fBb_error\fR field.
-.sp
-.LP
-\fBb_private\fR is for the private use of the device driver.
-.sp
-.LP
-\fBb_edev\fR contains the major and minor device numbers of the device
+track, and sector of a disk.
+This is a 64-bit value.
+The driver should use
+.Fa b_lblkno
+or
+.Fa b_blkno ,
+but not both.
+.Pp
+.Fa b_resid
+should be set to the number of bytes not transferred because of an error.
+.Pp
+.Fa b_bufsize
+contains the size of the allocated buffer.
+.Pp
+.Fa b_iodone
+identifies a specific
+.Xr biodone 9F
+routine to be called by the driver when the
+.Sy I/O
+is complete.
+.Pp
+.Fa b_error
+can hold an error code that should be passed as a return code
+from the driver.
+.Fa b_error
+is set in conjunction with the
+.Dv B_ERROR
+bit
+set in the
+.Fa b_flags
+member.
+.Xr bioerror 9F
+should be used in
+preference to setting the
+.Fa b_error
+field.
+.Pp
+.Fa b_private
+is for the private use of the device driver.
+.Pp
+.Fa b_edev
+contains the major and minor device numbers of the device
 accessed.
-.SH SEE ALSO
-.sp
-.LP
-\fBstrategy\fR(9E), \fBaphysio\fR(9F), \fBbioclone\fR(9F), \fBbiodone\fR(9F),
-\fBbioerror\fR(9F), \fBbioinit\fR(9F), \fBclrbuf\fR(9F), \fBgetrbuf\fR(9F),
-\fBphysio\fR(9F), \fBiovec\fR(9S), \fBuio\fR(9S)
-.sp
-.LP
-\fIWriting Device Drivers\fR
-.SH WARNINGS
-.sp
-.LP
-Buffers are a shared resource within the kernel. Drivers should read or write
-only the members listed in this section. Drivers that attempt to use
-undocumented members of the \fBbuf\fR structure risk corrupting data in the
-kernel or on the device.
+.Sh SEE ALSO
+.Xr strategy 9E ,
+.Xr aphysio 9F ,
+.Xr bioclone 9F ,
+.Xr biodone 9F ,
+.Xr bioerror 9F ,
+.Xr bioinit 9F ,
+.Xr clrbuf 9F ,
+.Xr getrbuf 9F ,
+.Xr physio 9F ,
+.Xr iovec 9S ,
+.Xr uio 9S
+.Rs
+.%T Writing Device Drivers
+.Re
+.Sh WARNINGS
+Buffers are a shared resource within the kernel.
+Drivers should read or write only the members listed in this section.
+Drivers that attempt to use undocumented members of the
+.Fa buf
+structure risk corrupting data in the kernel or on the device.

--- a/usr/src/man/man9s/cb_ops.9s
+++ b/usr/src/man/man9s/cb_ops.9s
@@ -1,90 +1,127 @@
-'\" te
 .\" Copyright (c) 2009, Sun Microsystems, Inc., All Rights Reserved
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH CB_OPS 9S "Apr 24, 2008"
-.SH NAME
-cb_ops \- character/block entry points structure
-.SH SYNOPSIS
-.LP
-.nf
-#include <sys/conf.h>
-#include <sys/ddi.h>
-#include <sys/sunddi.h>
-.fi
-
-.SH INTERFACE LEVEL
-.sp
-.LP
+.\" Copyright 2018, Joyent, Inc.
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt CB_OPS 9S
+.Os
+.Sh NAME
+.Nm cb_ops
+.Nd character/block entry points structure
+.Sh SYNOPSIS
+.In sys/conf.h
+.In sys/ddi.h
+.In sys/sunddi.h
+.Sh INTERFACE LEVEL
 Solaris DDI specific (Solaris DDI)
-.SH DESCRIPTION
-.sp
-.LP
-The \fBcb_ops\fR structure contains all entry points for drivers that support
-both character and block entry points. All leaf device drivers that support
-direct user process access to a device should declare a \fBcb_ops\fR structure.
-.sp
-.LP
+.Sh DESCRIPTION
+The
+.Nm
+structure contains all entry points for drivers that support
+both character and block entry points.
+All leaf device drivers that support
+direct user process access to a device should declare a
+.Nm
+structure.
+.Pp
 All drivers that safely allow multiple threads of execution in the driver at
-the same time must set the \fBD_MP\fR flag in the \fBcb_flag\fR field. See
-\fBopen\fR(9E).
-.sp
-.LP
+the same time must set the
+.Dv D_MP
+flag in the
+.Fa cb_flag
+field.
+See
+.Xr open 9E .
+.Pp
 If the driver properly handles 64-bit offsets, it should also set the
-\fBD_64BIT\fR flag in the \fBcb_flag\fR field. This specifies that the driver
-will use the \fBuio_loffset\fR field of the \fBuio\fR(9S) structure.
-.sp
-.LP
-If the driver returns \fBEINTR\fR from \fBopen\fR(9E), it should also set the
-\fBD_OPEN_RETURNS_EINTR\fR flag in the \fBcb_flag\fR field. This lets the
-framework know that it is safe for the driver to return \fBEINTR\fR when
-waiting, to provide exclusion for a last-reference \fBclose\fR(9E) call to
-complete before calling \fBopen\fR(9E).
-.sp
-.LP
-The \fBmt-streams\fR(9F) function describes other flags that can be set in the
-\fBcb_flag\fR field.
-.sp
-.LP
-The \fBcb_rev\fR is the \fBcb_ops\fR structure revision number. This field must
-be set to \fBCB_REV\fR.
-.sp
-.LP
-Non-\fBSTREAMS\fR drivers should set \fBcb_str\fR to \fINULL\fR.
-.sp
-.LP
-The following \fBDDI\fR/\fBDKI\fR or \fBDKI\fR-only or \fBDDI\fR-only functions
-are provided in the character/block driver operations structure.
-.sp
-
-.sp
-.TS
-c c c c
-l l l l .
-block/char	Function	Description	
-_
-b/c	XXopen	\fBDDI\fR/\fBDKI\fR	
-b/c	XXclose	\fBDDI\fR/\fBDKI\fR	
-b	XXstrategy	DDI/DKI	
-b	XXprint	DDI/DKI	
-b	XXdump	DDI(Sun)	
-c	XXread	DDI/DKI	
-c	XXwrite	DDI/DKI	
-c	XXioctl	DDI/DKI	
-c	XXdevmap	DDI(Sun)	
-c	XXmmap	DKI	
-c	XXsegmap	DKI	
-c	XXchpoll	DDI/DKI	
-c	XXprop_op	DDI(Sun)	
-c	XXaread	DDI(Sun)	
-c	XXawrite	DDI(Sun)	
-.TE
-
-.SH STRUCTURE MEMBERS
-.sp
-.in +2
-.nf
+.Dv D_64BIT
+flag in the
+.Fa cb_flag
+field.
+This specifies that the driver
+will use the
+.Fa uio_loffset
+field of the
+.Xr uio 9S
+structure.
+.Pp
+If the driver returns
+.Er EINTR
+from
+.Xr open 9E ,
+it should also set the
+.Dv D_OPEN_RETURNS_EINTR
+flag in the
+.Fa cb_flag
+field.
+This lets the
+framework know that it is safe for the driver to return
+.Er EINTR
+when waiting, to provide exclusion for a last-reference
+.Xr close 9E
+call to complete before calling
+.Xr open 9E .
+.Pp
+The
+.Xr mt-streams 9F
+function describes other flags that can be set in the
+.Fa cb_flag
+field.
+.Pp
+The
+.Fa cb_rev
+is the
+.Vt cb_ops
+structure revision number.
+This field must
+be set to
+.Dv CB_REV .
+.Pp
+.Pf Non- Ns Sy STREAMS
+drivers should set
+.Fa cb_str
+to
+.Sy NULL .
+.Pp
+The following
+.Sy DDI/DKI
+or
+.Sy DKI Ns -only
+or
+.Sy DDI Ns -only
+functions are provided in the character/block driver operations structure.
+.Bl -column "block/char" "Function" "Description"
+.It block/char	Function	Description
+.It b/c	XXopen	DDI/DKI
+.It b/c	XXclose	DDI/DKI
+.It b	XXstrategy	DDI/DKI
+.It b	XXprint	DDI/DKI
+.It b	XXdump	DDI(Sun)
+.It c	XXread	DDI/DKI
+.It c	XXwrite	DDI/DKI
+.It c	XXioctl	DDI/DKI
+.It c	XXdevmap	DDI(Sun)
+.It c	XXmmap	DKI
+.It c	XXsegmap	DKI
+.It c	XXchpoll	DDI/DKI
+.It c	XXprop_op	DDI(Sun)
+.It c	XXaread	DDI(Sun)
+.It c	XXawrite	DDI(Sun)
+.El
+.Sh STRUCTURE MEMBERS
+.Bd -literal -offset 2n
 int  (*cb_open)(dev_t *devp, int flag, int otyp, cred_t *credp);
 int  (*cb_close)(dev_t dev, int flag, int otyp, cred_t *credp);
 int  (*cb_strategy)(struct buf *bp);
@@ -93,37 +130,47 @@ int  (*cb_dump)(dev_t dev, caddr_t addr, daddr_t blkno, int nblk);
 int  (*cb_read)(dev_t dev, struct uio *uiop, cred_t *credp);
 int  (*cb_write)(dev_t dev, struct uio *uiop, cred_t *credp);
 int  (*cb_ioctl)(dev_t dev, int cmd, intptr_t arg, int mode,
-        cred_t *credp, int *rvalp);
+       cred_t *credp, int *rvalp);
 int  (*cb_devmap)(dev_t dev, devmap_cookie_t dhp, offset_t off,
-        size_t len, size_t *maplen, uint_t model);
+       size_t len, size_t *maplen, uint_t model);
 int  (*cb_mmap)(dev_t dev, off_t off, int prot);
 int  (*cb_segmap)(dev_t dev, off_t off, struct as *asp,
-        caddr_t *addrp, off_t len, unsigned int prot,
-        unsigned int maxprot, unsigned int flags, cred_t *credp);
+       caddr_t *addrp, off_t len, unsigned int prot,
+       unsigned int maxprot, unsigned int flags, cred_t *credp);
 int  (*cb_chpoll)(dev_t dev, short events, int anyyet,
-        short *reventsp, struct pollhead **phpp);
+       short *reventsp, struct pollhead **phpp);
 int  (*cb_prop_op)(dev_t dev, dev_info_t *dip,
-        ddi_prop_op_t prop_op, int mod_flags,
-        char *name, caddr_t valuep, int *length);
+       ddi_prop_op_t prop_op, int mod_flags,
+       char *name, caddr_t valuep, int *length);
 struct streamtab *cb_str;   /* streams information */
 int  cb_flag;
 int  cb_rev;
 int  (*cb_aread)(dev_t dev, struct aio_req *aio, cred_t *credp);
 int  (*cb_awrite)(dev_t dev, struct aio_req *aio, cred_t *credp);
-.fi
-.in -2
-
-.SH SEE ALSO
-.sp
-.LP
-\fBaread\fR(9E), \fBawrite\fR(9E), \fBchpoll\fR(9E), \fBclose\fR(9E),
-\fBdump\fR(9E), \fBioctl\fR(9E), \fBmmap\fR(9E), \fBopen\fR(9E),
-\fBprint\fR(9E), \fBprop_op\fR(9E), \fBread\fR(9E), \fBsegmap\fR(9E),
-\fBstrategy\fR(9E), \fBwrite\fR(9E), \fBnochpoll\fR(9F), \fBnodev\fR(9F),
-\fBnulldev\fR(9F), \fBdev_ops\fR(9S), \fBqinit\fR(9S)
-.sp
-.LP
-\fIWriting Device Drivers\fR
-.sp
-.LP
-\fISTREAMS Programming Guide\fR
+.Ed
+.Sh SEE ALSO
+.Xr aread 9E ,
+.Xr awrite 9E ,
+.Xr chpoll 9E ,
+.Xr close 9E ,
+.Xr dump 9E ,
+.Xr ioctl 9E ,
+.Xr mmap 9E ,
+.Xr open 9E ,
+.Xr print 9E ,
+.Xr prop_op 9E ,
+.Xr read 9E ,
+.Xr segmap 9E ,
+.Xr strategy 9E ,
+.Xr write 9E ,
+.Xr nochpoll 9F ,
+.Xr nodev 9F ,
+.Xr nulldev 9F ,
+.Xr dev_ops 9S ,
+.Xr qinit 9S
+.Rs
+.%T Writing Device Drivers
+.Re
+.Rs
+.%T STREAMS Programming Guide
+.Re

--- a/usr/src/man/man9s/copyreq.9s
+++ b/usr/src/man/man9s/copyreq.9s
@@ -1,43 +1,52 @@
-'\" te
 .\" Copyright (c) 2000, Sun Microsystems, Inc., All Rights Reserved.
 .\" Copyright 1989 AT&T
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH COPYREQ 9S "Oct 6, 2000"
-.SH NAME
-copyreq \- STREAMS data structure for the M_COPYIN and the M_COPYOUT message
-types
-.SH SYNOPSIS
-.LP
-.nf
-#include <sys/stream.h>
-.fi
-
-.SH INTERFACE LEVEL
-.sp
-.LP
+.\" Copyright 2018, Joyent, Inc.
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt COPYREQ 9S
+.Os
+.Sh NAME
+.Nm copyreq
+.Nd STREAMS data structure for the
+.Dv M_COPYIN
+and the
+.Dv M_COPYOUT
+message types
+.Sh SYNOPSIS
+.In sys/stream.h
+.Sh INTERFACE LEVEL
 Architecture independent level 1 (DDI/DKI)
-.SH DESCRIPTION
-.sp
-.LP
-The data structure for the \fBM_COPYIN\fR and the \fBM_COPYOUT\fR message
+.Sh DESCRIPTION
+The data structure for the
+.Dv M_COPYIN
+and the
+.Dv M_COPYOUT
+message
 types.
-.SH STRUCTURE MEMBERS
-.sp
-.in +2
-.nf
+.Sh STRUCTURE MEMBERS
+.Bd -literal -offset 2n
 int      cq_cmd;           /* ioctl command (from ioc_cmd) */
 cred_t   *cq_cr;           /* full credentials */
 uint_t   cq_id;            /* ioctl id (from ioc_id) */
-uint_t   cq_flag;	       /* must be zero */
+uint_t   cq_flag;	   /* must be zero */
 mblk_t   *cq_private;      /* private state information */
 caddr_t  cq_addr;          /* address to copy data to/from */
-size_t   cq_size;          /* number of bytes to copy */	
-.fi
-.in -2
-
-.SH SEE ALSO
-.sp
-.LP
-\fISTREAMS Programming Guide\fR
+size_t   cq_size;          /* number of bytes to copy */
+.Ed
+.Sh SEE ALSO
+.Rs
+.%T STREAMS Programming Guide
+.Re

--- a/usr/src/man/man9s/free_rtn.9s
+++ b/usr/src/man/man9s/free_rtn.9s
@@ -1,45 +1,56 @@
-'\" te
+.\" Copyright 2018, Joyent, Inc.
 .\" Copyright (c) 2000, Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright 1989 AT&T
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FREE_RTN 9S "Nov 13, 1996"
-.SH NAME
-free_rtn \- structure that specifies a driver's message-freeing routine
-.SH SYNOPSIS
-.LP
-.nf
-#include <sys/stream.h>
-.fi
-
-.SH INTERFACE LEVEL
-.sp
-.LP
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt FREE_RTN 9S
+.Os
+.Sh NAME
+.Nm free_rtn
+.Nd structure that specifies a driver's message-freeing routine
+.Sh SYNOPSIS
+.In sys/stream.h
+.Sh INTERFACE LEVEL
 Architecture independent level 1 (DDI/DKI).
-.SH DESCRIPTION
-.sp
-.LP
-The  \fBfree_rtn\fR structure is referenced by the  \fBdatab\fR structure. When
-\fBfreeb\fR(9F) is called to free the message, the driver's message-freeing
-routine (referenced through the  \fBfree_rtn\fR structure) is called, with
-arguments, to free the data buffer.
-.SH STRUCTURE MEMBERS
-.sp
-.in +2
-.nf
+.Sh DESCRIPTION
+The
+.Vt free_rtn
+structure is referenced by the
+.Vt datab
+structure.
+When
+.Xr freeb 9F
+is called to free the message, the driver's message-freeing
+routine (referenced through the
+.Vt free_rtn
+structure) is called, with arguments, to free the data buffer.
+.Sh STRUCTURE MEMBERS
+.Bd -literal -offset 2n
 void     (*free_func)()      /* user's freeing routine */
 char     *free_arg           /* arguments to free_func() */
-.fi
-.in -2
-
-.sp
-.LP
-The  \fBfree_rtn\fR structure is defined as type  \fBfrtn_t\fR.
-.SH SEE ALSO
-.sp
-.LP
-\fBesballoc\fR(9F), \fBfreeb\fR(9F), \fBdatab\fR(9S)
-.sp
-.LP
-\fISTREAMS Programming Guide\fR
+.Ed
+.Pp
+The
+.Vt free_rtn
+structure is defined as type
+.Vt frtn_t .
+.Sh SEE ALSO
+.Xr esballoc 9F ,
+.Xr freeb 9F ,
+.Xr datab 9S
+.Rs
+.%T STREAMS Programming Guide
+.Re

--- a/usr/src/man/man9s/iovec.9s
+++ b/usr/src/man/man9s/iovec.9s
@@ -1,42 +1,46 @@
-'\" te
+.\" Copyright 2018, Joyent, Inc.
 .\" Copyright (c) 2000, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 1989 AT&T
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH IOVEC 9S "Apr 11, 1991"
-.SH NAME
-iovec \- data storage structure for I/O using uio
-.SH SYNOPSIS
-.LP
-.nf
-#include <sys/uio.h>
-.fi
-
-.SH INTERFACE LEVEL
-.sp
-.LP
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.Dd July 9, 2018
+.Dt IOVEC 9S
+.Os
+.Sh NAME
+.Nm iovec
+.Nd data storage structure for I/O using uio
+.Sh SYNOPSIS
+.In sys/uio.h
+.Sh INTERFACE LEVEL
 Architecture independent level 1 (DDI/DKI).
-.SH DESCRIPTION
-.sp
-.LP
-An  \fBiovec\fR structure describes a data storage area for transfer in a
-\fBuio\fR(9S) structure.  Conceptually, it can be thought of as a base address
+.Sh DESCRIPTION
+An
+.Vt iovec
+structure describes a data storage area for transfer in a
+.Xr uio 9S
+structure.
+Conceptually, it can be thought of as a base address
 and length specification.
-.SH STRUCTURE MEMBERS
-.sp
-.in +2
-.nf
+.Sh STRUCTURE MEMBERS
+.Bd -literal -offset 2n
 caddr_t    iov_base;  /* base address of the data storage area */
                       /* represented by the iovec structure */
 int        iov_len;   /* size of the data storage area in bytes */
-.fi
-.in -2
-
-.SH SEE ALSO
-.sp
-.LP
-\fBuio\fR(9S)
-.sp
-.LP
-\fIWriting Device Drivers\fR
+.Ed
+.Sh SEE ALSO
+.Xr uio 9S
+.Rs
+.%T Writing Device Drivers
+.Re

--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -40,9 +40,9 @@
 #include <sys/fm/fs/zfs.h>
 
 /*
- * Tunable to enable TRIM, which is temporarily disabled by default.
+ * Tunable to disable TRIM in case we're using a problematic SSD.
  */
-uint_t zfs_no_trim = 1;
+uint_t zfs_no_trim = 0;
 
 /*
  * Tunable parameter for debugging or performance analysis. Setting this

--- a/usr/src/uts/common/io/bge/bge_impl.h
+++ b/usr/src/uts/common/io/bge/bge_impl.h
@@ -111,7 +111,7 @@ typedef uchar_t ether_addr_t[ETHERADDRL];
  */
 extern int secpolicy_net_config(const cred_t *, boolean_t);
 
-#include <sys/miiregs.h>		/* by fjlite out of intel 	*/
+#include <sys/miiregs.h>		/* by fjlite out of intel	*/
 
 #include "bge.h"
 #include "bge_hw.h"
@@ -409,7 +409,7 @@ typedef struct buff_ring {
 	uint64_t		rf_next;	/* next slot to refill	*/
 						/* ("producer index")	*/
 
-	sw_rbd_t		*sw_rbds; 	/* software descriptors	*/
+	sw_rbd_t		*sw_rbds;	/* software descriptors	*/
 	void			*spare[4];	/* padding		*/
 } buff_ring_t;					/* 0x100 (256) bytes	*/
 
@@ -558,7 +558,7 @@ typedef struct send_ring {
 	uint64_t		tc_next;	/* next slot to recycle	*/
 						/* ("consumer index")	*/
 
-	sw_sbd_t		*sw_sbds; 	/* software descriptors	*/
+	sw_sbd_t		*sw_sbds;	/* software descriptors	*/
 	uint64_t		mac_resid;	/* special per resource id */
 	uint64_t		pushed_bytes;
 } send_ring_t;					/* 0x100 (256) bytes	*/
@@ -757,7 +757,7 @@ typedef struct bge {
 	ddi_softintr_t		factotum_id;	/* factotum callback	*/
 	ddi_softintr_t		drain_id;	/* reschedule callback	*/
 
-	ddi_intr_handle_t 	*htable;	/* For array of interrupts */
+	ddi_intr_handle_t	*htable;	/* For array of interrupts */
 	int			intr_type;	/* What type of interrupt */
 	int			intr_cnt;	/* # of intrs count returned */
 	uint_t			intr_pri;	/* Interrupt priority	*/
@@ -826,7 +826,7 @@ typedef struct bge {
 	 *	protects the critical cyclic counters etc.
 	 *
 	 * Each send ring contains two locks: <tx_lock> for the send-path
-	 * 	protocol data and <tc_lock> for send-buffer recycling.
+	 *	protocol data and <tc_lock> for send-buffer recycling.
 	 *
 	 * Finally <genlock> is a general lock, protecting most other
 	 *	operational data in the state structure and chip register
@@ -983,7 +983,7 @@ typedef struct bge {
 
 	uint32_t		param_loop_mode;
 	uint32_t		param_msi_cnt;
-	uint32_t 		param_drain_max;
+	uint32_t		param_drain_max;
 	uint64_t		param_link_speed;
 	link_duplex_t		param_link_duplex;
 	uint32_t		eee_lpi_wait;
@@ -1119,7 +1119,7 @@ typedef struct bge {
 					{ command; }			\
 					_NOTE(CONSTANTCONDITION)	\
 				} while (0)
-#else 	/* BGE_DEBUGGING */
+#else	/* BGE_DEBUGGING */
 #define	BGE_DDB(command)	do {					\
 					{ _NOTE(EMPTY); }		\
 					_NOTE(CONSTANTCONDITION)	\

--- a/usr/src/uts/common/sys/sata/sata_defs.h
+++ b/usr/src/uts/common/sys/sata/sata_defs.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _SATA_DEFS_H
@@ -343,6 +344,9 @@ typedef struct sata_id {
 /* Identify (Packet) Device Word 88 */
 #define	SATA_UDMA_SUP_MASK		0x007f	/* UDMA modes supported */
 #define	SATA_UDMA_SEL_MASK	0x7f00	/* UDMA modes selected */
+
+/* Data Set Management: word 169 */
+#define	SATA_DSM_TRIM		0x0001	/* Set when TRIM is supported */
 
 /* Identify Device: command set supported/enabled bits - word 206 */
 


### PR DESCRIPTION
Weekly upstream for upstream_merge/2019121901

## Backports

None

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2019121901-6702d45f04 i86pc i386 i
```
## mail_msg

```

==== Nightly distributed build started:   Thu Dec 19 11:48:06 UTC 2019 ====
==== Nightly distributed build completed: Thu Dec 19 12:53:20 UTC 2019 ====

==== Total build time ====

real    1:05:14

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-8e56e550c6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-2

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_232-omnios-151033-09"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   71

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2019121901-6702d45f04

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:52.5
user  3:42:30.0
sys     58:53.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    23:12.5
user  3:16:45.8
sys     54:34.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
