### PR TITLE
Bhyve cleanup & re-sync with gate

### DIFF
--- a/usr/src/cmd/bhyve/bhyverun.c
+++ b/usr/src/cmd/bhyve/bhyverun.c
@@ -201,10 +201,10 @@ static char *progname;
 static const int BSP = 0;
 
 #ifndef	__FreeBSD__
-int console_wait = 0;
-int console_connected = 0;
-pthread_mutex_t console_wait_lock = PTHREAD_MUTEX_INITIALIZER;
-pthread_cond_t console_wait_done = PTHREAD_COND_INITIALIZER;
+int bcons_wait = 0;
+int bcons_connected = 0;
+pthread_mutex_t bcons_wait_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t bcons_wait_done = PTHREAD_COND_INITIALIZER;
 #endif
 
 static cpuset_t cpumask;
@@ -1336,16 +1336,16 @@ main(int argc, char *argv[])
 
 #ifndef	__FreeBSD__
 	/*
-	 * If applicable, wait for connection to console
+	 * If applicable, wait for bhyveconsole
 	 */
-	if (console_wait) {
-		printf("Waiting for console connection...\n");
-		(void) pthread_mutex_lock(&console_wait_lock);
-		while (!console_connected) {
-			(void) pthread_cond_wait(&console_wait_done,
-			    &console_wait_lock);
+	if (bcons_wait) {
+		printf("Waiting for bhyveconsole connection...\n");
+		(void) pthread_mutex_lock(&bcons_wait_lock);
+		while (!bcons_connected) {
+			(void) pthread_cond_wait(&bcons_wait_done,
+			    &bcons_wait_lock);
 		}
-		(void) pthread_mutex_unlock(&console_wait_lock);
+		(void) pthread_mutex_unlock(&bcons_wait_lock);
 	}
 #endif
 

--- a/usr/src/cmd/bhyve/bhyverun.h
+++ b/usr/src/cmd/bhyve/bhyverun.h
@@ -52,10 +52,10 @@ extern uint16_t cores, sockets, threads;
 extern char *guest_uuid_str;
 extern char *vmname;
 #ifndef	__FreeBSD__
-extern int console_wait;
-extern int console_connected;
-extern pthread_mutex_t console_wait_lock;
-extern pthread_cond_t console_wait_done;
+extern int bcons_wait;
+extern int bcons_connected;
+extern pthread_mutex_t bcons_wait_lock;
+extern pthread_cond_t bcons_wait_done;
 #endif
 
 void *paddr_guest2host(struct vmctx *ctx, uintptr_t addr, size_t len);

--- a/usr/src/cmd/bhyve/test/tst/mevent/lists.delete.c
+++ b/usr/src/cmd/bhyve/test/tst/mevent/lists.delete.c
@@ -163,7 +163,7 @@ main(int argc, const char *argv[])
 	 */
 	flush_and_wait(flush_pipe[1]);
 	count2 = get_count();
-	if (count1 - 1 != count2 ) {
+	if (count1 - 1 != count2) {
 		FAIL(("mevent_delete() did not decrease count by 1: "
 		    "was %d, now %d", count1, count2));
 	}

--- a/usr/src/cmd/bhyve/test/tst/mevent/testlib.c
+++ b/usr/src/cmd/bhyve/test/tst/mevent/testlib.c
@@ -25,7 +25,8 @@ const char *testlib_prog;
 boolean_t testlib_verbose;
 
 static void
-timed_out(int signo) {
+timed_out(int signo)
+{
 	ASSERT_INT_EQ(("timeout signal"), signo, SIGALRM);
 
 	FAIL(("Timed out"));

--- a/usr/src/cmd/bhyve/test/tst/mevent/testlib.h
+++ b/usr/src/cmd/bhyve/test/tst/mevent/testlib.h
@@ -13,6 +13,9 @@
  * Copyright 2018 Joyent, Inc.
  */
 
+#ifndef _TESTLIB_H_
+#define	_TESTLIB_H_
+
 #include <assert.h>
 #include <errno.h>
 #include <signal.h>
@@ -28,7 +31,7 @@
 #define	EXIT_PASS 0
 #define	EXIT_FAIL 1
 
-#define VERBOSE(msg)							\
+#define	VERBOSE(msg)							\
 	if (testlib_verbose) {						\
 		(void) printf("VERBOSE %s: %s:%d %s: ", testlib_prog,	\
 		    __FILE__, __LINE__, __func__);			\
@@ -36,7 +39,7 @@
 		(void) printf("\n");					\
 	}
 
-#define FAIL_PROLOGUE() \
+#define	FAIL_PROLOGUE() \
 	(void) printf("FAIL %s: %s:%d: ", testlib_prog, __FILE__, __LINE__)
 
 #define	FAIL(msg)							\
@@ -47,7 +50,7 @@
 		exit(EXIT_FAIL);					\
 	}
 
-#define FAIL_ERRNO(msg) FAIL((msg ": %s", strerror(errno)))
+#define	FAIL_ERRNO(msg) FAIL((msg ": %s", strerror(errno)))
 
 #define	PASS()								\
 	{								\
@@ -86,3 +89,5 @@ extern boolean_t	testlib_verbose;
 extern void start_test(const char *, uint32_t);
 extern void start_event_thread(void);
 extern void test_mevent_count_lists(int *, int *, int *);
+
+#endif /* _TESTLIB_H_ */

--- a/usr/src/cmd/bhyve/uart_emul.c
+++ b/usr/src/cmd/bhyve/uart_emul.c
@@ -69,10 +69,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/socket.h>
 #endif
 
-#ifndef	__FreeBSD__
-#include "bhyverun.h"
-#endif
-
 #include "mevent.h"
 #include "uart_emul.h"
 
@@ -755,10 +751,6 @@ uart_sock_accept(int fd, enum ev_type ev, void *arg)
 			sc->usc_sock.clifd = connfd;
 			sc->mev = mevent_add(sc->usc_sock.clifd, EVF_READ,
 			    uart_sock_drain, sc);
-			pthread_mutex_lock(&console_wait_lock);
-			console_connected = B_TRUE;
-			pthread_cond_signal(&console_wait_done);
-			pthread_mutex_unlock(&console_wait_lock);
 		}
 	}
 
@@ -863,10 +855,6 @@ uart_sock_backend(struct uart_softc *sc, const char *inopts)
 	    opt = strsep(&nextopt, ",")) {
 		if (path == NULL && *opt == '/') {
 			path = opt;
-			continue;
-		}
-		if (!strcmp(opt, "wait")) {
-			console_wait = true;
 			continue;
 		}
 		/*

--- a/usr/src/uts/i86pc/io/vmm/intel/vmx.c
+++ b/usr/src/uts/i86pc/io/vmm/intel/vmx.c
@@ -225,7 +225,9 @@ static int pirvec = -1;
 SYSCTL_INT(_hw_vmm_vmx, OID_AUTO, posted_interrupt_vector, CTLFLAG_RD,
     &pirvec, 0, "APICv posted interrupt vector");
 
+#ifdef __FreeBSD__
 static struct unrhdr *vpid_unr;
+#endif /* __FreeBSD__ */
 static u_int vpid_alloc_failed;
 SYSCTL_UINT(_hw_vmm_vmx, OID_AUTO, vpid_alloc_failed, CTLFLAG_RD,
 	    &vpid_alloc_failed, 0, NULL);

--- a/usr/src/uts/i86pc/io/vmm/vm/vm_map.h
+++ b/usr/src/uts/i86pc/io/vmm/vm/vm_map.h
@@ -21,13 +21,13 @@
 /*
  * vm_map_wire and vm_map_unwire option flags
  */
-#define VM_MAP_WIRE_SYSTEM	0	/* wiring in a kernel map */
-#define VM_MAP_WIRE_USER	1	/* wiring in a user map */
+#define	VM_MAP_WIRE_SYSTEM	0	/* wiring in a kernel map */
+#define	VM_MAP_WIRE_USER	1	/* wiring in a user map */
 
-#define VM_MAP_WIRE_NOHOLES	0	/* region must not have holes */
-#define VM_MAP_WIRE_HOLESOK	2	/* region may have holes */
+#define	VM_MAP_WIRE_NOHOLES	0	/* region must not have holes */
+#define	VM_MAP_WIRE_HOLESOK	2	/* region may have holes */
 
-#define VM_MAP_WIRE_WRITE	4	/* Validate writable. */
+#define	VM_MAP_WIRE_WRITE	4	/* Validate writable. */
 
 /*
  * The following "find_space" options are supported by vm_map_find().

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
@@ -12,6 +12,7 @@
 /*
  * Copyright 2015 Pluribus Networks Inc.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/types.h>
@@ -65,6 +66,7 @@
 static kmutex_t		vmmdev_mtx;
 static dev_info_t	*vmmdev_dip;
 static hma_reg_t	*vmmdev_hma_reg;
+static uint_t		vmmdev_hma_ref;
 static sdev_plugin_hdl_t vmmdev_sdev_hdl;
 
 static kmutex_t		vmm_mtx;
@@ -1333,6 +1335,52 @@ vmm_lookup(const char *name)
 	return (sc);
 }
 
+/*
+ * Acquire an HMA registration if not already held.
+ */
+static boolean_t
+vmm_hma_acquire(void)
+{
+	mutex_enter(&vmmdev_mtx);
+
+	if (vmmdev_hma_reg == NULL) {
+		VERIFY3U(vmmdev_hma_ref, ==, 0);
+		vmmdev_hma_reg = hma_register(vmmdev_hvm_name);
+		if (vmmdev_hma_reg == NULL) {
+			cmn_err(CE_WARN, "%s HMA registration failed.",
+			    vmmdev_hvm_name);
+			mutex_exit(&vmmdev_mtx);
+			return (B_FALSE);
+		}
+	}
+
+	vmmdev_hma_ref++;
+
+	mutex_exit(&vmmdev_mtx);
+
+	return (B_TRUE);
+}
+
+/*
+ * Release the HMA registration if held and there are no remaining VMs.
+ */
+static void
+vmm_hma_release(void)
+{
+	mutex_enter(&vmmdev_mtx);
+
+	VERIFY3U(vmmdev_hma_ref, !=, 0);
+
+	vmmdev_hma_ref--;
+
+	if (vmmdev_hma_ref == 0) {
+		VERIFY(vmmdev_hma_reg != NULL);
+		hma_unregister(vmmdev_hma_reg);
+		vmmdev_hma_reg = NULL;
+	}
+	mutex_exit(&vmmdev_mtx);
+}
+
 static int
 vmmdev_do_vm_create(char *name, cred_t *cr)
 {
@@ -1344,11 +1392,15 @@ vmmdev_do_vm_create(char *name, cred_t *cr)
 		return (EINVAL);
 	}
 
+	if (!vmm_hma_acquire())
+		return (ENXIO);
+
 	mutex_enter(&vmm_mtx);
 
-	/* Look for duplicates names */
+	/* Look for duplicate names */
 	if (vmm_lookup(name) != NULL) {
 		mutex_exit(&vmm_mtx);
+		vmm_hma_release();
 		return (EEXIST);
 	}
 
@@ -1358,6 +1410,7 @@ vmmdev_do_vm_create(char *name, cred_t *cr)
 		    sc = list_next(&vmm_list, sc)) {
 			if (sc->vmm_zone == curzone) {
 				mutex_exit(&vmm_mtx);
+				vmm_hma_release();
 				return (EINVAL);
 			}
 		}
@@ -1408,6 +1461,7 @@ fail:
 		ddi_soft_state_free(vmm_statep, minor);
 	}
 	mutex_exit(&vmm_mtx);
+	vmm_hma_release();
 
 	return (error);
 }
