### PR TITLE
Packages should be able to augment /etc/inet/services

### DIFF
--- a/usr/src/cmd/cmd-inet/etc/Makefile
+++ b/usr/src/cmd/cmd-inet/etc/Makefile
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 SYMPROG= hosts inetd.conf networks protocols services netmasks
 
@@ -26,6 +27,7 @@ SYMPROG= hosts inetd.conf networks protocols services netmasks
 EDITPROG= ipaddrsel.conf ipsecalgs
 PROG= datemsk.ndpd ipsecinit.sample ipqosconf.1.sample ipqosconf.2.sample \
     ipqosconf.3.sample
+DPROG= services
 ETCPROG= $(SYMPROG) $(EDITPROG) $(PROG)
 SUBDIRS= default dhcp init.d ike nca ppp secret sock2path.d
 
@@ -37,10 +39,12 @@ install:=	TARGET= install
 ROOTVAR=	$(ROOT)/var
 INETETCDIR=	$(ROOTETC)/inet
 INETVARDIR=	$(ROOTVAR)/inet
-DIRS= 		$(INETETCDIR) $(INETVARDIR)
+DPROGDIRS=	$(DPROG:%=$(INETETCDIR)/%.d)
+DIRS= 		$(INETETCDIR) $(INETVARDIR) $(DPROGDIRS)
 SYMDIR= 	inet
 ETCINETPROG=	$(ETCPROG:%=$(INETETCDIR)/%)
 EDITFILES=	$(SYMPROG:%=$(INETETCDIR)/%) $(EDITPROG:%=$(INETETCDIR)/%)
+DPROGFILES=	$(DPROG:%=$(INETETCDIR)/%.d/_%)
 # Only old /etc/inet files get symlinks in /etc.
 SYMETCPROG=	$(SYMPROG:%=sym_%)
 SYMIPNODES=	$(INETETCDIR)/ipnodes
@@ -50,10 +54,12 @@ FILEMODE= 0444
 .KEEP_STATE:
 
 $(EDITFILES) := FILEMODE= 0644
+$(DPROGFILES) := FILEMODE= 0644
 
 all: $(ETCPROG) $(SUBDIRS)
 
-install: all $(DIRS) $(ETCINETPROG) $(SYMETCPROG) $(SYMIPNODES) $(SUBDIRS)
+install: all $(DIRS) $(ETCINETPROG) $(SYMETCPROG) $(SYMIPNODES) $(SUBDIRS) \
+	$(DPROGFILES)
 
 $(SYMIPNODES) :
 	$(RM) $@
@@ -61,6 +67,9 @@ $(SYMIPNODES) :
 
 $(INETETCDIR)/% : %
 	$(INS.file)
+
+$(INETETCDIR)/%.d/_% : %
+	$(INS.rename)
 
 sym_% : %
 	$(RM) $(ROOTETC)/$<

--- a/usr/src/cmd/svc/milestone/Makefile
+++ b/usr/src/cmd/svc/milestone/Makefile
@@ -71,6 +71,7 @@ SYSDEVMANIFESTS= $(SYSDEVSVCS:%=$(ROOTSVCSYSTEMDEVICE)/%)
 
 SYSTEMSVCS= \
 	boot-archive.xml \
+	config-assemble.xml \
 	console-login.xml \
 	early-manifest-import.xml \
 	identity.xml \
@@ -101,6 +102,7 @@ MANIFEST= $(FSSVCS) $(NETSVCS) $(MAINMILESTONES) $(SYSTEMSVCS) \
 
 SVCMETHOD=\
 	boot-archive \
+	config-assemble \
 	console-login \
 	devices-audio \
 	devices-local \

