### PR TITLE
Upstream merge joyent_merge/2020032301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,7 +264,6 @@ usr/src/cmd/bc/bc.xpg6
 usr/src/cmd/bc/lib.b
 usr/src/cmd/bdiff/bdiff
 usr/src/cmd/beadm/beadm
-usr/src/cmd/bhhwcompat/bhhwcompat
 usr/src/cmd/bhyve/bhyve
 usr/src/cmd/bhyve/mevent_test
 usr/src/cmd/bhyvectl/bhyvectl
@@ -898,6 +897,7 @@ usr/src/cmd/getopt/getopt
 usr/src/cmd/getopt/getoptcvt
 usr/src/cmd/gettext/gettext
 usr/src/cmd/gettxt/gettxt
+usr/src/cmd/grep/file
 usr/src/cmd/grep/grep
 usr/src/cmd/groups/groups
 usr/src/cmd/growfs/growfs
@@ -4289,6 +4289,8 @@ usr/src/test/os-tests/tests/sockfs/sockpair
 usr/src/test/os-tests/tests/spoof-ras/spoof-ras
 usr/src/test/os-tests/tests/stress/dladm-kstat
 usr/src/test/os-tests/tests/timer/timer_limit
+usr/src/test/os-tests/tests/writev.32
+usr/src/test/os-tests/tests/writev.64
 usr/src/test/smbclient-tests/cmd/abort_conn/abort_conn
 usr/src/test/smbclient-tests/cmd/close_wr/close_wr
 usr/src/test/smbclient-tests/cmd/cp_mmap/cp_mmap

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 9d22e2850a0de9d638d7d3ca0516384e3aefbdd2
+Last illumos-joyent commit: da036f5cbc2608d7100a682f9c91a938e76cefdc
 

--- a/usr/src/cmd/bhyve/block_if.c
+++ b/usr/src/cmd/bhyve/block_if.c
@@ -372,8 +372,12 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 				.dfl_num_exts = 1,
 				.dfl_offset = 0,
 				.dfl_flags = 0,
-				.dfl_exts[0].dfle_start = br->br_offset,
-				.dfl_exts[0].dfle_length = br->br_resid
+				.dfl_exts = {
+					{
+						.dfle_start = br->br_offset,
+						.dfle_length = br->br_resid
+					}
+				}
 			};
 
 			if (ioctl(bc->bc_fd, DKIOCFREE, &dfl))

--- a/usr/src/cmd/bhyve/pci_virtio_block.c
+++ b/usr/src/cmd/bhyve/pci_virtio_block.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2011 NetApp, Inc.
  * All rights reserved.
- * Copyright (c) 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,31 +70,53 @@ __FBSDID("$FreeBSD$");
 #include "virtio.h"
 #include "block_if.h"
 
-#define VTBLK_RINGSZ	128
+#define	VTBLK_BSIZE	512
+#define	VTBLK_RINGSZ	128
 
 _Static_assert(VTBLK_RINGSZ <= BLOCKIF_RING_MAX, "Each ring entry must be able to queue a request");
 
-#define VTBLK_S_OK	0
-#define VTBLK_S_IOERR	1
+#define	VTBLK_S_OK	0
+#define	VTBLK_S_IOERR	1
 #define	VTBLK_S_UNSUPP	2
 
 #define	VTBLK_BLK_ID_BYTES	20 + 1
 
 /* Capability bits */
