### PR TITLE
Upstream merge r151034 backports

### DIFF
--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -21,7 +21,7 @@
 
 #
 # Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2019, Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 # Copyright (c) 2013 DEY Storage Systems, Inc. All rights reserved.
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
@@ -120,6 +120,7 @@ COMMON_SUBDIRS=		\
 	date		\
 	dc		\
 	dd		\
+	demangle	\
 	deroff		\
 	devfsadm	\
 	syseventd	\

--- a/usr/src/cmd/demangle/Makefile
+++ b/usr/src/cmd/demangle/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+PROG=		demangle
+OBJS=		demangle.o
+SRCS=		$(OBJS:%.o=%.c)
+
+include		$(SRC)/cmd/Makefile.cmd
+include		$(SRC)/cmd/Makefile.ctf
+
+CSTD=	$(CSTD_GNU99)
+
+LDLIBS +=	-ldemangle-sys -lcustr
+
+.KEEP_STATE:
+
+all:		$(PROG)
+
+$(PROG):	$(OBJS)
+		$(LINK.c) $(OBJS) -o $@ $(LDLIBS)
+		$(POST_PROCESS)
+
+clean:
+		$(RM) $(OBJS)
+
+install:	all $(ROOTPROG)
+
+include		$(SRC)/cmd/Makefile.targ

