### PR TITLE
Joyent merge/2020060401

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 535ab7f694a50841ab0a4107fd8f48e95a266c11
+Last illumos-joyent commit: 71b43f2a12f58ef8bc5a1965a3b742749bb49231
 

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -203,6 +203,7 @@ file path=opt/zfs-tests/bin/randwritecomp mode=0555
 file path=opt/zfs-tests/bin/readmmap mode=0555
 file path=opt/zfs-tests/bin/rename_dir mode=0555
 file path=opt/zfs-tests/bin/rm_lnkcnt_zero_file mode=0555
+file path=opt/zfs-tests/bin/watch_dir mode=0555
 file path=opt/zfs-tests/bin/zfstest mode=0555
 file path=opt/zfs-tests/callbacks/zfs_dbgmsg mode=0555
 file path=opt/zfs-tests/callbacks/zfs_mmp mode=0555
@@ -1024,6 +1025,12 @@ file \
     mode=0555
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_encrypted \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_watched_inotify \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_watched_portfs \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/cleanup \
     mode=0555

--- a/usr/src/test/zfs-tests/cmd/watch_dir/Makefile
+++ b/usr/src/test/zfs-tests/cmd/watch_dir/Makefile
@@ -1,0 +1,19 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+PROG = watch_dir
+
+include $(SRC)/cmd/Makefile.cmd
+include ../Makefile.subdirs

