### PR TITLE
Upstream merge upstream_merge/2020051501

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4423,6 +4423,7 @@ usr/src/test/zfs-tests/tests/functional/cli_root/zfs_diff/socket
 usr/src/test/zfs-tests/tests/functional/ctime/ctime_001_pos
 usr/src/test/zfs-tests/tests/functional/exec/mmap_exec
 usr/src/test/zfs-tests/tests/functional/libzfs/many_fds
+usr/src/test/zfs-tests/tests/functional/resilver/sysevent
 usr/src/test/zfs-tests/tests/functional/threadsappend/threadsappend
 usr/src/tools/aw/aw
 usr/src/tools/btxld/btxld

--- a/usr/src/cmd/mdb/sparc/modules/genunix/gcore_isadep.c
+++ b/usr/src/cmd/mdb/sparc/modules/genunix/gcore_isadep.c
@@ -17,8 +17,6 @@
  * implemented.
  */
 
-#ifndef _KMDB
-
 #include <mdb/mdb_gcore.h>
 
 /* ARGSUSED */
@@ -54,5 +52,3 @@ gcore_prgetrvals(mdb_klwp_t *lwp, long *rval1, long *rval2)
 {
 	return (0);
 }
-
-#endif /* _KMDB */

--- a/usr/src/cmd/mdb/sparc/v9/genunix/Makefile
+++ b/usr/src/cmd/mdb/sparc/v9/genunix/Makefile
@@ -38,6 +38,7 @@ KMODSRCS = \
 
 MODSRCS = \
 	$(COMMONSRCS) \
+	gcore.c \
 	typegraph.c
 
 #

--- a/usr/src/lib/libc/port/gen/sysconf.c
+++ b/usr/src/lib/libc/port/gen/sysconf.c
@@ -27,7 +27,7 @@
  */
 
 /*	Copyright (c) 1988 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 /* sysconf(3C) - returns system configuration information */
 
@@ -463,6 +463,9 @@ sysconf(int name)
 
 		case _SC_EPHID_MAX:
 			return (_sysconfig(_CONFIG_EPHID_MAX));
+
+		case _SC_UADDR_MAX:
+			return (_sysconfig(_CONFIG_UADDR_MAX));
 
 		/* UNIX 03 names - XPG6/SUSv3/POSIX.1-2001 */
 

--- a/usr/src/man/man3c/sysconf.3c
+++ b/usr/src/man/man3c/sysconf.3c
@@ -45,11 +45,10 @@
 .\" Copyright (c) 2008, Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright (c) 2013 Gary Mills
 .\"
-.TH SYSCONF 3C "Apr 16, 2013"
+.TH SYSCONF 3C "May 04, 2020"
 .SH NAME
 sysconf \- get configurable system variables
 .SH SYNOPSIS
-.LP
 .nf
 #include <unistd.h>
 
@@ -57,8 +56,6 @@ sysconf \- get configurable system variables
 .fi
 
 .SH DESCRIPTION
-.sp
-.LP
 The \fBsysconf()\fR function provides a method for an application to determine
 the current value of a configurable system limit or option (variable).
 .sp
@@ -319,6 +316,12 @@ _SC_TTY_NAME_MAX        TTYNAME_MAX                Max length of tty
 _SC_TZNAME_MAX          TZNAME_MAX                 Max number of bytes
                                                    supported for name
                                                    of a time zone
+_SC_UADDR_MAX                                      Maximum valid user
+                                                   address in a process.
+                                                   The returned value
+                                                   should be cast to a
+                                                   uintptr_t before
+                                                   being interpreted.
 _SC_V6_ILP32_OFF32      _POSIX_V6_ILP32_OFF32      Supports  X/Open
                                                    ILP32 w/32-bit
                                                    offset build
@@ -424,8 +427,6 @@ l l .
 .TE
 
 .SH RETURN VALUES
-.sp
-.LP
 Upon successful completion, \fBsysconf()\fR returns the current variable value
 on the system. The value returned will not be more restrictive than the
 corresponding value described to the application when it was compiled with the
@@ -474,8 +475,6 @@ _SC_SPLIT_CACHE
 .in -2
 
 .SH ERRORS
-.sp
-.LP
 The \fBsysconf()\fR function will fail if:
 .sp
 .ne 2
@@ -487,8 +486,6 @@ The value of the \fIname\fR argument is invalid.
 .RE
 
 .SH ATTRIBUTES
-.sp
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -509,13 +506,9 @@ Standard	See \fBstandards\fR(5).
 .TE
 
 .SH SEE ALSO
-.sp
-.LP
 \fBpooladm\fR(1M), \fBzoneadm\fR(1M), \fBfpathconf\fR(2), \fBseteuid\fR(2),
 \fBsetrlimit\fR(2), \fBconfstr\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)
 .SH NOTES
-.sp
-.LP
 A call to \fBsetrlimit()\fR can cause the value of \fBOPEN_MAX\fR to change.
 .sp
 .LP

--- a/usr/src/man/man9e/_fini.9e
+++ b/usr/src/man/man9e/_fini.9e
@@ -3,11 +3,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH _FINI 9E "Jan 22, 2002"
+.TH _FINI 9E "May 06, 2020"
 .SH NAME
 _fini, _info, _init \- loadable module configuration entry points
 .SH SYNOPSIS
-.LP
 .nf
 #include <sys/modctl.h>
 
@@ -27,13 +26,10 @@ _fini, _info, _init \- loadable module configuration entry points
 .fi
 
 .SH INTERFACE LEVEL
-.sp
-.LP
 Solaris DDI specific (Solaris DDI). These entry points are required. You must
 write them.
 .SH PARAMETERS
 .SS "_info(\|)"
-.sp
 .ne 2
 .na
 \fB\fImodinfop\fR \fR
@@ -43,8 +39,6 @@ A pointer to an opaque \fBmodinfo\fR structure.
 .RE
 
 .SH DESCRIPTION
-.sp
-.LP
 \fB_init()\fR initializes a loadable module. It is called before any other
 routine in a loadable module. \fB_init()\fR returns the value returned by
 \fBmod_install\fR(9F). The module may optionally perform some other work before
@@ -61,10 +55,10 @@ returns the value returned by \fBmod_info\fR(9F).
 system wants to unload a module. If the module determines that it can be
 unloaded, then \fB_fini()\fR returns the value returned by
 \fBmod_remove\fR(9F). Upon successful return from \fB_fini()\fR no other
-routine in the module will be called before \fB_init()\fR is called.
+routine in the module will be called before \fB_init()\fR is called. If
+\fB_init()\fR did not successfully complete, \fB_fini()\fR will not be
+called.
 .SH RETURN VALUES
-.sp
-.LP
 \fB_init()\fR should return the appropriate error number if there is an error,
 otherwise it should return the return value from \fBmod_install\fR(9F).
 .sp
@@ -79,7 +73,6 @@ resources, such as mutexes and calls to \fBddi_soft_state_fini\fR(9F), should
 only be destroyed in \fB_fini()\fR after \fBmod_remove()\fR returns
 successfully.
 .SH EXAMPLES
-.LP
 \fBExample 1 \fRInitializing and Freeing a Mutex
 .sp
 .LP
@@ -158,8 +151,6 @@ _fini(void)
 .in -2
 
 .SH SEE ALSO
-.sp
-.LP
 \fBadd_drv\fR(1M), \fBmod_info\fR(9F), \fBmod_install\fR(9F),
 \fBmod_remove\fR(9F), \fBmutex\fR(9F), \fBmodldrv\fR(9S), \fBmodlinkage\fR(9S),
 \fBmodlstrmod\fR(9S)
@@ -167,17 +158,11 @@ _fini(void)
 .LP
 \fIWriting Device Drivers\fR
 .SH WARNINGS
-.sp
-.LP
 Do not change the structures referred to by the \fBmodlinkage\fR structure
 after the call to \fBmod_install()\fR, as the system may copy or change them.
 .SH NOTES
-.sp
-.LP
 Even though the identifiers \fB_fini()\fR, \fB_info()\fR, and \fB_init()\fR
 appear to be declared as globals, their scope is restricted by the kernel to
 the module that they are defined in.
 .SH BUGS
