### PR TITLE
Upstream merge upstream_merge/2020030201

### DIFF
--- a/usr/src/man/man1m/Makefile
+++ b/usr/src/man/man1m/Makefile
@@ -170,6 +170,7 @@ _MANFILES=	6to4relay.1m		\
 		halt.1m			\
 		hextoalabel.1m		\
 		hostconfig.1m		\
+		hotplug.1m		\
 		id.1m			\
 		idmap.1m		\
 		idmapd.1m		\

--- a/usr/src/man/man1m/hotplug.1m
+++ b/usr/src/man/man1m/hotplug.1m
@@ -1,0 +1,330 @@
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\"
+.\" Copyright (c) 2010, Sun Microsystems, Inc. All Rights Reserved
+.\" Copyright 2020 Joyent, Inc.
+.\"
+.Dd March 2, 2020
+.Dt HOTPLUG 1M
+.Os
+.Sh NAME
+.Nm hotplug
+.Nd configure hotplug connectors and ports
+.Sh SYNOPSIS
+.Nm
+.Fl \&?
+.Nm
+.Cm list
+.Op Fl lv
+.Op Ar path
+.Op Ar connection
+.Nm
+.Cm online
+.Ar path
+.Ar port
+.Nm
+.Cm offline
+.Op Fl fq
+.Ar path
+.Ar port
+.Nm
+.Cm enable
+.Ar path
+.Ar connector
+.Nm
+.Cm disable
+.Op Fl fq
+.Ar path
+.Ar connector
+.Nm
+.Cm poweron
+.Ar path
+.Ar connector
+.Nm
+.Cm poweroff
+.Op Fl fq
+.Ar path
+.Ar connector
+.Nm
+.Cm set
+.Fl o Ar options
+.Ar path
+.Ar connector
+.Nm
+.Cm get
+.Fl o Ar options
+.Ar path
+.Ar connector
+.Sh DESCRIPTION
+The
+.Nm
+command is used to manage hotplug connections.
+A connection can be a connector or port.
+A hotplug connector is a representation of a physical point in the system where
+components can be inserted or removed.
+A hotplug port is a representation of a logical point in the system device tree
+where the connection of a device to the system is managed.
+.Pp
+The
+.Nm
+command only supports hotplug operations on hotplug connectors for PCI Express
+buses and PCI buses that implement the Standard PCI Hotplug feature.
+Hotplug ports on PCI Express and PCI buses in systems with PCI Express fabrics
+are also supported.
+Additional buses may be supported in the future.
+.Pp
+The
+.Nm
+command operates on the following kinds of objects:
+.Bl -tag -width "connection"
+.It Cm path
+Hotplug connectors and ports are integrated into the system device tree.
+The names of connectors and ports are unique relative only to their bus
+controller.
+A device path is required to uniquely reference a connector or port.
+.It Cm connector
+If a hardware component supports being physically inserted or removed, then a
+hotplug connector represents the location where this action may occur.
+When a connector exists, it has a hierarchy of ports and device nodes that
+depend upon it.
+.It Cm port
+All device nodes can be virtually hotplugged, even if their hardware does not
+support physical hotplugging.
+A hotplug port exists between a device node and its parent node in the system
+device tree.
+It represents the location where the device node and its dependents can be
+managed.
+.It Cm connection
+A hotplug connection is a generic term to refer to either a hotplug connector or
+a hotplug port.
+.El
+.Pp
+Hotplug connectors and ports are managed according to a state model.
+The
+.Nm
+command can list information about the hotplug connections in a system, or it
+can initiate change of state operations on specific hotplug connections.
+.Pp
+Hotplug connectors can be in the following states:
+.Bl -tag -width "present"
+.It Cm empty
+A component is not physically inserted in the connector.
+.It Cm present
+A component is physically inserted in the connector, but the component is
+powered off.
+The component is not in use.
+.It Cm powered
+A component is physically inserted in the connector, and the component is
+powered on.
+The component is disabled and is not in use.
+.It Cm enabled
+A component is physically inserted in the connector.
+The component is powered on and has been probed and tested.
+The component is enabled and devices that represent its functions can be used.
+.El
+.Pp
+Hotplug ports can be in the following states:
+.Bl -tag -width "port-present"
+.It Cm port-empty
+No device exists for the hotplug port.
+.It Cm port-present
+A device exists for the hotplug port, but the device has not been probed and it
+has no attached device driver.
+The device is not in use.
+.It Cm offline
+A device exists for the hotplug port, and the device has been probed.
+A device driver is not attached, and the device is not in use.
+.It Cm online
+A device exists for the hotplug port, and its device driver is fully attached.
+The device is in use.
+.It Cm maintenance
+A device exists for the hotplug port, and its device driver is fully attached.
+The device is in use, but not fully operational.
+A maintenance or fault management operation is affecting the device.
+.El
+.Pp
+The
+.Nm
+command can also access bus private properties for each hotplug connector.
+The current values of bus private properties can be displayed.
+New values for each bus private property can be set directly.
+.Sh EXIT STATUS
+.Bl -diag
+.It 0
+Successful completion.
+.It 1
+Invalid command line options were specified.
+.It 2
+The specified path or connection does not exist.
+.It 3
+A fatal error occurred.
+One or more error messages are displayed on standard error.
+.It 4
+The hotplug service is not available.
+.El
+.Sh EXAMPLES
+.Bl -tag -width 0n
+.It Sy Example 1 No Showing All Hotplug Connections
+The following command shows all hotplug connections:
+.Bd -literal
+# hotplug list -v
+pci@0,0
+        <pci.2,1> (ONLINE)
+         pci108e,534a@2,1
+                 [pci30] (EMPTY)
+        <pci.e,0> (ONLINE)
+         pci10de,5d@e
+                 <pci.b,0> (ONLINE)
+                 display@b
+                 [NEM0] (ENABLED)
+                 <pci.a,0> (ONLINE)
+                 pci108e,534a@a,0
+                         { Network interface nge0 }
+                         { nge0: hosts IP addresses: 10.0.0.1 }
+                 <pci.a,1> (MAINTENANCE)
+                 pci108e,534a@a,1
+                 [NEM1] (EMPTY)
+         <pci.c,0> (OFFLINE)
+                pci108e,534a@4
+.Ed
+.Pp
+To show the full paths of hotplug connections and devices, enter the following
+command:
+.Bd -literal
+# hotplug list -l
+/pci@0,0 <pci.2,1> (ONLINE)
+/pci@0,0/pci108e,534a@2,1 [pci30] (EMPTY)
+/pci@0,0 pci.e,0> (ONLINE)
+/pci@0,0/pci10de,5d@e <pci.b,0> (ONLINE)
+/pci@0,0/pci10de,5d@e/display@b
+/pci@0,0/pci10de,5d@e [NEM0] (ENABLED)
+/pci@0,0/pci10de,5d@e <pci.a,0> (ONLINE)
+/pci@0,0/pci10de,5d@e/pci108e,534a@a,0
+/pci@0,0/pci10de,5d@e <pci.a,1> (MAINTENANCE)
+/pci@0,0/pci10de,5d@e/pci108e,534a@a,0
+/pci@0,0/pci10de,5d@e [NEM1] (EMPTY)
+/pci@0,0 pci.c,0> (OFFLINE)
+/pci@0,0/pci108e,534a@4
+.Ed
+.It Sy Example 2 No Reporting Failure During State Change Operation
+If a change of state operation fails, an explanation is displayed to describe
+the failure.
+An attempt to offline a hotplug port with dependent devices that are currently
+in use by the system might fail as follows:
+.Bd -literal
+# hotplug offline /pci@0,0/pci10de,5d@e pci.a,0
+ERROR: devices or resources are busy.
+pci108e,534a@a,0:
+    { Network interface nge0 }
+    { nge0: hosts IP addresses: 10.0.0.1 }
+    { Plumbed IP Address }
+.Ed
+.It Sy Example 3 No Displaying Bus-Specific Properties and Values
+The following command displays all supported bus-specific properties and their
+possible values:
+.Bd -literal
+# hotplug get -o help /pci@0,0 pci.2,1
+power_led=<on|off|blink>
+fault_led=<on|off|blink>
+active_led=<on|off|blink>
+attn_led=<on|off|blink>
+card_type=<type description>
+board_type=<type description>
+.Ed
+.It Sy Example 4 Displaying Bus-Specific Options
+The following command displays the card type and the current state of the Power
+LED of a PCI hotplug connector:
+.Bd -literal
+# hotplug get -o card_type,power_led /pci@0,0 pci.2,1
+card_type=fibre
+power_led=on
+.Ed
+.It Sy Example 5 No Setting a Bus-Specific Property
+The following command turns on the attention LED of a PCI hotplug connector:
+.Bd -literal
+# hotplug set -o attn_led=on /pci@0,0 pci.2,1
+.Ed
+.El
+.Sh DIAGNOSTICS
+The following error message is displayed on systems that do not have any
+supported I/O buses:
+.Bd -literal
+ERROR: there are no connections to display.
+(See hotplug(1m) for more information.)
+.Ed
+.Pp
+If this error message is seen, note that the system might still have other I/O
+devices that support hotplugging, through the
+.Xr cfgadm 1M
+command instead of
+.Nm .
+.Sh INTERFACE STABILITY
+.Sy Committed
+.Sh SEE ALSO
+.Xr cfgadm 1M ,
+.Xr hotplugd 1M ,
+.Xr getsubopt 3C ,
+.Xr rcmscript 4 ,
+.Xr attributes 5
+.Sh NOTES
+The
+.Nm
+service
+.Po FMRI
+.Pa svc:/system/hotplug
+.Pc
+must be enabled as a prerequisite for using the
+.Nm
+command.
+See
+.Xr hotplugd 1M .
+.Pp
+The authorization
+.Pa solaris.hotplug.modify
+must be granted in order to perform change-of-state operations.
+Alternatively, the rights profile
+.Qq Hotplug Management
+can be granted, which includes that authorization.
+.Pp
+Verbose usage information is gathered from the RCM framework.
+Its format and content is subject to change.
+.Pp
+The following bus specific properties are supported in PCI bus controllers:
+.Bl -tag -width Ds
+.It Cm power_led No \&| Cm fault_led No \&| Cm attn_led No \&| Cm active_led
+States of a specific LED of a slot.
+The value could be
+.Cm on , off ,
+or
+.Cm blink .
+.Pp
+They can all be used with
+.Cm get
+subcommand, but only property
+.Cm attn_led
+can be used with
+.Cm set
+subcommand.
+.It Cm card_type No \&| Cm board_type
+Type of a card or board of a slot.
+.Pp
+They can all be used with
+.Cm get
+subcommand, but neither can be used with
+.Cm set
+subcommand.
+.El