--- a/usr/src/test/zfs-tests/cmd/watch_dir/watch_dir.c
+++ b/usr/src/test/zfs-tests/cmd/watch_dir/watch_dir.c
@@ -1,0 +1,151 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+/*
+ * This program watches a directory with portfs or inotify, exiting when the
+ * directory is removed.  It is useful in tests that ensure that watching a
+ * directory does not prevent it from being used as a mount point.
+ */
+#include <limits.h>
+#include <port.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+
+void
+fail_usage(void)
+{
+	(void) fprintf(stderr, "Usage: watch <portfs|inotify> directory\n");
+	exit(1);
+}
+
+#define	MAX_PES 8
+
+void
+watch_port(const char *path)
+{
+	int port;
+	struct file_obj fobj = {0};
+
+	if ((port = port_create()) < 0) {
+		perror("port_create");
+		exit(1);
+	}
+
+	fobj.fo_name = (char *)path;
+	for (;;) {
+		timespec_t ts = {300, 0};
+		port_event_t pe;
+
+		if (port_associate(port, PORT_SOURCE_FILE, (uintptr_t)&fobj,
+		    0, (char *)path) != 0) {
+			perror("port_associate");
+			exit(1);
+		}
+
+		if (port_get(port, &pe, &ts) != 0) {
+			perror("port_get");
+			exit(1);
+		}
+
+		if (pe.portev_events & FILE_DELETE) {
+			(void) printf("DELETE\t%s\n", path);
+			exit(0);
+		}
+		if (pe.portev_events & MOUNTEDOVER) {
+			(void) printf("MOUNTEDOVER\t%s\n", path);
+		}
+	}
+}
+
+void
+watch_inotify(const char *path)
+{
+	int in, wd;
+	struct inotify_event ev;
+
+	if ((in = inotify_init()) < 0) {
+		perror("inotify_init");
+		exit(1);
+	}
+	if ((wd = inotify_add_watch(in, path, IN_DELETE_SELF)) == -1) {
+		perror("inotify_add_watch");
+		exit(1);
+	}
+
+	for (;;) {
+		ssize_t cnt;
+		char evpath[PATH_MAX];
+
+		cnt = read(in, &ev, sizeof (ev));
+		if (cnt != sizeof (ev)) {
+			(void) fprintf(stderr,
+			    "read: expected %ld bytes got %ld\n",
+			    sizeof (ev), cnt);
+			exit(1);
+		}
+		if (ev.len != 0) {
+			if (ev.len > sizeof (evpath)) {
+				(void) fprintf(stderr, "read: oversize "
+				    "path (%u bytes)\n", ev.len);
+				exit(1);
+			}
+			cnt = read(in, evpath, ev.len);
+			if (cnt != ev.len) {
+				(void) fprintf(stderr, "read: expected %ld "
+				    "bytes for path, got %ld\n", ev.len, cnt);
+				exit(1);
+			}
+			evpath[ev.len - 1] = '\0';
+		} else {
+			evpath[0] = '\0';
+		}
+		if (ev.mask & IN_DELETE_SELF) {
+			/*
+			 * IN_DELETE_SELF events don't appear to include
+			 * the path in the event.
+			 */
+			(void) printf("DELETE_SELF\n");
+			exit(0);
+		} else {
+			(void) printf("EVENT_%08x\t%s\n", ev.mask, evpath);
+		}
+
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *watcher, *path;
+
+	if (argc != 3) {
+		fail_usage();
+	}
+	watcher = argv[1];
+	path = argv[2];
+
+	if (strcmp(watcher, "portfs") == 0) {
+		watch_port(path);
+	} else if (strcmp(watcher, "inotify") == 0) {
+		watch_inotify(path);
+	} else {
+		fail_usage();
+	}
+
+	return (0);
+}

--- a/usr/src/test/zfs-tests/include/commands.cfg
+++ b/usr/src/test/zfs-tests/include/commands.cfg
@@ -196,4 +196,5 @@ export ZFSTEST_FILES='chg_usr_exec
     randwritecomp
     readmmap
     rename_dir
-    rm_lnkcnt_zero_file'
+    rm_lnkcnt_zero_file
+    watch_dir'

--- a/usr/src/test/zfs-tests/runfiles/smartos.run
+++ b/usr/src/test/zfs-tests/runfiles/smartos.run
@@ -129,7 +129,8 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_007_pos', 'zfs_mount_008_pos', 'zfs_mount_009_neg',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_012_neg',
     'zfs_mount_all_001_pos', 'zfs_mount_all_fail', 'zfs_mount_all_mountpoints',
-    'zfs_mount_encrypted']
+    'zfs_mount_encrypted', 'zfs_mount_watched_inotify',
+    'zfs_mount_watched_portfs' ]
 
 [/opt/zfs-tests/tests/functional/cli_root/zfs_program]
 tests = ['zfs_program_json']

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_watched_inotify.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_watched_inotify.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs mount' should not get EBUSY due to inotify(5) watching a directory
+#
+# STRATEGY:
+# 1. Create a directory
+# 2. Start watching the directory with inotify(5).
+# 3. Create a filesystem
+# 4. Mount the filesystem at the directory created in step 1
+# 5. Destroy the filesystem
+# 6. Remove the directory
+# 7. Verify the watcher saw the directory removal
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+	log_must rm -rf "$TESTDIR/mntpt" "$TESTDIR/watch_dir.log"
+}
+
+log_onexit cleanup
+
+log_assert "'zfs mount' should not get EBUSY due to inotify(5) watching a directory"
+
+# 1. Create a directory.
+log_must mkdir -p "$TESTDIR/mntpt"
+
+# 2. Start watching the directory with inotify(5).
+watch_dir inotify $TESTDIR/mntpt > $TESTDIR/watch_dir.log &
+
+# 3. Create a filesystem
+log_must zfs create $TESTPOOL/$TESTFS1
+
+# 4. Mount the file system at the directory created in step 1
+log_must zfs set mountpoint=$TESTDIR/mntpt $TESTPOOL/$TESTFS1
+
+# 5. Destroy the filesystem
+log_must zfs destroy $TESTPOOL/$TESTFS1
+
+# 6. Remove the directory.  The corresponding inotify event will cause the
+# watcher to exit.
+log_must rmdir $TESTDIR/mntpt
+
+# 7. Verify the watcher saw the directory removal. This ensures that the watcher
+# was watching the directory we are interested in.
+wait
+log_must grep -q DELETE_SELF $TESTDIR/watch_dir.log
+
+log_pass "'zfs mount' should not get EBUSY due to inotify(5) watching a directory"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_watched_portfs.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_watched_portfs.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2020 Joyent, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# 'zfs mount' should not get EBUSY due to portfs watching a directory
+#
+# STRATEGY:
+# 1. Create a directory
+# 2. Start watching the directory with port_associate
+# 3. Create a filesystem
+# 4. Mount the filesystem at the directory created in step 1
+# 5. Destroy the filesystem
+# 6. Remove the directory
+# 7. Verify the watcher saw the directory removal
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		log_must zfs destroy -f $TESTPOOL/$TESTFS1
+	log_must rm -rf "$TESTDIR/mntpt" "$TESTDIR/watch_dir.log"
+}
+
+log_onexit cleanup
+
+log_assert "'zfs mount' should not get EBUSY due to portfs watching a directory"
+
+# 1. Create a directory.
+log_must mkdir -p "$TESTDIR/mntpt"
+
+# 2. Start watching the directory with port_associate
+watch_dir portfs $TESTDIR/mntpt > $TESTDIR/watch_dir.log &
+
+# 3. Create a filesystem
+log_must zfs create $TESTPOOL/$TESTFS1
+
+# 4. Mount the file system at the directory created in step 1
+log_must zfs set mountpoint=$TESTDIR/mntpt $TESTPOOL/$TESTFS1
+
+# 5. Destroy the filesystem
+log_must zfs destroy $TESTPOOL/$TESTFS1
+
+# 6. Remove the directory.  The corresponding portfs event will cause the
+# watcher to exit.
+log_must rmdir $TESTDIR/mntpt
+
+# 7. Verify the watcher saw the directory removal. This ensures that the watcher
+# was watching the directory we are interested in.
+wait
+log_must grep -q DELETE.$TESTDIR/mntpt $TESTDIR/watch_dir.log
+
+log_pass "'zfs mount' should not get EBUSY due to portfs watching a directory"

