### PR TITLE
Upstream merge joyent_merge/2020010301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1145,6 +1145,7 @@ usr/src/cmd/logger/logger
 usr/src/cmd/login/login
 usr/src/cmd/login/logindevperm
 usr/src/cmd/logins/logins
+usr/src/cmd/logname/logname
 usr/src/cmd/look/look
 usr/src/cmd/lp/cmd/lpadmin/lpadmin
 usr/src/cmd/lp/cmd/lpfilter

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 09f69895a11ea4b8eb83c65cc9de22502d7d41a8
+Last illumos-joyent commit: fc356053b6fcdfb2eb1f9353e1b7e5332fbfcaf8
 

--- a/usr/src/cmd/zlogin/zlogin.c
+++ b/usr/src/cmd/zlogin/zlogin.c
@@ -23,7 +23,7 @@
  * Copyright 2013 DEY Storage Systems, Inc.
  * Copyright (c) 2014 Gary Mills
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
@@ -940,6 +940,9 @@ doio(int stdin_fd, int appin_fd, int stdout_fd, int stderr_fd, int sig_fd,
 
 		/* event from master side stderr */
 		if (pollfds[1].revents) {
+			if (pollfds[1].revents & POLLHUP)
+				break;
+
 			if (pollfds[1].revents &
 			    (POLLIN | POLLRDNORM | POLLRDBAND | POLLPRI)) {
 				if (process_output(stderr_fd, STDERR_FILENO)
@@ -953,6 +956,9 @@ doio(int stdin_fd, int appin_fd, int stdout_fd, int stderr_fd, int sig_fd,
 
 		/* event from master side stdout */
 		if (pollfds[0].revents) {
+			if (pollfds[0].revents & POLLHUP)
+				break;
+
 			if (pollfds[0].revents &
 			    (POLLIN | POLLRDNORM | POLLRDBAND | POLLPRI)) {
 				if (process_output(stdout_fd, STDOUT_FILENO)

--- a/usr/src/uts/common/inet/ipf/ip_fil_solaris.c
+++ b/usr/src/uts/common/inet/ipf/ip_fil_solaris.c
@@ -116,7 +116,7 @@ u_long		*ip_forwarding = NULL;
 #endif
 
 vmem_t	*ipf_minor;	/* minor number arena */
-void 	*ipf_state;	/* DDI state */
+void	*ipf_state;	/* DDI state */
 
 /*
  * GZ-controlled and per-zone stacks:
@@ -141,34 +141,67 @@ void 	*ipf_state;	/* DDI state */
  */
 
 /* IPv4 hook names */
-char *hook4_nicevents = 	"ipfilter_hook4_nicevents";
-char *hook4_nicevents_gz = 	"ipfilter_hook4_nicevents_gz";
-char *hook4_in = 		"ipfilter_hook4_in";
-char *hook4_in_gz = 		"ipfilter_hook4_in_gz";
-char *hook4_out = 		"ipfilter_hook4_out";
-char *hook4_out_gz = 		"ipfilter_hook4_out_gz";
-char *hook4_loop_in = 		"ipfilter_hook4_loop_in";
-char *hook4_loop_in_gz = 	"ipfilter_hook4_loop_in_gz";
-char *hook4_loop_out = 		"ipfilter_hook4_loop_out";
-char *hook4_loop_out_gz = 	"ipfilter_hook4_loop_out_gz";
+char *hook4_nicevents =		"ipfilter_hook4_nicevents";
+char *hook4_nicevents_gz =	"ipfilter_hook4_nicevents_gz";
+char *hook4_in =		"ipfilter_hook4_in";
+char *hook4_in_gz =		"ipfilter_hook4_in_gz";
+char *hook4_out =		"ipfilter_hook4_out";
+char *hook4_out_gz =		"ipfilter_hook4_out_gz";
+char *hook4_loop_in =		"ipfilter_hook4_loop_in";
+char *hook4_loop_in_gz =	"ipfilter_hook4_loop_in_gz";
+char *hook4_loop_out =		"ipfilter_hook4_loop_out";
+char *hook4_loop_out_gz =	"ipfilter_hook4_loop_out_gz";
 
 /* IPv6 hook names */
-char *hook6_nicevents = 	"ipfilter_hook6_nicevents";
-char *hook6_nicevents_gz = 	"ipfilter_hook6_nicevents_gz";
-char *hook6_in = 		"ipfilter_hook6_in";
-char *hook6_in_gz = 		"ipfilter_hook6_in_gz";
-char *hook6_out = 		"ipfilter_hook6_out";
-char *hook6_out_gz = 		"ipfilter_hook6_out_gz";
-char *hook6_loop_in = 		"ipfilter_hook6_loop_in";
-char *hook6_loop_in_gz = 	"ipfilter_hook6_loop_in_gz";
-char *hook6_loop_out = 		"ipfilter_hook6_loop_out";
-char *hook6_loop_out_gz = 	"ipfilter_hook6_loop_out_gz";
+char *hook6_nicevents =		"ipfilter_hook6_nicevents";
+char *hook6_nicevents_gz =	"ipfilter_hook6_nicevents_gz";
+char *hook6_in =		"ipfilter_hook6_in";
+char *hook6_in_gz =		"ipfilter_hook6_in_gz";
+char *hook6_out =		"ipfilter_hook6_out";
+char *hook6_out_gz =		"ipfilter_hook6_out_gz";
+char *hook6_loop_in =		"ipfilter_hook6_loop_in";
+char *hook6_loop_in_gz =	"ipfilter_hook6_loop_in_gz";
+char *hook6_loop_out =		"ipfilter_hook6_loop_out";
+char *hook6_loop_out_gz =	"ipfilter_hook6_loop_out_gz";
 
 /* viona hook names */
 char *hook_viona_in =		"ipfilter_hookviona_in";
 char *hook_viona_in_gz =	"ipfilter_hookviona_in_gz";
 char *hook_viona_out =		"ipfilter_hookviona_out";
 char *hook_viona_out_gz =	"ipfilter_hookviona_out_gz";
+
+/*
+ * For VIONA. The net_{instance,protocol}_notify_register() functions only
+ * deal with per-callback-function granularity. We need two wrapper functions
+ * for GZ-controlled and per-zone instances.
+ */
+static int
+ipf_hook_instance_notify_gz(hook_notify_cmd_t command, void *arg,
+    const char *netid, const char *dummy, const char *instance)
+{
+	return (ipf_hook_instance_notify(command, arg, netid, dummy, instance));
+}
+
+static int
+ipf_hook_instance_notify_ngz(hook_notify_cmd_t command, void *arg,
+    const char *netid, const char *dummy, const char *instance)
+{
+	return (ipf_hook_instance_notify(command, arg, netid, dummy, instance));
+}
+
+static int
+ipf_hook_protocol_notify_gz(hook_notify_cmd_t command, void *arg,
+    const char *name, const char *dummy, const char *he_name)
+{
+	return (ipf_hook_protocol_notify(command, arg, name, dummy, he_name));
+}
+
+static int
+ipf_hook_protocol_notify_ngz(hook_notify_cmd_t command, void *arg,
+    const char *name, const char *dummy, const char *he_name)
+{
+	return (ipf_hook_protocol_notify(command, arg, name, dummy, he_name));
+}
 
 /* ------------------------------------------------------------------------ */
 /* Function:    ipldetach                                                   */
@@ -270,7 +303,8 @@ ipf_stack_t *ifs;
 	 * Remove notification of viona hooks
 	 */
 	(void) net_instance_notify_unregister(ifs->ifs_netid,
-	    ipf_hook_instance_notify);
+	    ifs->ifs_gz_controlled ? ipf_hook_instance_notify_gz :
+	    ipf_hook_instance_notify_ngz);
 
 #undef UNDO_HOOK
 
@@ -278,6 +312,10 @@ ipf_stack_t *ifs;
 	 * Normally, viona will unregister itself before ipldetach() is called,
 	 * so these will be no-ops, but out of caution, we try to make sure
 	 * we've removed any of our references.
+	 *
+	 * For now, the _gz and _ngz versions are both wrappers to what's
+	 * below.  Just call it directly, but if that changes fix here as
+	 * well.
 	 */
 	(void) ipf_hook_protocol_notify(HN_UNREGISTER, ifs, Hn_VIONA, NULL,
 	    NH_PHYSICAL_IN);
@@ -295,6 +333,10 @@ ipf_stack_t *ifs;
 		 * traced, we pass the same value the nethook framework would
 		 * pass, even though the callback does not currently use the
 		 * value.
+		 *
+		 * For now, the _gz and _ngz versions are both wrappers to
+		 * what's below.  Just call it directly, but if that changes
+		 * fix here as well.
 		 */
 		(void) ipf_hook_instance_notify(HN_UNREGISTER, ifs, netidstr,
 		    NULL, Hn_VIONA);
@@ -504,9 +546,15 @@ ipf_stack_t *ifs;
 	 * is unloaded, the viona module cannot later re-register them if it
 	 * gets reloaded.  As the ip, vnd, and ipf modules are rarely unloaded
 	 * even on DEBUG kernels, they do not experience this issue.
+	 *
+	 * Today, the per-zone ones don't matter for a BHYVE-branded zone, BUT
+	 * the ipf_hook_protocol_notify() function is GZ vs. per-zone aware.
+	 * Employ two different versions of ipf_hook_instance_notify(), one for
+	 * the GZ-controlled, and one for the per-zone one.
 	 */
-	if (net_instance_notify_register(id, ipf_hook_instance_notify,
-	    ifs) != 0)
+	if (net_instance_notify_register(id, ifs->ifs_gz_controlled ?
+	    ipf_hook_instance_notify_gz : ipf_hook_instance_notify_ngz, ifs) !=
+	    0)
 		goto hookup_failed;
 
 	/*
@@ -598,7 +646,6 @@ ipf_hook_protocol_notify(hook_notify_cmd_t command, void *arg,
 	hook_hint_t hint;
 	boolean_t out;
 	int ret = 0;
-
 	const boolean_t gz = ifs->ifs_gz_controlled;
 
 	/* We currently only care about viona hooks notifications */
@@ -690,6 +737,7 @@ ipf_hook_instance_notify(hook_notify_cmd_t command, void *arg,
 {
 	ipf_stack_t *ifs = arg;
 	int ret = 0;
+	const boolean_t gz = ifs->ifs_gz_controlled;
 
 	/* We currently only care about viona hooks */
 	if (strcmp(instance, Hn_VIONA) != 0)
@@ -707,14 +755,16 @@ ipf_hook_instance_notify(hook_notify_cmd_t command, void *arg,
 			return (EPROTONOSUPPORT);
 
 		ret = net_protocol_notify_register(ifs->ifs_ipf_viona,
-		    ipf_hook_protocol_notify, ifs);
+		    gz ? ipf_hook_protocol_notify_gz :
+		    ipf_hook_protocol_notify_ngz, ifs);
 		VERIFY(ret == 0 || ret == ESHUTDOWN);
 		break;
 	case HN_UNREGISTER:
 		if (ifs->ifs_ipf_viona == NULL)
 			break;
 		VERIFY0(net_protocol_notify_unregister(ifs->ifs_ipf_viona,
-		    ipf_hook_protocol_notify));
+		    gz ? ipf_hook_protocol_notify_gz :
+		    ipf_hook_protocol_notify_ngz));
 		VERIFY0(net_protocol_release(ifs->ifs_ipf_viona));
 		ifs->ifs_ipf_viona = NULL;
 		break;
@@ -1131,14 +1181,14 @@ ipf_stack_t *ifs;
 {
 	net_handle_t nif;
  
-  	if (v == 4)
- 		nif = ifs->ifs_ipf_ipv4;
-  	else if (v == 6)
- 		nif = ifs->ifs_ipf_ipv6;
-  	else
- 		return 0;
+ 	if (v == 4)
+		nif = ifs->ifs_ipf_ipv4;
+ 	else if (v == 6)
+		nif = ifs->ifs_ipf_ipv6;
+ 	else
+		return 0;
 
- 	return (net_phylookup(nif, name));
+	return (net_phylookup(nif, name));
 }
 
 /*
@@ -3119,16 +3169,16 @@ fr_info_t *fin;
 /* both IP versions. The details are going to be explained here.	    */
 /*                                                                          */
 /* The packet looks as follows:						    */
-/*    xxx | IP hdr | IP payload    ...	| 				    */
-/*    ^   ^        ^            	^				    */
-/*    |   |        |            	|				    */
+/*    xxx | IP hdr | IP payload    ...	|				    */
+/*    ^   ^        ^           	        ^				    */
+/*    |   |        |           	        |				    */
 /*    |   |        |		fin_m->b_wptr = fin->fin_dp + fin->fin_dlen */
 /*    |   |        |							    */
 /*    |   |        `- fin_m->fin_dp (in case of IPv4 points to L4 header)   */
 /*    |   |								    */
 /*    |   `- fin_m->b_rptr + fin_ipoff (fin_ipoff is most likely 0 in case  */
 /*    |      of loopback)						    */
-/*    |   								    */
+/*    |  								    */
 /*    `- fin_m->b_rptr -  points to L2 header in case of physical NIC	    */
 /*                                                                          */
 /* All relevant IP headers are pulled up into the first mblk. It happened   */


### PR DESCRIPTION
Weekly upstream for joyent_merge/2020010301

## Backports

None

## onu

```
Last login: Fri Jan  3 16:13:06 2020 from 172.27.10.79
OmniOS 5.11     omnios-joyent_merge-2020010301-db479f15561      Jan. 03, 2020
SunOS Internal Development: af 2020-Jan-03 [illumos]
You have new mail.
bloody%
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2020010301-db479f15561 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Fri Jan  3 15:29:42 UTC 2020 ====
==== Nightly distributed build completed: Fri Jan  3 16:37:50 UTC 2020 ====

==== Total build time ====

real    1:08:07

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-8e56e550c6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-2

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_232-omnios-151033-09"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   115

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2020010301-db479f15561

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:19.2
user  3:48:20.0
sys   1:07:59.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:07.2
user  3:21:43.5
sys     59:35.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
