### PR TITLE
Backports to illumos-omnios r151034

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -18,6 +18,14 @@ are included at the end of this file.
 	system/file-system/zfs
 	https://hf.omnios.org/r151034/zfs-12894.p5p
 
+## 12744 gfx_private: bitmap_cons_clear 8-bit mode is using wrong color
+
+	system/kernel/platform
+	https://hf.omnios.org/r151034/console-12744.p5p
+
+## 12976 system panics with error in IP module
+	system/kernel
+
 =======================================================================
 
 =============================

--- a/usr/src/uts/common/inet/ip/ipclassifier.c
+++ b/usr/src/uts/common/inet/ip/ipclassifier.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Joyent, Inc.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -2771,7 +2772,11 @@ conn_get_socket_info(conn_t *connp, mib2_socketInfoEntry_t *sie)
 		return (NULL);
 	}
 
-	mutex_exit(&connp->conn_lock);
+	/*
+	 * Continue to hold conn_lock because we don't want to race with an
+	 * in-progress close, which will have set-to-NULL (and destroyed
+	 * upper_handle, aka sonode (and vnode)) BEFORE setting CONN_CLOSING.
+	 */
 
 	if (connp->conn_upper_handle != NULL) {
 		vn = (*connp->conn_upcalls->su_get_vnode)
@@ -2782,6 +2787,8 @@ conn_get_socket_info(conn_t *connp, mib2_socketInfoEntry_t *sie)
 			VN_HOLD(vn);
 		flags |= MIB2_SOCKINFO_STREAM;
 	}
+
+	mutex_exit(&connp->conn_lock);
 
 	if (vn == NULL || VOP_GETATTR(vn, &attr, 0, CRED(), NULL) != 0) {
 		if (vn != NULL)

--- a/usr/src/uts/common/inet/tcp/tcp.c
+++ b/usr/src/uts/common/inet/tcp/tcp.c
@@ -21,10 +21,10 @@
 
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2013, 2017 by Delphix. All rights reserved.
  * Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright 2020 Joyent, Inc.
  */
 /* Copyright (c) 1990 Mentat Inc. */
 
@@ -1019,10 +1019,23 @@ finish:
 
 	/* If we have an upper handle (socket), release it */
 	if (IPCL_IS_NONSTR(connp)) {
-		ASSERT(connp->conn_upper_handle != NULL);
-		(*connp->conn_upcalls->su_closed)(connp->conn_upper_handle);
+		sock_upcalls_t *upcalls = connp->conn_upcalls;
+		sock_upper_handle_t handle = connp->conn_upper_handle;
+
+		ASSERT(upcalls != NULL);
+		ASSERT(upcalls->su_closed != NULL);
+		ASSERT(handle != NULL);
+		/*
+		 * Set these to NULL first because closed() will free upper
+		 * structures.  Acquire conn_lock because an external caller
+		 * like conn_get_socket_info() will upcall if these are
+		 * non-NULL.
+		 */
+		mutex_enter(&connp->conn_lock);
 		connp->conn_upper_handle = NULL;
 		connp->conn_upcalls = NULL;
+		mutex_exit(&connp->conn_lock);
+		upcalls->su_closed(handle);
 	}
 }
 
@@ -1436,13 +1449,26 @@ tcp_free(tcp_t *tcp)
 	 * nothing to do other than clearing the field.
 	 */
 	if (connp->conn_upper_handle != NULL) {
-		if (IPCL_IS_NONSTR(connp)) {
-			(*connp->conn_upcalls->su_closed)(
-			    connp->conn_upper_handle);
-			tcp->tcp_detached = B_TRUE;
-		}
+		sock_upcalls_t *upcalls = connp->conn_upcalls;
+		sock_upper_handle_t handle = connp->conn_upper_handle;
+
+		/*
+		 * Set these to NULL first because closed() will free upper
+		 * structures.  Acquire conn_lock because an external caller
+		 * like conn_get_socket_info() will upcall if these are
+		 * non-NULL.
+		 */
+		mutex_enter(&connp->conn_lock);
 		connp->conn_upper_handle = NULL;
 		connp->conn_upcalls = NULL;
+		mutex_exit(&connp->conn_lock);
+		if (IPCL_IS_NONSTR(connp)) {
+			ASSERT(upcalls != NULL);
+			ASSERT(upcalls->su_closed != NULL);
+			ASSERT(handle != NULL);
+			upcalls->su_closed(handle);
+			tcp->tcp_detached = B_TRUE;
+		}
 	}
 }
 

--- a/usr/src/uts/common/sys/socket_proto.h
+++ b/usr/src/uts/common/sys/socket_proto.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 Joyent, Inc.
  */
 
 #ifndef _SYS_SOCKET_PROTO_H_
@@ -202,7 +203,16 @@ struct sock_upcalls_s {
 	void	(*su_signal_oob)(sock_upper_handle_t, ssize_t);
 	void	(*su_zcopy_notify)(sock_upper_handle_t);
 	void	(*su_set_error)(sock_upper_handle_t, int);
+	/*
+	 * NOTE: This function frees upper handle items. Caller cannot
+	 * rely on them after this upcall.
+	 */
 	void	(*su_closed)(sock_upper_handle_t);
+	/*
+	 * NOTE: This function MUST be implemented without using lower-level
+	 * downcalls or accesses. This allows callers to ensure su_closed()
+	 * upcalls can happen indepdently or concurrently.
+	 */
 	vnode_t *(*su_get_vnode)(sock_upper_handle_t);
 };
 

--- a/usr/src/uts/i86pc/io/gfx_private/gfxp_bitmap.c
+++ b/usr/src/uts/i86pc/io/gfx_private/gfxp_bitmap.c
@@ -450,10 +450,10 @@ bitmap_cons_clear(struct gfxp_fb_softc *softc, struct vis_consclear *ca)
 		for (i = 0; i < console->fb.screen.y; i++) {
 			if (softc->mode == KD_TEXT) {
 				fb = console->fb.fb + i * pitch;
-				(void) memset(fb, ca->bg_color, pitch);
+				(void) memset(fb, data, pitch);
 			}
 			fb = console->fb.shadow_fb + i * pitch;
-			(void) memset(fb, ca->bg_color, pitch);
+			(void) memset(fb, data, pitch);
 		}
 		break;
 	case 15:


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Sat Sep  5 12:08:03 UTC 2020 ====
==== Nightly distributed build completed: Sat Sep  5 13:07:09 UTC 2020 ====

==== Total build time ====

real    0:59:06

==== Build environment ====

/usr/bin/uname
SunOS r151034 5.11 omnios-r151034-b3d6e2addc i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151034/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_265-omnios-151034-b01"

/usr/bin/openssl
OpenSSL 1.1.1g  21 Apr 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   90

==== Nightly argument issues ====


==== Build version ====

omnios-bpr34-45ba66c716

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:54.9
user  2:22:18.2
sys     47:14.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    19:54.1
user  1:48:39.8
sys     40:20.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
