### PR TITLE
Revert "NEX-9723 SMB2 open delays with exclusive oplocks"

### DIFF
--- a/usr/src/cmd/smbsrv/smbd/server.xml
+++ b/usr/src/cmd/smbsrv/smbd/server.xml
@@ -155,7 +155,7 @@ file.
 		<propval name='value_authorization' type='astring'
 			value='solaris.smf.value.smb' />
 		<propval name='oplock_enable' type='boolean'
-			value='false' override='true'/>
+			value='true' override='true'/>
 		<propval name='autohome_map' type='astring'
 			value='/etc' override='true'/>
 		<propval name='bypass_traverse_checking' type='boolean'


### PR DESCRIPTION
This reverts commit 59e17ede6a43437ce6e61d5233c93cbe7bcd8b0f.

Conflicts:
	usr/src/cmd/smbsrv/smbd/server.xml