### PR TITLE
Accessing /etc/zones/did.txt should be alternate-root aware

### DIFF
--- a/usr/src/lib/libzonecfg/common/libzonecfg.c
+++ b/usr/src/lib/libzonecfg/common/libzonecfg.c
@@ -5965,9 +5965,16 @@ new_zone_did()
 	int len;
 	int val;
 	struct flock lck;
+	char pathbuf[PATH_MAX];
 	char buf[80];
 
-	if ((fd = open(DEBUGID_FILE, O_RDWR | O_CREAT,
+	if (snprintf(pathbuf, sizeof (pathbuf), "%s%s", zonecfg_get_root(),
+	    DEBUGID_FILE) >= sizeof (pathbuf)) {
+		printf(gettext("alternate root path is too long"));
+		return (-1);
+	}
+
+	if ((fd = open(pathbuf, O_RDWR | O_CREAT,
 	    S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0) {
 		perror("new_zone_did open failed");
 		return (-1);


### PR DESCRIPTION
Test script:

```
#!/bin/ksh

rm -rf /tmp/aaa
mkdir -p /tmp/aaa/etc/zones
mkdir -p /tmp/aaa/var/run
cp /etc/zones/SUNW*.xml /tmp/aaa/etc/zones/
echo global:installed:/ > /tmp/aaa/etc/zones/index

sleep 1
cat /etc/zones/did.txt
zonecfg -R /tmp/aaa -z test1 'create -b; set zonepath=/tmp/aaa/test1; exit'
cat /etc/zones/did.txt
cat /tmp/aaa/etc/zones/did.txt

find /etc/zones -newer /tmp/aaa
```

Before:

```
bloody# ./did
21
22
cat: /tmp/aaa/etc/zones/did.txt: cannot open [No such file or directory]
/etc/zones/did.txt
```

After:

```
bloody# ./did
22
22
1
```