-.sp
-.LP
 On some implementations \fB_info()\fR may be called before \fB_init()\fR.

--- a/usr/src/man/man9e/ioctl.9e
+++ b/usr/src/man/man9e/ioctl.9e
@@ -3,11 +3,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH IOCTL 9E "Dec 3, 1996"
+.TH IOCTL 9E "May 6, 2020"
 .SH NAME
 ioctl \- control a character device
 .SH SYNOPSIS
-.LP
 .nf
 #include <sys/cred.h>
 #include <sys/file.h>
@@ -23,11 +22,8 @@ ioctl \- control a character device
 .fi
 
 .SH INTERFACE LEVEL
-.sp
-.LP
 Architecture independent level 1 (DDI/DKI). This entry point is \fBoptional\fR.
 .SH ARGUMENTS
-.sp
 .ne 2
 .na
 \fB\fIdev\fR\fR
@@ -112,8 +108,6 @@ value which is valid only if the  \fBioctl()\fR succeeds.
 .RE
 
 .SH DESCRIPTION
-.sp
-.LP
 \fBioctl()\fR provides character-access drivers with an alternate entry point
 that can be used for almost any operation other than a simple transfer of
 characters in and out of buffers. Most often,  \fBioctl()\fR is used to control
@@ -132,7 +126,10 @@ I/O control commands are used to implement the terminal settings passed from
 \fBttymon\fR(1M) and  \fBstty\fR(1), to format disk devices, to implement a
 trace driver for debugging, and to clean up character queues. Since the kernel
 does not interpret the command type that defines the operation, a driver is
-free to define its own commands.
+free to define its own commands. Drivers must be prepared to receive commands
+that they do not recognize or are in contexts that they do not expect. In the
+case where \fIcmd\fR is unknown, it is recommended that the driver return
+\fBENOTTY\fR.
 .sp
 .LP
 Drivers that use an  \fBioctl()\fR routine typically have a command to ``read''
@@ -205,13 +202,10 @@ action that should be taken. However, the command passed to the driver by the
 user process is an integer value associated with the command name in the
 header.
 .SH RETURN VALUES
-.sp
-.LP
 \fBioctl()\fR should return  \fB0\fR on success, or the appropriate error
 number. The driver may also set the value returned to the calling process
 through \fIrval_p\fR.
 .SH EXAMPLES
-.LP
 \fBExample 1 \fR\fBioctl()\fR entry point
 .sp
 .LP
@@ -263,8 +257,6 @@ xxioctl(dev_t dev, int cmd, intptr_t arg, int mode,
 .in -2
 
 .SH SEE ALSO
-.sp
-.LP
 \fBstty\fR(1), \fBttymon\fR(1M), \fBdkio\fR(7I), \fBfbio\fR(7I),
 \fBtermio\fR(7I), \fBopen\fR(9E), \fBput\fR(9E), \fBsrv\fR(9E),
 \fBcopyin\fR(9F), \fBcopyout\fR(9F), \fBddi_copyin\fR(9F),
@@ -273,7 +265,6 @@ xxioctl(dev_t dev, int cmd, intptr_t arg, int mode,
 .LP
 \fIWriting Device Drivers\fR
 .SH WARNINGS
-.sp
 .LP
 Non-STREAMS driver  \fBioctl()\fR routines must make sure that user data is
 copied into or out of the kernel address space explicitly using
@@ -288,8 +279,6 @@ even when in user context.
 Failure to use the appropriate copying routines can result in panics under load
 on some platforms, and reproducible panics on others.
 .SH NOTES
-.sp
-.LP
 STREAMS drivers do not have  \fBioctl()\fR routines. The stream head converts
 I/O control commands to  \fBM_IOCTL\fR messages, which are handled by the
 driver's  \fBput\fR(9E) or \fBsrv\fR(9E) routine.

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -150,6 +150,7 @@ dir path=opt/zfs-tests/tests/functional/removal
 dir path=opt/zfs-tests/tests/functional/rename_dirs
 dir path=opt/zfs-tests/tests/functional/replacement
 dir path=opt/zfs-tests/tests/functional/reservation
+dir path=opt/zfs-tests/tests/functional/resilver
 dir path=opt/zfs-tests/tests/functional/rootpool
 dir path=opt/zfs-tests/tests/functional/rsend
 dir path=opt/zfs-tests/tests/functional/scrub_mirror
@@ -2928,6 +2929,12 @@ file path=opt/zfs-tests/tests/functional/reservation/reservation_021_neg \
 file path=opt/zfs-tests/tests/functional/reservation/reservation_022_pos \
     mode=0555
 file path=opt/zfs-tests/tests/functional/reservation/setup mode=0555
+file path=opt/zfs-tests/tests/functional/resilver/cleanup mode=0555
+file path=opt/zfs-tests/tests/functional/resilver/resilver.cfg mode=0444
+file path=opt/zfs-tests/tests/functional/resilver/resilver_restart_001 \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/resilver/setup mode=0555
+file path=opt/zfs-tests/tests/functional/resilver/sysevent mode=0555
 file path=opt/zfs-tests/tests/functional/rootpool/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/rootpool/rootpool_002_neg mode=0555
 file path=opt/zfs-tests/tests/functional/rootpool/rootpool_003_neg mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -370,6 +370,10 @@ tests = ['zpool_replace_001_neg', 'zpool_replace_002_neg', 'replace-o_ashift',
 tests = ['zpool_resilver_bad_args', 'zpool_resilver_restart']
 tags = ['functional', 'cli_root', 'zpool_resilver']
 
+[/opt/zfs-tests/tests/functional/resilver]
+tests = ['resilver_restart_001']
+tags = ['functional', 'resilver']
+
 [/opt/zfs-tests/tests/functional/cli_root/zpool_scrub]
 tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos',
     'zpool_scrub_004_pos', 'zpool_scrub_005_pos', 'zpool_scrub_print_repairing',

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -204,6 +204,10 @@ tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
 [/opt/zfs-tests/tests/functional/cli_root/zfs_reservation]
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 
+[/opt/zfs-tests/tests/functional/resilver]
+tests = ['resilver_restart_001']
+tags = ['functional', 'resilver']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_rollback]
 tests = ['zfs_rollback_001_pos', 'zfs_rollback_002_pos',
     'zfs_rollback_003_neg', 'zfs_rollback_004_neg']

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -204,6 +204,10 @@ tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
 [/opt/zfs-tests/tests/functional/cli_root/zfs_reservation]
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 
+[/opt/zfs-tests/tests/functional/resilver]
+tests = ['resilver_restart_001']
+tags = ['functional', 'resilver']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_rollback]
 tests = ['zfs_rollback_001_pos', 'zfs_rollback_002_pos',
     'zfs_rollback_003_neg', 'zfs_rollback_004_neg']

--- a/usr/src/test/zfs-tests/runfiles/smartos.run
+++ b/usr/src/test/zfs-tests/runfiles/smartos.run
@@ -163,6 +163,10 @@ tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',
 [/opt/zfs-tests/tests/functional/cli_root/zfs_reservation]
 tests = ['zfs_reservation_001_pos', 'zfs_reservation_002_pos']
 
+[/opt/zfs-tests/tests/functional/resilver]
+tests = ['resilver_restart_001']
+tags = ['functional', 'resilver']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_rollback]
 tests = ['zfs_rollback_001_pos', 'zfs_rollback_002_pos',
     'zfs_rollback_003_neg', 'zfs_rollback_004_neg']