@@ -1696,7 +1750,8 @@ done:
 }
 
 static int
-vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd)
+vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd,
+    boolean_t *hma_release)
 {
 	dev_info_t	*pdip = ddi_get_parent(vmmdev_dip);
 	minor_t		minor;
@@ -1725,6 +1780,7 @@ vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd)
 		vm_destroy(sc->vmm_vm);
 		ddi_soft_state_free(vmm_statep, minor);
 		id_free(vmm_minors, minor);
+		*hma_release = B_TRUE;
 	}
 	(void) devfs_clean(pdip, NULL, DV_CLEAN_FORCE);
 
@@ -1734,11 +1790,15 @@ vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd)
 int
 vmm_do_vm_destroy(vmm_softc_t *sc, boolean_t clean_zsd)
 {
+	boolean_t	hma_release = B_FALSE;
 	int		err;
 
 	mutex_enter(&vmm_mtx);
-	err = vmm_do_vm_destroy_locked(sc, clean_zsd);
+	err = vmm_do_vm_destroy_locked(sc, clean_zsd, &hma_release);
 	mutex_exit(&vmm_mtx);
+
+	if (hma_release)
+		vmm_hma_release();
 
 	return (err);
 }
@@ -1747,6 +1807,7 @@ vmm_do_vm_destroy(vmm_softc_t *sc, boolean_t clean_zsd)
 static int
 vmmdev_do_vm_destroy(const char *name, cred_t *cr)
 {
+	boolean_t	hma_release = B_FALSE;
 	vmm_softc_t	*sc;
 	int		err;
 
@@ -1767,12 +1828,15 @@ vmmdev_do_vm_destroy(const char *name, cred_t *cr)
 		mutex_exit(&vmm_mtx);
 		return (EPERM);
 	}
