### PR TITLE
Upstream merge joyent_merge/2020032601

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: da036f5cbc2608d7100a682f9c91a938e76cefdc
+Last illumos-joyent commit: 94eb3b821b728e8dc462bb87d35b5f55b5835edc
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -3989,24 +3989,32 @@ lxpr_read_meminfo(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	 * wing it and kill a random process if they run out of backing store
 	 * for virtual memory. Our swap reservation doesn't translate to that
 	 * model, so just inform the caller that no swap is being used.
+	 *
+	 * MemAvailable
+	 * MemAvailable entry is available since Linux Kernel +3.14, is an 
+	 * estimate of how much memory is available for starting new applications, 
+	 * without swapping. In lxbrand we will always return the available free 
+	 * memory as an estimate of this value.
 	 */
 	lxpr_uiobuf_printf(uiobuf,
-	    "MemTotal:  %8lu kB\n"
-	    "MemFree:   %8lu kB\n"
-	    "MemShared: %8u kB\n"
-	    "Buffers:   %8u kB\n"
-	    "Cached:    %8u kB\n"
-	    "SwapCached:%8u kB\n"
-	    "Active:    %8u kB\n"
-	    "Inactive:  %8u kB\n"
-	    "HighTotal: %8u kB\n"
-	    "HighFree:  %8u kB\n"
-	    "LowTotal:  %8u kB\n"
-	    "LowFree:   %8u kB\n"
-	    "SwapTotal: %8lu kB\n"
-	    "SwapFree:  %8lu kB\n",
+	    "MemTotal:       %8lu kB\n"
+	    "MemFree:        %8lu kB\n"
+	    "MemAvailable:   %8lu kB\n"
+	    "MemShared:      %8u kB\n"
+	    "Buffers:        %8u kB\n"
+	    "Cached:         %8u kB\n"
+	    "SwapCached:     %8u kB\n"
+	    "Active:         %8u kB\n"
+	    "Inactive:       %8u kB\n"
+	    "HighTotal:      %8u kB\n"
+	    "HighFree:       %8u kB\n"
+	    "LowTotal:       %8u kB\n"
+	    "LowFree:        %8u kB\n"
+	    "SwapTotal:      %8lu kB\n"
+	    "SwapFree:       %8lu kB\n",
 	    btok(total_mem),				/* MemTotal */
 	    btok(free_mem),				/* MemFree */
+	    btok(free_mem),				/* MemAvailable */
 	    0,						/* MemShared */
 	    0,						/* Buffers */
 	    0,						/* Cached */


### PR DESCRIPTION
Weekly upstream for joyent_merge/2020032601

## Backports

None

## onu

```
OmniOS 5.11     omnios-joyent_merge-2020032601-6fa14b9afa       Mar. 26, 2020
SunOS Internal Development: af 2020-Mar-26 [illumos]

bloody%
bloody% uname -a
SunOS bloody 5.11 omnios-joyent_merge-2020032601-6fa14b9afa i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Mar 26 22:14:20 UTC 2020 ====
==== Nightly distributed build completed: Thu Mar 26 23:22:05 UTC 2020 ====

==== Total build time ====

real    1:07:44

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-5b83ca0623 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151033-b07"

/usr/bin/openssl
OpenSSL 1.1.1e  17 Mar 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   77

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2020032601-6fa14b9afa

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:04.9
user  3:43:14.0
sys   1:04:04.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:05.8
user  3:16:02.6
sys     57:41.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
