### PR TITLE
loader: Improve kmdb option; add framebuffer option

### DIFF
--- a/usr/src/boot/sys/boot/forth/menu-commands.4th
+++ b/usr/src/boot/sys/boot/forth/menu-commands.4th
@@ -23,8 +23,8 @@
 \ SUCH DAMAGE.
 \
 \ Copyright 2015 Toomas Soome <tsoome@me.com>
-\ Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 \ Copyright 2019 Joyent, Inc.
+\ Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 marker task-menu-commands.4th
 
@@ -34,16 +34,10 @@ only forth definitions
 
 variable osconsole_state
 variable acpi_state
-variable kernel_state
-variable root_state
 variable kmdb_state
-variable drop_into_kmdb_state
-0 kmdb_state !
-0 drop_into_kmdb_state !
 0 osconsole_state !
 0 acpi_state !
-0 kernel_state !
-0 root_state !
+0 kmdb_state !
 
 also menu-namespace also menu-command-helpers
 
@@ -186,101 +180,6 @@ also menu-namespace also menu-command-helpers
 ;
 
 \
-\ kmdb
-\
-
-: kmdb_enabled? ( -- flag )
-	s" boot_kmdb" getenv -1 <> dup if
-		swap drop ( c-addr flag -- flag )
-	then
-;
-
-: kmdb_enable ( -- )
-	s" set boot_kmdb=YES" evaluate
-;
-
-: kmdb_disable ( -- )
-	s" boot_kmdb" unsetenv
-	s" boot_drop_into_kmdb" unsetenv
-;
-
-: init_kmdb ( N -- N )
-	dup kmdb_state !		\ store entry number for kmdb+drop_into_kmdb
-	kmdb_enabled? if
-		toggle_menuitem ( n -- n )
-	then
-;
-
-: toggle_kmdb ( N -- N TRUE )
-	toggle_menuitem
-	dup toggle_stateN @ 0= if ( kmdb is not set )
-		drop_into_kmdb_state @ if ( drop_into_kmdb is set? )
-			drop_into_kmdb_state @ toggle_stateN @ if ( drop_into_kmdb is enabled? )
-				drop_into_kmdb_state @ toggle_menuitem drop
-			then
-		then
-	then
-	menu-redraw
-
-	\ Now we're going to make the change effective
-
-	dup toggle_stateN @ 0= if
-		kmdb_disable
-	else
-		kmdb_enable
-	then
-
-	TRUE \ loop menu again
-;
-
-\
-\ drop into kmdb
-\
-
-: drop_into_kmdb_disable ( -- )
-	s" boot_drop_into_kmdb" unsetenv
-;
-
-: drop_into_kmdb_enabled? ( -- flag )
-	\ -d is only allowed with -k
-	s" boot_drop_into_kmdb" getenv -1 <> kmdb_enabled? and dup if
-		swap drop ( c-addr flag -- flag )
-	else
-		drop_into_kmdb_disable		\ make sure env is not set
-	then
-;
-
-: drop_into_kmdb_enable ( -- )
-	kmdb_enable
-	s" set boot_drop_into_kmdb=YES" evaluate
-;
-
-: init_drop_into_kmdb ( N -- N )
-	dup drop_into_kmdb_state !		\ store entry number for kmdb
-	kmdb_enabled? drop_into_kmdb_enabled? and if
-		toggle_menuitem ( n -- n )
-	then
-;
-
-: toggle_drop_into_kmdb ( N -- N TRUE )
-	toggle_menuitem
-	kmdb_enabled? 0= if
-		kmdb_state @ toggle_menuitem drop
-	then
-	menu-redraw
-
-	\ Now we're going to make the change effective
-
-	dup toggle_stateN @ 0= if
-		drop_into_kmdb_disable
-	else
-		drop_into_kmdb_enable
-	then
-
-	TRUE \ loop menu again
-;
-
-\
 \ Reconfiguration boot
 \
 
@@ -320,6 +219,33 @@ also menu-namespace also menu-command-helpers
 ;
 
 \
+\ Framebuffer
+\
+
+: init_framebuffer ( N -- N )
+	framebuffer? if
+		toggle_menuitem ( n -- n )
+	then
+;
+
+: toggle_framebuffer ( N -- N TRUE )
+	toggle_menuitem
+
+	dup toggle_stateN @ 0= if
+		s" off"
+	else
+		s" on"
+	then 1 framebuffer
+
+	draw-beastie
+	draw-brand
+	menu-init		\ needed to reset menu position
+	menu-redraw
+
+	TRUE \ loop menu again
+;
+
+\
 \ Escape to Prompt
 \
 
