### PR TITLE
Backports for r151034

### DIFF
--- a/usr/src/cmd/fs.d/nfs/lockd/lockd.c
+++ b/usr/src/cmd/fs.d/nfs/lockd/lockd.c
@@ -23,6 +23,7 @@
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T		*/
@@ -88,7 +89,7 @@
 struct lm_svc_args lmargs = {
 	.version = LM_SVC_CUR_VERS,
 	/* fd, n_fmly, n_proto, n_rdev (below) */
-	.debug = 0,
+	.n_v4_only = 0,
 	.timout = 5 * 60,
 	.grace = 90,
 	.retransmittimeout = 5
@@ -136,6 +137,8 @@ int	listen_backlog = 32;	/* used by bind_to_{provider,proto}() */
 int	(*Mysvc)(int, struct netbuf, struct netconfig *) = nlmsvc;
 				/* used by cots_listen_event() */
 int	max_conns_allowed = -1;	/* used by cots_listen_event() */
+
+int	debug = 0;
 
 int
 main(int ac, char *av[])
@@ -238,7 +241,7 @@ main(int ac, char *av[])
 			break;
 
 		case 'd': /* debug */
-			lmargs.debug = atoi(optarg);
+			debug = atoi(optarg);
 			break;
 
 		case 'g': /* grace_period */
@@ -288,12 +291,12 @@ main(int ac, char *av[])
 	if (optind != ac)
 		usage();
 
-	if (lmargs.debug) {
+	if (debug != 0) {
 		printf("%s: debug= %d, conn_idle_timout= %d,"
 		    " grace_period= %d, listen_backlog= %d,"
 		    " max_connections= %d, max_servers= %d,"
 		    " retrans_timeout= %d\n",
-		    MyName, lmargs.debug, lmargs.timout,
+		    MyName, debug, lmargs.timout,
 		    lmargs.grace, listen_backlog,
 		    max_conns_allowed, max_servers,
 		    lmargs.retransmittimeout);
@@ -309,7 +312,7 @@ main(int ac, char *av[])
 	}
 
 	/* Daemonize, if not debug. */
-	if (lmargs.debug == 0)
+	if (debug == 0)
 		pipe_fd = daemonize_init();
 
 	openlog(MyName, LOG_PID | LOG_NDELAY, LOG_DAEMON);
@@ -405,7 +408,7 @@ main(int ac, char *av[])
 	/*
 	 * lockd is up and running as far as we are concerned.
 	 */
-	if (lmargs.debug == 0)
+	if (debug == 0)
 		daemonize_fini(pipe_fd);
 
 	/*

--- a/usr/src/tools/scripts/Makefile
+++ b/usr/src/tools/scripts/Makefile
@@ -135,7 +135,7 @@ all:	$(SHFILES) $(PERLFILES) $(PERLMODULES) $(PYFILES) \
 	$(MAN1ONBLDFILES) $(MAKEFILES) $(SCRIPTS)
 
 onu.sh:	onu.sh.in
-	$(SED) -e "s:@PYTHON_VERSION@:$(PYTHON_VERSION):g" < onu.sh.in > $@
+	$(SED) -e "s:@PYTHON3_VERSION@:$(PYTHON3_VERSION):g" < onu.sh.in > $@
 
 $(ROOTONBLDBIN)/git-nits:
 	$(RM) $(ROOTONBLDBIN)/git-nits

--- a/usr/src/uts/common/fs/nfs/nfs_sys.c
+++ b/usr/src/uts/common/fs/nfs/nfs_sys.c
@@ -25,11 +25,13 @@
  */
 
 /*
+ *
  * Copyright (c) 1983,1984,1985,1986,1987,1988,1989  AT&T.
  * All rights reserved.
  */
 
 /*
+ * Copyright 2017 Joyent, Inc.
  * Copyright 2018 Nexenta Systems, Inc.
  */
 
@@ -242,7 +244,7 @@ nfssys(enum nfssys_op opcode, void *arg)
 			lsa.n_fmly = STRUCT_FGET(ulsa, n_fmly);
 			lsa.n_proto = STRUCT_FGET(ulsa, n_proto);
 			lsa.n_rdev = expldev(STRUCT_FGET(ulsa, n_rdev));
-			lsa.debug = STRUCT_FGET(ulsa, debug);
+			lsa.n_v4_only = STRUCT_FGET(ulsa, n_v4_only);
 			lsa.timout = STRUCT_FGET(ulsa, timout);
 			lsa.grace = STRUCT_FGET(ulsa, grace);
 			lsa.retransmittimeout = STRUCT_FGET(ulsa,

--- a/usr/src/uts/common/klm/klmmod.c
+++ b/usr/src/uts/common/klm/klmmod.c
@@ -12,6 +12,7 @@
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*
@@ -278,6 +279,10 @@ lm_svc(struct lm_svc_args *args)
 		if (INGLOBALZONE(curproc)) {
 			rfs4_grace_period = args->grace;
 			rfs4_lease_time   = args->grace;
+		}
+
+		if (args->n_v4_only == -1) {
+			g->nlm_v4_only = B_TRUE;
 		}
 
 		mutex_exit(&g->lock);

--- a/usr/src/uts/common/klm/nlm_impl.c
+++ b/usr/src/uts/common/klm/nlm_impl.c
@@ -2378,6 +2378,13 @@ nlm_svc_starting(struct nlm_globals *g, struct file *fp,
 	VERIFY(g->run_status == NLM_ST_STARTING);
 	VERIFY(g->nlm_gc_thread == NULL);
 
+	if (g->nlm_v4_only) {
+		NLM_WARN("Zone %d has no rpcbind, NLM is v4 only", getzoneid());
+		bzero(&g->nlm_nsm, sizeof (struct nlm_nsm));
+		g->nlm_nsm.ns_addr_handle = (void *)-1;
+		goto v4_only;
+	}
+
 	error = nlm_nsm_init_local(&g->nlm_nsm);
 	if (error != 0) {
 		NLM_ERR("Failed to initialize NSM handler "
@@ -2414,6 +2421,7 @@ nlm_svc_starting(struct nlm_globals *g, struct file *fp,
 		    "(rpcerr=%d)\n", stat);
 		goto shutdown_lm;
 	}
+v4_only:
 
 	g->grace_threshold = ddi_get_lbolt() +
 	    SEC_TO_TICK(g->grace_period);
@@ -2537,7 +2545,9 @@ nlm_svc_stopping(struct nlm_globals *g)
 
 	ASSERT(TAILQ_EMPTY(&g->nlm_slocks));
 
-	nlm_nsm_fini(&g->nlm_nsm);
+	/* If started with rpcbind (the normal case) */
+	if (g->nlm_nsm.ns_addr_handle != (void *)-1)
+		nlm_nsm_fini(&g->nlm_nsm);
 	g->lockd_pid = 0;
 	g->run_status = NLM_ST_DOWN;
 }

--- a/usr/src/uts/common/klm/nlm_impl.h
+++ b/usr/src/uts/common/klm/nlm_impl.h
@@ -30,6 +30,7 @@
 /*
  * Copyright 2012 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2016 Joyent, Inc.
  */
 
 /*
@@ -459,6 +460,7 @@ struct nlm_globals {
 	int				cn_idle_tmo;		/* (z) */
 	int				grace_period;		/* (z) */
 	int				retrans_tmo;		/* (z) */
+	boolean_t			nlm_v4_only;		/* (z) */
 	zoneid_t			nlm_zoneid;		/* (c) */
 	kmutex_t			clean_lock;		/* (c) */
 	TAILQ_ENTRY(nlm_globals)	nlm_link;		/* (g) */

--- a/usr/src/uts/common/nfs/nfssys.h
+++ b/usr/src/uts/common/nfs/nfssys.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2017 Joyent, Inc.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -122,13 +123,20 @@ struct nfs_revauth_args32 {
 enum lm_fmly  { LM_INET, LM_INET6, LM_LOOPBACK };
 enum lm_proto { LM_TCP, LM_UDP };
 
+/*
+ * The 'n_v4_only' member was formerly called 'debug'. This member is not used
+ * in the kernel. To avoid a new version of this user/kernel interface
+ * structure, the member was renamed in a binary compatible way. It is now used
+ * by the user-level code to indicate that the zone is not running
+ * rpcbind/rpc.statd and that only NFSv4 locking is needed.
+ */
 struct lm_svc_args {
 	int		version;	/* keep this first */
 	int		fd;
 	enum lm_fmly	n_fmly;		/* protocol family */
 	enum lm_proto	n_proto;	/* protocol */
 	dev_t		n_rdev;		/* device ID */
-	int		debug;		/* debugging level */
+	int		n_v4_only;	/* NFSv4 locking only */
 	time_t		timout;		/* client handle life (asynch RPCs) */
 	int		grace;		/* secs in grace period */
 	time_t	retransmittimeout;	/* retransmission interval */
@@ -141,7 +149,7 @@ struct lm_svc_args32 {
 	enum lm_fmly	n_fmly;		/* protocol family */
 	enum lm_proto	n_proto;	/* protocol */
 	dev32_t		n_rdev;		/* device ID */
-	int32_t		debug;		/* debugging level */
+	int32_t		n_v4_only;	/* NFSv4 locking only */
 	time32_t	timout;		/* client handle life (asynch RPCs) */
 	int32_t		grace;		/* secs in grace period */
 	time32_t	retransmittimeout;	/* retransmission interval */


### PR DESCRIPTION
Backport(s) for r34
## mail_msg

```

==== Nightly distributed build started:   Thu May  7 10:38:48 UTC 2020 ====
==== Nightly distributed build completed: Thu May  7 11:55:39 UTC 2020 ====

==== Total build time ====

real    1:16:50

==== Build environment ====

/usr/bin/uname
SunOS r151034 5.11 omnios-r151034-f57f507df0 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151034/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151034/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151034-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   83

==== Nightly argument issues ====


==== Build version ====

omnios-r34up-0cd39c3244

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:40.5
user  4:10:51.6
sys   1:09:38.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    27:51.3
user  3:44:07.6
sys   1:05:54.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
