### PR TITLE
Upstream merge joyent_merge/2020051301

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: a59b194a7b40a08dc3d3ffe01f7781acd43ae60f
+Last illumos-joyent commit: 535ab7f694a50841ab0a4107fd8f48e95a266c11
 

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_glue.c
@@ -37,6 +37,7 @@
  *
  * Copyright 2014 Pluribus Networks Inc.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Oxide Computer Company
  */
 
 #include <sys/types.h>
@@ -320,8 +321,13 @@ vmm_glue_callout_handler(void *arg)
 {
 	struct callout *c = arg;
 
-	c->c_flags &= ~CALLOUT_PENDING;
-	if (c->c_flags & CALLOUT_ACTIVE) {
+	if (callout_active(c)) {
+		/*
+		 * Record the handler fire time so that callout_pending() is
+		 * able to detect if the callout becomes rescheduled during the
+		 * course of the handler.
+		 */
+		c->c_fired = gethrtime();
 		(c->c_func)(c->c_arg);
 	}
 }
@@ -337,17 +343,9 @@ vmm_glue_callout_init(struct callout *c, int mpsafe)
 	hdlr.cyh_arg = c;
 	when.cyt_when = CY_INFINITY;
 	when.cyt_interval = CY_INFINITY;
+	bzero(c, sizeof (*c));
 
 	mutex_enter(&cpu_lock);
-#if 0
-	/*
-	 * XXXJOY: according to the freebsd sources, callouts do not begin
-	 * their life in the ACTIVE state.
-	 */
-	c->c_flags |= CALLOUT_ACTIVE;
-#else
-	bzero(c, sizeof (*c));
-#endif
 	c->c_cyc_id = cyclic_add(&hdlr, &when);
 	mutex_exit(&cpu_lock);
 }
@@ -367,15 +365,14 @@ vmm_glue_callout_reset_sbt(struct callout *c, sbintime_t sbt, sbintime_t pr,
 
 	ASSERT(c->c_cyc_id != CYCLIC_NONE);
 
+	if ((flags & C_ABSOLUTE) == 0) {
+		target += gethrtime();
+	}
+
 	c->c_func = func;
 	c->c_arg = arg;
-	c->c_flags |= (CALLOUT_ACTIVE | CALLOUT_PENDING);
-
-	if (flags & C_ABSOLUTE) {
-		cyclic_reprogram(c->c_cyc_id, target);
-	} else {
-		cyclic_reprogram(c->c_cyc_id, target + gethrtime());
-	}
+	c->c_target = target;
+	cyclic_reprogram(c->c_cyc_id, target);
 
 	return (0);
 }
@@ -384,8 +381,9 @@ int
 vmm_glue_callout_stop(struct callout *c)
 {
 	ASSERT(c->c_cyc_id != CYCLIC_NONE);
+
+	c->c_target = 0;
 	cyclic_reprogram(c->c_cyc_id, CY_INFINITY);
-	c->c_flags &= ~(CALLOUT_ACTIVE | CALLOUT_PENDING);
 
 	return (0);
 }
@@ -394,10 +392,11 @@ int
 vmm_glue_callout_drain(struct callout *c)
 {
 	ASSERT(c->c_cyc_id != CYCLIC_NONE);
+
+	c->c_target = 0;
 	mutex_enter(&cpu_lock);
 	cyclic_remove(c->c_cyc_id);
 	c->c_cyc_id = CYCLIC_NONE;
-	c->c_flags &= ~(CALLOUT_ACTIVE | CALLOUT_PENDING);
 	mutex_exit(&cpu_lock);
 
 	return (0);


### PR DESCRIPTION
Weekly upstream for joyent_merge/2020051301

## mail_msg

```

==== Nightly distributed build started:   Wed May 13 15:59:35 UTC 2020 ====
==== Nightly distributed build completed: Wed May 13 17:02:38 UTC 2020 ====

==== Total build time ====

real    1:03:02

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-6f16462a87 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151035-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   148

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2020051301-3298e220ad9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:08.5
user  3:39:11.1
sys   1:04:45.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:06.6
user  3:11:53.4
sys     57:48.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
