### PR TITLE
Joyent merge/2020041001

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ lint.out
 /usr/src/tools/clobber-*.out
 /usr/src/tools/install-*.out
 # BEGIN AUTO-GENERATED
-l
 usr/src/boot/sys/boot/efi/libefi/amd64/machine
 usr/src/boot/sys/boot/efi/libefi/amd64/x86
 usr/src/boot/sys/boot/efi/libefi/i386/machine
@@ -2511,6 +2510,7 @@ usr/src/lib/brand/lx/zone/lx_boot_zone_debian
 usr/src/lib/brand/lx/zone/lx_boot_zone_redhat
 usr/src/lib/brand/lx/zone/lx_boot_zone_suse
 usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu
+usr/src/lib/brand/lx/zone/lx_boot_zone_void
 usr/src/lib/brand/lx/zone/lx_install
 usr/src/lib/brand/shared/brand/amd64/assym.h
 usr/src/lib/brand/shared/brand/i386/assym.h
@@ -4276,6 +4276,7 @@ usr/src/test/os-tests/tests/i386/badseg
 usr/src/test/os-tests/tests/i386/badseg_exec
 usr/src/test/os-tests/tests/i386/ldt
 usr/src/test/os-tests/tests/imc/imc_test
+usr/src/test/os-tests/tests/libtopo/digraph-test
 usr/src/test/os-tests/tests/odirectory.32
 usr/src/test/os-tests/tests/odirectory.64
 usr/src/test/os-tests/tests/pf_key/acquire-compare
@@ -4668,7 +4669,8 @@ usr/src/uts/intel/md5/md5_amd64.s
 usr/src/uts/intel/mwlfw/mw88W8363fw
 usr/src/uts/intel/mwlfw/mwlboot
 usr/src/uts/intel/opteron_pcbe/opteron_pcbe_cpcgen.h
-usr/src/uts/intel/opteron_pcbe/opteron_pcbe_f17h.c
+usr/src/uts/intel/opteron_pcbe/opteron_pcbe_f17h_zen1.c
+usr/src/uts/intel/opteron_pcbe/opteron_pcbe_f17h_zen2.c
 usr/src/uts/intel/os/priv_names
 usr/src/uts/intel/sha1/sha1-x86_64.s
 usr/src/uts/intel/sha2/sha256-x86_64.s

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 94eb3b821b728e8dc462bb87d35b5f55b5835edc
+Last illumos-joyent commit: 4fc8237742a380d4833394892fb148e1a34acb28
 

--- a/usr/src/lib/brand/lx/zone/Makefile
+++ b/usr/src/lib/brand/lx/zone/Makefile
@@ -21,14 +21,14 @@
 
 #
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
-# Copyright 2015 Joyent, Inc.  All rights reserved.
 # Copyright 2016 OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2020 Joyent, Inc.
 # Copyright 2017 ASS-Einrichtungssysteme GmbH, Inc.  All rights reserved.
 #
 
 PROGS =	lx_install lx_boot
 PROGS += lx_boot_zone_redhat lx_boot_zone_ubuntu lx_boot_zone_debian
-PROGS += lx_boot_zone_busybox lx_boot_zone_suse
+PROGS += lx_boot_zone_busybox lx_boot_zone_suse lx_boot_zone_void
 XMLDOCS =	config.xml platform.xml
 TEMPLATES =	OMNIlx.xml OMNIlx26.xml
 

--- a/usr/src/lib/brand/lx/zone/lx_boot.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot.ksh
@@ -21,9 +21,9 @@
 #
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2015, Joyent, Inc.
 # Copyright 2017 ASS-Einrichtungssysteme GmbH, Inc.
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 Joyent, Inc.
 #
 # lx boot script.
 #
@@ -84,6 +84,8 @@ elif [[ -f $ZONEROOT/etc/alpine-release ]]; then
 	distro="busybox"
 elif [[ -f $ZONEROOT/etc/SuSE-release ]]; then
 	distro="suse"
+elif [[ -f $ZONEROOT/etc/void-release ]]; then
+	distro="void"
 fi
 
 [[ -z $distro ]] && fatal "Unsupported distribution!"

--- a/usr/src/lib/brand/lx/zone/lx_boot_zone_void.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot_zone_void.ksh
@@ -1,0 +1,17 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+# Hand control back to lx_boot

--- a/usr/src/pkg/manifests/system-zones-brand-lx.mf
+++ b/usr/src/pkg/manifests/system-zones-brand-lx.mf
@@ -104,6 +104,7 @@ file path=usr/lib/brand/lx/lx_boot_zone_debian mode=0755
 file path=usr/lib/brand/lx/lx_boot_zone_redhat mode=0755
 file path=usr/lib/brand/lx/lx_boot_zone_suse mode=0755
 file path=usr/lib/brand/lx/lx_boot_zone_ubuntu mode=0755