--- a/usr/src/test/zfs-tests/tests/functional/resilver/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/resilver/Makefile
@@ -1,0 +1,71 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+include $(SRC)/Makefile.master
+
+PROG = sysevent
+
+SCRIPTS = cleanup \
+	resilver_restart_001 \
+	setup
+
+include $(SRC)/cmd/Makefile.cmd
+include $(SRC)/test/Makefile.com
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/resilver
+
+OBJS = $(PROG:%=%.o)
+SRCS = $(OBJS:%.o=%.c)
+SRCFILES = resilver.cfg
+
+CMDS = $(PROG:%=$(TARGETDIR)/%) $(SCRIPTS:%=$(TARGETDIR)/%)
+$(CMDS) := FILEMODE = 0555
+
+FILES = $(SRCFILES:%=$(TARGETDIR)/%)
+$(FILES) := FILEMODE = 0444
+
+CPPFLAGS += -D__EXTENSIONS__
+LDLIBS += -lsysevent
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(LINK.c) $(OBJS) -o $@ $(LDFLAGS) $(LDLIBS)
+	$(POST_PROCESS)
+
+%.o: %.c
+	$(COMPILE.c) $<
+
+install: all $(CMDS) $(FILES)
+
+clobber: clean
+	-$(RM) $(PROG)
+
+clean:
+	-$(RM) $(OBJS)
+
+$(CMDS): $(TARGETDIR) $(PROG)
+
+$(FILES): $(SRCFILES)
+
+$(TARGETDIR):
+	$(INS.dir)
+
+$(TARGETDIR)/%: %
+	$(INS.file)
+
+$(TARGETDIR)/%: %.ksh
+	$(INS.rename)

--- a/usr/src/test/zfs-tests/tests/functional/resilver/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/resilver/cleanup.ksh
@@ -1,0 +1,31 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+
+#
+# Copyright (c) 2019, Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/resilver/resilver.cfg
+
+verify_runnable "global"
+
+log_pass

--- a/usr/src/test/zfs-tests/tests/functional/resilver/resilver.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/resilver/resilver.cfg
@@ -1,0 +1,32 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+
+#
+# Copyright (c) 2019, Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+set -A VDEV_FILES $TEST_BASE_DIR/file-{1..4}
+SPARE_VDEV_FILE=$TEST_BASE_DIR/spare-1
+
+VDEV_FILE_SIZE=$(( $SPA_MINDEVSIZE * 2 ))

