### PR TITLE
Disable XPG4v2 slave PTY changes (pending 12306)

### DIFF
--- a/usr/src/lib/libc/port/sys/open.c
+++ b/usr/src/lib/libc/port/sys/open.c
@@ -42,16 +42,22 @@
 #include <sys/syscall.h>
 #include "libc.h"
 
+#ifdef _DISABLED_PENDING_12306
 static int xpg4_fixup(int fd);
 static void push_module(int fd);
 static int isptsfd(int fd);
 static void itoa(int i, char *ptr);
+#endif
 
 int
 __openat(int dfd, const char *path, int oflag, mode_t mode)
 {
 	int fd = syscall(SYS_openat, dfd, path, oflag, mode);
+#ifdef _DISABLED_PENDING_12306
 	return (xpg4_fixup(fd));
+#else
+	return (fd);
+#endif
 }
 
 int
@@ -59,7 +65,11 @@ __open(const char *path, int oflag, mode_t mode)
 {
 #if defined(_RETAIN_OLD_SYSCALLS)
 	int fd = syscall(SYS_open, path, oflag, mode);
+#ifdef _DISABLED_PENDING_12306
 	return (xpg4_fixup(fd));
+#else
+	return (fd);
+#endif
 #else
 	return (__openat(AT_FDCWD, path, oflag, mode));
 #endif
@@ -71,7 +81,11 @@ int
 __openat64(int dfd, const char *path, int oflag, mode_t mode)
 {
 	int fd = syscall(SYS_openat64, dfd, path, oflag, mode);
+#ifdef _DISABLED_PENDING_12306
 	return (xpg4_fixup(fd));
+#else
+	return (fd);
+#endif
 }
 
 int
@@ -79,7 +93,11 @@ __open64(const char *path, int oflag, mode_t mode)
 {
 #if defined(_RETAIN_OLD_SYSCALLS)
 	int fd = syscall(SYS_open64, path, oflag, mode);
+#ifdef _DISABLED_PENDING_12306
 	return (xpg4_fixup(fd));
+#else
+	return (fd);
+#endif
 #else
 	return (__openat64(AT_FDCWD, path, oflag, mode));
 #endif
@@ -87,6 +105,7 @@ __open64(const char *path, int oflag, mode_t mode)
 
 #endif	/* !_LP64 */
 
+#ifdef _DISABLED_PENDING_12306
 /*
  * XPG4v2 requires that open of a slave pseudo terminal device
  * provides the process with an interface that is identical to
@@ -181,3 +200,4 @@ push_module(int fd)
 	}
 	errno = oerrno;
 }
+#endif


### PR DESCRIPTION
Pending the full upstream fix for [12306](https://www.illumos.org/issues/12306), this is a change to disable the XPG4v2 slave PTY behaviour completely.

## mail_msg

```

==== Nightly distributed build started:   Sat Feb 15 11:14:04 UTC 2020 ====
==== Nightly distributed build completed: Sat Feb 15 12:23:40 UTC 2020 ====

==== Total build time ====

real    1:09:36

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-59c7565d72 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151033-b07"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   133

==== Nightly argument issues ====


==== Build version ====

omnios-xpg4off-458e6828bb

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:01.3
user  3:47:07.1
sys   1:01:13.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:22.8
user  3:19:17.2
sys     55:38.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
