### PR TITLE
Revert bright-white boot text change

### DIFF
--- a/usr/src/uts/i86pc/boot/boot_fb.c
+++ b/usr/src/uts/i86pc/boot/boot_fb.c
@@ -355,39 +355,47 @@ boot_get_color(uint32_t *fg, uint32_t *bg)
 	if (fb_info.inverse == B_TRUE ||
 	    fb_info.inverse_screen == B_TRUE) {
 		if (fb_info.fg_color < XLATE_NCOLORS) {
+#ifdef BRIGHT_WHITE_BOOT
 			/*
 			 * white fg -> bright white bg
 			 */
 			if (fb_info.fg_color == pc_white)
 				*bg = brt_xlate[fb_info.fg_color];
 			else
+#endif
 				*bg = dim_xlate[fb_info.fg_color];
 		} else {
 			*bg = fb_info.fg_color;
 		}
 
 		if (fb_info.bg_color < XLATE_NCOLORS) {
+#ifdef BRIGHT_WHITE_BOOT
 			if (fb_info.bg_color == pc_white)
 				*fg = brt_xlate[fb_info.bg_color];
 			else
+#endif
 				*fg = dim_xlate[fb_info.bg_color];
 		} else {
 			*fg = fb_info.bg_color;
 		}
 	} else {
 		if (fb_info.fg_color < XLATE_NCOLORS) {
+#ifdef BRIGHT_WHITE_BOOT
 			if (fb_info.fg_color == pc_white)
 				*fg = brt_xlate[fb_info.fg_color];
 			else
+#endif
 				*fg = dim_xlate[fb_info.fg_color];
 		} else {
 			*fg = fb_info.fg_color;
 		}
 
 		if (fb_info.bg_color < XLATE_NCOLORS) {
+#ifdef BRIGHT_WHITE_BOOT
 			if (fb_info.bg_color == pc_white)
 				*bg = brt_xlate[fb_info.bg_color];
 			else
+#endif
 				*bg = dim_xlate[fb_info.bg_color];
 		} else {
 			*bg = fb_info.bg_color;


### PR DESCRIPTION
This change came in as part of https://www.illumos.org/issues/13003 and changes the boot screen so that the initial messages are emboldened.

![image](https://user-images.githubusercontent.com/29426693/91438594-2645d480-e85b-11ea-9915-f9a7a5069030.png)

Revert this change by putting it under a guard.