--- a/usr/src/test/zfs-tests/tests/functional/resilver/resilver_restart_001.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/resilver/resilver_restart_001.ksh
@@ -1,0 +1,196 @@
+#!/bin/ksh -p
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2019, Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/resilver/resilver.cfg
+
+SYSEVENT=$STF_SUITE/tests/functional/resilver/sysevent
+
+#
+# DESCRIPTION:
+# Testing resilver restart logic both with and without the deferred resilver
+# feature enabled, verifying that resilver is not restarted when it is
+# unecessary.
+#
+# STRATEGY:
+# 1. Create a pool
+# 2. Create four filesystems with the primary cache disable to force reads
+# 3. Write four files simultaneously, one to each filesystem
+# 4. Do with and without deferred resilvers enabled
+#    a. Replace a vdev with a spare & suspend resilver immediately
+#    b. Verify resilver starts properly
+#    c. Offline / online another vdev to introduce a new DTL range
+#    d. Verify resilver restart restart or defer
+#    e. Inject read errors on vdev that was offlined / onlned
+#    f. Verify that resilver did not restart
+#    g. Unsuspend resilver and wait for it to finish
+#    h. Verify that there are two resilvers and nothing is deferred
+#
+
+function cleanup
+{
+	log_must set_tunable32 zfs_resilver_min_time_ms $ORIG_RESILVER_MIN_TIME
+	log_must set_tunable32 zfs_scan_suspend_progress \
+	    $ORIG_SCAN_SUSPEND_PROGRESS
+	log_must zinject -c all
+	destroy_pool $TESTPOOL
+	rm -f ${VDEV_FILES[@]} $SPARE_VDEV_FILE
+	[[ -n "$EVTFILE" ]] && rm -f "$EVTFILE"
+	[[ -n "$EVTPID" ]] && kill "$EVTPID"
+}
+
+# count resilver events in zpool and number of deferred rsilvers on vdevs
+function verify_restarts # <msg> <cnt> <defer>
+{
+	msg=$1
+	cnt=$2
+	defer=$3
+
+	# check the number of resilver start in events log
+	RESILVERS=$(wc -l $EVTFILE | awk '{ print $1 }')
+	log_note "expected $cnt resilver start(s)$msg, found $RESILVERS"
+	[[ "$RESILVERS" -ne "$cnt" ]] &&
+	    log_fail "expected $cnt resilver start(s)$msg, found $RESILVERS"
+
+	[[ -z "$defer" ]] && return
+
+	# use zdb to find which vdevs have the resilver defer flag
+	VDEV_DEFERS=$(zdb -C $TESTPOOL | awk '
+	    /children/ { gsub(/[^0-9]/, ""); child = $0 }
+	    /com\.datto:resilver_defer$/ { print child }
+	')
+
+	if [[ "$defer" == "-" ]]
+	then
+		[[ -n $VDEV_DEFERS ]] &&
+		    log_fail "didn't expect any vdevs to have resilver deferred"
+		return
+	fi
+
+	[[ $VDEV_DEFERS -eq $defer ]] ||
+	    log_fail "resilver deferred set on unexpected vdev: $VDEV_DEFERS"
+}
+
+log_assert "Check for unnecessary resilver restarts"
+
+ORIG_RESILVER_MIN_TIME=$(get_tunable zfs_resilver_min_time_ms)
+ORIG_SCAN_SUSPEND_PROGRESS=$(get_tunable zfs_scan_suspend_progress)
+
+set -A RESTARTS -- '1' '2' '2' '2'
+set -A VDEVS -- '' '' '' ''
+set -A DEFER_RESTARTS -- '1' '1' '1' '2'
+set -A DEFER_VDEVS -- '-' '2' '2' '-'
+
+VDEV_REPLACE="${VDEV_FILES[1]} $SPARE_VDEV_FILE"
+
+log_onexit cleanup
+
+# Monitor for resilver start events and log them to $EVTFILE as they occur
+EVTFILE=$(mktemp /tmp/resilver_events.XXXXXX)
+EVTPID=$($SYSEVENT $EVTFILE)
+log_must test -n "$EVTPID"
+
+log_must truncate -s $VDEV_FILE_SIZE ${VDEV_FILES[@]} $SPARE_VDEV_FILE
+
+log_must zpool create -f -o feature@resilver_defer=disabled $TESTPOOL \
+    raidz ${VDEV_FILES[@]}
+
+# create 4 filesystems
+for fs in fs{0..3}
+do
+	log_must zfs create -o primarycache=none -o recordsize=1k $TESTPOOL/$fs
+done
+
+# simultaneously write 16M to each of them
+set -A DATAPATHS /$TESTPOOL/fs{0..3}/dat.0
+log_note "Writing data files"
+for path in ${DATAPATHS[@]}
+do
+	dd if=/dev/urandom of=$path bs=1M count=16 > /dev/null 2>&1 &
+done
+wait
+
+# test without and with deferred resilve feature enabled
+for test in "without" "with"
+do
+	log_note "Testing $test deferred resilvers"
+
+	if [[ $test == "with" ]]
+	then
+		log_must zpool set feature@resilver_defer=enabled $TESTPOOL
+		RESTARTS=( "${DEFER_RESTARTS[@]}" )
+		VDEVS=( "${DEFER_VDEVS[@]}" )
+		VDEV_REPLACE="$SPARE_VDEV_FILE ${VDEV_FILES[1]}"
+	fi
+
+	# clear the events
+	cp /dev/null $EVTFILE
+
+	# limit scanning time
+	log_must set_tunable32 zfs_resilver_min_time_ms 50
+
+	# initiate a resilver and suspend the scan as soon as possible
+	log_must zpool replace $TESTPOOL $VDEV_REPLACE
+	log_must set_tunable32 zfs_scan_suspend_progress 1
+
+	# there should only be 1 resilver start
+	verify_restarts '' "${RESTARTS[0]}" "${VDEVS[0]}"
+
+	# offline then online a vdev to introduce a new DTL range after current
+	# scan, which should restart (or defer) the resilver
+	log_must zpool offline $TESTPOOL ${VDEV_FILES[2]}
+	log_must zpool sync $TESTPOOL
+	log_must zpool online $TESTPOOL ${VDEV_FILES[2]}
+	log_must zpool sync $TESTPOOL
+
+	# there should now be 2 resilver starts w/o defer, 1 with defer
+	verify_restarts ' after offline/online' "${RESTARTS[1]}" "${VDEVS[1]}"
+
+	# inject read io errors on vdev and verify resilver does not restart
+	log_must zinject -a -d ${VDEV_FILES[2]} -e io -T read -f 0.25 $TESTPOOL
+	log_must cat ${DATAPATHS[1]} > /dev/null
+	log_must zinject -c all
+
+	# there should still be 2 resilver starts w/o defer, 1 with defer
+	verify_restarts ' after zinject' "${RESTARTS[2]}" "${VDEVS[2]}"
+
+	# unsuspend resilver
+	log_must set_tunable32 zfs_scan_suspend_progress 0
+	log_must set_tunable32 zfs_resilver_min_time_ms 3000
+
+	# wait for resilver to finish
+	for iter in {0..59}
+	do
+		is_pool_resilvered $TESTPOOL && break
+		sleep 1
+	done
+	is_pool_resilvered $TESTPOOL ||
+	    log_fail "resilver timed out"
+
+	# wait for a few txg's to see if a resilver happens
+	log_must zpool sync $TESTPOOL
+	log_must zpool sync $TESTPOOL
+
+	# there should now be 2 resilver starts
+	verify_restarts ' after resilver' "${RESTARTS[3]}" "${VDEVS[3]}"
+done
+
+log_pass "Resilver did not restart unnecessarily"

--- a/usr/src/test/zfs-tests/tests/functional/resilver/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/resilver/setup.ksh
@@ -1,0 +1,31 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+
+#
+# Copyright (c) 2019, Datto Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/resilver/resilver.cfg
+
+verify_runnable "global"
+
+log_pass

--- a/usr/src/test/zfs-tests/tests/functional/resilver/sysevent.c
+++ b/usr/src/test/zfs-tests/tests/functional/resilver/sysevent.c
@@ -1,0 +1,148 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at http://smartos.org/CDDL
+ *
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file.
+ *
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright 2020 Joyent, Inc.
+ *
+ */
+
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/debug.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <libsysevent.h>
+#include <sys/sysevent/eventdefs.h>
+
+FILE *out;
+
+static void
+process_event(sysevent_t *ev)
+{
+	char *class = NULL;
+	char *subclass = NULL;
+
+	/* get sysevent metadata and add to the nvlist */
+	class = sysevent_get_class_name(ev);
+	subclass = sysevent_get_subclass_name(ev);
+
+	if (class == NULL || subclass == NULL)
+		errx(EXIT_FAILURE, "failed to retrieve sysevent metadata");
+
+	VERIFY0(strcmp(class, EC_ZFS));
+	VERIFY0(strcmp(subclass, ESC_ZFS_RESILVER_START));
+
+	flockfile(out);
+	(void) fprintf(out, "Received %s.%s event\n", class, subclass);
+	(void) fflush(out);
+	funlockfile(out);
+}
+
+static void
+child_fatal(int fd, const char *msg, ...)
+{
+	va_list ap;
+	int fail = EXIT_FAILURE;
+
+	va_start(ap, msg);
+	(void) vfprintf(stderr, msg, ap);
+	va_end(ap);
+	(void) fputc('\n', stderr);
+
+	(void) write(fd, &fail, sizeof (fail));
+	(void) close(fd);
+	exit(EXIT_FAILURE);
+}
+
+static void
+do_child(int fd)
+{
+	const char *subclasses[] = {
+		ESC_ZFS_RESILVER_START,
+	};
+	sysevent_handle_t *handle;
+	int ret = 0;
+
+	if ((handle = sysevent_bind_handle(process_event)) == NULL) {
+		child_fatal(fd, "sysevent_bind_handle() failed: %s",
+		    strerror(errno));
+	}
+
+	if (sysevent_subscribe_event(handle, EC_ZFS, subclasses,
+	    ARRAY_SIZE(subclasses)) != 0) {
+		child_fatal(fd, "failed to subscribe to sysevents: %s",
+		    strerror(errno));
+	}
+
+	(void) write(fd, &ret, sizeof (ret));
+	(void) close(fd);
+
+	/* leave stderr open so any errors get captured by test harness */
+	(void) fclose(stdin);
+	(void) fclose(stdout);
+
+	for (;;)
+		(void) pause();
+}
+
+int
+main(int argc, char **argv)
+{
+	pid_t child;
+	int fds[2];
+	int ret = 0;
+
+	if (argc < 2) {
+		(void) fprintf(stderr, "Usage: %s outfile\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	if ((out = fopen(argv[1], "w")) == NULL)
+		err(EXIT_FAILURE, "unable to open %s", argv[1]);
+
+	VERIFY0(pipe(fds));
+
+	switch (child = fork()) {
+	case -1:
+		err(EXIT_FAILURE, "unable to fork");
+	case 0:
+		do_child(fds[1]);
+		break;
+	default:
+		break;
+	}
+
+	(void) close(fds[1]);
+
+	if (read(fds[0], &ret, sizeof (ret)) < 0)
+		err(EXIT_FAILURE, "failure waiting on child");
+
+	if (ret != 0)
+		return (ret);
+
+	(void) close(fds[0]);
+	(void) printf("%d\n", child);
+	return (0);
+}

--- a/usr/src/uts/common/fs/zfs/dsl_scan.c
+++ b/usr/src/uts/common/fs/zfs/dsl_scan.c
@@ -24,7 +24,7 @@
  * Copyright 2016 Gary Mills
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright 2019 Joyent, Inc.
- * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
  */
 
 #include <sys/dsl_scan.h>
@@ -599,6 +599,13 @@ dsl_scan_restarting(dsl_scan_t *scn, dmu_tx_t *tx)
 }
 
 boolean_t
+dsl_scan_resilver_scheduled(dsl_pool_t *dp)
+{
+	return ((dp->dp_scan && dp->dp_scan->scn_restart_txg != 0) ||
+	    (spa_async_tasks(dp->dp_spa) & SPA_ASYNC_RESILVER));
+}
+
+boolean_t
 dsl_scan_scrubbing(const dsl_pool_t *dp)
 {
 	dsl_scan_phys_t *scn_phys = &dp->dp_scan->scn_phys;
@@ -794,7 +801,7 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
 	(void) spa_vdev_state_exit(spa, NULL, 0);
 
 	if (func == POOL_SCAN_RESILVER) {
-		dsl_resilver_restart(spa->spa_dsl_pool, 0);
+		dsl_scan_restart_resilver(spa->spa_dsl_pool, 0);
 		return (0);
 	}
 
@@ -811,41 +818,6 @@ dsl_scan(dsl_pool_t *dp, pool_scan_func_t func)
 
 	return (dsl_sync_task(spa_name(spa), dsl_scan_setup_check,
 	    dsl_scan_setup_sync, &func, 0, ZFS_SPACE_CHECK_EXTRA_RESERVED));
-}
-
-/*
- * Sets the resilver defer flag to B_FALSE on all leaf devs under vd. Returns
- * B_TRUE if we have devices that need to be resilvered and are available to
- * accept resilver I/Os.
- */
-static boolean_t
-dsl_scan_clear_deferred(vdev_t *vd, dmu_tx_t *tx)
-{
-	boolean_t resilver_needed = B_FALSE;
-	spa_t *spa = vd->vdev_spa;
-
-	for (int c = 0; c < vd->vdev_children; c++) {
-		resilver_needed |=
-		    dsl_scan_clear_deferred(vd->vdev_child[c], tx);
-	}
-
-	if (vd == spa->spa_root_vdev &&
-	    spa_feature_is_active(spa, SPA_FEATURE_RESILVER_DEFER)) {
-		spa_feature_decr(spa, SPA_FEATURE_RESILVER_DEFER, tx);
-		vdev_config_dirty(vd);
-		spa->spa_resilver_deferred = B_FALSE;
-		return (resilver_needed);
-	}
-
-	if (!vdev_is_concrete(vd) || vd->vdev_aux ||
-	    !vd->vdev_ops->vdev_op_leaf)
-		return (resilver_needed);
-
-	if (vd->vdev_resilver_deferred)
-		vd->vdev_resilver_deferred = B_FALSE;
-
-	return (!vdev_is_dead(vd) && !vd->vdev_offline &&
-	    vdev_resilver_needed(vd, NULL, NULL));
 }
 
 /* ARGSUSED */
@@ -949,24 +921,21 @@ dsl_scan_done(dsl_scan_t *scn, boolean_t complete, dmu_tx_t *tx)
 		spa_async_request(spa, SPA_ASYNC_RESILVER_DONE);
 
 		/*
-		 * Clear any deferred_resilver flags in the config.
+		 * Clear any resilver_deferred flags in the config.
 		 * If there are drives that need resilvering, kick
 		 * off an asynchronous request to start resilver.
-		 * dsl_scan_clear_deferred() may update the config
+		 * vdev_clear_resilver_deferred() may update the config
 		 * before the resilver can restart. In the event of
 		 * a crash during this period, the spa loading code
 		 * will find the drives that need to be resilvered
-		 * when the machine reboots and start the resilver then.
+		 * and start the resilver then.
 		 */
-		if (spa_feature_is_enabled(spa, SPA_FEATURE_RESILVER_DEFER)) {
-			boolean_t resilver_needed =
-			    dsl_scan_clear_deferred(spa->spa_root_vdev, tx);
-			if (resilver_needed) {
-				spa_history_log_internal(spa,
-				    "starting deferred resilver", tx,
-				    "errors=%llu", spa_get_errlog_size(spa));
-				spa_async_request(spa, SPA_ASYNC_RESILVER);
-			}
+		if (spa_feature_is_enabled(spa, SPA_FEATURE_RESILVER_DEFER) &&
+		    vdev_clear_resilver_deferred(spa->spa_root_vdev, tx)) {
+			spa_history_log_internal(spa,
+			    "starting deferred resilver", tx, "errors=%llu",
+			    (u_longlong_t)spa_get_errlog_size(spa));
+			spa_async_request(spa, SPA_ASYNC_RESILVER);
 		}
 	}
 
@@ -1073,7 +1042,7 @@ dsl_scrub_set_pause_resume(const dsl_pool_t *dp, pool_scrub_cmd_t cmd)
 
 /* start a new scan, or restart an existing one. */
 void
-dsl_resilver_restart(dsl_pool_t *dp, uint64_t txg)
+dsl_scan_restart_resilver(dsl_pool_t *dp, uint64_t txg)
 {
 	if (txg == 0) {
 		dmu_tx_t *tx;
@@ -1221,10 +1190,13 @@ scan_ds_queue_sync(dsl_scan_t *scn, dmu_tx_t *tx)
 static boolean_t
 dsl_scan_should_clear(dsl_scan_t *scn)
 {
+	spa_t *spa = scn->scn_dp->dp_spa;
 	vdev_t *rvd = scn->scn_dp->dp_spa->spa_root_vdev;
-	uint64_t mlim_hard, mlim_soft, mused;
-	uint64_t alloc = metaslab_class_get_alloc(spa_normal_class(
-	    scn->scn_dp->dp_spa));
+	uint64_t alloc, mlim_hard, mlim_soft, mused;
+
+	alloc = metaslab_class_get_alloc(spa_normal_class(spa));
+	alloc += metaslab_class_get_alloc(spa_special_class(spa));
+	alloc += metaslab_class_get_alloc(spa_dedup_class(spa));
 
 	mlim_hard = MAX((physmem / zfs_scan_mem_lim_fact) * PAGESIZE,
 	    zfs_scan_mem_lim_min);
@@ -4207,4 +4179,34 @@ dsl_scan_freed(spa_t *spa, const blkptr_t *bp)
 
 	for (int i = 0; i < BP_GET_NDVAS(bp); i++)
 		dsl_scan_freed_dva(spa, bp, i);
+}
+
+/*
+ * Check if a vdev needs resilvering (non-empty DTL), if so, and resilver has
+ * not started, start it. Otherwise, only restart if max txg in DTL range is
+ * greater than the max txg in the current scan. If the DTL max is less than
+ * the scan max, then the vdev has not missed any new data since the resilver
+ * started, so a restart is not needed.
+ */
+void
+dsl_scan_assess_vdev(dsl_pool_t *dp, vdev_t *vd)
+{
+	uint64_t min, max;
+
+	if (!vdev_resilver_needed(vd, &min, &max))
+		return;
+
+	if (!dsl_scan_resilvering(dp)) {
+		spa_async_request(dp->dp_spa, SPA_ASYNC_RESILVER);
+		return;
+	}
+
+	if (max <= dp->dp_scan->scn_phys.scn_max_txg)
+		return;
+
+	/* restart is needed, check if it can be deferred */
+	if (spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_RESILVER_DEFER))
+		vdev_defer_resilver(vd);
+	else
+		spa_async_request(dp->dp_spa, SPA_ASYNC_RESILVER);
 }

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -27,9 +27,9 @@
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Toomas Soome <tsoome@me.com>
+ * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
  * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2017, Intel Corporation.
- * Copyright (c) 2017 Datto Inc.
  * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
@@ -6380,9 +6380,9 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing)
 	 */
 	if (dsl_scan_resilvering(spa_get_dsl(spa)) &&
 	    spa_feature_is_enabled(spa, SPA_FEATURE_RESILVER_DEFER))
-		vdev_set_deferred_resilver(spa, newvd);
+		vdev_defer_resilver(newvd);
 	else
-		dsl_resilver_restart(spa->spa_dsl_pool, dtl_max_txg);
+		dsl_scan_restart_resilver(spa->spa_dsl_pool, dtl_max_txg);
 
 	if (spa->spa_bootfs)
 		spa_event_notify(spa, newvd, NULL, ESC_ZFS_BOOTFS_VDEV_ATTACH);
@@ -7620,7 +7620,7 @@ spa_async_thread(void *arg)
 	if (tasks & SPA_ASYNC_RESILVER &&
 	    (!dsl_scan_resilvering(dp) ||
 	    !spa_feature_is_enabled(dp->dp_spa, SPA_FEATURE_RESILVER_DEFER)))
-		dsl_resilver_restart(dp, 0);
+		dsl_scan_restart_resilver(dp, 0);
 
 	if (tasks & SPA_ASYNC_INITIALIZE_RESTART) {
 		mutex_enter(&spa_namespace_lock);
@@ -7734,6 +7734,12 @@ spa_async_request(spa_t *spa, int task)
 	mutex_enter(&spa->spa_async_lock);
 	spa->spa_async_tasks |= task;
 	mutex_exit(&spa->spa_async_lock);
+}
+
+int
+spa_async_tasks(spa_t *spa)
+{
+	return (spa->spa_async_tasks);
 }
 
 /*

--- a/usr/src/uts/common/fs/zfs/sys/dsl_scan.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_scan.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
- * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
  */
 
 #ifndef	_SYS_DSL_SCAN_H
@@ -164,10 +164,12 @@ void dsl_scan_fini(struct dsl_pool *dp);
 void dsl_scan_sync(struct dsl_pool *, dmu_tx_t *);
 int dsl_scan_cancel(struct dsl_pool *);
 int dsl_scan(struct dsl_pool *, pool_scan_func_t);
+void dsl_scan_assess_vdev(struct dsl_pool *dp, vdev_t *vd);
 boolean_t dsl_scan_scrubbing(const struct dsl_pool *dp);
 int dsl_scrub_set_pause_resume(const struct dsl_pool *dp, pool_scrub_cmd_t cmd);
-void dsl_resilver_restart(struct dsl_pool *, uint64_t txg);
+void dsl_scan_restart_resilver(struct dsl_pool *, uint64_t txg);
 boolean_t dsl_scan_resilvering(struct dsl_pool *dp);
+boolean_t dsl_scan_resilver_scheduled(struct dsl_pool *dp);
 boolean_t dsl_dataset_unstable(struct dsl_dataset *ds);
 void dsl_scan_ddt_entry(dsl_scan_t *scn, enum zio_checksum checksum,
     ddt_entry_t *dde, dmu_tx_t *tx);

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -26,7 +26,7 @@
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2019 Joyent, Inc.
- * Copyright (c) 2017 Datto Inc.
+ * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  */
@@ -775,6 +775,7 @@ extern void spa_async_request(spa_t *spa, int flag);
 extern void spa_async_unrequest(spa_t *spa, int flag);
 extern void spa_async_suspend(spa_t *spa);
 extern void spa_async_resume(spa_t *spa);
+extern int spa_async_tasks(spa_t *spa);
 extern spa_t *spa_inject_addref(char *pool);
 extern void spa_inject_delref(spa_t *spa);
 extern void spa_scan_stat_init(spa_t *spa);

--- a/usr/src/uts/common/fs/zfs/sys/vdev.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev.h
@@ -23,6 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2019, Datto Inc. All rights reserved.
  */
 
 #ifndef _SYS_VDEV_H
@@ -153,6 +154,8 @@ extern void vdev_state_dirty(vdev_t *vd);
 extern void vdev_state_clean(vdev_t *vd);
 
 extern void vdev_set_deferred_resilver(spa_t *spa, vdev_t *vd);
+extern void vdev_defer_resilver(vdev_t *vd);
+extern boolean_t vdev_clear_resilver_deferred(vdev_t *vd, dmu_tx_t *tx);
 
 typedef enum vdev_config_flag {
 	VDEV_CONFIG_SPARE = 1 << 0,

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -27,6 +27,7 @@
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2019, Datto Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -772,7 +773,7 @@ vdev_alloc(spa_t *spa, vdev_t **vdp, nvlist_t *nv, vdev_t *parent, uint_t id,
 		    &vd->vdev_resilver_txg);
 
 		if (nvlist_exists(nv, ZPOOL_CONFIG_RESILVER_DEFER))
-			vdev_set_deferred_resilver(spa, vd);
+			vdev_defer_resilver(vd);
 
 		/*
 		 * When importing a pool, we want to ignore the persistent fault
@@ -1764,18 +1765,12 @@ vdev_open(vdev_t *vd)
 	}
 
 	/*
-	 * If a leaf vdev has a DTL, and seems healthy, then kick off a
-	 * resilver.  But don't do this if we are doing a reopen for a scrub,
-	 * since this would just restart the scrub we are already doing.
+	 * If this is a leaf vdev, assess whether a resilver is needed.
+	 * But don't do this if we are doing a reopen for a scrub, since
+	 * this would just restart the scrub we are already doing.
 	 */
-	if (vd->vdev_ops->vdev_op_leaf && !spa->spa_scrub_reopen &&
-	    vdev_resilver_needed(vd, NULL, NULL)) {
-		if (dsl_scan_resilvering(spa->spa_dsl_pool) &&
-		    spa_feature_is_enabled(spa, SPA_FEATURE_RESILVER_DEFER))
-			vdev_set_deferred_resilver(spa, vd);
-		else
-			spa_async_request(spa, SPA_ASYNC_RESILVER);
-	}
+	if (vd->vdev_ops->vdev_op_leaf && !spa->spa_scrub_reopen)
+		dsl_scan_assess_vdev(spa->spa_dsl_pool, vd);
 
 	return (0);
 }
@@ -3543,14 +3538,11 @@ vdev_clear(spa_t *spa, vdev_t *vd)
 		if (vd != rvd && vdev_writeable(vd->vdev_top))
 			vdev_state_dirty(vd->vdev_top);
 
-		if (vd->vdev_aux == NULL && !vdev_is_dead(vd)) {
-			if (dsl_scan_resilvering(spa->spa_dsl_pool) &&
-			    spa_feature_is_enabled(spa,
-			    SPA_FEATURE_RESILVER_DEFER))
-				vdev_set_deferred_resilver(spa, vd);
-			else
-				spa_async_request(spa, SPA_ASYNC_RESILVER);
-		}
+		/* If a resilver isn't required, check if vdevs can be culled */
+		if (vd->vdev_aux == NULL && !vdev_is_dead(vd) &&
+		    !dsl_scan_resilvering(spa->spa_dsl_pool) &&
+		    !dsl_scan_resilver_scheduled(spa->spa_dsl_pool))
+			spa_async_request(spa, SPA_ASYNC_RESILVER_DONE);
 
 		spa_event_notify(spa, vd, NULL, ESC_ZFS_VDEV_CLEAR);
 	}
@@ -4559,18 +4551,46 @@ vdev_deadman(vdev_t *vd)
 }
 
 void
