### PR TITLE
Specify network-physical's dependency on varpd in the varpd manifest

### DIFF
--- a/usr/src/cmd/svc/milestone/network-physical.xml
+++ b/usr/src/cmd/svc/milestone/network-physical.xml
@@ -48,14 +48,6 @@
 		<service_fmri value='svc:/network/loopback' />
 	</dependency>
 
-	<dependency
-		name='network-physical-varpd'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/network/varpd' />
-	</dependency>
-
 	<instance name='default' enabled='true'>
 
 	<!--

--- a/usr/src/cmd/varpd/varpd.xml
+++ b/usr/src/cmd/varpd/varpd.xml
@@ -50,6 +50,12 @@ Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 			<service_fmri value="svc:/system/filesystem/minimal:default" />
 		</dependency>
 
+		<dependent name='varpd-network-physical-default'
+			grouping='optional_all'
+			restart_on='none'>
+			<service_fmri value='svc:/network/physical:default' />
+		</dependent>
+
 		<exec_method
 			type="method"
 			name="start"


### PR DESCRIPTION
It makes more sense to set up the dependency this way around since the varpd service is not installed in a non-global zone. With the original configuration, `network/physical:default` in an NGZ still had a dependency on varpd and this way it does not.

```
bloody% svcs -x
bloody%
bloody% svcs varpd
STATE          STIME    FMRI
disabled       22:09:38 svc:/network/varpd:default

bloody% svcs -D varpd
STATE          STIME    FMRI
online         22:09:39 svc:/network/physical:default

bloody% svcs -d network/physical:default
STATE          STIME    FMRI
disabled       22:09:38 svc:/network/install:default
disabled       22:09:38 svc:/network/varpd:default
online         22:09:38 svc:/network/datalink-management:default
online         22:09:38 svc:/network/ip-interface-management:default
online         22:09:38 svc:/network/loopback:default

bloody% svcprop network/physical | grep varp
bloody% svcprop varpd | grep physical
dependents/varpd-network-physical-default fmri svc:/network/physical:default
```