### PR TITLE
12469 Mlxcx: pkg errors (r151034)

### DIFF
--- a/usr/src/pkg/manifests/driver-network-mlxcx.mf
+++ b/usr/src/pkg/manifests/driver-network-mlxcx.mf
@@ -24,7 +24,7 @@ set name=pkg.fmri value=pkg:/driver/network/mlxcx@$(PKGVERS)
 set name=pkg.description value="Mellanox ConnectX-4/5/6 Ethernet Driver"
 set name=pkg.summary value="Mellanox ConnectX-4/5/6 Ethernet Driver"
 set name=info.classification \
-    value=org.opensolaris.category.2008:Drivers/Storage
+    value=org.opensolaris.category.2008:Drivers/Networking
 set name=variant.arch value=i386
 dir path=kernel group=sys
 dir path=kernel/drv group=sys
@@ -48,7 +48,7 @@ driver name=mlxcx \
 file path=kernel/drv/$(ARCH64)/mlxcx group=sys
 file path=kernel/drv/mlxcx.conf group=sys
 file path=usr/share/man/man7d/mlxcx.7d
-legacy pkg=SUNWmrsas desc="Mellanox ConnectX-4/5/6 Ethernet Driver" \
+legacy pkg=SUNWmlxcx desc="Mellanox ConnectX-4/5/6 Ethernet Driver" \
     name="Mellanox ConnectX-4/5/6 Ethernet Driver"
 license cr_Sun license=cr_Sun
 license lic_CDDL license=lic_CDDL


### PR DESCRIPTION
Fix needed to allow the installation of `driver/network/mlxcx`.

```
omniosce# pkg install --reject ntpsec \*
Creating Plan (Checking for conflicting actions): \
pkg install: The requested change to the system attempts to install multiple actions
for legacy 'SUNWmrsas' with conflicting attributes:

    1 package delivers 'legacy category=system desc="LSI MegaRAID SAS2.0 Controller HBA Driver" hotline="Please contact your local service provider" name="LSI MegaRAID SAS2.0 HBA Driver" pkg=SUNWmrsas vendor=Illumos version=11.11,REV=2009.11.11':
        pkg://omnios/driver/storage/mr_sas@0.5.11,5.11-151034.0:20200419T131209Z
    1 package delivers 'legacy category=system desc="Mellanox ConnectX-4/5/6 Ethernet Driver" hotline="Please contact your local service provider" name="Mellanox ConnectX-4/5/6 Ethernet Driver" pkg=SUNWmrsas vendor=Illumos version=11.11,REV=2009.11.11':
        pkg://omnios/driver/network/mlxcx@0.5.11,5.11-151034.0:20200419T131158Z


These packages cannot be installed together. Any non-conflicting subset
of the above packages can be installed.
```