--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -3974,6 +3974,20 @@ lx_getsockopt_socket(sonode_t *so, int optname, void *optval,
 	lx_socket_aux_data_t *sad;
 
 	switch (optname) {
+	case LX_SO_PROTOCOL:
+		/*
+		 * We need to special-case netlink and AF_UNIX too.
+		 */
+		if (so->so_family != AF_LX_NETLINK && so->so_family != AF_UNIX)
+			break;	/* Common-case it. */
+		if (*optlen < sizeof (int)) {
+			error = EINVAL;
+		} else {
+			*intval = so->so_protocol;
+		}
+		*optlen = sizeof (int);
+		return (error);
+
 	case LX_SO_TYPE:
 		/*
 		 * Special handling for connectionless AF_UNIX sockets.

--- a/usr/src/uts/common/fs/vnode.c
+++ b/usr/src/uts/common/fs/vnode.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  */
@@ -849,6 +849,37 @@ vn_rele(vnode_t *vp)
 	}
 	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
+}
+
+void
+vn_phantom_rele(vnode_t *vp)
+{
+	VERIFY(vp->v_count > 0);
+
+	mutex_enter(&vp->v_lock);
+	VERIFY3U(vp->v_count, >=, vp->v_phantom_count);
+	vp->v_phantom_count--;
+	DTRACE_PROBE1(vn__phantom_rele, vnode_t *, vp);
+	if (vp->v_count == 1) {
+		ASSERT0(vp->v_phantom_count);
+		mutex_exit(&vp->v_lock);
+		VOP_INACTIVE(vp, CRED(), NULL);
+		return;
+	}
+	VN_RELE_LOCKED(vp);
+	mutex_exit(&vp->v_lock);
+}
+
+/*
+ * Return the number of non-phantom holds. Things such as portfs will use
+ * phantom holds to prevent it from blocking filesystems from mounting over
+ * watched directories.
+ */
+uint_t
+vn_count(vnode_t *vp)
+{
+	ASSERT(MUTEX_HELD(&vp->v_lock));
+	return (vp->v_count - vp->v_phantom_count);
 }
 
 /*
@@ -2427,6 +2458,7 @@ vn_reinit(vnode_t *vp)
 {
 	vp->v_count = 1;
 	vp->v_count_dnlc = 0;
+	vp->v_phantom_count = 0;
 	vp->v_vfsp = NULL;
 	vp->v_stream = NULL;
 	vp->v_vfsmountedhere = NULL;
@@ -2483,6 +2515,7 @@ vn_free(vnode_t *vp)
 	 */
 	ASSERT((vp->v_count == 0) || (vp->v_count == 1));
 	ASSERT(vp->v_count_dnlc == 0);