-#define	VTBLK_F_SEG_MAX		(1 << 2)	/* Maximum request segments */
-#define	VTBLK_F_BLK_SIZE	(1 << 6)	/* cfg block size valid */
-#define	VTBLK_F_FLUSH		(1 << 9)	/* Cache flush support */
-#define	VTBLK_F_TOPOLOGY	(1 << 10)	/* Optimal I/O alignment */
+#define	VTBLK_F_BARRIER		(1 << 0)	/* Does host support barriers? */
+#define	VTBLK_F_SIZE_MAX	(1 << 1)	/* Indicates maximum segment size */
+#define	VTBLK_F_SEG_MAX		(1 << 2)	/* Indicates maximum # of segments */
+#define	VTBLK_F_GEOMETRY	(1 << 4)	/* Legacy geometry available  */
+#define	VTBLK_F_RO		(1 << 5)	/* Disk is read-only */
+#define	VTBLK_F_BLK_SIZE	(1 << 6)	/* Block size of disk is available*/
+#define	VTBLK_F_SCSI		(1 << 7)	/* Supports scsi command passthru */
+#define	VTBLK_F_FLUSH		(1 << 9)	/* Writeback mode enabled after reset */
+#define	VTBLK_F_WCE		(1 << 9)	/* Legacy alias for FLUSH */
+#define	VTBLK_F_TOPOLOGY	(1 << 10)	/* Topology information is available */
+#define	VTBLK_F_CONFIG_WCE	(1 << 11)	/* Writeback mode available in config */
+#define	VTBLK_F_DISCARD		(1 << 13)	/* Trim blocks */
+#define	VTBLK_F_WRITE_ZEROES	(1 << 14)	/* Write zeros */
 
 /*
  * Host capabilities
  */
-#define VTBLK_S_HOSTCAPS      \
+#define	VTBLK_S_HOSTCAPS      \
   ( VTBLK_F_SEG_MAX  |						    \
     VTBLK_F_BLK_SIZE |						    \
     VTBLK_F_FLUSH    |						    \
     VTBLK_F_TOPOLOGY |						    \
     VIRTIO_RING_F_INDIRECT_DESC )	/* indirect descriptors */
+
+/*
+ * The current blockif_delete() interface only allows a single delete
+ * request at a time.
+ */
+#define	VTBLK_MAX_DISCARD_SEG	1
+
+/*
+ * An arbitrary limit to prevent excessive latency due to large
+ * delete requests.
+ */
+#define	VTBLK_MAX_DISCARD_SECT	((16 << 20) / VTBLK_BSIZE)	/* 16 MiB */
 
 /*
  * Config space "registers"
@@ -116,6 +138,14 @@ struct vtblk_config {
 		uint32_t opt_io_size;
 	} vbc_topology;
 	uint8_t		vbc_writeback;
+	uint8_t		unused0[3];
+	uint32_t	max_discard_sectors;
+	uint32_t	max_discard_seg;
+	uint32_t	discard_sector_alignment;
+	uint32_t	max_write_zeroes_sectors;
+	uint32_t	max_write_zeroes_seg;
+	uint8_t		write_zeroes_may_unmap;
+	uint8_t		unused1[3];
 } __packed;
 
 /*
@@ -124,9 +154,14 @@ struct vtblk_config {
 struct virtio_blk_hdr {
 #define	VBH_OP_READ		0
 #define	VBH_OP_WRITE		1
+#define	VBH_OP_SCSI_CMD		2
+#define	VBH_OP_SCSI_CMD_OUT	3
 #define	VBH_OP_FLUSH		4
 #define	VBH_OP_FLUSH_OUT	5
 #define	VBH_OP_IDENT		8
+#define	VBH_OP_DISCARD		11
+#define	VBH_OP_WRITE_ZEROES	13
+
 #define	VBH_FLAG_BARRIER	0x80000000	/* OR'ed into vbh_type */
 	uint32_t	vbh_type;
 	uint32_t	vbh_ioprio;