+file path=usr/lib/brand/lx/lx_boot_zone_void mode=0755
 file path=usr/lib/brand/lx/lx_install mode=0755
 file path=usr/lib/brand/lx/lx_librtld_db.so.1
 file path=usr/lib/brand/lx/lx_lockd mode=0555

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -470,6 +470,8 @@ typedef struct lxpr_rlimtab {
 	char	*rlim_rctl;	/* rctl source */
 } lxpr_rlimtab_t;
 
+#define RLIM_MAXFD	"Max open files"
+
 static lxpr_rlimtab_t lxpr_rlimtab[] = {
 	{ "Max cpu time",	"seconds",	"process.max-cpu-time" },
 	{ "Max file size",	"bytes",	"process.max-file-size" },
@@ -478,7 +480,7 @@ static lxpr_rlimtab_t lxpr_rlimtab[] = {
 	{ "Max core file size",	"bytes",	"process.max-core-size" },
 	{ "Max resident set",	"bytes",	"zone.max-physical-memory" },
 	{ "Max processes",	"processes",	"zone.max-lwps" },
-	{ "Max open files",	"files",	"process.max-file-descriptor" },
+	{ RLIM_MAXFD,		"files",	"process.max-file-descriptor" },
 	{ "Max locked memory",	"bytes",	"zone.max-locked-memory" },
 	{ "Max address space",	"bytes",	"process.max-address-space" },
 	{ "Max file locks",	"locks",	NULL },
@@ -1730,6 +1732,14 @@ lxpr_read_pid_limits(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 				break;
 			}
 		}
+		/*
+		 * If "Max open files" is still set to RLIM_INFINITY, make it
+		 * match the max value so that we do not output "unlimited".
+		 */
+		if (strcmp(lxpr_rlimtab[i].rlim_name, RLIM_MAXFD) == 0 &&
+		    cur[i] == RLIM_INFINITY)
+		    cur[i] = max[i];
+
 	}
 	lxpr_unlock(p);
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -1738,7 +1738,7 @@ lxpr_read_pid_limits(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 		 */
 		if (strcmp(lxpr_rlimtab[i].rlim_name, RLIM_MAXFD) == 0 &&
 		    cur[i] == RLIM_INFINITY)
-		    cur[i] = max[i];
+			cur[i] = max[i];
 
 	}
 	lxpr_unlock(p);

--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
@@ -1401,6 +1401,18 @@ lx_socket_create(int domain, int type, int protocol, int options, file_t **fpp,
 	vnode_t *vp;
 	file_t *fp;
 	int err, fd;
+
+	/*
+	 * EACCES is returned in Linux when the user isn't allowed to use a
+	 * "ping socket". EACCES is also used by the iputils-ping userland
+	 * application to determine if fallback to SOCK_RAW is necessary.
+	 *
+	 * This can be removed if we ever implement SOCK_DGRAM + IPPROTO_ICMP.
+	 */
+	if ((domain == AF_INET && type == SOCK_DGRAM && protocol ==
+	    IPPROTO_ICMP) || (domain == AF_INET6 && type == SOCK_DGRAM &&
+	    protocol == IPPROTO_ICMPV6))
+		return (EACCES);
 
 	/* logic cloned from so_socket */
 	so = socket_create(domain, type, protocol, NULL, NULL, SOCKET_SLEEP,


### PR DESCRIPTION
Weekly upstream for Joyent merge/2020041001

## Notes
- mainfest has been fixed after build

## Backports

* none

## onu

```
OmniOS 5.11     omnios-joyent_merge-2020041001-284039ff46       Apr. 10, 2020
SunOS Internal Development: hadfl 2020-Apr-10 [illumos-omnios]
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2020041001-284039ff46 i86pc i386 i86pc
```
## mail_msg

```
==== Nightly distributed build started:   Fri Apr 10 11:36:36 CEST 2020 ====
==== Nightly distributed build completed: Fri Apr 10 12:58:47 CEST 2020 ====

==== Total build time ====

real    1:22:10

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-9a0c008aef i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151033/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_242-omnios-151033-b07"

/usr/bin/openssl
OpenSSL 1.1.1f  31 Mar 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   78

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2020041001-284039ff46

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    37:22.0
user  3:28:52.8
sys     41:55.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    32:47.0
user  3:01:54.3
sys     36:19.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====

Entries present in proto area but not manifests:
	file usr/lib/brand/lx/lx_boot_zone_void group=group mode=0755 owner=owner path=usr/lib/brand/lx/lx_boot_zone_void


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```