+	ASSERT0(vp->v_phantom_count);
 	VERIFY(vp->v_path != NULL);
 	if (vp->v_path != vn_vpath_empty) {
 		kmem_free(vp->v_path, strlen(vp->v_path) + 1);

--- a/usr/src/uts/common/fs/zfs/zfs_vfsops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vfsops.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Nexenta Systems, Inc. All rights reserved.
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
@@ -1892,7 +1892,7 @@ zfs_mount(vfs_t *vfsp, vnode_t *mvp, struct mounta *uap, cred_t *cr)
 	mutex_enter(&mvp->v_lock);
 	if ((uap->flags & MS_REMOUNT) == 0 &&
 	    (uap->flags & MS_OVERLAY) == 0 &&
-	    (mvp->v_count != 1 || (mvp->v_flag & VROOT))) {
+	    (vn_count(mvp) != 1 || (mvp->v_flag & VROOT))) {
 		mutex_exit(&mvp->v_lock);
 		return (SET_ERROR(EBUSY));
 	}

--- a/usr/src/uts/common/sys/vnode.h
+++ b/usr/src/uts/common/sys/vnode.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright 2017 RackTop Systems.
  */
@@ -197,6 +197,7 @@ struct vsd_node {
  *   v_count
  *   v_shrlocks
  *   v_path
+ *   v_phantom_count
  *   v_vsd
  *   v_xattrdir
  *
@@ -214,6 +215,7 @@ struct vsd_node {
  *     v_lock
  *     v_flag
  *     v_count
+ *     v_phantom_count
  *     v_data
  *     v_vfsp
  *     v_stream
@@ -285,6 +287,8 @@ typedef struct vnode {
 	kmutex_t	v_lock;		/* protects vnode fields */
 	uint_t		v_flag;		/* vnode flags (see below) */
 	uint_t		v_count;	/* reference count */
+				/* non vn_count() ref count (see below) */
+	uint_t		v_phantom_count;
 	void		*v_data;	/* private data for fs */
 	struct vfs	*v_vfsp;	/* ptr to containing VFS */
 	struct stdata	*v_stream;	/* associated stream */
@@ -811,9 +815,9 @@ typedef enum vnevent	{
 	VE_REMOVE	= 3,	/* Remove of vnode's name */
 	VE_RMDIR	= 4,	/* Remove of directory vnode's name */
 	VE_CREATE	= 5,	/* Create with vnode's name which exists */
-	VE_LINK		= 6, 	/* Link with vnode's name as source */
-	VE_RENAME_DEST_DIR	= 7, 	/* Rename with vnode as target dir */
-	VE_MOUNTEDOVER	= 8, 	/* File or Filesystem got mounted over vnode */
+	VE_LINK		= 6,	/* Link with vnode's name as source */
+	VE_RENAME_DEST_DIR = 7,	/* Rename with vnode as target dir */
+	VE_MOUNTEDOVER	= 8,	/* File or Filesystem got mounted over vnode */
 	VE_TRUNCATE = 9,	/* Truncate */
 	VE_PRE_RENAME_SRC = 10,	/* Pre-rename, with vnode as source */
 	VE_PRE_RENAME_DEST = 11, /* Pre-rename, with vnode as target/dest. */
@@ -1294,9 +1298,9 @@ void	vn_recycle(vnode_t *);
 void	vn_free(vnode_t *);
 
 int	vn_is_readonly(vnode_t *);
-int   	vn_is_opened(vnode_t *, v_mode_t);
-int   	vn_is_mapped(vnode_t *, v_mode_t);
-int   	vn_has_other_opens(vnode_t *, v_mode_t);
+int	vn_is_opened(vnode_t *, v_mode_t);
+int	vn_is_mapped(vnode_t *, v_mode_t);
+int	vn_has_other_opens(vnode_t *, v_mode_t);
 void	vn_open_upgrade(vnode_t *, int);
 void	vn_open_downgrade(vnode_t *, int);
 
@@ -1335,10 +1339,12 @@ int	vn_createat(char *pnamep, enum uio_seg seg, struct vattr *vap,
 int	vn_rdwr(enum uio_rw rw, struct vnode *vp, caddr_t base, ssize_t len,
 		offset_t offset, enum uio_seg seg, int ioflag, rlim64_t ulimit,
 		cred_t *cr, ssize_t *residp);
+uint_t	vn_count(struct vnode *vp);
 void	vn_rele(struct vnode *vp);
 void	vn_rele_async(struct vnode *vp, struct taskq *taskq);
 void	vn_rele_dnlc(struct vnode *vp);
 void	vn_rele_stream(struct vnode *vp);
+void	vn_phantom_rele(struct vnode *vp);
 int	vn_link(char *from, char *to, enum uio_seg seg);
 int	vn_linkat(vnode_t *fstartvp, char *from, enum symfollow follow,
 		vnode_t *tstartvp, char *to, enum uio_seg seg);
@@ -1443,6 +1449,16 @@ extern uint_t pvn_vmodsort_supported;
  *	    this->vp->v_path == NULL ? "NULL" : stringof(this->vp->v_path),
  *	    this->vp->v_count)
  * }'
+ *
+ * There are some situations where we don't want a hold to make the vnode
+ * 'busy'. For example, watching a directory via port events or inotify
+ * should not prevent a filesystem from mounting on a watched directory.
+ * For those instances, a phantom hold is used via VN_PHANTOM_HOLD().
+ *
+ * A phantom hold works identically to regular hold, except that those holds
+ * are excluded from the return value of vn_count().
+ *
+ * A phantom hold must be released by VN_PHANTOM_RELE().
  */
 #define	VN_HOLD_LOCKED(vp) {			\
 	ASSERT(mutex_owned(&(vp)->v_lock));	\
@@ -1471,6 +1487,22 @@ extern uint_t pvn_vmodsort_supported;
 	DTRACE_PROBE1(vn__rele, vnode_t *, vp);	\
 }
 
+#define	VN_PHANTOM_HOLD_LOCKED(vp) {			\
+	VN_HOLD_LOCKED(vp);				\
+	(vp)->v_phantom_count++;			\
+	DTRACE_PROBE1(vn__phantom_hold, vnode_t *, vp);	\
+}
+
+#define	VN_PHANTOM_HOLD(vp) {		\
+	mutex_enter(&(vp)->v_lock);	\
+	VN_PHANTOM_HOLD_LOCKED(vp);	\
+	mutex_exit(&(vp)->v_lock);	\
+}
+
+#define	VN_PHANTOM_RELE(vp) {	\
+	vn_phantom_rele(vp);	\
+}
+
 #define	VN_SET_VFS_TYPE_DEV(vp, vfsp, type, dev)	{ \
 	(vp)->v_vfsp = (vfsp); \
 	(vp)->v_type = (type); \
