### PR TITLE
Upstream merge/2019122701

### DIFF
--- a/usr/src/common/devid/devid_scsi.c
+++ b/usr/src/common/devid/devid_scsi.c
@@ -25,6 +25,10 @@
  */
 
 /*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+/*
  * These functions are used to encode SCSI INQUIRY data into
  * Solaris devid / guid values.
  */
@@ -232,7 +236,7 @@ devid_scsi_encode(
 				(void) strncat(msg, inq_std->inq_revision,
 				    sizeof (inq_std->inq_revision));
 				(void) strcat(msg, "\n");
-				cmn_err(CE_WARN, msg);
+				cmn_err(CE_WARN, "%s", msg);
 				kmem_free(msg,
 				    MSG_NOT_STANDARDS_COMPLIANT_SIZE);
 			}
@@ -301,7 +305,7 @@ static int
 is_page83_data_valid(uchar_t *inq83, size_t inq83_len)
 {
 
-	int 	covered_desc_len	= 0;
+	int	covered_desc_len	= 0;
 	int	dlen			= 0;
 	uchar_t	*dblk			= NULL;
 
@@ -1336,7 +1340,7 @@ scsi_wwnstr_hexcase(char *wwnstr, int upper_case_hex)
  * Function: scsi_wwnstr_skip_ua_prefix
  *
  * Description: This routine removes the leading 'w' in wwnstr,
- * 		if its in unit-address form.
+ *		if its in unit-address form.
  *
  * Arguments: wwnstr - the string wwn to be transformed
  *

--- a/usr/src/lib/sun_fc/common/Sun_fcScsiInquiryV2.cc
+++ b/usr/src/lib/sun_fc/common/Sun_fcScsiInquiryV2.cc
@@ -53,7 +53,7 @@ extern "C" {
  * @param	    responseBuffer User-allocated response buffer
  * @param	    responseSize Size of User-allocated response buffer
  * @param	    scsiStatus User-allocated scsi status byte
- * 
+ *
  * @doc		    This routine will attempt a limited number of retries
  *		    When busy or again errors are encountered.
  */
@@ -91,6 +91,7 @@ Sun_fcScsiInquiryV2(HBA_HANDLE handle, HBA_WWN portWWN, HBA_WWN targetPortWWN,
 		return (HBA_STATUS_ERROR);
 	    }
 	}
+	return (HBA_STATUS_ERROR_TRY_AGAIN);
 }
 #ifdef	__cplusplus
 }

--- a/usr/src/lib/sun_fc/common/Sun_fcScsiReadCapacityV2.cc
+++ b/usr/src/lib/sun_fc/common/Sun_fcScsiReadCapacityV2.cc
@@ -50,7 +50,7 @@ extern "C" {
  * @param	    responseBuffer User-allocated response buffer
  * @param	    responseSize Size of User-allocated response buffer
  * @param	    scsiStatus User-allocated scsi status byte
- * 
+ *
  * @doc		    This routine will attempt a limited number of retries
  *		    When busy or again errors are encountered.
  */
@@ -87,6 +87,7 @@ Sun_fcScsiReadCapacityV2(HBA_HANDLE handle, HBA_WWN portWWN,
 		return (HBA_STATUS_ERROR);
 	    }
 	}
+	return (HBA_STATUS_ERROR_TRY_AGAIN);
 }
 #ifdef	__cplusplus
 }

--- a/usr/src/pkg/manifests/driver-cpu-sensor.mf
+++ b/usr/src/pkg/manifests/driver-cpu-sensor.mf
@@ -38,6 +38,7 @@ driver name=pchtemp \
     alias=pci8086,8ca4,p \
     alias=pci8086,8d24,p \
     alias=pci8086,9d31,p \
+    alias=pci8086,9df9,p \
     alias=pci8086,a131,p \
     alias=pci8086,a1b1,p \
     alias=pci8086,a231,p \

--- a/usr/src/uts/common/fs/zfs/dsl_scan.c
+++ b/usr/src/uts/common/fs/zfs/dsl_scan.c
@@ -1241,7 +1241,7 @@ dsl_scan_should_clear(dsl_scan_t *scn)
 		if (queue != NULL) {
 			/* # extents in exts_by_size = # in exts_by_addr */
 			mused += zfs_btree_numnodes(&queue->q_exts_by_size) *
-			    sizeof (range_seg_t) + queue->q_sio_memused;
+			    sizeof (range_seg_gap_t) + queue->q_sio_memused;
 		}
 		mutex_exit(&tvd->vdev_scan_io_queue_lock);
 	}

--- a/usr/src/uts/common/fs/zfs/sys/range_tree.h
+++ b/usr/src/uts/common/fs/zfs/sys/range_tree.h
@@ -126,11 +126,11 @@ rs_get_start_raw(const range_seg_t *rs, const range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
-		return (((range_seg32_t *)rs)->rs_start);
+		return (((const range_seg32_t *)rs)->rs_start);
 	case RANGE_SEG64:
-		return (((range_seg64_t *)rs)->rs_start);
+		return (((const range_seg64_t *)rs)->rs_start);
 	case RANGE_SEG_GAP:
-		return (((range_seg_gap_t *)rs)->rs_start);
+		return (((const range_seg_gap_t *)rs)->rs_start);
 	default:
 		VERIFY(0);
 		return (0);
@@ -143,11 +143,11 @@ rs_get_end_raw(const range_seg_t *rs, const range_tree_t *rt)
 	ASSERT3U(rt->rt_type, <=, RANGE_SEG_NUM_TYPES);
 	switch (rt->rt_type) {
 	case RANGE_SEG32:
-		return (((range_seg32_t *)rs)->rs_end);
+		return (((const range_seg32_t *)rs)->rs_end);
 	case RANGE_SEG64:
-		return (((range_seg64_t *)rs)->rs_end);
+		return (((const range_seg64_t *)rs)->rs_end);
 	case RANGE_SEG_GAP:
-		return (((range_seg_gap_t *)rs)->rs_end);
+		return (((const range_seg_gap_t *)rs)->rs_end);
 	default:
 		VERIFY(0);
 		return (0);

--- a/usr/src/uts/intel/io/pchtemp/pchtemp.c
+++ b/usr/src/uts/intel/io/pchtemp/pchtemp.c
@@ -39,6 +39,7 @@
  *  - Intel 100 Series PCH
  *  - Intel 200 Series and Z730 PCH
  *  - Intel Sunrise Point-LP (Kaby Lake-U) PCH
+ *  - Intel Cannon Lake (Whiskey Lake-U) PCH
  *  - Intel 300 Series and C240 Chipset
  *
  * The following chipsets use a different format and are not currently


### PR DESCRIPTION
Weekly illumos-gate upstream merge

## Backports

* none

## onu

```
OmniOS 5.11     omnios-upstream_merge-2019122701-33a1fd26f4     Dec. 27, 2019
SunOS Internal Development: hadfl 2019-Dec-27 [illumos-omnios]
```

## mail_msg

```
==== Nightly distributed build started:   Fri Dec 27 12:35:05 UTC 2019 ====
==== Nightly distributed build completed: Fri Dec 27 14:39:16 UTC 2019 ====

==== Total build time ====

real    2:04:10

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-8e56e550c6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-2

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_232-omnios-151033-09"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   126

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2019122701-33a1fd26f4

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    56:53.8
user  4:25:25.1
sys     51:52.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    51:36.1
user  3:58:22.5
sys     46:55.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```