### PR TITLE
Backports to r151034

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -13,7 +13,18 @@ are included at the end of this file.
 
 =======================================================================
 
-## No pending updates
+### 12867 Mis-programmed pcie bridge leaves 64-bit device unusable
+
+	Packages: system/kernel
+	Hotfix: https://hf.omnios.org/r151034/pci-enumeration.p5p
+
+### 12901 loader: can not read zfs pool with slog removed
+
+	Packages: system/boot/loader
+
+### Add facet to selectively disable dependencies from illumos-omnios to omnios-extra
+
+	Packages: system/test/smbclient
 
 =======================================================================
 

--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2020.03.19.1
+BOOT_VERSION = $(LOADER_VERSION)-2020.06.26.1

--- a/usr/src/pkg/manifests/system-test-smbclient.mf
+++ b/usr/src/pkg/manifests/system-test-smbclient.mf
@@ -194,5 +194,5 @@ file path=opt/smbclient-tests/tests/smbutil/tp_smbutil_015 mode=0555
 file path=opt/smbclient-tests/tests/smbutil/tp_smbutil_016 mode=0555
 license cr_Sun license=cr_Sun
 license lic_CDDL license=lic_CDDL
-depend fmri=ooce/runtime/expect type=require
+depend fmri=ooce/runtime/expect type=require facet.depend.ooceextra=true
 depend fmri=system/test/testrunner type=require

--- a/usr/src/uts/i86pc/sys/pci_cfgacc_x86.h
+++ b/usr/src/uts/i86pc/sys/pci_cfgacc_x86.h
@@ -21,6 +21,9 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ *
  */
 
 #ifndef	_SYS_PCI_CFGACC_X86_H
@@ -66,8 +69,8 @@ extern "C" {
 
 #define	IS_AMD_8132_CHIP(vid, did) \
 	    (((vid) == AMD_NTBRDIGE_VID) && \
-	    (((did) == AMD_8132_BRIDGE_DID)) || \
-	    (((did) == AMD_8132_IOAPIC_DID)))
+	    (((did) == AMD_8132_BRIDGE_DID) || \
+	    ((did) == AMD_8132_IOAPIC_DID)))
 
 #define	MSR_AMD_NB_MMIO_CFG_BADDR	0xc0010058
 #define	AMD_MMIO_CFG_BADDR_ADDR_MASK	0xFFFFFFF00000ULL

--- a/usr/src/uts/intel/io/pci/pci_memlist.c
+++ b/usr/src/uts/intel/io/pci/pci_memlist.c
@@ -21,6 +21,9 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ *
  */
 
 /*
@@ -43,13 +46,13 @@ extern int pci_boot_debug;
 void
 memlist_dump(struct memlist *listp)
 {
-	dprintf("memlist 0x%p content", (void *)listp);
+	dprintf("memlist 0x%p content: ", (void *)listp);
 	while (listp) {
-		dprintf("(0x%x%x, 0x%x%x)",
-		    (int)(listp->ml_address >> 32), (int)listp->ml_address,
-		    (int)(listp->ml_size >> 32), (int)listp->ml_size);
+		dprintf("(0x%lx, 0x%lx) ",
+		    listp->ml_address, listp->ml_size);
 		listp = listp->ml_next;
 	}
+	dprintf("\n");
 }
 
 struct memlist *

--- a/usr/src/uts/intel/pci_autoconfig/Makefile
+++ b/usr/src/uts/intel/pci_autoconfig/Makefile
@@ -24,6 +24,7 @@
 # Use is subject to license terms.
 #
 # Copyright 2016 Joyent, Inc.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 #	This makefile drives the production of the PCI autoconfiguration
 #	kernel module.
@@ -41,7 +42,6 @@ UTSBASE	= ../..
 #
 MODULE		= pci_autoconfig
 OBJECTS		= $(PCI_AUTOCONFIG_OBJS:%=$(OBJS_DIR)/%)
-LINTS		= $(PCI_AUTOCONFIG_OBJS:%.o=$(LINTS_DIR)/%.ln)
 ROOTMODULE	= $(ROOT_MISC_DIR)/$(MODULE)
 INC_PATH	+= -I$(UTSBASE)/i86pc
 
@@ -54,25 +54,12 @@ include $(UTSBASE)/intel/Makefile.intel
 #	Define targets
 #
 ALL_TARGET	= $(BINARY)
-LINT_TARGET	= $(MODULE).lint
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
 #
 # Depends on acpica ACPI CA interpreter and PCI-E framework
 #
 LDFLAGS		+= -dy -Nmisc/acpica -Nmisc/pcie
-
-#
-# For now, disable these lint checks; maintainers should endeavor
-# to investigate and remove these for maximum lint coverage.
-# Please do not carry these forward to new Makefiles.
-#
-LINTTAGS	+= -erroff=E_BAD_PTR_CAST_ALIGN
-LINTTAGS	+= -erroff=E_ASSIGN_NARROW_CONV
-
-CERRWARN	+= -_gcc=-Wno-parentheses
-$(OBJS_DIR)/pci_boot.o :=	CERRWARN += -_gcc=-Wno-unused-function
-$(OBJS_DIR)/pci_resource.o :=	CERRWARN += -_gcc=-Wno-unused-function
 
 #
 #	Default build targets.
@@ -86,12 +73,6 @@ all:		$(ALL_DEPS)
 clean:		$(CLEAN_DEPS)
 
 clobber:	$(CLOBBER_DEPS)
-
-lint:		$(LINT_DEPS)
-
-modlintlib:	$(MODLINTLIB_DEPS)
-
-clean.lint:	$(CLEAN_LINT_DEPS)
 
 install:	$(INSTALL_DEPS)
 


### PR DESCRIPTION
## onu

```
OmniOS 5.11     omnios-pcir34-d392265a34        Jul. 02, 2020
SunOS Internal Development: af 2020-Jul-02 [illumos]
r151034%
r151034% uname -a
SunOS r151034 5.11 omnios-pcir34-d392265a34 i86pc i386 i86pc
r151034%
```

## mail_msg

```

==== Nightly distributed build started:   Thu Jul  2 22:16:48 UTC 2020 ====
==== Nightly distributed build completed: Thu Jul  2 23:36:08 UTC 2020 ====

==== Total build time ====

real    1:19:20

==== Build environment ====

/usr/bin/uname
SunOS r151034 5.11 omnios-r151034-b35d9a8b4a i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151034/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151034/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-4

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151034-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   78

==== Nightly argument issues ====


==== Build version ====

omnios-pcir34-d392265a34

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    32:29.6
user  4:39:38.5
sys   1:24:42.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    29:18.1
user  4:06:56.5
sys   1:13:10.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