--- a/usr/src/man/man3c/directio.3c
+++ b/usr/src/man/man3c/directio.3c
@@ -1,9 +1,10 @@
 '\" te
 .\" Copyright (c) 2003, Sun Microsystems, Inc.  All Rights Reserved.
+.\" Copyright 2020 Joyent, Inc.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH DIRECTIO 3C "Apr 9, 2003"
+.TH DIRECTIO 3C "Feb 28, 2020"
 .SH NAME
 directio \- provide advice to file system
 .SH SYNOPSIS
@@ -130,7 +131,7 @@ when a file is sparse or is being extended and is opened with \fBO_SYNC\fR or
 \fBO_DSYNC\fR (see  \fBopen\fR(2)).
 .sp
 .LP
-The \fBdirectio()\fR function is supported for the NFS and UFS file system
+The \fBdirectio()\fR function is supported for the NFS, UFS and ZFS file system
 types (see \fBfstyp\fR(1M)).
 .SH ATTRIBUTES
 .sp

--- a/usr/src/pkg/manifests/SUNWcs.man1m.inc
+++ b/usr/src/pkg/manifests/SUNWcs.man1m.inc
@@ -110,6 +110,7 @@ file path=usr/share/man/man1m/groupmod.1m
 file path=usr/share/man/man1m/growfs.1m
 file path=usr/share/man/man1m/halt.1m
 file path=usr/share/man/man1m/hostconfig.1m