@@ -1481,7 +1513,7 @@ extern uint_t pvn_vmodsort_supported;
  * Compare two vnodes for equality.  In general this macro should be used
  * in preference to calling VOP_CMP directly.
  */
-#define	VN_CMP(VP1, VP2)	((VP1) == (VP2) ? 1 : 	\
+#define	VN_CMP(VP1, VP2)	((VP1) == (VP2) ? 1 :	\
 	((VP1) && (VP2) && (vn_getops(VP1) == vn_getops(VP2)) ? \
 	VOP_CMP(VP1, VP2, NULL) : 0))
 


### PR DESCRIPTION
Weekly upstream for Joyent

## Backports

* tbd

## onu

```
OmniOS r151035  omnios-joyent_merge-2020060401-1737f1b3d3       June 2020
illumos development build: 2020-Jun-04 [illumos-omnios]
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-joyent_merge-2020060401-1737f1b3d3 i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Thu Jun  4 17:50:47 CEST 2020 ====
==== Nightly distributed build completed: Thu Jun  4 19:08:49 CEST 2020 ====

==== Total build time ====

real    1:18:01

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-a84f9c312d i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151035-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   78

==== Nightly argument issues ====


==== Build version ====

omnios-joyent_merge-2020060401-1737f1b3d3

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    35:07.0
user  3:23:29.6
sys     40:37.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    29:57.1
user  2:54:06.8
sys     34:09.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====

```