### PR TITLE
OS-7999 out of bounds read in ict_siocgifconf64()

### DIFF
--- a/usr/src/uts/common/brand/lx/syscall/lx_ioctl.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_ioctl.c
@@ -1469,54 +1469,67 @@ ict_siocgifconf32(file_t *fp, int cmd, intptr_t arg, int lxcmd)
 	lx_ifconf32_t	conf;
 	lx_ifreq32_t	*oreq;
 	struct ifconf	sconf;
-	int		ifcount, error, i, buf_len;
+	int		ifcount, error, i;
+	size_t		native_len, lx_len;
 
 	if (copyin((lx_ifconf32_t *)arg, &conf, sizeof (conf)) != 0)
 		return (set_errno(EFAULT));
 
+	/*
+	 * First, figure out how many interfaces exist so that kmem allocations
+	 * are no larger than needed.
+	 */
+	error = ict_if_ioctl(fp->f_vnode, SIOCGIFNUM, (intptr_t)&ifcount,
+	    FLFAKE(fp), fp->f_cred);
+	if (error != 0) {
+		return (set_errno(error));
+	}
+
 	/* They want to know how many interfaces there are. */
 	if (conf.if_len <= 0 || conf.if_buf == (uint32_t)(uintptr_t)NULL) {
-		error = ict_if_ioctl(fp->f_vnode, SIOCGIFNUM,
-		    (intptr_t)&ifcount, FLFAKE(fp), fp->f_cred);
-		if (error != 0)
-			return (set_errno(error));
-
 		conf.if_len = ifcount * sizeof (lx_ifreq32_t);
 
 		if (copyout(&conf, (lx_ifconf32_t *)arg, sizeof (conf)) != 0)
 			return (set_errno(EFAULT));
 		return (0);
-	} else {
-		ifcount = conf.if_len / sizeof (lx_ifreq32_t);
 	}
 
+	ifcount = MIN(ifcount, conf.if_len / sizeof (lx_ifreq32_t));
+
 	/* Get interface configuration list. */
-	sconf.ifc_len = ifcount * sizeof (struct ifreq);
+	native_len = ifcount * sizeof (struct ifreq);
+	sconf.ifc_len = native_len;
 	sconf.ifc_req = (struct ifreq *)kmem_alloc(sconf.ifc_len, KM_SLEEP);
 
 	error = ict_if_ioctl(fp->f_vnode, cmd, (intptr_t)&sconf, FLFAKE(fp),
 	    fp->f_cred);
 	if (error != 0) {
-		kmem_free(sconf.ifc_req, ifcount * sizeof (struct ifreq));
+		kmem_free(sconf.ifc_req, native_len);
 		return (set_errno(error));
 	}
+	/* Recalculate in case a nic was removed between ict_if_ioctl calls. */
+	ifcount = sconf.ifc_len / sizeof (struct ifreq);
 
 	/* Convert data to Linux format & rename interfaces */
-	buf_len = ifcount * sizeof (lx_ifreq32_t);
-	oreq = (lx_ifreq32_t *)kmem_alloc(buf_len, KM_SLEEP);
-	for (i = 0; i < sconf.ifc_len / sizeof (struct ifreq); i++) {
+	lx_len = ifcount * sizeof (lx_ifreq32_t);
+	oreq = (lx_ifreq32_t *)kmem_alloc(lx_len, KM_SLEEP);
+	for (i = 0; i < ifcount; i++) {
+		/*
+		 * struct ifreq and lx_ifreq32_t are the same size, unlike the
+		 * 64-bit version of this function.
+		 */
 		bcopy(&sconf.ifc_req[i], oreq + i, sizeof (lx_ifreq32_t));
 		lx_ifname_convert(oreq[i].ifr_name, LX_IF_FROMNATIVE);
 	}
-	conf.if_len = i * sizeof (*oreq);
-	kmem_free(sconf.ifc_req, ifcount * sizeof (struct ifreq));
+	conf.if_len = lx_len;
+	kmem_free(sconf.ifc_req, native_len);
 
 	error = 0;
 	if (copyout(oreq, (caddr_t)(uintptr_t)conf.if_buf, conf.if_len) != 0 ||
 	    copyout(&conf, (lx_ifconf32_t *)arg, sizeof (conf)) != 0)
 		error = set_errno(EFAULT);
 
-	kmem_free(oreq, buf_len);
+	kmem_free(oreq, lx_len);
 	return (error);
 }
 
@@ -1527,54 +1540,69 @@ ict_siocgifconf64(file_t *fp, int cmd, intptr_t arg, int lxcmd)
 	lx_ifconf64_t	conf;
 	lx_ifreq64_t	*oreq;
 	struct ifconf	sconf;