@@ -336,7 +262,7 @@ also menu-namespace also menu-command-helpers
 ;
 
 \
-\ Cyclestate (used by osconsole/acpi/kernel/root below)
+\ Cyclestate (used by osconsole/acpi/kmdb below)
 \
 
 : init_cyclestate ( N K -- N )
@@ -451,53 +377,70 @@ also menu-namespace also menu-command-helpers
 ;
 
 \
-\ Kernel
+\ kmdb
 \
 
-: init_kernel ( N -- N )
-	kernel_state @  ( n -- n k )
-	init_cyclestate ( n k -- n )
+: kmdb_disable
+	s" boot_kmdb" unsetenv
+	s" boot_drop_into_kmdb" unsetenv
 ;
 
-: activate_kernel ( N -- N )
+: init_kmdb ( N -- N )
+	\ Retrieve the contents of "nmi" or default to "panic"
+	( N -- N c-addr/u )
+	s" nmi" getenv dup -1 <> if else drop s" panic" then
+	\ Store the string in "nmi_initial" if not already set
+	\ (to support re-entering the menu from the loader prompt)
+	s" nmi_initial" getenv? if else
+		2dup s" nmi_initial" setenv
+	then
+	( N caddr/u -- N flag )
+	s" kmdb" compare if false else true then
+
+	s" boot_kmdb" getenv -1 <> if
+		drop
+		s" boot_drop_into_kmdb" getenv -1 <> if
+			drop
+			if 4 else 3 then
+		else
+			if 2 else 1 then
+		then
+	else
+		drop	\ drop flag
+		0
+	then
+	kmdb_state !
+;
+
+: activate_kmdb ( N -- N )
 	dup cycle_stateN @	( n -- n n2 )