-vdev_set_deferred_resilver(spa_t *spa, vdev_t *vd)
+vdev_defer_resilver(vdev_t *vd)
 {
-	for (uint64_t i = 0; i < vd->vdev_children; i++)
-		vdev_set_deferred_resilver(spa, vd->vdev_child[i]);
-
-	if (!vd->vdev_ops->vdev_op_leaf || !vdev_writeable(vd) ||
-	    range_tree_is_empty(vd->vdev_dtl[DTL_MISSING])) {
-		return;
-	}
+	ASSERT(vd->vdev_ops->vdev_op_leaf);
 
 	vd->vdev_resilver_deferred = B_TRUE;
-	spa->spa_resilver_deferred = B_TRUE;
+	vd->vdev_spa->spa_resilver_deferred = B_TRUE;
+}
+
+/*
+ * Clears the resilver deferred flag on all leaf devs under vd. Returns
+ * B_TRUE if we have devices that need to be resilvered and are available to
+ * accept resilver I/Os.
+ */
+boolean_t
+vdev_clear_resilver_deferred(vdev_t *vd, dmu_tx_t *tx)
+{
+	boolean_t resilver_needed = B_FALSE;
+	spa_t *spa = vd->vdev_spa;
+
+	for (int c = 0; c < vd->vdev_children; c++) {
+		vdev_t *cvd = vd->vdev_child[c];
+		resilver_needed |= vdev_clear_resilver_deferred(cvd, tx);
+	}
+
+	if (vd == spa->spa_root_vdev &&
+	    spa_feature_is_active(spa, SPA_FEATURE_RESILVER_DEFER)) {
+		spa_feature_decr(spa, SPA_FEATURE_RESILVER_DEFER, tx);
+		vdev_config_dirty(vd);
+		spa->spa_resilver_deferred = B_FALSE;
+		return (resilver_needed);
+	}
+
+	if (!vdev_is_concrete(vd) || vd->vdev_aux ||
+	    !vd->vdev_ops->vdev_op_leaf)
+		return (resilver_needed);
+
+	vd->vdev_resilver_deferred = B_FALSE;
+
+	return (!vdev_is_dead(vd) && !vd->vdev_offline &&
+	    vdev_resilver_needed(vd, NULL, NULL));
 }
 
 /*

--- a/usr/src/uts/common/sys/sysconfig.h
+++ b/usr/src/uts/common/sys/sysconfig.h
@@ -101,6 +101,7 @@ extern int	mach_sysconfig(int);
 #define	_CONFIG_SYMLOOP_MAX	46	/* maximum # of symlinks in pathname */
 
 #define	_CONFIG_EPHID_MAX	47	/* maximum ephemeral uid */
