### PR TITLE
Upstream merge upstream_merge/2020070201

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2512,7 +2512,6 @@ usr/src/lib/brand/lx/zone/lx_boot_zone_redhat
 usr/src/lib/brand/lx/zone/lx_boot_zone_suse
 usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu
 usr/src/lib/brand/lx/zone/lx_boot_zone_void
-usr/src/lib/brand/lx/zone/lx_install
 usr/src/lib/brand/shared/brand/amd64/assym.h
 usr/src/lib/brand/shared/brand/i386/assym.h
 usr/src/lib/brand/shared/zadump/zadump

--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2020.06.10.1
+BOOT_VERSION = $(LOADER_VERSION)-2020.06.26.1

--- a/usr/src/boot/lib/libstand/zfs/zfsimpl.c
+++ b/usr/src/boot/lib/libstand/zfs/zfsimpl.c
@@ -996,6 +996,13 @@ vdev_disk_read(vdev_t *vdev, const blkptr_t *bp, void *buf,
 	    offset + VDEV_LABEL_START_SIZE, bytes));
 }
 
+static int
+vdev_missing_read(vdev_t *vdev __unused, const blkptr_t *bp __unused,
+    void *buf __unused, off_t offset __unused, size_t bytes __unused)
+{
+
+	return (ENOTSUP);
+}
 
 static int
 vdev_mirror_read(vdev_t *vdev, const blkptr_t *bp, void *buf,
@@ -1135,9 +1142,10 @@ vdev_init(uint64_t guid, const unsigned char *nvlist, vdev_t **vdevp)
 #endif
 	    memcmp(type, VDEV_TYPE_RAIDZ, len) != 0 &&
 	    memcmp(type, VDEV_TYPE_INDIRECT, len) != 0 &&
-	    memcmp(type, VDEV_TYPE_REPLACING, len) != 0) {
+	    memcmp(type, VDEV_TYPE_REPLACING, len) != 0 &&
+	    memcmp(type, VDEV_TYPE_HOLE, len) != 0) {
 		printf("ZFS: can only boot from disk, mirror, raidz1, "
-		    "raidz2 and raidz3 vdevs\n");
+		    "raidz2 and raidz3 vdevs, got: %.*s\n", len, type);
 		return (EIO);
 	}
 
@@ -1168,6 +1176,8 @@ vdev_init(uint64_t guid, const unsigned char *nvlist, vdev_t **vdevp)
 			    DATA_TYPE_UINT64,
 			    NULL, &vic->vic_prev_indirect_vdev, NULL);
 		}
+	} else if (memcmp(type, VDEV_TYPE_HOLE, len) == 0) {
+		vdev = vdev_create(guid, vdev_missing_read);
 	} else {
 		vdev = vdev_create(guid, vdev_disk_read);
 	}

--- a/usr/src/data/locale/Makefile
+++ b/usr/src/data/locale/Makefile
@@ -146,8 +146,10 @@ locale/%/$(DTIME): locale/%/stamp
 
 $(ROOTDATA):	$(ROOTLOCDIRS) $(ROOTCATDIRS) $(DATA)
 		$(RM) $@
-		-$(CP) $(@:$(ROOTLIB)/%=%) $@
-		$(CHMOD) -f 0444 $@
+		if [[ -f $(@:$(ROOTLIB)/%=%) ]]; then \
+			$(CP) $(@:$(ROOTLIB)/%=%) $@; \
+			$(CHMOD) -f 0444 $@ ; \
+		fi
 
 %.mo:		%.po
 		$(MSGFMT) -o $@ $<

--- a/usr/src/lib/cfgadm_plugins/ccid/Makefile
+++ b/usr/src/lib/cfgadm_plugins/ccid/Makefile
@@ -27,7 +27,7 @@
 
 include		../../Makefile.lib
 
-$(INTEL_BLD)SUBDIRS =	$(MACH) $(BUILD64) $(MACH64)
+SUBDIRS =	$(MACH) $(BUILD64) $(MACH64)
 
 all :=		TARGET= all
 clean :=	TARGET= clean

--- a/usr/src/lib/cfgadm_plugins/ccid/sparc/Makefile
+++ b/usr/src/lib/cfgadm_plugins/ccid/sparc/Makefile
@@ -1,0 +1,20 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, Joyent, Inc.
+#
+
+include ../Makefile.com
+
+.KEEP_STATE:
+
+install: all $(ROOTLIBS) $(ROOTLINKS)

--- a/usr/src/lib/cfgadm_plugins/ccid/sparcv9/Makefile
+++ b/usr/src/lib/cfgadm_plugins/ccid/sparcv9/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, Joyent, Inc.
+#
+
+include ../Makefile.com
+include ../../../Makefile.lib.64
+
+.KEEP_STATE:
+
+install: all $(ROOTLIBS64) $(ROOTLINKS64)

