### PR TITLE
/etc/ppt_aliases needs to be in the boot archive

### DIFF
--- a/usr/src/cmd/boot/filelist/i386/filelist.ramdisk
+++ b/usr/src/cmd/boot/filelist/i386/filelist.ramdisk
@@ -14,6 +14,7 @@ etc/mach
 etc/name_to_major
 etc/name_to_sysnum
 etc/path_to_inst
+etc/ppt_aliases
 etc/rtc_config
 etc/system
 etc/system.d


### PR DESCRIPTION
Without, there is no way to get the ppt driver to bind to a device and use it for bhyve PCI passthrough.

Problem reported by @stellarpower