-	dup kernel_state !	( n n2 -- n n2 )  \ copy for re-initialization
-	48 +			( n n2 -- n n2' ) \ kernel_state to ASCII num
+	dup kmdb_state !	( n n2 -- n n2 )
 
-	s" set kernel=${kernel_prefix}${kernel[N]}${kernel_suffix}"
-	36 +c!		( n n2 c-addr/u -- n c-addr/u ) \ 'N' to ASCII num
-	evaluate	( n c-addr/u -- n ) \ sets $kernel to full kernel-path
+	\ Reset "nmi" to its initial value
+	s" nmi_initial" getenv s" nmi" setenv
+
+	case 4 of		\ drop + nmi=kmdb
+		s" set boot_kmdb=YES" evaluate
+		s" set boot_drop_into_kmdb=YES" evaluate
+		s" set nmi=kmdb" evaluate
+	endof 3 of		\ drop
+		s" set boot_kmdb=YES" evaluate
+		s" set boot_drop_into_kmdb=YES" evaluate
+	endof 2 of		\ load + nmi=kmdb
+		s" set boot_kmdb=YES" evaluate
+		s" boot_drop_into_kmdb" unsetenv
+		s" set nmi=kmdb" evaluate
+	endof 1 of		\ load
+		s" set boot_kmdb=YES" evaluate
+		s" boot_drop_into_kmdb" unsetenv
+	endof
+		kmdb_disable
+	endcase
 ;
 
-: cycle_kernel ( N -- N TRUE )
+: cycle_kmdb ( N -- N TRUE )
 	cycle_menuitem	\ cycle cycle_stateN to next value
-	activate_kernel \ apply current cycle_stateN
-	menu-redraw	\ redraw menu
-	TRUE		\ loop menu again
-;
-
-\
-\ Root
-\
-
-: init_root ( N -- N )
-	root_state @    ( n -- n k )
-	init_cyclestate ( n k -- n )
-;
-
-: activate_root ( N -- N )
-	dup cycle_stateN @	( n -- n n2 )
-	dup root_state !	( n n2 -- n n2 )  \ copy for re-initialization
-	48 +			( n n2 -- n n2' ) \ root_state to ASCII num
-
-	s" set root=${root_prefix}${root[N]}${root_suffix}"
-	30 +c!		( n n2 c-addr/u -- n c-addr/u ) \ 'N' to ASCII num
-	evaluate	( n c-addr/u -- n ) \ sets $root to full kernel-path
-;
-
-: cycle_root ( N -- N TRUE )
-	cycle_menuitem	\ cycle cycle_stateN to next value
-	activate_root	\ apply current cycle_stateN
+	activate_kmdb	\ apply current cycle_stateN
 	menu-redraw	\ redraw menu
 	TRUE		\ loop menu again
 ;
@@ -524,7 +467,7 @@ also menu-namespace also menu-command-helpers
 	s" boot_ask" unsetenv
 	singleuser_disable
 	verbose_disable
-	kmdb_disable		\ disables drop_into_kmdb as well
+	kmdb_disable		\ disables drop_into_kmdb as well
 	reconfigure_disable
 ;
 

--- a/usr/src/boot/sys/boot/forth/menu.4th
+++ b/usr/src/boot/sys/boot/forth/menu.4th
@@ -1,7 +1,7 @@
 \ Copyright (c) 2003 Scott Long <scottl@FreeBSD.org>
 \ Copyright (c) 2003 Aleksander Fafula <alex@fafula.com>
 \ Copyright (c) 2006-2015 Devin Teske <dteske@FreeBSD.org>
-\ Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+\ Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 \ All rights reserved.
 \
 \ Redistribution and use in source and binary forms, with or without
@@ -65,22 +65,12 @@ variable menuY     \ Menu Y offset (rows)
 \ Menu-item elements
 variable menurebootadded
 
-\ Parsing of kernels into menu-items
-variable kernidx
-variable kernlen
-variable kernmenuidx
-
 \ Menu timer [count-down] variables
 variable menu_timeout_enabled \ timeout state (internal use only)
 variable menu_time            \ variable for tracking the passage of time
 variable menu_timeout         \ determined configurable delay duration
 variable menu_timeout_x       \ column position of timeout message
 variable menu_timeout_y       \ row position of timeout message
-
-\ Containers for parsing kernels into menu-items
-create kerncapbuf 64 allot
-create kerndefault 64 allot
-create kernelsbuf 256 allot
 
 only forth also menu-namespace definitions
 
@@ -96,8 +86,8 @@ variable menukey8
 variable menureboot
 variable menuacpi
 variable menuosconsole
+variable menukmdb
 variable menuoptions
-variable menukernel
 
 \ Menu initialization status variables
 variable init_state1
@@ -185,7 +175,6 @@ only forth also menu-namespace definitions
 : init_textN    ( N -- C-ADDR ) s" init_textN"     9 namespace ;
 
 \ Environment variables
-: kernel[x]          ( N -- C-ADDR/U )   s" kernel[x]"           7 +c! ;
 : menu_init[x]       ( N -- C-ADDR/U )   s" menu_init[x]"       10 +c! ;
 : menu_command[x]    ( N -- C-ADDR/U )   s" menu_command[x]"    13 +c! ;
 : menu_caption[x]    ( N -- C-ADDR/U )   s" menu_caption[x]"    13 +c! ;
@@ -251,189 +240,7 @@ also menu-infrastructure definitions
 	swap drop		( c bool -- bool )	\ return boolean
 ;
 
-\ This function parses $kernels into variables that are used by the menu to
-\ display which kernel to boot when the [overloaded] `boot' word is interpreted.
-\ Used internally by menu-create, you need not (nor should you) call this
-\ directly.
-\
-: parse-kernels ( N -- ) \ kernidx
-	kernidx ! ( n -- )	\ store provided `x' value
-	[char] 0 kernmenuidx !	\ initialize `y' value for menu_caption[x][y]
-
-	\ Attempt to get a list of kernels, fall back to sensible default
-	s" kernels" getenv dup -1 = if
-		drop ( cruft )
-		s" kernel kernel.old"
-	then ( -- c-addr/u )
-
-	\ Check to see if the user has altered $kernel by comparing it against
-	\ $kernel[N] where N is kernel_state (the actively displayed kernel).
-	s" kernel_state" evaluate @ 48 + s" kernel[N]" 7 +c! getenv
-	dup -1 <> if
-		s" kernel" getenv dup -1 = if
-			drop ( cruft ) s" "
-		then
-		2swap 2over compare 0= if
-			2drop FALSE ( skip below conditional )
-		else \ User has changed $kernel
-			TRUE ( slurp in new value )
-		then
-	else \ We haven't yet parsed $kernels into $kernel[N]
-		drop ( getenv cruft )
-		s" kernel" getenv dup -1 = if
-			drop ( cruft ) s" "
-		then
-		TRUE ( slurp in initial value )
-	then ( c-addr/u -- c-addr/u c-addr/u,-1 | 0 )
-	if \ slurp new value into kerndefault
-		kerndefault 1+ 0 2swap strcat swap 1- c!
-	then
-
-	\ Clear out existing parsed-kernels
-	kernidx @ [char] 0
-	begin
-		dup kernel[x] unsetenv
-		2dup menu_caption[x][y] unsetenv
-		2dup ansi_caption[x][y] unsetenv
-		1+ dup [char] 8 >
-	until
-	2drop
-
-	\ Step through the string until we find the end
-	begin
-		0 kernlen ! \ initialize length of value
-
-		\ Skip leading whitespace and/or comma delimiters
-		begin
-			dup 0<> if
-				over c@ delim? ( c-addr/u -- c-addr/u bool )
-			else
-				false ( c-addr/u -- c-addr/u bool )
-			then
-		while
-			1- swap 1+ swap ( c-addr/u -- c-addr'/u' )
-		repeat
-		( c-addr/u -- c-addr'/u' )
-
-		dup 0= if \ end of string while eating whitespace
-			2drop ( c-addr/u -- )
-			kernmenuidx @ [char] 0 <> if \ found at least one
-				exit \ all done
-			then
-
-			\ No entries in $kernels; use $kernel instead
-			s" kernel" getenv dup -1 = if
-				drop ( cruft ) s" "
-			then ( -- c-addr/u )
-			dup kernlen ! \ store entire value length as kernlen
-		else
-			\ We're still within $kernels parsing toward the end;
-			\ find delimiter/end to determine kernlen
-			2dup ( c-addr/u -- c-addr/u c-addr/u )
-			begin dup 0<> while
-				over c@ delim? if
-					drop 0 ( break ) \ found delimiter
-				else
-					kernlen @ 1+ kernlen ! \ incrememnt
-					1- swap 1+ swap \ c-addr++ u--
-				then
-			repeat
-			2drop ( c-addr/u c-addr'/u' -- c-addr/u )
-
-			\ If this is the first entry, compare it to $kernel
-			\ If different, then insert $kernel beforehand
-			kernmenuidx @ [char] 0 = if
-				over kernlen @ kerndefault count compare if
-					kernelsbuf 0 kerndefault count strcat
-					s" ," strcat 2swap strcat
-					kerndefault count swap drop kernlen !
-				then
-			then
-		then
-		( c-addr/u -- c-addr'/u' )
-
-		\ At this point, we should have something on the stack to store
-		\ as the next kernel menu option; start assembling variables
-
-		over kernlen @ ( c-addr/u -- c-addr/u c-addr/u2 )
-
-		\ Assign first to kernel[x]
-		2dup kernmenuidx @ kernel[x] setenv
-
-		\ Assign second to menu_caption[x][y]
-		kerncapbuf 0 s" [K]ernel: " strcat
-		2over strcat
-		kernidx @ kernmenuidx @ menu_caption[x][y]
-		setenv
-
-		\ Assign third to ansi_caption[x][y]
-		kerncapbuf 0 s" @[1mK@[37mernel: " [char] @ escc! strcat
-		kernmenuidx @ [char] 0 = if
-			s" default/@[32m"
-		else
-			s" @[34;1m"
-		then
-		[char] @ escc! strcat
-		2over strcat
-		s" @[37m" [char] @ escc! strcat
-		kernidx @ kernmenuidx @ ansi_caption[x][y]
-		setenv
-
-		2drop ( c-addr/u c-addr/u2 -- c-addr/u )
-
-		kernmenuidx @ 1+ dup kernmenuidx ! [char] 8 > if
-			2drop ( c-addr/u -- ) exit
-		then
-
-		kernlen @ - swap kernlen @ + swap ( c-addr/u -- c-addr'/u' )
-	again
-;
-
-\ This function goes through the kernels that were discovered by the
-\ parse-kernels function [above], adding " (# of #)" text to the end of each
-\ caption.
-\
-: tag-kernels ( -- )
-	kernidx @ ( -- x ) dup 0= if exit then
-	[char] 0 s"  (Y of Z)" ( x -- x y c-addr/u )
-	kernmenuidx @ -rot 7 +c! \ Replace 'Z' with number of kernels parsed
-	begin
-		2 pick 1+ -rot 2 +c! \ Replace 'Y' with current ASCII num
-
-		2over menu_caption[x][y] getenv dup -1 <> if
-			2dup + 1- c@ [char] ) = if
-				2drop \ Already tagged
-			else
-				kerncapbuf 0 2swap strcat
-				2over strcat
-				5 pick 5 pick menu_caption[x][y] setenv
-			then
-		else
-			drop ( getenv cruft )
-		then
-
-		2over ansi_caption[x][y] getenv dup -1 <> if
-			2dup + 1- c@ [char] ) = if
-				2drop \ Already tagged
-			else
-				kerncapbuf 0 2swap strcat
-				2over strcat
-				5 pick 5 pick ansi_caption[x][y] setenv
-			then
-		else
-			drop ( getenv cruft )
-		then
-
-		rot 1+ dup [char] 8 > if
-			-rot 2drop TRUE ( break )
-		else
-			-rot FALSE
-		then
-	until
-	2drop ( x y -- )
-;
-
-\ Illumos kernel acpi-user-options has following values:
+\ illumos kernel acpi-user-options has following values:
 \ default:	0 - system will enable acpi based on bios date
 \ on:		1 - acpi is set on
 \ off:		2 - acpi is set off
@@ -442,41 +249,80 @@ also menu-infrastructure definitions
 
 : acpi-captions ( N -- )
   \ first entry
-  dup s" [A]CPI.............. default" rot 48 menu_caption[x][y] setenv
+  dup s" [A]CPI................ default" rot 48 menu_caption[x][y] setenv
   dup s" ^[1mA^[mCPI.............. ^[32;7mdefault^[m" rot 48 ansi_caption[x][y] setenv
 
-  dup s" [A]CPI.............. On" rot 49 menu_caption[x][y] setenv
+  dup s" [A]CPI................ On" rot 49 menu_caption[x][y] setenv
   dup s" ^[1mA^[mCPI.............. ^[34;1mOn^[m" rot 49 ansi_caption[x][y] setenv
 
-  dup s" [A]CPI.............. Off" rot 50 menu_caption[x][y] setenv
+  dup s" [A]CPI................ Off" rot 50 menu_caption[x][y] setenv
   dup s" ^[1mA^[mCPI.............. ^[34;1mOff^[m" rot 50 ansi_caption[x][y] setenv
 
-  dup s" [A]CPI.............. MADT" rot 51 menu_caption[x][y] setenv
+  dup s" [A]CPI................ MADT" rot 51 menu_caption[x][y] setenv
   dup s" ^[1mA^[mCPI.............. ^[34;1mMADT^[m" rot 51 ansi_caption[x][y] setenv
 
-  dup s" [A]CPI.............. Legacy" rot 52 menu_caption[x][y] setenv
+  dup s" [A]CPI................ Legacy" rot 52 menu_caption[x][y] setenv
   s" ^[1mA^[mCPI.............. ^[34;1mLegacy^[m" rot 52 ansi_caption[x][y] setenv
 ;
 
-\ Illumos console has following values:
+\ illumos console has following values:
 \ text, ttya, ttyb, ttyc, ttyd
 
 : osconsole-captions ( N -- )
   \ first entry
-  dup s" Os[C]onsole............ text" rot 48 menu_caption[x][y] setenv
+  dup s" Os[C]onsole........... text" rot 48 menu_caption[x][y] setenv
   dup s" Os^[1mC^[monsole............ ^[32;7mtext^[m" rot 48 ansi_caption[x][y] setenv
 
-  dup s" Os[C]onsole............ ttya" rot 49 menu_caption[x][y] setenv
+  dup s" Os[C]onsole........... ttya" rot 49 menu_caption[x][y] setenv
   dup s" Os^[1mC^[monsole............ ^[34;1mttya^[m" rot 49 ansi_caption[x][y] setenv
 
-  dup s" Os[C]onsole............ ttyb" rot 50 menu_caption[x][y] setenv
+  dup s" Os[C]onsole........... ttyb" rot 50 menu_caption[x][y] setenv
   dup s" Os^[1mC^[monsole............ ^[34;1mttyb^[m" rot 50 ansi_caption[x][y] setenv
 
-  dup s" Os[C]onsole............ ttyc" rot 51 menu_caption[x][y] setenv
+  dup s" Os[C]onsole........... ttyc" rot 51 menu_caption[x][y] setenv
   dup s" Os^[1mC^[monsole............ ^[34;1mttyc^[m" rot 51 ansi_caption[x][y] setenv
 
-  dup s" Os[C]onsole............ ttyd" rot 52 menu_caption[x][y] setenv
+  dup s" Os[C]onsole........... ttyd" rot 52 menu_caption[x][y] setenv
   s" Os^[1mC^[monsole............ ^[34;1mttyd^[m" rot 52 ansi_caption[x][y] setenv
+;
+
+\ kmdb options are as follows
+\ default:	0 - disabled
+\		1 - boot with -k option
+\		2 - as 1 + configure NMI to drop to kmdb
+\		3 - boot with -k and -d options
+\		4 - as 3 + configure NMI to drop to kmdb
+
+: kmdb-captions ( N -- )
+  \ first entry
+  dup s" [k]mdb Mode........... Off" rot 48 menu_caption[x][y] setenv
+  dup s" ^[1mk^[mmdb Mode............. ^[34;1mOff^[m" rot 48 ansi_caption[x][y] setenv
+
+  dup s" [k]mdb Mode........... Loaded" rot 49 menu_caption[x][y] setenv
+  dup s" ^[1mk^[mmdb Mode............. ^[32;7mLoaded^[m" rot 49 ansi_caption[x][y] setenv
+
+  dup s" [k]mdb Mode........... On NMI" rot 50 menu_caption[x][y] setenv
+  dup s" ^[1mk^[mmdb Mode............. ^[32;7mOn NMI^[m" rot 50 ansi_caption[x][y] setenv
+
+  dup s" [k]mdb Mode........... On Boot" rot 51 menu_caption[x][y] setenv
+  dup s" ^[1mk^[mmdb Mode............. ^[32;7mOn Boot^[m" rot 51 ansi_caption[x][y] setenv
+
+  dup s" [k]mdb Mode........... On Boot/NMI" rot 52 menu_caption[x][y] setenv
+  s" ^[1mk^[mmdb Mode............. ^[32;7mOn Boot/NMI^[m" rot 52 ansi_caption[x][y] setenv
+;
+
+: set-captions ( x y - x y )
+	\ Set the current non-ANSI caption
+	2dup swap dup ( x y -- x y y x x )
+	s" set menu_caption[x]=$menu_caption[x][y]"
+	17 +c! 34 +c! 37 +c! evaluate
+	( x y y x x c-addr/u -- x y  )
+
+	\ Set the current ANSI caption
+	2dup swap dup ( x y -- x y y x x )
+	s" set ansi_caption[x]=$ansi_caption[x][y]"
+	17 +c! 34 +c! 37 +c! evaluate
+	( x y y x x c-addr/u -- x y )
 ;
 
 \ This function creates the list of menu items. This function is called by the
@@ -546,17 +392,7 @@ also menu-infrastructure definitions
 			\ Get the current cycle state (entry to use)
 			s" osconsole_state" evaluate @ 48 + ( n -- n y )
 
-			\ Set the current non-ANSI caption
-			2dup swap dup ( n y -- n y y n n )
-			s" set menu_caption[x]=$menu_caption[x][y]"
-			17 +c! 34 +c! 37 +c! evaluate
-			( n y y n n c-addr/u -- n y  )
-
-			\ Set the current ANSI caption
-			2dup swap dup ( n y -- n y y n n )
-			s" set ansi_caption[x]=$ansi_caption[x][y]"
-			17 +c! 34 +c! 37 +c! evaluate
-			( n y y n n c-addr/u -- n y )
+			set-captions
 
 			\ Initialize cycle state from stored value
 			48 - ( n y -- n k )
@@ -582,17 +418,7 @@ also menu-infrastructure definitions
 			\ Get the current cycle state (entry to use)
 			s" acpi_state" evaluate @ 48 + ( n -- n y )
 
-			\ Set the current non-ANSI caption
-			2dup swap dup ( n y -- n y y n n )
-			s" set menu_caption[x]=$menu_caption[x][y]"
-			17 +c! 34 +c! 37 +c! evaluate
-			( n y y n n c-addr/u -- n y  )
-
-			\ Set the current ANSI caption
-			2dup swap dup ( n y -- n y y n n )
-			s" set ansi_caption[x]=$ansi_caption[x][y]"
-			17 +c! 34 +c! 37 +c! evaluate
-			( n y y n n c-addr/u -- n y )
+			set-captions
 
 			\ Initialize cycle state from stored value
 			48 - ( n y -- n k )
@@ -605,42 +431,27 @@ also menu-infrastructure definitions
 	then
 
 	\
-	\ Initialize kernel captions after parsing $kernels
+	\ Initialize the kmdb option status.
 	\
-	0 menukernel !
-	s" menu_kernel" getenv -1 <> if
+	0 menukmdb !
+	s" menu_kmdb" getenv -1 <> if
 		c@ dup 48 > over 57 < and if ( '1' <= c1 <= '8' )
-			dup menukernel !
-			dup parse-kernels tag-kernels
+			dup menukmdb !
+			dup kmdb-captions
+
+			s" init_kmdb" evaluate
 
 			\ Get the current cycle state (entry to use)
-			s" kernel_state" evaluate @ 48 + ( n -- n y )
+			s" kmdb_state" evaluate @ 48 + ( n -- n y )
 
-			\ If state is invalid, reset
-			dup kernmenuidx @ 1- > if
-				drop [char] 0 ( n y -- n 48 )
-				0 s" kernel_state" evaluate !
-				over s" init_kernel" evaluate drop
-			then
-
-			\ Set the current non-ANSI caption
-			2dup swap dup ( n y -- n y y n n )
-			s" set menu_caption[x]=$menu_caption[x][y]"
-			17 +c! 34 +c! 37 +c! evaluate
-			( n y y n n c-addr/u -- n y  )
-
-			\ Set the current ANSI caption
-			2dup swap dup ( n y -- n y y n n )
-			s" set ansi_caption[x]=$ansi_caption[x][y]"
-			17 +c! 34 +c! 37 +c! evaluate
-			( n y y n n c-addr/u -- n y )
+			set-captions
 
 			\ Initialize cycle state from stored value
 			48 - ( n y -- n k )
 			s" init_cyclestate" evaluate ( n k -- n )
 
-			\ Set $kernel to $kernel[y]
-			s" activate_kernel" evaluate ( n -- n )
+			\ Activate the current option
+			s" activate_kmdb" evaluate ( n -- n )
 		then
 		drop
 	then
@@ -1063,6 +874,23 @@ only forth definitions also menu-infrastructure
 	menu-create
 ;
 
+: menu-box ( -- )
+	\ Interpret a custom frame type for the menu
+	TRUE ( draw a box? default yes, but might be altered below )
+	s" loader_menu_frame" getenv dup -1 = if ( 1 )
+		drop \ no custom frame type
+	else ( 1 )  2dup s" single" compare-insensitive 0= if ( 2 )
+		f_single ( see frames.4th )
+	else ( 2 )  2dup s" double" compare-insensitive 0= if ( 3 )
+		f_double ( see frames.4th )
+	else ( 3 ) s" none" compare-insensitive 0= if ( 4 )
+		drop FALSE \ don't draw a box
+	( 4 ) then ( 3 ) then ( 2 )  then ( 1 ) then
+	if
+		42 13 menuX @ 3 - menuY @ 1- box \ Draw frame (w,h,x,y)
+	then
+;
+
 \ This function initializes the menu. Call this from your `loader.rc' file
 \ before calling any other menu-related functions.
 \
@@ -1093,21 +921,7 @@ only forth definitions also menu-infrastructure
 	then
 	menuX !
 
-	\ Interpret a custom frame type for the menu
-	TRUE ( draw a box? default yes, but might be altered below )
-	s" loader_menu_frame" getenv dup -1 = if ( 1 )
-		drop \ no custom frame type
-	else ( 1 )  2dup s" single" compare-insensitive 0= if ( 2 )
-		f_single ( see frames.4th )
-	else ( 2 )  2dup s" double" compare-insensitive 0= if ( 3 )
-		f_double ( see frames.4th )
-	else ( 3 ) s" none" compare-insensitive 0= if ( 4 )
-		drop FALSE \ don't draw a box
-	( 4 ) then ( 3 ) then ( 2 )  then ( 1 ) then
-	if
-		42 13 menuX @ 3 - menuY @ 1- box \ Draw frame (w,h,x,y)
-	then
-
+	menu-box
 	at-bl
 ;
 
@@ -1324,14 +1138,15 @@ also menu-namespace
 	s" menu_timeout_command" unsetenv	\ menu timeout command
 	s" menu_reboot"          unsetenv	\ Reboot menu option flag
 	s" menu_acpi"            unsetenv	\ ACPI menu option flag
+	s" menu_kmdb"            unsetenv	\ kmdb menu option flag
 	s" menu_osconsole"       unsetenv	\ osconsole menu option flag
-	s" menu_kernel"          unsetenv	\ Kernel menu option flag
 	s" menu_options"         unsetenv	\ Options separator flag
 	s" menu_optionstext"     unsetenv	\ separator display text
 	s" menu_init"            unsetenv	\ menu initializer
 
 	0 menureboot !
 	0 menuacpi !
+	0 menukmdb !
 	0 menuosconsole !
 	0 menuoptions !
 ;

--- a/usr/src/boot/sys/boot/forth/menu.rc
+++ b/usr/src/boot/sys/boot/forth/menu.rc
@@ -71,11 +71,6 @@ set mainmenu_reboot
 \
 set mainmenu_options=5
 
-\ illumos does not have multiple kernels
-\ set mainmenu_kernel=5
-\ set mainmenu_command[5]="cycle_kernel"
-\ set mainmenu_keycode[5]=107
-
 set mainmenu_caption[5]="Configure Boot [O]ptions..."
 set mainmenu_command[5]="2 goto_menu"
 set mainmenu_keycode[5]=111
@@ -154,22 +149,17 @@ set optionsmenu_keycode[6]=114
 set optionsansi_caption[6]="^[1mR^[meconfigure........... ^[34;1mOff^[m"
 set optionstoggled_ansi[6]="^[1mR^[meconfigure........... ^[32;7mOn^[m"
 
-set optionsmenu_init[7]="init_kmdb"
-set optionsmenu_caption[7]="Load [k]mdb........... Off"
-set optionstoggled_text[7]="Load [k]mdb........... On"
-set optionsmenu_command[7]="toggle_kmdb"
+set optionsmenu_kmdb=7
+set optionsmenu_command[7]="cycle_kmdb"
 set optionsmenu_keycode[7]=107
-set optionsansi_caption[7]="Load ^[1mk^[mmdb............. ^[34;1mOff^[m"
-set optionstoggled_ansi[7]="Load ^[1mk^[mmdb............. ^[32;7mOn^[m"
 
-set optionsmenu_init[8]="init_drop_into_kmdb"
-set optionsmenu_caption[8]="[D]rop into kmdb...... Off"
-set optionstoggled_text[8]="[D]rop into kmdb...... On"
-set optionsmenu_command[8]="toggle_drop_into_kmdb"
-set optionsmenu_keycode[8]=100
-set optionsansi_caption[8]="^[1mD^[mrop into kmdb........ ^[34;1mOff^[m"
-set optionstoggled_ansi[8]="^[1mD^[mrop into kmdb........ ^[32;7mOn^[m"
-
+set optionsmenu_init[8]="init_framebuffer"
+set optionsmenu_caption[8]="[F]ramebuffer......... Off"
+set optionstoggled_text[8]="[F]ramebuffer......... On"
+set optionsmenu_command[8]="toggle_framebuffer"
+set optionsmenu_keycode[8]=102
+set optionsansi_caption[8]="^[1mF^[mramebuffer........... ^[34;1mOff^[m"
+set optionstoggled_ansi[8]="^[1mF^[mramebuffer........... ^[32;7mOn^[m"
 
 \
 \ BOOT ENVIRONMENT MENU

--- a/usr/src/boot/sys/boot/forth/menusets.4th
+++ b/usr/src/boot/sys/boot/forth/menusets.4th
@@ -1,5 +1,5 @@
 \ Copyright (c) 2012 Devin Teske <dteske@FreeBSD.org>
-\ Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+\ Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 \ All rights reserved.
 \
 \ Redistribution and use in source and binary forms, with or without
@@ -537,8 +537,8 @@ only forth definitions also menusets-infrastructure
 	s" set var=osconsole" evaluate
 	menuset-loadmenuvar
 
-	\ ... menu_kernel ...
-	s" set var=kernel" evaluate
+	\ ... menu_kmdb ...
+	s" set var=kmdb" evaluate
 	menuset-loadmenuvar
 
 	\ ... menu_options ...
@@ -622,8 +622,8 @@ only forth definitions also menusets-infrastructure
 
 		s" set var=acpi"        evaluate menuset-unloadmenuvar
 		s" set var=osconsole"   evaluate menuset-unloadmenuvar
+		s" set var=kmdb"        evaluate menuset-unloadmenuvar
 		s" set var=init"        evaluate menuset-unloadmenuvar
-		s" set var=kernel"      evaluate menuset-unloadmenuvar
 		s" set var=options"     evaluate menuset-unloadmenuvar
 		s" set var=optionstext" evaluate menuset-unloadmenuvar
 		s" set var=reboot"      evaluate menuset-unloadmenuvar


### PR DESCRIPTION
This consolidates the two kmdb options down into a new menu which has additional options, adds a Framebuffer menu option and removes unused code around kernel selection (to save space)

After:

> Dictionary: 722 words, 28145 cells used of 30000 total

![image](https://user-images.githubusercontent.com/29426693/77548773-ea22d800-6ea6-11ea-97fa-25f27949596d.png)

and the options are:

![image](https://user-images.githubusercontent.com/29426693/77549008-39690880-6ea7-11ea-844c-dee0c32a33c6.png)

![image](https://user-images.githubusercontent.com/29426693/77549071-4b4aab80-6ea7-11ea-8ba0-be8b10a90355.png)

![image](https://user-images.githubusercontent.com/29426693/77549102-556caa00-6ea7-11ea-9c2a-40badaca928c.png)

![image](https://user-images.githubusercontent.com/29426693/77549169-6cab9780-6ea7-11ea-9c12-d5c6e160d466.png)

And selecting the new `[F]ramebuffer` option toggles between this screen and:

![image](https://user-images.githubusercontent.com/29426693/77550257-cc567280-6ea8-11ea-8dc2-003b42963473.png)
