### PR TITLE
Backports to r151034

### DIFF
--- a/usr/src/cmd/modload/Makefile
+++ b/usr/src/cmd/modload/Makefile
@@ -21,9 +21,7 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# cmd/modload/Makefile
-#
-# makefile for loadable module utilities
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 DRVPROG = add_drv rem_drv update_drv
 MODPROG = modinfo modunload modload
@@ -42,13 +40,12 @@ all	:=	TARGET = all
 install	:=	TARGET = install
 clean	:=	TARGET = clean
 clobber	:=	TARGET = clobber
-lint	:=	TARGET = lint
 
 .KEEP_STATE:
 
 all:	$(SUBDIRS)
 
-clean clobber lint:	$(SUBDIRS)
+clean clobber:	$(SUBDIRS)
 
 install:	$(SUBDIRS) $(XPRIV)
 

--- a/usr/src/cmd/modload/Makefile.com
+++ b/usr/src/cmd/modload/Makefile.com
@@ -23,6 +23,7 @@
 # Use is subject to license terms.
 #
 # Copyright (c) 2018, Joyent, Inc.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 # makefile for loadable module utilities
 
@@ -52,18 +53,6 @@ COMMONSRC = $(DRVCOMMONSRC) $(MODCOMMONSRC)
 
 CLOBBERFILES = $(PROG)
 
-# lint is complicated here by the fact that we
-# build multiple commands and with differing
-# common source, drvsubr vs modsubr/plcysubr
-#
-LINT_PROG= $(PROG:%=lint_%.c)
-LINTFLAGS += -erroff=E_NAME_DEF_NOT_USED2
-
-CERRWARN += -_gcc=-Wno-parentheses
-
-# not linted
-SMATCH=off
-
 # install specifics
 
 $(ROOTDRVPROG) := FILEMODE = 0555
@@ -71,10 +60,6 @@ $(ROOTDRVPROG) := FILEMODE = 0555
 add_drv			:= LDLIBS += -ldevinfo -lelf
 rem_drv			:= LDLIBS += -ldevinfo
 update_drv		:= LDLIBS += -ldevinfo
-
-lint_add_drv.c		:= LDLIBS += -ldevinfo -lelf
-lint_rem_drv.c		:= LDLIBS += -ldevinfo
-lint_update_drv.c	:= LDLIBS += -ldevinfo
 
 .KEEP_STATE:
 
@@ -109,10 +94,5 @@ modinfo:	modinfo.o $(MODCOMMONOBJ)
 
 clean:
 	$(RM) $(OBJECTS)
-
-lint_%.c:
-	$(LINT.c) $(@:lint_%.c=../%.c) $(COMMONSRC) $(LDLIBS)
-
-lint:	$(LINT_PROG)
 
 include ../../Makefile.targ

