### PR TITLE
Joyent merge/2020080301

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from Joyent (a massive and
 continuing side-pull).
 
-Last illumos-joyent commit: 6ce401c3b04dbcc0ce211f9ae316ff006ff5a39f
+Last illumos-joyent commit: 425a83377a83720d1e9907ec3641a499a5eed18f
 

--- a/usr/src/uts/common/brand/lx/io/lx_netlink.c
+++ b/usr/src/uts/common/brand/lx/io/lx_netlink.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*


### PR DESCRIPTION
This is effectively a null commit - just adding a missing copyright and updating the last Joyent commit. It will push a commit to lx-port-data too.