### PR TITLE
Upstream merge joyent_merge/2020062201

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 71b43f2a12f58ef8bc5a1965a3b742749bb49231
+Last illumos-joyent commit: 6682e4c38cf4cf5fd5fc490fac27f3d7af9bab4c
 

--- a/usr/src/uts/common/fs/portfs/port_fop.c
+++ b/usr/src/uts/common/fs/portfs/port_fop.c
@@ -778,12 +778,12 @@ port_fop_getdvp(void *objptr, vnode_t **vp, vnode_t **dvp,
 	}
 
 	/* Trade VN_HOLD()s from lookuppn with VN_PHANTOM_HOLD()s */
-	if (dvp != NULL) {
+	if (dvp != NULL && *dvp != NULL) {
 		VN_PHANTOM_HOLD(*dvp);
 		VN_RELE(*dvp);
 	}
 
-	if (vp != NULL) {
+	if (vp != NULL && *vp != NULL) {
 		VN_PHANTOM_HOLD(*vp);
 		VN_RELE(*vp);
 	}


### PR DESCRIPTION
Weekly upstream for joyent_merge/2020062201

Picking up this fix for a panic recently introduced with 
`LX: OS-8054 inotify watches lead to EBUSY during zfs mount` (e0bc238d0549b65f981e36b78bc56895d6014335)