--- a/usr/src/cmd/demangle/demangle.c
+++ b/usr/src/cmd/demangle/demangle.c
@@ -1,0 +1,211 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+#include <ctype.h>
+#include <demangle-sys.h>
+#include <err.h>
+#include <errno.h>
+#include <libcustr.h>
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define	_(x) gettext(x)
+
+locale_t c_locale;
+
+static int do_symbols(sysdem_lang_t, int, char * const *);
+static int do_input(sysdem_lang_t, FILE *restrict, FILE *restrict);
+static int do_demangle(const char *, sysdem_lang_t, FILE *);
+static void appendc(custr_t *, char);
+static void xputc(int, FILE *);
+
+static void
+usage(void)
+{
+	(void) fprintf(stderr, _("Usage: %s [-l lang] [sym...]\n"),
+	    getprogname());
+	exit(2);
+}
+
+int
+main(int argc, char * const *argv)
+{
+	sysdem_lang_t lang = SYSDEM_LANG_AUTO;
+	int c;
+	int ret;
+
+	(void) setlocale(LC_ALL, "");
+
+#if !defined(TEXT_DOMAIN)
+#define	TEXT_DOMAIN "SYS_TEST"
+#endif
+	(void) textdomain(TEXT_DOMAIN);
+
+	/*
+	 * For detecting symbol boundaries, we want to use the C locale
+	 * definitions for use in isalnum_l().
+	 */
+	if ((c_locale = newlocale(LC_CTYPE_MASK, "C", NULL)) == NULL)
+		err(EXIT_FAILURE, _("failed to construct C locale"));
+
+	while ((c = getopt(argc, argv, "hl:")) != -1) {
+		switch (c) {
+		case 'l':
+			if (sysdem_parse_lang(optarg, &lang))
+				break;
+
+			errx(EXIT_FAILURE, _("Unsupported language '%s'\n"),
+			    optarg);
+		case 'h':
+		case '?':
+			usage();
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc > 0)
+		ret = do_symbols(lang, argc, argv);
+	else
+		ret = do_input(lang, stdin, stdout);
+
+	return ((ret < 0) ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+
+static int
+do_symbols(sysdem_lang_t lang, int argc, char * const *argv)
+{
+	int ret = 0;
+
+	for (int i = 0; i < argc; i++) {
+		if (do_demangle(argv[i], lang, stdout) < 0)
+			ret = -1;
+		else
+			xputc('\n', stdout);
+	}
+
+	return (ret);
+}
+
+static int
+do_input(sysdem_lang_t lang, FILE *restrict in, FILE *restrict out)
+{
+	custr_t *word = NULL;
+	int c;
+	int ret = 0;
+	boolean_t in_symbol = B_FALSE;
+
+	if (custr_alloc(&word) != 0)
+		err(EXIT_FAILURE, _("failed to allocate memory"));
+
+	while ((c = fgetc(in)) != EOF) {
+		if (in_symbol) {
+			/*
+			 * All currently supported mangling formats only use
+			 * alphanumeric characters, '.', '_', or '$' in
+			 * mangled names. Once we've seen the potential start
+			 * of a symbol ('_'), we accumulate subsequent
+			 * charaters into 'word'. If we encounter a character
+			 * that is not a part of that set ([A-Za-z0-9._$]), we
+			 * treat it as a delimiter, we stop accumulating
+			 * characters into word, and we attempt to demangle the
+			 * accumulated string in 'word' by calling
+			 * demangle_custr().
+			 *
+			 * Similar utilities like c++filt behave in a similar
+			 * fashion when reading from stdin to allow for
+			 * demangling of symbols embedded in surrounding text.
+			 */
+			if (isalnum_l(c, c_locale) || c == '.' || c == '_' ||
+			    c == '$') {
+				appendc(word, c);
+				continue;
+			}
+
+			/*
+			 * Hit a symbol boundary, attempt to demangle what
+			 * we've accumulated in word and reset word.
+			 */
+			if (do_demangle(custr_cstr(word), lang, out) < 0)
+				ret = -1;
+
+			custr_reset(word);
+			in_symbol = B_FALSE;
+		}
+
+		if (c != '_') {
+			xputc(c, out);
+		} else {
+			in_symbol = B_TRUE;
+			appendc(word, c);
+		}
+	}
+
+	if (ferror(in))
+		err(EXIT_FAILURE, _("error reading input"));
+
+	/*
+	 * If we were accumulating characters for a symbol and hit EOF,
+	 * attempt to demangle what we accumulated.
+	 */
+	if (custr_len(word) > 0 && do_demangle(custr_cstr(word), lang, out) < 0)
+		ret = -1;
+
+	custr_free(word);
+	return (ret);
+}
+
+/*
+ * Attempt to demangle 'sym' as a symbol for 'lang' and write the result
+ * to 'out'. If 'sym' could not be demangled as 'lang' symbol, the original
+ * string is output instead.
+ *
+ * If an error other than 'not a mangled symbol' is encountered (e.g. ENOMEM),
+ * a warning is sent to stderr and -1 is returned. Otherwise, 0 is returned
+ * (including when 'sym' is merely not a mangled symbol of 'lang').
+ */
+static int
+do_demangle(const char *sym, sysdem_lang_t lang, FILE *out)
+{
+	char *demangled = sysdemangle(sym, lang, NULL);
+
+	if (demangled == NULL && errno != EINVAL) {
+		warn(_("error while demangling '%s'"), sym);
+		return (-1);
+	}
+
+	if (fprintf(out, "%s", (demangled != NULL) ? demangled : sym) < 0)
+		err(EXIT_FAILURE, _("failed to write to output"));
+
+	free(demangled);
+	return (0);
+}
+
+static void
+appendc(custr_t *cus, char c)
+{
+	if (custr_appendc(cus, c) == 0)
+		return;
+	err(EXIT_FAILURE, _("failed to save character from input"));
+}
+
+static void
+xputc(int c, FILE *out)
+{
+	if (fputc(c, out) < 0)
+		err(EXIT_FAILURE, _("failed to write output"));
+}

--- a/usr/src/lib/libdemangle/common/demangle-sys.h
+++ b/usr/src/lib/libdemangle/common/demangle-sys.h
@@ -11,7 +11,7 @@
 
 /*
  * Copyright 2017 Jason King
- * Copyright 2018, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 #ifndef _DEMANGLE_SYS_H
@@ -34,6 +34,7 @@ typedef struct sysdem_alloc_s {
 	void (*free)(void *, size_t);
 } sysdem_ops_t;
 
+boolean_t sysdem_parse_lang(const char *, sysdem_lang_t *);
 char *sysdemangle(const char *, sysdem_lang_t, sysdem_ops_t *);
 
 #ifdef __cplusplus

--- a/usr/src/lib/libdemangle/common/demangle.c
+++ b/usr/src/lib/libdemangle/common/demangle.c
@@ -21,6 +21,7 @@
 #include <pthread.h>
 #include <sys/ctype.h>
 #include <sys/debug.h>
+#include <sys/sysmacros.h>
 #include <stdarg.h>
 #include "demangle-sys.h"
 #include "demangle_int.h"
@@ -31,19 +32,40 @@ static pthread_once_t debug_once = PTHREAD_ONCE_INIT;
 volatile boolean_t demangle_debug;
 FILE *debugf = stderr;
 
+static struct {
+	const char	*str;
+	sysdem_lang_t	lang;
+} lang_tbl[] = {
+	{ "auto", SYSDEM_LANG_AUTO },
+	{ "c++", SYSDEM_LANG_CPP },
+	{ "rust", SYSDEM_LANG_RUST },
+};
+
 static const char *
 langstr(sysdem_lang_t lang)
 {
-	switch (lang) {
-	case SYSDEM_LANG_AUTO:
-		return ("auto");
-	case SYSDEM_LANG_CPP:
-		return ("c++");
-	case SYSDEM_LANG_RUST:
-		return ("rust");
-	default:
-		return ("invalid");
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(lang_tbl); i++) {
+		if (lang == lang_tbl[i].lang)
+			return (lang_tbl[i].str);
 	}
+	return ("invalid");
+}
+
+boolean_t
+sysdem_parse_lang(const char *str, sysdem_lang_t *langp)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(lang_tbl); i++) {
+		if (strcmp(str, lang_tbl[i].str) == 0) {
+			*langp = lang_tbl[i].lang;
+			return (B_TRUE);
+		}
+	}
+
+	return (B_FALSE);
 }
 
 static sysdem_lang_t

--- a/usr/src/lib/libdemangle/common/mapfile-vers
+++ b/usr/src/lib/libdemangle/common/mapfile-vers
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Jason King
+# Copyright 2019 Joyent, Inc.
 #
 
 #
@@ -30,6 +31,7 @@ $mapfile_version 2
 
 SYMBOL_VERSION ILLUMOSprivate {
     global:
+	sysdem_parse_lang;
 	sysdemangle;
     local:
         *;

--- a/usr/src/man/man1/Makefile
+++ b/usr/src/man/man1/Makefile
@@ -16,6 +16,7 @@
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
 # Copyright 2015 Nexenta Systems, Inc. All rights reserved.
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 Joyent, Inc.
 #
 
 include		$(SRC)/Makefile.master
@@ -96,6 +97,7 @@ MANFILES=	acctcom.1			\
 		date.1				\
 		dc.1				\
 		deallocate.1			\
+		demangle.1			\
 		deroff.1			\
 		dhcpinfo.1			\
 		diff.1				\

--- a/usr/src/man/man1/demangle.1
+++ b/usr/src/man/man1/demangle.1
@@ -1,0 +1,119 @@
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" Copyright 2020 Joyent, Inc.
+.\"
+.Dd March  3, 2020
+.Dt DEMANGLE 1
+.Os
+.Sh NAME
+.Nm demangle
+.Nd demangle symbols
+.Sh SYNOPSIS
+.Nm
+.Oo
+.Fl l
+.Ar lang
+.Oc
+.Op Ar symbol Ns ...
+.Sh DESCRIPTION
+The
+.Nm
+utility attempts to detect mangled symbols and transform them back into a
+more human friendly version of the symbol.
+.Pp
+Some languages allow the same identifier to refer to multiple things
+(functions, variables, etc\&.) where some additional context such as
+parameter types, return types, etc\&. are used to disambiguate between the
+symbols sharing the same name.
+When compiling such languages into an executable form, most binary formats
+do not allow for duplicate symbol names or provide a way to disambiguate
+between duplicate names.
+.Pp
+To solve this problem, many languages will use the additional context from
+the source code to transform the symbol name into a unique name.
+This process is called name mangling.
+While the resulting name is predictable, the mangled names are often difficult
+for humans to interpret.
+.Pp
+The
+.Nm
+utility can be invoked in one of two ways.
+In the first method,
+.Ar symbol
+is demangled and the result is written to standard out, one line per input
+.Ar symbol .
+If any input
+.Ar symbol
+cannot be demangled, the original value of
+.Ar symbol
+is output unchanged.
+In the second method,
+.Nm
+reads standard in, and whenever it encounters a potential symbol, it will
+attempt to replace the symbol in stdandard out with the demangled version.
+If the symbol cannot be demangled, it is output unchanged.
+.Pp
+For either method, if an error other than attempting to demangle an non-mangled
+symbol (e.g. out of memory), that error will be written to standard error.
+.Sh OPTIONS
+.Bl -tag -width Fl
+.It Fl l Ar lang
+Treat all potential symbols as symbols from
+.Ar lang .
+By default,
+.Nm
+will attempt to detect the language and demangle symbols for all supported
+languages.
+Current supported values of
+.Ar lang
+are:
+.Bl -tag -width rust -offset indent
+.It c++
+The C++ mangling format defined by the Itanium ABI.
+While the mangling format was originally defined for the Itanium processor, g++
+and clang use this format for all their supported platforms (including x86 and
+SPARC).
+.It rust
+The legacy rust mangling format.
+.It auto
+Attempt to detect the language automatically (default).
+.El
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+.Sy Example 1
+Demangle symbols given as command line arguments.
+.Bd -literal
+% demangle '_ZGVN9__gnu_cxx16bitmap_allocatorIwE13_S_mem_blocksE'
+guard variable for __gnu_cxx::bitmap_allocator<wchar_t>::_S_mem_blocks
+%
+.Ed
+.Pp
+.Sy Example 2
+Demangle symbols from the output of another command.
+.Bd -literal
+% grep slice rust.c | head -1
+    T("__ZN4core5slice89_$LT$impl$u20$core..iter..traits..IntoIterator$u20$for$u20$$RF$$u27$a$u20$$u5b$T$u5d$$GT$9into_iter17h450e234d27262170E",
+% grep slice rust.c | head -1 | demangle
+    T("core::slice::<impl core::iter::traits::IntoIterator for &'a [T]>::into_iter::h450e234d27262170",
+%
+.Ed
+.Sh INTERFACE STABILITY
+The command line options are
+.Sy Uncommitted .
+The output format is
+.Sy Not-an-Interface .

--- a/usr/src/pkg/manifests/developer-object-file.mf
+++ b/usr/src/pkg/manifests/developer-object-file.mf
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 Joyent, Inc.
 #
 
 set name=pkg.fmri value=pkg:/developer/object-file@$(PKGVERS)
@@ -53,6 +54,7 @@ file path=usr/bin/$(ARCH64)/mcs mode=0555
 file path=usr/bin/$(ARCH64)/nm mode=0555
 file path=usr/bin/$(ARCH64)/size mode=0555
 file path=usr/bin/ar mode=0555
+file path=usr/bin/demangle mode=0555
 file path=usr/bin/dis mode=0555
 file path=usr/bin/dump mode=0555
 file path=usr/bin/elfdump mode=0555
@@ -95,6 +97,7 @@ file path=usr/share/lib/ccs/ncform
 file path=usr/share/lib/ccs/nrform
 file path=usr/share/lib/ccs/yaccpar
 file path=usr/share/man/man1/ar.1
+file path=usr/share/man/man1/demangle.1
 file path=usr/share/man/man1/dis.1
 file path=usr/share/man/man1/dump.1
 file path=usr/share/man/man1/elfdump.1

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -31,6 +31,7 @@
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2017 Datto Inc.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 /*
@@ -5358,10 +5359,9 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
  * Get the root pool information from the root disk, then import the root pool
  * during the system boot up time.
  */
-extern int vdev_disk_read_rootlabel(char *, char *, nvlist_t **);
-
 static nvlist_t *
-spa_generate_rootconf(char *devpath, char *devid, uint64_t *guid)
+spa_generate_rootconf(const char *devpath, const char *devid, uint64_t *guid,
+    uint64_t pool_guid)
 {
 	nvlist_t *config;
 	nvlist_t *nvtop, *nvroot;
@@ -5378,6 +5378,19 @@ spa_generate_rootconf(char *devpath, char *devid, uint64_t *guid)
 	VERIFY(nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_GUID,
 	    &pgid) == 0);
 	VERIFY(nvlist_lookup_uint64(config, ZPOOL_CONFIG_GUID, guid) == 0);
+
+	if (pool_guid != 0 && pool_guid != pgid) {
+		/*
+		 * The boot loader provided a pool GUID, but it does not match
+		 * the one we found in the label.  Return failure so that we
+		 * can fall back to the full device scan.
+		 */
+		zfs_dbgmsg("spa_generate_rootconf: loader pool guid %llu != "
+		    "label pool guid %llu", (u_longlong_t)pool_guid,
+		    (u_longlong_t)pgid);
+		nvlist_free(config);
+		return (NULL);
+	}
 
 	/*
 	 * Put this pool's top-level vdevs into a root vdev.
@@ -5445,7 +5458,8 @@ spa_alt_rootvdev(vdev_t *vd, vdev_t **avd, uint64_t *txg)
  *	"/pci@1f,0/ide@d/disk@0,0:a"
  */
 int
-spa_import_rootpool(char *devpath, char *devid)
+spa_import_rootpool(char *devpath, char *devid, uint64_t pool_guid,
+    uint64_t vdev_guid)
 {
 	spa_t *spa;
 	vdev_t *rvd, *bvd, *avd = NULL;
@@ -5453,11 +5467,12 @@ spa_import_rootpool(char *devpath, char *devid)
 	uint64_t guid, txg;
 	char *pname;
 	int error;
+	const char *altdevpath = NULL;
 
 	/*
 	 * Read the label from the boot device and generate a configuration.
 	 */
-	config = spa_generate_rootconf(devpath, devid, &guid);
+	config = spa_generate_rootconf(devpath, devid, &guid, pool_guid);
 #if defined(_OBP) && defined(_KERNEL)
 	if (config == NULL) {
 		if (strstr(devpath, "/iscsi/ssd") != NULL) {
@@ -5467,6 +5482,27 @@ spa_import_rootpool(char *devpath, char *devid)
 		}
 	}
 #endif
+
+	/*
+	 * We were unable to import the pool using the /devices path or devid
+	 * provided by the boot loader.  This may be the case if the boot
+	 * device has been connected to a different location in the system, or
+	 * if a new boot environment has changed the driver used to access the
+	 * boot device.
+	 *
+	 * Attempt an exhaustive scan of all visible block devices to see if we
+	 * can locate an alternative /devices path with a label that matches
+	 * the expected pool and vdev GUID.
+	 */
+	if (config == NULL && (altdevpath =
+	    vdev_disk_preroot_lookup(pool_guid, vdev_guid)) != NULL) {
+		cmn_err(CE_NOTE, "Original /devices path (%s) not available; "
+		    "ZFS is trying an alternate path (%s)", devpath,
+		    altdevpath);
+		config = spa_generate_rootconf(altdevpath, NULL, &guid,
+		    pool_guid);
+	}
+
 	if (config == NULL) {
 		cmn_err(CE_NOTE, "Cannot read the pool label from '%s'",
 		    devpath);

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -28,6 +28,7 @@
  * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2017 Datto Inc.
  * Copyright (c) 2017, Intel Corporation.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #ifndef _SYS_SPA_H
@@ -759,7 +760,8 @@ extern int spa_get_stats(const char *pool, nvlist_t **config, char *altroot,
     size_t buflen);
 extern int spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
     nvlist_t *zplprops, struct dsl_crypto_params *dcp);
-extern int spa_import_rootpool(char *devpath, char *devid);
+extern int spa_import_rootpool(char *devpath, char *devid, uint64_t pool_guid,
+    uint64_t vdev_guid);
 extern int spa_import(const char *pool, nvlist_t *config, nvlist_t *props,
     uint64_t flags);
 extern nvlist_t *spa_tryimport(nvlist_t *tryconfig);

--- a/usr/src/uts/common/fs/zfs/sys/spa_boot.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa_boot.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #ifndef _SYS_SPA_BOOT_H
@@ -36,8 +37,8 @@
 extern "C" {
 #endif
 
-extern char *spa_get_bootprop(char *prop);
-extern void spa_free_bootprop(char *prop);
+extern char *spa_get_bootprop(const char *propname);
+extern void spa_free_bootprop(char *propval);
 
 extern void spa_arch_init(void);
 

--- a/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
@@ -25,6 +25,7 @@
  * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #ifndef _SYS_VDEV_IMPL_H
@@ -556,6 +557,14 @@ typedef struct vdev_buf {
 	buf_t	vb_buf;		/* buffer that describes the io */
 	zio_t	*vb_io;		/* pointer back to the original zio_t */
 } vdev_buf_t;
+
+/*
+ * Support routines used during boot from a ZFS pool
+ */
+extern int vdev_disk_read_rootlabel(const char *, const char *, nvlist_t **);
+extern void vdev_disk_preroot_init(void);
+extern void vdev_disk_preroot_fini(void);
+extern const char *vdev_disk_preroot_lookup(uint64_t, uint64_t);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #include <sys/zfs_context.h>
@@ -363,7 +364,6 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	error = EINVAL;		/* presume failure */
 
 	if (vd->vdev_path != NULL) {
-
 		if (vd->vdev_wholedisk == -1ULL) {
 			size_t len = strlen(vd->vdev_path) + 3;
 			char *buf = kmem_alloc(len, KM_SLEEP);
@@ -475,6 +475,28 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		if (error != 0 && vd->vdev_path != NULL) {
 			error = ldi_open_by_name(vd->vdev_path, spa_mode(spa),
 			    kcred, &dvd->vd_lh, zfs_li);
+		}
+	}
+
+	/*
+	 * If this is early in boot, a sweep of available block devices may
+	 * locate an alternative path that we can try.
+	 */
+	if (error != 0) {
+		const char *altdevpath = vdev_disk_preroot_lookup(
+		    spa_guid(spa), vd->vdev_guid);
+
+		if (altdevpath != NULL) {
+			vdev_dbgmsg(vd, "Trying alternate preroot path (%s)",
+			    altdevpath);
+
+			validate_devid = B_TRUE;
+
+			if ((error = ldi_open_by_name((char *)altdevpath,
+			    spa_mode(spa), kcred, &dvd->vd_lh, zfs_li)) != 0) {
+				vdev_dbgmsg(vd, "Failed to open by preroot "
+				    "path (%s)", altdevpath);
+			}
 		}
 	}
 
@@ -1056,7 +1078,8 @@ vdev_ops_t vdev_disk_ops = {
  * the device, and construct a configuration nvlist.
  */
 int
-vdev_disk_read_rootlabel(char *devpath, char *devid, nvlist_t **config)
+vdev_disk_read_rootlabel(const char *devpath, const char *devid,
+    nvlist_t **config)
 {
 	ldi_handle_t vd_lh;
 	vdev_label_t *label;
@@ -1069,7 +1092,7 @@ vdev_disk_read_rootlabel(char *devpath, char *devid, nvlist_t **config)
 	/*
 	 * Read the device label and build the nvlist.
 	 */
-	if (devid != NULL && ddi_devid_str_decode(devid, &tmpdevid,
+	if (devid != NULL && ddi_devid_str_decode((char *)devid, &tmpdevid,
 	    &minor_name) == 0) {
 		error = ldi_open_by_devid(tmpdevid, minor_name,
 		    FREAD, kcred, &vd_lh, zfs_li);
@@ -1077,9 +1100,10 @@ vdev_disk_read_rootlabel(char *devpath, char *devid, nvlist_t **config)
 		ddi_devid_str_free(minor_name);
 	}
 
-	if (error && (error = ldi_open_by_name(devpath, FREAD, kcred, &vd_lh,
-	    zfs_li)))
+	if (error != 0 && (error = ldi_open_by_name((char *)devpath, FREAD,
+	    kcred, &vd_lh, zfs_li)) != 0) {
 		return (error);
+	}
 
 	if (ldi_get_size(vd_lh, &s)) {
 		(void) ldi_close(vd_lh, FREAD, kcred);
@@ -1128,4 +1152,151 @@ vdev_disk_read_rootlabel(char *devpath, char *devid, nvlist_t **config)
 		error = SET_ERROR(EIDRM);
 
 	return (error);
+}
+
+struct veb {
+	list_t veb_ents;
+	boolean_t veb_scanned;
+};
+
+struct veb_ent {
+	uint64_t vebe_pool_guid;
+	uint64_t vebe_vdev_guid;
+
+	char *vebe_devpath;
+
+	list_node_t vebe_link;
+};
+
+static kmutex_t veb_lock;
+static struct veb *veb;
+
+static int
+vdev_disk_preroot_scan_walk(const char *devpath, void *arg)
+{
+	int r;
+	nvlist_t *cfg = NULL;
+	uint64_t pguid = 0, vguid = 0;
+
+	/*
+	 * Attempt to read the label from this block device.
+	 */
+	if ((r = vdev_disk_read_rootlabel(devpath, NULL, &cfg)) != 0) {
+		/*
+		 * Many of the available block devices will represent slices or
+		 * partitions of disks, or may represent disks that are not at
+		 * all initialised with ZFS.  As this is a best effort
+		 * mechanism to locate an alternate path to a particular vdev,
+		 * we will ignore any failures and keep scanning.
+		 */
+		return (PREROOT_WALK_BLOCK_DEVICES_NEXT);
+	}
+
+	/*
+	 * Determine the pool and vdev GUID read from the label for this
+	 * device.  Both values must be present and have a non-zero value.
+	 */
+	if (nvlist_lookup_uint64(cfg, ZPOOL_CONFIG_POOL_GUID, &pguid) != 0 ||
+	    nvlist_lookup_uint64(cfg, ZPOOL_CONFIG_GUID, &vguid) != 0 ||
+	    pguid == 0 || vguid == 0) {
+		/*
+		 * This label was not complete.
+		 */
+		goto out;
+	}
+
+	/*
+	 * Keep track of all of the GUID-to-devpath mappings we find so that
+	 * vdev_disk_preroot_lookup() can search them.
+	 */
+	struct veb_ent *vebe = kmem_zalloc(sizeof (*vebe), KM_SLEEP);
+	vebe->vebe_pool_guid = pguid;
+	vebe->vebe_vdev_guid = vguid;
+	vebe->vebe_devpath = spa_strdup(devpath);
+
+	list_insert_tail(&veb->veb_ents, vebe);
+
+out:
+	nvlist_free(cfg);
+	return (PREROOT_WALK_BLOCK_DEVICES_NEXT);
+}
+
+const char *
+vdev_disk_preroot_lookup(uint64_t pool_guid, uint64_t vdev_guid)
+{
+	if (pool_guid == 0 || vdev_guid == 0) {
+		/*
+		 * If we aren't provided both a pool and a vdev GUID, we cannot
+		 * perform a lookup.
+		 */
+		return (NULL);
+	}
+
+	mutex_enter(&veb_lock);
+	if (veb == NULL) {
+		/*
+		 * If vdev_disk_preroot_fini() has been called already, there
+		 * is nothing we can do.
+		 */
+		mutex_exit(&veb_lock);
+		return (NULL);
+	}
+
+	/*
+	 * We want to perform at most one scan of all block devices per boot.
+	 */
+	if (!veb->veb_scanned) {
+		cmn_err(CE_NOTE, "Performing full ZFS device scan!");
+
+		preroot_walk_block_devices(vdev_disk_preroot_scan_walk, NULL);
+
+		veb->veb_scanned = B_TRUE;
+	}
+
+	const char *path = NULL;
+	for (struct veb_ent *vebe = list_head(&veb->veb_ents); vebe != NULL;
+	    vebe = list_next(&veb->veb_ents, vebe)) {
+		if (vebe->vebe_pool_guid == pool_guid &&
+		    vebe->vebe_vdev_guid == vdev_guid) {
+			path = vebe->vebe_devpath;
+			break;
+		}
+	}
+
+	mutex_exit(&veb_lock);
+
+	return (path);
+}
+
+void
+vdev_disk_preroot_init(void)
+{
+	mutex_init(&veb_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	VERIFY3P(veb, ==, NULL);
+	veb = kmem_zalloc(sizeof (*veb), KM_SLEEP);
+	list_create(&veb->veb_ents, sizeof (struct veb_ent),
+	    offsetof(struct veb_ent, vebe_link));
+	veb->veb_scanned = B_FALSE;
+}
+
+void
+vdev_disk_preroot_fini(void)
+{
+	mutex_enter(&veb_lock);
+
+	if (veb != NULL) {
+		while (!list_is_empty(&veb->veb_ents)) {
+			struct veb_ent *vebe = list_remove_head(&veb->veb_ents);
+
+			spa_strfree(vebe->vebe_devpath);
+
+			kmem_free(vebe, sizeof (*vebe));
+		}
+
+		kmem_free(veb, sizeof (*veb));
+		veb = NULL;
+	}
+
+	mutex_exit(&veb_lock);
 }

--- a/usr/src/uts/common/fs/zfs/zfs_vfsops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vfsops.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -63,10 +64,12 @@
 #include <sys/zfs_ctldir.h>
 #include <sys/zfs_fuid.h>
 #include <sys/bootconf.h>
+#include <sys/ddi.h>
 #include <sys/sunddi.h>
 #include <sys/dnlc.h>
 #include <sys/dmu_objset.h>
 #include <sys/spa_boot.h>
+#include <sys/vdev_impl.h>
 #include "zfs_comutil.h"
 
 int zfsfstype;
@@ -1710,6 +1713,36 @@ zfs_mount_label_policy(vfs_t *vfsp, char *osname)
 	return (retv);
 }
 
+/*
+ * Load a string-valued boot property and attempt to convert it to a 64-bit
+ * unsigned integer.  If the value is not present, or the conversion fails,
+ * return the provided default value.
+ */
+static uint64_t
+spa_get_bootprop_uint64(const char *name, uint64_t defval)
+{
+	char *propval;
+	u_longlong_t r;
+	int e;
+
+	if ((propval = spa_get_bootprop(name)) == NULL) {
+		/*
+		 * The property does not exist.
+		 */
+		return (defval);
+	}
+
+	e = ddi_strtoull(propval, NULL, 10, &r);
+
+	spa_free_bootprop(propval);
+
+	/*
+	 * If the conversion succeeded, return the value.  If there was any
+	 * kind of failure, just return the default value.
+	 */
+	return (e == 0 ? r : defval);
+}
+
 static int
 zfs_mountroot(vfs_t *vfsp, enum whymountroot why)
 {
@@ -1720,6 +1753,8 @@ zfs_mountroot(vfs_t *vfsp, enum whymountroot why)
 	vnode_t *vp = NULL;
 	char *zfs_bootfs;
 	char *zfs_devid;
+	uint64_t zfs_bootpool;
+	uint64_t zfs_bootvdev;
 
 	ASSERT(vfsp);
 
@@ -1731,6 +1766,7 @@ zfs_mountroot(vfs_t *vfsp, enum whymountroot why)
 	if (why == ROOT_INIT) {
 		if (zfsrootdone++)
 			return (SET_ERROR(EBUSY));
+
 		/*
 		 * the process of doing a spa_load will require the
 		 * clock to be set before we could (for example) do
@@ -1745,23 +1781,47 @@ zfs_mountroot(vfs_t *vfsp, enum whymountroot why)
 			return (SET_ERROR(EINVAL));
 		}
 		zfs_devid = spa_get_bootprop("diskdevid");
-		error = spa_import_rootpool(rootfs.bo_name, zfs_devid);
-		if (zfs_devid)
-			spa_free_bootprop(zfs_devid);
-		if (error) {
+
+		/*
+		 * The boot loader may also provide us with the GUID for both
+		 * the pool and the nominated boot vdev.  A GUID value of 0 is
+		 * explicitly invalid (see "spa_change_guid()"), so we use this
+		 * as a sentinel value when no GUID is present.
+		 */
+		zfs_bootpool = spa_get_bootprop_uint64("zfs-bootpool", 0);
+		zfs_bootvdev = spa_get_bootprop_uint64("zfs-bootvdev", 0);
+
+		/*
+		 * Initialise the early boot device rescan mechanism.  A scan
+		 * will not actually be performed unless we need to do so in
+		 * order to find the correct /devices path for a relocated
+		 * device.
+		 */
+		vdev_disk_preroot_init();
+
+		error = spa_import_rootpool(rootfs.bo_name, zfs_devid,
+		    zfs_bootpool, zfs_bootvdev);
+
+		spa_free_bootprop(zfs_devid);
+
+		if (error != 0) {
 			spa_free_bootprop(zfs_bootfs);
+			vdev_disk_preroot_fini();
 			cmn_err(CE_NOTE, "spa_import_rootpool: error %d",
 			    error);
 			return (error);
 		}
+
 		if (error = zfs_parse_bootfs(zfs_bootfs, rootfs.bo_name)) {
 			spa_free_bootprop(zfs_bootfs);
+			vdev_disk_preroot_fini();
 			cmn_err(CE_NOTE, "zfs_parse_bootfs: error %d",
 			    error);
 			return (error);
 		}
 
 		spa_free_bootprop(zfs_bootfs);
+		vdev_disk_preroot_fini();
 
 		if (error = vfs_lock(vfsp))
 			return (error);

--- a/usr/src/uts/common/sys/ddi_implfuncs.h
+++ b/usr/src/uts/common/sys/ddi_implfuncs.h
@@ -25,6 +25,7 @@
  */
 /*
  * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #ifndef _SYS_DDI_IMPLFUNCS_H
@@ -236,6 +237,16 @@ extern void i_ddi_decr_locked_memory(proc_t *, rctl_qty_t);
  * Direct I/O support functions
  */
 extern void translate_devid(dev_info_t *dip);
+
+/*
+ * Support routine for file systems that need to scan block devices searching
+ * for a label as part of mounting the root file system.
+ */
+extern void preroot_walk_block_devices(int (*)(const char *, void *), void *);
+
+#define	PREROOT_WALK_BLOCK_DEVICES_NEXT		1
+#define	PREROOT_WALK_BLOCK_DEVICES_CANCEL	2
+
 
 #endif	/* _KERNEL */
 

--- a/usr/src/uts/intel/zfs/spa_boot.c
+++ b/usr/src/uts/intel/zfs/spa_boot.c
@@ -26,6 +26,7 @@
 
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #include <sys/zio.h>
@@ -36,19 +37,25 @@
 extern int zfs_deadman_enabled;
 
 char *
-spa_get_bootprop(char *propname)
+spa_get_bootprop(const char *propname)
 {
 	char *value;
 
 	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, ddi_root_node(),
-	    DDI_PROP_DONTPASS, propname, &value) != DDI_SUCCESS)
+	    DDI_PROP_DONTPASS, (char *)propname, &value) != DDI_SUCCESS) {
 		return (NULL);
+	}
+
 	return (value);
 }
 
 void
 spa_free_bootprop(char *value)
 {
+	if (value == NULL) {
+		return;
+	}
+
 	ddi_prop_free(value);
 }
 

--- a/usr/src/uts/sparc/zfs/spa_boot.c
+++ b/usr/src/uts/sparc/zfs/spa_boot.c
@@ -26,6 +26,7 @@
 
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
 
 #include <sys/zio.h>
@@ -35,7 +36,7 @@
 extern int zfs_deadman_enabled;
 
 char *
-spa_get_bootprop(char *propname)
+spa_get_bootprop(const char *propname)
 {
 	int proplen;
 	char *value;
@@ -54,9 +55,13 @@ spa_get_bootprop(char *propname)
 }
 
 void
-spa_free_bootprop(char *propname)
+spa_free_bootprop(char *propval)
 {
-	kmem_free(propname, strlen(propname) + 1);
+	if (propval == NULL) {
+		return;
+	}
+
+	kmem_free(propval, strlen(propval) + 1);
 }
 
 void


### PR DESCRIPTION

## onu

```
OmniOS 5.11     omnios-bpr34-8effd1d7de Apr. 02, 2020
SunOS Internal Development: af 2020-Apr-02 [illumos]
r151034%
r151034% uname -a
SunOS r151034 5.11 omnios-bpr34-8effd1d7de i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Apr  2 09:49:06 UTC 2020 ====
==== Nightly distributed build completed: Thu Apr  2 11:00:12 UTC 2020 ====

==== Total build time ====

real    1:11:06

==== Build environment ====

/usr/bin/uname
SunOS r151034 5.11 omnios-r151034-2e94bc8321 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151034/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151034/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151034-b07"

/usr/bin/openssl
OpenSSL 1.1.1f  31 Mar 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   116

==== Nightly argument issues ====


==== Build version ====

omnios-bpr34-8effd1d7de

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    26:48.1
user  3:43:34.3
sys   1:03:35.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:53.8
user  3:17:52.6
sys     58:54.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
