### PR TITLE
OS-7925 rw_exit lockstat patch point has garbage %rcx (r151030)

### DIFF
--- a/usr/src/uts/intel/ia32/ml/lock_prim.s
+++ b/usr/src/uts/intel/ia32/ml/lock_prim.s
@@ -970,6 +970,7 @@ rw_exit(krwlock_t *lp)
 	jnz	rw_exit_wakeup
 .rw_read_exit_lockstat_patch_point:
 	ret
+	movq	%gs:CPU_THREAD, %rcx		/* rcx = thread ptr */
 	movq	%rdi, %rsi			/* rsi = lock ptr */
 	movl	$LS_RW_EXIT_RELEASE, %edi
 	movl	$RW_READER, %edx


### PR DESCRIPTION
We missed pulling this back into r151030 and it causes a crash when using the `lockstat` command.
Reported on IRC by _mjg