--- a/usr/src/cmd/svc/milestone/config-assemble
+++ b/usr/src/cmd/svc/milestone/config-assemble
@@ -1,0 +1,167 @@
+#!/usr/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+#
+
+. /lib/svc/share/smf_include.sh
+
+if [ -z "$SMF_FMRI" ]; then
+	echo "This script can only be invoked by smf(5)"
+	exit $SMF_EXIT_ERR_NOSMF
+fi
+
+tmpd=
+
+function setup {
+	tmpd=`/usr/bin/mktemp -d /tmp/assemble.XXXXXX`
+	if [[ -z "$tmpd" ]]; then
+		echo "Could not create temporary directory."
+		exit $SMF_EXIT_ERR_FATAL
+	fi
+}
+
+function cleanup {
+	[[ -n "$tmpd" && -d "$tmpd" ]] && rm -rf $tmpd
+}
+
+function assemble_services {
+	typeset -r svc=/etc/inet/services
+	typeset -r svcdir=$svc.d
+	typeset -r defsvc=$svcdir/_services
+	typeset -r tf=$tmpd/services
+
+	echo "Assembling $svc"
+
+	if [[ ! -f $defsvc ]]; then
+		echo "... $defsvc does not exist, no action taken"
+		return
+	fi
+
+	# In case the user has previously customised /etc/inet/services
+	# create a local changes file on first startup.
+	if [[ `svcprop -c -p state/migrated $SMF_FMRI` != true ]]; then
+		echo "... first startup, extracting local changes"
+		comm -13 $defsvc $svc > $svcdir/local-changes
+		[[ -s $svcdir/local-changes ]] || rm -f $svcdir/local-changes
+		svccfg -s $SMF_FMRI setprop state/migrated = true
+	fi
+
+	# Extract the header from the default file
+	sed -e '/^[^#]/q' $defsvc | sed '$d' > $tf.header
+
+	# Add to it
+	cat <<-EOM >> $tf.header
+
+###########################################################################
+#                                                                         #
+#  This file has been automatically generated from fragment files found   #
+#  under /etc/inet/services.d/                                            #
+#                                                                         #
+#  Packages which wish to add entries to this file should deliver a file  #
+#  to that location. The recommended naming schema for the fragment       #
+#  files is to use the name of the package which is delivering the file   #
+#  with '/' characters replaced by ':'                                    #
+#                                                                         #
+###########################################################################
+	EOM
+
+	# Copy the original file to duplicate the permissions before truncating
+	cp -p $svc $tf.services
+
+	for f in $svcdir/*; do
+		[[ -f "$f" ]] || continue
+		egrep -v '^[[:blank:]]*$' $f
+	done | nawk -v cpy=$tf.copyrights '
+	/^ *#.*[Cc]opyright +[0-9]/ {
+		print $0 >> cpy
+	}
+	/^ *#/ { next }
+	$2 ~ /[0-9]+\// {
+		name = $1
+		service = $2
+		split($0, a, "# *")
+		comment = a[2]
+		split(a[1], b)
+
+		if (service in services) {
+			if (services[service] != name)
+				aliases[service] = aliases[service] " " name
+		} else {
+			services[service] = name
+		}
+
+		if (length(comment) && !(service in comments))
+			comments[service] = a[2]
+
+		for (i = 3; i <= length(b); i++)
+			aliases[service] = aliases[service] " " b[i]
+	}
+	END {
+		for (s in services) {
+			alist = ""
+			if (s in aliases) {
+				delete seen
+				split(aliases[s], c);
+				for (i = 0; i < length(c); i++) {
+					al = c[i]
+					if (!(al in seen)) {
+						if (length(alist))
+							alist = alist " "
+						alist = alist al
+						seen[al] = 1
+					}
+				}
+			}
+			printf("%-14s %-10s %-10s", services[s], s, alist)
+			if (s in comments)
+				printf("	# %s", comments[s])
+			printf("\n")
+		}
+	}
+	' | sort -k 2,2n > $tf.services
+
+	(
+		cat $tf.header
+		echo
+		if [[ -s $tf.copyrights ]]; then
+			cat $tf.copyrights
+			echo
+		fi
+		cat $tf.services
+	) > $tf.new
+
+	if cmp -s $svc $tf.new; then
+		echo "... do change detected, no action taken"
+	else
+		echo "... detected change, installing new $svc"
+		mv $tf.new $svc
+		# nscd will detect the updated timestamp on the file and
+		# invalidate its cache without us having to do anything here.
+	fi
+}
+
+case "$1" in
+services)
+	setup
+	assemble_services
+	;;
+*)
+	echo "Usage: $0 { services }"
+	exit $SMF_EXIT_ERR_FATAL
+	;;
+esac
+
+cleanup
+
+exit $SMF_EXIT_OK

--- a/usr/src/cmd/svc/milestone/config-assemble.xml
+++ b/usr/src/cmd/svc/milestone/config-assemble.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+    This file and its contents are supplied under the terms of the
+    Common Development and Distribution License ("CDDL"), version 1.0.
+    You may only use this file in accordance with the terms of version
+    1.0 of the CDDL.
+
+    A full copy of the text of the CDDL should have accompanied this
+    source. A copy of the CDDL is also available via the Internet at
+    http://www.illumos.org/license/CDDL.
+
+    Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+-->
+
+<service_bundle type='manifest' name='SUNWcs:config-assemble'>
+
+<service
+	name='system/config-assemble'
+	type='service'
+	version='1'>
+
+	<dependency
+		name='filesystem_minimal'
+		type='service'
+		grouping='require_all'
+		restart_on='none'>
+		<service_fmri value='svc:/system/filesystem/minimal' />
+	</dependency>
+
+	<dependent
+		name='assemble_name-service-cache'
+		grouping='optional_all'
+		restart_on='none'>
+		<service_fmri value='svc:/system/name-service-cache' />
+	</dependent>
+
+	<exec_method
+		type='method'
+		name='start'
+		exec='/lib/svc/method/config-assemble %i'
+		timeout_seconds='300'>
+	</exec_method>
+
+	<exec_method
+		type='method'
+		name='refresh'
+		exec='/lib/svc/method/config-assemble %i'
+		timeout_seconds='300'>
+	</exec_method>
+
+	<exec_method
+		type='method'
+		name='stop'
+		exec=':true'
+		timeout_seconds='300'>
+	</exec_method>
+
+	<property_group name='startd' type='framework'>
+		<propval name='duration' type='astring' value='transient' />
+	</property_group>
+
+	<instance name='services' enabled='true' >
+		<property_group name='state' type='application'>
+			<propval name='migrated' type='boolean' value='false' />
+		</property_group>
+	</instance>
+
+	<stability value='Unstable' />
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'>
+				Assemble system configuration files
+			</loctext>
+		</common_name>
+	</template>
+</service>
+
+</service_bundle>

--- a/usr/src/pkg/manifests/SUNWcs.mf
+++ b/usr/src/pkg/manifests/SUNWcs.mf
@@ -61,6 +61,7 @@ dir path=etc/fs/hsfs group=sys
 dir path=etc/fs/ufs group=sys
 dir path=etc/ftpd group=sys
 dir path=etc/inet group=sys
+dir path=etc/inet/services.d group=sys
 dir path=etc/init.d group=sys
 dir path=etc/lib group=sys
 dir path=etc/logadm.d group=sys
@@ -383,6 +384,7 @@ file path=etc/inet/netmasks group=sys preserve=true
 file path=etc/inet/networks group=sys preserve=true
 file path=etc/inet/protocols group=sys preserve=true
 file path=etc/inet/services group=sys preserve=true
+file path=etc/inet/services.d/_services group=sys preserve=true
 file path=etc/init.d/PRESERVE group=sys mode=0744 preserve=true
 file path=etc/init.d/README group=sys preserve=true
 file path=etc/init.d/sysetup group=sys mode=0744 preserve=true
@@ -532,6 +534,7 @@ file path=lib/svc/manifest/system/auditset.xml group=sys mode=0444
 file path=lib/svc/manifest/system/boot-archive-update.xml group=sys mode=0444
 file path=lib/svc/manifest/system/boot-archive.xml group=sys mode=0444
 file path=lib/svc/manifest/system/boot-config.xml group=sys mode=0444
+file path=lib/svc/manifest/system/config-assemble.xml group=sys mode=0444
 file path=lib/svc/manifest/system/consadm.xml group=sys mode=0444
 file path=lib/svc/manifest/system/console-login.xml group=sys mode=0444
 file path=lib/svc/manifest/system/coreadm.xml group=sys mode=0444
@@ -570,6 +573,7 @@ file path=lib/svc/manifest/system/utmp.xml group=sys mode=0444
 file path=lib/svc/manifest/system/vtdaemon.xml group=sys mode=0444
 file path=lib/svc/method/boot-archive mode=0555
 file path=lib/svc/method/boot-archive-update mode=0555
+file path=lib/svc/method/config-assemble mode=0555
 file path=lib/svc/method/console-login mode=0555
 file path=lib/svc/method/devices-audio mode=0555
 file path=lib/svc/method/devices-local mode=0555


### PR DESCRIPTION
I've tested this by adding a custom service to the end of `/etc/inet/services`, and then ONU-ing to a new debug BE with these changes in. Here's services before:

```
bloody% tail -5 /etc/inet/services
solaris-audit   16162/tcp                       # Secure remote audit logging
wnn6            22273/tcp                       # Wnn6 jserver
wnn6            22273/udp                       # Wnn6 jserver

ttest           12345/tcp                       # test service

bloody% ls /etc/inet/services.d
/etc/inet/services.d: No such file or directory
```

The ONU also pulled in an updated `git` package (see https://github.com/omniosorg/omnios-build/pull/2023 ) which delivers a services fragment.

After a reboot, the new service is online and the log shows that an initial migration was done:

```
bloody% svcs config-assemble
STATE          STIME    FMRI
online         10:52:21 svc:/system/config-assemble:services
bloody% cat `svcs -L config-assemble`
[ Sep 14 10:52:18 Enabled. ]
[ Sep 14 10:52:20 Executing start method ("/lib/svc/method/config-assemble services"). ]
Assembling /etc/inet/services
... first startup, extracting local changes
... detected change, installing new /etc/inet/services
[ Sep 14 10:52:21 Method "start" exited with status 0. ]
```

The local changes have been extracted and put into a separate file

```
bloody% ls /etc/inet/services.d
_services                  local-changes
developer:versioning:git

bloody% cat /etc/inet/services.d/local-changes

ttest           12345/tcp                       # test service
```

and both this and git are now in the main services file:

```
bloody% rg 'ttest|git' /etc/inet/serv*
/etc/inet/services.d/local-changes
2:ttest          12345/tcp                       # test service

/etc/inet/services.d/developer:versioning:git
1:git            9418/tcp                        # git pack transfer service

/etc/inet/services
245:git            9418/tcp              # git pack transfer service
248:ttest          12345/tcp             # test service
```
Subsequent restart/refresh operations result in no changes:

```
bloody% svcadm restart config-assemble
bloody% svcadm refresh config-assemble
bloody% cat `svcs -L config-assemble`
...
[ Sep 14 11:06:15 Stopping because service restarting. ]
[ Sep 14 11:06:15 Executing stop method (null). ]
[ Sep 14 11:06:15 Executing start method ("/lib/svc/method/config-assemble services"). ]
Assembling /etc/inet/services
... do change detected, no action taken
[ Sep 14 11:06:15 Method "start" exited with status 0. ]

[ Sep 14 11:06:24 Rereading configuration. ]
[ Sep 14 11:06:24 Executing refresh method ("/lib/svc/method/config-assemble services"). ]
Assembling /etc/inet/services
... do change detected, no action taken
[ Sep 14 11:06:24 Method "refresh" exited with status 0. ]
```
