### PR TITLE
LX: netlink errors must set flags to 0

### DIFF
--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -922,6 +922,7 @@ lx_netlink_reply_done(lx_netlink_reply_t *reply)
 		hdr->lxnh_len = sizeof (lx_netlink_err_t);
 		hdr->lxnh_seq = reply->lxnr_hdr.lxnh_seq;
 		hdr->lxnh_pid = lxsock->lxns_port;
+		hdr->lxnh_flags = 0;
 	} else {
 		uint32_t status = 0;
 


### PR DESCRIPTION
Fixes #798 

With this fix in place, I've booted an lx zone 2000 times successfully, where it was about a 50% success rate before.