@@ -137,14 +172,23 @@ struct virtio_blk_hdr {
  * Debug printf
  */
 static int pci_vtblk_debug;
-#define DPRINTF(params) if (pci_vtblk_debug) printf params
-#define WPRINTF(params) printf params
+#define	DPRINTF(params) if (pci_vtblk_debug) printf params
+#define	WPRINTF(params) printf params
 
 struct pci_vtblk_ioreq {
 	struct blockif_req		io_req;
 	struct pci_vtblk_softc		*io_sc;
 	uint8_t				*io_status;
 	uint16_t			io_idx;
+};
+
+struct virtio_blk_discard_write_zeroes {
+	uint64_t	sector;
+	uint32_t	num_sectors;
+	struct {
+		uint32_t unmap:1;
+		uint32_t reserved:31;
+	} flags;
 };
 
 /*
@@ -155,6 +199,7 @@ struct pci_vtblk_softc {
 	pthread_mutex_t vsc_mtx;
 	struct vqueue_info vbsc_vq;
 	struct vtblk_config vbsc_cfg;
+	struct virtio_consts vbsc_consts;
 	struct blockif_ctxt *bc;
 #ifndef __FreeBSD__
 	int vbsc_wce;
@@ -244,6 +289,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	int writeop, type;
 	struct iovec iov[BLOCKIF_IOV_MAX + 2];
 	uint16_t idx, flags[BLOCKIF_IOV_MAX + 2];
+	struct virtio_blk_discard_write_zeroes *discard;
 
 	n = vq_getchain(vq, &idx, iov, BLOCKIF_IOV_MAX + 2, flags);
 
@@ -263,7 +309,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	vbh = (struct virtio_blk_hdr *)iov[0].iov_base;
 	memcpy(&io->io_req.br_iov, &iov[1], sizeof(struct iovec) * (n - 2));
 	io->io_req.br_iovcnt = n - 2;
-	io->io_req.br_offset = vbh->vbh_sector * DEV_BSIZE;
+	io->io_req.br_offset = vbh->vbh_sector * VTBLK_BSIZE;
 	io->io_status = (uint8_t *)iov[--n].iov_base;
 	assert(iov[n].iov_len == 1);
 	assert(flags[n] & VRING_DESC_F_WRITE);
@@ -274,7 +320,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	 * we don't advertise the capability.
 	 */
 	type = vbh->vbh_type & ~VBH_FLAG_BARRIER;
-	writeop = (type == VBH_OP_WRITE);
+	writeop = (type == VBH_OP_WRITE || type == VBH_OP_DISCARD);
 
 	iolen = 0;
 	for (i = 1; i < n; i++) {
@@ -290,7 +336,7 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	io->io_req.br_resid = iolen;
 
 	DPRINTF(("virtio-block: %s op, %zd bytes, %d segs, offset %ld\n\r",
-		 writeop ? "write" : "read/ident", iolen, i - 1,
+		 writeop ? "write/discard" : "read/ident", iolen, i - 1,
 		 io->io_req.br_offset));
 
 	switch (type) {
@@ -299,6 +345,46 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 		break;
 	case VBH_OP_WRITE:
 		err = blockif_write(sc->bc, &io->io_req);
+		break;
+	case VBH_OP_DISCARD:
+		/*
+		 * We currently only support a single request, if the guest
+		 * has submitted a request that doesn't conform to the
+		 * requirements, we return a error.
+		 */
+		if (iov[1].iov_len != sizeof (*discard)) {
+			pci_vtblk_done_locked(io, EINVAL);
+			return;
+		}
+
+		/* The segments to discard are provided rather than data */
+		discard = (struct virtio_blk_discard_write_zeroes *)
+		    iov[1].iov_base;
+
+		/*
+		 * virtio v1.1 5.2.6.2:
+		 * The device MUST set the status byte to VIRTIO_BLK_S_UNSUPP
+		 * for discard and write zeroes commands if any unknown flag is
+		 * set. Furthermore, the device MUST set the status byte to
+		 * VIRTIO_BLK_S_UNSUPP for discard commands if the unmap flag
+		 * is set.
+		 *
+		 * Currently there are no known flags for a DISCARD request.
+		 */
+		if (discard->flags.unmap != 0 || discard->flags.reserved != 0) {
+			pci_vtblk_done_locked(io, ENOTSUP);
+			return;
+		}
+
+		/* Make sure the request doesn't exceed our size limit */
+		if (discard->num_sectors > VTBLK_MAX_DISCARD_SECT) {
+			pci_vtblk_done_locked(io, EINVAL);
+			return;
+		}
+
+		io->io_req.br_offset = discard->sector * VTBLK_BSIZE;
+		io->io_req.br_resid = discard->num_sectors * VTBLK_BSIZE;
+		err = blockif_delete(sc->bc, &io->io_req);
 		break;
 	case VBH_OP_FLUSH:
 	case VBH_OP_FLUSH_OUT:
@@ -402,6 +488,10 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 		io->io_idx = i;
 	}
 
+	bcopy(&vtblk_vi_consts, &sc->vbsc_consts, sizeof (vtblk_vi_consts));
+	if (blockif_candelete(sc->bc))
+		sc->vbsc_consts.vc_hv_caps |= VTBLK_F_DISCARD;
+
 #ifndef __FreeBSD__
 	/* Disable write cache until FLUSH feature is negotiated */
 	(void) blockif_set_wce(sc->bc, 0);
@@ -411,7 +501,7 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	pthread_mutex_init(&sc->vsc_mtx, NULL);
 
 	/* init virtio softc and virtqueues */
-	vi_softc_linkup(&sc->vbsc_vs, &vtblk_vi_consts, sc, pi, &sc->vbsc_vq);
+	vi_softc_linkup(&sc->vbsc_vs, &sc->vbsc_consts, sc, pi, &sc->vbsc_vq);
 	sc->vbsc_vs.vs_mtx = &sc->vsc_mtx;
 
 	sc->vbsc_vq.vq_qsize = VTBLK_RINGSZ;
@@ -435,7 +525,7 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 #endif
 
 	/* setup virtio block config space */
-	sc->vbsc_cfg.vbc_capacity = size / DEV_BSIZE; /* 512-byte units */
+	sc->vbsc_cfg.vbc_capacity = size / VTBLK_BSIZE; /* 512-byte units */
 	sc->vbsc_cfg.vbc_size_max = 0;	/* not negotiated */
 
 	/*
@@ -457,6 +547,9 @@ pci_vtblk_init(struct vmctx *ctx, struct pci_devinst *pi, char *opts)
 	sc->vbsc_cfg.vbc_topology.min_io_size = 0;
 	sc->vbsc_cfg.vbc_topology.opt_io_size = 0;
 	sc->vbsc_cfg.vbc_writeback = 0;
+	sc->vbsc_cfg.max_discard_sectors = VTBLK_MAX_DISCARD_SECT;
+	sc->vbsc_cfg.max_discard_seg = VTBLK_MAX_DISCARD_SEG;
+	sc->vbsc_cfg.discard_sector_alignment = sectsz / VTBLK_BSIZE;
 
 	/*
 	 * Should we move some of this into virtio.c?  Could


### PR DESCRIPTION
Weekly upstream for joyent_merge/2020032301

## Backports

To r151030, r151032:

* OS-8141 lx futex called with NULL... causes panic

## onu

```
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2020032301-bec234425c i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Mon Mar 23 23:31:03 UTC 2020 ====
==== Nightly distributed build completed: Tue Mar 24 00:40:20 UTC 2020 ====

==== Total build time ====

real    1:09:17

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-5b83ca0623 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151033-b07"

/usr/bin/openssl
OpenSSL 1.1.1e  17 Mar 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   166

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2020032301-bec234425c

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:37.4
user  3:43:34.5
sys   1:08:10.9

==== Build noise differences (non-DEBUG) ====

120,124d119
< The following command caused the error:
< block_if.c: In function 'blockif_proc':
< block_if.c:376: error: (near initialization for 'dfl') [-Woverride-init]
< block_if.c:376: error: initialized field overwritten [-Woverride-init]
< cc1: warnings being treated as errors
131,132d125
< dmake: Warning: Command failed for target `bhyve'
< dmake: Warning: Target `install' not remade because of errors

==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:31.3
user  3:17:45.1
sys     59:37.8

==== Build noise differences (DEBUG) ====

88,92d87
< The following command caused the error:
< block_if.c: In function 'blockif_proc':
< block_if.c:376: error: (near initialization for 'dfl') [-Woverride-init]
< block_if.c:376: error: initialized field overwritten [-Woverride-init]
< cc1: warnings being treated as errors
98,99d92
< dmake: Warning: Command failed for target `bhyve'
< dmake: Warning: Target `install' not remade because of errors

==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
