### PR TITLE
LX: OS-6344/OS-6150 - fix mismerge

### DIFF
--- a/usr/src/uts/common/inet/ip/ip_squeue.c
+++ b/usr/src/uts/common/inet/ip/ip_squeue.c
@@ -153,7 +153,7 @@ ip_squeue_create(pri_t pri)
 {
 	squeue_t *sqp;
 
-	sqp = squeue_create(pri, B_TRUE);
+	sqp = squeue_create(pri);
 	ASSERT(sqp != NULL);
 	if (ip_squeue_create_callback != NULL)
 		ip_squeue_create_callback(sqp);

--- a/usr/src/uts/common/inet/squeue.c
+++ b/usr/src/uts/common/inet/squeue.c
@@ -241,7 +241,7 @@ squeue_init(void)
 }
 
 squeue_t *
-squeue_create(pri_t pri, boolean_t isip)
+squeue_create(pri_t pri)
 {
 	squeue_t *sqp = kmem_cache_alloc(squeue_cache, KM_SLEEP);
 
@@ -407,7 +407,7 @@ squeue_enter(squeue_t *sqp, mblk_t *mp, mblk_t *tail, uint32_t cnt,
 				 * still be best to process a single queued
 				 * item if it matches the active connection.
 				 */
-				if (sqp->sq_first != NULL && sqp->sq_isip) {
+				if (sqp->sq_first != NULL) {
 					squeue_try_drain_one(sqp, connp);
 				}
 
@@ -1374,7 +1374,6 @@ squeue_try_drain_one(squeue_t *sqp, conn_t *compare_conn)
 	ASSERT(MUTEX_HELD(&sqp->sq_lock));
 	ASSERT((sqp->sq_state & SQS_PROC) == 0);
 	ASSERT(sqp->sq_run == NULL);
-	ASSERT(sqp->sq_isip);
 	VERIFY(mp != NULL);
 
 	/*
@@ -1452,7 +1451,6 @@ squeue_synch_exit(conn_t *connp, int flag)
 {
 	squeue_t *sqp = connp->conn_sqp;
 
-	VERIFY(sqp->sq_isip == B_TRUE);
 	ASSERT(flag == SQ_NODRAIN || flag == SQ_PROCESS);
 
 	mutex_enter(&sqp->sq_lock);

--- a/usr/src/uts/common/sys/squeue.h
+++ b/usr/src/uts/common/sys/squeue.h
@@ -77,7 +77,7 @@ typedef enum {
 
 struct ip_recv_attr_s;
 extern void squeue_init(void);
-extern squeue_t *squeue_create(pri_t, boolean_t);
+extern squeue_t *squeue_create(pri_t);
 extern void squeue_bind(squeue_t *, processorid_t);
 extern void squeue_unbind(squeue_t *);
 extern void squeue_enter(squeue_t *, mblk_t *, mblk_t *,


### PR DESCRIPTION
OmniOS does not have generalised squeues. (SmartOS uses them for vnd)