+#define	_CONFIG_UADDR_MAX	48	/* maximum user address */
 
 #define	_CONFIG_NPROC_NCPU	48	/* NCPU (sometimes > NPROC_MAX) */
 

--- a/usr/src/uts/common/sys/sysconfig.h
+++ b/usr/src/uts/common/sys/sysconfig.h
@@ -103,7 +103,7 @@ extern int	mach_sysconfig(int);
 #define	_CONFIG_EPHID_MAX	47	/* maximum ephemeral uid */
 #define	_CONFIG_UADDR_MAX	48	/* maximum user address */
 
-#define	_CONFIG_NPROC_NCPU	48	/* NCPU (sometimes > NPROC_MAX) */
+#define	_CONFIG_NPROC_NCPU	49	/* NCPU (sometimes > NPROC_MAX) */
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/sys/unistd.h
+++ b/usr/src/uts/common/sys/unistd.h
@@ -106,9 +106,9 @@ extern "C" {
 #define	_SC_ARG_MAX			1
 #define	_SC_CHILD_MAX			2
 #define	_SC_CLK_TCK			3
-#define	_SC_NGROUPS_MAX 		4
+#define	_SC_NGROUPS_MAX			4
 #define	_SC_OPEN_MAX			5
-#define	_SC_JOB_CONTROL 		6
+#define	_SC_JOB_CONTROL			6
 #define	_SC_SAVED_IDS			7
 #define	_SC_VERSION			8
 /* SVR4 names */
@@ -151,21 +151,21 @@ extern "C" {
 #define	_SC_TIMER_MAX			44
 /* XPG4 names */
 #define	_SC_2_C_BIND			45
-#define	_SC_2_C_DEV    			46
+#define	_SC_2_C_DEV			46
 #define	_SC_2_C_VERSION			47
-#define	_SC_2_FORT_DEV 			48
-#define	_SC_2_FORT_RUN 			49
+#define	_SC_2_FORT_DEV			48
+#define	_SC_2_FORT_RUN			49
 #define	_SC_2_LOCALEDEF			50
-#define	_SC_2_SW_DEV   			51
+#define	_SC_2_SW_DEV			51
 #define	_SC_2_UPE			52
 #define	_SC_2_VERSION			53
 #define	_SC_BC_BASE_MAX			54
-#define	_SC_BC_DIM_MAX 			55
+#define	_SC_BC_DIM_MAX			55
 #define	_SC_BC_SCALE_MAX		56
 #define	_SC_BC_STRING_MAX		57
 #define	_SC_COLL_WEIGHTS_MAX		58
 #define	_SC_EXPR_NEST_MAX		59
-#define	_SC_LINE_MAX 			60
+#define	_SC_LINE_MAX			60
 #define	_SC_RE_DUP_MAX			61
 #define	_SC_XOPEN_CRYPT			62
 #define	_SC_XOPEN_ENH_I18N		63
@@ -210,6 +210,7 @@ extern "C" {
 #define	_SC_NPROCESSORS_MAX	516	/* maximum # of processors */
 #define	_SC_CPUID_MAX		517	/* maximum CPU id */
 #define	_SC_EPHID_MAX		518	/* maximum ephemeral id */
+#define	_SC_UADDR_MAX		519	/* maximum user address */
 
 /*
  * POSIX.1c (pthreads) names. These values are defined above
@@ -351,7 +352,7 @@ extern "C" {
 #ifdef	_XPG6
 #define	_POSIX_VERSION		200112L	/* Supports IEEE Std 1003.1-2001 */
 #else
-#define	_POSIX_VERSION		199506L /* Supports POSIX-1c DIS */
+#define	_POSIX_VERSION		199506L	/* Supports POSIX-1c DIS */
 #endif
 #endif /* _POSIX_VERSION */
 
@@ -359,7 +360,7 @@ extern "C" {
 #ifdef	_XPG6
 #define	_POSIX2_VERSION		200112L	/* Supports IEEE Std 1003.1-2001 */
 #else
-#define	_POSIX2_VERSION		199209L /* Supports ISO POSIX-2 DIS */
+#define	_POSIX2_VERSION		199209L	/* Supports ISO POSIX-2 DIS */
 #endif
 #endif /* _POSIX2_VERSION */
 
@@ -395,14 +396,14 @@ extern "C" {
 #define	_POSIX2_FORT_RUN  200112L	/* Supports FORTRAN runtime */
 #define	_POSIX2_LOCALEDEF 200112L	/* Supports creation of locales */
 #define	_POSIX2_SW_DEV	  200112L	/* Supports S/W Development Utility */
-#define	_POSIX2_UPE	  200112L 	/* Supports User Portability Utility */
+#define	_POSIX2_UPE	  200112L	/* Supports User Portability Utility */
 #else
 #define	_POSIX2_C_BIND		1	/* Supports C Language Bindings */
 #define	_POSIX2_C_DEV		1	/* Supports C language dev utility */
 #define	_POSIX2_FORT_RUN	1	/* Supports FORTRAN runtime */
 #define	_POSIX2_LOCALEDEF	1	/* Supports creation of locales */
 #define	_POSIX2_SW_DEV		1	/* Supports S/W Development Utility */
-#define	_POSIX2_UPE		1 	/* Supports User Portability Utility */
+#define	_POSIX2_UPE		1	/* Supports User Portability Utility */
 #endif /* _XPG6 */
 
 /* UNIX 03 names */

--- a/usr/src/uts/common/syscall/sysconfig.c
+++ b/usr/src/uts/common/syscall/sysconfig.c
@@ -47,6 +47,7 @@
 #include <sys/timer.h>
 #include <sys/zone.h>
 #include <sys/vm_usage.h>
+#include <vm/as.h>
 
 extern rctl_hndl_t rc_process_sigqueue;
 
@@ -207,6 +208,9 @@ sysconfig(int which)
 
 	case _CONFIG_EPHID_MAX:
 		return (MAXEPHUID);
+
+	case _CONFIG_UADDR_MAX:
+		return ((long)(uintptr_t)curproc->p_as->a_userlimit);
 
 	case _CONFIG_SYMLOOP_MAX:
 		return (MAXSYMLINKS);

--- a/usr/src/uts/sfmmu/vm/hat_sfmmu.c
+++ b/usr/src/uts/sfmmu/vm/hat_sfmmu.c
@@ -4411,10 +4411,11 @@ rehash:
 	if (flags & HAC_PAGELOCK) {
 		if (!page_trylock(pp, SE_SHARED)) {
 			/*
-			 * Somebody is holding SE_EXCL lock. Might
-			 * even be hat_page_relocate(). Drop all
-			 * our locks, lookup the page in &kvp, and
-			 * retry. If it doesn't exist in &kvp and &zvp,
+			 * Somebody is holding SE_EXCL lock. Might even be
+			 * hat_page_relocate().
+			 * Drop all our locks, lookup the page in &kvp, and
+			 * retry.
+			 * If it doesn't exist in &kvp and &kvps[KV_ZVP],
 			 * then we must be dealing with a kernel mapped
 			 * page which doesn't actually belong to
 			 * segkmem so we punt.
@@ -4423,10 +4424,10 @@ rehash:
 			SFMMU_HASH_UNLOCK(hmebp);
 			pp = page_lookup(&kvp, (u_offset_t)saddr, SE_SHARED);
 
-			/* check zvp before giving up */
+			/* check &kvps[KV_ZVP] before giving up */
 			if (pp == NULL)
-				pp = page_lookup(&zvp, (u_offset_t)saddr,
-				    SE_SHARED);
+				pp = page_lookup(&kvps[KV_ZVP],
+				    (u_offset_t)saddr, SE_SHARED);
 
 			/* Okay, we didn't find it, give up */
 			if (pp == NULL) {
@@ -4590,10 +4591,11 @@ rehash:
 	if (flags & HAC_PAGELOCK) {
 		if (!page_trylock(pp, SE_SHARED)) {
 			/*
-			 * Somebody is holding SE_EXCL lock. Might
-			 * even be hat_page_relocate(). Drop all
-			 * our locks, lookup the page in &kvp, and
-			 * retry. If it doesn't exist in &kvp and &zvp,
+			 * Somebody is holding SE_EXCL lock. Might even be
+			 * hat_page_relocate().
+			 * Drop all our locks, lookup the page in &kvp, and
+			 * retry.
+			 * If it doesn't exist in &kvp and &kvps[KV_ZVP],
 			 * then we must be dealing with a kernel mapped
 			 * page which doesn't actually belong to
 			 * segkmem so we punt.
@@ -4601,10 +4603,11 @@ rehash:
 			sfmmu_mlist_exit(pml);
 			SFMMU_HASH_UNLOCK(hmebp);
 			pp = page_lookup(&kvp, (u_offset_t)saddr, SE_SHARED);
-			/* check zvp before giving up */
+
+			/* check &kvps[KV_ZVP] before giving up */
 			if (pp == NULL)
-				pp = page_lookup(&zvp, (u_offset_t)saddr,
-				    SE_SHARED);
+				pp = page_lookup(&kvps[KV_ZVP],
+				    (u_offset_t)saddr, SE_SHARED);
 
 			if (pp == NULL) {
 				ASSERT(cookie == NULL);

--- a/usr/src/uts/sun4u/io/sbbc.c
+++ b/usr/src/uts/sun4u/io/sbbc.c
@@ -172,15 +172,15 @@ static struct bus_ops sbbc_bus_ops = {
 	0,
 	0,
 	0,
-	NULL, 			/* (*bus_map_fault)() */
+	NULL,			/* (*bus_map_fault)() */
 	ddi_no_dma_map,
 	ddi_no_dma_allochdl,
-	ddi_no_dma_freehdl, 	/* (*bus_dma_freehdl)() */
-	ddi_no_dma_bindhdl, 	/* (*bus_dma_bindhdl)() */
-	ddi_no_dma_unbindhdl, 	/* (*bus_dma_unbindhdl)() */
-	ddi_no_dma_flush, 	/* (*bus_dma_flush)() */
-	ddi_no_dma_win, 	/* (*bus_dma_win)() */
-	ddi_no_dma_mctl, 	/* (*bus_dma_ctl)() */
+	ddi_no_dma_freehdl,	/* (*bus_dma_freehdl)() */
+	ddi_no_dma_bindhdl,	/* (*bus_dma_bindhdl)() */
+	ddi_no_dma_unbindhdl,	/* (*bus_dma_unbindhdl)() */
+	ddi_no_dma_flush,	/* (*bus_dma_flush)() */
+	ddi_no_dma_win,		/* (*bus_dma_win)() */
+	ddi_no_dma_mctl,	/* (*bus_dma_ctl)() */
 	sbbc_ctlops,
 	ddi_bus_prop_op,
 	0,			/* (*bus_get_eventcookie)();	*/
@@ -425,7 +425,7 @@ sbbc_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	(void) sprintf(name, "sbbc%d", instance);
 
 	if (ddi_create_minor_node(dip, name, S_IFCHR, instance, NULL,
-	    NULL) == DDI_FAILURE) {
+	    0) == DDI_FAILURE) {
 		ddi_remove_minor_node(dip, NULL);
 		goto failed;
 	}
@@ -510,7 +510,7 @@ sbbc_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
  */
 static int
 sbbc_busmap(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp,
-	    off_t off, off_t len, caddr_t *addrp)
+    off_t off, off_t len, caddr_t *addrp)
 {
 	struct sbbcsoft *sbbcsoftp;
 	sbbc_child_regspec_t *child_rp, *child_regs;
@@ -690,7 +690,7 @@ sbbc_add_intr_impl(dev_info_t *dip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 	childintr->status = SBBC_INTR_STATE_DISABLE;
 
 	for (i = 0; i < MAX_SBBC_DEVICES; i++) {
-		if (sbbcsoftp->child_intr[i] == 0) {
+		if (sbbcsoftp->child_intr[i] == NULL) {
 			sbbcsoftp->child_intr[i] = childintr;
 			break;
 		}
@@ -705,7 +705,8 @@ sbbc_add_intr_impl(dev_info_t *dip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 		cmn_err(CE_WARN, "sbbc%d: failed to add intr for %s",
 		    instance, ddi_get_name(rdip));
 		kmem_free(childintr, sizeof (struct sbbc_child_intr));
-		sbbcsoftp->child_intr[i] = NULL;
+		if (i < MAX_SBBC_DEVICES)
+			sbbcsoftp->child_intr[i] = NULL;
 	}
 
 	/*
@@ -817,7 +818,7 @@ sbbc_update_intr_state(dev_info_t *dip, dev_info_t *rdip, ddi_intr_op_t intr_op,
  */
 static int
 sbbc_ctlops(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t op,
-	    void *arg, void *result)
+    void *arg, void *result)
 {
 	sbbc_child_regspec_t *child_rp;
 	int i, n;
@@ -1121,7 +1122,7 @@ sbbc_close(dev_t dev, int flag, int otype, cred_t *credp)
 /*ARGSUSED2*/
 static int
 sbbc_ioctl(dev_t dev, int cmd, intptr_t arg, int mode, cred_t *credp,
-		int *rvalp)
+    int *rvalp)
 {
 	struct sbbcsoft *sbbcsoftp;
 
@@ -1144,7 +1145,7 @@ sbbc_ioctl(dev_t dev, int cmd, intptr_t arg, int mode, cred_t *credp,
 			return (EINVAL);
 		}
 
-		if (arg == NULL) {
+		if (arg == (intptr_t)NULL) {
 			return (ENXIO);
 		}
 
@@ -1184,7 +1185,7 @@ sbbc_ioctl(dev_t dev, int cmd, intptr_t arg, int mode, cred_t *credp,
 			return (EINVAL);
 		}
 
-		if (arg == NULL) {
+		if (arg == (intptr_t)NULL) {
 			return (ENXIO);
 		}
 
@@ -1372,7 +1373,8 @@ sbbc_intr_wrapper(caddr_t arg)
  * used to crash the system.
  */
 static int
-sbbc_offset_valid(uint32_t offset) {
+sbbc_offset_valid(uint32_t offset)
+{
 	/*
 	 * Check for proper alignment first.
 	 */
@@ -1415,7 +1417,7 @@ sbbc_offset_valid(uint32_t offset) {
 #ifdef DEBUG
 void
 sbbc_dbg(uint32_t flag, dev_info_t *dip, char *fmt,
-	uintptr_t a1, uintptr_t a2, uintptr_t a3, uintptr_t a4, uintptr_t a5)
+    uintptr_t a1, uintptr_t a2, uintptr_t a3, uintptr_t a4, uintptr_t a5)
 {
 	char *s = NULL;
 

--- a/usr/src/uts/sun4u/sbbc/Makefile
+++ b/usr/src/uts/sun4u/sbbc/Makefile
@@ -40,7 +40,6 @@ UTSBASE	= ../..
 #
 MODULE		= sbbc
 OBJECTS		= $(SBBC_OBJS:%=$(OBJS_DIR)/%)
-LINTS		= $(SBBC_OBJS:%.o=$(LINTS_DIR)/%.ln)
 ROOTMODULE	= $(ROOT_PSM_DRV_DIR)/$(MODULE)
 
 #
@@ -52,29 +51,15 @@ include $(UTSBASE)/sun4u/Makefile.sun4u
 #	Define targets
 #
 ALL_TARGET	= $(BINARY)
-LINT_TARGET	= $(MODULE).lint
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
 # Turn this on once compiler understands v9 in it's backend
 #INLINES		+= $(UTSBASE)/sun4u/io/sbbc.il
 
 #
-# lint pass one enforcement
-#
-CFLAGS += $(CCVERBOSE)
-
-#
 # Turn on doubleword alignment for 64 bit registers
 #
 CFLAGS += -dalign
-
-#
-# For now, disable these lint checks; maintainers should endeavor
-# to investigate and remove these for maximum lint coverage.
-# Please do not carry these forward to new Makefiles.
-#
-LINTTAGS	+= -erroff=E_BAD_PTR_CAST_ALIGN
-LINTTAGS	+= -erroff=E_ASSIGN_NARROW_CONV
 
 CERRWARN	+= -_gcc=-Wno-switch
 
@@ -90,12 +75,6 @@ all:		$(ALL_DEPS)
 clean:		$(CLEAN_DEPS)
 
 clobber:	$(CLOBBER_DEPS)
-
-lint:		$(LINT_DEPS)
-
-modlintlib:	$(MODLINTLIB_DEPS)
-
-clean.lint:	$(CLEAN_LINT_DEPS)
 
 install:	$(INSTALL_DEPS)
 


### PR DESCRIPTION
Weekly upstream for upstream_merge/2020051501

## Backports

None

## onu

```
OmniOS r151035  omnios-upstream_merge-2020051501-69886b1909c    May 2020
illumos development build: 2020-May-15 [illumos]
bloody%
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2020051501-69886b1909c i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Fri May 15 20:50:29 UTC 2020 ====
==== Nightly distributed build completed: Fri May 15 21:53:06 UTC 2020 ====

==== Total build time ====

real    1:02:37

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-8f3520627a i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151035-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   142

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020051501-69886b1909c

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    23:49.5
user  3:37:49.0
sys   1:02:04.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    20:52.3
user  3:11:14.6
sys     55:54.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
