### PR TITLE
Upstream merge/2020030501

### DIFF
--- a/usr/src/cmd/dladm/dladm.c
+++ b/usr/src/cmd/dladm/dladm.c
@@ -24,6 +24,7 @@
  * Copyright 2016 Nexenta Systems, Inc.
  * Copyright (c) 2015 Joyent, Inc. All rights reserved.
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 Peter Tribble.
  */
 
 #include <stdio.h>
@@ -1147,7 +1148,7 @@ typedef struct  usage_fields_buf_s {
 	char	usage_rbytes[10];
 	char	usage_opackets[9];
 	char	usage_obytes[10];
-	char	usage_bandwidth[14];
+	char	usage_bandwidth[15];
 } usage_fields_buf_t;
 
 static const ofmt_field_t usage_fields[] = {
@@ -1163,7 +1164,7 @@ static const ofmt_field_t usage_fields[] = {
 	offsetof(usage_fields_buf_t, usage_opackets), print_default_cb},
 { "OBYTES",	11,
 	offsetof(usage_fields_buf_t, usage_obytes), print_default_cb},
-{ "BANDWIDTH",	15,
+{ "BANDWIDTH",	16,
 	offsetof(usage_fields_buf_t, usage_bandwidth), print_default_cb},
 { NULL,		0, 0, NULL}}
 ;
@@ -1179,7 +1180,7 @@ typedef struct  usage_l_fields_buf_s {
 	char	usage_l_etime[13];
 	char	usage_l_rbytes[8];
 	char	usage_l_obytes[8];
-	char	usage_l_bandwidth[14];
+	char	usage_l_bandwidth[15];
 } usage_l_fields_buf_t;
 
 static const ofmt_field_t usage_l_fields[] = {
@@ -1194,7 +1195,7 @@ static const ofmt_field_t usage_l_fields[] = {
 	offsetof(usage_l_fields_buf_t, usage_l_rbytes), print_default_cb},
 { "OBYTES",	9,
 	offsetof(usage_l_fields_buf_t, usage_l_obytes), print_default_cb},
-{ "BANDWIDTH",	15,
+{ "BANDWIDTH",	16,
 	offsetof(usage_l_fields_buf_t, usage_l_bandwidth), print_default_cb},
 { NULL,		0, 0, NULL}}
 ;

--- a/usr/src/cmd/dlstat/dlstat.c
+++ b/usr/src/cmd/dlstat/dlstat.c
@@ -27,6 +27,10 @@
  * Copyright 2017 Joyent, Inc.
  */
 
+/*
+ * Copyright 2020 Peter Tribble.
+ */
+
 #include <stdio.h>
 #include <ctype.h>
 #include <locale.h>
@@ -414,7 +418,7 @@ typedef struct  history_fields_buf_s {
 	char	h_rbytes[10];
 	char	h_opackets[9];
 	char	h_obytes[10];
-	char	h_bandwidth[14];
+	char	h_bandwidth[15];
 } history_fields_buf_t;
 
 static ofmt_field_t history_fields[] = {
@@ -430,7 +434,7 @@ static ofmt_field_t history_fields[] = {
 	offsetof(history_fields_buf_t, h_opackets), print_default_cb},
 { "OBYTES",	11,
 	offsetof(history_fields_buf_t, h_obytes), print_default_cb},
-{ "BANDWIDTH",	15,
+{ "BANDWIDTH",	16,
 	offsetof(history_fields_buf_t, h_bandwidth), print_default_cb},
 { NULL,		0, 0, NULL}};
 
@@ -443,7 +447,7 @@ typedef struct  history_l_fields_buf_s {
 	char	hl_etime[13];
 	char	hl_rbytes[8];
 	char	hl_obytes[8];
-	char	hl_bandwidth[14];
+	char	hl_bandwidth[15];
 } history_l_fields_buf_t;
 
 static ofmt_field_t history_l_fields[] = {
@@ -458,7 +462,7 @@ static ofmt_field_t history_l_fields[] = {
 	offsetof(history_l_fields_buf_t, hl_rbytes), print_default_cb},
 { "OBYTES",	9,
 	offsetof(history_l_fields_buf_t, hl_obytes), print_default_cb},
-{ "BANDWIDTH",	15,
+{ "BANDWIDTH",	16,
 	offsetof(history_l_fields_buf_t, hl_bandwidth), print_default_cb},
 { NULL,		0, 0, NULL}}
 ;
@@ -566,7 +570,7 @@ show_history_time(dladm_usage_t *history, void *arg)
 {
 	show_history_state_t	*state = arg;
 	char			buf[DLADM_STRSIZE];
-	history_l_fields_buf_t 	ubuf;
+	history_l_fields_buf_t	ubuf;
 	time_t			time;
 	double			bw;
 	dladm_status_t		status;
@@ -751,7 +755,7 @@ do_show_history(int argc, char *argv[], const char *use)
 		die("show-link -h requires a file");
 
 	if (optind == (argc-1)) {
-		uint32_t 	flags;
+		uint32_t	flags;
 
 		resource = argv[optind];
 		if (!state.hs_showall &&
@@ -1494,7 +1498,7 @@ static int
 show_queried_stats(dladm_handle_t dh, datalink_id_t linkid, void *arg)
 {
 	show_state_t		*state = arg;
-	int 			i;
+	int			i;
 	dladm_stat_chain_t	*diff_stat;
 	char			linkname[DLPI_LINKNAME_MAX];
 
@@ -1639,7 +1643,7 @@ do_show(int argc, char *argv[], const char *use)
 	ofmt_handle_t		ofmt;
 	ofmt_status_t		oferr;
 	uint_t			ofmtflags = OFMT_RIGHTJUST;
-	ofmt_field_t 		*oftemplate;
+	ofmt_field_t		*oftemplate;
 
 	bzero(&state, sizeof (state));
 	opterr = 0;
@@ -1840,7 +1844,7 @@ do_show_phys(int argc, char *argv[], const char *use)
 	ofmt_handle_t		ofmt;
 	ofmt_status_t		oferr;
 	uint_t			ofmtflags = OFMT_RIGHTJUST;
-	ofmt_field_t 		*oftemplate;
+	ofmt_field_t		*oftemplate;
 
 	bzero(&state, sizeof (state));
 	opterr = 0;
@@ -2022,7 +2026,7 @@ do_show_link(int argc, char *argv[], const char *use)
 	ofmt_handle_t		ofmt;
 	ofmt_status_t		oferr;
 	uint_t			ofmtflags = OFMT_RIGHTJUST;
-	ofmt_field_t 		*oftemplate;
+	ofmt_field_t		*oftemplate;
 
 	bzero(&state, sizeof (state));
 	opterr = 0;
@@ -2227,7 +2231,7 @@ do_show_aggr(int argc, char *argv[], const char *use)
 	ofmt_handle_t		ofmt;
 	ofmt_status_t		oferr;
 	uint_t			ofmtflags = OFMT_RIGHTJUST;
-	ofmt_field_t 		*oftemplate;
+	ofmt_field_t		*oftemplate;
 
 	bzero(&state, sizeof (state));
 	opterr = 0;

--- a/usr/src/cmd/ed/ed.c
+++ b/usr/src/cmd/ed/ed.c
@@ -24,7 +24,7 @@
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 /*
  * Editor
@@ -41,7 +41,7 @@
 #include	<errno.h>
 #include	<paths.h>
 
-static const 	char	*msgtab[] =
+static const	char	*msgtab[] =
 {
 	"write or open on pipe failed",			/*  0 */
 	"warning: expecting `w'",			/*  1 */
@@ -252,15 +252,15 @@ static int	fflg, shflg;
 static char	prompt[16] = "*";
 static int	rflg;
 static int	readflg;
-static int 	eflg;
-static int 	qflg = 0;
-static int 	ncflg;
-static int 	listn;
-static int 	listf;
-static int 	pflag;
-static int 	flag28 = 0; /* Prevents write after a partial read */
-static int 	save28 = 0; /* Flag whether buffer empty at start of read */
-static long 	savtime;
+static int	eflg;
+static int	qflg = 0;
+static int	ncflg;
+static int	listn;
+static int	listf;
+static int	pflag;
+static int	flag28 = 0; /* Prevents write after a partial read */
+static int	save28 = 0; /* Flag whether buffer empty at start of read */
+static long	savtime;
 static char	*name = "SHELL";
 static char	*rshell = "/usr/lib/rsh";
 static char	*val;
@@ -465,7 +465,7 @@ main(int argc, char **argv)
 			;
 		globp = "e";
 		fflg++;
-	} else 	/* editing with no file so set savtime to 0 */
+	} else	/* editing with no file so set savtime to 0 */
 		savtime = 0;
 	eflg++;
 	if ((tfname = tempnam("", "ea")) == NULL) {
@@ -3060,8 +3060,8 @@ static char stdtabs[] = {
 'f', 0, 1, 7, 11, 15, 19, 23, 0,		/* FORTRAN */
 'p', 0, 1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61, 0,
 						/* PL/I */
-'s', 0, 1, 10, 55, 0,    			/* SNOBOL */
-'u', 0, 1, 12, 20, 44, 0, 			/* UNIVAC ASM */
+'s', 0, 1, 10, 55, 0,				/* SNOBOL */
+'u', 0, 1, 12, 20, 44, 0,			/* UNIVAC ASM */
 0 };
 
 

--- a/usr/src/cmd/flowstat/flowstat.c
+++ b/usr/src/cmd/flowstat/flowstat.c
@@ -31,6 +31,10 @@
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
+/*
+ * Copyright 2020 Peter Tribble.
+ */
+
 #include <stdio.h>
 #include <locale.h>
 #include <stdarg.h>
@@ -139,7 +143,7 @@ typedef struct  history_fields_buf_s {
 	char	history_rbytes[10];
 	char	history_opackets[9];
 	char	history_obytes[10];
-	char	history_bandwidth[14];
+	char	history_bandwidth[15];
 } history_fields_buf_t;
 
 static ofmt_field_t history_fields[] = {
@@ -156,7 +160,7 @@ static ofmt_field_t history_fields[] = {
 	offsetof(history_fields_buf_t, history_opackets), print_default_cb},
 { "OBYTES",	11,
 	offsetof(history_fields_buf_t, history_obytes), print_default_cb},
-{ "BANDWIDTH",	15,
+{ "BANDWIDTH",	16,
 	offsetof(history_fields_buf_t, history_bandwidth), print_default_cb},
 NULL_OFMT}
 ;
@@ -167,7 +171,7 @@ typedef struct  history_l_fields_buf_s {
 	char	history_l_etime[13];
 	char	history_l_rbytes[8];
 	char	history_l_obytes[8];
-	char	history_l_bandwidth[14];
+	char	history_l_bandwidth[15];
 } history_l_fields_buf_t;
 
 static ofmt_field_t history_l_fields[] = {
@@ -182,7 +186,7 @@ static ofmt_field_t history_l_fields[] = {
 	offsetof(history_l_fields_buf_t, history_l_rbytes), print_default_cb},
 { "OBYTES",	9,
 	offsetof(history_l_fields_buf_t, history_l_obytes), print_default_cb},
-{ "BANDWIDTH",	15,
+{ "BANDWIDTH",	16,
 	offsetof(history_l_fields_buf_t, history_l_bandwidth),
 	    print_default_cb},
 NULL_OFMT}
@@ -544,7 +548,7 @@ dump_all_flow_stats(dladm_flow_attr_t *attrp, void *arg, datalink_id_t linkid,
 int
 main(int argc, char *argv[])
 {
-	dladm_status_t 		status;
+	dladm_status_t		status;
 	int			option;
 	boolean_t		r_arg = B_FALSE;
 	boolean_t		t_arg = B_FALSE;
@@ -782,7 +786,7 @@ show_history_time(dladm_usage_t *history, void *arg)
 {
 	show_history_state_t	*state = (show_history_state_t *)arg;
 	char			buf[DLADM_STRSIZE];
-	history_l_fields_buf_t 	ubuf;
+	history_l_fields_buf_t	ubuf;
 	time_t			time;
 	double			bw;
 	dladm_flow_attr_t	attr;

--- a/usr/src/cmd/iscsiadm/cmdparse.c
+++ b/usr/src/cmd/iscsiadm/cmdparse.c
@@ -23,6 +23,10 @@
  * Use is subject to license terms.
  */
 
+/*
+ * Copyright 2020 Joyent Inc.
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -70,7 +74,7 @@ static void subUsage(uint_t, subcommand_t *);
 static void subUsageObject(uint_t, subcommand_t *, object_t *);
 static int getObject(char *, object_t **);
 static int getObjectRules(uint_t, objectRules_t **);
-static char *getLongOption(int);
+static const char *getLongOption(int);
 static optionProp_t *getOptions(uint_t, uint_t);
 static char *getOptionArgDesc(int);
 extern void seeMan(void);
@@ -208,7 +212,7 @@ getOptions(uint_t object, uint_t subcommand)
  *  on success, long option name
  *  on failure, NULL
  */
-static char *
+static const char *
 getLongOption(int shortOption)
 {
 	struct option *op;
@@ -319,7 +323,7 @@ subUsageObject(uint_t usageType, subcommand_t *subcommand, object_t *objp)
 	opCmd_t *opCmd = NULL;
 	optionProp_t *options;
 	char *optionArgDesc;
-	char *longOpt;
+	const char *longOpt;
 
 
 	if (getObjectRules(objp->value, &objRules) != 0) {

--- a/usr/src/cmd/isns/isnsadm/cmdparse.c
+++ b/usr/src/cmd/isns/isnsadm/cmdparse.c
@@ -22,6 +22,9 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2020 Joyent Inc.
+ */
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -69,7 +72,7 @@ static int getSubcommandProps(char *, subCommandProps_t **);
 static char *getExecBasename(char *);
 static void usage(uint_t);
 static void subUsage(uint_t, subCommandProps_t *);
-static char *getLongOption(int);
+static const char *getLongOption(int);
 static char *getOptionArgDesc(int);
 
 /* global data */
@@ -119,7 +122,7 @@ getSubcommandProps(char *subCommand, subCommandProps_t **subCommandProps)
  *  on success, long option name
  *  on failure, NULL
  */
-static char *
+static const char *
 getLongOption(int shortOption)
 {
 	struct option *op;
@@ -169,7 +172,7 @@ subUsage(uint_t usageType, subCommandProps_t *subcommand)
 {
 	int i;
 	char *optionArgDesc;
-	char *longOpt;
+	const char *longOpt;
 
 	if (usageType == GENERAL_USAGE) {
 	    (void) printf("%s:\t%s %s [", gettext("Usage"), commandName,

--- a/usr/src/cmd/mdb/common/modules/mac/mac.c
+++ b/usr/src/cmd/mdb/common/modules/mac/mac.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/mdb_modapi.h>
@@ -967,6 +968,8 @@ mac_ring_classify2str(mac_classify_type_t classify)
 		return ("sw");
 	case MAC_HW_CLASSIFIER:
 		return ("hw");
+	case MAC_PASSTHRU_CLASSIFIER:
+		return ("pass");
 	}
 	return ("--");
 }

--- a/usr/src/cmd/mpathadm/cmdparse.c
+++ b/usr/src/cmd/mpathadm/cmdparse.c
@@ -22,6 +22,10 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2020 Joyent Inc.
+ */
+
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -70,7 +74,7 @@ static void subUsage(uint_t, subcommand_t *);
 static void subUsageObject(uint_t, subcommand_t *, object_t *);
 static int getObject(char *, object_t **);
 static int getObjectRules(uint_t, objectRules_t **);
-static char *getLongOption(int);
+static const char *getLongOption(int);
 static optionProp_t *getOptions(uint_t, uint_t);
 static char *getOptionArgDesc(int);
 
@@ -207,7 +211,7 @@ getOptions(uint_t object, uint_t subcommand)
  *  on success, long option name
  *  on failure, NULL
  */
-static char *
+static const char *
 getLongOption(int shortOption)
 {
 	struct option *op;
@@ -317,7 +321,7 @@ subUsageObject(uint_t usageType, subcommand_t *subcommand, object_t *objp)
 	opCmd_t *opCmd = NULL;
 	optionProp_t *options;
 	char *optionArgDesc;
-	char *longOpt;
+	const char *longOpt;
 
 
 	if (getObjectRules(objp->value, &objRules) != 0) {

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -349,7 +349,7 @@ get_usage(zpool_help_t idx)
 	case HELP_IOSTAT:
 		return (gettext("\tiostat "
 		    "[[-lq]|[-rw]] [-T d | u] [-ghHLpPvy]\n"
-		    "\t    [pool] ..."
+		    "\t    [[pool] ...]|[pool vdev ...]|[vdev ...]]"
 		    " [[-n] interval [count]]\n"));
 	case HELP_LABELCLEAR:
 		return (gettext("\tlabelclear [-f] <vdev>\n"));
@@ -4984,6 +4984,7 @@ zpool_do_iostat(int argc, char **argv)
 			    cb.cb_vdev_names_count)) &&
 			    !cb.cb_scripted) {
 				print_iostat_separator(&cb);
+				printf("\n");
 			}
 		}
 

--- a/usr/src/common/cmdparse/cmdparse.c
+++ b/usr/src/common/cmdparse/cmdparse.c
@@ -24,7 +24,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent Inc.
  */
 
 #include <stdlib.h>
@@ -71,7 +71,7 @@ static int getSubcommandProps(char *, subCommandProps_t **);
 static char *getExecBasename(char *);
 static void usage(uint_t);
 static void subUsage(uint_t, subCommandProps_t *);
-static char *getLongOption(int);
+static const char *getLongOption(int);
 static char *getOptionArgDesc(int);
 
 /* global data */
@@ -121,7 +121,7 @@ getSubcommandProps(char *subCommand, subCommandProps_t **subCommandProps)
  *  on success, long option name
  *  on failure, NULL
  */
-static char *
+static const char *
 getLongOption(int shortOption)
 {
 	struct option *op;
@@ -171,7 +171,7 @@ subUsage(uint_t usageType, subCommandProps_t *subcommand)
 {
 	int i;
 	char *optionArgDesc;
-	char *longOpt;
+	const char *longOpt;
 
 	if (usageType == GENERAL_USAGE) {
 		(void) printf("%s:\t%s %s [", gettext("Usage"), commandName,

--- a/usr/src/head/getopt.h
+++ b/usr/src/head/getopt.h
@@ -27,6 +27,10 @@
  */
 
 /*
+ * Copyright 2020 Joyent Inc.
+ */
+
+/*
  * GNU-like getopt_long(), getopt_long_only().
  * Solaris-specific getopt_clip().
  */
@@ -49,11 +53,13 @@ extern "C" {
 #define	optional_argument	2
 
 struct option {
-	char *name;	/* name of long option */
-	int has_arg;	/* whether option takes an argument */
-	int *flag;	/* if not NULL, set *flag to val when option found */
-	int val;	/* if flag is not NULL, value to set *flag to. */
-			/* if flag is NULL, return value */
+	const char *name;	/* name of long option */
+	int has_arg;		/* whether option takes an argument */
+	int *flag;		/* if not NULL, set *flag to val when option */
+				/* found */
+	int val;		/* if flag is not NULL, value to set *flag */
+				/* to. */
+				/* if flag is NULL, return value */
 };
 
 /*

--- a/usr/src/lib/libc/port/gen/pt.c
+++ b/usr/src/lib/libc/port/gen/pt.c
@@ -138,8 +138,7 @@ unlockpt(int fd)
 /*
  * XPG4v2 requires that open of a slave pseudo terminal device
  * provides the process with an interface that is identical to
- * the terminal interface. For a more detailed discussion,
- * see bugid 4025044.
+ * the terminal interface.
  *
  * To satisfy this, in strict XPG4v2 mode, this routine also sends
  * a message down the stream that sets a flag in the kernel module
@@ -153,7 +152,7 @@ unlockpt(int fd)
  *
  * Most applications do not expect this behaviour so it is only
  * enabled for programs compiled in strict XPG4v2 mode (see
- * stdlib.h)
+ * stdlib.h).
  */
 int
 __unlockpt_xpg4(int fd)

--- a/usr/src/lib/libdladm/common/libdladm.c
+++ b/usr/src/lib/libdladm/common/libdladm.c
@@ -27,6 +27,10 @@
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
+/*
+ * Copyright 2020 Peter Tribble.
+ */
+
 #include <unistd.h>
 #include <errno.h>
 #include <ctype.h>
@@ -70,23 +74,23 @@ static media_type_t media_type_table[] =  {
 	{ DL_HDLC,	"HDLC" },
 	{ DL_CHAR,	"SyncCharacter" },
 	{ DL_CTCA,	"CTCA" },
-	{ DL_FDDI, 	"FDDI" },
-	{ DL_FC, 	"FiberChannel" },
-	{ DL_ATM, 	"ATM" },
-	{ DL_IPATM, 	"ATM(ClassicIP)" },
-	{ DL_X25, 	"X.25" },
-	{ DL_IPX25, 	"X.25(ClassicIP)" },
-	{ DL_ISDN, 	"ISDN" },
-	{ DL_HIPPI, 	"HIPPI" },
-	{ DL_100VG, 	"100BaseVGEthernet" },
-	{ DL_100VGTPR, 	"100BaseVGTokenRing" },
-	{ DL_ETH_CSMA, 	"IEEE802.3" },
-	{ DL_100BT, 	"100BaseT" },
-	{ DL_FRAME, 	"FrameRelay" },
-	{ DL_MPFRAME, 	"MPFrameRelay" },
-	{ DL_ASYNC, 	"AsyncCharacter" },
-	{ DL_IPNET, 	"IPNET" },
-	{ DL_OTHER, 	"Other" }
+	{ DL_FDDI,	"FDDI" },
+	{ DL_FC,	"FiberChannel" },
+	{ DL_ATM,	"ATM" },
+	{ DL_IPATM,	"ATM(ClassicIP)" },
+	{ DL_X25,	"X.25" },
+	{ DL_IPX25,	"X.25(ClassicIP)" },
+	{ DL_ISDN,	"ISDN" },
+	{ DL_HIPPI,	"HIPPI" },
+	{ DL_100VG,	"100BaseVGEthernet" },
+	{ DL_100VGTPR,	"100BaseVGTokenRing" },
+	{ DL_ETH_CSMA,	"IEEE802.3" },
+	{ DL_100BT,	"100BaseT" },
+	{ DL_FRAME,	"FrameRelay" },
+	{ DL_MPFRAME,	"MPFrameRelay" },
+	{ DL_ASYNC,	"AsyncCharacter" },
+	{ DL_IPNET,	"IPNET" },
+	{ DL_OTHER,	"Other" }
 };
 #define	MEDIATYPECOUNT	(sizeof (media_type_table) / sizeof (media_type_t))
 
@@ -590,11 +594,7 @@ dladm_bw2str(int64_t bw, char *buf)
 	kbps = (bw%1000000)/1000;
 	mbps = bw/1000000;
 	if (kbps != 0) {
-		if (mbps == 0)
-			(void) snprintf(buf, DLADM_STRSIZE, "0.%03u", kbps);
-		else
-			(void) snprintf(buf, DLADM_STRSIZE, "%5u.%03u", mbps,
-			    kbps);
+		(void) snprintf(buf, DLADM_STRSIZE, "%5u.%03u", mbps, kbps);
 	} else {
 		(void) snprintf(buf, DLADM_STRSIZE, "%5u", mbps);
 	}

--- a/usr/src/man/man1m/flowadm.1m
+++ b/usr/src/man/man1m/flowadm.1m
@@ -1,24 +1,19 @@
 '\" te
+.\" Copyright 2020 Peter Tribble
 .\" Copyright (c) 2009, Sun Microsystems, Inc. All Rights Reserved
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FLOWADM 1M "April 9, 2016"
+.TH FLOWADM 1M "February 26, 2020"
 .SH NAME
 flowadm \- administer bandwidth resource control and priority for protocols,
 services, containers, and virtual machines
 .SH SYNOPSIS
-.LP
-.nf
-\fBflowadm show-flow\fR [\fB-pP\fR] [\fB-S\fR] [\fB-s\fR [\fB-i\fR \fIinterval\fR]] [\fB-l\fR \fIlink\fR]
-     [\fB-o\fR \fIfield\fR[,...]] [\fIflow\fR]
-.fi
-
-.LP
 .nf
 \fBflowadm add-flow\fR [\fB-t\fR] [\fB-R\fR \fIroot-dir\fR] \fB-l\fR \fIlink\fR \fB-a\fR \fIattr\fR=\fIvalue\fR[,...]
-     \fB-p\fR \fIprop\fR=\fIvalue\fR[,...] \fIflow\fR
+     [\fB-p\fR \fIprop\fR=\fIvalue\fR[,...]] \fIflow\fR
 \fBflowadm remove-flow\fR [\fB-t\fR] [\fB-R\fR \fIroot-dir\fR] {\fB-l\fR \fIlink\fR | \fIflow\fR}
+\fBflowadm show-flow\fR [\fB-p\fR] [\fB-l\fR \fIlink\fR] [\fB-o\fR \fIfield\fR[,...]] [\fIflow\fR]
 .fi
 
 .LP
@@ -29,14 +24,7 @@ services, containers, and virtual machines
      [\fB-p\fR \fIprop\fR[,...]] [\fIflow\fR]
 .fi
 
-.LP
-.nf
-\fBflowadm show-usage\fR [\fB-a\fR] [\fB-d\fR | {\fB-p\fR \fIplotfile\fR \fB-F\fR \fIformat\fR}] [\fB-s\fR \fItime\fR]
-     [\fB-e\fR \fItime\fR] \fB-f\fR \fIfilename\fR [\fIflow\fR]
-.fi
-
 .SH DESCRIPTION
-.LP
 The \fBflowadm\fR command is used to create, modify, remove, and show
 networking bandwidth and associated resources for a type of traffic on a
 particular link.
@@ -61,7 +49,7 @@ Inbound and outbound packet are matched to flows in a very fast and scalable
 way, so that limits can be enforced with minimal performance impact.
 .sp
 .LP
-The \fBflowadm\fR command can be used to identify a flow without imposing any
+The \fBflowadm\fR command can be used to define a flow without imposing any
 bandwidth resource control. This would result in the traffic type getting its
 own resources and queues so that it is isolated from rest of the networking
 traffic for more observable and deterministic behavior.
@@ -70,165 +58,13 @@ traffic for more observable and deterministic behavior.
 \fBflowadm\fR is implemented as a set of subcommands with corresponding
 options. Options are described in the context of each subcommand.
 .SH SUBCOMMANDS
-.LP
 The following subcommands are supported:
 .sp
 .ne 2
 .na
-\fB\fBflowadm show-flow\fR [\fB-pP\fR] [\fB-s\fR [\fB-i\fR \fIinterval\fR]]
-[\fB-o\fR \fIfield\fR[,...]] [\fB-l\fR \fIlink\fR] [\fIflow\fR]\fR
-.ad
-.sp .6
-.RS 4n
-Show flow configuration information (the default) or statistics, either for all
-flows, all flows on a link, or for the specified \fIflow\fR.
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIfield\fR[,...]\fR
-.ad
-.sp .6
-.RS 4n
-A case-insensitive, comma-separated list of output fields to display. The field
-name must be one of the fields listed below, or a special value \fBall\fR, to
-display all fields. For each flow found, the following fields can be displayed:
-.sp
-.ne 2
-.na
-\fB\fBflow\fR\fR
-.ad
-.sp .6
-.RS 4n
-The name of the flow.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlink\fR\fR
-.ad
-.sp .6
-.RS 4n
-The name of the link the flow is on.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBipaddr\fR\fR
-.ad
-.sp .6
-.RS 4n
-IP address of the flow. This can be either local or remote depending on how the
-flow was defined.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBtransport\fR\fR
-.ad
-.sp .6
-.RS 4n
-The name of the layer for protocol to be used.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBport\fR\fR
-.ad
-.sp .6
-.RS 4n
-Local port of service for flow.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBdsfield\fR\fR
-.ad
-.sp .6
-.RS 4n
-Differentiated services value for flow and mask used with \fBDSFIELD\fR value
-to state the bits of interest in the differentiated services field of the IP
-header.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR, \fB--parsable\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display using a stable machine-parsable format.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-P\fR, \fB--persistent\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display persistent flow property information.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-S\fR, \fB--continuous\fR\fR
-.ad
-.sp .6
-.RS 4n
-Continuously display network utilization by flow in a manner similar to the way
-that \fBprstat\fR(1M) displays CPU utilization by process.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR, \fB--statistics\fR\fR
-.ad
-.sp .6
-.RS 4n
-Displays flow statistics.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-i\fR \fIinterval\fR, \fB--interval\fR=\fIinterval\fR\fR
-.ad
-.sp .6
-.RS 4n
-Used with the \fB-s\fR option to specify an interval, in seconds, at which
-statistics should be displayed. If this option is not specified, statistics are
-displayed once.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-l\fR \fIlink\fR, \fB--link\fR=\fIlink\fR | \fIflow\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display information for all flows on the named link or information for the
-named flow.
-.RE
-
-.RE
-
-.sp
-.ne 2
-.na
 \fB\fBflowadm add-flow\fR [\fB-t\fR] [\fB-R\fR \fIroot-dir\fR] \fB-l\fR
-\fIlink\fR \fB-a\fR \fIattr\fR=\fIvalue\fR[,...] \fB-p\fR
-\fIprop\fR=\fIvalue\fR[,...] \fIflow\fR\fR
+\fIlink\fR \fB-a\fR \fIattr\fR=\fIvalue\fR[,...] [\fB-p\fR
+\fIprop\fR=\fIvalue\fR[,...]] \fIflow\fR\fR
 .ad
 .sp .6
 .RS 4n
@@ -280,7 +116,8 @@ Specify the link to which the flow will be added.
 .ad
 .sp .6
 .RS 4n
-A comma-separated list of attributes to be set to the specified values.
+A mandatory comma-separated list of attributes to be set to the specified
+values.
 .RE
 
 .sp
@@ -290,7 +127,8 @@ A comma-separated list of attributes to be set to the specified values.
 .ad
 .sp .6
 .RS 4n
-A comma-separated list of properties to be set to the specified values.
+An optional comma-separated list of properties to be set to the specified
+values. Flow properties are documented in the "Flow Properties" section, below.
 .RE
 
 .RE
@@ -342,13 +180,141 @@ specified, remove only that flow.
 .sp
 .ne 2
 .na
+\fB\fBflowadm show-flow\fR [\fB-pP\fR] [\fB-s\fR [\fB-i\fR \fIinterval\fR]]
+[\fB-o\fR \fIfield\fR[,...]] [\fB-l\fR \fIlink\fR] [\fIflow\fR]\fR
+.ad
+.sp .6
+.RS 4n
+Show flow configuration information, either for all
+flows, all flows on a link, or for the specified \fIflow\fR.
+.sp
+.ne 2
+.na
+\fB\fB-o\fR \fIfield\fR[,...]\fR
+.ad
+.sp .6
+.RS 4n
+A case-insensitive, comma-separated list of output fields to display. The field
+name must be one of the fields listed below, or a special value \fBall\fR, to
+display all fields. For each flow found, the following fields can be displayed:
+.sp
+.ne 2
+.na
+\fB\fBflow\fR\fR
+.ad
+.sp .6
+.RS 4n
+The name of the flow.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBlink\fR\fR
+.ad
+.sp .6
+.RS 4n
+The name of the link the flow is on.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBipaddr\fR\fR
+.ad
+.sp .6
+.RS 4n
+IP address of the flow. This can be either local or remote depending on how the
+flow was defined.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBproto\fR\fR
+.ad
+.sp .6
+.RS 4n
+The name of the layer for protocol to be used.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBlport\fR\fR
+.ad
+.sp .6
+.RS 4n
+Local port of service for flow.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBrport\fR\fR
+.ad
+.sp .6
+.RS 4n
+Remote port of service for flow.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBdsfld\fR\fR
+.ad
+.sp .6
+.RS 4n
+Differentiated services value for flow and mask used with \fBDSFIELD\fR value
+to state the bits of interest in the differentiated services field of the IP
+header.
+.RE
+
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-p\fR, \fB--parsable\fR\fR
+.ad
+.sp .6
+.RS 4n
+Display using a stable machine-parsable format.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-P\fR, \fB--persistent\fR\fR
+.ad
+.sp .6
+.RS 4n
+Display persistent flow property information.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-l\fR \fIlink\fR, \fB--link\fR=\fIlink\fR | \fIflow\fR\fR
+.ad
+.sp .6
+.RS 4n
+Display information for all flows on the named link or information for the
+named flow.
+.RE
+
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fBflowadm set-flowprop\fR [\fB-t\fR] [\fB-R\fR \fIroot-dir\fR] \fB-p\fR
 \fIprop\fR=\fIvalue\fR[,...] \fIflow\fR\fR
 .ad
 .sp .6
 .RS 4n
 Set values of one or more properties on the flow specified by name. The
-complete list of properties can be retrieved using the \fBshow-flow\fR
+complete list of properties can be retrieved using the \fBshow-flowprop\fR
 subcommand.
 .sp
 .ne 2
@@ -534,100 +500,7 @@ A comma-separated list of properties to show.
 
 .RE
 
-.sp
-.ne 2
-.na
-\fB\fBflowadm show-usage\fR [\fB-a\fR] [\fB-d\fR | {\fB-p\fR \fIplotfile\fR
-\fB-F\fR \fIformat\fR}] [\fB-s\fR \fItime\fR] [\fB-e\fR \fItime\fR]
-[\fIflow\fR]\fR
-.ad
-.sp .6
-.RS 4n
-Show the historical network flow usage from a stored extended accounting file.
-Configuration and enabling of network accounting through \fBacctadm\fR(1M) is
-required. The default output will be the summary of flow usage for the entire
-period of time in which extended accounting was enabled.
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display all historical network usage for the specified period of time during
-which extended accounting is enabled. This includes the usage information for
-the flows that have already been deleted.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-d\fR\fR
-.ad
-.sp .6
-.RS 4n
-Display the dates for which there is logging information. The date is in the
-format \fIDD\fR/\fIMM\fR/\fIYYYY\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-F\fR \fIformat\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies the format of \fIplotfile\fR that is specified by the \fB-p\fR
-option. As of this release, \fBgnuplot\fR is the only supported format.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR \fIplotfile\fR\fR
-.ad
-.sp .6
-.RS 4n
-When specified with \fB-s\fR or \fB-e\fR (or both), outputs flow usage data to
-a file of the format specified by the \fB-F\fR option, which is required.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR \fItime\fR, \fB-e\fR \fItime\fR\fR
-.ad
-.sp .6
-.RS 4n
-Start and stop times for data display. Time is in the format
-\fIYYYY\fR.\fIMM\fR.\fIDD\fR,\fIhh\fR:\fImm\fR:\fIss\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-f\fR \fIfilename\fR\fR
-.ad
-.sp .6
-.RS 4n
-Read extended accounting records of network flow usage from \fIfilename\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIflow\fR\fR
-.ad
-.sp .6
-.RS 4n
-If specified, display the network flow usage only from the named flow.
-Otherwise, display network usage from all flows.
-.RE
-
-.RE
-
 .SS "Flow Attributes"
-.LP
 The flow operand that identify a flow in a \fBflowadm\fR command is a
 comma-separated list of one or more keyword, value pairs from the list below.
 .sp
@@ -656,7 +529,7 @@ address is \fB/32\fR and for IPv6 is \fB/128\fR.
 .sp .6
 .RS 4n
 Identifies a network flow by the remote IP address. The syntax is the same as
-\fBlocal_ip\fR attributes
+the \fBlocal_ip\fR attribute.
 .RE
 
 .sp
@@ -683,6 +556,16 @@ Identifies a service specified by the local port.
 .sp
 .ne 2
 .na
+\fB\fBremote_port\fR\fR
+.ad
+.sp .6
+.RS 4n
+Identifies a service specified by the remote port.
+.RE
+
+.sp
+.ne 2
+.na
 \fB\fBdsfield\fR[\fB:\fR\fIdsfield_mask\fR]\fR
 .ad
 .sp .6
@@ -699,7 +582,7 @@ is used. Both the \fBdsfield\fR value and mask must be in hexadecimal.
 
 .sp
 .LP
-The following five types of combinations of attributes are supported:
+The following six types of combinations of attributes are supported:
 .sp
 .in +2
 .nf
@@ -707,6 +590,7 @@ local_ip[/\fIprefixlen\fR]=\fIaddress\fR
 remote_ip[/\fIprefixlen\fR]=\fIaddress\fR
 transport={tcp|udp|sctp|icmp|icmpv6}
 transport={tcp|udp|sctp},local_port=\fIport\fR
+transport={tcp|udp|sctp},remote_port=\fIport\fR
 dsfield=\fIval\fR[:\fIdsfield_mask\fR]
 .fi
 .in -2
@@ -714,13 +598,11 @@ dsfield=\fIval\fR[:\fIdsfield_mask\fR]
 
 .sp
 .LP
-On a given link, the combinations above are mutually exclusive. An attempt to
-create flows of different combinations will fail.
+On a given link, the types of combinations above are mutually exclusive. An
+attempt to create flows of different types on a given link will fail.
 .SS "Restrictions"
-.LP
 There are individual flow restrictions and flow restrictions per zone.
 .SS "Individual Flow Restrictions"
-.LP
 Restrictions on individual flows do not require knowledge of other flows that
 have been added to the link.
 .sp
@@ -766,12 +648,10 @@ flow16\fR
 .sp
 
 .SS "Flow Restrictions Per Zone"
-.LP
 Within a zone, no two flows can have the same name. After adding a flow with
 the link specified, the link will not be required for display, modification, or
 deletion of the flow.
 .SS "Flow Properties"
-.LP
 The following flow properties are supported. Note that the ability to set a
 given property to a given value depends on the driver and hardware.
 .sp
@@ -799,7 +679,6 @@ tokens \fBhigh\fR, \fBmedium\fR, or \fBlow\fR. The default is \fBmedium\fR.
 .RE
 
 .SH EXAMPLES
-.LP
 \fBExample 1 \fRCreating a Policy Around a Mission-Critical Port
 .sp
 .LP
@@ -813,8 +692,8 @@ delete the policy.
 .nf
 # \fBflowadm add-flow -l bge0 -a transport=TCP,local_port=443 https-1\fR
 # \fBflowadm show-flow -l bge0\fR
-FLOW         LINK         IP ADDR                PROTO  PORT    DSFLD
-https1       bge0         --                     tcp    443     --
+FLOW         LINK       IPADDR                   PROTO  LPORT   RPORT   DSFLD
+https1       bge0       --                       tcp    443     --      --
 .fi
 .in -2
 .sp
@@ -832,13 +711,13 @@ priority.
 .nf
 # \fBflowadm set-flowprop -p maxbw=500M,priority=high https-1\fR
 # \fBflowadm show-flow https-1\fR
-FLOW         LINK         IP ADDR                PROTO  PORT    DSFLD
-https1       bge0         --                     tcp    443     --
+FLOW        LINK        IPADDR                   PROTO  LPORT   RPORT   DSFLD
+https-1     bge0        --                       tcp    443     --      --
 
 # \fBflowadm show-flowprop https-1\fR
-FLOW        PROPERTY    VALUE     DEFAULT      POSSIBLE
-https-1     maxbw       500       --           --
-https-1     priority    HIGH      --          LOW,NORMAL,HIGH
+FLOW         PROPERTY        VALUE          DEFAULT        POSSIBLE
+https-1      maxbw             500          --             --
+https-1      priority        high           --             low,medium,high
 .fi
 .in -2
 .sp
@@ -861,33 +740,7 @@ priority=low limit-udp-1\fR
 .sp
 
 .LP
-\fBExample 4 \fRShowing Flow Usage
-.sp
-.LP
-Flow usage statistics can be stored using the extended accounting facility,
-\fBacctadm\fR(1M).
-
-.sp
-.in +2
-.nf
-# \fBacctadm -e extended -f /var/log/net.log net\fR
-
-# \fBacctadm net\fR
-Network accounting: active
-Network accounting file: /var/log/net.log
-Tracked Network resources: extended
-Untracked Network resources: none
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-The historical data that was saved can be retrieved in summary form using the
-\fBshow-usage\fR subcommand of \fBflowadm\fR.
-
-.LP
-\fBExample 5 \fRSetting Policy, Making Use of \fBdsfield\fR Attribute
+\fBExample 4 \fRSetting Policy, Making Use of \fBdsfield\fR Attribute
 .sp
 .LP
 The following command sets a policy for EF PHB (DSCP value of 101110 from RFC
@@ -900,71 +753,6 @@ for this flow will be \fB0x2e\fR (101110) with the \fBdsfield_mask\fR being
 .nf
 # \fBflowadm add-flow -l bge0 -a dsfield=0x2e:0xfc \e
 -p maxbw=500M,priority=high efphb-flow\fR
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-Display summary information:
-
-.sp
-.in +2
-.nf
-# \fBflowadm show-usage -f /var/log/net.log\fR
-FLOW      DURATION  IPACKETS RBYTES      OPACKETS OBYTES     BANDWIDTH
-flowtcp   100       1031     546908      0        0          43.76 Kbps
-flowudp   0         0        0           0        0           0.00 Mbps
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-Display dates for which logging information is available:
-
-.sp
-.in +2
-.nf
-# \fBflowadm show-usage -d -f /var/log/net.log\fR
-02/19/2008
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-Display logging information for \fBflowtcp\fR starting at 02/19/2008, 10:38:46
-and ending at 02/19/2008, 10:40:06:
-
-.sp
-.in +2
-.nf
-# \fBflowadm show-usage -s 02/19/2008,10:39:06 -e 02/19/2008,10:40:06 \e
--f /var/log/net.log flowtcp\fR
-FLOW      TIME       IPACKETS RBYTES      OPACKETS OBYTES     BANDWIDTH
-flowtcp   10:39:06   1        1546         4       6539       3.23 Kbps
-flowtcp   10:39:26   2        3586         5       9922       5.40 Kbps
-flowtcp   10:39:46   1        240          1       216       182.40 bps
-flowtcp   10:40:06   0        0            0       0           0.00 bps
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-Output the same information as above as a plotfile:
-
-.sp
-.in +2
-.nf
-# \fBflowadm show-usage -s 02/19/2008,10:39:06 -e 02/19/2008,10:40:06 \e
--p /home/plot/myplot -F gnuplot -f /var/log/net.log flowtcp\fR
-# \fBTime tcp-flow\fR
-10:39:06 3.23
-10:39:26 5.40
-10:39:46 0.18
-10:40:06 0.00
 .fi
 .in -2
 .sp
@@ -990,7 +778,6 @@ An error occurred.
 .RE
 
 .SH ATTRIBUTES
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -1005,6 +792,10 @@ Interface Stability	Committed
 .TE
 
 .SH SEE ALSO
-.LP
-\fBacctadm\fR(1M), \fBdladm\fR(1M), \fBifconfig\fR(1M), \fBprstat\fR(1M),
-\fBroute\fR(1M), \fBattributes\fR(5), \fBdlpi\fR(7P)
+\fBdladm\fR(1M), \fBflowstat\fR(1M), \fBifconfig\fR(1M),
+\fBroute\fR(1M), \fBattributes\fR(5)
+
+.SH NOTES
+The display of statistics by the \fBshow-flow\fR subcommand, and the
+\fBshow-usage\fR subcommand, have been removed. This functionality can
+now be accessed using the \fBflowstat\fR(1M) utility.

--- a/usr/src/man/man7d/pts.7d
+++ b/usr/src/man/man7d/pts.7d
@@ -1,14 +1,13 @@
 '\" te
+.\" Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 .\"  Copyright 1992 Sun Microsystems
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH PTS 7D "Aug 21, 1992"
+.TH PTS 7D "Feb 29, 2020"
 .SH NAME
 pts \- STREAMS pseudo-tty slave driver
 .SH DESCRIPTION
-.sp
-.LP
 The pseudo-tty subsystem simulates a terminal connection, where the master side
 represents the terminal and the slave represents the user process's special
 device end point. In order to use the pseudo-tty subsystem, a node for the
@@ -26,9 +25,10 @@ Only one open is allowed on a master device. Multiple opens are allowed on the
 slave device. After both the master and slave have been opened, the user has
 two file descriptors which are end points of a full duplex connection composed
 of two streams automatically connected at the master and slave drivers. The
-user may then push modules onto either side of the stream pair. The user needs
-to push the \fBptem\fR(7M) and \fBldterm\fR(7M) modules onto the slave side of
-the pseudo-terminal subsystem to get terminal semantics.
+user may then push modules onto either side of the stream pair. Unless compiled
+in XPG4v2 mode (see below), the consumer needs to push the \fBptem\fR(7M) and
+\fBldterm\fR(7M) modules onto the slave side of the pseudo-terminal subsystem
+to get terminal semantics.
 .sp
 .LP
 The master and slave drivers pass all messages to their adjacent queues. Only
@@ -48,14 +48,23 @@ device is not closed, the pseudo-tty subsystem will be available to another
 user to open the slave device. Since 0-length messages are used to indicate
 that the process on the slave side has closed and should be interpreted that
 way by the process on the master side, applications on the slave side should
-not write 0-length messages. If that occurs, the write returns 0, and the
-0-length message is discarded by the  \fBptem\fR module.
+not write 0-length messages. Unless the application is compiled in XPG4v2 mode
+(see below) then any 0-length messages written on the slave side will be
+discarded by the \fBptem\fR module.
 .sp
 .LP
 The standard STREAMS system calls can access the pseudo-tty devices. The slave
 devices support the \fBO_NDELAY\fR and \fBO_NONBLOCK\fR flags.
-.SH EXAMPLES
+.SH XPG4v2 MODE
+XPG4v2 requires that open of a slave pseudo terminal device provides the
+process with an interface that is identical to the terminal interface (without
+having to explicitly push any modules to achieve this). It also requires that
+0-length messages written on the slave side will be propagated to the master.
 .sp
+Experience has shown, however, that most software does not expect slave pty
+devices to operate in this manner and therefore this XPG4v2-compliant
+behaviour is only enabled in XPG4v2/SUS (see \fBstandards\fR(5)) mode.
+.SH EXAMPLES
 .in +2
 .nf
 int    fdm fds;
@@ -73,7 +82,6 @@ ioctl(fds, I_PUSH, "ldterm");     /* push ldterm*/
 .in -2
 
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/dev/ptmx\fR\fR
@@ -92,10 +100,8 @@ slave devices (M = 0 -> N-1)
 .RE
 
 .SH SEE ALSO
-.sp
-.LP
 \fBgrantpt\fR(3C), \fBptsname\fR(3C), \fBunlockpt\fR(3C), \fBldterm\fR(7M),
-\fBptm\fR(7D), \fBptem\fR(7M)
+\fBptm\fR(7D), \fBptem\fR(7M), \fBstandards\fR(5)
 .sp
 .LP
 \fISTREAMS Programming Guide\fR

--- a/usr/src/uts/common/inet/ip/ip6_input.c
+++ b/usr/src/uts/common/inet/ip/ip6_input.c
@@ -144,11 +144,9 @@ static void	ip_input_multicast_v6(ire_t *, mblk_t *, ip6_t *,
  * The ill will always be valid if this function is called directly from
  * the driver.
  *
- * If ip_input_v6() is called from GLDv3:
- *
- *   - This must be a non-VLAN IP stream.
- *   - 'mp' is either an untagged or a special priority-tagged packet.
- *   - Any VLAN tag that was in the MAC header has been stripped.
+ * If this chain is part of a VLAN stream, then the VLAN tag is
+ * stripped from the MAC header before being delivered to this
+ * function.
  *
  * If the IP header in packet is not 32-bit aligned, every message in the
  * chain will be aligned before further operations. This is required on SPARC

--- a/usr/src/uts/common/inet/ip/ip_input.c
+++ b/usr/src/uts/common/inet/ip/ip_input.c
@@ -148,11 +148,9 @@ static void	ip_input_multicast_v4(ire_t *, mblk_t *, ipha_t *,
  * The ill will always be valid if this function is called directly from
  * the driver.
  *
- * If ip_input() is called from GLDv3:
- *
- *   - This must be a non-VLAN IP stream.
- *   - 'mp' is either an untagged or a special priority-tagged packet.
- *   - Any VLAN tag that was in the MAC header has been stripped.
+ * If this chain is part of a VLAN stream, then the VLAN tag is
+ * stripped from the MAC header before being delivered to this
+ * function.
  *
  * If the IP header in packet is not 32-bit aligned, every message in the
  * chain will be aligned before further operations. This is required on SPARC

--- a/usr/src/uts/common/io/aggr/aggr_port.c
+++ b/usr/src/uts/common/io/aggr/aggr_port.c
@@ -22,6 +22,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 OmniTI Computer Consulting, Inc  All rights reserved.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -70,10 +71,10 @@ aggr_port_destructor(void *buf, void *arg)
 {
 	aggr_port_t *port = buf;
 
-	ASSERT(port->lp_mnh == NULL);
-	ASSERT(port->lp_mphp == NULL);
-	ASSERT(!port->lp_rx_grp_added && !port->lp_tx_grp_added);
-	ASSERT(port->lp_hwgh == NULL);
+	ASSERT3P(port->lp_mnh, ==, NULL);
+	ASSERT(!port->lp_tx_grp_added);
+	for (uint_t i = 0; i < MAX_GROUPS_PER_PORT; i++)
+		ASSERT3P(port->lp_hwghs[i], ==, NULL);
 }
 
 void
@@ -127,7 +128,6 @@ aggr_port_init_callbacks(aggr_port_t *port)
 	aggr_grp_port_hold(port);
 }
 
-/* ARGSUSED */
 int
 aggr_port_create(aggr_grp_t *grp, const datalink_id_t linkid, boolean_t force,
     aggr_port_t **pp)
@@ -196,9 +196,9 @@ aggr_port_create(aggr_grp_t *grp, const datalink_id_t linkid, boolean_t force,
 	}
 
 	/*
-	 * As the underlying mac's current margin size is used to determine
+	 * As the underlying MAC's current margin size is used to determine
 	 * the margin size of the aggregation itself, request the underlying
-	 * mac not to change to a smaller size.
+	 * MAC not to change to a smaller size.
 	 */
 	if ((err = mac_margin_add(mh, &margin, B_TRUE)) != 0) {
 		id_free(aggr_portids, portid);
@@ -207,7 +207,7 @@ aggr_port_create(aggr_grp_t *grp, const datalink_id_t linkid, boolean_t force,
 
 	if ((err = mac_unicast_add(mch, NULL, MAC_UNICAST_PRIMARY |
 	    MAC_UNICAST_DISABLE_TX_VID_CHECK, &mah, 0, &diag)) != 0) {
-		VERIFY(mac_margin_remove(mh, margin) == 0);
+		VERIFY3S(mac_margin_remove(mh, margin), ==, 0);
 		id_free(aggr_portids, portid);
 		goto fail;
 	}
@@ -262,6 +262,7 @@ aggr_port_create(aggr_grp_t *grp, const datalink_id_t linkid, boolean_t force,
 fail:
 	if (mch != NULL)
 		mac_client_close(mch, MAC_CLOSE_FLAGS_EXCLUSIVE);
+
 	mac_close(mh);
 	return (err);
 }
@@ -271,13 +272,11 @@ aggr_port_delete(aggr_port_t *port)
 {
 	aggr_lacp_port_t *pl = &port->lp_lacp;
 
-	ASSERT(port->lp_mphp == NULL);
 	ASSERT(!port->lp_promisc_on);
-
 	port->lp_closing = B_TRUE;
+	VERIFY0(mac_margin_remove(port->lp_mh, port->lp_margin));
+	mac_client_clear_flow_cb(port->lp_mch);
 
-	VERIFY(mac_margin_remove(port->lp_mh, port->lp_margin) == 0);
-	mac_rx_clear(port->lp_mch);
 	/*
 	 * If the notification callback is already in process and waiting for
 	 * the aggr grp's mac perimeter, don't wait (otherwise there would be
@@ -308,8 +307,10 @@ aggr_port_delete(aggr_port_t *port)
 	 * port's MAC_NOTE_UNICST notify callback function being called.
 	 */
 	(void) mac_unicast_primary_set(port->lp_mh, port->lp_addr);
+
 	if (port->lp_mah != NULL)
 		(void) mac_unicast_remove(port->lp_mch, port->lp_mah);
+
 	mac_client_close(port->lp_mch, MAC_CLOSE_FLAGS_EXCLUSIVE);
 	mac_close(port->lp_mh);
 	AGGR_PORT_REFRELE(port);
@@ -374,10 +375,14 @@ aggr_port_notify_link(aggr_grp_t *grp, aggr_port_t *port)
 	/* link speed changes? */
 	ifspeed = aggr_port_stat(port, MAC_STAT_IFSPEED);
 	if (port->lp_ifspeed != ifspeed) {
+		mutex_enter(&grp->lg_stat_lock);
+
 		if (port->lp_state == AGGR_PORT_STATE_ATTACHED)
 			do_detach |= (ifspeed != grp->lg_ifspeed);
 		else
 			do_attach |= (ifspeed == grp->lg_ifspeed);
+
+		mutex_exit(&grp->lg_stat_lock);
 	}
 	port->lp_ifspeed = ifspeed;
 
@@ -516,6 +521,10 @@ aggr_port_stop(aggr_port_t *port)
 	port->lp_started = B_FALSE;
 }
 
+/*
+ * Set the promisc mode of the port. If the port is already in the
+ * requested mode then do nothing.
+ */
 int
 aggr_port_promisc(aggr_port_t *port, boolean_t on)
 {
@@ -524,32 +533,14 @@ aggr_port_promisc(aggr_port_t *port, boolean_t on)
 	ASSERT(MAC_PERIM_HELD(port->lp_mh));
 
 	if (on == port->lp_promisc_on)
-		/* already in desired promiscous mode */
 		return (0);
 
-	if (on) {
-		mac_rx_clear(port->lp_mch);
-		/* We use the promisc callback because without hardware
-		 * rings, we deliver through flows that will cause duplicate
-		 * delivery of packets when we've flipped into this mode
-		 * to compensate for the lack of hardware MAC matching
-		 */
-		rc = mac_promisc_add(port->lp_mch, MAC_CLIENT_PROMISC_ALL,
-		    aggr_recv_promisc_cb, port, &port->lp_mphp,
-		    MAC_PROMISC_FLAGS_NO_TX_LOOP);
-		if (rc != 0) {
-			mac_rx_set(port->lp_mch, aggr_recv_cb, port);
-			return (rc);
-		}
-	} else {
-		mac_promisc_remove(port->lp_mphp);
-		port->lp_mphp = NULL;
-		mac_rx_set(port->lp_mch, aggr_recv_cb, port);
-	}
+	rc = mac_set_promisc(port->lp_mh, on);
 
-	port->lp_promisc_on = on;
+	if (rc == 0)
+		port->lp_promisc_on = on;
 
-	return (0);
+	return (rc);
 }
 
 /*
@@ -589,35 +580,45 @@ aggr_port_stat(aggr_port_t *port, uint_t stat)
 }
 
 /*
- * Add a non-primary unicast address to the underlying port. If the port
- * supports HW Rx group, try to add the address into the HW Rx group of
- * the port first. If that fails, or if the port does not support HW Rx
- * group, enable the port's promiscous mode.
+ * Add a non-primary unicast address to the underlying port. If the
+ * port supports HW Rx groups, then try to add the address filter to
+ * the HW group first. If that fails, or if the port does not support
+ * RINGS capab, then enable the port's promiscous mode.
  */
 int
-aggr_port_addmac(aggr_port_t *port, const uint8_t *mac_addr)
+aggr_port_addmac(aggr_port_t *port, uint_t idx, const uint8_t *mac_addr)
 {
 	aggr_unicst_addr_t	*addr, **pprev;
 	mac_perim_handle_t	pmph;
 	int			err;
 
 	ASSERT(MAC_PERIM_HELD(port->lp_grp->lg_mh));
+	ASSERT3U(idx, <, MAX_GROUPS_PER_PORT);
 	mac_perim_enter_by_mh(port->lp_mh, &pmph);
 
 	/*
-	 * If the underlying port support HW Rx group, add the mac to its
-	 * RX group directly.
+	 * If the port doesn't have a HW group to back the aggr's
+	 * pseudo group, then try using the port's default group and
+	 * let the aggr SW classify its traffic. This scenario happens
+	 * when mixing ports with a different number of HW groups.
 	 */
-	if ((port->lp_hwgh != NULL) &&
-	    ((mac_hwgroup_addmac(port->lp_hwgh, mac_addr)) == 0)) {
+	if (port->lp_hwghs[idx] == NULL)
+		idx = 0;
+
+	/*
+	 * If there is an underlying HW Rx group, then try adding this
+	 * unicast address to it.
+	 */
+	if ((port->lp_hwghs[idx] != NULL) &&
+	    ((mac_hwgroup_addmac(port->lp_hwghs[idx], mac_addr)) == 0)) {
 		mac_perim_exit(pmph);
 		return (0);
 	}
 
 	/*
-	 * If that fails, or if the port does not support HW Rx group, enable
-	 * the port's promiscous mode. (Note that we turn on the promiscous
-	 * mode only if the port is already started.
+	 * If the port doesn't have HW groups, or we failed to add the
+	 * HW filter, then enable the port's promiscuous mode. We
+	 * enable promiscuous mode only if the port is already started.
 	 */
 	if (port->lp_started &&
 	    ((err = aggr_port_promisc(port, B_TRUE)) != 0)) {
@@ -649,13 +650,14 @@ aggr_port_addmac(aggr_port_t *port, const uint8_t *mac_addr)
  * promiscous mode.
  */
 void
-aggr_port_remmac(aggr_port_t *port, const uint8_t *mac_addr)
+aggr_port_remmac(aggr_port_t *port, uint_t idx, const uint8_t *mac_addr)
 {
 	aggr_grp_t		*grp = port->lp_grp;
 	aggr_unicst_addr_t	*addr, **pprev;
 	mac_perim_handle_t	pmph;
 
 	ASSERT(MAC_PERIM_HELD(grp->lg_mh));
+	ASSERT3U(idx, <, MAX_GROUPS_PER_PORT);
 	mac_perim_enter_by_mh(port->lp_mh, &pmph);
 
 	/*
@@ -668,6 +670,7 @@ aggr_port_remmac(aggr_port_t *port, const uint8_t *mac_addr)
 			break;
 		pprev = &addr->aua_next;
 	}
+
 	if (addr != NULL) {
 		/*
 		 * This unicast address put the port into the promiscous mode,
@@ -680,8 +683,65 @@ aggr_port_remmac(aggr_port_t *port, const uint8_t *mac_addr)
 		if (port->lp_prom_addr == NULL && !grp->lg_promisc)
 			(void) aggr_port_promisc(port, B_FALSE);
 	} else {
-		ASSERT(port->lp_hwgh != NULL);
-		(void) mac_hwgroup_remmac(port->lp_hwgh, mac_addr);
+		/* See comment in aggr_port_addmac(). */
+		if (port->lp_hwghs[idx] == NULL)
+			idx = 0;
+
+		ASSERT3P(port->lp_hwghs[idx], !=, NULL);
+		(void) mac_hwgroup_remmac(port->lp_hwghs[idx], mac_addr);
 	}
+
 	mac_perim_exit(pmph);
+}
+
+int
+aggr_port_addvlan(aggr_port_t *port, uint_t idx, uint16_t vid)
+{
+	mac_perim_handle_t	pmph;
+	int			err;
+
+	ASSERT(MAC_PERIM_HELD(port->lp_grp->lg_mh));
+	ASSERT3U(idx, <, MAX_GROUPS_PER_PORT);
+	mac_perim_enter_by_mh(port->lp_mh, &pmph);
+
+	/* See comment in aggr_port_addmac(). */
+	if (port->lp_hwghs[idx] == NULL)
+		idx = 0;
+
+	/*
+	 * Add the VLAN filter to the HW group if the port has a HW
+	 * group. If the port doesn't have a HW group, then it will
+	 * implicitly allow tagged traffic to pass and there is
+	 * nothing to do.
+	 */
+	if (port->lp_hwghs[idx] == NULL)
+		err = 0;
+	else
+		err = mac_hwgroup_addvlan(port->lp_hwghs[idx], vid);
+
+	mac_perim_exit(pmph);
+	return (err);
+}
+
+int
+aggr_port_remvlan(aggr_port_t *port, uint_t idx, uint16_t vid)
+{
+	mac_perim_handle_t	pmph;
+	int			err;
+
+	ASSERT(MAC_PERIM_HELD(port->lp_grp->lg_mh));
+	ASSERT3U(idx, <, MAX_GROUPS_PER_PORT);
+	mac_perim_enter_by_mh(port->lp_mh, &pmph);
+
+	/* See comment in aggr_port_addmac(). */
+	if (port->lp_hwghs[idx] == NULL)
+		idx = 0;
+
+	if (port->lp_hwghs[idx] == NULL)
+		err = 0;
+	else
+		err = mac_hwgroup_remvlan(port->lp_hwghs[idx], vid);
+
+	mac_perim_exit(pmph);
+	return (err);
 }

--- a/usr/src/uts/common/io/aggr/aggr_recv.c
+++ b/usr/src/uts/common/io/aggr/aggr_recv.c
@@ -80,17 +80,6 @@ aggr_recv_path_cb(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 	aggr_port_t *port = (aggr_port_t *)arg;
 	aggr_grp_t *grp = port->lp_grp;
 
-	/* In the case where lp_promisc_on has been turned on to
-	 * compensate for insufficient hardware MAC matching and
-	 * hardware rings are not in use we will fall back to
-	 * using flows for delivery which can result in duplicates
-	 * pushed up the stack. Only respect the chosen path.
-	 */
-	if (port->lp_promisc_on != promisc_path) {
-		freemsgchain(mp);
-		return;
-	}
-
 	if (grp->lg_lacp_mode == AGGR_LACP_OFF) {
 		aggr_mac_rx(grp->lg_mh, mrh, mp);
 	} else {

--- a/usr/src/uts/common/io/aggr/aggr_recv.c
+++ b/usr/src/uts/common/io/aggr/aggr_recv.c
@@ -22,6 +22,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 OmniTI Computer Consulting, Inc  All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -56,7 +57,7 @@ aggr_recv_lacp(aggr_port_t *port, mac_resource_handle_t mrh, mblk_t *mp)
 {
 	aggr_grp_t *grp = port->lp_grp;
 
-	/* in promiscuous mode, send copy of packet up */
+	/* In promiscuous mode, pass copy of packet up. */
 	if (grp->lg_promisc) {
 		mblk_t *nmp = copymsg(mp);
 
@@ -74,7 +75,7 @@ aggr_recv_lacp(aggr_port_t *port, mac_resource_handle_t mrh, mblk_t *mp)
 /* ARGSUSED */
 static void
 aggr_recv_path_cb(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
-    boolean_t loopback, boolean_t promisc_path)
+    boolean_t loopback)
 {
 	aggr_port_t *port = (aggr_port_t *)arg;
 	aggr_grp_t *grp = port->lp_grp;
@@ -174,18 +175,9 @@ aggr_recv_path_cb(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 	}
 }
 
-/* ARGSUSED */
 void
 aggr_recv_cb(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
     boolean_t loopback)
 {
-	aggr_recv_path_cb(arg, mrh, mp, loopback, B_FALSE);
-}
-
-/* ARGSUSED */
-void
-aggr_recv_promisc_cb(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
-    boolean_t loopback)
-{
-	aggr_recv_path_cb(arg, mrh, mp, loopback, B_TRUE);
+	aggr_recv_path_cb(arg, mrh, mp, loopback);
 }

--- a/usr/src/uts/common/io/dld/dld_proto.c
+++ b/usr/src/uts/common/io/dld/dld_proto.c
@@ -1398,24 +1398,22 @@ dld_capab_direct(dld_str_t *dsp, void *data, uint_t flags)
 }
 
 /*
- * dld_capab_poll_enable()
+ * This function is misnamed. All polling and fanouts are run out of
+ * the lower MAC for VNICs and out of the MAC for NICs. The
+ * availability of Rx rings and promiscous mode is taken care of
+ * between the soft ring set (mac_srs), the Rx ring, and the SW
+ * classifier. Fanout, if necessary, is done by the soft rings that
+ * are part of the SRS. By default the SRS divvies up the packets
+ * based on protocol: TCP, UDP, or Other (OTH).
  *
- * This function is misnamed. All polling  and fanouts are run out of the
- * lower mac (in case of VNIC and the only mac in case of NICs). The
- * availability of Rx ring and promiscous mode is all taken care between
- * the soft ring set (mac_srs), the Rx ring, and S/W classifier. Any
- * fanout necessary is done by the soft rings that are part of the
- * mac_srs (by default mac_srs sends the packets up via a TCP and
- * non TCP soft ring).
- *
- * The mac_srs (or its associated soft rings) always store the ill_rx_ring
+ * The SRS (or its associated soft rings) always store the ill_rx_ring
  * (the cookie returned when they registered with IP during plumb) as their
  * 2nd argument which is passed up as mac_resource_handle_t. The upcall
  * function and 1st argument is what the caller registered when they
  * called mac_rx_classify_flow_add() to register the flow. For VNIC,
  * the function is vnic_rx and argument is vnic_t. For regular NIC
  * case, it mac_rx_default and mac_handle_t. As explained above, the
- * mac_srs (or its soft ring) will add the ill_rx_ring (mac_resource_handle_t)
+ * SRS (or its soft ring) will add the ill_rx_ring (mac_resource_handle_t)
  * from its stored 2nd argument.
  */
 static int
@@ -1428,11 +1426,11 @@ dld_capab_poll_enable(dld_str_t *dsp, dld_capab_poll_t *poll)
 		return (ENOTSUP);
 
 	/*
-	 * Enable client polling if and only if DLS bypass is possible.
-	 * Special cases like VLANs need DLS processing in the Rx data path.
-	 * In such a case we can neither allow the client (IP) to directly
-	 * poll the softring (since DLS processing hasn't been done) nor can
-	 * we allow DLS bypass.
+	 * Enable client polling if and only if DLS bypass is
+	 * possible. Some traffic requires DLS processing in the Rx
+	 * data path. In such a case we can neither allow the client
+	 * (IP) to directly poll the soft ring (since DLS processing
+	 * hasn't been done) nor can we allow DLS bypass.
 	 */
 	if (!mac_rx_bypass_set(dsp->ds_mch, dsp->ds_rx, dsp->ds_rx_arg))
 		return (ENOTSUP);

--- a/usr/src/uts/common/io/dls/dls.c
+++ b/usr/src/uts/common/io/dls/dls.c
@@ -171,16 +171,16 @@ dls_bind(dld_str_t *dsp, uint32_t sap)
 	/*
 	 * The MAC layer does the VLAN demultiplexing and will only pass up
 	 * untagged packets to non-promiscuous primary MAC clients. In order to
-	 * support the binding to the VLAN SAP which is required by DLPI, dls
+	 * support binding to the VLAN SAP, which is required by DLPI, DLS
 	 * needs to get a copy of all tagged packets when the client binds to
 	 * the VLAN SAP. We do this by registering a separate promiscuous
-	 * callback for each dls client binding to that SAP.
+	 * callback for each DLS client binding to that SAP.
 	 *
 	 * Note: even though there are two promiscuous handles in dld_str_t,
 	 * ds_mph is for the regular promiscuous mode, ds_vlan_mph is the handle
-	 * to receive VLAN pkt when promiscuous mode is not on. Only one of
-	 * them can be non-NULL at the same time, to avoid receiving dup copies
-	 * of pkts.
+	 * to receive VLAN traffic when promiscuous mode is not on. Only one of
+	 * them can be non-NULL at the same time, to avoid receiving duplicate
+	 * copies of packets.
 	 */
 	if (sap == ETHERTYPE_VLAN && dsp->ds_promisc == 0) {
 		int err;
@@ -680,8 +680,8 @@ dls_mac_active_set(dls_link_t *dlp)
 		/* request the primary MAC address */
 		if ((err = mac_unicast_add(dlp->dl_mch, NULL,
 		    MAC_UNICAST_PRIMARY | MAC_UNICAST_TAG_DISABLE |
-		    MAC_UNICAST_DISABLE_TX_VID_CHECK, &dlp->dl_mah, 0,
-		    &diag)) != 0) {
+		    MAC_UNICAST_DISABLE_TX_VID_CHECK, &dlp->dl_mah,
+		    VLAN_ID_NONE, &diag)) != 0) {
 			return (err);
 		}
 

--- a/usr/src/uts/common/io/dls/dls_link.c
+++ b/usr/src/uts/common/io/dls/dls_link.c
@@ -382,7 +382,16 @@ i_dls_link_rx(void *arg, mac_resource_handle_t mrh, mblk_t *mp,
 
 		vid = VLAN_ID(mhi.mhi_tci);
 
+		/*
+		 * This condition is true only when a sun4v vsw client
+		 * is on the scene; as it is the only type of client
+		 * that multiplexes VLANs on a single client instance.
+		 * All other types of clients have one VLAN per client
+		 * instance. In that case, MAC strips the VLAN tag
+		 * before delivering it to DLS (see mac_rx_deliver()).
+		 */
 		if (mhi.mhi_istagged) {
+
 			/*
 			 * If it is tagged traffic, send it upstream to
 			 * all dld_str_t which are attached to the physical

--- a/usr/src/uts/common/io/ixgbe/ixgbe_main.c
+++ b/usr/src/uts/common/io/ixgbe/ixgbe_main.c
@@ -25,7 +25,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2012 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013 OSN Online Service Nuernberg GmbH. All rights reserved.
@@ -57,8 +57,8 @@ static int ixgbe_alloc_rings(ixgbe_t *);
 static void ixgbe_free_rings(ixgbe_t *);
 static int ixgbe_alloc_rx_data(ixgbe_t *);
 static void ixgbe_free_rx_data(ixgbe_t *);
-static void ixgbe_setup_rings(ixgbe_t *);
-static void ixgbe_setup_rx(ixgbe_t *);
+static int ixgbe_setup_rings(ixgbe_t *);
+static int ixgbe_setup_rx(ixgbe_t *);
 static void ixgbe_setup_tx(ixgbe_t *);
 static void ixgbe_setup_rx_ring(ixgbe_rx_ring_t *);
 static void ixgbe_setup_tx_ring(ixgbe_tx_ring_t *);
@@ -67,6 +67,7 @@ static void ixgbe_setup_vmdq(ixgbe_t *);
 static void ixgbe_setup_vmdq_rss(ixgbe_t *);
 static void ixgbe_setup_rss_table(ixgbe_t *);
 static void ixgbe_init_unicst(ixgbe_t *);
+static int ixgbe_init_vlan(ixgbe_t *);
 static int ixgbe_unicst_find(ixgbe_t *, const uint8_t *);
 static void ixgbe_setup_multicst(ixgbe_t *);
 static void ixgbe_get_hw_state(ixgbe_t *);
@@ -113,6 +114,8 @@ static void ixgbe_intr_other_work(ixgbe_t *, uint32_t);
 static void ixgbe_get_driver_control(struct ixgbe_hw *);
 static int ixgbe_addmac(void *, const uint8_t *);
 static int ixgbe_remmac(void *, const uint8_t *);
+static int ixgbe_addvlan(mac_group_driver_t, uint16_t);
+static int ixgbe_remvlan(mac_group_driver_t, uint16_t);
 static void ixgbe_release_driver_control(struct ixgbe_hw *);
 
 static int ixgbe_attach(dev_info_t *, ddi_attach_cmd_t);
@@ -1159,6 +1162,8 @@ ixgbe_init_driver_settings(ixgbe_t *ixgbe)
 		rx_group = &ixgbe->rx_groups[i];
 		rx_group->index = i;
 		rx_group->ixgbe = ixgbe;
+		list_create(&rx_group->vlans, sizeof (ixgbe_vlan_t),
+		    offsetof(ixgbe_vlan_t, ixvl_link));
 	}
 
 	for (i = 0; i < ixgbe->num_tx_rings; i++) {
@@ -1909,7 +1914,8 @@ ixgbe_start(ixgbe_t *ixgbe, boolean_t alloc_buffer)
 	/*
 	 * Setup the rx/tx rings
 	 */
-	ixgbe_setup_rings(ixgbe);
+	if (ixgbe_setup_rings(ixgbe) != IXGBE_SUCCESS)
+		goto start_failure;
 
 	/*
 	 * ixgbe_start() will be called when resetting, however if reset
@@ -2282,6 +2288,16 @@ ixgbe_free_rings(ixgbe_t *ixgbe)
 		ixgbe->tx_rings = NULL;
 	}
 
+	for (uint_t i = 0; i < ixgbe->num_rx_groups; i++) {
+		ixgbe_vlan_t *vlp;
+		ixgbe_rx_group_t *rx_group = &ixgbe->rx_groups[i];
+
+		while ((vlp = list_remove_head(&rx_group->vlans)) != NULL)
+			kmem_free(vlp, sizeof (ixgbe_vlan_t));
+
+		list_destroy(&rx_group->vlans);
+	}
+
 	if (ixgbe->rx_groups != NULL) {
 		kmem_free(ixgbe->rx_groups,
 		    sizeof (ixgbe_rx_group_t) * ixgbe->num_rx_groups);
@@ -2336,7 +2352,7 @@ ixgbe_free_rx_data(ixgbe_t *ixgbe)
 /*
  * ixgbe_setup_rings - Setup rx/tx rings.
  */
-static void
+static int
 ixgbe_setup_rings(ixgbe_t *ixgbe)
 {
 	/*
@@ -2346,9 +2362,12 @@ ixgbe_setup_rings(ixgbe_t *ixgbe)
 	 * 2. Initialize necessary registers for receive/transmit;
 	 * 3. Initialize software pointers/parameters for receive/transmit;
 	 */
-	ixgbe_setup_rx(ixgbe);
+	if (ixgbe_setup_rx(ixgbe) != IXGBE_SUCCESS)
+		return (IXGBE_FAILURE);
 
 	ixgbe_setup_tx(ixgbe);
+
+	return (IXGBE_SUCCESS);
 }
 
 static void
@@ -2435,7 +2454,7 @@ ixgbe_setup_rx_ring(ixgbe_rx_ring_t *rx_ring)
 	IXGBE_WRITE_REG(hw, IXGBE_SRRCTL(rx_ring->hw_index), reg_val);
 }
 
-static void
+static int
 ixgbe_setup_rx(ixgbe_t *ixgbe)
 {
 	ixgbe_rx_ring_t *rx_ring;
@@ -2525,6 +2544,15 @@ ixgbe_setup_rx(ixgbe_t *ixgbe)
 
 	default:
 		break;
+	}
+
+	/*
+	 * Initialize VLAN SW and HW state if VLAN filtering is
+	 * enabled.
+	 */
+	if (ixgbe->vlft_enabled) {
+		if (ixgbe_init_vlan(ixgbe) != IXGBE_SUCCESS)
+			return (IXGBE_FAILURE);
 	}
 
 	/*
@@ -2618,6 +2646,8 @@ ixgbe_setup_rx(ixgbe_t *ixgbe)
 
 		IXGBE_WRITE_REG(hw, IXGBE_RDRXCTL, reg_val);
 	}
+
+	return (IXGBE_SUCCESS);
 }
 
 static void
@@ -2819,7 +2849,7 @@ static void
 ixgbe_setup_vmdq(ixgbe_t *ixgbe)
 {
 	struct ixgbe_hw *hw = &ixgbe->hw;
-	uint32_t vmdctl, i, vtctl;
+	uint32_t vmdctl, i, vtctl, vlnctl;
 
 	/*
 	 * Setup the VMDq Control register, enable VMDq based on
@@ -2855,8 +2885,18 @@ ixgbe_setup_vmdq(ixgbe_t *ixgbe)
 		/*
 		 * Enable Virtualization and Replication.
 		 */
-		vtctl = IXGBE_VT_CTL_VT_ENABLE | IXGBE_VT_CTL_REPLEN;
+		vtctl = IXGBE_READ_REG(hw, IXGBE_VT_CTL);
+		ixgbe->rx_def_group = vtctl & IXGBE_VT_CTL_POOL_MASK;
+		vtctl |= IXGBE_VT_CTL_VT_ENABLE | IXGBE_VT_CTL_REPLEN;
 		IXGBE_WRITE_REG(hw, IXGBE_VT_CTL, vtctl);
+
+		/*
+		 * Enable VLAN filtering and switching (VFTA and VLVF).
+		 */
+		vlnctl = IXGBE_READ_REG(hw, IXGBE_VLNCTRL);
+		vlnctl |= IXGBE_VLNCTRL_VFE;
+		IXGBE_WRITE_REG(hw, IXGBE_VLNCTRL, vlnctl);
+		ixgbe->vlft_enabled = B_TRUE;
 
 		/*
 		 * Enable receiving packets to all VFs
@@ -2878,7 +2918,7 @@ ixgbe_setup_vmdq_rss(ixgbe_t *ixgbe)
 {
 	struct ixgbe_hw *hw = &ixgbe->hw;
 	uint32_t i, mrqc;
-	uint32_t vtctl, vmdctl;
+	uint32_t vtctl, vmdctl, vlnctl;
 
 	/*
 	 * Initialize RETA/ERETA table
@@ -2962,8 +3002,19 @@ ixgbe_setup_vmdq_rss(ixgbe_t *ixgbe)
 		/*
 		 * Enable Virtualization and Replication.
 		 */
+		vtctl = IXGBE_READ_REG(hw, IXGBE_VT_CTL);
+		ixgbe->rx_def_group = vtctl & IXGBE_VT_CTL_POOL_MASK;
+		vtctl |= IXGBE_VT_CTL_VT_ENABLE | IXGBE_VT_CTL_REPLEN;
 		vtctl = IXGBE_VT_CTL_VT_ENABLE | IXGBE_VT_CTL_REPLEN;
 		IXGBE_WRITE_REG(hw, IXGBE_VT_CTL, vtctl);
+
+		/*
+		 * Enable VLAN filtering and switching (VFTA and VLVF).
+		 */
+		vlnctl = IXGBE_READ_REG(hw, IXGBE_VLNCTRL);
+		vlnctl |= IXGBE_VLNCTRL_VFE;
+		IXGBE_WRITE_REG(hw, IXGBE_VLNCTRL, vlnctl);
+		ixgbe->vlft_enabled = B_TRUE;
 
 		/*
 		 * Enable receiving packets to all VFs
@@ -3133,6 +3184,53 @@ ixgbe_unicst_find(ixgbe_t *ixgbe, const uint8_t *mac_addr)
 	}
 
 	return (-1);
+}
+
+/*
+ * Restore the HW state to match the SW state during restart.
+ */
+static int
+ixgbe_init_vlan(ixgbe_t *ixgbe)
+{
+	/*
+	 * The device is starting for the first time; there is nothing
+	 * to do.
+	 */
+	if (!ixgbe->vlft_init) {
+		ixgbe->vlft_init = B_TRUE;
+		return (IXGBE_SUCCESS);
+	}
+
+	for (uint_t i = 0; i < ixgbe->num_rx_groups; i++) {
+		int			ret;
+		boolean_t		vlvf_bypass;
+		ixgbe_rx_group_t	*rxg = &ixgbe->rx_groups[i];
+		struct ixgbe_hw		*hw = &ixgbe->hw;
+
+		if (rxg->aupe) {
+			uint32_t vml2flt;
+
+			vml2flt = IXGBE_READ_REG(hw, IXGBE_VMOLR(rxg->index));
+			vml2flt |= IXGBE_VMOLR_AUPE;
+			IXGBE_WRITE_REG(hw, IXGBE_VMOLR(rxg->index), vml2flt);
+		}
+
+		vlvf_bypass = (rxg->index == ixgbe->rx_def_group);
+		for (ixgbe_vlan_t *vlp = list_head(&rxg->vlans); vlp != NULL;
+		    vlp = list_next(&rxg->vlans, vlp)) {
+			ret = ixgbe_set_vfta(hw, vlp->ixvl_vid, rxg->index,
+			    B_TRUE, vlvf_bypass);
+
+			if (ret != IXGBE_SUCCESS) {
+				ixgbe_error(ixgbe, "Failed to program VFTA"
+				    " for group %u, VID: %u, ret: %d.",
+				    rxg->index, vlp->ixvl_vid, ret);
+				return (IXGBE_FAILURE);
+			}
+		}
+	}
+
+	return (IXGBE_SUCCESS);
 }
 
 /*
@@ -6161,6 +6259,7 @@ ixgbe_fill_group(void *arg, mac_ring_type_t rtype, const int index,
     mac_group_info_t *infop, mac_group_handle_t gh)
 {
 	ixgbe_t *ixgbe = (ixgbe_t *)arg;
+	struct ixgbe_hw *hw = &ixgbe->hw;
 
 	switch (rtype) {
 	case MAC_RING_TYPE_RX: {
@@ -6174,6 +6273,20 @@ ixgbe_fill_group(void *arg, mac_ring_type_t rtype, const int index,
 		infop->mgi_stop = NULL;
 		infop->mgi_addmac = ixgbe_addmac;
 		infop->mgi_remmac = ixgbe_remmac;
+
+		if ((ixgbe->classify_mode == IXGBE_CLASSIFY_VMDQ ||
+		    ixgbe->classify_mode == IXGBE_CLASSIFY_VMDQ_RSS) &&
+		    (hw->mac.type == ixgbe_mac_82599EB ||
+		    hw->mac.type == ixgbe_mac_X540 ||
+		    hw->mac.type == ixgbe_mac_X550 ||
+		    hw->mac.type == ixgbe_mac_X550EM_x)) {
+			infop->mgi_addvlan = ixgbe_addvlan;
+			infop->mgi_remvlan = ixgbe_remvlan;
+		} else {
+			infop->mgi_addvlan = NULL;
+			infop->mgi_remvlan = NULL;
+		}
+
 		infop->mgi_count = (ixgbe->num_rx_rings / ixgbe->num_rx_groups);
 
 		break;
@@ -6270,6 +6383,232 @@ ixgbe_rx_ring_intr_disable(mac_intr_handle_t intrh)
 
 	mutex_exit(&ixgbe->gen_lock);
 
+	return (0);
+}
+
+static ixgbe_vlan_t *
+ixgbe_find_vlan(ixgbe_rx_group_t *rx_group, uint16_t vid)
+{
+	for (ixgbe_vlan_t *vlp = list_head(&rx_group->vlans); vlp != NULL;
+	    vlp = list_next(&rx_group->vlans, vlp)) {
+		if (vlp->ixvl_vid == vid)
+			return (vlp);
+	}
+
+	return (NULL);
+}
+
+/*
+ * Attempt to use a VLAN HW filter for this group. If the group is
+ * interested in untagged packets then set AUPE only. If the group is
+ * the default then only set the VFTA. Leave the VLVF slots open for
+ * reserved groups to guarantee their use of HW filtering.
+ */
+static int
+ixgbe_addvlan(mac_group_driver_t gdriver, uint16_t vid)
+{
+	ixgbe_rx_group_t	*rx_group = (ixgbe_rx_group_t *)gdriver;
+	ixgbe_t			*ixgbe = rx_group->ixgbe;
+	struct ixgbe_hw		*hw = &ixgbe->hw;
+	ixgbe_vlan_t		*vlp;
+	int			ret;
+	boolean_t		is_def_grp;
+
+	mutex_enter(&ixgbe->gen_lock);
+
+	if (ixgbe->ixgbe_state & IXGBE_SUSPENDED) {
+		mutex_exit(&ixgbe->gen_lock);
+		return (ECANCELED);
+	}
+
+	/*
+	 * Let's be sure VLAN filtering is enabled.
+	 */
+	VERIFY3B(ixgbe->vlft_enabled, ==, B_TRUE);
+	is_def_grp = (rx_group->index == ixgbe->rx_def_group);
+
+	/*
+	 * VLAN filtering is enabled but we want to receive untagged
+	 * traffic on this group -- set the AUPE bit on the group and
+	 * leave the VLAN tables alone.
+	 */
+	if (vid == MAC_VLAN_UNTAGGED) {
+		/*
+		 * We never enable AUPE on the default group; it is
+		 * redundant. Untagged traffic which passes L2
+		 * filtering is delivered to the default group if no
+		 * other group is interested.
+		 */
+		if (!is_def_grp) {
+			uint32_t vml2flt;
+
+			vml2flt = IXGBE_READ_REG(hw,
+			    IXGBE_VMOLR(rx_group->index));
+			vml2flt |= IXGBE_VMOLR_AUPE;
+			IXGBE_WRITE_REG(hw, IXGBE_VMOLR(rx_group->index),
+			    vml2flt);
+			rx_group->aupe = B_TRUE;
+		}
+
+		mutex_exit(&ixgbe->gen_lock);
+		return (0);
+	}
+
+	vlp = ixgbe_find_vlan(rx_group, vid);
+	if (vlp != NULL) {
+		/* Only the default group supports multiple clients. */
+		VERIFY3B(is_def_grp, ==, B_TRUE);
+		vlp->ixvl_refs++;
+		mutex_exit(&ixgbe->gen_lock);
+		return (0);
+	}
+
+	/*
+	 * The default group doesn't require a VLVF entry, only a VFTA
+	 * entry. All traffic passing L2 filtering (MPSAR + VFTA) is
+	 * delivered to the default group if no other group is
+	 * interested. The fourth argument, vlvf_bypass, tells the
+	 * ixgbe common code to avoid using a VLVF slot if one isn't
+	 * already allocated to this VLAN.
+	 *
+	 * This logic is meant to reserve VLVF slots for use by
+	 * reserved groups: guaranteeing their use of HW filtering.
+	 */
+	ret = ixgbe_set_vfta(hw, vid, rx_group->index, B_TRUE, is_def_grp);
+
+	if (ret == IXGBE_SUCCESS) {
+		vlp = kmem_zalloc(sizeof (ixgbe_vlan_t), KM_SLEEP);
+		vlp->ixvl_vid = vid;
+		vlp->ixvl_refs = 1;
+		list_insert_tail(&rx_group->vlans, vlp);
+		mutex_exit(&ixgbe->gen_lock);
+		return (0);
+	}
+
+	/*
+	 * We should actually never return ENOSPC because we've set
+	 * things up so that every reserved group is guaranteed to
+	 * have a VLVF slot.
+	 */
+	if (ret == IXGBE_ERR_PARAM)
+		ret = EINVAL;
+	else if (ret == IXGBE_ERR_NO_SPACE)
+		ret = ENOSPC;
+	else
+		ret = EIO;
+
+	mutex_exit(&ixgbe->gen_lock);
+	return (ret);
+}
+
+/*
+ * Attempt to remove the VLAN HW filter associated with this group. If
+ * we are removing a HW filter for the default group then we know only
+ * the VFTA was set (VLVF is reserved for non-default/reserved
+ * groups). If the group wishes to stop receiving untagged traffic
+ * then clear the AUPE but leave the VLAN filters alone.
+ */
+static int
+ixgbe_remvlan(mac_group_driver_t gdriver, uint16_t vid)
+{
+	ixgbe_rx_group_t	*rx_group = (ixgbe_rx_group_t *)gdriver;
+	ixgbe_t			*ixgbe = rx_group->ixgbe;
+	struct ixgbe_hw		*hw = &ixgbe->hw;
+	int			ret;
+	ixgbe_vlan_t		*vlp;
+	boolean_t		is_def_grp;
+
+	mutex_enter(&ixgbe->gen_lock);
+
+	if (ixgbe->ixgbe_state & IXGBE_SUSPENDED) {
+		mutex_exit(&ixgbe->gen_lock);
+		return (ECANCELED);
+	}
+
+	is_def_grp = (rx_group->index == ixgbe->rx_def_group);
+
+	/* See the AUPE comment in ixgbe_addvlan(). */
+	if (vid == MAC_VLAN_UNTAGGED) {
+		if (!is_def_grp) {
+			uint32_t vml2flt;
+
+			vml2flt = IXGBE_READ_REG(hw,
+			    IXGBE_VMOLR(rx_group->index));
+			vml2flt &= ~IXGBE_VMOLR_AUPE;
+			IXGBE_WRITE_REG(hw,
+			    IXGBE_VMOLR(rx_group->index), vml2flt);
+			rx_group->aupe = B_FALSE;
+		}
+		mutex_exit(&ixgbe->gen_lock);
+		return (0);
+	}
+
+	vlp = ixgbe_find_vlan(rx_group, vid);
+	if (vlp == NULL) {
+		mutex_exit(&ixgbe->gen_lock);
+		return (ENOENT);
+	}
+
+	/*
+	 * See the comment in ixgbe_addvlan() about is_def_grp and
+	 * vlvf_bypass.
+	 */
+	if (vlp->ixvl_refs == 1) {
+		ret = ixgbe_set_vfta(hw, vid, rx_group->index, B_FALSE,
+		    is_def_grp);
+	} else {
+		/*
+		 * Only the default group can have multiple clients.
+		 * If there is more than one client, leave the
+		 * VFTA[vid] bit alone.
+		 */
+		VERIFY3B(is_def_grp, ==, B_TRUE);
+		VERIFY3U(vlp->ixvl_refs, >, 1);
+		vlp->ixvl_refs--;
+		mutex_exit(&ixgbe->gen_lock);
+		return (0);
+	}
+
+	if (ret != IXGBE_SUCCESS) {
+		mutex_exit(&ixgbe->gen_lock);
+		/* IXGBE_ERR_PARAM should be the only possible error here. */
+		if (ret == IXGBE_ERR_PARAM)
+			return (EINVAL);
+		else
+			return (EIO);
+	}
+
+	VERIFY3U(vlp->ixvl_refs, ==, 1);
+	vlp->ixvl_refs = 0;
+	list_remove(&rx_group->vlans, vlp);
+	kmem_free(vlp, sizeof (ixgbe_vlan_t));
+
+	/*
+	 * Calling ixgbe_set_vfta() on a non-default group may have
+	 * cleared the VFTA[vid] bit even though the default group
+	 * still has clients using the vid. This happens because the
+	 * ixgbe common code doesn't ref count the use of VLANs. Check
+	 * for any use of vid on the default group and make sure the
+	 * VFTA[vid] bit is set. This operation is idempotent: setting
+	 * VFTA[vid] to true if already true won't hurt anything.
+	 */
+	if (!is_def_grp) {
+		ixgbe_rx_group_t *defgrp;
+
+		defgrp = &ixgbe->rx_groups[ixgbe->rx_def_group];
+		vlp = ixgbe_find_vlan(defgrp, vid);
+		if (vlp != NULL) {
+			/* This shouldn't fail, but if it does return EIO. */
+			ret = ixgbe_set_vfta(hw, vid, rx_group->index, B_TRUE,
+			    B_TRUE);
+			if (ret != IXGBE_SUCCESS) {
+				mutex_exit(&ixgbe->gen_lock);
+				return (EIO);
+			}
+		}
+	}
+
+	mutex_exit(&ixgbe->gen_lock);
 	return (0);
 }
 

--- a/usr/src/uts/common/io/ixgbe/ixgbe_sw.h
+++ b/usr/src/uts/common/io/ixgbe/ixgbe_sw.h
@@ -91,6 +91,8 @@ extern "C" {
 
 #define	MAX_NUM_UNICAST_ADDRESSES	0x80
 #define	MAX_NUM_MULTICAST_ADDRESSES	0x1000
+#define	MAX_NUM_VLAN_FILTERS		0x40
+
 #define	IXGBE_INTR_NONE			0
 #define	IXGBE_INTR_MSIX			1
 #define	IXGBE_INTR_MSI			2
@@ -387,6 +389,15 @@ typedef union ixgbe_ether_addr {
 	} mac;
 } ixgbe_ether_addr_t;
 
+/*
+ * The list of VLANs an Rx group will accept.
+ */
+typedef struct ixgbe_vlan {
+	list_node_t		ixvl_link;
+	uint16_t		ixvl_vid;   /* The VLAN ID */
+	uint_t			ixvl_refs;  /* Number of users of this VLAN */
+} ixgbe_vlan_t;
+
 typedef enum {
 	USE_NONE,
 	USE_COPY,
@@ -589,6 +600,7 @@ typedef struct ixgbe_rx_ring {
 
 	struct ixgbe		*ixgbe;		/* Pointer to ixgbe struct */
 } ixgbe_rx_ring_t;
+
 /*
  * Software Receive Ring Group
  */
@@ -596,6 +608,8 @@ typedef struct ixgbe_rx_group {
 	uint32_t		index;		/* Group index */
 	mac_group_handle_t	group_handle;   /* call back group handle */
 	struct ixgbe		*ixgbe;		/* Pointer to ixgbe struct */
+	boolean_t		aupe;		/* AUPE bit */
+	list_t			vlans;		/* list of VLANs to allow */
 } ixgbe_rx_group_t;
 
 /*
@@ -662,6 +676,7 @@ typedef struct ixgbe {
 	 */
 	ixgbe_rx_group_t	*rx_groups;	/* Array of rx groups */
 	uint32_t		num_rx_groups;	/* Number of rx groups in use */
+	uint32_t		rx_def_group;	/* Default Rx group index */
 
 	/*
 	 * Transmit Rings
@@ -714,6 +729,9 @@ typedef struct ixgbe {
 	ixgbe_ether_addr_t	unicst_addr[MAX_NUM_UNICAST_ADDRESSES];
 	uint32_t		mcast_count;
 	struct ether_addr	mcast_table[MAX_NUM_MULTICAST_ADDRESSES];
+
+	boolean_t		vlft_enabled; /* VLAN filtering enabled? */
+	boolean_t		vlft_init;    /* VLAN filtering initialized? */
 
 	ulong_t			sys_page_size;
 

--- a/usr/src/uts/common/io/mac/mac.c
+++ b/usr/src/uts/common/io/mac/mac.c
@@ -1753,7 +1753,7 @@ mac_client_clear_flow_cb(mac_client_handle_t mch)
 	flow_entry_t		*flent = mcip->mci_flent;
 
 	mutex_enter(&flent->fe_lock);
-	flent->fe_cb_fn = (flow_fn_t)mac_pkt_drop;
+	flent->fe_cb_fn = (flow_fn_t)mac_rx_def;
 	flent->fe_cb_arg1 = NULL;
 	flent->fe_cb_arg2 = NULL;
 	flent->fe_flags |= FE_MC_NO_DATAPATH;

--- a/usr/src/uts/common/io/mac/mac.c
+++ b/usr/src/uts/common/io/mac/mac.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2015 Garrett D'Amore <garrett@damore.org>
  */
 
@@ -460,7 +460,7 @@ mac_init(void)
 	mac_logging_interval = 20;
 	mac_flow_log_enable = B_FALSE;
 	mac_link_log_enable = B_FALSE;
-	mac_logging_timer = 0;
+	mac_logging_timer = NULL;
 
 	/* Register to be notified of noteworthy pools events */
 	mac_pool_event_reg.pec_func =  mac_pool_event_cb;
@@ -1197,9 +1197,10 @@ mac_start(mac_handle_t mh)
 
 		if ((defgrp = MAC_DEFAULT_RX_GROUP(mip)) != NULL) {
 			/*
-			 * Start the default ring, since it will be needed
-			 * to receive broadcast and multicast traffic for
-			 * both primary and non-primary MAC clients.
+			 * Start the default group which is responsible
+			 * for receiving broadcast and multicast
+			 * traffic for both primary and non-primary
+			 * MAC clients.
 			 */
 			ASSERT(defgrp->mrg_state == MAC_GROUP_STATE_REGISTERED);
 			err = mac_start_group_and_rings(defgrp);
@@ -1538,7 +1539,7 @@ mac_rx_group_unmark(mac_group_t *grp, uint_t flag)
  * used by the aggr driver to access and control the underlying HW Rx group
  * and rings. In this case, the aggr driver has exclusive control of the
  * underlying HW Rx group/rings, it calls the following functions to
- * start/stop the HW Rx rings, disable/enable polling, add/remove mac'
+ * start/stop the HW Rx rings, disable/enable polling, add/remove MAC
  * addresses, or set up the Rx callback.
  */
 /* ARGSUSED */
@@ -1583,8 +1584,9 @@ mac_hwrings_get(mac_client_handle_t mch, mac_group_handle_t *hwgh,
 		ASSERT(B_FALSE);
 		return (-1);
 	}
+
 	/*
-	 * The mac client did not reserve any RX group, return directly.
+	 * The MAC client did not reserve an Rx group, return directly.
 	 * This is probably because the underlying MAC does not support
 	 * any groups.
 	 */
@@ -1593,7 +1595,7 @@ mac_hwrings_get(mac_client_handle_t mch, mac_group_handle_t *hwgh,
 	if (grp == NULL)
 		return (0);
 	/*
-	 * This group must be reserved by this mac client.
+	 * This group must be reserved by this MAC client.
 	 */
 	ASSERT((grp->mrg_state == MAC_GROUP_STATE_RESERVED) &&
 	    (mcip == MAC_GROUP_ONLY_CLIENT(grp)));
@@ -1602,6 +1604,78 @@ mac_hwrings_get(mac_client_handle_t mch, mac_group_handle_t *hwgh,
 		ASSERT(cnt < MAX_RINGS_PER_GROUP);
 		hwrh[cnt] = (mac_ring_handle_t)ring;
 	}
+	if (hwgh != NULL)
+		*hwgh = (mac_group_handle_t)grp;
+
+	return (cnt);
+}
+
+/*
+ * Get the HW ring handles of the given group index. If the MAC
+ * doesn't have a group at this index, or any groups at all, then 0 is
+ * returned and hwgh is set to NULL. This is a private client API. The
+ * MAC perimeter must be held when calling this function.
+ *
+ * mh: A handle to the MAC that owns the group.
+ *
+ * idx: The index of the HW group to be read.
+ *
+ * hwgh: If non-NULL, contains a handle to the HW group on return.
+ *
+ * hwrh: An array of ring handles pointing to the HW rings in the
+ * group. The array must be large enough to hold a handle to each ring
+ * in the group. To be safe, this array should be of size MAX_RINGS_PER_GROUP.
+ *
+ * rtype: Used to determine if we are fetching Rx or Tx rings.
+ *
+ * Returns the number of rings in the group.
+ */
+uint_t
+mac_hwrings_idx_get(mac_handle_t mh, uint_t idx, mac_group_handle_t *hwgh,
+    mac_ring_handle_t *hwrh, mac_ring_type_t rtype)
+{
+	mac_impl_t		*mip = (mac_impl_t *)mh;
+	mac_group_t		*grp;
+	mac_ring_t		*ring;
+	uint_t			cnt = 0;
+
+	/*
+	 * The MAC perimeter must be held when accessing the
+	 * mi_{rx,tx}_groups fields.
+	 */
+	ASSERT(MAC_PERIM_HELD(mh));
+	ASSERT(rtype == MAC_RING_TYPE_RX || rtype == MAC_RING_TYPE_TX);
+
+	if (rtype == MAC_RING_TYPE_RX) {
+		grp = mip->mi_rx_groups;
+	} else {
+		ASSERT(rtype == MAC_RING_TYPE_TX);
+		grp = mip->mi_tx_groups;
+	}
+
+	while (grp != NULL && grp->mrg_index != idx)
+		grp = grp->mrg_next;
+
+	/*
+	 * If the MAC doesn't have a group at this index or doesn't
+	 * impelement RINGS capab, then set hwgh to NULL and return 0.
+	 */
+	if (hwgh != NULL)
+		*hwgh = NULL;
+
+	if (grp == NULL)
+		return (0);
+
+	ASSERT3U(idx, ==, grp->mrg_index);
+
+	for (ring = grp->mrg_rings; ring != NULL; ring = ring->mr_next, cnt++) {
+		ASSERT3U(cnt, <, MAX_RINGS_PER_GROUP);
+		hwrh[cnt] = (mac_ring_handle_t)ring;
+	}
+
+	/* A group should always have at least one ring. */
+	ASSERT3U(cnt, >, 0);
+
 	if (hwgh != NULL)
 		*hwgh = (mac_group_handle_t)grp;
 
@@ -1621,6 +1695,69 @@ mac_hwring_getinfo(mac_ring_handle_t rh)
 	mac_ring_info_t *info = &ring->mr_info;
 
 	return (info->mri_flags);
+}
+
+/*
+ * Set the passthru callback on the hardware ring.
+ */
+void
+mac_hwring_set_passthru(mac_ring_handle_t hwrh, mac_rx_t fn, void *arg1,
+    mac_resource_handle_t arg2)
+{
+	mac_ring_t *hwring = (mac_ring_t *)hwrh;
+
+	ASSERT3S(hwring->mr_type, ==, MAC_RING_TYPE_RX);
+
+	hwring->mr_classify_type = MAC_PASSTHRU_CLASSIFIER;
+
+	hwring->mr_pt_fn = fn;
+	hwring->mr_pt_arg1 = arg1;
+	hwring->mr_pt_arg2 = arg2;
+}
+
+/*
+ * Clear the passthru callback on the hardware ring.
+ */
+void
+mac_hwring_clear_passthru(mac_ring_handle_t hwrh)
+{
+	mac_ring_t *hwring = (mac_ring_t *)hwrh;
+
+	ASSERT3S(hwring->mr_type, ==, MAC_RING_TYPE_RX);
+
+	hwring->mr_classify_type = MAC_NO_CLASSIFIER;
+
+	hwring->mr_pt_fn = NULL;
+	hwring->mr_pt_arg1 = NULL;
+	hwring->mr_pt_arg2 = NULL;
+}
+
+void
+mac_client_set_flow_cb(mac_client_handle_t mch, mac_rx_t func, void *arg1)
+{
+	mac_client_impl_t	*mcip = (mac_client_impl_t *)mch;
+	flow_entry_t		*flent = mcip->mci_flent;
+
+	mutex_enter(&flent->fe_lock);
+	flent->fe_cb_fn = (flow_fn_t)func;
+	flent->fe_cb_arg1 = arg1;
+	flent->fe_cb_arg2 = NULL;
+	flent->fe_flags &= ~FE_MC_NO_DATAPATH;
+	mutex_exit(&flent->fe_lock);
+}
+
+void
+mac_client_clear_flow_cb(mac_client_handle_t mch)
+{
+	mac_client_impl_t	*mcip = (mac_client_impl_t *)mch;
+	flow_entry_t		*flent = mcip->mci_flent;
+
+	mutex_enter(&flent->fe_lock);
+	flent->fe_cb_fn = (flow_fn_t)mac_pkt_drop;
+	flent->fe_cb_arg1 = NULL;
+	flent->fe_cb_arg2 = NULL;
+	flent->fe_flags |= FE_MC_NO_DATAPATH;
+	mutex_exit(&flent->fe_lock);
 }
 
 /*
@@ -1695,8 +1832,44 @@ mac_hwring_enable_intr(mac_ring_handle_t rh)
 	return (intr->mi_enable(intr->mi_handle));
 }
 
+/*
+ * Start the HW ring pointed to by rh.
+ *
+ * This is used by special MAC clients that are MAC themselves and
+ * need to exert control over the underlying HW rings of the NIC.
+ */
 int
 mac_hwring_start(mac_ring_handle_t rh)
+{
+	mac_ring_t *rr_ring = (mac_ring_t *)rh;
+	int rv = 0;
+
+	if (rr_ring->mr_state != MR_INUSE)
+		rv = mac_start_ring(rr_ring);
+
+	return (rv);
+}
+
+/*
+ * Stop the HW ring pointed to by rh. Also see mac_hwring_start().
+ */
+void
+mac_hwring_stop(mac_ring_handle_t rh)
+{
+	mac_ring_t *rr_ring = (mac_ring_t *)rh;
+
+	if (rr_ring->mr_state != MR_FREE)
+		mac_stop_ring(rr_ring);
+}
+
+/*
+ * Remove the quiesced flag from the HW ring pointed to by rh.
+ *
+ * This is used by special MAC clients that are MAC themselves and
+ * need to exert control over the underlying HW rings of the NIC.
+ */
+int
+mac_hwring_activate(mac_ring_handle_t rh)
 {
 	mac_ring_t *rr_ring = (mac_ring_t *)rh;
 
@@ -1704,8 +1877,11 @@ mac_hwring_start(mac_ring_handle_t rh)
 	return (0);
 }
 
+/*
+ * Quiesce the HW ring pointed to by rh. Also see mac_hwring_activate().
+ */
 void
-mac_hwring_stop(mac_ring_handle_t rh)
+mac_hwring_quiesce(mac_ring_handle_t rh)
 {
 	mac_ring_t *rr_ring = (mac_ring_t *)rh;
 
@@ -1813,6 +1989,68 @@ mac_hwgroup_remmac(mac_group_handle_t gh, const uint8_t *addr)
 	mac_group_t *group = (mac_group_t *)gh;
 
 	return (mac_group_remmac(group, addr));
+}
+
+/*
+ * Program the group's HW VLAN filter if it has such support.
+ * Otherwise, the group will implicitly accept tagged traffic and
+ * there is nothing to do.
+ */
+int
+mac_hwgroup_addvlan(mac_group_handle_t gh, uint16_t vid)
+{
+	mac_group_t *group = (mac_group_t *)gh;
+
+	if (!MAC_GROUP_HW_VLAN(group))
+		return (0);
+
+	return (mac_group_addvlan(group, vid));
+}
+
+int
+mac_hwgroup_remvlan(mac_group_handle_t gh, uint16_t vid)
+{
+	mac_group_t *group = (mac_group_t *)gh;
+
+	if (!MAC_GROUP_HW_VLAN(group))
+		return (0);
+
+	return (mac_group_remvlan(group, vid));
+}
+
+/*
+ * Determine if a MAC has HW VLAN support. This is a private API
+ * consumed by aggr. In the future it might be nice to have a bitfield
+ * in mac_capab_rings_t to track which forms of HW filtering are
+ * supported by the MAC.
+ */
+boolean_t
+mac_has_hw_vlan(mac_handle_t mh)
+{
+	mac_impl_t *mip = (mac_impl_t *)mh;
+
+	return (MAC_GROUP_HW_VLAN(mip->mi_rx_groups));
+}
+
+/*
+ * Get the number of Rx HW groups on this MAC.
+ */
+uint_t
+mac_get_num_rx_groups(mac_handle_t mh)
+{
+	mac_impl_t *mip = (mac_impl_t *)mh;
+
+	ASSERT(MAC_PERIM_HELD(mh));
+	return (mip->mi_rx_group_count);
+}
+
+int
+mac_set_promisc(mac_handle_t mh, boolean_t value)
+{
+	mac_impl_t *mip = (mac_impl_t *)mh;
+
+	ASSERT(MAC_PERIM_HELD(mh));
+	return (i_mac_promisc_set(mip, value));
 }
 
 /*
@@ -2500,7 +2738,6 @@ mac_disable(mac_handle_t mh)
 /*
  * Called when the MAC instance has a non empty flow table, to de-multiplex
  * incoming packets to the right flow.
- * The MAC's rw lock is assumed held as a READER.
  */
 /* ARGSUSED */
 static mblk_t *
@@ -2509,19 +2746,6 @@ mac_rx_classify(mac_impl_t *mip, mac_resource_handle_t mrh, mblk_t *mp)
 	flow_entry_t	*flent = NULL;
 	uint_t		flags = FLOW_INBOUND;
 	int		err;
-
-	/*
-	 * If the mac is a port of an aggregation, pass FLOW_IGNORE_VLAN
-	 * to mac_flow_lookup() so that the VLAN packets can be successfully
-	 * passed to the non-VLAN aggregation flows.
-	 *
-	 * Note that there is possibly a race between this and
-	 * mac_unicast_remove/add() and VLAN packets could be incorrectly
-	 * classified to non-VLAN flows of non-aggregation mac clients. These
-	 * VLAN packets will be then filtered out by the mac module.
-	 */
-	if ((mip->mi_state_flags & MIS_EXCLUSIVE) != 0)
-		flags |= FLOW_IGNORE_VLAN;
 
 	err = mac_flow_lookup(mip->mi_flow_tab, mp, flags, &flent);
 	if (err != 0) {
@@ -3856,9 +4080,27 @@ mac_start_group_and_rings(mac_group_t *group)
 
 	for (ring = group->mrg_rings; ring != NULL; ring = ring->mr_next) {
 		ASSERT(ring->mr_state == MR_FREE);
+
 		if ((rv = mac_start_ring(ring)) != 0)
 			goto error;
-		ring->mr_classify_type = MAC_SW_CLASSIFIER;
+
+		/*
+		 * When aggr_set_port_sdu() is called, it will remove
+		 * the port client's unicast address. This will cause
+		 * MAC to stop the default group's rings on the port
+		 * MAC. After it modifies the SDU, it will then re-add
+		 * the unicast address. At which time, this function is
+		 * called to start the default group's rings. Normally
+		 * this function would set the classify type to
+		 * MAC_SW_CLASSIFIER; but that will break aggr which
+		 * relies on the passthru classify mode being set for
+		 * correct delivery (see mac_rx_common()). To avoid
+		 * that, we check for a passthru callback and set the
+		 * classify type to MAC_PASSTHRU_CLASSIFIER; as it was
+		 * before the rings were stopped.
+		 */
+		ring->mr_classify_type = (ring->mr_pt_fn != NULL) ?
+		    MAC_PASSTHRU_CLASSIFIER : MAC_SW_CLASSIFIER;
 	}
 	return (0);
 
@@ -4161,12 +4403,15 @@ mac_init_rings(mac_impl_t *mip, mac_ring_type_t rtype)
 
 
 		/*
-		 * Driver must register group->mgi_addmac/remmac() for rx groups
-		 * to support multiple MAC addresses.
+		 * The driver must register some form of hardware MAC
+		 * filter in order for Rx groups to support multiple
+		 * MAC addresses.
 		 */
 		if (rtype == MAC_RING_TYPE_RX &&
-		    ((group_info.mgi_addmac == NULL) ||
-		    (group_info.mgi_remmac == NULL))) {
+		    (group_info.mgi_addmac == NULL ||
+		    group_info.mgi_remmac == NULL)) {
+			DTRACE_PROBE1(mac__init__rings__no__mac__filter,
+			    char *, mip->mi_name);
 			err = EINVAL;
 			goto bail;
 		}
@@ -4213,8 +4458,9 @@ mac_init_rings(mac_impl_t *mip, mac_ring_type_t rtype)
 
 		/* Update this group's status */
 		mac_set_group_state(group, MAC_GROUP_STATE_REGISTERED);
-	} else
+	} else {
 		group->mrg_rings = NULL;
+	}
 
 	ASSERT(ring_left == 0);
 
@@ -4404,6 +4650,38 @@ mac_free_rings(mac_impl_t *mip, mac_ring_type_t rtype)
 }
 
 /*
+ * Associate the VLAN filter to the receive group.
+ */
+int
+mac_group_addvlan(mac_group_t *group, uint16_t vlan)
+{
+	VERIFY3S(group->mrg_type, ==, MAC_RING_TYPE_RX);
+	VERIFY3P(group->mrg_info.mgi_addvlan, !=, NULL);
+
+	if (vlan > VLAN_ID_MAX)
+		return (EINVAL);
+
+	vlan = MAC_VLAN_UNTAGGED_VID(vlan);
+	return (group->mrg_info.mgi_addvlan(group->mrg_info.mgi_driver, vlan));
+}
+
+/*
+ * Dissociate the VLAN from the receive group.
+ */
+int
+mac_group_remvlan(mac_group_t *group, uint16_t vlan)
+{
+	VERIFY3S(group->mrg_type, ==, MAC_RING_TYPE_RX);
+	VERIFY3P(group->mrg_info.mgi_remvlan, !=, NULL);
+
+	if (vlan > VLAN_ID_MAX)
+		return (EINVAL);
+
+	vlan = MAC_VLAN_UNTAGGED_VID(vlan);
+	return (group->mrg_info.mgi_remvlan(group->mrg_info.mgi_driver, vlan));
+}
+
+/*
  * Associate a MAC address with a receive group.
  *
  * The return value of this function should always be checked properly, because
@@ -4419,8 +4697,8 @@ mac_free_rings(mac_impl_t *mip, mac_ring_type_t rtype)
 int
 mac_group_addmac(mac_group_t *group, const uint8_t *addr)
 {
-	ASSERT(group->mrg_type == MAC_RING_TYPE_RX);
-	ASSERT(group->mrg_info.mgi_addmac != NULL);
+	VERIFY3S(group->mrg_type, ==, MAC_RING_TYPE_RX);
+	VERIFY3P(group->mrg_info.mgi_addmac, !=, NULL);
 
 	return (group->mrg_info.mgi_addmac(group->mrg_info.mgi_driver, addr));
 }
@@ -4431,8 +4709,8 @@ mac_group_addmac(mac_group_t *group, const uint8_t *addr)
 int
 mac_group_remmac(mac_group_t *group, const uint8_t *addr)
 {
-	ASSERT(group->mrg_type == MAC_RING_TYPE_RX);
-	ASSERT(group->mrg_info.mgi_remmac != NULL);
+	VERIFY3S(group->mrg_type, ==, MAC_RING_TYPE_RX);
+	VERIFY3P(group->mrg_info.mgi_remmac, !=, NULL);
 
 	return (group->mrg_info.mgi_remmac(group->mrg_info.mgi_driver, addr));
 }
@@ -4633,28 +4911,20 @@ i_mac_group_add_ring(mac_group_t *group, mac_ring_t *ring, int index)
 	switch (ring->mr_type) {
 	case MAC_RING_TYPE_RX:
 		/*
-		 * Setup SRS on top of the new ring if the group is
-		 * reserved for someones exclusive use.
+		 * Setup an SRS on top of the new ring if the group is
+		 * reserved for someone's exclusive use.
 		 */
 		if (group->mrg_state == MAC_GROUP_STATE_RESERVED) {
-			mac_client_impl_t *mcip;
+			mac_client_impl_t *mcip =  MAC_GROUP_ONLY_CLIENT(group);
 
-			mcip = MAC_GROUP_ONLY_CLIENT(group);
-			/*
-			 * Even though this group is reserved we migth still
-			 * have multiple clients, i.e a VLAN shares the
-			 * group with the primary mac client.
-			 */
-			if (mcip != NULL) {
-				flent = mcip->mci_flent;
-				ASSERT(flent->fe_rx_srs_cnt > 0);
-				mac_rx_srs_group_setup(mcip, flent, SRST_LINK);
-				mac_fanout_setup(mcip, flent,
-				    MCIP_RESOURCE_PROPS(mcip), mac_rx_deliver,
-				    mcip, NULL, NULL);
-			} else {
-				ring->mr_classify_type = MAC_SW_CLASSIFIER;
-			}
+			VERIFY3P(mcip, !=, NULL);
+			flent = mcip->mci_flent;
+			VERIFY3S(flent->fe_rx_srs_cnt, >, 0);
+			mac_rx_srs_group_setup(mcip, flent, SRST_LINK);
+			mac_fanout_setup(mcip, flent, MCIP_RESOURCE_PROPS(mcip),
+			    mac_rx_deliver, mcip, NULL, NULL);
+		} else {
+			ring->mr_classify_type = MAC_SW_CLASSIFIER;
 		}
 		break;
 	case MAC_RING_TYPE_TX:
@@ -4680,7 +4950,7 @@ i_mac_group_add_ring(mac_group_t *group, mac_ring_t *ring, int index)
 
 			mcip = mgcp->mgc_client;
 			flent = mcip->mci_flent;
-			is_aggr = (mcip->mci_state_flags & MCIS_IS_AGGR);
+			is_aggr = (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT);
 			mac_srs = MCIP_TX_SRS(mcip);
 			tx = &mac_srs->srs_tx;
 			mac_tx_client_quiesce((mac_client_handle_t)mcip);
@@ -4824,7 +5094,7 @@ i_mac_group_rem_ring(mac_group_t *group, mac_ring_t *ring,
 
 			mcip = MAC_GROUP_ONLY_CLIENT(group);
 			ASSERT(mcip != NULL);
-			ASSERT(mcip->mci_state_flags & MCIS_IS_AGGR);
+			ASSERT(mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT);
 			mac_srs = MCIP_TX_SRS(mcip);
 			ASSERT(mac_srs->srs_tx.st_mode == SRS_TX_AGGR ||
 			    mac_srs->srs_tx.st_mode == SRS_TX_BW_AGGR);
@@ -5032,12 +5302,12 @@ mac_free_macaddr(mac_address_t *map)
 	mac_impl_t *mip = map->ma_mip;
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mip));
-	ASSERT(mip->mi_addresses != NULL);
+	VERIFY3P(mip->mi_addresses, !=, NULL);
 
-	map = mac_find_macaddr(mip, map->ma_addr);
-
-	ASSERT(map != NULL);
-	ASSERT(map->ma_nusers == 0);
+	VERIFY3P(map, ==, mac_find_macaddr(mip, map->ma_addr));
+	VERIFY3P(map, !=, NULL);
+	VERIFY3S(map->ma_nusers, ==, 0);
+	VERIFY3P(map->ma_vlans, ==, NULL);
 
 	if (map == mip->mi_addresses) {
 		mip->mi_addresses = map->ma_next;
@@ -5053,85 +5323,201 @@ mac_free_macaddr(mac_address_t *map)
 	kmem_free(map, sizeof (mac_address_t));
 }
 
+static mac_vlan_t *
+mac_find_vlan(mac_address_t *map, uint16_t vid)
+{
+	mac_vlan_t *mvp;
+
+	for (mvp = map->ma_vlans; mvp != NULL; mvp = mvp->mv_next) {
+		if (mvp->mv_vid == vid)
+			return (mvp);
+	}
+
+	return (NULL);
+}
+
+static mac_vlan_t *
+mac_add_vlan(mac_address_t *map, uint16_t vid)
+{
+	mac_vlan_t *mvp;
+
+	/*
+	 * We should never add the same {addr, VID} tuple more
+	 * than once, but let's be sure.
+	 */
+	for (mvp = map->ma_vlans; mvp != NULL; mvp = mvp->mv_next)
+		VERIFY3U(mvp->mv_vid, !=, vid);
+
+	/* Add the VLAN to the head of the VLAN list. */
+	mvp = kmem_zalloc(sizeof (mac_vlan_t), KM_SLEEP);
+	mvp->mv_vid = vid;
+	mvp->mv_next = map->ma_vlans;
+	map->ma_vlans = mvp;
+
+	return (mvp);
+}
+
+static void
+mac_rem_vlan(mac_address_t *map, mac_vlan_t *mvp)
+{
+	mac_vlan_t *pre;
+
+	if (map->ma_vlans == mvp) {
+		map->ma_vlans = mvp->mv_next;
+	} else {
+		pre = map->ma_vlans;
+		while (pre->mv_next != mvp) {
+			pre = pre->mv_next;
+
+			/*
+			 * We've reached the end of the list without
+			 * finding mvp.
+			 */
+			VERIFY3P(pre, !=, NULL);
+		}
+		pre->mv_next = mvp->mv_next;
+	}
+
+	kmem_free(mvp, sizeof (mac_vlan_t));
+}
+
 /*
- * Add a MAC address reference for a client. If the desired MAC address
- * exists, add a reference to it. Otherwise, add the new address by adding
- * it to a reserved group or setting promiscuous mode. Won't try different
- * group is the group is non-NULL, so the caller must explictly share
- * default group when needed.
- *
- * Note, the primary MAC address is initialized at registration time, so
- * to add it to default group only need to activate it if its reference
- * count is still zero. Also, some drivers may not have advertised RINGS
- * capability.
+ * Create a new mac_address_t if this is the first use of the address
+ * or add a VID to an existing address. In either case, the
+ * mac_address_t acts as a list of {addr, VID} tuples where each tuple
+ * shares the same addr. If group is non-NULL then attempt to program
+ * the MAC's HW filters for this group. Otherwise, if group is NULL,
+ * then the MAC has no rings and there is nothing to program.
  */
 int
-mac_add_macaddr(mac_impl_t *mip, mac_group_t *group, uint8_t *mac_addr,
-    boolean_t use_hw)
+mac_add_macaddr_vlan(mac_impl_t *mip, mac_group_t *group, uint8_t *addr,
+    uint16_t vid, boolean_t use_hw)
 {
-	mac_address_t *map;
-	int err = 0;
-	boolean_t allocated_map = B_FALSE;
+	mac_address_t	*map;
+	mac_vlan_t	*mvp;
+	int		err = 0;
+	boolean_t	allocated_map = B_FALSE;
+	boolean_t	hw_mac = B_FALSE;
+	boolean_t	hw_vlan = B_FALSE;
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mip));
 
-	map = mac_find_macaddr(mip, mac_addr);
+	map = mac_find_macaddr(mip, addr);
 
 	/*
-	 * If the new MAC address has not been added. Allocate a new one
-	 * and set it up.
+	 * If this is the first use of this MAC address then allocate
+	 * and initialize a new structure.
 	 */
 	if (map == NULL) {
 		map = kmem_zalloc(sizeof (mac_address_t), KM_SLEEP);
 		map->ma_len = mip->mi_type->mt_addr_length;
-		bcopy(mac_addr, map->ma_addr, map->ma_len);
+		bcopy(addr, map->ma_addr, map->ma_len);
 		map->ma_nusers = 0;
 		map->ma_group = group;
 		map->ma_mip = mip;
+		map->ma_untagged = B_FALSE;
 
-		/* add the new MAC address to the head of the address list */
+		/* Add the new MAC address to the head of the address list. */
 		map->ma_next = mip->mi_addresses;
 		mip->mi_addresses = map;
 
 		allocated_map = B_TRUE;
 	}
 
-	ASSERT(map->ma_group == NULL || map->ma_group == group);
+	VERIFY(map->ma_group == NULL || map->ma_group == group);
 	if (map->ma_group == NULL)
 		map->ma_group = group;
 
+	if (vid == VLAN_ID_NONE) {
+		map->ma_untagged = B_TRUE;
+		mvp = NULL;
+	} else {
+		mvp = mac_add_vlan(map, vid);
+	}
+
 	/*
-	 * If the MAC address is already in use, simply account for the
-	 * new client.
+	 * Set the VLAN HW filter if:
+	 *
+	 * o the MAC's VLAN HW filtering is enabled, and
+	 * o the address does not currently rely on promisc mode.
+	 *
+	 * This is called even when the client specifies an untagged
+	 * address (VLAN_ID_NONE) because some MAC providers require
+	 * setting additional bits to accept untagged traffic when
+	 * VLAN HW filtering is enabled.
 	 */
-	if (map->ma_nusers++ > 0)
+	if (MAC_GROUP_HW_VLAN(group) &&
+	    map->ma_type != MAC_ADDRESS_TYPE_UNICAST_PROMISC) {
+		if ((err = mac_group_addvlan(group, vid)) != 0)
+			goto bail;
+
+		hw_vlan = B_TRUE;
+	}
+
+	VERIFY3S(map->ma_nusers, >=, 0);
+	map->ma_nusers++;
+
+	/*
+	 * If this MAC address already has a HW filter then simply
+	 * increment the counter.
+	 */
+	if (map->ma_nusers > 1)
 		return (0);
+
+	/*
+	 * All logic from here on out is executed during initial
+	 * creation only.
+	 */
+	VERIFY3S(map->ma_nusers, ==, 1);
 
 	/*
 	 * Activate this MAC address by adding it to the reserved group.
 	 */
 	if (group != NULL) {
-		err = mac_group_addmac(group, (const uint8_t *)mac_addr);
-		if (err == 0) {
-			map->ma_type = MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED;
-			return (0);
+		err = mac_group_addmac(group, (const uint8_t *)addr);
+
+		/*
+		 * If the driver is out of filters then we can
+		 * continue and use promisc mode. For any other error,
+		 * assume the driver is in a state where we can't
+		 * program the filters or use promisc mode; so we must
+		 * bail.
+		 */
+		if (err != 0 && err != ENOSPC) {
+			map->ma_nusers--;
+			goto bail;
 		}
+
+		hw_mac = (err == 0);
+	}
+
+	if (hw_mac) {
+		map->ma_type = MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED;
+		return (0);
 	}
 
 	/*
 	 * The MAC address addition failed. If the client requires a
-	 * hardware classified MAC address, fail the operation.
+	 * hardware classified MAC address, fail the operation. This
+	 * feature is only used by sun4v vsw.
 	 */
-	if (use_hw) {
+	if (use_hw && !hw_mac) {
 		err = ENOSPC;
+		map->ma_nusers--;
 		goto bail;
 	}
 
 	/*
-	 * Try promiscuous mode.
-	 *
-	 * For drivers that don't advertise RINGS capability, do
-	 * nothing for the primary address.
+	 * If we reach this point then either the MAC doesn't have
+	 * RINGS capability or we are out of MAC address HW filters.
+	 * In any case we must put the MAC into promiscuous mode.
+	 */
+	VERIFY(group == NULL || !hw_mac);
+
+	/*
+	 * The one exception is the primary address. A non-RINGS
+	 * driver filters the primary address by default; promisc mode
+	 * is not needed.
 	 */
 	if ((group == NULL) &&
 	    (bcmp(map->ma_addr, mip->mi_addr, map->ma_len) == 0)) {
@@ -5140,8 +5526,11 @@ mac_add_macaddr(mac_impl_t *mip, mac_group_t *group, uint8_t *mac_addr,
 	}
 
 	/*
-	 * Enable promiscuous mode in order to receive traffic
-	 * to the new MAC address.
+	 * Enable promiscuous mode in order to receive traffic to the
+	 * new MAC address. All existing HW filters still send their
+	 * traffic to their respective group/SRSes. But with promisc
+	 * enabled all unknown traffic is delivered to the default
+	 * group where it is SW classified via mac_rx_classify().
 	 */
 	if ((err = i_mac_promisc_set(mip, B_TRUE)) == 0) {
 		map->ma_type = MAC_ADDRESS_TYPE_UNICAST_PROMISC;
@@ -5149,44 +5538,71 @@ mac_add_macaddr(mac_impl_t *mip, mac_group_t *group, uint8_t *mac_addr,
 	}
 
 	/*
-	 * Free the MAC address that could not be added. Don't free
-	 * a pre-existing address, it could have been the entry
-	 * for the primary MAC address which was pre-allocated by
-	 * mac_init_macaddr(), and which must remain on the list.
+	 * We failed to set promisc mode and we are about to free 'map'.
 	 */
+	map->ma_nusers = 0;
+
 bail:
-	map->ma_nusers--;
+	if (hw_vlan) {
+		int err2 = mac_group_remvlan(group, vid);
+
+		if (err2 != 0) {
+			cmn_err(CE_WARN, "Failed to remove VLAN %u from group"
+			    " %d on MAC %s: %d.", vid, group->mrg_index,
+			    mip->mi_name, err2);
+		}
+	}
+
+	if (mvp != NULL)
+		mac_rem_vlan(map, mvp);
+
 	if (allocated_map)
 		mac_free_macaddr(map);
+
 	return (err);
 }
 
-/*
- * Remove a reference to a MAC address. This may cause to remove the MAC
- * address from an associated group or to turn off promiscuous mode.
- * The caller needs to handle the failure properly.
- */
 int
-mac_remove_macaddr(mac_address_t *map)
+mac_remove_macaddr_vlan(mac_address_t *map, uint16_t vid)
 {
-	mac_impl_t *mip = map->ma_mip;
-	int err = 0;
+	mac_vlan_t	*mvp;
+	mac_impl_t	*mip = map->ma_mip;
+	mac_group_t	*group = map->ma_group;
+	int		err = 0;
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mip));
+	VERIFY3P(map, ==, mac_find_macaddr(mip, map->ma_addr));
 
-	ASSERT(map == mac_find_macaddr(mip, map->ma_addr));
+	if (vid == VLAN_ID_NONE) {
+		map->ma_untagged = B_FALSE;
+		mvp = NULL;
+	} else {
+		mvp = mac_find_vlan(map, vid);
+		VERIFY3P(mvp, !=, NULL);
+	}
+
+	if (MAC_GROUP_HW_VLAN(group) &&
+	    map->ma_type == MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED &&
+	    ((err = mac_group_remvlan(group, vid)) != 0))
+		return (err);
+
+	if (mvp != NULL)
+		mac_rem_vlan(map, mvp);
 
 	/*
 	 * If it's not the last client using this MAC address, only update
 	 * the MAC clients count.
 	 */
-	if (--map->ma_nusers > 0)
+	map->ma_nusers--;
+	if (map->ma_nusers > 0)
 		return (0);
 
+	VERIFY3S(map->ma_nusers, ==, 0);
+
 	/*
-	 * The MAC address is no longer used by any MAC client, so remove
-	 * it from its associated group, or turn off promiscuous mode
-	 * if it was enabled for the MAC address.
+	 * The MAC address is no longer used by any MAC client, so
+	 * remove it from its associated group. Turn off promiscuous
+	 * mode if this is the last address relying on it.
 	 */
 	switch (map->ma_type) {
 	case MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED:
@@ -5194,22 +5610,60 @@ mac_remove_macaddr(mac_address_t *map)
 		 * Don't free the preset primary address for drivers that
 		 * don't advertise RINGS capability.
 		 */
-		if (map->ma_group == NULL)
+		if (group == NULL)
 			return (0);
 
-		err = mac_group_remmac(map->ma_group, map->ma_addr);
-		if (err == 0)
-			map->ma_group = NULL;
+		if ((err = mac_group_remmac(group, map->ma_addr)) != 0) {
+			if (vid == VLAN_ID_NONE)
+				map->ma_untagged = B_TRUE;
+			else
+				(void) mac_add_vlan(map, vid);
+
+			/*
+			 * If we fail to remove the MAC address HW
+			 * filter but then also fail to re-add the
+			 * VLAN HW filter then we are in a busted
+			 * state. We do our best by logging a warning
+			 * and returning the original 'err' that got
+			 * us here. At this point, traffic for this
+			 * address + VLAN combination will be dropped
+			 * until the user reboots the system. In the
+			 * future, it would be nice to have a system
+			 * that can compare the state of expected
+			 * classification according to mac to the
+			 * actual state of the provider, and report
+			 * and fix any inconsistencies.
+			 */
+			if (MAC_GROUP_HW_VLAN(group)) {
+				int err2;
+
+				err2 = mac_group_addvlan(group, vid);
+				if (err2 != 0) {
+					cmn_err(CE_WARN, "Failed to readd VLAN"
+					    " %u to group %d on MAC %s: %d.",
+					    vid, group->mrg_index, mip->mi_name,
+					    err2);
+				}
+			}
+
+			map->ma_nusers = 1;
+			return (err);
+		}
+
+		map->ma_group = NULL;
 		break;
 	case MAC_ADDRESS_TYPE_UNICAST_PROMISC:
 		err = i_mac_promisc_set(mip, B_FALSE);
 		break;
 	default:
-		ASSERT(B_FALSE);
+		panic("Unexpected ma_type 0x%x, file: %s, line %d",
+		    map->ma_type, __FILE__, __LINE__);
 	}
 
-	if (err != 0)
+	if (err != 0) {
+		map->ma_nusers = 1;
 		return (err);
+	}
 
 	/*
 	 * We created MAC address for the primary one at registration, so we
@@ -5362,8 +5816,9 @@ mac_fini_macaddr(mac_impl_t *mip)
 	 * If mi_addresses is initialized, there should be exactly one
 	 * entry left on the list with no users.
 	 */
-	ASSERT(map->ma_nusers == 0);
-	ASSERT(map->ma_next == NULL);
+	VERIFY3S(map->ma_nusers, ==, 0);
+	VERIFY3P(map->ma_next, ==, NULL);
+	VERIFY3P(map->ma_vlans, ==, NULL);
 
 	kmem_free(map, sizeof (mac_address_t));
 	mip->mi_addresses = NULL;
@@ -5925,7 +6380,7 @@ mac_stop_logusage(mac_logtype_t type)
 	mod_hash_walk(i_mac_impl_hash, i_mac_fastpath_walker, &estate);
 
 	(void) untimeout(mac_logging_timer);
-	mac_logging_timer = 0;
+	mac_logging_timer = NULL;
 
 	/* Write log entries for each mac_impl in the list */
 	i_mac_log_info(&net_log_list, &lstate);
@@ -6043,7 +6498,7 @@ mac_reserve_tx_ring(mac_impl_t *mip, mac_ring_t *desired_ring)
 }
 
 /*
- * For a reserved group with multiple clients, return the primary client.
+ * For a non-default group with multiple clients, return the primary client.
  */
 static mac_client_impl_t *
 mac_get_grp_primary(mac_group_t *grp)
@@ -6402,13 +6857,12 @@ mac_group_add_client(mac_group_t *grp, mac_client_impl_t *mcip)
 			break;
 	}
 
-	VERIFY(mgcp == NULL);
+	ASSERT(mgcp == NULL);
 
 	mgcp = kmem_zalloc(sizeof (mac_grp_client_t), KM_SLEEP);
 	mgcp->mgc_client = mcip;
 	mgcp->mgc_next = grp->mrg_clients;
 	grp->mrg_clients = mgcp;
-
 }
 
 void
@@ -6429,8 +6883,27 @@ mac_group_remove_client(mac_group_t *grp, mac_client_impl_t *mcip)
 }
 
 /*
- * mac_reserve_rx_group()
- *
+ * Return true if any client on this group explicitly asked for HW
+ * rings (of type mask) or have a bound share.
+ */
+static boolean_t
+i_mac_clients_hw(mac_group_t *grp, uint32_t mask)
+{
+	mac_grp_client_t	*mgcip;
+	mac_client_impl_t	*mcip;
+	mac_resource_props_t	*mrp;
+
+	for (mgcip = grp->mrg_clients; mgcip != NULL; mgcip = mgcip->mgc_next) {
+		mcip = mgcip->mgc_client;
+		mrp = MCIP_RESOURCE_PROPS(mcip);
+		if (mcip->mci_share != 0 || (mrp->mrp_mask & mask) != 0)
+			return (B_TRUE);
+	}
+
+	return (B_FALSE);
+}
+
+/*
  * Finds an available group and exclusively reserves it for a client.
  * The group is chosen to suit the flow's resource controls (bandwidth and
  * fanout requirements) and the address type.
@@ -6453,7 +6926,6 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 	int			need_rings = 0;
 	mac_group_t		*candidate_grp = NULL;
 	mac_client_impl_t	*gclient;
-	mac_resource_props_t	*gmrp;
 	mac_group_t		*donorgrp = NULL;
 	boolean_t		rxhw = mrp->mrp_mask & MRP_RX_RINGS;
 	boolean_t		unspec = mrp->mrp_mask & MRP_RXRINGS_UNSPEC;
@@ -6464,18 +6936,20 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 	isprimary = mcip->mci_flent->fe_type & FLOW_PRIMARY_MAC;
 
 	/*
-	 * Check if a group already has this mac address (case of VLANs)
+	 * Check if a group already has this MAC address (case of VLANs)
 	 * unless we are moving this MAC client from one group to another.
 	 */
 	if (!move && (map = mac_find_macaddr(mip, mac_addr)) != NULL) {
 		if (map->ma_group != NULL)
 			return (map->ma_group);
 	}
+
 	if (mip->mi_rx_groups == NULL || mip->mi_rx_group_count == 0)
 		return (NULL);
+
 	/*
-	 * If exclusive open, return NULL which will enable the
-	 * caller to use the default group.
+	 * If this client is requesting exclusive MAC access then
+	 * return NULL to ensure the client uses the default group.
 	 */
 	if (mcip->mci_state_flags & MCIS_EXCLUSIVE)
 		return (NULL);
@@ -6485,6 +6959,7 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 	    mip->mi_rx_group_type == MAC_GROUP_TYPE_DYNAMIC) {
 		mrp->mrp_nrxrings = 1;
 	}
+
 	/*
 	 * For static grouping we allow only specifying rings=0 and
 	 * unspecified
@@ -6493,6 +6968,7 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 	    mip->mi_rx_group_type == MAC_GROUP_TYPE_STATIC) {
 		return (NULL);
 	}
+
 	if (rxhw) {
 		/*
 		 * We have explicitly asked for a group (with nrxrings,
@@ -6554,25 +7030,19 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 		 * that didn't ask for an exclusive group, but got
 		 * one and it has enough rings (combined with what
 		 * the donor group can donate) for the new MAC
-		 * client
+		 * client.
 		 */
 		if (grp->mrg_state >= MAC_GROUP_STATE_RESERVED) {
 			/*
-			 * If the primary/donor group is not the default
-			 * group, don't bother looking for a candidate group.
-			 * If we don't have enough rings we will check
-			 * if the primary group can be vacated.
+			 * If the donor group is not the default
+			 * group, don't bother looking for a candidate
+			 * group. If we don't have enough rings we
+			 * will check if the primary group can be
+			 * vacated.
 			 */
 			if (candidate_grp == NULL &&
 			    donorgrp == MAC_DEFAULT_RX_GROUP(mip)) {
-				ASSERT(!MAC_GROUP_NO_CLIENT(grp));
-				gclient = MAC_GROUP_ONLY_CLIENT(grp);
-				if (gclient == NULL)
-					gclient = mac_get_grp_primary(grp);
-				ASSERT(gclient != NULL);
-				gmrp = MCIP_RESOURCE_PROPS(gclient);
-				if (gclient->mci_share == 0 &&
-				    (gmrp->mrp_mask & MRP_RX_RINGS) == 0 &&
+				if (!i_mac_clients_hw(grp, MRP_RX_RINGS) &&
 				    (unspec ||
 				    (grp->mrg_cur_count + donor_grp_rcnt >=
 				    need_rings))) {
@@ -6638,6 +7108,7 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 		 */
 		mac_stop_group(grp);
 	}
+
 	/* We didn't find an exclusive group for this MAC client */
 	if (i >= mip->mi_rx_group_count) {
 
@@ -6645,12 +7116,12 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 			return (NULL);
 
 		/*
-		 * If we found a candidate group then we switch the
-		 * MAC client from the candidate_group to the default
-		 * group and give the group to this MAC client. If
-		 * we didn't find a candidate_group, check if the
-		 * primary is in its own group and if it can make way
-		 * for this MAC client.
+		 * If we found a candidate group then move the
+		 * existing MAC client from the candidate_group to the
+		 * default group and give the candidate_group to the
+		 * new MAC client. If we didn't find a candidate
+		 * group, then check if the primary is in its own
+		 * group and if it can make way for this MAC client.
 		 */
 		if (candidate_grp == NULL &&
 		    donorgrp != MAC_DEFAULT_RX_GROUP(mip) &&
@@ -6661,15 +7132,15 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 			boolean_t	prim_grp = B_FALSE;
 
 			/*
-			 * Switch the MAC client from the candidate group
-			 * to the default group.. If this group was the
-			 * donor group, then after the switch we need
-			 * to update the donor group too.
+			 * Switch the existing MAC client from the
+			 * candidate group to the default group. If
+			 * the candidate group is the donor group,
+			 * then after the switch we need to update the
+			 * donor group too.
 			 */
 			grp = candidate_grp;
-			gclient = MAC_GROUP_ONLY_CLIENT(grp);
-			if (gclient == NULL)
-				gclient = mac_get_grp_primary(grp);
+			gclient = grp->mrg_clients->mgc_client;
+			VERIFY3P(gclient, !=, NULL);
 			if (grp == mip->mi_rx_donor_grp)
 				prim_grp = B_TRUE;
 			if (mac_rx_switch_group(gclient, grp,
@@ -6681,7 +7152,6 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 				    MAC_DEFAULT_RX_GROUP(mip);
 				donorgrp = MAC_DEFAULT_RX_GROUP(mip);
 			}
-
 
 			/*
 			 * Now give this group with the required rings
@@ -6730,10 +7200,10 @@ mac_reserve_rx_group(mac_client_impl_t *mcip, uint8_t *mac_addr, boolean_t move)
 /*
  * mac_rx_release_group()
  *
- * This is called when there are no clients left for the group.
- * The group is stopped and marked MAC_GROUP_STATE_REGISTERED,
- * and if it is a non default group, the shares are removed and
- * all rings are assigned back to default group.
+ * Release the group when it has no remaining clients. The group is
+ * stopped and its shares are removed and all rings are assigned back
+ * to default group. This should never be called against the default
+ * group.
  */
 void
 mac_release_rx_group(mac_client_impl_t *mcip, mac_group_t *group)
@@ -6742,6 +7212,7 @@ mac_release_rx_group(mac_client_impl_t *mcip, mac_group_t *group)
 	mac_ring_t		*ring;
 
 	ASSERT(group != MAC_DEFAULT_RX_GROUP(mip));
+	ASSERT(MAC_GROUP_NO_CLIENT(group) == B_TRUE);
 
 	if (mip->mi_rx_donor_grp == group)
 		mip->mi_rx_donor_grp = MAC_DEFAULT_RX_GROUP(mip);
@@ -6793,56 +7264,7 @@ mac_release_rx_group(mac_client_impl_t *mcip, mac_group_t *group)
 }
 
 /*
- * When we move the primary's mac address between groups, we need to also
- * take all the clients sharing the same mac address along with it (VLANs)
- * We remove the mac address for such clients from the group after quiescing
- * them. When we add the mac address we restart the client. Note that
- * the primary's mac address is removed from the group after all the
- * other clients sharing the address are removed. Similarly, the primary's
- * mac address is added before all the other client's mac address are
- * added. While grp is the group where the clients reside, tgrp is
- * the group where the addresses have to be added.
- */
-static void
-mac_rx_move_macaddr_prim(mac_client_impl_t *mcip, mac_group_t *grp,
-    mac_group_t *tgrp, uint8_t *maddr, boolean_t add)
-{
-	mac_impl_t		*mip = mcip->mci_mip;
-	mac_grp_client_t	*mgcp = grp->mrg_clients;
-	mac_client_impl_t	*gmcip;
-	boolean_t		prim;
-
-	prim = (mcip->mci_state_flags & MCIS_UNICAST_HW) != 0;
-
-	/*
-	 * If the clients are in a non-default group, we just have to
-	 * walk the group's client list. If it is in the default group
-	 * (which will be shared by other clients as well, we need to
-	 * check if the unicast address matches mcip's unicast.
-	 */
-	while (mgcp != NULL) {
-		gmcip = mgcp->mgc_client;
-		if (gmcip != mcip &&
-		    (grp != MAC_DEFAULT_RX_GROUP(mip) ||
-		    mcip->mci_unicast == gmcip->mci_unicast)) {
-			if (!add) {
-				mac_rx_client_quiesce(
-				    (mac_client_handle_t)gmcip);
-				(void) mac_remove_macaddr(mcip->mci_unicast);
-			} else {
-				(void) mac_add_macaddr(mip, tgrp, maddr, prim);
-				mac_rx_client_restart(
-				    (mac_client_handle_t)gmcip);
-			}
-		}
-		mgcp = mgcp->mgc_next;
-	}
-}
-
-
-/*
- * Move the MAC address from fgrp to tgrp. If this is the primary client,
- * we need to take any VLANs etc. together too.
+ * Move the MAC address from fgrp to tgrp.
  */
 static int
 mac_rx_move_macaddr(mac_client_impl_t *mcip, mac_group_t *fgrp,
@@ -6851,56 +7273,86 @@ mac_rx_move_macaddr(mac_client_impl_t *mcip, mac_group_t *fgrp,
 	mac_impl_t		*mip = mcip->mci_mip;
 	uint8_t			maddr[MAXMACADDRLEN];
 	int			err = 0;
-	boolean_t		prim;
-	boolean_t		multiclnt = B_FALSE;
+	uint16_t		vid;
+	mac_unicast_impl_t	*muip;
+	boolean_t		use_hw;
 
 	mac_rx_client_quiesce((mac_client_handle_t)mcip);
-	ASSERT(mcip->mci_unicast != NULL);
+	VERIFY3P(mcip->mci_unicast, !=, NULL);
 	bcopy(mcip->mci_unicast->ma_addr, maddr, mcip->mci_unicast->ma_len);
 
-	prim = (mcip->mci_state_flags & MCIS_UNICAST_HW) != 0;
-	if (mcip->mci_unicast->ma_nusers > 1) {
-		mac_rx_move_macaddr_prim(mcip, fgrp, NULL, maddr, B_FALSE);
-		multiclnt = B_TRUE;
-	}
-	ASSERT(mcip->mci_unicast->ma_nusers == 1);
-	err = mac_remove_macaddr(mcip->mci_unicast);
+	/*
+	 * Does the client require MAC address hardware classifiction?
+	 */
+	use_hw = (mcip->mci_state_flags & MCIS_UNICAST_HW) != 0;
+	vid = i_mac_flow_vid(mcip->mci_flent);
+
+	/*
+	 * You can never move an address that is shared by multiple
+	 * clients. mac_datapath_setup() ensures that clients sharing
+	 * an address are placed on the default group. This guarantees
+	 * that a non-default group will only ever have one client and
+	 * thus make full use of HW filters.
+	 */
+	if (mac_check_macaddr_shared(mcip->mci_unicast))
+		return (EINVAL);
+
+	err = mac_remove_macaddr_vlan(mcip->mci_unicast, vid);
+
 	if (err != 0) {
 		mac_rx_client_restart((mac_client_handle_t)mcip);
-		if (multiclnt) {
-			mac_rx_move_macaddr_prim(mcip, fgrp, fgrp, maddr,
-			    B_TRUE);
-		}
 		return (err);
 	}
+
 	/*
-	 * Program the H/W Classifier first, if this fails we need
-	 * not proceed with the other stuff.
+	 * If this isn't the primary MAC address then the
+	 * mac_address_t has been freed by the last call to
+	 * mac_remove_macaddr_vlan(). In any case, NULL the reference
+	 * to avoid a dangling pointer.
 	 */
-	if ((err = mac_add_macaddr(mip, tgrp, maddr, prim)) != 0) {
+	mcip->mci_unicast = NULL;
+
+	/*
+	 * We also have to NULL all the mui_map references -- sun4v
+	 * strikes again!
+	 */
+	rw_enter(&mcip->mci_rw_lock, RW_WRITER);
+	for (muip = mcip->mci_unicast_list; muip != NULL; muip = muip->mui_next)
+		muip->mui_map = NULL;
+	rw_exit(&mcip->mci_rw_lock);
+
+	/*
+	 * Program the H/W Classifier first, if this fails we need not
+	 * proceed with the other stuff.
+	 */
+	if ((err = mac_add_macaddr_vlan(mip, tgrp, maddr, vid, use_hw)) != 0) {
+		int err2;
+
 		/* Revert back the H/W Classifier */
-		if ((err = mac_add_macaddr(mip, fgrp, maddr, prim)) != 0) {
-			/*
-			 * This should not fail now since it worked earlier,
-			 * should we panic?
-			 */
-			cmn_err(CE_WARN,
-			    "mac_rx_switch_group: switching %p back"
-			    " to group %p failed!!", (void *)mcip,
-			    (void *)fgrp);
+		err2 = mac_add_macaddr_vlan(mip, fgrp, maddr, vid, use_hw);
+
+		if (err2 != 0) {
+			cmn_err(CE_WARN, "Failed to revert HW classification"
+			    " on MAC %s, for client %s: %d.", mip->mi_name,
+			    mcip->mci_name, err2);
 		}
+
 		mac_rx_client_restart((mac_client_handle_t)mcip);
-		if (multiclnt) {
-			mac_rx_move_macaddr_prim(mcip, fgrp, fgrp, maddr,
-			    B_TRUE);
-		}
 		return (err);
 	}
+
+	/*
+	 * Get a reference to the new mac_address_t and update the
+	 * client's reference. Then restart the client and add the
+	 * other clients of this MAC addr (if they exsit).
+	 */
 	mcip->mci_unicast = mac_find_macaddr(mip, maddr);
+	rw_enter(&mcip->mci_rw_lock, RW_WRITER);
+	for (muip = mcip->mci_unicast_list; muip != NULL; muip = muip->mui_next)
+		muip->mui_map = mcip->mci_unicast;
+	rw_exit(&mcip->mci_rw_lock);
 	mac_rx_client_restart((mac_client_handle_t)mcip);
-	if (multiclnt)
-		mac_rx_move_macaddr_prim(mcip, fgrp, tgrp, maddr, B_TRUE);
-	return (err);
+	return (0);
 }
 
 /*
@@ -6921,19 +7373,34 @@ mac_rx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 	mac_impl_t		*mip = mcip->mci_mip;
 	mac_grp_client_t	*mgcp;
 
-	ASSERT(fgrp == mcip->mci_flent->fe_rx_ring_group);
+	VERIFY3P(fgrp, ==, mcip->mci_flent->fe_rx_ring_group);
 
 	if ((err = mac_rx_move_macaddr(mcip, fgrp, tgrp)) != 0)
 		return (err);
 
 	/*
-	 * The group might be reserved, but SRSs may not be set up, e.g.
-	 * primary and its vlans using a reserved group.
+	 * If the group is marked as reserved and in use by a single
+	 * client, then there is an SRS to teardown.
 	 */
 	if (fgrp->mrg_state == MAC_GROUP_STATE_RESERVED &&
 	    MAC_GROUP_ONLY_CLIENT(fgrp) != NULL) {
 		mac_rx_srs_group_teardown(mcip->mci_flent, B_TRUE);
 	}
+
+	/*
+	 * If we are moving the client from a non-default group, then
+	 * we know that any additional clients on this group share the
+	 * same MAC address. Since we moved the MAC address filter, we
+	 * need to move these clients too.
+	 *
+	 * If we are moving the client from the default group and its
+	 * MAC address has VLAN clients, then we must move those
+	 * clients as well.
+	 *
+	 * In both cases the idea is the same: we moved the MAC
+	 * address filter to the tgrp, so we must move all clients
+	 * using that MAC address to tgrp as well.
+	 */
 	if (fgrp != MAC_DEFAULT_RX_GROUP(mip)) {
 		mgcp = fgrp->mrg_clients;
 		while (mgcp != NULL) {
@@ -6944,20 +7411,21 @@ mac_rx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 			gmcip->mci_flent->fe_rx_ring_group = tgrp;
 		}
 		mac_release_rx_group(mcip, fgrp);
-		ASSERT(MAC_GROUP_NO_CLIENT(fgrp));
+		VERIFY3B(MAC_GROUP_NO_CLIENT(fgrp), ==, B_TRUE);
 		mac_set_group_state(fgrp, MAC_GROUP_STATE_REGISTERED);
 	} else {
 		mac_group_remove_client(fgrp, mcip);
 		mac_group_add_client(tgrp, mcip);
 		mcip->mci_flent->fe_rx_ring_group = tgrp;
+
 		/*
 		 * If there are other clients (VLANs) sharing this address
-		 * we should be here only for the primary.
+		 * then move them too.
 		 */
-		if (mcip->mci_unicast->ma_nusers > 1) {
+		if (mac_check_macaddr_shared(mcip->mci_unicast)) {
 			/*
 			 * We need to move all the clients that are using
-			 * this h/w address.
+			 * this MAC address.
 			 */
 			mgcp = fgrp->mrg_clients;
 			while (mgcp != NULL) {
@@ -6971,20 +7439,24 @@ mac_rx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 				}
 			}
 		}
+
 		/*
-		 * The default group will still take the multicast,
-		 * broadcast traffic etc., so it won't go to
+		 * The default group still handles multicast and
+		 * broadcast traffic; it won't transition to
 		 * MAC_GROUP_STATE_REGISTERED.
 		 */
 		if (fgrp->mrg_state == MAC_GROUP_STATE_RESERVED)
 			mac_rx_group_unmark(fgrp, MR_CONDEMNED);
 		mac_set_group_state(fgrp, MAC_GROUP_STATE_SHARED);
 	}
+
 	next_state = mac_group_next_state(tgrp, &group_only_mcip,
 	    MAC_DEFAULT_RX_GROUP(mip), B_TRUE);
 	mac_set_group_state(tgrp, next_state);
+
 	/*
-	 * If the destination group is reserved, setup the SRSs etc.
+	 * If the destination group is reserved, then setup the SRSes.
+	 * Otherwise make sure to use SW classification.
 	 */
 	if (tgrp->mrg_state == MAC_GROUP_STATE_RESERVED) {
 		mac_rx_srs_group_setup(mcip, mcip->mci_flent, SRST_LINK);
@@ -6995,6 +7467,7 @@ mac_rx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 	} else {
 		mac_rx_switch_grp_to_sw(tgrp);
 	}
+
 	return (0);
 }
 
@@ -7025,6 +7498,7 @@ mac_reserve_tx_group(mac_client_impl_t *mcip, boolean_t move)
 	boolean_t		isprimary;
 
 	isprimary = mcip->mci_flent->fe_type & FLOW_PRIMARY_MAC;
+
 	/*
 	 * When we come here for a VLAN on the primary (dladm create-vlan),
 	 * we need to pair it along with the primary (to keep it consistent
@@ -7106,8 +7580,7 @@ mac_reserve_tx_group(mac_client_impl_t *mcip, boolean_t move)
 			if (grp->mrg_state == MAC_GROUP_STATE_RESERVED &&
 			    candidate_grp == NULL) {
 				gclient = MAC_GROUP_ONLY_CLIENT(grp);
-				if (gclient == NULL)
-					gclient = mac_get_grp_primary(grp);
+				VERIFY3P(gclient, !=, NULL);
 				gmrp = MCIP_RESOURCE_PROPS(gclient);
 				if (gclient->mci_share == 0 &&
 				    (gmrp->mrp_mask & MRP_TX_RINGS) == 0 &&
@@ -7144,13 +7617,14 @@ mac_reserve_tx_group(mac_client_impl_t *mcip, boolean_t move)
 		 */
 		if (need_exclgrp && candidate_grp != NULL) {
 			/*
-			 * Switch the MAC client from the candidate group
-			 * to the default group.
+			 * Switch the MAC client from the candidate
+			 * group to the default group. We know the
+			 * candidate_grp came from a reserved group
+			 * and thus only has one client.
 			 */
 			grp = candidate_grp;
 			gclient = MAC_GROUP_ONLY_CLIENT(grp);
-			if (gclient == NULL)
-				gclient = mac_get_grp_primary(grp);
+			VERIFY3P(gclient, !=, NULL);
 			mac_tx_client_quiesce((mac_client_handle_t)gclient);
 			mac_tx_switch_group(gclient, grp, defgrp);
 			mac_tx_client_restart((mac_client_handle_t)gclient);
@@ -7318,7 +7792,7 @@ mac_tx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 		 */
 		mac_group_remove_client(fgrp, mcip);
 		mac_tx_dismantle_soft_rings(fgrp, flent);
-		if (mcip->mci_unicast->ma_nusers > 1) {
+		if (mac_check_macaddr_shared(mcip->mci_unicast)) {
 			mgcp = fgrp->mrg_clients;
 			while (mgcp != NULL) {
 				gmcip = mgcp->mgc_client;
@@ -7564,7 +8038,7 @@ mac_no_active(mac_handle_t mh)
  * changes and update the mac_resource_props_t for the VLAN's client.
  * We need to do this since we don't support setting these properties
  * on the primary's VLAN clients, but the VLAN clients have to
- * follow the primary w.r.t the rings property;
+ * follow the primary w.r.t the rings property.
  */
 void
 mac_set_prim_vlan_rings(mac_impl_t  *mip, mac_resource_props_t *mrp)
@@ -7713,13 +8187,10 @@ mac_group_ring_modify(mac_client_impl_t *mcip, mac_group_t *group,
 				    MAC_GROUP_STATE_RESERVED) {
 					continue;
 				}
-				mcip = MAC_GROUP_ONLY_CLIENT(tgrp);
-				if (mcip == NULL)
-					mcip = mac_get_grp_primary(tgrp);
-				ASSERT(mcip != NULL);
-				mrp = MCIP_RESOURCE_PROPS(mcip);
-				if ((mrp->mrp_mask & MRP_RX_RINGS) != 0)
+				if (i_mac_clients_hw(tgrp, MRP_RX_RINGS))
 					continue;
+				mcip = tgrp->mrg_clients->mgc_client;
+				VERIFY3P(mcip, !=, NULL);
 				if ((tgrp->mrg_cur_count +
 				    defgrp->mrg_cur_count) < (modify + 1)) {
 					continue;
@@ -7734,12 +8205,10 @@ mac_group_ring_modify(mac_client_impl_t *mcip, mac_group_t *group,
 				    MAC_GROUP_STATE_RESERVED) {
 					continue;
 				}
-				mcip = MAC_GROUP_ONLY_CLIENT(tgrp);
-				if (mcip == NULL)
-					mcip = mac_get_grp_primary(tgrp);
-				mrp = MCIP_RESOURCE_PROPS(mcip);
-				if ((mrp->mrp_mask & MRP_TX_RINGS) != 0)
+				if (i_mac_clients_hw(tgrp, MRP_TX_RINGS))
 					continue;
+				mcip = tgrp->mrg_clients->mgc_client;
+				VERIFY3P(mcip, !=, NULL);
 				if ((tgrp->mrg_cur_count +
 				    defgrp->mrg_cur_count) < (modify + 1)) {
 					continue;
@@ -8009,10 +8478,10 @@ mac_pool_event_cb(pool_event_t what, poolid_t id, void *arg)
  * Set effective rings property. This could be called from datapath_setup/
  * datapath_teardown or set-linkprop.
  * If the group is reserved we just go ahead and set the effective rings.
- * Additionally, for TX this could mean the default  group has lost/gained
+ * Additionally, for TX this could mean the default group has lost/gained
  * some rings, so if the default group is reserved, we need to adjust the
  * effective rings for the default group clients. For RX, if we are working
- * with the non-default group, we just need * to reset the effective props
+ * with the non-default group, we just need to reset the effective props
  * for the default group clients.
  */
 void
@@ -8142,6 +8611,7 @@ mac_check_primary_relocation(mac_client_impl_t *mcip, boolean_t rxhw)
 	 * the first non-primary.
 	 */
 	ASSERT(mip->mi_nactiveclients == 2);
+
 	/*
 	 * OK, now we have the primary that needs to be relocated.
 	 */

--- a/usr/src/uts/common/io/mac/mac_client.c
+++ b/usr/src/uts/common/io/mac/mac_client.c
@@ -866,9 +866,12 @@ mac_unicast_update_client_flow(mac_client_impl_t *mcip)
 	mac_protect_update_mac_token(mcip);
 
 	/*
-	 * A MAC client could have one MAC address but multiple
-	 * VLANs. In that case update the flow entries corresponding
-	 * to all VLANs of the MAC client.
+	 * When there are multiple VLANs sharing the same MAC address,
+	 * each gets its own MAC client, except when running on sun4v
+	 * vsw. In that case the mci_flent_list is used to place
+	 * multiple VLAN flows on one MAC client. If we ever get rid
+	 * of vsw then this code can go, but until then we need to
+	 * update all flow entries.
 	 */
 	for (flent = mcip->mci_flent_list; flent != NULL;
 	    flent = flent->fe_client_next) {
@@ -1026,7 +1029,7 @@ mac_unicast_primary_set(mac_handle_t mh, const uint8_t *addr)
 		return (0);
 	}
 
-	if (mac_find_macaddr(mip, (uint8_t *)addr) != 0) {
+	if (mac_find_macaddr(mip, (uint8_t *)addr) != NULL) {
 		i_mac_perim_exit(mip);
 		return (EBUSY);
 	}
@@ -1041,9 +1044,9 @@ mac_unicast_primary_set(mac_handle_t mh, const uint8_t *addr)
 		mac_capab_aggr_t aggr_cap;
 
 		/*
-		 * If the mac is an aggregation, other than the unicast
+		 * If the MAC is an aggregation, other than the unicast
 		 * addresses programming, aggr must be informed about this
-		 * primary unicst address change to change its mac address
+		 * primary unicst address change to change its MAC address
 		 * policy to be user-specified.
 		 */
 		ASSERT(map->ma_type == MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED);
@@ -1375,7 +1378,7 @@ mac_client_open(mac_handle_t mh, mac_client_handle_t *mchp, char *name,
 		mcip->mci_state_flags |= MCIS_IS_AGGR_PORT;
 
 	if (mip->mi_state_flags & MIS_IS_AGGR)
-		mcip->mci_state_flags |= MCIS_IS_AGGR;
+		mcip->mci_state_flags |= MCIS_IS_AGGR_CLIENT;
 
 	if ((flags & MAC_OPEN_FLAGS_USE_DATALINK_NAME) != 0) {
 		datalink_id_t	linkid;
@@ -1434,6 +1437,7 @@ mac_client_open(mac_handle_t mh, mac_client_handle_t *mchp, char *name,
 	mcip->mci_flent = flent;
 	FLOW_MARK(flent, FE_MC_NO_DATAPATH);
 	flent->fe_mcip = mcip;
+
 	/*
 	 * Place initial creation reference on the flow. This reference
 	 * is released in the corresponding delete action viz.
@@ -1540,7 +1544,8 @@ mac_client_close(mac_client_handle_t mch, uint16_t flags)
 }
 
 /*
- * Set the rx bypass receive callback.
+ * Set the Rx bypass receive callback and return B_TRUE. Return
+ * B_FALSE if it's not possible to enable bypass.
  */
 boolean_t
 mac_rx_bypass_set(mac_client_handle_t mch, mac_direct_rx_t rx_fn, void *arg1)
@@ -1551,11 +1556,11 @@ mac_rx_bypass_set(mac_client_handle_t mch, mac_direct_rx_t rx_fn, void *arg1)
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mip));
 
 	/*
-	 * If the mac_client is a VLAN, we should not do DLS bypass and
-	 * instead let the packets come up via mac_rx_deliver so the vlan
-	 * header can be stripped.
+	 * If the client has more than one VLAN then process packets
+	 * through DLS. This should happen only when sun4v vsw is on
+	 * the scene.
 	 */
-	if (mcip->mci_nvids > 0)
+	if (mcip->mci_nvids > 1)
 		return (B_FALSE);
 
 	/*
@@ -1609,8 +1614,8 @@ mac_rx_set(mac_client_handle_t mch, mac_rx_t rx_fn, void *arg)
 	i_mac_perim_exit(mip);
 
 	/*
-	 * If we're changing the rx function on the primary mac of a vnic,
-	 * make sure any secondary macs on the vnic are updated as well.
+	 * If we're changing the Rx function on the primary MAC of a VNIC,
+	 * make sure any secondary addresses on the VNIC are updated as well.
 	 */
 	if (umip != NULL) {
 		ASSERT((umip->mi_state_flags & MIS_IS_VNIC) != 0);
@@ -1814,6 +1819,14 @@ mac_client_set_rings_prop(mac_client_impl_t *mcip, mac_resource_props_t *mrp,
 				}
 			/* Let check if we can give this an excl group */
 			} else if (group == defgrp) {
+				/*
+				 * If multiple clients share an
+				 * address then they must stay on the
+				 * default group.
+				 */
+				if (mac_check_macaddr_shared(mcip->mci_unicast))
+					return (0);
+
 				ngrp = mac_reserve_rx_group(mcip, mac_addr,
 				    B_TRUE);
 				/* Couldn't give it a group, that's fine */
@@ -1836,6 +1849,16 @@ mac_client_set_rings_prop(mac_client_impl_t *mcip, mac_resource_props_t *mrp,
 		}
 
 		if (group == defgrp && ((mrp->mrp_nrxrings > 0) || unspec)) {
+			/*
+			 * We are requesting Rx rings. Try to reserve
+			 * a non-default group.
+			 *
+			 * If multiple clients share an address then
+			 * they must stay on the default group.
+			 */
+			if (mac_check_macaddr_shared(mcip->mci_unicast))
+				return (EINVAL);
+
 			ngrp = mac_reserve_rx_group(mcip, mac_addr, B_TRUE);
 			if (ngrp == NULL)
 				return (ENOSPC);
@@ -2193,10 +2216,10 @@ mac_unicast_flow_create(mac_client_impl_t *mcip, uint8_t *mac_addr,
 		flent_flags = FLOW_VNIC_MAC;
 
 	/*
-	 * For the first flow we use the mac client's name - mci_name, for
-	 * subsequent ones we just create a name with the vid. This is
+	 * For the first flow we use the MAC client's name - mci_name, for
+	 * subsequent ones we just create a name with the VID. This is
 	 * so that we can add these flows to the same flow table. This is
-	 * fine as the flow name (except for the one with the mac client's
+	 * fine as the flow name (except for the one with the MAC client's
 	 * name) is not visible. When the first flow is removed, we just replace
 	 * its fdesc with another from the list, so we will still retain the
 	 * flent with the MAC client's flow name.
@@ -2354,6 +2377,7 @@ mac_client_datapath_setup(mac_client_impl_t *mcip, uint16_t vid,
 		 * The unicast MAC address must have been added successfully.
 		 */
 		ASSERT(mcip->mci_unicast != NULL);
+
 		/*
 		 * Push down the sub-flows that were defined on this link
 		 * hitherto. The flows are added to the active flow table
@@ -2365,15 +2389,23 @@ mac_client_datapath_setup(mac_client_impl_t *mcip, uint16_t vid,
 
 		ASSERT(!no_unicast);
 		/*
-		 * A unicast flow already exists for that MAC client,
-		 * this flow must be the same mac address but with
-		 * different VID. It has been checked by mac_addr_in_use().
+		 * A unicast flow already exists for that MAC client
+		 * so this flow must be the same MAC address but with
+		 * a different VID. It has been checked by
+		 * mac_addr_in_use().
 		 *
-		 * We will use the SRS etc. from the mci_flent. Note that
-		 * We don't need to create kstat for this as except for
-		 * the fdesc, everything will be used from in the 1st flent.
+		 * We will use the SRS etc. from the initial
+		 * mci_flent. We don't need to create a kstat for
+		 * this, as except for the fdesc, everything will be
+		 * used from the first flent.
+		 *
+		 * The only time we should see multiple flents on the
+		 * same MAC client is on the sun4v vsw. If we removed
+		 * that code we should be able to remove the entire
+		 * notion of multiple flents on a MAC client (this
+		 * doesn't affect sub/user flows because they have
+		 * their own list unrelated to mci_flent_list).
 		 */
-
 		if (bcmp(mac_addr, map->ma_addr, map->ma_len) != 0) {
 			err = EINVAL;
 			goto bail;
@@ -2433,7 +2465,17 @@ done_setup:
 	if (flent->fe_rx_ring_group != NULL)
 		mac_rx_group_unmark(flent->fe_rx_ring_group, MR_INCIPIENT);
 	FLOW_UNMARK(flent, FE_INCIPIENT);
-	FLOW_UNMARK(flent, FE_MC_NO_DATAPATH);
+
+	/*
+	 * If this is an aggr port client, don't enable the flow's
+	 * datapath at this stage. Otherwise, bcast traffic could
+	 * arrive while the aggr port is in the process of
+	 * initializing. Instead, the flow's datapath is started later
+	 * when mac_client_set_flow_cb() is called.
+	 */
+	if ((mcip->mci_state_flags & MCIS_IS_AGGR_PORT) == 0)
+		FLOW_UNMARK(flent, FE_MC_NO_DATAPATH);
+
 	mac_tx_client_unblock(mcip);
 	return (0);
 bail:
@@ -2502,8 +2544,12 @@ i_mac_unicast_add(mac_client_handle_t mch, uint8_t *mac_addr, uint16_t flags,
 	boolean_t		is_vnic_primary =
 	    (flags & MAC_UNICAST_VNIC_PRIMARY);
 
-	/* when VID is non-zero, the underlying MAC can not be VNIC */
-	ASSERT(!((mip->mi_state_flags & MIS_IS_VNIC) && (vid != 0)));
+	/*
+	 * When the VID is non-zero the underlying MAC cannot be a
+	 * VNIC. I.e., dladm create-vlan cannot take a VNIC as
+	 * argument, only the primary MAC client.
+	 */
+	ASSERT(!((mip->mi_state_flags & MIS_IS_VNIC) && (vid != VLAN_ID_NONE)));
 
 	/*
 	 * Can't unicast add if the client asked only for minimal datapath
@@ -2516,18 +2562,19 @@ i_mac_unicast_add(mac_client_handle_t mch, uint8_t *mac_addr, uint16_t flags,
 	 * Check for an attempted use of the current Port VLAN ID, if enabled.
 	 * No client may use it.
 	 */
-	if (mip->mi_pvid != 0 && vid == mip->mi_pvid)
+	if (mip->mi_pvid != VLAN_ID_NONE && vid == mip->mi_pvid)
 		return (EBUSY);
 
 	/*
 	 * Check whether it's the primary client and flag it.
 	 */
-	if (!(mcip->mci_state_flags & MCIS_IS_VNIC) && is_primary && vid == 0)
+	if (!(mcip->mci_state_flags & MCIS_IS_VNIC) && is_primary &&
+	    vid == VLAN_ID_NONE)
 		mcip->mci_flags |= MAC_CLIENT_FLAGS_PRIMARY;
 
 	/*
 	 * is_vnic_primary is true when we come here as a VLAN VNIC
-	 * which uses the primary mac client's address but with a non-zero
+	 * which uses the primary MAC client's address but with a non-zero
 	 * VID. In this case the MAC address is not specified by an upper
 	 * MAC client.
 	 */
@@ -2579,7 +2626,7 @@ i_mac_unicast_add(mac_client_handle_t mch, uint8_t *mac_addr, uint16_t flags,
 		/*
 		 * Create a handle for vid 0.
 		 */
-		ASSERT(vid == 0);
+		ASSERT(vid == VLAN_ID_NONE);
 		muip = kmem_zalloc(sizeof (mac_unicast_impl_t), KM_SLEEP);
 		muip->mui_vid = vid;
 		*mah = (mac_unicast_handle_t)muip;
@@ -2599,7 +2646,9 @@ i_mac_unicast_add(mac_client_handle_t mch, uint8_t *mac_addr, uint16_t flags,
 	}
 
 	/*
-	 * If this is a VNIC/VLAN, disable softmac fast-path.
+	 * If this is a VNIC/VLAN, disable softmac fast-path. This is
+	 * only relevant to legacy devices which use softmac to
+	 * interface with GLDv3.
 	 */
 	if (mcip->mci_state_flags & MCIS_IS_VNIC) {
 		err = mac_fastpath_disable((mac_handle_t)mip);
@@ -2647,9 +2696,11 @@ i_mac_unicast_add(mac_client_handle_t mch, uint8_t *mac_addr, uint16_t flags,
 		(void) mac_client_set_resources(mch, mrp);
 	} else if (mcip->mci_state_flags & MCIS_IS_VNIC) {
 		/*
-		 * This is a primary VLAN client, we don't support
-		 * specifying rings property for this as it inherits the
-		 * rings property from its MAC.
+		 * This is a VLAN client sharing the address of the
+		 * primary MAC client; i.e., one created via dladm
+		 * create-vlan. We don't support specifying ring
+		 * properties for this type of client as it inherits
+		 * these from the primary MAC client.
 		 */
 		if (is_vnic_primary) {
 			mac_resource_props_t	*vmrp;
@@ -2708,7 +2759,7 @@ i_mac_unicast_add(mac_client_handle_t mch, uint8_t *mac_addr, uint16_t flags,
 
 	/*
 	 * Set the flags here so that if this is a passive client, we
-	 * can return  and set it when we call mac_client_datapath_setup
+	 * can return and set it when we call mac_client_datapath_setup
 	 * when this becomes the active client. If we defer to using these
 	 * flags to mac_client_datapath_setup, then for a passive client,
 	 * we'd have to store the flags somewhere (probably fe_flags)
@@ -3011,14 +3062,14 @@ mac_unicast_remove(mac_client_handle_t mch, mac_unicast_handle_t mah)
 	i_mac_perim_enter(mip);
 	if (mcip->mci_flags & MAC_CLIENT_FLAGS_VNIC_PRIMARY) {
 		/*
-		 * Called made by the upper MAC client of a VNIC.
+		 * Call made by the upper MAC client of a VNIC.
 		 * There's nothing much to do, the unicast address will
 		 * be removed by the VNIC driver when the VNIC is deleted,
 		 * but let's ensure that all our transmit is done before
 		 * the client does a mac_client_stop lest it trigger an
 		 * assert in the driver.
 		 */
-		ASSERT(muip->mui_vid == 0);
+		ASSERT(muip->mui_vid == VLAN_ID_NONE);
 
 		mac_tx_client_flush(mcip);
 
@@ -3082,6 +3133,7 @@ mac_unicast_remove(mac_client_handle_t mch, mac_unicast_handle_t mah)
 		i_mac_perim_exit(mip);
 		return (0);
 	}
+
 	/*
 	 * Remove the VID from the list of client's VIDs.
 	 */
@@ -3108,7 +3160,7 @@ mac_unicast_remove(mac_client_handle_t mch, mac_unicast_handle_t mah)
 		 * flows.
 		 */
 		flent = mac_client_get_flow(mcip, muip);
-		ASSERT(flent != NULL);
+		VERIFY3P(flent, !=, NULL);
 
 		/*
 		 * The first one is disappearing, need to make sure
@@ -3136,6 +3188,7 @@ mac_unicast_remove(mac_client_handle_t mch, mac_unicast_handle_t mah)
 
 		FLOW_FINAL_REFRELE(flent);
 		ASSERT(!(mcip->mci_state_flags & MCIS_EXCLUSIVE));
+
 		/*
 		 * Enable fastpath if this is a VNIC or a VLAN.
 		 */
@@ -3149,7 +3202,8 @@ mac_unicast_remove(mac_client_handle_t mch, mac_unicast_handle_t mah)
 	mui_vid = muip->mui_vid;
 	mac_client_datapath_teardown(mch, muip, flent);
 
-	if ((mcip->mci_flags & MAC_CLIENT_FLAGS_PRIMARY) && mui_vid == 0) {
+	if ((mcip->mci_flags & MAC_CLIENT_FLAGS_PRIMARY) &&
+	    mui_vid == VLAN_ID_NONE) {
 		mcip->mci_flags &= ~MAC_CLIENT_FLAGS_PRIMARY;
 	} else {
 		i_mac_perim_exit(mip);

--- a/usr/src/uts/common/io/mac/mac_datapath_setup.c
+++ b/usr/src/uts/common/io/mac/mac_datapath_setup.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017, Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #include <sys/types.h>
@@ -1197,7 +1197,7 @@ mac_srs_fanout_list_alloc(mac_soft_ring_set_t *mac_srs)
 		mac_srs->srs_tx_soft_rings = (mac_soft_ring_t **)
 		    kmem_zalloc(sizeof (mac_soft_ring_t *) *
 		    MAX_RINGS_PER_GROUP, KM_SLEEP);
-		if (mcip->mci_state_flags & MCIS_IS_AGGR) {
+		if (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT) {
 			mac_srs_tx_t *tx = &mac_srs->srs_tx;
 
 			tx->st_soft_rings = (mac_soft_ring_t **)
@@ -1606,13 +1606,13 @@ mac_srs_update_bwlimit(flow_entry_t *flent, mac_resource_props_t *mrp)
 
 /*
  * When the first sub-flow is added to a link, we disable polling on the
- * link and also modify the entry point to mac_rx_srs_subflow_process.
+ * link and also modify the entry point to mac_rx_srs_subflow_process().
  * (polling is disabled because with the subflow added, accounting
  * for polling needs additional logic, it is assumed that when a subflow is
  * added, we can take some hit as a result of disabling polling rather than
  * adding more complexity - if this becomes a perf. issue we need to
  * re-rvaluate this logic).  When the last subflow is removed, we turn back
- * polling and also reset the entry point to mac_rx_srs_process.
+ * polling and also reset the entry point to mac_rx_srs_process().
  *
  * In the future if there are multiple SRS, we can simply
  * take one and give it to the flow rather than disabling polling and
@@ -1657,7 +1657,7 @@ mac_client_update_classifier(mac_client_impl_t *mcip, boolean_t enable)
 	 * Change the S/W classifier so that we can land in the
 	 * correct processing function with correct argument.
 	 * If all subflows have been removed we can revert to
-	 * mac_rx_srsprocess, else we need mac_rx_srs_subflow_process.
+	 * mac_rx_srs_process(), else we need mac_rx_srs_subflow_process().
 	 */
 	mutex_enter(&flent->fe_lock);
 	flent->fe_cb_fn = (flow_fn_t)rx_func;
@@ -1986,8 +1986,6 @@ no_softrings:
 }
 
 /*
- * mac_fanout_setup:
- *
  * Calls mac_srs_fanout_init() or modify() depending upon whether
  * the SRS is getting initialized or re-initialized.
  */
@@ -2000,14 +1998,14 @@ mac_fanout_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	int i, rx_srs_cnt;
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mcip->mci_mip));
-	/*
-	 * This is an aggregation port. Fanout will be setup
-	 * over the aggregation itself.
-	 */
-	if (mcip->mci_state_flags & MCIS_EXCLUSIVE)
-		return;
 
+	/*
+	 * Aggr ports do not have SRSes. This function should never be
+	 * called on an aggr port.
+	 */
+	ASSERT3U((mcip->mci_state_flags & MCIS_IS_AGGR_PORT), ==, 0);
 	mac_rx_srs = flent->fe_rx_srs[0];
+
 	/*
 	 * Set up the fanout on the tx side only once, with the
 	 * first rx SRS. The CPU binding, fanout, and bandwidth
@@ -2063,8 +2061,6 @@ mac_fanout_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 }
 
 /*
- * mac_srs_create:
- *
  * Create a mac_soft_ring_set_t (SRS). If soft_ring_fanout_type is
  * SRST_TX, an SRS for Tx side is created. Otherwise an SRS for Rx side
  * processing is created.
@@ -2196,7 +2192,7 @@ mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
 	 *    find nothing plus we have an existing backlog
 	 *    (sr_poll_pkt_cnt > 0), we stay in polling mode but don't poll
 	 *    the H/W for packets anymore (let the polling thread go to sleep).
-	 * 5) Once the backlog is relived (packets are processed) we reenable
+	 * 5) Once the backlog is relieved (packets are processed) we reenable
 	 *    polling (by signalling the poll thread) only when the backlog
 	 *    dips below sr_poll_thres.
 	 * 6) sr_hiwat is used exclusively when we are not polling capable
@@ -2267,8 +2263,8 @@ mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
 		/*
 		 * Some drivers require serialization and don't send
 		 * packet chains in interrupt context. For such
-		 * drivers, we should always queue in soft ring
-		 * so that we get a chance to switch into a polling
+		 * drivers, we should always queue in the soft ring
+		 * so that we get a chance to switch into polling
 		 * mode under backlog.
 		 */
 		ring_info = mac_hwring_getinfo((mac_ring_handle_t)ring);
@@ -2366,6 +2362,10 @@ mac_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	mac_rx_srs_group_setup(mcip, flent, link_type);
 	mac_tx_srs_group_setup(mcip, flent, link_type);
 
+	/* Aggr ports don't have SRSes; thus there is no soft ring fanout. */
+	if ((mcip->mci_state_flags & MCIS_IS_AGGR_PORT) != 0)
+		return;
+
 	pool_lock();
 	cpupart = mac_pset_find(mrp, &use_default);
 	mac_fanout_setup(mcip, flent, MCIP_RESOURCE_PROPS(mcip),
@@ -2375,9 +2375,11 @@ mac_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 }
 
 /*
- * Set up the RX SRSs. If the S/W SRS is not set, set  it up, if there
- * is a group associated with this MAC client, set up SRSs for individual
- * h/w rings.
+ * Set up the Rx SRSes. If there is no group associated with the
+ * client, then only setup SW classification. If the client has
+ * exlusive (MAC_GROUP_STATE_RESERVED) use of the group, then create an
+ * SRS for each HW ring. If the client is sharing a group, then make
+ * sure to teardown the HW SRSes.
  */
 void
 mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
@@ -2388,13 +2390,37 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	mac_ring_t		*ring;
 	uint32_t		fanout_type;
 	mac_group_t		*rx_group = flent->fe_rx_ring_group;
+	boolean_t		no_unicast;
+
+	/*
+	 * If this is an an aggr port, then don't setup Rx SRS and Rx
+	 * soft rings as they won't be used. However, we still need to
+	 * start the rings to receive data on them.
+	 */
+	if (mcip->mci_state_flags & MCIS_IS_AGGR_PORT) {
+		if (rx_group == NULL)
+			return;
+
+		for (ring = rx_group->mrg_rings; ring != NULL;
+		    ring = ring->mr_next) {
+			if (ring->mr_state != MR_INUSE)
+				(void) mac_start_ring(ring);
+		}
+
+		return;
+	}
+
+	/*
+	 * Aggr ports should never have SRSes.
+	 */
+	ASSERT3U((mcip->mci_state_flags & MCIS_IS_AGGR_PORT), ==, 0);
 
 	fanout_type = mac_find_fanout(flent, link_type);
+	no_unicast = (mcip->mci_state_flags & MCIS_NO_UNICAST_ADDR) != 0;
 
-	/* Create the SRS for S/W classification if none exists */
+	/* Create the SRS for SW classification if none exists */
 	if (flent->fe_rx_srs[0] == NULL) {
 		ASSERT(flent->fe_rx_srs_cnt == 0);
-		/* Setup the Rx SRS */
 		mac_srs = mac_srs_create(mcip, flent, fanout_type | link_type,
 		    mac_rx_deliver, mcip, NULL, NULL);
 		mutex_enter(&flent->fe_lock);
@@ -2406,15 +2432,17 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 
 	if (rx_group == NULL)
 		return;
+
 	/*
-	 * fanout for default SRS is done when default SRS are created
-	 * above. As each ring is added to the group, we setup the
-	 * SRS and fanout to it.
+	 * If the group is marked RESERVED then setup an SRS and
+	 * fanout for each HW ring.
 	 */
 	switch (rx_group->mrg_state) {
 	case MAC_GROUP_STATE_RESERVED:
 		for (ring = rx_group->mrg_rings; ring != NULL;
 		    ring = ring->mr_next) {
+			uint16_t vid = i_mac_flow_vid(mcip->mci_flent);
+
 			switch (ring->mr_state) {
 			case MR_INUSE:
 			case MR_FREE:
@@ -2424,20 +2452,23 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 					(void) mac_start_ring(ring);
 
 				/*
-				 * Since the group is exclusively ours create
-				 * an SRS for this ring to allow the
-				 * individual SRS to dynamically poll the
-				 * ring. Do this only if the  client is not
-				 * a VLAN MAC client, since for VLAN we do
-				 * s/w classification for the VID check, and
-				 * if it has a unicast address.
+				 * If a client requires SW VLAN
+				 * filtering or has no unicast address
+				 * then we don't create any HW ring
+				 * SRSes.
 				 */
-				if ((mcip->mci_state_flags &
-				    MCIS_NO_UNICAST_ADDR) ||
-				    i_mac_flow_vid(mcip->mci_flent) !=
-				    VLAN_ID_NONE) {
+				if ((!MAC_GROUP_HW_VLAN(rx_group) &&
+				    vid != VLAN_ID_NONE) || no_unicast)
 					break;
-				}
+
+				/*
+				 * When a client has exclusive use of
+				 * a group, and that group's traffic
+				 * is fully HW classified, we create
+				 * an SRS for each HW ring in order to
+				 * make use of dynamic polling of said
+				 * HW rings.
+				 */
 				mac_srs = mac_srs_create(mcip, flent,
 				    fanout_type | link_type,
 				    mac_rx_deliver, mcip, NULL, ring);
@@ -2453,14 +2484,9 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 		break;
 	case MAC_GROUP_STATE_SHARED:
 		/*
-		 * Set all rings of this group to software classified.
-		 *
-		 * If the group is current RESERVED, the existing mac
-		 * client (the only client on this group) is using
-		 * this group exclusively.  In that case we need to
-		 * disable polling on the rings of the group (if it
-		 * was enabled), and free the SRS associated with the
-		 * rings.
+		 * When a group is shared by multiple clients, we must
+		 * use SW classifiction to ensure packets are
+		 * delivered to the correct client.
 		 */
 		mac_rx_switch_grp_to_sw(rx_group);
 		break;
@@ -2477,46 +2503,49 @@ void
 mac_tx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
     uint32_t link_type)
 {
-	int			cnt;
-	int			ringcnt;
-	mac_ring_t		*ring;
-	mac_group_t		*grp;
-
 	/*
-	 * If we are opened exclusively (like aggr does for aggr_ports),
-	 * don't set up Tx SRS and Tx soft rings as they won't be used.
-	 * The same thing has to be done for Rx side also. See bug:
-	 * 6880080
+	 * If this is an exclusive client (e.g. an aggr port), then
+	 * don't setup Tx SRS and Tx soft rings as they won't be used.
+	 * However, we still need to start the rings to send data
+	 * across them.
 	 */
 	if (mcip->mci_state_flags & MCIS_EXCLUSIVE) {
-		/*
-		 * If we have rings, start them here.
-		 */
-		if (flent->fe_tx_ring_group == NULL)
-			return;
+		mac_ring_t		*ring;
+		mac_group_t		*grp;
+
 		grp = (mac_group_t *)flent->fe_tx_ring_group;
-		ringcnt = grp->mrg_cur_count;
-		ring = grp->mrg_rings;
-		for (cnt = 0; cnt < ringcnt; cnt++) {
-			if (ring->mr_state != MR_INUSE) {
+
+		if (grp == NULL)
+			return;
+
+		for (ring = grp->mrg_rings; ring != NULL;
+		    ring = ring->mr_next) {
+			if (ring->mr_state != MR_INUSE)
 				(void) mac_start_ring(ring);
-			}
-			ring = ring->mr_next;
 		}
+
 		return;
 	}
+
+	/*
+	 * Aggr ports should never have SRSes.
+	 */
+	ASSERT3U((mcip->mci_state_flags & MCIS_IS_AGGR_PORT), ==, 0);
+
 	if (flent->fe_tx_srs == NULL) {
 		(void) mac_srs_create(mcip, flent, SRST_TX | link_type,
 		    NULL, mcip, NULL, NULL);
 	}
+
 	mac_tx_srs_setup(mcip, flent);
 }
 
 /*
- * Remove all the RX SRSs. If we want to remove only the SRSs associated
- * with h/w rings, leave the S/W SRS alone. This is used when we want to
- * move the MAC client from one group to another, so we need to teardown
- * on the h/w SRSs.
+ * Teardown all the Rx SRSes. Unless hwonly is set, then only teardown
+ * the Rx HW SRSes and leave the SW SRS alone. The hwonly flag is set
+ * when we wish to move a MAC client from one group to another. In
+ * that case, we need to release the current HW SRSes but keep the SW
+ * SRS for continued traffic classifiction.
  */
 void
 mac_rx_srs_group_teardown(flow_entry_t *flent, boolean_t hwonly)
@@ -2534,8 +2563,16 @@ mac_rx_srs_group_teardown(flow_entry_t *flent, boolean_t hwonly)
 		flent->fe_rx_srs[i] = NULL;
 		flent->fe_rx_srs_cnt--;
 	}
-	ASSERT(!hwonly || flent->fe_rx_srs_cnt == 1);
-	ASSERT(hwonly || flent->fe_rx_srs_cnt == 0);
+
+	/*
+	 * If we are only tearing down the HW SRSes then there must be
+	 * one SRS left for SW classification. Otherwise we are tearing
+	 * down both HW and SW and there should be no SRSes left.
+	 */
+	if (hwonly)
+		VERIFY3S(flent->fe_rx_srs_cnt, ==, 1);
+	else
+		VERIFY3S(flent->fe_rx_srs_cnt, ==, 0);
 }
 
 /*
@@ -2837,6 +2874,7 @@ mac_group_next_state(mac_group_t *grp, mac_client_impl_t **group_only_mcip,
  * even if this is the only client in the default group, we will
  * leave group as shared).
  */
+
 int
 mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
     uint32_t link_type)
@@ -2847,6 +2885,7 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	mac_group_t		*default_rgroup;
 	mac_group_t		*default_tgroup;
 	int			err;
+	uint16_t		vid;
 	uint8_t			*mac_addr;
 	mac_group_state_t	next_state;
 	mac_client_impl_t	*group_only_mcip;
@@ -2859,6 +2898,7 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	boolean_t		no_unicast;
 	boolean_t		isprimary = flent->fe_type & FLOW_PRIMARY_MAC;
 	mac_client_impl_t	*reloc_pmcip = NULL;
+	boolean_t		use_hw;
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mip));
 
@@ -2890,15 +2930,19 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 		    (mrp->mrp_mask & MRP_TXRINGS_UNSPEC));
 
 		/*
-		 * By default we have given the primary all the rings
-		 * i.e. the default group. Let's see if the primary
-		 * needs to be relocated so that the addition of this
-		 * client doesn't impact the primary's performance,
-		 * i.e. if the primary is in the default group and
-		 * we add this client, the primary will lose polling.
-		 * We do this only for NICs supporting dynamic ring
-		 * grouping and only when this is the first client
-		 * after the primary (i.e. nactiveclients is 2)
+		 * All the rings initially belong to the default group
+		 * under dynamic grouping. The primary client uses the
+		 * default group when it is the only client. The
+		 * default group is also used as the destination for
+		 * all multicast and broadcast traffic of all clients.
+		 * Therefore, the primary client loses its ability to
+		 * poll the softrings on addition of a second client.
+		 * To avoid a performance penalty, MAC will move the
+		 * primary client to a dedicated group when it can.
+		 *
+		 * When using static grouping, the primary client
+		 * begins life on a non-default group. There is
+		 * no moving needed upon addition of a second client.
 		 */
 		if (!isprimary && mip->mi_nactiveclients == 2 &&
 		    (group_only_mcip = mac_primary_client_handle(mip)) !=
@@ -2906,6 +2950,7 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 			reloc_pmcip = mac_check_primary_relocation(
 			    group_only_mcip, rxhw);
 		}
+
 		/*
 		 * Check to see if we can get an exclusive group for
 		 * this mac address or if there already exists a
@@ -2919,6 +2964,26 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 		} else if (rgroup == NULL) {
 			rgroup = default_rgroup;
 		}
+
+		/*
+		 * If we are adding a second client to a
+		 * non-default group then we need to move the
+		 * existing client to the default group and
+		 * add the new client to the default group as
+		 * well.
+		 */
+		if (rgroup != default_rgroup &&
+		    rgroup->mrg_state == MAC_GROUP_STATE_RESERVED) {
+			group_only_mcip = MAC_GROUP_ONLY_CLIENT(rgroup);
+			err = mac_rx_switch_group(group_only_mcip, rgroup,
+			    default_rgroup);
+
+			if (err != 0)
+				goto setup_failed;
+
+			rgroup = default_rgroup;
+		}
+
 		/*
 		 * Check to see if we can get an exclusive group for
 		 * this mac client. If no groups are available, use
@@ -2950,14 +3015,17 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 					    rgroup->mrg_cur_count);
 				}
 			}
+
 			flent->fe_rx_ring_group = rgroup;
 			/*
-			 * Add the client to the group. This could cause
-			 * either this group to move to the shared state or
-			 * cause the default group to move to the shared state.
-			 * The actions on this group are done here, while the
-			 * actions on the default group are postponed to
-			 * the end of this function.
+			 * Add the client to the group and update the
+			 * group's state. If rgroup != default_group
+			 * then the rgroup should only ever have one
+			 * client and be in the RESERVED state. But no
+			 * matter what, the default_rgroup will enter
+			 * the SHARED state since it has to receive
+			 * all broadcast and multicast traffic. This
+			 * case is handled later in the function.
 			 */
 			mac_group_add_client(rgroup, mcip);
 			next_state = mac_group_next_state(rgroup,
@@ -2982,28 +3050,37 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 			    &group_only_mcip, default_tgroup, B_FALSE);
 			tgroup->mrg_state = next_state;
 		}
-		/*
-		 * Setup the Rx and Tx SRSes. If we got a pristine group
-		 * exclusively above, mac_srs_group_setup would simply create
-		 * the required SRSes. If we ended up sharing a previously
-		 * reserved group, mac_srs_group_setup would also dismantle the
-		 * SRSes of the previously exclusive group
-		 */
-		mac_srs_group_setup(mcip, flent, link_type);
 
 		/* We are setting up minimal datapath only */
-		if (no_unicast)
+		if (no_unicast) {
+			mac_srs_group_setup(mcip, flent, link_type);
 			break;
-		/* Program the S/W Classifer */
+		}
+
+		/* Program software classification. */
 		if ((err = mac_flow_add(mip->mi_flow_tab, flent)) != 0)
 			goto setup_failed;
 
-		/* Program the H/W Classifier */
-		if ((err = mac_add_macaddr(mip, rgroup, mac_addr,
-		    (mcip->mci_state_flags & MCIS_UNICAST_HW) != 0)) != 0)
+		/* Program hardware classification. */
+		vid = i_mac_flow_vid(flent);
+		use_hw = (mcip->mci_state_flags & MCIS_UNICAST_HW) != 0;
+		err = mac_add_macaddr_vlan(mip, rgroup, mac_addr, vid, use_hw);
+
+		if (err != 0)
 			goto setup_failed;
+
 		mcip->mci_unicast = mac_find_macaddr(mip, mac_addr);
-		ASSERT(mcip->mci_unicast != NULL);
+		VERIFY3P(mcip->mci_unicast, !=, NULL);
+
+		/*
+		 * Setup the Rx and Tx SRSes. If the client has a
+		 * reserved group, then mac_srs_group_setup() creates
+		 * the required SRSes for the HW rings. If we have a
+		 * shared group, mac_srs_group_setup() dismantles the
+		 * HW SRSes of the previously exclusive group.
+		 */
+		mac_srs_group_setup(mcip, flent, link_type);
+
 		/* (Re)init the v6 token & local addr used by link protection */
 		mac_protect_update_mac_token(mcip);
 		break;
@@ -3047,17 +3124,23 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 			ASSERT(default_rgroup->mrg_state ==
 			    MAC_GROUP_STATE_SHARED);
 		}
+
 		/*
-		 * If we get an exclusive group for a VLAN MAC client we
-		 * need to take the s/w path to make the additional check for
-		 * the vid. Disable polling and set it to s/w classification.
-		 * Similarly for clients that don't have a unicast address.
+		 * A VLAN MAC client on a reserved group still
+		 * requires SW classification if the MAC doesn't
+		 * provide VLAN HW filtering.
+		 *
+		 * Clients with no unicast address also require SW
+		 * classification.
 		 */
 		if (rgroup->mrg_state == MAC_GROUP_STATE_RESERVED &&
-		    (i_mac_flow_vid(flent) != VLAN_ID_NONE || no_unicast)) {
+		    ((!MAC_GROUP_HW_VLAN(rgroup) && vid != VLAN_ID_NONE) ||
+		    no_unicast)) {
 			mac_rx_switch_grp_to_sw(rgroup);
 		}
+
 	}
+
 	mac_set_rings_effective(mcip);
 	return (0);
 
@@ -3083,6 +3166,7 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 	boolean_t		check_default_group = B_FALSE;
 	mac_group_state_t	next_state;
 	mac_resource_props_t	*mrp = MCIP_RESOURCE_PROPS(mcip);
+	uint16_t		vid;
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mip));
 
@@ -3095,16 +3179,24 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 	case SRST_LINK:
 		/* Stop sending packets */
 		mac_tx_client_block(mcip);
+		group = flent->fe_rx_ring_group;
+		vid = i_mac_flow_vid(flent);
 
-		/* Stop the packets coming from the H/W */
+		/*
+		 * Stop the packet flow from the hardware by disabling
+		 * any hardware filters assigned to this client.
+		 */
 		if (mcip->mci_unicast != NULL) {
 			int err;
-			err = mac_remove_macaddr(mcip->mci_unicast);
+
+			err = mac_remove_macaddr_vlan(mcip->mci_unicast, vid);
+
 			if (err != 0) {
-				cmn_err(CE_WARN, "%s: failed to remove a MAC"
-				    " address because of error 0x%x",
+				cmn_err(CE_WARN, "%s: failed to remove a MAC HW"
+				    " filters because of error 0x%x",
 				    mip->mi_name, err);
 			}
+
 			mcip->mci_unicast = NULL;
 		}
 
@@ -3112,12 +3204,12 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 		mac_flow_remove(mip->mi_flow_tab, flent, B_FALSE);
 		mac_flow_wait(flent, FLOW_DRIVER_UPCALL);
 
-		/* Now quiesce and destroy all SRS and soft rings */
+		/* Quiesce and destroy all the SRSes. */
 		mac_rx_srs_group_teardown(flent, B_FALSE);
 		mac_tx_srs_group_teardown(mcip, flent, SRST_LINK);
 
-		ASSERT((mcip->mci_flent == flent) &&
-		    (flent->fe_next == NULL));
+		ASSERT3P(mcip->mci_flent, ==, flent);
+		ASSERT3P(flent->fe_next, ==, NULL);
 
 		/*
 		 * Release our hold on the group as well. We need
@@ -3125,17 +3217,17 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 		 * left who can use it exclusively. Also, if we
 		 * were the last client, release the group.
 		 */
-		group = flent->fe_rx_ring_group;
 		default_group = MAC_DEFAULT_RX_GROUP(mip);
 		if (group != NULL) {
 			mac_group_remove_client(group, mcip);
 			next_state = mac_group_next_state(group,
 			    &grp_only_mcip, default_group, B_TRUE);
+
 			if (next_state == MAC_GROUP_STATE_RESERVED) {
 				/*
 				 * Only one client left on this RX group.
 				 */
-				ASSERT(grp_only_mcip != NULL);
+				VERIFY3P(grp_only_mcip, !=, NULL);
 				mac_set_group_state(group,
 				    MAC_GROUP_STATE_RESERVED);
 				group_only_flent = grp_only_mcip->mci_flent;
@@ -3160,7 +3252,7 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 				 * to see if the primary client can get
 				 * exclusive access to the default group.
 				 */
-				ASSERT(group != MAC_DEFAULT_RX_GROUP(mip));
+				VERIFY3P(group, !=, MAC_DEFAULT_RX_GROUP(mip));
 				if (mrp->mrp_mask & MRP_RX_RINGS) {
 					MAC_RX_GRP_RELEASED(mip);
 					if (mip->mi_rx_group_type ==
@@ -3174,7 +3266,8 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 				    MAC_GROUP_STATE_REGISTERED);
 				check_default_group = B_TRUE;
 			} else {
-				ASSERT(next_state == MAC_GROUP_STATE_SHARED);
+				VERIFY3S(next_state, ==,
+				    MAC_GROUP_STATE_SHARED);
 				mac_set_group_state(group,
 				    MAC_GROUP_STATE_SHARED);
 				mac_rx_group_unmark(group, MR_CONDEMNED);
@@ -3263,12 +3356,12 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 	 */
 	if (check_default_group) {
 		default_group = MAC_DEFAULT_RX_GROUP(mip);
-		ASSERT(default_group->mrg_state == MAC_GROUP_STATE_SHARED);
+		VERIFY3S(default_group->mrg_state, ==, MAC_GROUP_STATE_SHARED);
 		next_state = mac_group_next_state(default_group,
 		    &grp_only_mcip, default_group, B_TRUE);
 		if (next_state == MAC_GROUP_STATE_RESERVED) {
-			ASSERT(grp_only_mcip != NULL &&
-			    mip->mi_nactiveclients == 1);
+			VERIFY3P(grp_only_mcip, !=, NULL);
+			VERIFY3U(mip->mi_nactiveclients, ==, 1);
 			mac_set_group_state(default_group,
 			    MAC_GROUP_STATE_RESERVED);
 			mac_rx_srs_group_setup(grp_only_mcip,
@@ -3792,7 +3885,7 @@ mac_tx_srs_del_ring(mac_soft_ring_set_t *mac_srs, mac_ring_t *tx_ring)
 	 * is also stored in st_soft_rings[] array. That entry should
 	 * be removed.
 	 */
-	if (mcip->mci_state_flags & MCIS_IS_AGGR) {
+	if (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT) {
 		mac_srs_tx_t *tx = &mac_srs->srs_tx;
 
 		ASSERT(tx->st_soft_rings[tx_ring->mr_index] == remove_sring);
@@ -3821,7 +3914,7 @@ mac_tx_srs_setup(mac_client_impl_t *mcip, flow_entry_t *flent)
 	boolean_t		is_aggr;
 	uint_t			ring_info = 0;
 
-	is_aggr = (mcip->mci_state_flags & MCIS_IS_AGGR) != 0;
+	is_aggr = (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT) != 0;
 	grp = flent->fe_tx_ring_group;
 	if (grp == NULL) {
 		ring = (mac_ring_t *)mip->mi_default_tx_ring;
@@ -3965,8 +4058,8 @@ mac_fanout_recompute_client(mac_client_impl_t *mcip, cpupart_t *cpupart)
 }
 
 /*
- * Walk through the list of mac clients for the MAC.
- * For each active mac client, recompute the number of soft rings
+ * Walk through the list of MAC clients for the MAC.
+ * For each active MAC client, recompute the number of soft rings
  * associated with every client, only if current speed is different
  * from the speed that was previously used for soft ring computation.
  * If the cable is disconnected whlie the NIC is started, we would get
@@ -3989,6 +4082,10 @@ mac_fanout_recompute(mac_impl_t *mip)
 
 	for (mcip = mip->mi_clients_list; mcip != NULL;
 	    mcip = mcip->mci_client_next) {
+		/* Aggr port clients don't have SRSes. */
+		if ((mcip->mci_state_flags & MCIS_IS_AGGR_PORT) != 0)
+			continue;
+
 		if ((mcip->mci_state_flags & MCIS_SHARE_BOUND) != 0 ||
 		    !MCIP_DATAPATH_SETUP(mcip))
 			continue;
@@ -4001,6 +4098,7 @@ mac_fanout_recompute(mac_impl_t *mip)
 		mac_set_pool_effective(use_default, cpupart, mrp, emrp);
 		pool_unlock();
 	}
+
 	i_mac_perim_exit(mip);
 }
 

--- a/usr/src/uts/common/io/mac/mac_provider.c
+++ b/usr/src/uts/common/io/mac/mac_provider.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2018 Joyent, Inc.
  * Copyright 2017 OmniTI Computer Consulting, Inc. All rights reserved.
  * Copyright 2019 Joyent, Inc.
  */
@@ -57,6 +58,7 @@
 #include <sys/sdt.h>
 #include <sys/pattr.h>
 #include <sys/strsun.h>
+#include <sys/vlan.h>
 
 /*
  * MAC Provider Interface.
@@ -734,9 +736,8 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 {
 	mac_impl_t		*mip = (mac_impl_t *)mh;
 	mac_ring_t		*mr = (mac_ring_t *)mrh;
-	mac_soft_ring_set_t 	*mac_srs;
+	mac_soft_ring_set_t	*mac_srs;
 	mblk_t			*bp = mp_chain;
-	boolean_t		hw_classified = B_FALSE;
 
 	/*
 	 * If there are any promiscuous mode callbacks defined for
@@ -748,7 +749,7 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 	if (mr != NULL) {
 		/*
 		 * If the SRS teardown has started, just return. The 'mr'
-		 * continues to be valid until the driver unregisters the mac.
+		 * continues to be valid until the driver unregisters the MAC.
 		 * Hardware classified packets will not make their way up
 		 * beyond this point once the teardown has started. The driver
 		 * is never passed a pointer to a flow entry or SRS or any
@@ -761,11 +762,25 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 			freemsgchain(mp_chain);
 			return;
 		}
-		if (mr->mr_classify_type == MAC_HW_CLASSIFIER) {
-			hw_classified = B_TRUE;
+
+		/*
+		 * The ring is in passthru mode; pass the chain up to
+		 * the pseudo ring.
+		 */
+		if (mr->mr_classify_type == MAC_PASSTHRU_CLASSIFIER) {
 			MR_REFHOLD_LOCKED(mr);
+			mutex_exit(&mr->mr_lock);
+			mr->mr_pt_fn(mr->mr_pt_arg1, mr->mr_pt_arg2, mp_chain,
+			    B_FALSE);
+			MR_REFRELE(mr);
+			return;
 		}
-		mutex_exit(&mr->mr_lock);
+
+		/*
+		 * The passthru callback should only be set when in
+		 * MAC_PASSTHRU_CLASSIFIER mode.
+		 */
+		ASSERT3P(mr->mr_pt_fn, ==, NULL);
 
 		/*
 		 * We check if an SRS is controlling this ring.
@@ -773,19 +788,24 @@ mac_rx_common(mac_handle_t mh, mac_resource_handle_t mrh, mblk_t *mp_chain)
 		 * routine otherwise we need to go through mac_rx_classify
 		 * to reach the right place.
 		 */
-		if (hw_classified) {
+		if (mr->mr_classify_type == MAC_HW_CLASSIFIER) {
+			MR_REFHOLD_LOCKED(mr);
+			mutex_exit(&mr->mr_lock);
+			ASSERT3P(mr->mr_srs, !=, NULL);
 			mac_srs = mr->mr_srs;
+
 			/*
-			 * This is supposed to be the fast path.
-			 * All packets received though here were steered by
-			 * the hardware classifier, and share the same
-			 * MAC header info.
+			 * This is the fast path. All packets received
+			 * on this ring are hardware classified and
+			 * share the same MAC header info.
 			 */
 			mac_srs->srs_rx.sr_lower_proc(mh,
 			    (mac_resource_handle_t)mac_srs, mp_chain, B_FALSE);
 			MR_REFRELE(mr);
 			return;
 		}
+
+		mutex_exit(&mr->mr_lock);
 		/* We'll fall through to software classification */
 	} else {
 		flow_entry_t *flent;

--- a/usr/src/uts/common/io/mac/mac_sched.c
+++ b/usr/src/uts/common/io/mac/mac_sched.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  * Copyright 2013 Nexenta Systems, Inc. All rights reserved.
  */
 
@@ -300,9 +300,8 @@
  *
  * Otherwise, all fanout is performed by software. MAC divides incoming frames
  * into one of three buckets -- IPv4 TCP traffic, IPv4 UDP traffic, and
- * everything else. Note, VLAN tagged traffic is considered other, regardless of
- * the interior EtherType. Regardless of the type of fanout, these three
- * categories or buckets are always used.
+ * everything else. Regardless of the type of fanout, these three categories
+ * or buckets are always used.
  *
  * The difference between protocol level fanout and full software ring protocol
  * fanout is the number of software rings that end up getting created. The
@@ -1476,16 +1475,15 @@ enum pkt_type {
 #define	PORTS_SIZE 4
 
 /*
- * mac_rx_srs_proto_fanout
- *
- * This routine delivers packets destined to an SRS into one of the
+ * This routine delivers packets destined for an SRS into one of the
  * protocol soft rings.
  *
- * Given a chain of packets we need to split it up into multiple sub chains
- * destined into TCP, UDP or OTH soft ring. Instead of entering
- * the soft ring one packet at a time, we want to enter it in the form of a
- * chain otherwise we get this start/stop behaviour where the worker thread
- * goes to sleep and then next packets comes in forcing it to wake up etc.
+ * Given a chain of packets we need to split it up into multiple sub
+ * chains: TCP, UDP or OTH soft ring. Instead of entering the soft
+ * ring one packet at a time, we want to enter it in the form of a
+ * chain otherwise we get this start/stop behaviour where the worker
+ * thread goes to sleep and then next packet comes in forcing it to
+ * wake up.
  */
 static void
 mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
@@ -1524,9 +1522,9 @@ mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 	    mac_srs->srs_ring->mr_classify_type == MAC_HW_CLASSIFIER;
 
 	/*
-	 * Special clients (eg. VLAN, non ether, etc) need DLS
-	 * processing in the Rx path. SRST_DLS_BYPASS will be clear for
-	 * such SRSs. Another way of disabling bypass is to set the
+	 * Some clients, such as non-ethernet, need DLS processing in
+	 * the Rx path. Such clients clear the SRST_DLS_BYPASS flag.
+	 * DLS bypass may also be disabled via the
 	 * MCIS_RX_BYPASS_DISABLE flag.
 	 */
 	dls_bypass = ((mac_srs->srs_type & SRST_DLS_BYPASS) != 0) &&
@@ -1538,10 +1536,11 @@ mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 	bzero(sz, MAX_SR_TYPES * sizeof (size_t));
 
 	/*
-	 * We got a chain from SRS that we need to send to the soft rings.
-	 * Since squeues for TCP & IPv4 sap poll their soft rings (for
-	 * performance reasons), we need to separate out v4_tcp, v4_udp
-	 * and the rest goes in other.
+	 * We have a chain from SRS that we need to split across the
+	 * soft rings. The squeues for the TCP and IPv4 SAPs use their
+	 * own soft rings to allow polling from the squeue. The rest of
+	 * the packets are delivered on the OTH soft ring which cannot
+	 * be polled.
 	 */
 	while (head != NULL) {
 		mp = head;
@@ -1569,9 +1568,14 @@ mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 				evhp = (struct ether_vlan_header *)mp->b_rptr;
 				sap = ntohs(evhp->ether_type);
 				hdrsize = sizeof (struct ether_vlan_header);
+
 				/*
-				 * Check if the VID of the packet, if any,
-				 * belongs to this client.
+				 * Check if the VID of the packet, if
+				 * any, belongs to this client.
+				 * Technically, if this packet came up
+				 * via a HW classified ring then we
+				 * don't need to perform this check.
+				 * Perhaps a future optimization.
 				 */
 				if (!mac_client_check_flow_vid(mcip,
 				    VLAN_ID(ntohs(evhp->ether_tci)))) {
@@ -1636,7 +1640,6 @@ mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 		 * performance and may bypass DLS. All other cases go through
 		 * the 'OTH' type path without DLS bypass.
 		 */
-
 		ipha = (ipha_t *)(mp->b_rptr + hdrsize);
 		if ((type != OTH) && MBLK_RX_FANOUT_SLOWPATH(mp, ipha))
 			type = OTH;
@@ -1648,11 +1651,13 @@ mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 		}
 
 		ASSERT(type == UNDEF);
+
 		/*
-		 * We look for at least 4 bytes past the IP header to get
-		 * the port information. If we get an IP fragment, we don't
-		 * have the port information, and we use just the protocol
-		 * information.
+		 * Determine the type from the IP protocol value. If
+		 * classified as TCP or UDP, then update the read
+		 * pointer to the beginning of the IP header.
+		 * Otherwise leave the message as is for further
+		 * processing by DLS.
 		 */
 		switch (ipha->ipha_protocol) {
 		case IPPROTO_TCP:
@@ -1696,11 +1701,10 @@ mac_rx_srs_proto_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 int	fanout_unaligned = 0;
 
 /*
- * mac_rx_srs_long_fanout
- *
- * The fanout routine for VLANs, and for anything else that isn't performing
- * explicit dls bypass.  Returns -1 on an error (drop the packet due to a
- * malformed packet), 0 on success, with values written in *indx and *type.
+ * The fanout routine for any clients with DLS bypass disabled or for
+ * traffic classified as "other". Returns -1 on an error (drop the
+ * packet due to a malformed packet), 0 on success, with values
+ * written in *indx and *type.
  */
 static int
 mac_rx_srs_long_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *mp,
@@ -1866,16 +1870,15 @@ src_dst_based_fanout:
 }
 
 /*
- * mac_rx_srs_fanout
- *
- * This routine delivers packets destined to an SRS into a soft ring member
+ * This routine delivers packets destined for an SRS into a soft ring member
  * of the set.
  *
- * Given a chain of packets we need to split it up into multiple sub chains
- * destined for one of the TCP, UDP or OTH soft rings. Instead of entering
- * the soft ring one packet at a time, we want to enter it in the form of a
- * chain otherwise we get this start/stop behaviour where the worker thread
- * goes to sleep and then next packets comes in forcing it to wake up etc.
+ * Given a chain of packets we need to split it up into multiple sub
+ * chains: TCP, UDP or OTH soft ring. Instead of entering the soft
+ * ring one packet at a time, we want to enter it in the form of a
+ * chain otherwise we get this start/stop behaviour where the worker
+ * thread goes to sleep and then next packet comes in forcing it to
+ * wake up.
  *
  * Note:
  * Since we know what is the maximum fanout possible, we create a 2D array
@@ -1936,10 +1939,11 @@ mac_rx_srs_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 	    mac_srs->srs_ring->mr_classify_type == MAC_HW_CLASSIFIER;
 
 	/*
-	 * Special clients (eg. VLAN, non ether, etc) need DLS
-	 * processing in the Rx path. SRST_DLS_BYPASS will be clear for
-	 * such SRSs. Another way of disabling bypass is to set the
-	 * MCIS_RX_BYPASS_DISABLE flag.
+	 * Some clients, such as non Ethernet, need DLS processing in
+	 * the Rx path. Such clients clear the SRST_DLS_BYPASS flag.
+	 * DLS bypass may also be disabled via the
+	 * MCIS_RX_BYPASS_DISABLE flag, but this is only consumed by
+	 * sun4v vsw currently.
 	 */
 	dls_bypass = ((mac_srs->srs_type & SRST_DLS_BYPASS) != 0) &&
 	    ((mcip->mci_state_flags & MCIS_RX_BYPASS_DISABLE) == 0);
@@ -1961,7 +1965,7 @@ mac_rx_srs_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 
 	/*
 	 * We got a chain from SRS that we need to send to the soft rings.
-	 * Since squeues for TCP & IPv4 sap poll their soft rings (for
+	 * Since squeues for TCP & IPv4 SAP poll their soft rings (for
 	 * performance reasons), we need to separate out v4_tcp, v4_udp
 	 * and the rest goes in other.
 	 */
@@ -1991,9 +1995,14 @@ mac_rx_srs_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 				evhp = (struct ether_vlan_header *)mp->b_rptr;
 				sap = ntohs(evhp->ether_type);
 				hdrsize = sizeof (struct ether_vlan_header);
+
 				/*
-				 * Check if the VID of the packet, if any,
-				 * belongs to this client.
+				 * Check if the VID of the packet, if
+				 * any, belongs to this client.
+				 * Technically, if this packet came up
+				 * via a HW classified ring then we
+				 * don't need to perform this check.
+				 * Perhaps a future optimization.
 				 */
 				if (!mac_client_check_flow_vid(mcip,
 				    VLAN_ID(ntohs(evhp->ether_tci)))) {
@@ -2032,7 +2041,6 @@ mac_rx_srs_fanout(mac_soft_ring_set_t *mac_srs, mblk_t *head)
 			    sz[type][indx], sz1, mp);
 			continue;
 		}
-
 
 		/*
 		 * If we are using the default Rx ring where H/W or S/W
@@ -2622,7 +2630,6 @@ again:
 
 	mac_srs->srs_state |= (SRS_PROC|proc_type);
 
-
 	/*
 	 * mcip is NULL for broadcast and multicast flows. The promisc
 	 * callbacks for broadcast and multicast packets are delivered from
@@ -2642,10 +2649,8 @@ again:
 	}
 
 	/*
-	 * Check if SRS itself is doing the processing
-	 * This direct path does not apply when subflows are present. In this
-	 * case, packets need to be dispatched to a soft ring according to the
-	 * flow's bandwidth and other resources contraints.
+	 * Check if SRS itself is doing the processing. This direct
+	 * path applies only when subflows are present.
 	 */
 	if (mac_srs->srs_type & SRST_NO_SOFT_RINGS) {
 		mac_direct_rx_t		proc;
@@ -4633,6 +4638,9 @@ mac_rx_deliver(void *arg1, mac_resource_handle_t mrh, mblk_t *mp_chain,
 		 * the packet to the promiscuous listeners of the
 		 * client, since they expect to see the whole
 		 * frame including the VLAN headers.
+		 *
+		 * The MCIS_STRIP_DISABLE is only issued when sun4v
+		 * vsw is in play.
 		 */
 		mp_chain = mac_strip_vlan_tag_chain(mp_chain);
 	}
@@ -4641,13 +4649,11 @@ mac_rx_deliver(void *arg1, mac_resource_handle_t mrh, mblk_t *mp_chain,
 }
 
 /*
- * mac_rx_soft_ring_process
- *
- * process a chain for a given soft ring. The number of packets queued
- * in the SRS and its associated soft rings (including this one) is
- * very small (tracked by srs_poll_pkt_cnt), then allow the entering
- * thread (interrupt or poll thread) to do inline processing. This
- * helps keep the latency down under low load.
+ * Process a chain for a given soft ring. If the number of packets
+ * queued in the SRS and its associated soft rings (including this
+ * one) is very small (tracked by srs_poll_pkt_cnt) then allow the
+ * entering thread (interrupt or poll thread) to process the chain
+ * inline. This is meant to reduce latency under low load.
  *
  * The proc and arg for each mblk is already stored in the mblk in
  * appropriate places.
@@ -4706,13 +4712,13 @@ mac_rx_soft_ring_process(mac_client_impl_t *mcip, mac_soft_ring_t *ringp,
 
 			ASSERT(MUTEX_NOT_HELD(&ringp->s_ring_lock));
 			/*
-			 * If we have a soft ring set which is doing
-			 * bandwidth control, we need to decrement
-			 * srs_size and count so it the SRS can have a
-			 * accurate idea of what is the real data
-			 * queued between SRS and its soft rings. We
-			 * decrement the counters only when the packet
-			 * gets processed by both SRS and the soft ring.
+			 * If we have an SRS performing bandwidth
+			 * control then we need to decrement the size
+			 * and count so the SRS has an accurate count
+			 * of the data queued between the SRS and its
+			 * soft rings. We decrement the counters only
+			 * when the packet is processed by both the
+			 * SRS and the soft ring.
 			 */
 			mutex_enter(&mac_srs->srs_lock);
 			MAC_UPDATE_SRS_COUNT_LOCKED(mac_srs, cnt);
@@ -4728,8 +4734,8 @@ mac_rx_soft_ring_process(mac_client_impl_t *mcip, mac_soft_ring_t *ringp,
 			if ((ringp->s_ring_first == NULL) ||
 			    (ringp->s_ring_state & S_RING_BLANK)) {
 				/*
-				 * We processed inline our packet and
-				 * nothing new has arrived or our
+				 * We processed a single packet inline
+				 * and nothing new has arrived or our
 				 * receiver doesn't want to receive
 				 * any packets. We are done.
 				 */

--- a/usr/src/uts/common/io/mac/mac_soft_ring.c
+++ b/usr/src/uts/common/io/mac/mac_soft_ring.c
@@ -21,7 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -207,7 +207,7 @@ mac_soft_ring_create(int id, clock_t wait, uint16_t type,
 		ringp->s_ring_tx_hiwat =
 		    (mac_tx_soft_ring_hiwat > mac_tx_soft_ring_max_q_cnt) ?
 		    mac_tx_soft_ring_max_q_cnt : mac_tx_soft_ring_hiwat;
-		if (mcip->mci_state_flags & MCIS_IS_AGGR) {
+		if (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT) {
 			mac_srs_tx_t *tx = &mac_srs->srs_tx;
 
 			ASSERT(tx->st_soft_rings[
@@ -339,15 +339,14 @@ mac_soft_ring_fire(void *arg)
 }
 
 /*
- * mac_rx_soft_ring_drain
+ * Drain the soft ring pointed to by ringp.
  *
- * Called when worker thread model (ST_RING_WORKER_ONLY) of processing
- * incoming packets is used. s_ring_first contain the queued packets.
- * s_ring_rx_func contains the upper level (client) routine where the
- * packets are destined and s_ring_rx_arg1/s_ring_rx_arg2 are the
- * cookie meant for the client.
+ *    o s_ring_first: pointer to the queued packet chain.
+ *
+ *    o s_ring_rx_func: pointer to to the client's Rx routine.
+ *
+ *    o s_ring_rx_{arg1,arg2}: opaque values specific to the client.
  */
-/* ARGSUSED */
 static void
 mac_rx_soft_ring_drain(mac_soft_ring_t *ringp)
 {
@@ -392,13 +391,12 @@ mac_rx_soft_ring_drain(mac_soft_ring_t *ringp)
 		(*proc)(arg1, arg2, mp, NULL);
 
 		/*
-		 * If we have a soft ring set which is doing
-		 * bandwidth control, we need to decrement its
-		 * srs_size so it can have a accurate idea of
-		 * what is the real data queued between SRS and
-		 * its soft rings. We decrement the size for a
-		 * packet only when it gets processed by both
-		 * SRS and the soft ring.
+		 * If we have an SRS performing bandwidth control, then
+		 * we need to decrement the size and count so the SRS
+		 * has an accurate measure of the data queued between
+		 * the SRS and its soft rings. We decrement the
+		 * counters only when the packet is processed by both
+		 * the SRS and the soft ring.
 		 */
 		mutex_enter(&mac_srs->srs_lock);
 		MAC_UPDATE_SRS_COUNT_LOCKED(mac_srs, cnt);
@@ -414,12 +412,10 @@ mac_rx_soft_ring_drain(mac_soft_ring_t *ringp)
 }
 
 /*
- * mac_soft_ring_worker
- *
  * The soft ring worker routine to process any queued packets. In
- * normal case, the worker thread is bound to a CPU. It the soft
- * ring is dealing with TCP packets, then the worker thread will
- * be bound to the same CPU as the TCP squeue.
+ * normal case, the worker thread is bound to a CPU. If the soft ring
+ * handles TCP packets then the worker thread is bound to the same CPU
+ * as the TCP squeue.
  */
 static void
 mac_soft_ring_worker(mac_soft_ring_t *ringp)
@@ -605,7 +601,7 @@ mac_soft_ring_dls_bypass(void *arg, mac_direct_rx_t rx_func, void *rx_arg1)
 	mac_soft_ring_t		*softring = arg;
 	mac_soft_ring_set_t	*srs;
 
-	ASSERT(rx_func != NULL);
+	VERIFY3P(rx_func, !=, NULL);
 
 	mutex_enter(&softring->s_ring_lock);
 	softring->s_ring_rx_func = rx_func;

--- a/usr/src/uts/common/io/mac/mac_stat.c
+++ b/usr/src/uts/common/io/mac/mac_stat.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -261,7 +262,7 @@ static stat_info_t rx_srs_stats_list[] = {
 	{RX_SRS_STAT_OFF(mrs_chaincntover50)},
 	{RX_SRS_STAT_OFF(mrs_ierrors)}
 };
-#define	RX_SRS_STAT_SIZE 		\
+#define	RX_SRS_STAT_SIZE		\
 	(sizeof (rx_srs_stats_list) / sizeof (stat_info_t))
 
 #define	TX_SOFTRING_STAT_OFF(f)	(offsetof(mac_tx_stats_t, f))
@@ -273,14 +274,14 @@ static stat_info_t tx_softring_stats_list[] = {
 	{TX_SOFTRING_STAT_OFF(mts_unblockcnt)},
 	{TX_SOFTRING_STAT_OFF(mts_sdrops)},
 };
-#define	TX_SOFTRING_STAT_SIZE 		\
+#define	TX_SOFTRING_STAT_SIZE		\
 	(sizeof (tx_softring_stats_list) / sizeof (stat_info_t))
 
 static void
 i_mac_add_stats(void *sum, void *op1, void *op2,
     stat_info_t stats_list[], uint_t size)
 {
-	int 	i;
+	int	i;
 
 	for (i = 0; i < size; i++) {
 		uint64_t *op1_val = (uint64_t *)
@@ -678,8 +679,8 @@ i_mac_rx_hwlane_stat_create(mac_soft_ring_set_t *mac_srs, const char *modname,
 static uint64_t
 i_mac_misc_stat_get(void *handle, uint_t stat)
 {
-	flow_entry_t 		*flent = handle;
-	mac_client_impl_t 	*mcip = flent->fe_mcip;
+	flow_entry_t		*flent = handle;
+	mac_client_impl_t	*mcip = flent->fe_mcip;
 	mac_misc_stats_t	*mac_misc_stat = &mcip->mci_misc_stat;
 	mac_rx_stats_t		*mac_rx_stat;
 	mac_tx_stats_t		*mac_tx_stat;
@@ -870,9 +871,9 @@ i_mac_tx_hwlane_stat_create(mac_soft_ring_t *ringp, const char *modname,
 static uint64_t
 i_mac_rx_fanout_stat_get(void *handle, uint_t stat)
 {
-	mac_soft_ring_t 	*tcp_ringp = (mac_soft_ring_t *)handle;
+	mac_soft_ring_t		*tcp_ringp = (mac_soft_ring_t *)handle;
 	mac_soft_ring_t		*udp_ringp = NULL, *oth_ringp = NULL;
-	mac_soft_ring_set_t 	*mac_srs = tcp_ringp->s_ring_set;
+	mac_soft_ring_set_t	*mac_srs = tcp_ringp->s_ring_set;
 	int			index;
 	uint64_t		val;
 
@@ -1003,6 +1004,7 @@ void
 mac_ring_stat_create(mac_ring_t *ring)
 {
 	mac_impl_t	*mip = ring->mr_mip;
+	mac_group_t	*grp = (mac_group_t *)ring->mr_gh;
 	char		statname[MAXNAMELEN];
 	char		modname[MAXNAMELEN];
 
@@ -1014,8 +1016,8 @@ mac_ring_stat_create(mac_ring_t *ring)
 
 	switch (ring->mr_type) {
 	case MAC_RING_TYPE_RX:
-		(void) snprintf(statname, sizeof (statname), "mac_rx_ring%d",
-		    ring->mr_index);
+		(void) snprintf(statname, sizeof (statname),
+		    "mac_rx_ring_%d_%d", grp->mrg_index, ring->mr_index);
 		i_mac_rx_ring_stat_create(ring, modname, statname);
 		break;
 
@@ -1035,7 +1037,7 @@ void
 mac_srs_stat_create(mac_soft_ring_set_t *mac_srs)
 {
 	flow_entry_t	*flent = mac_srs->srs_flent;
-	char 		statname[MAXNAMELEN];
+	char		statname[MAXNAMELEN];
 	boolean_t	is_tx_srs;
 
 	/* No hardware/software lanes for user defined flows */

--- a/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
+++ b/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
@@ -1432,6 +1432,7 @@ ahci_tran_probe_port(dev_info_t *dip, sata_device_t *sd)
 	uint8_t port;
 	int rval = SATA_SUCCESS, rval_init;
 
+	port_state = 0;
 	ahci_ctlp = ddi_get_soft_state(ahci_statep, ddi_get_instance(dip));
 	port = ahci_ctlp->ahcictl_cport_to_port[cport];
 
@@ -1996,6 +1997,7 @@ ahci_claim_free_slot(ahci_ctl_t *ahci_ctlp, ahci_port_t *ahci_portp,
 	    ahci_portp->ahciport_pending_tags,
 	    ahci_portp->ahciport_pending_ncq_tags);
 
+	free_slots = 0;
 	/*
 	 * According to the AHCI spec, system software is responsible to
 	 * ensure that queued and non-queued commands are not mixed in
@@ -9842,6 +9844,8 @@ ahci_watchdog_handler(ahci_ctl_t *ahci_ctlp)
 	AHCIDBG(AHCIDBG_ENTRY, ahci_ctlp,
 	    "ahci_watchdog_handler entered", NULL);
 
+	current_slot = 0;
+	current_tags = 0;
 	for (port = 0; port < ahci_ctlp->ahcictl_num_ports; port++) {
 		if (!AHCI_PORT_IMPLEMENTED(ahci_ctlp, port)) {
 			continue;

--- a/usr/src/uts/common/io/vnic/vnic_dev.c
+++ b/usr/src/uts/common/io/vnic/vnic_dev.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  * Copyright 2016 OmniTI Computer Consulting, Inc. All rights reserved.
  */
 
@@ -354,7 +354,7 @@ vnic_dev_create(datalink_id_t vnic_id, datalink_id_t linkid,
 
 	rw_enter(&vnic_lock, RW_WRITER);
 
-	/* does a VNIC with the same id already exist? */
+	/* Does a VNIC with the same id already exist? */
 	err = mod_hash_find(vnic_hash, VNIC_HASH_KEY(vnic_id),
 	    (mod_hash_val_t *)&vnic);
 	if (err == 0) {
@@ -1060,7 +1060,7 @@ static int
 vnic_m_setprop(void *m_driver, const char *pr_name, mac_prop_id_t pr_num,
     uint_t pr_valsize, const void *pr_val)
 {
-	int 		err = 0;
+	int		err = 0;
 	vnic_t		*vn = m_driver;
 
 	switch (pr_num) {
@@ -1158,7 +1158,7 @@ vnic_m_getprop(void *arg, const char *pr_name, mac_prop_id_t pr_num,
     uint_t pr_valsize, void *pr_val)
 {
 	vnic_t		*vn = arg;
-	int 		ret = 0;
+	int		ret = 0;
 	boolean_t	out;
 
 	switch (pr_num) {

--- a/usr/src/uts/common/mapfiles/ddi.mapfile
+++ b/usr/src/uts/common/mapfiles/ddi.mapfile
@@ -165,6 +165,7 @@ SYMBOL_SCOPE {
 	list_insert_tail		{ FLAGS = EXTERN };
 	list_next			{ FLAGS = EXTERN };
 	list_remove			{ FLAGS = EXTERN };
+	list_remove_head		{ FLAGS = EXTERN };
 	memcpy				{ FLAGS = EXTERN };
 	memset				{ FLAGS = EXTERN };
 	miocack				{ FLAGS = EXTERN };

--- a/usr/src/uts/common/sys/mac_client.h
+++ b/usr/src/uts/common/sys/mac_client.h
@@ -88,6 +88,7 @@ typedef enum {
 } mac_client_promisc_type_t;
 
 /* flags passed to mac_unicast_add() */
+
 #define	MAC_UNICAST_NODUPCHECK			0x0001
 #define	MAC_UNICAST_PRIMARY			0x0002
 #define	MAC_UNICAST_HW				0x0004

--- a/usr/src/uts/common/sys/mac_client_impl.h
+++ b/usr/src/uts/common/sys/mac_client_impl.h
@@ -24,7 +24,7 @@
  * Copyright (c) 2012, Joyent, Inc.  All rights reserved.
  */
 /*
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 #ifndef	_SYS_MAC_CLIENT_IMPL_H
@@ -57,7 +57,7 @@ typedef struct mac_unicast_impl_s {			/* Protected by */
 	uint16_t			mui_vid;	/* SL */
 } mac_unicast_impl_t;
 
-#define	MAC_CLIENT_FLAGS_PRIMARY		0X0001
+#define	MAC_CLIENT_FLAGS_PRIMARY		0x0001
 #define	MAC_CLIENT_FLAGS_VNIC_PRIMARY		0x0002
 #define	MAC_CLIENT_FLAGS_MULTI_PRIMARY		0x0004
 #define	MAC_CLIENT_FLAGS_PASSIVE_PRIMARY	0x0008
@@ -132,12 +132,17 @@ struct mac_client_impl_s {			/* Protected by */
 	uint32_t		mci_flags;		/* SL */
 	krwlock_t		mci_rw_lock;
 	mac_unicast_impl_t	*mci_unicast_list;	/* mci_rw_lock */
+
 	/*
 	 * The mac_client_impl_t may be shared by multiple clients, i.e
 	 * multiple VLANs sharing the same MAC client. In this case the
-	 * address/vid tubles differ and are each associated with their
+	 * address/vid tuples differ and are each associated with their
 	 * own flow entry, but the rest underlying components SRS, etc,
 	 * are common.
+	 *
+	 * This is only needed to support sun4v vsw. There are several
+	 * places in MAC we could simplify the code if we removed
+	 * sun4v support.
 	 */
 	flow_entry_t		*mci_flent_list;	/* mci_rw_lock */
 	uint_t			mci_nflents;		/* mci_rw_lock */
@@ -225,7 +230,7 @@ extern	int	mac_tx_percpu_cnt;
 	&(mcip)->mci_flent->fe_resource_props)
 
 #define	MCIP_EFFECTIVE_PROPS(mcip)		\
-	(mcip->mci_flent == NULL ? NULL : 	\
+	(mcip->mci_flent == NULL ? NULL :	\
 	&(mcip)->mci_flent->fe_effective_props)
 
 #define	MCIP_RESOURCE_PROPS_MASK(mcip)		\
@@ -314,6 +319,74 @@ extern	int	mac_tx_percpu_cnt;
 	(((mcip)->mci_state_flags & MCIS_TAG_DISABLE) == 0 &&		\
 	(mcip)->mci_nvids == 1)						\
 
+/*
+ * MAC Client Implementation State (mci_state_flags)
+ *
+ * MCIS_IS_VNIC
+ *
+ *	The client is a VNIC.
+ *
+ * MCIS_EXCLUSIVE
+ *
+ *	The client has exclusive control over the MAC, such that it is
+ *	the sole client of the MAC.
+ *
+ * MCIS_TAG_DISABLE
+ *
+ *	MAC will not add VLAN tags to outgoing traffic. If this flag
+ *	is set it is up to the client to add the correct VLAN tag.
+ *
+ * MCIS_STRIP_DISABLE
+ *
+ *	MAC will not strip the VLAN tags on incoming traffic before
+ *	passing it to mci_rx_fn. This only applies to non-bypass
+ *	traffic.
+ *
+ * MCIS_IS_AGGR_PORT
+ *
+ *	The client represents a port on an aggr.
+ *
+ * MCIS_CLIENT_POLL_CAPABLE
+ *
+ *	The client is capable of polling the Rx TCP/UDP softrings.
+ *
+ * MCIS_DESC_LOGGED
+ *
+ *	This flag is set when the client's link info has been logged
+ *	by the mac_log_linkinfo() timer. This ensures that the
+ *	client's link info is only logged once.
+ *
+ * MCIS_SHARE_BOUND
+ *
+ *	This client has an HIO share bound to it.
+ *
+ * MCIS_DISABLE_TX_VID_CHECK
+ *
+ *	MAC will not check the VID of the client's Tx traffic.
+ *
+ * MCIS_USE_DATALINK_NAME
+ *
+ *	The client is using the same name as its underlying MAC. This
+ *	happens when dlmgmtd is unreachable during client creation.
+ *
+ * MCIS_UNICAST_HW
+ *
+ *	The client requires MAC address hardware classification. This
+ *	is only used by sun4v vsw.
+ *
+ * MCIS_IS_AGGR_CLIENT
+ *
+ *	The client sits atop an aggr.
+ *
+ * MCIS_RX_BYPASS_DISABLE
+ *
+ *	Do not allow the client to enable DLS bypass.
+ *
+ * MCIS_NO_UNICAST_ADDR
+ *
+ *	This client has no MAC unicast addresss associated with it.
+ *
+ */
 /* MCI state flags */
 #define	MCIS_IS_VNIC			0x0001
 #define	MCIS_EXCLUSIVE			0x0002
@@ -326,7 +399,7 @@ extern	int	mac_tx_percpu_cnt;
 #define	MCIS_DISABLE_TX_VID_CHECK	0x0100
 #define	MCIS_USE_DATALINK_NAME		0x0200
 #define	MCIS_UNICAST_HW			0x0400
-#define	MCIS_IS_AGGR			0x0800
+#define	MCIS_IS_AGGR_CLIENT		0x0800
 #define	MCIS_RX_BYPASS_DISABLE		0x1000
 #define	MCIS_NO_UNICAST_ADDR		0x2000
 

--- a/usr/src/uts/common/sys/mac_client_priv.h
+++ b/usr/src/uts/common/sys/mac_client_priv.h
@@ -22,7 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  */
 
 /*
@@ -121,9 +121,17 @@ extern void mac_tx_client_quiesce(mac_client_handle_t);
 extern void mac_tx_client_condemn(mac_client_handle_t);
 extern void mac_tx_client_restart(mac_client_handle_t);
 extern void mac_srs_perm_quiesce(mac_client_handle_t, boolean_t);
+extern uint_t mac_hwrings_idx_get(mac_handle_t, uint_t, mac_group_handle_t *,
+    mac_ring_handle_t *, mac_ring_type_t);
 extern int mac_hwrings_get(mac_client_handle_t, mac_group_handle_t *,
     mac_ring_handle_t *, mac_ring_type_t);
 extern uint_t mac_hwring_getinfo(mac_ring_handle_t);
+extern void mac_hwring_set_passthru(mac_ring_handle_t, mac_rx_t, void *,
+    mac_resource_handle_t);
+extern void mac_hwring_clear_passthru(mac_ring_handle_t);
+extern void mac_client_set_flow_cb(mac_client_handle_t, mac_rx_t, void *);
+extern void mac_client_clear_flow_cb(mac_client_handle_t);
+
 extern void mac_hwring_setup(mac_ring_handle_t, mac_resource_handle_t,
     mac_ring_handle_t);
 extern void mac_hwring_teardown(mac_ring_handle_t);
@@ -131,6 +139,8 @@ extern int mac_hwring_disable_intr(mac_ring_handle_t);
 extern int mac_hwring_enable_intr(mac_ring_handle_t);
 extern int mac_hwring_start(mac_ring_handle_t);
 extern void mac_hwring_stop(mac_ring_handle_t);
+extern int mac_hwring_activate(mac_ring_handle_t);
+extern void mac_hwring_quiesce(mac_ring_handle_t);
 extern mblk_t *mac_hwring_poll(mac_ring_handle_t, int);
 extern mblk_t *mac_hwring_tx(mac_ring_handle_t, mblk_t *);
 extern int mac_hwring_getstat(mac_ring_handle_t, uint_t, uint64_t *);
@@ -144,6 +154,13 @@ extern void mac_hwring_set_default(mac_handle_t, mac_ring_handle_t);
 
 extern int mac_hwgroup_addmac(mac_group_handle_t, const uint8_t *);
 extern int mac_hwgroup_remmac(mac_group_handle_t, const uint8_t *);
+extern int mac_hwgroup_addvlan(mac_group_handle_t, uint16_t);
+extern int mac_hwgroup_remvlan(mac_group_handle_t, uint16_t);
+
+extern boolean_t mac_has_hw_vlan(mac_handle_t);
+
+extern uint_t mac_get_num_rx_groups(mac_handle_t);
+extern int mac_set_promisc(mac_handle_t, boolean_t);
 
 extern void mac_set_upper_mac(mac_client_handle_t, mac_handle_t,
     mac_resource_props_t *);

--- a/usr/src/uts/common/sys/mac_impl.h
+++ b/usr/src/uts/common/sys/mac_impl.h
@@ -188,9 +188,18 @@ struct mac_ring_s {
 	mac_ring_t		*mr_next;	/* next ring in the chain */
 	mac_group_handle_t	mr_gh;		/* reference to group */
 
-	mac_classify_type_t	mr_classify_type;	/* HW vs SW */
+	mac_classify_type_t	mr_classify_type;
 	struct mac_soft_ring_set_s *mr_srs;	/* associated SRS */
-	mac_ring_handle_t	mr_prh;		/* associated pseudo ring hdl */
+	mac_ring_handle_t	mr_prh;	/* associated pseudo ring hdl */
+
+	/*
+	 * Ring passthru callback and arguments. See the
+	 * MAC_PASSTHRU_CLASSIFIER comment in mac_provider.h.
+	 */
+	mac_rx_t		mr_pt_fn;
+	void			*mr_pt_arg1;
+	mac_resource_handle_t	mr_pt_arg2;
+
 	uint_t			mr_refcnt;	/* Ring references */
 	/* ring generation no. to guard against drivers using stale rings */
 	uint64_t		mr_gen_num;
@@ -235,8 +244,8 @@ struct mac_ring_s {
 }
 
 /*
- * Per mac client flow information associated with a RX group.
- * The entire structure is SL protected.
+ * Used to attach MAC clients to an Rx group. The members are SL
+ * protected.
  */
 typedef struct mac_grp_client {
 	struct mac_grp_client		*mgc_next;
@@ -250,15 +259,20 @@ typedef struct mac_grp_client {
 	((g)->mrg_clients->mgc_next == NULL)) ?		\
 	(g)->mrg_clients->mgc_client : NULL)
 
+#define	MAC_GROUP_HW_VLAN(g)				\
+	(((g) != NULL) &&				\
+	((g)->mrg_info.mgi_addvlan != NULL) &&		\
+	((g)->mrg_info.mgi_remvlan != NULL))
+
 /*
  * Common ring group data structure for ring control and management.
- * The entire structure is SL protected
+ * The entire structure is SL protected.
  */
 struct mac_group_s {
 	int			mrg_index;	/* index in the list */
 	mac_ring_type_t		mrg_type;	/* ring type */
 	mac_group_state_t	mrg_state;	/* state of the group */
-	mac_group_t		*mrg_next;	/* next ring in the chain */
+	mac_group_t		*mrg_next;	/* next group in the chain */
 	mac_handle_t		mrg_mh;		/* reference to MAC */
 	mac_ring_t		*mrg_rings;	/* grouped rings */
 	uint_t			mrg_cur_count;	/* actual size of group */
@@ -276,6 +290,54 @@ struct mac_group_s {
 #define	GROUP_INTR_ENABLE_FUNC(g)	(g)->mrg_info.mgi_intr.mi_enable
 #define	GROUP_INTR_DISABLE_FUNC(g)	(g)->mrg_info.mgi_intr.mi_disable
 
+#define	MAC_RING_TX(mhp, rh, mp, rest) {				\
+	mac_ring_handle_t mrh = rh;					\
+	mac_impl_t *mimpl = (mac_impl_t *)mhp;				\
+	/*								\
+	 * Send packets through a selected tx ring, or through the	\
+	 * default handler if there is no selected ring.		\
+	 */								\
+	if (mrh == NULL)						\
+		mrh = mimpl->mi_default_tx_ring;			\
+	if (mrh == NULL) {						\
+		rest = mimpl->mi_tx(mimpl->mi_driver, mp);		\
+	} else {							\
+		rest = mac_hwring_tx(mrh, mp);				\
+	}								\
+}
+
+/*
+ * This is the final stop before reaching the underlying driver
+ * or aggregation, so this is where the bridging hook is implemented.
+ * Packets that are bridged will return through mac_bridge_tx(), with
+ * rh nulled out if the bridge chooses to send output on a different
+ * link due to forwarding.
+ */
+#define	MAC_TX(mip, rh, mp, src_mcip) {					\
+	mac_ring_handle_t	rhandle = (rh);				\
+	/*								\
+	 * If there is a bound Hybrid I/O share, send packets through	\
+	 * the default tx ring. (When there's a bound Hybrid I/O share,	\
+	 * the tx rings of this client are mapped in the guest domain	\
+	 * and not accessible from here.)				\
+	 */								\
+	_NOTE(CONSTANTCONDITION)					\
+	if ((src_mcip)->mci_state_flags & MCIS_SHARE_BOUND)		\
+		rhandle = (mip)->mi_default_tx_ring;			\
+	if (mip->mi_promisc_list != NULL)				\
+		mac_promisc_dispatch(mip, mp, src_mcip);		\
+	/*								\
+	 * Grab the proper transmit pointer and handle. Special		\
+	 * optimization: we can test mi_bridge_link itself atomically,	\
+	 * and if that indicates no bridge send packets through tx ring.\
+	 */								\
+	if (mip->mi_bridge_link == NULL) {				\
+		MAC_RING_TX(mip, rhandle, mp, mp);			\
+	} else {							\
+		mp = mac_bridge_tx(mip, rhandle, mp);			\
+	}								\
+}
+
 /* mci_tx_flag */
 #define	MCI_TX_QUIESCE	0x1
 
@@ -292,17 +354,23 @@ typedef struct mac_mcast_addrs_s {
 } mac_mcast_addrs_t;
 
 typedef enum {
-	MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED = 1,	/* hardware steering */
+	MAC_ADDRESS_TYPE_UNICAST_CLASSIFIED = 1,	/* HW classification */
 	MAC_ADDRESS_TYPE_UNICAST_PROMISC		/* promiscuous mode */
 } mac_address_type_t;
 
+typedef struct mac_vlan_s {
+	struct mac_vlan_s	*mv_next;
+	uint16_t		mv_vid;
+} mac_vlan_t;
+
 typedef struct mac_address_s {
 	mac_address_type_t	ma_type;		/* address type */
-	int			ma_nusers;		/* number of users */
-							/* of that address */
+	int			ma_nusers;		/* num users of addr */
 	struct mac_address_s	*ma_next;		/* next address */
 	uint8_t			ma_addr[MAXMACADDRLEN];	/* address value */
 	size_t			ma_len;			/* address length */
+	mac_vlan_t		*ma_vlans;		/* VLANs on this addr */
+	boolean_t		ma_untagged;		/* accept untagged? */
 	mac_group_t		*ma_group;		/* asscociated group */
 	mac_impl_t		*ma_mip;		/* MAC handle */
 } mac_address_t;
@@ -422,7 +490,7 @@ struct mac_impl_s {
 	uint16_t		mi_tx_cksum_flags; /* SL */
 
 	/*
-	 * MAC address list. SL protected.
+	 * MAC address and VLAN lists. SL protected.
 	 */
 	mac_address_t		*mi_addresses;
 
@@ -710,6 +778,8 @@ extern void mac_client_bcast_refresh(mac_client_impl_t *, mac_multicst_t,
  */
 extern int mac_group_addmac(mac_group_t *, const uint8_t *);
 extern int mac_group_remmac(mac_group_t *, const uint8_t *);
+extern int mac_group_addvlan(mac_group_t *, uint16_t);
+extern int mac_group_remvlan(mac_group_t *, uint16_t);
 extern int mac_rx_group_add_flow(mac_client_impl_t *, flow_entry_t *,
     mac_group_t *);
 extern mblk_t *mac_hwring_tx(mac_ring_handle_t, mblk_t *);
@@ -730,6 +800,7 @@ extern void mac_rx_switch_grp_to_sw(mac_group_t *);
  * MAC address functions are used internally by MAC layer.
  */
 extern mac_address_t *mac_find_macaddr(mac_impl_t *, uint8_t *);
+extern mac_address_t *mac_find_macaddr_vlan(mac_impl_t *, uint8_t *, uint16_t);
 extern boolean_t mac_check_macaddr_shared(mac_address_t *);
 extern int mac_update_macaddr(mac_address_t *, uint8_t *);
 extern void mac_freshen_macaddr(mac_address_t *, uint8_t *);
@@ -813,8 +884,9 @@ extern int mac_start_group(mac_group_t *);
 extern void mac_stop_group(mac_group_t *);
 extern int mac_start_ring(mac_ring_t *);
 extern void mac_stop_ring(mac_ring_t *);
-extern int mac_add_macaddr(mac_impl_t *, mac_group_t *, uint8_t *, boolean_t);
-extern int mac_remove_macaddr(mac_address_t *);
+extern int mac_add_macaddr_vlan(mac_impl_t *, mac_group_t *, uint8_t *,
+    uint16_t, boolean_t);
+extern int mac_remove_macaddr_vlan(mac_address_t *, uint16_t);
 
 extern void mac_set_group_state(mac_group_t *, mac_group_state_t);
 extern void mac_group_add_client(mac_group_t *, mac_client_impl_t *);

--- a/usr/src/uts/common/sys/mac_provider.h
+++ b/usr/src/uts/common/sys/mac_provider.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 #ifndef	_SYS_MAC_PROVIDER_H
@@ -243,16 +243,59 @@ typedef struct mac_callbacks_s {
 /*
  * Virtualization Capabilities
  */
+
 /*
- * The ordering of entries below is important. MAC_HW_CLASSIFIER
- * is the cutoff below which are entries which don't depend on
- * H/W. MAC_HW_CLASSIFIER and entries after that are cases where
- * H/W has been updated through add/modify/delete APIs.
+ * The type of ring classification. This is used by MAC to determine
+ * what, if any, processing it has to do upon receiving traffic on a
+ * particular Rx ring.
+ *
+ * MAC_NO_CLASSIFIER
+ *
+ *	No classification has been set. No traffic should cross an Rx
+ *	ring in this state.
+ *
+ * MAC_SW_CLASSIFIER
+ *
+ *	The driver delivers traffic for multiple clients to this ring.
+ *	All traffic must be software classified by MAC to guarantee
+ *	delivery to the correct client. This classification type may
+ *	be chosen for several reasons.
+ *
+ *	o The driver provides only one group and there are multiple
+ *	  clients using the MAC.
+ *
+ *	o The driver provides some hardware filtering but not enough
+ *	  to fully classify the traffic. E.g., a VLAN VNIC requires L2
+ *	  unicast address filtering as well as VLAN filtering, but
+ *	  some drivers may only support the former.
+ *
+ *	o The ring belongs to the default group. The default group
+ *	  acts as a spillover for all clients that can't reserve an
+ *	  exclusive group. It also handles multicast traffic for all
+ *	  clients. For these reasons, the default group's rings are
+ *	  always software classified.
+ *
+ * MAC_HW_CLASSIFIER
+ *
+ *	The driver delivers traffic for a single MAC client across
+ *	this ring. With this guarantee, MAC can simply pass the
+ *	traffic up the stack or even allow polling of the ring.
+ *
+ * MAC_PASSTHRU_CLASSIFIER
+ *
+ *	The ring is in "passthru" mode. In this mode we bypass all of
+ *	the typical MAC processing and pass the traffic directly to
+ *	the mr_pt_fn callback, see mac_rx_common(). This is used in
+ *	cases where there is another module acting as MAC provider on
+ *	behalf of the driver. E.g., link aggregations use this mode to
+ *	take full control of the port's rings; allowing it to enforce
+ *	LACP protocols and aggregate rings across discrete drivers.
  */
 typedef enum {
 	MAC_NO_CLASSIFIER = 0,
 	MAC_SW_CLASSIFIER,
-	MAC_HW_CLASSIFIER
+	MAC_HW_CLASSIFIER,
+	MAC_PASSTHRU_CLASSIFIER
 } mac_classify_type_t;
 
 typedef	void	(*mac_rx_func_t)(void *, mac_resource_handle_t, mblk_t *,
@@ -280,6 +323,28 @@ typedef enum {
 	MAC_RING_TYPE_RX = 1,	/* Receive ring */
 	MAC_RING_TYPE_TX	/* Transmit ring */
 } mac_ring_type_t;
+
+/*
+ * The value VLAN_ID_NONE (VID 0) means a client does not have
+ * membership to any VLAN. However, this statement is true for both
+ * untagged packets and priority tagged packets leading to confusion
+ * over what semantic is intended. To the provider, VID 0 is a valid
+ * VID when priority tagging is in play. To MAC and everything above
+ * VLAN_ID_NONE almost universally implies untagged traffic. Thus, we
+ * convert VLAN_ID_NONE to a sentinel value (MAC_VLAN_UNTAGGED) at the
+ * border between MAC and MAC provider. This informs the provider that
+ * the client is interested in untagged traffic and the provider
+ * should set any relevant bits to receive such traffic.
+ *
+ * Currently, the API between MAC and the provider passes the VID as a
+ * unit16_t. In the future this could actually be the entire TCI mask
+ * (PCP, DEI, and VID). This current scheme is safe in that potential
+ * future world as well; as 0xFFFF is not a valid TCI (the 0xFFF VID
+ * is reserved and never transmitted across networks).
+ */
+#define	MAC_VLAN_UNTAGGED		UINT16_MAX
+#define	MAC_VLAN_UNTAGGED_VID(vid)	\
+	(((vid) == VLAN_ID_NONE) ? MAC_VLAN_UNTAGGED : (vid))
 
 /*
  * Grouping type of a ring group
@@ -343,6 +408,7 @@ typedef struct mac_ring_info_s {
 		mac_ring_poll_t	poll;
 	} mrfunion;
 	mac_ring_stat_t		mri_stat;
+
 	/*
 	 * mri_flags will have some bits set to indicate some special
 	 * property/feature of a ring like serialization needed for a
@@ -359,6 +425,8 @@ typedef struct mac_ring_info_s {
  * #defines for mri_flags. The flags are temporary flags that are provided
  * only to workaround issues in specific drivers, and they will be
  * removed in the future.
+ *
+ * These are consumed only by sun4v and neptune (nxge).
  */
 #define	MAC_RING_TX_SERIALIZE		0x1
 #define	MAC_RING_RX_ENQUEUE		0x2
@@ -367,6 +435,8 @@ typedef	int	(*mac_group_start_t)(mac_group_driver_t);
 typedef	void	(*mac_group_stop_t)(mac_group_driver_t);
 typedef	int	(*mac_add_mac_addr_t)(void *, const uint8_t *);
 typedef	int	(*mac_rem_mac_addr_t)(void *, const uint8_t *);
+typedef int	(*mac_add_vlan_filter_t)(mac_group_driver_t, uint16_t);
+typedef int	(*mac_rem_vlan_filter_t)(mac_group_driver_t, uint16_t);
 
 struct mac_group_info_s {
 	mac_group_driver_t	mgi_driver;	/* Driver reference */
@@ -375,9 +445,11 @@ struct mac_group_info_s {
 	uint_t			mgi_count;	/* Count of rings */
 	mac_intr_t		mgi_intr;	/* Optional per-group intr */
 
-	/* Only used for rx groups */
+	/* Only used for Rx groups */
 	mac_add_mac_addr_t	mgi_addmac;	/* Add a MAC address */
 	mac_rem_mac_addr_t	mgi_remmac;	/* Remove a MAC address */
+	mac_add_vlan_filter_t	mgi_addvlan;	/* Add a VLAN filter */
+	mac_rem_vlan_filter_t	mgi_remvlan;	/* Remove a VLAN filter */
 };
 
 /*
@@ -495,14 +567,14 @@ extern void			mac_free(mac_register_t *);
 extern int			mac_register(mac_register_t *, mac_handle_t *);
 extern int			mac_disable_nowait(mac_handle_t);
 extern int			mac_disable(mac_handle_t);
-extern int  			mac_unregister(mac_handle_t);
-extern void 			mac_rx(mac_handle_t, mac_resource_handle_t,
+extern int			mac_unregister(mac_handle_t);
+extern void			mac_rx(mac_handle_t, mac_resource_handle_t,
 				    mblk_t *);
-extern void 			mac_rx_ring(mac_handle_t, mac_ring_handle_t,
+extern void			mac_rx_ring(mac_handle_t, mac_ring_handle_t,
 				    mblk_t *, uint64_t);
-extern void 			mac_link_update(mac_handle_t, link_state_t);
-extern void 			mac_link_redo(mac_handle_t, link_state_t);
-extern void 			mac_unicst_update(mac_handle_t,
+extern void			mac_link_update(mac_handle_t, link_state_t);
+extern void			mac_link_redo(mac_handle_t, link_state_t);
+extern void			mac_unicst_update(mac_handle_t,
 				    const uint8_t *);
 extern void			mac_dst_update(mac_handle_t, const uint8_t *);
 extern void			mac_tx_update(mac_handle_t);

--- a/usr/src/uts/common/sys/strsubr.h
+++ b/usr/src/uts/common/sys/strsubr.h
@@ -33,7 +33,7 @@
  */
 
 /*
- * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #ifndef _SYS_STRSUBR_H


### PR DESCRIPTION
Weekly illumos-gate upstream merge

## Backports

* none

## onu

```
Last login: Thu Mar  5 20:52:04 2020 from 10.88.22.88
OmniOS 5.11     omnios-upstream_merge-2020030501-46fdfc92ba     Mar. 05, 2020
SunOS Internal Development: hadfl 2020-Mar-05 [illumos-omnios]
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2020030501-46fdfc92ba i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu Mar  5 22:02:25 CET 2020 ====
==== Nightly distributed build completed: Thu Mar  5 23:22:54 CET 2020 ====

==== Total build time ====

real    1:20:28

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-b463bb4090 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151033-b07"

/usr/bin/openssl
OpenSSL 1.1.1d  10 Sep 2019
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   76

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020030501-46fdfc92ba

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    36:16.6
user  3:19:57.9
sys     42:01.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    32:01.2
user  2:57:13.1
sys     35:12.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```