-	err = vmm_do_vm_destroy_locked(sc, B_TRUE);
+	err = vmm_do_vm_destroy_locked(sc, B_TRUE, &hma_release);
+
 	mutex_exit(&vmm_mtx);
+
+	if (hma_release)
+		vmm_hma_release();
 
 	return (err);
 }
-
 
 static int
 vmm_open(dev_t *devp, int flag, int otyp, cred_t *credp)
@@ -1810,6 +1874,7 @@ vmm_close(dev_t dev, int flag, int otyp, cred_t *credp)
 {
 	minor_t		minor;
 	vmm_softc_t	*sc;
+	boolean_t	hma_release = B_FALSE;
 
 	minor = getminor(dev);
 	if (minor == VMM_CTL_MINOR)
@@ -1825,13 +1890,21 @@ vmm_close(dev_t dev, int flag, int otyp, cred_t *credp)
 	VERIFY(sc->vmm_is_open);
 	sc->vmm_is_open = B_FALSE;
 
+	/*
+	 * If this VM was destroyed while the vmm device was open, then
+	 * clean it up now that it is closed.
+	 */
 	if (sc->vmm_flags & VMM_DESTROY) {
 		list_remove(&vmm_destroy_list, sc);
 		vm_destroy(sc->vmm_vm);
 		ddi_soft_state_free(vmm_statep, minor);
 		id_free(vmm_minors, minor);
+		hma_release = B_TRUE;
 	}
 	mutex_exit(&vmm_mtx);
+
+	if (hma_release)
+		vmm_hma_release();
 
 	return (0);
 }