--- a/usr/src/lib/libctf/common/ctf_dwarf.c
+++ b/usr/src/lib/libctf/common/ctf_dwarf.c
@@ -1456,13 +1456,102 @@ ctf_dwarf_create_sou(ctf_cu_t *cup, Dwarf_Die die, ctf_id_t *idp,
 }
 
 static int
+ctf_dwarf_array_upper_bound(ctf_cu_t *cup, Dwarf_Die range, ctf_arinfo_t *ar)
+{
+	Dwarf_Attribute attr;
+	Dwarf_Unsigned uval;
+	Dwarf_Signed sval;
+	Dwarf_Half form;
+	Dwarf_Error derr;
+	const char *formstr = NULL;
+	int ret = 0;
+
+	ctf_dprintf("setting array upper bound\n");
+
+	ar->ctr_nelems = 0;
+
+	ret = ctf_dwarf_attribute(cup, range, DW_AT_upper_bound, &attr);
+	/*
+	 * Treat the lack of an upper bound attribute as a zero element array
+	 * and return success, otherwise return the error.
+	 */
+	if (ret != 0) {
+		if (ret == ENOENT)
+			return (0);
+		return (ret);
+	}
+
+	if (dwarf_whatform(attr, &form, &derr) != DW_DLV_OK) {
+		(void) snprintf(cup->cu_errbuf, cup->cu_errlen,
+		    "failed to get DW_AT_upper_bound attribute form: %s\n",
+		    dwarf_errmsg(derr));
+		ret = ECTF_CONVBKERR;
+		goto done;
+	}
+
+	/*
+	 * Compilers can indicate array bounds using signed or unsigned values.
+	 * Additionally, some compilers may also store the array bounds
+	 * using as DW_FORM_data{1,2,4,8} (which DWARF treats as raw data and
+	 * expects the caller to understand how to interpret the value).
+	 *
+	 * GCC 4.4.4 appears to always use unsigned values to encode the
+	 * array size (using '(unsigned)-1' to represent a zero-length or
+	 * unknown length array). Later versions of GCC use a signed value of
+	 * -1 for zero/unknown length arrays, and unsigned values to encode
+	 * known array sizes.
+	 *
+	 * Both dwarf_formsdata() and dwarf_formudata() will retrieve values
+	 * as their respective signed/unsigned forms, but both will also
+	 * retreive DW_FORM_data{1,2,4,8} values and treat them as signed or
+	 * unsigned integers (i.e. dwarf_formsdata() treats DW_FORM_dataXX
+	 * as signed integers and dwarf_formudata() treats DW_FORM_dataXX as
+	 * unsigned integers). Both will return an error if the form is not
+	 * their respective signed/unsigned form, or DW_FORM_dataXX.
+	 *
+	 * To obtain the upper bound, we use the appropriate
+	 * dwarf_form[su]data() function based on the form of DW_AT_upper_bound.
+	 * Additionally, we let dwarf_formudata() handle the DW_FORM_dataXX
+	 * forms (via the default option in the switch). If the value is in an
+	 * unexpected form (i.e. not DW_FORM_udata or DW_FORM_dataXX),
+	 * dwarf_formudata() will return failure (i.e. not DW_DLV_OK) and set
+	 * derr with the specific error value.
+	 */
+	switch (form) {
+	case DW_FORM_sdata:
+		if (dwarf_formsdata(attr, &sval, &derr) == DW_DLV_OK) {
+			ar->ctr_nelems = sval + 1;
+			goto done;
+		}
+		break;
+	case DW_FORM_udata:
+	default:
+		if (dwarf_formudata(attr, &uval, &derr) == DW_DLV_OK) {
+			ar->ctr_nelems = uval + 1;
+			goto done;
+		}
+		break;
+	}
+
+	if (dwarf_get_FORM_name(form, &formstr) != DW_DLV_OK)
+		formstr = "unknown DWARF form";
+
+	(void) snprintf(cup->cu_errbuf, cup->cu_errlen,
+	    "failed to get %s (%hu) value for DW_AT_upper_bound: %s\n",
+	    formstr, form, dwarf_errmsg(derr));
+	ret = ECTF_CONVBKERR;
+
+done:
+	dwarf_dealloc(cup->cu_dwarf, attr, DW_DLA_ATTR);
+	return (ret);
+}
+
+static int
 ctf_dwarf_create_array_range(ctf_cu_t *cup, Dwarf_Die range, ctf_id_t *idp,
     ctf_id_t base, int isroot)
 {
 	int ret;
 	Dwarf_Die sib;
-	Dwarf_Unsigned val;
-	Dwarf_Signed sval;
 	ctf_arinfo_t ar;
 
 	ctf_dprintf("creating array range\n");
@@ -1482,30 +1571,8 @@ ctf_dwarf_create_array_range(ctf_cu_t *cup, Dwarf_Die range, ctf_id_t *idp,
 	if ((ar.ctr_index = ctf_dwarf_long(cup)) == CTF_ERR)
 		return (ctf_errno(cup->cu_ctfp));
 
-	/*
-	 * Array bounds can be signed or unsigned, but there are several kinds
-	 * of signless forms (data1, data2, etc) that take their sign from the
-	 * routine that is trying to interpret them.  That is, data1 can be
-	 * either signed or unsigned, depending on whether you use the signed or
-	 * unsigned accessor function.  GCC will use the signless forms to store
-	 * unsigned values which have their high bit set, so we need to try to
-	 * read them first as unsigned to get positive values.  We could also
-	 * try signed first, falling back to unsigned if we got a negative
-	 * value.
-	 */
-	if ((ret = ctf_dwarf_unsigned(cup, range, DW_AT_upper_bound,
-	    &val)) == 0) {
-		ar.ctr_nelems = val + 1;
-	} else if (ret != ENOENT) {
+	if ((ret = ctf_dwarf_array_upper_bound(cup, range, &ar)) != 0)
 		return (ret);
-	} else if ((ret = ctf_dwarf_signed(cup, range, DW_AT_upper_bound,
-	    &sval)) == 0) {
-		ar.ctr_nelems = sval + 1;
-	} else if (ret != ENOENT) {
-		return (ret);
-	} else {
-		ar.ctr_nelems = 0;
-	}
 
 	if ((*idp = ctf_add_array(cup->cu_ctfp, isroot, &ar)) == CTF_ERR)
 		return (ctf_errno(cup->cu_ctfp));
@@ -1684,40 +1751,12 @@ ctf_dwarf_create_reference(ctf_cu_t *cup, Dwarf_Die die, ctf_id_t *idp,
 	return (ctf_dwmap_add(cup, *idp, die, B_FALSE));
 }
 
-/*
- * Get the size of the type of a particular die. Note that this is a simple
- * version that doesn't attempt to traverse further than expecting a single
- * sized type reference (so no qualifiers etc.). Nor does it attempt to do as
- * much as ctf_type_size() - which we cannot use here as that doesn't look up
- * dynamic types, and we don't yet want to do a ctf_update().
- */
-static int
-ctf_dwarf_get_type_size(ctf_cu_t *cup, Dwarf_Die die, size_t *sizep)
-{
-	const ctf_type_t *t;
-	Dwarf_Die tdie;
-	ctf_id_t tid;
-	int ret;
-
-	if ((ret = ctf_dwarf_refdie(cup, die, DW_AT_type, &tdie)) != 0)
-		return (ret);
-
-	if ((ret = ctf_dwarf_convert_type(cup, tdie, &tid,
-	    CTF_ADD_NONROOT)) != 0)
-		return (ret);
-
-	if ((t = ctf_dyn_lookup_by_id(cup->cu_ctfp, tid)) == NULL)
-		return (ENOENT);
-
-	*sizep = ctf_get_ctt_size(cup->cu_ctfp, t, NULL, NULL);
-	return (0);
-}
-
 static int
 ctf_dwarf_create_enum(ctf_cu_t *cup, Dwarf_Die die, ctf_id_t *idp, int isroot)
 {
 	size_t size = 0;
 	Dwarf_Die child;
+	Dwarf_Unsigned dw;
 	ctf_id_t id;
 	char *name;
 	int ret;
@@ -1728,7 +1767,15 @@ ctf_dwarf_create_enum(ctf_cu_t *cup, Dwarf_Die die, ctf_id_t *idp, int isroot)
 	if (ret == ENOENT)
 		name = NULL;
 
-	(void) ctf_dwarf_get_type_size(cup, die, &size);
+	/*
+	 * Enumerations may have a size associated with them, particularly if
+	 * they're packed. Note, a Dwarf_Unsigned is larger than a size_t on an
+	 * ILP32 system.
+	 */
+	if (ctf_dwarf_unsigned(cup, die, DW_AT_byte_size, &dw) == 0 &&
+	    dw < SIZE_MAX) {
+		size = (size_t)dw;
+	}
 
 	id = ctf_add_enum(cup->cu_ctfp, isroot, name, size);
 	ctf_dprintf("added enum %s (%d)\n", name, id);

--- a/usr/src/man/man1m/mkfifo.1m
+++ b/usr/src/man/man1m/mkfifo.1m
@@ -44,25 +44,21 @@
 .\" Copyright (c) 1992, X/Open Company Limited  All Rights Reserved
 .\" Portions Copyright (c) 2009, Sun Microsystems, Inc.  All Rights Reserved
 .\"
-.TH MKFIFO 1M "Aug 11, 2009"
+.TH MKFIFO 1M "Jun 24, 2020"
 .SH NAME
 mkfifo \- make FIFO special file
 .SH SYNOPSIS
-.LP
 .nf
-\fB/usr/bin/mkfifo\fR [\fB-m\fR \fImode\fR] \fIpath\fR...
+\fB/usr/bin/mkfifo\fR [\fB-m\fR \fImode\fR] \fIfile\fR...
 .fi
 
 .SS "ksh93"
-.LP
 .nf
 mkfifo [ \fIoptions\fR ] \fIfile\fR...
 .fi
 
 .SH DESCRIPTION
 .SS "/usr/bin/mkfifo"
-.sp
-.LP
 The \fBmkfifo\fR utility creates the \fBFIFO\fR special files named by its
 argument list. The arguments are taken sequentially, in the order specified;
 and each \fBFIFO\fR special file is either created completely or, in the case
@@ -70,23 +66,19 @@ of an error or signal, not created at all.
 .sp
 .LP
 If errors are encountered in creating one of the special files, \fBmkfifo\fR
-writes a diagnostic message to the standard error and continues with the
+writes a diagnostic message to standard error and continues with the
 remaining arguments, if any.
 .sp
 .LP
-The \fBmkfifo\fR utility calls the library routine \fBmkfifo\fR(3C), with the
-\fIpath\fR argument is passed as the \fIpath\fR argument from the command line,
-and  \fImode\fR is set to the equivalent of \fBa=rw\fR, modified by the current
+The \fBmkfifo\fR utility calls the library routine \fBmkfifo\fR(3C), with a
+\fIpath\fR argument equivalent to the \fIfile\fR argument from the command line,
+and \fImode\fR is set to the equivalent of \fBa=rw\fR, modified by the current
 value of the file mode creation mask \fBumask\fR(1).
 .SS "ksh93"
-.sp
-.LP
 The \fBmkfifo\fR utility creates one or more \fBFIFO\fRs. By default, the mode
 of the created FIFO is \fBa=rw\fR minus the bits set in \fBumask\fR(1).
 .SH OPTIONS
-.SS "/usr/bin/ksh93"
-.sp
-.LP
+.SS "/usr/bin/mkfifo"
 The following option is supported for \fB/usr/bin/mkfifo\fR:
 .sp
 .ne 2
@@ -96,14 +88,12 @@ The following option is supported for \fB/usr/bin/mkfifo\fR:
 .RS 11n
 Set the file permission bits of the newly-created \fBFIFO\fR to the specified
 \fImode\fR value. The \fImode\fR option-argument will be the same as the
-\fImode\fR operand defined for the \fBchmod\fR(1) command. In
-<\fIsymbolic\fRmode> strings, the \fIop\fR characters \fB+\fR and \fB\(mi\fR
+\fImode\fR operand defined for the \fBchmod\fR(1) command. For a
+symbolic mode option-argument, the \fIop\fR characters \fB+\fR and \fB\(mi\fR
 will be interpreted relative to an assumed initial mode of \fBa=rw\fR.
 .RE
 
 .SS "ksh93"
-.sp
-.LP
 The following option is supported for \fBksh93\fR:
 .sp
 .ne 2
@@ -121,8 +111,6 @@ initial mode of \fBa=rw\fR.
 .RE
 
 .SH OPERANDS
-.sp
-.LP
 The following operand is supported:
 .sp
 .ne 2
@@ -134,19 +122,13 @@ A path name of the \fBFIFO\fR special file to be created.
 .RE
 
 .SH USAGE
-.sp
-.LP
 See \fBlargefile\fR(5) for the description of the behavior of \fBmkfifo\fR when
 encountering files greater than or equal to 2 Gbyte ( 2^31 bytes).
 .SH ENVIRONMENT VARIABLES
-.sp
-.LP
 See \fBenviron\fR(5) for descriptions of the following environment variables
 that affect the execution of \fBmkfifo\fR: \fBLANG\fR, \fBLC_ALL\fR,
 \fBLC_CTYPE\fR, \fBLC_MESSAGES\fR, and \fBNLSPATH\fR.
 .SH EXIT STATUS
-.sp
-.LP
 The following exit values are returned:
 .sp
 .ne 2
@@ -167,8 +149,6 @@ An error occurred.
 .RE
 
 .SH ATTRIBUTES
-.sp
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -183,7 +163,5 @@ Interface Stability	Standard
 .TE
 
 .SH SEE ALSO
-.sp
-.LP
 \fBchmod\fR(1), \fBumask\fR(1), \fBmkfifo\fR(3C), \fBattributes\fR(5),
 \fBenviron\fR(5), \fBlargefile\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man3c/wcswidth.3c
+++ b/usr/src/man/man3c/wcswidth.3c
@@ -1,106 +1,133 @@
 .\"
-.\" Sun Microsystems, Inc. gratefully acknowledges The Open Group for
-.\" permission to reproduce portions of its copyrighted documentation.
-.\" Original documentation from The Open Group can be obtained online at
-.\" http://www.opengroup.org/bookstore/.
+.\" This file and its contents are supplied under the terms of the
+.\" Common Development and Distribution License ("CDDL"), version 1.0.
+.\" You may only use this file in accordance with the terms of version
+.\" 1.0 of the CDDL.
 .\"
-.\" The Institute of Electrical and Electronics Engineers and The Open
-.\" Group, have given us permission to reprint portions of their
-.\" documentation.
-.\"
-.\" In the following statement, the phrase ``this text'' refers to portions
-.\" of the system documentation.
-.\"
-.\" Portions of this text are reprinted and reproduced in electronic form
-.\" in the SunOS Reference Manual, from IEEE Std 1003.1, 2004 Edition,
-.\" Standard for Information Technology -- Portable Operating System
-.\" Interface (POSIX), The Open Group Base Specifications Issue 6,
-.\" Copyright (C) 2001-2004 by the Institute of Electrical and Electronics
-.\" Engineers, Inc and The Open Group.  In the event of any discrepancy
-.\" between these versions and the original IEEE and The Open Group
-.\" Standard, the original IEEE and The Open Group Standard is the referee
-.\" document.  The original Standard can be obtained online at
-.\" http://www.opengroup.org/unix/online.html.
-.\"
-.\" This notice shall appear on any product containing this material.
-.\"
-.\" The contents of this file are subject to the terms of the
-.\" Common Development and Distribution License (the "License").
-.\" You may not use this file except in compliance with the License.
-.\"
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-.\" or http://www.opensolaris.org/os/licensing.
-.\" See the License for the specific language governing permissions
-.\" and limitations under the License.
-.\"
-.\" When distributing Covered Code, include this CDDL HEADER in each
-.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-.\" If applicable, add the following below this CDDL HEADER, with the
-.\" fields enclosed by brackets "[]" replaced with your own identifying
-.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\" A full copy of the text of the CDDL should have accompanied this
+.\" source.  A copy of the CDDL is also available via the Internet at
+.\" http://www.illumos.org/license/CDDL.
 .\"
 .\"
-.\" Copyright (c) 1992, X/Open Company Limited.  All Rights Reserved.
-.\" Portions Copyright (c) 2002, Sun Microsystems, Inc.  All Rights Reserved
-.\" Copyright 2014 Garrett D'Amore <garrett@damore.org>
+.\" Copyright 2020 Oxide Computer Company
 .\"
-.TH WCSWIDTH 3C "Jul 11, 2014"
-.SH NAME
-wcswidth, wcswidth_l \- number of column positions of a wide-character string
-.SH SYNOPSIS
-.LP
-.nf
+.Dd June 17, 2020
+.Dt WCSWIDTH 3C
+.Os
+.Sh NAME
+.Nm wcswidth ,
+.Nm wcswidth_l
+.Nd determine number of columns for wide-character string
+.Sh SYNOPSIS
+.In wchar.h
+.Ft int
+.Fo wcswidth
+.Fa "const wchar_t *str"
+.Fa "size_t len"
+.Fc
+.In wchar.h
+.In xlocale.h
+.Ft int
+.Fo wcswidth_l
+.Fa "const wchar_t *str"
+.Fa "size_t len"
+.Fa "locale_t loc"
+.Fc
+.Sh DESCRIPTION
+The
+.Fn wcswidth
+and
+.Fn wcswidth_l
+functions count the total number of columns that are required
+to display the contents of the wide-character string
+.Fa str .
+For each wide-character in the string
+.Fa str ,
+the equivalent of
+.Xr wcwidth 3C
+is called and the result summed to a running total which is returned.
+.Pp
+Up to
+.Fa len
+wide-characters from
+.Fa str
+will be evaluated; however, the functions will stop iterating if they
+encounter the null wide-character
+.Pq L'\e0' .
+.Pp
+The wide-characters in
+.Fa str
+must be valid characters in the current locale or in the case of the
+.Fn wcswidth_l
+function, the locale specified by
+.Fa loc .
+The functions will fail if any of the wide-characters in
+.Fa str
+are valid in the current
+locale, but considered non-printable
+.Po
+as in
+.Xr iswprint 3C
+would fail for the character
+.Pc
+or the wide-character does not represent a valid character in the
+locale.
+.Sh RETURN VALUES
+Upon successful completion, the
+.Fn wcswidth
+and
+.Fn wcswidth_l
+functions return the total number of columns that are required to
+display the wide-character string.
+Otherwise,
+.Sy -1
+is returned to indicate that an invalid or non-printable wide-character
+was encountered.
+.Sh EXAMPLES
+.Sy Example 1
+Using the
+.Fn wcswidth
+function to count characters in a string.
+.Bd -literal
 #include <wchar.h>
+#include <stdio.h>
 
-\fBint\fR \fBwcswidth\fR(\fBconst wchar_t *\fR\fIpwcs\fR, \fBsize_t\fR \fIn\fR);
-.fi
-.LP
-.nf
-#include <wchar.h>
-#include <xlocale.h>
-
-\fBint\fR \fBwcswidth_l\fR(\fBconst wchar_t *\fR\fIpwcs\fR, \fBsize_t\fR \fIn\fR, \fBlocale_t\fR \fIloc\fR);
-.fi
-
-.SH DESCRIPTION
-.sp
-.LP
-The \fBwcswidth()\fR function determines the number of column positions
-required for \fIn\fR wide-character codes (or fewer than \fIn\fR wide-character
-codes if a null wide-character code is encountered before \fIn\fR
-wide-character codes are exhausted) in the string pointed to by \fIpwcs\fR.
-.SH RETURN VALUES
-.LP
-The \fBwcswidth()\fR function either returns \fB0\fR (if \fIpwcs\fR points to a
-null wide-character code), or returns the number of column positions to be
-occupied by the wide-character string pointed to by \fIpwcs\fR, or returns
-\fB\(mi1\fR (if any of the first \fIn\fR wide-character codes in the
-wide-character string pointed to by \fIpwcs\fR is not a printing wide-character
-code).
-.LP
-The function \fBwcwidth_l()\fR behaves identically to \fBwcwidth()\fR, except
-instead of operating in the current environemtn, it operates in the environment
-specified by \fIloc\fR.
-.SH ERRORS
-.LP
-No errors are defined.
-.SH ATTRIBUTES
-.LP
-See \fBattributes\fR(5) for descriptions of the following attributes:
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-_
-Interface Stability	Standard
-_
-MT-Level	MT-Safe with exceptions
-.TE
-
-.SH SEE ALSO
-.LP
-\fBnewlocale\fR(3C), \fBsetlocale\fR(3C), \fBuselocale\fR(3C),
-\fBwcwidth\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)
+int
+main(void)
+{
+        wchar_t *str = L"Hello world";
+        int ret = wcswidth(str, wcslen(str));
+        (void) printf("wcswidth returned: %d\n", ret);
+        return (0);
+}
+.Ed
+.Pp
+When compiled and run, this program outputs:
+.Bd -literal
+$ gcc -Wall -Wextra example.c
+$ ./a.out
+wcswidth returned: 11
+.Ed
+.Sh MT-LEVEL
+The
+.Fn wcswidth
+function is
+.Sy MT-Safe
+as long as the thread-specific or global locale is not changed while it
+is running.
+.Pp
+The
+.Fn wcswidth_l
+function is
+.Sy MT-Safe
+as long as the locale
+.Fa loc
+is not freed while the function is running.
+.Sh INTERFACE STABILITY
+.Sy Committed
+.Sh SEE ALSO
+.Xr iswprint 3C ,
+.Xr newlocale 3C ,
+.Xr setlocale 3C ,
+.Xr uselocale 3C ,
+.Xr wcwidth 3C

--- a/usr/src/pkg/manifests/driver-misc-ccid.mf
+++ b/usr/src/pkg/manifests/driver-misc-ccid.mf
@@ -24,7 +24,7 @@ set name=pkg.description \
 set name=pkg.summary value="CCID driver"
 set name=info.classification \
     value=org.opensolaris.category.2008:System/Hardware
-set name=variant.arch value=i386
+set name=variant.arch value=$(ARCH)
 dir path=kernel group=sys variant.opensolaris.zone=global
 dir path=kernel/drv group=sys variant.opensolaris.zone=global
 dir path=kernel/drv/$(ARCH64) group=sys variant.opensolaris.zone=global

--- a/usr/src/test/util-tests/tests/ctf/check-array.c
+++ b/usr/src/test/util-tests/tests/ctf/check-array.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -36,6 +36,7 @@ static check_symbol_t check_syms[] = {
 	{ "g", "int [4][5][6][7][8]" },
 	{ "h", "int [4][5][6][7][8][9]" },
 	{ "i", "int [4][5][6][7][8][9][10]" },
+	{ "empty", "int [0]" },
 	{ NULL }
 };
 
@@ -72,11 +73,18 @@ static check_descent_t check_array_i[] = {
 	{ NULL },
 };
 
+static check_descent_t check_array_empty[] = {
+	{ "int [0]", CTF_K_ARRAY, "int", 0 },
+	{ "int", CTF_K_INTEGER },
+	{ NULL }
+};
+
 static check_descent_test_t descents[] = {
 	{ "a", check_array_a },
 	{ "b", check_array_b },
 	{ "c", check_array_c },
 	{ "i", check_array_i },
+	{ "empty", check_array_empty },
 	{ NULL }
 };
 

--- a/usr/src/test/util-tests/tests/ctf/test-array.c
+++ b/usr/src/test/util-tests/tests/ctf/test-array.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -27,3 +27,5 @@ int f[4][5][6][7];
 int g[4][5][6][7][8];
 int h[4][5][6][7][8][9];
 int i[4][5][6][7][8][9][10];
+
+int empty[] = { };

--- a/usr/src/tools/stabs/sparc/Makefile
+++ b/usr/src/tools/stabs/sparc/Makefile
@@ -47,9 +47,9 @@ include ../../Makefile.tools
 
 FILEMODE        = 555
 
-CFLAGS		+= $(CCVERBOSE)
-
 INC_PATH	= -I$(STABS_SRC)
+# GCC false positive in stabs.c
+CERRWARN	+= -_gcc=-Wno-clobbered
 
 LDLIBS		+= -lm
 NATIVE_LIBS	+= libm.so

--- a/usr/src/tools/stabs/stabs.c
+++ b/usr/src/tools/stabs/stabs.c
@@ -261,9 +261,8 @@ lookup(int h)
 static char *
 whitesp(char *cp)
 {
-	char *orig, c;
+	char c;
 
-	orig = cp;
 	for (c = *cp++; isspace(c); c = *cp++)
 		;
 	--cp;

--- a/usr/src/uts/common/io/dld/dld_drv.c
+++ b/usr/src/uts/common/io/dld/dld_drv.c
@@ -718,8 +718,18 @@ drv_ioc_prop_common(dld_ioc_macprop_t *prop, intptr_t arg, boolean_t set,
 			else
 				err = drv_ioc_clrap(linkid);
 		} else {
-			if (kprop->pr_valsize == 0)
-				return (ENOBUFS);
+			/*
+			 * You might think that the earlier call to
+			 * mac_prop_check_size() should catch this but
+			 * it can't. The autopush prop uses 0 as a
+			 * sentinel value to clear the prop. This
+			 * check ensures we don't allow a get with a
+			 * valsize of 0.
+			 */
+			if (kprop->pr_valsize == 0) {
+				err = ENOBUFS;
+				goto done;
+			}
 
 			kprop->pr_perm_flags = MAC_PROP_PERM_RW;
 			err = drv_ioc_getap(linkid, dlap);

--- a/usr/src/uts/i86pc/io/vmm/amd/svm.c
+++ b/usr/src/uts/i86pc/io/vmm/amd/svm.c
@@ -1564,6 +1564,9 @@ svm_vmexit(struct svm_softc *svm_sc, int vcpu, struct vm_exit *vmexit)
 	    handled ? "handled" : "unhandled", exit_reason_to_str(code),
 	    vmexit->rip, vmexit->inst_length);
 
+	DTRACE_PROBE3(vmm__vexit, int, vcpu, uint64_t, vmexit->rip, uint32_t,
+	    code);
+
 	if (handled) {
 		vmexit->rip += vmexit->inst_length;
 		vmexit->inst_length = 0;

--- a/usr/src/uts/i86pc/sys/pci_cfgacc_x86.h
+++ b/usr/src/uts/i86pc/sys/pci_cfgacc_x86.h
@@ -21,6 +21,9 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ *
  */
 
 #ifndef	_SYS_PCI_CFGACC_X86_H
@@ -66,8 +69,8 @@ extern "C" {
 
 #define	IS_AMD_8132_CHIP(vid, did) \
 	    (((vid) == AMD_NTBRDIGE_VID) && \
-	    (((did) == AMD_8132_BRIDGE_DID)) || \
-	    (((did) == AMD_8132_IOAPIC_DID)))
+	    (((did) == AMD_8132_BRIDGE_DID) || \
+	    ((did) == AMD_8132_IOAPIC_DID)))
 
 #define	MSR_AMD_NB_MMIO_CFG_BADDR	0xc0010058
 #define	AMD_MMIO_CFG_BADDR_ADDR_MASK	0xFFFFFFF00000ULL

--- a/usr/src/uts/intel/io/pci/pci_memlist.c
+++ b/usr/src/uts/intel/io/pci/pci_memlist.c
@@ -21,6 +21,9 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ *
  */
 
 /*
@@ -43,13 +46,13 @@ extern int pci_boot_debug;
 void
 memlist_dump(struct memlist *listp)
 {
-	dprintf("memlist 0x%p content", (void *)listp);
+	dprintf("memlist 0x%p content: ", (void *)listp);
 	while (listp) {
-		dprintf("(0x%x%x, 0x%x%x)",
-		    (int)(listp->ml_address >> 32), (int)listp->ml_address,
-		    (int)(listp->ml_size >> 32), (int)listp->ml_size);
+		dprintf("(0x%lx, 0x%lx) ",
+		    listp->ml_address, listp->ml_size);
 		listp = listp->ml_next;
 	}
+	dprintf("\n");
 }
 
 struct memlist *

--- a/usr/src/uts/intel/pci_autoconfig/Makefile
+++ b/usr/src/uts/intel/pci_autoconfig/Makefile
@@ -24,6 +24,7 @@
 # Use is subject to license terms.
 #
 # Copyright 2016 Joyent, Inc.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 #	This makefile drives the production of the PCI autoconfiguration
 #	kernel module.
@@ -41,7 +42,6 @@ UTSBASE	= ../..
 #
 MODULE		= pci_autoconfig
 OBJECTS		= $(PCI_AUTOCONFIG_OBJS:%=$(OBJS_DIR)/%)
-LINTS		= $(PCI_AUTOCONFIG_OBJS:%.o=$(LINTS_DIR)/%.ln)
 ROOTMODULE	= $(ROOT_MISC_DIR)/$(MODULE)
 INC_PATH	+= -I$(UTSBASE)/i86pc
 
@@ -54,25 +54,12 @@ include $(UTSBASE)/intel/Makefile.intel
 #	Define targets
 #
 ALL_TARGET	= $(BINARY)
-LINT_TARGET	= $(MODULE).lint
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
 #
 # Depends on acpica ACPI CA interpreter and PCI-E framework
 #
 LDFLAGS		+= -dy -Nmisc/acpica -Nmisc/pcie
-
-#
-# For now, disable these lint checks; maintainers should endeavor
-# to investigate and remove these for maximum lint coverage.
-# Please do not carry these forward to new Makefiles.
-#
-LINTTAGS	+= -erroff=E_BAD_PTR_CAST_ALIGN
-LINTTAGS	+= -erroff=E_ASSIGN_NARROW_CONV
-
-CERRWARN	+= -_gcc=-Wno-parentheses
-$(OBJS_DIR)/pci_boot.o :=	CERRWARN += -_gcc=-Wno-unused-function
-$(OBJS_DIR)/pci_resource.o :=	CERRWARN += -_gcc=-Wno-unused-function
 
 #
 #	Default build targets.
@@ -86,12 +73,6 @@ all:		$(ALL_DEPS)
 clean:		$(CLEAN_DEPS)
 
 clobber:	$(CLOBBER_DEPS)
-
-lint:		$(LINT_DEPS)
-
-modlintlib:	$(MODLINTLIB_DEPS)
-
-clean.lint:	$(CLEAN_LINT_DEPS)
 
 install:	$(INSTALL_DEPS)
 

--- a/usr/src/uts/sparc/Makefile.sparc
+++ b/usr/src/uts/sparc/Makefile.sparc
@@ -290,13 +290,32 @@ DRV_KMODS	+= bge dmfe eri fas hme qfe
 DRV_KMODS	+= openeepr options sd ses st
 DRV_KMODS	+= ssd
 DRV_KMODS	+= ecpp
-DRV_KMODS	+= hid hubd ehci ohci uhci usb_mid usb_ia scsa2usb usbprn ugen
-DRV_KMODS	+= usbser usbsacm usbsksp usbsprl
-DRV_KMODS	+= usb_as usb_ac
+
+#
+#	USB specific modules
+#
+DRV_KMODS	+= ccid
+DRV_KMODS	+= hid
+DRV_KMODS	+= hubd
+DRV_KMODS	+= ehci
+DRV_KMODS	+= ohci
+DRV_KMODS	+= uhci
+DRV_KMODS	+= usb_mid
+DRV_KMODS	+= usb_ia
+DRV_KMODS	+= scsa2usb
+DRV_KMODS	+= usbprn
+DRV_KMODS	+= ugen
+DRV_KMODS	+= usbser
+DRV_KMODS	+= usbsacm
+DRV_KMODS	+= usbsksp
+DRV_KMODS	+= usbsprl
+DRV_KMODS	+= usb_as
+DRV_KMODS	+= usb_ac
 DRV_KMODS	+= usbskel
 DRV_KMODS	+= usbvc
 DRV_KMODS	+= usbftdi
 DRV_KMODS	+= usbecm
+
 DRV_KMODS	+= hci1394 av1394 scsa1394 dcam1394
 DRV_KMODS	+= sbp2
 DRV_KMODS	+= ib ibp eibnx eoib rdsib sdp iser daplt hermon tavor sol_ucma sol_uverbs

--- a/usr/src/uts/sparc/ccid/Makefile
+++ b/usr/src/uts/sparc/ccid/Makefile
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, Joyent, Inc.
+#
+
+UTSBASE = ../..
+
+MODULE		= ccid
+OBJECTS		= $(CCID_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+include $(UTSBASE)/sparc/Makefile.sparc
+
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+CPPFLAGS	+= -I$(SRC)/common/ccid
+
+LDFLAGS		+= -dy -N misc/usba
+
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+include $(UTSBASE)/sparc/Makefile.targ


### PR DESCRIPTION
Weekly upstream for upstream_merge/2020070201

## Backports

To r151034:

* 12867 Mis-programmed pcie bridge leaves 64-bit device unusable
* 12901 loader: can not read zfs pool with slog removed

## onu

```
OmniOS r151035  omnios-upstream_merge-2020070201-703b2b26e7     July 2020
illumos development build: 2020-Jul-02 [illumos]
bloody%
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2020070201-703b2b26e7 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Jul  2 19:23:56 UTC 2020 ====
==== Nightly distributed build completed: Thu Jul  2 20:29:15 UTC 2020 ====

==== Total build time ====

real    1:05:19

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-5f05325a4c i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151035-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   2088

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020070201-703b2b26e7

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:21.2
user  3:45:39.7
sys   1:07:25.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:37.2
user  3:15:23.7
sys   1:00:35.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
