### PR TITLE
Ship the demangle-sys.h header file

### DIFF
--- a/exception_lists/packaging
+++ b/exception_lists/packaging
@@ -45,7 +45,6 @@ usr/include/auth_list.h
 usr/include/bsm/audit_door_infc.h
 usr/include/bsm/audit_private.h
 usr/include/bsm/devalloc.h
-usr/include/demangle-sys.h
 usr/include/getxby_door.h
 usr/include/lastlog.h
 usr/include/passwdutil.h

--- a/usr/src/pkg/manifests/system-library-demangle.mf
+++ b/usr/src/pkg/manifests/system-library-demangle.mf
@@ -21,7 +21,7 @@
 
 #
 # Copyright 2018 Jason King
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 set name=pkg.fmri value=pkg:/system/library/demangle@$(PKGVERS)
@@ -30,8 +30,10 @@ set name=pkg.summary value="Symbol demangling support"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
 set name=variant.arch value=$(ARCH)
 dir path=usr group=sys
+dir path=usr/include
 dir path=usr/lib
 dir path=usr/lib/$(ARCH64)
+file path=usr/include/demangle-sys.h
 file path=usr/lib/$(ARCH64)/libdemangle-sys.so.1
 file path=usr/lib/libdemangle-sys.so.1
 license lic_CDDL license=lic_CDDL


### PR DESCRIPTION
Although libdemangle-sys is still a private interface which may change, we can use it to replace the closed libdemangle for openjdk. Since we have releases, we are isolated from changes in the upstream library and can adjust bloody as necessary - @jasonbking