@@ -2087,12 +2160,18 @@ vmm_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	vmm_sol_glue_init();
 	vmm_arena_init();
 
+	/*
+	 * Perform temporary HMA registration to determine if the hardware
+	 * is capable.
+	 */
 	if ((reg = hma_register(vmmdev_hvm_name)) == NULL) {
 		goto fail;
 	} else if (vmm_mod_load() != 0) {
 		goto fail;
 	}
 	vmm_loaded = B_TRUE;
+	hma_unregister(reg);
+	reg = NULL;
 
 	/* Create control node.  Other nodes will be created on demand. */
 	if (ddi_create_minor_node(dip, "ctl", S_IFCHR,
@@ -2107,7 +2186,6 @@ vmm_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	}
 
 	ddi_report_dev(dip);
-	vmmdev_hma_reg = reg;
 	vmmdev_sdev_hdl = sph;
 	vmmdev_dip = dip;
 	mutex_exit(&vmmdev_mtx);
@@ -2164,8 +2242,7 @@ vmm_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
 	vmmdev_dip = NULL;
 
 	VERIFY0(vmm_mod_unload());
-	hma_unregister(vmmdev_hma_reg);
-	vmmdev_hma_reg = NULL;
+	VERIFY3U(vmmdev_hma_reg, ==, NULL);
 	vmm_arena_fini();
 	vmm_sol_glue_cleanup();
 


### PR DESCRIPTION
Re-synchronise remaining bhyve bits with upstream-gate.
Drop local console `wait`option (it only works for socket consoles and is something that Joyent removed upstream)
Replace HMA registration patch with the version that is pending upstream.

I did a full build which was successful.