-	int		ifcount, error, i, buf_len;
+	int		ifcount, error, i;
+	size_t		native_len, lx_len;
 
 	if (copyin((lx_ifconf64_t *)arg, &conf, sizeof (conf)) != 0)
 		return (set_errno(EFAULT));
 
+	/*
+	 * First, figure out how many interfaces exist so that kmem allocations
+	 * are no larger than needed.
+	 */
+	error = ict_if_ioctl(fp->f_vnode, SIOCGIFNUM, (intptr_t)&ifcount,
+	    FLFAKE(fp), fp->f_cred);
+	if (error != 0) {
+		return (set_errno(error));
+	}
+
 	/* They want to know how many interfaces there are. */
 	if (conf.if_len <= 0 || conf.if_buf == NULL) {
-		error = ict_if_ioctl(fp->f_vnode, SIOCGIFNUM,
-		    (intptr_t)&ifcount, FLFAKE(fp), fp->f_cred);
-		if (error != 0)
-			return (set_errno(error));
-
 		conf.if_len = ifcount * sizeof (lx_ifreq64_t);
 
 		if (copyout(&conf, (lx_ifconf64_t *)arg, sizeof (conf)) != 0)
 			return (set_errno(EFAULT));
 		return (0);
-	} else {
-		ifcount = conf.if_len / sizeof (lx_ifreq64_t);
 	}
 
+	ifcount = MIN(ifcount, conf.if_len / sizeof (lx_ifreq64_t));
+
 	/* Get interface configuration list. */
-	sconf.ifc_len = ifcount * sizeof (struct ifreq);
+	native_len = ifcount * sizeof (struct ifreq);
+	sconf.ifc_len = native_len;
 	sconf.ifc_req = (struct ifreq *)kmem_alloc(sconf.ifc_len, KM_SLEEP);
 
 	error = ict_if_ioctl(fp->f_vnode, cmd, (intptr_t)&sconf, FLFAKE(fp),
 	    fp->f_cred);
 	if (error != 0) {
-		kmem_free(sconf.ifc_req, ifcount * sizeof (struct ifreq));
+		kmem_free(sconf.ifc_req, native_len);
 		return (set_errno(error));
 	}
+	/* Recalculate in case a nic was removed between ict_if_ioctl calls. */
+	ifcount = sconf.ifc_len / sizeof (struct ifreq);
 
 	/* Convert data to Linux format & rename interfaces */
-	buf_len = ifcount * sizeof (lx_ifreq64_t);
-	oreq = (lx_ifreq64_t *)kmem_alloc(buf_len, KM_SLEEP);
-	for (i = 0; i < sconf.ifc_len / sizeof (struct ifreq); i++) {
-		bcopy(&sconf.ifc_req[i], oreq + i, sizeof (lx_ifreq64_t));
+	lx_len = ifcount * sizeof (lx_ifreq64_t);
+	oreq = (lx_ifreq64_t *)kmem_zalloc(lx_len, KM_SLEEP);
+	for (i = 0; i < ifcount; i++) {
+		/*
+		 * struct ifreq and lx_ifreq64_t start with common elements.
+		 * Anything after that is padding, which is zeroed with
+		 * kmem_zalloc above.
+		 */
+		bcopy(&sconf.ifc_req[i], oreq + i, sizeof (oreq->ifr_name) +
+		    sizeof (oreq->ifr_ifrn.ifru_addr));
 		lx_ifname_convert(oreq[i].ifr_name, LX_IF_FROMNATIVE);
 	}
-	conf.if_len = i * sizeof (*oreq);
-	kmem_free(sconf.ifc_req, ifcount * sizeof (struct ifreq));
+	conf.if_len = lx_len;
+	kmem_free(sconf.ifc_req, native_len);
 
 	error = 0;
 	if (copyout(oreq, (caddr_t)(uintptr_t)conf.if_buf, conf.if_len) != 0 ||
 	    copyout(&conf, (lx_ifconf64_t *)arg, sizeof (conf)) != 0)
 		error = set_errno(EFAULT);
 
-	kmem_free(oreq, buf_len);
+	kmem_free(oreq, lx_len);
 	return (error);
 }
 


### PR DESCRIPTION
```
==== Nightly distributed build started:   Sun Jul 12 13:25:38 CEST 2020 ====
==== Nightly distributed build completed: Sun Jul 12 14:42:09 CEST 2020 ====

==== Total build time ====

real    1:16:31

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-ca9dd52f78 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_252-omnios-151035-b09"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   75

==== Nightly argument issues ====


==== Build version ====

omnios-lx-73d55d3098

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    33:46.9
user  3:18:41.6
sys     36:59.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    29:53.2
user  2:54:54.3
sys     33:27.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```