### PR TITLE
Further improvements to onu-to-gate

### DIFF
--- a/usr/src/pkg/manifests/system-bhyve-tests.mf
+++ b/usr/src/pkg/manifests/system-bhyve-tests.mf
@@ -14,9 +14,10 @@
 #
 
 #
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
+<include omnios_only>
 set name=pkg.fmri value=pkg:/system/bhyve/tests@$(PKGVERS)
 set name=pkg.description value="BSD hypervisor tests"
 set name=pkg.summary value="BSD hypervisor tests"

--- a/usr/src/pkg/manifests/system-bhyve.mf
+++ b/usr/src/pkg/manifests/system-bhyve.mf
@@ -24,6 +24,7 @@
 # information about overriding the defaults.
 #
 <include global_zone_only_component>
+<include omnios_only>
 set name=pkg.fmri value=pkg:/system/bhyve@$(PKGVERS)
 set name=pkg.description value="BSD hypervisor"
 set name=pkg.summary value="BSD hypervisor"

--- a/usr/src/pkg/manifests/system-library-bhyve.mf
+++ b/usr/src/pkg/manifests/system-library-bhyve.mf
@@ -14,9 +14,10 @@
 #
 
 #
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
+<include omnios_only>
 set name=pkg.fmri value=pkg:/system/library/bhyve@$(PKGVERS)
 set name=pkg.description value="BSD hypervisor (libraries)"
 set name=pkg.summary value="BSD hypervisor (libraries)"

--- a/usr/src/pkg/manifests/system-network-overlay.mf
+++ b/usr/src/pkg/manifests/system-network-overlay.mf
@@ -24,6 +24,7 @@
 #
 
 <include global_zone_only_component>
+<include omnios_only>
 set name=pkg.fmri value=pkg:/system/network/overlay@$(PKGVERS)
 set name=pkg.description value="Device driver implementing network overlays"
 set name=pkg.summary value="ilumos overlay driver"

--- a/usr/src/pkg/manifests/system-zones-brand-lx.mf
+++ b/usr/src/pkg/manifests/system-zones-brand-lx.mf
@@ -33,6 +33,7 @@
 # will only be installed into the global zone.
 #
 <include global_zone_only_component>
+<include omnios_only>
 set name=pkg.fmri value=pkg:/system/zones/brand/lx@$(PKGVERS)
 set name=pkg.description value="Support for the 'lx' Brand"
 set name=pkg.summary value="lx Brand"

--- a/usr/src/pkg/transforms/omnios_only
+++ b/usr/src/pkg/transforms/omnios_only
@@ -1,0 +1,20 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+
+# These transforms mark all path-delivering payloads and drivers in the
+# including package with the OmniOS-only facet. This is used to deactivate
+# them when performing an ONU to stock illumos-gate.
+
+<transform path=. -> default facet.onu.ooceonly true>
+<transform driver -> default facet.onu.ooceonly true>
+

--- a/usr/src/tools/scripts/onu.sh.in
+++ b/usr/src/tools/scripts/onu.sh.in
@@ -124,7 +124,7 @@ prepare_image()
 		banner "Preparing for ONU to illumos-gate"
 		# This removes files from the image that cause conflicts
 		# with stock illumos-gate
-		do_cmd pkg -R $root change-facet onu.ooceonly=false
+		do_cmd pkg -R $root change-facet -r onu.ooceonly=false
 	fi
 }
 


### PR DESCRIPTION
A nice clean boot to a gate onu now:

```
 (_)| || | _   _  _ __ ___    ___   ___
 | || || || | | || '_ ` _ \  / _ \ / __|
 | || || || |_| || | | | | || (_) |\__ \         ,
 |_||_||_| \__,_||_| |_| |_| \___/ |___/        ,./% &
                                                (*****(
                                                  */*//
                                                  *,///((
 +============Welcome to illumos===========+        ,*//((/%
 |                                         |          ///((((%
 |  1. Boot Multi User [Enter]             |           ,*/(((((%       &#///((&
 |  2. Boot [S]ingle User                  |            .///((((((%  %/(((/
 |  3. [Esc]ape to loader prompt           |             .////(((((///((,
 |  4. Reboot                              |             .*////((((((((((
 |                                         |                  ./((((((((/
 |  Options:                               |                   (/(((((((
 |  5. Configure Boot [O]ptions...         |                   ,,((((((/
 |  6. Select Boot [E]nvironment...        |                     /((((
 |                                         |                  %/((((
 |                                         |              &%#/((((.
 |                                         |            ,( ,/ /(/
 +=========================================+                ,/


Loading unix...
Loading /platform/i86pc/amd64/boot_archive...
Loading /platform/i86pc/amd64/boot_archive.hash...
Booting...
Loading kmdb...
illumos Version gate-ig_pkglint-7b803ee920a 64-bit
NOTICE: hma_vmx_init: CPU does not support VMX
Loading smf(5) service descriptions: 8/8
Delete service svc:/system/initial-boot as there are no supporting manifests
Delete instance data from service svc:/network/socket-filter
Delete instance http from service svc:/network/socket-filter
Delete service svc:/network/varpd as there are no supporting manifests
Hostname: bloody

bloody console login:
```