--- a/usr/src/cmd/modload/addrem.h
+++ b/usr/src/cmd/modload/addrem.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #ifndef _CMD_MODLOAD_ADDREM_H
@@ -44,7 +45,7 @@ extern "C" {
 
 #define	MAX_CMD_LINE	256
 #define	MAX_N2M_ALIAS_LINE	FILENAME_MAX + FILENAME_MAX + 1
-#define	MAXLEN_NAM_TO_MAJ_ENT 	FILENAME_MAX + MAX_STR_MAJOR + 1
+#define	MAXLEN_NAM_TO_MAJ_ENT	FILENAME_MAX + MAX_STR_MAJOR + 1
 #define	OPT_LEN		128
 #define	CADDR_HEX_STR	16
 #define	UINT_STR	10
@@ -118,7 +119,7 @@ extern char *get_perm_entry(char *, char *);
 extern int check_perms_aliases(int, int);
 extern int check_name_to_major(int);
 extern void enter_lock(void);
-extern void err_exit(void);
+extern void err_exit(void) __NORETURN;
 extern void exit_unlock(void);
 extern char *get_entry(char *, char *, char, int);
 extern int build_filenames(char *);

--- a/usr/src/cmd/modload/amd64/Makefile
+++ b/usr/src/cmd/modload/amd64/Makefile
@@ -22,10 +22,9 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 include ../Makefile.com
 include ../../Makefile.cmd.64
-
-LINTFLAGS64 += -erroff=E_NAME_DEF_NOT_USED2
 
 install: all $(ROOTUSRSBINPROG)

--- a/usr/src/cmd/modload/drvsubr.c
+++ b/usr/src/cmd/modload/drvsubr.c
@@ -26,6 +26,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -116,7 +119,7 @@ log_minorperm_error(minorperm_err_t err, int key)
  *  open file
  * for each entry in list
  *	where list entries are separated by <list_separator>
- * 	append entry : driver_name <entry_separator> entry
+ *	append entry : driver_name <entry_separator> entry
  * close file
  * return error/noerr
  */
@@ -207,7 +210,7 @@ append_to_file(
  *  open file
  * for each entry in list
  *	where list entries are separated by <list_separator>
- * 	append entry : driver_name <entry_separator> entry
+ *	append entry : driver_name <entry_separator> entry
  * close file
  * return error/noerr
  */
@@ -347,7 +350,7 @@ delete_entry(
 	int		rv, i;
 	int		status = NOERR;
 	int		drvr_found = 0;
-	boolean_t 	nomatch = B_TRUE;
+	boolean_t	nomatch = B_TRUE;
 	char		newfile[MAXPATHLEN];
 	char		*cp;
 	char		line[MAX_DBFILE_ENTRY];
@@ -1213,9 +1216,6 @@ exec_devfsadm(
 	int n = 0;
 	char *cmdline[MAX_CMD_LINE];
 	char maj_num[128];
-	char *previous;
-	char *current;
-	int len;
 	int rv;
 
 	/* build command line */
@@ -1242,24 +1242,35 @@ exec_devfsadm(
 		cmdline[n++] = "-x";
 
 	if (aliases != NULL) {
+		char *buf, *p;
+		size_t len;
+		int n_start = n;
+
 		len = strlen(aliases);
-		previous = aliases;
-		do {
-			cmdline[n++] = "-a";
-			cmdline[n] = calloc(len + 1, 1);
-			if (cmdline[n] == NULL) {
-				(void) fprintf(stderr,
-				    gettext(ERR_NO_MEM));
-				return (ERROR);
+
+		p = buf = calloc(len + 1, 1);
+		if (buf == NULL) {
+			(void) fprintf(stderr, gettext(ERR_NO_MEM));
+			return (ERROR);
+		}
+
+		while (*aliases != '\0') {
+			while (n < MAX_CMD_LINE - 3 && *aliases != '\0') {
+				cmdline[n++] = "-a";
+				aliases = get_entry(aliases, p, ' ', 0);
+				cmdline[n++] = p;
+				p += strlen(p) + 1;
 			}
-			current = get_entry(previous,
-			    cmdline[n++], ' ', 0);
-			previous = current;
-
-		} while (*current != '\0');
-
+			cmdline[n] = NULL;
+			rv = exec_command(DRVCONFIG_PATH, cmdline);
+			if (rv != NOERR)
+				break;
+			n = n_start;
+		}
+		free(buf);
+		return (rv == NOERR ? NOERR : ERROR);
 	}
-	cmdline[n] = (char *)0;
+	cmdline[n] = NULL;
 
 	rv = exec_command(DRVCONFIG_PATH, cmdline);
 	if (rv == NOERR)
@@ -1387,7 +1398,7 @@ create_reconfig(char *basedir)
  *	open file
  *	for each entry in list
  *		where list entries are separated by <list_separator>
- * 		modify entry : driver_name <entry_separator> entry
+ *		modify entry : driver_name <entry_separator> entry
  *	close file
  *
  *	return error/noerr
@@ -1538,7 +1549,7 @@ update_minor_entry(char *driver_name, char *perm_list)
 	}
 
 	if (!match) {
-		(void) bzero(line, sizeof (&line[0]));
+		(void) bzero(line, sizeof (line));
 		(void) snprintf(line, sizeof (line),
 		    "%s:%s %s %s %s\n",
 		    driver_name, minor, perm, own, grp);
@@ -1929,7 +1940,7 @@ unique_drv_alias(char *drv_alias)
 				continue;
 			/* sanity-check */
 			if (sscanf(line,
-			    "%" VAL2STR(FILENAME_MAX) "s" 	/* drv */
+			    "%" VAL2STR(FILENAME_MAX) "s"	/* drv */
 			    "%" VAL2STR(FILENAME_MAX) "s",	/* alias */
 			    drv, alias) != 2)
 				(void) fprintf(stderr, gettext(ERR_BAD_LINE),
@@ -1965,8 +1976,7 @@ unique_drv_alias(char *drv_alias)
  * from the remainder of the line by white space.
  */
 int
-unique_driver_name(char *driver_name, char *file_name,
-	int *is_unique)
+unique_driver_name(char *driver_name, char *file_name, int *is_unique)
 {
 	int ret, err;
 
@@ -2174,7 +2184,7 @@ update_name_to_major(char *driver_name, major_t *major_num, int server)
 
 	/*
 	 * if driver_name already in rem_name_to_major
-	 * 	delete entry from rem_nam_to_major
+	 *	delete entry from rem_nam_to_major
 	 *	put entry into name_to_major
 	 */
 

--- a/usr/src/cmd/modload/plcysubr.c
+++ b/usr/src/cmd/modload/plcysubr.c
@@ -27,7 +27,9 @@
  * drvsubr.c because of static linking requirements.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
+/*
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -87,18 +89,16 @@ devplcy_init(void)
 	devplcysys_sz = DEVPLCYSYS_SZ(privimplinfo);
 
 	toktab[RDPOL].off =
-		(char *)DEVPLCYSYS_RDP((devplcysys_t *)0, privimplinfo) -
-				(char *)0;
+	    (char *)DEVPLCYSYS_RDP((devplcysys_t *)0, privimplinfo) - (char *)0;
 	toktab[WRPOL].off =
-		(char *)DEVPLCYSYS_WRP((devplcysys_t *)0, privimplinfo) -
-				(char *)0;
+	    (char *)DEVPLCYSYS_WRP((devplcysys_t *)0, privimplinfo) - (char *)0;
 }
 
 /*
  * Read a configuration file line and return a static buffer pointing to it.
  * It returns a static struct fileentry which has several fields:
  *	- rawbuf, which includes the lines including empty lines and comments
- * 	leading up to the file and the entry as found in the file
+ *	leading up to the file and the entry as found in the file
  *	- orgentry, pointer in rawbuf to the start of the entry proper.
  *	- entry, a pre-parsed entry, escaped newlines removed.
  *	- startline, the line number of the first line in the file
@@ -481,13 +481,14 @@ parse_plcy_token(char *token, devplcysys_t *dp)
 			case PSET:
 				pset = priv_str_to_set(val, ",", &perr);
 				if (pset == NULL) {
-					if (perr == NULL)
-					    (void) fprintf(stderr,
-							gettext(ERR_NO_MEM));
-					else
-					    (void) fprintf(stderr,
-						gettext(ERR_BAD_PRIVS),
-						perr - val, val, perr);
+					if (perr == NULL) {
+						(void) fprintf(stderr,
+						    gettext(ERR_NO_MEM));
+					} else {
+						(void) fprintf(stderr,
+						    gettext(ERR_BAD_PRIVS),
+						    perr - val, val, perr);
+					}
 					return (1);
 				}
 				priv_copyset(pset, item);
@@ -495,8 +496,8 @@ parse_plcy_token(char *token, devplcysys_t *dp)
 				break;
 			default:
 				(void) fprintf(stderr,
-					"Internal Error: bad token type: %d\n",
-						toktab[i].type);
+				    "Internal Error: bad token type: %d\n",
+				    toktab[i].type);
 				return (1);
 			}
 			/* Standard cleanup & return for good tokens */
@@ -547,6 +548,7 @@ check_plcy_entry(char *entry, const char *driver, boolean_t todel)
 
 	if (res == NULL || ds == NULL) {
 		(void) fprintf(stderr, gettext(ERR_NO_MEM));
+		free(res);
 		return (NULL);
 	}
 
@@ -612,7 +614,7 @@ check_plcy_entry(char *entry, const char *driver, boolean_t todel)
 			tokseen = B_TRUE;
 		}
 	}
-	if (todel && tokseen || *res == '\0' || !todel && !tokseen) {
+	if ((todel && tokseen) || *res == '\0' || (!todel && !tokseen)) {
 		(void) fprintf(stderr, gettext(ERR_INVALID_PLCY));
 		free(res);
 		return (NULL);
@@ -690,7 +692,7 @@ check_priv_entry(const char *privlist, boolean_t add)
 
 		if (add && modctl(MODALLOCPRIV, pr) != 0) {
 			(void) fprintf(stderr, gettext(ERR_BAD_PRIV), pr,
-				strerror(errno));
+			    strerror(errno));
 			return (ERROR);
 		}
 	}

--- a/usr/src/cmd/modload/sparcv9/Makefile
+++ b/usr/src/cmd/modload/sparcv9/Makefile
@@ -22,10 +22,9 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 include ../Makefile.com
 include ../../Makefile.cmd.64
-
-LINTFLAGS64 += -erroff=E_NAME_DEF_NOT_USED2
 
 install: all $(ROOTUSRSBINPROG)

--- a/usr/src/lib/libzonecfg/common/libzonecfg.c
+++ b/usr/src/lib/libzonecfg/common/libzonecfg.c
@@ -5965,9 +5965,16 @@ new_zone_did()
 	int len;
 	int val;
 	struct flock lck;
+	char pathbuf[PATH_MAX];
 	char buf[80];
 
-	if ((fd = open(DEBUGID_FILE, O_RDWR | O_CREAT,
+	if (snprintf(pathbuf, sizeof (pathbuf), "%s%s", zonecfg_get_root(),
+	    DEBUGID_FILE) >= sizeof (pathbuf)) {
+		printf(gettext("alternate root path is too long"));
+		return (-1);
+	}
+
+	if ((fd = open(pathbuf, O_RDWR | O_CREAT,
 	    S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0) {
 		perror("new_zone_did open failed");
 		return (-1);

--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -1402,8 +1402,15 @@ lx_brandsys(int cmd, int64_t *rval, uintptr_t arg1, uintptr_t arg2,
 	if (p->p_brand == NULL)
 		return (ENOSYS);
 
-	VERIFY(p->p_brand == &lx_brand);
-	VERIFY(p->p_brand_data != NULL);
+	/*
+	 * Certain native applications may wish to start the lx_lockd process.
+	 * Every other process that's not branded should be denied.
+	 */
+	if (p->p_brand != &lx_brand && cmd != B_START_NFS_LOCKD)
+		return (ENOSYS);
+
+	if (cmd != B_START_NFS_LOCKD)
+		VERIFY(p->p_brand_data != NULL);
 
 	switch (cmd) {
 	case B_REGISTER:

--- a/usr/src/uts/common/brand/lx/sys/lx_brand.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_brand.h
@@ -94,6 +94,7 @@ extern "C" {
 #define	B_LPID_TO_SPAIR		128
 #define	B_GET_CURRENT_CONTEXT	129
 #define	B_EMULATION_DONE	130
+/* Some native programs use B_START_NFS_LOCKD, so don't change this. */
 #define	B_START_NFS_LOCKD	131
 #define	B_BLOCK_ALL_SIGS	132
 #define	B_UNBLOCK_ALL_SIGS	133


### PR DESCRIPTION
Backports to r151034

## mail_msg

```

==== Nightly distributed build started:   Tue Apr 28 16:26:21 UTC 2020 ====
==== Nightly distributed build completed: Tue Apr 28 17:41:21 UTC 2020 ====

==== Total build time ====

real    1:15:00

==== Build environment ====

/usr/bin/uname
SunOS r151034 5.11 omnios-r151034-9ce5cf3455 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151034/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151034/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151034-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   72

==== Nightly argument issues ====


==== Build version ====

omnios-bpr34-353fed36e9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    31:01.1
user  4:27:08.5
sys   1:11:11.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:04.9
user  3:40:55.1
sys   1:02:45.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