+file path=usr/share/man/man1m/hotplug.1m
 file path=usr/share/man/man1m/id.1m
 file path=usr/share/man/man1m/idmap.1m
 file path=usr/share/man/man1m/idmapd.1m

--- a/usr/src/uts/common/fs/zfs/zfs_vnops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vnops.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2017 Nexenta Systems, Inc.
  */
 
@@ -374,6 +374,46 @@ zfs_ioctl(vnode_t *vp, int com, intptr_t data, int flag, cred_t *cred,
 	case _FIOGDIO:
 	case _FIOSDIO:
 	{
+		return (0);
+	}
+
+	case _FIODIRECTIO:
+	{
+		/*
+		 * ZFS inherently provides the basic semantics for directio.
+		 * This is the summary from the ZFS on Linux support for
+		 * O_DIRECT, which is the common form of directio, and required
+		 * no changes to ZFS.
+		 *
+		 * 1. Minimize cache effects of the I/O.
+		 *
+		 *    By design the ARC is already scan-resistant, which helps
+		 *    mitigate the need for special O_DIRECT handling.
+		 *
+		 * 2. O_DIRECT _MAY_ impose restrictions on IO alignment and
+		 *    length.
+		 *
+		 *    No additional alignment or length restrictions are
+		 *    imposed by ZFS.
+		 *
+		 * 3. O_DIRECT _MAY_ perform unbuffered IO operations directly
+		 *    between user memory and block device.
+		 *
+		 *    No unbuffered IO operations are currently supported. In
+		 *    order to support features such as compression, encryption,
+		 *    and checksumming a copy must be made to transform the
+		 *    data.
+		 *
+		 * 4. O_DIRECT _MAY_ imply O_DSYNC (XFS).
+		 *
+		 *    O_DIRECT does not imply O_DSYNC for ZFS.
+		 *
+		 * 5. O_DIRECT _MAY_ disable file locking that serializes IO
+		 *    operations.
+		 *
+		 *    All I/O in ZFS is locked for correctness and this locking
+		 *    is not disabled by O_DIRECT.
+		 */
 		return (0);
 	}
 


### PR DESCRIPTION
Weekly upstream for upstream_merge/2020030201

## Backports

None

## mail_msg

```

==== Nightly distributed build started:   Tue Mar  3 00:01:02 UTC 2020 ====
==== Nightly distributed build completed: Tue Mar  3 01:07:44 UTC 2020 ====

==== Total build time ====

real    1:06:42

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-b463bb4090 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151033-b07"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   131

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020030201-c29e6a9d15f

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    26:35.3
user  3:40:28.1
sys   1:00:50.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    23:39.6
user  3:13:43.2
sys     55:40.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
