### PR TITLE
zoneadm should cleanup etc/ too

### DIFF
--- a/usr/src/cmd/zoneadm/zoneadm.c
+++ b/usr/src/cmd/zoneadm/zoneadm.c
@@ -3950,9 +3950,9 @@ cleanup_zonepath(char *zonepath, boolean_t all)
 			 * migration.
 			 */
 	char		*std_entries[] = {"dev", "lastexited", "logs", "lu",
-			    "root", "SUNWattached.xml", NULL};
-			/* (MAXPATHLEN * 5) is for the 5 std_entries dirs */
-	char		cmdbuf[sizeof (RMCOMMAND) + (MAXPATHLEN * 5) + 64];
+			    "root", "etc", "SUNWattached.xml", NULL};
+			/* (MAXPATHLEN * 6) is for the 6 std_entries dirs */
+	char		cmdbuf[sizeof (RMCOMMAND) + (MAXPATHLEN * 6) + 64];
 
 	/*
 	 * We shouldn't need these checks but lets be paranoid since we


### PR DESCRIPTION
This avoids the following behaviour:

```
r151034% pfexec zadm halt testzone
r151034% pfexec zadm delete testzone
Are you sure you want to uninstall zone testzone (y/[n])? y
WARNING: Unable to completely remove /zones/testzone
because it contains additional user data.  Only the standard directory
entries have been removed.
Are you sure you want to delete zone testzone (y/[n])? y

r151034% pfexec ls /zones/testzone
etc/
```