### PR TITLE
Upstream merge upstream_merge/2020093001

### DIFF
--- a/usr/src/man/man7d/igb.7d
+++ b/usr/src/man/man7d/igb.7d
@@ -1,215 +1,126 @@
-'\" te
-.\"  Copyright (c) 2007, Sun Microsystems, Inc.  All Rights Reserved
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH IGB 7D "Jul 20, 2007"
-.SH NAME
-igb \- Intel 82575 1Gb PCI Express NIC Driver
-.SH SYNOPSIS
-.LP
-.nf
-\fB/dev/igb*\fR
-.fi
-
-.SH DESCRIPTION
-.sp
-.LP
-The \fBigb\fR Gigabit Ethernet driver is a  multi-threaded,  loadable,
-clonable, GLD-based STREAMS driver supporting the Data Link Provider Interface,
-\fBdlpi\fR(7P),  on  Intel 82575 Gigabit Ethernet controllers.
-.sp
-.LP
-The \fBigb\fR driver functions include controller  initialization, frame
-transmit and receive, promiscuous and multicast support, and error recovery and
-reporting.
-.sp
-.LP
-The \fBigb\fR driver and hardware support auto-negotiation, a protocol
-specified by the 1000  Base-T  standard.  Auto-negotiation allows each device
-to advertise its capabilities and discover those of its peer (link partner).
-The highest common  denominator  supported  by  both link  partners  is
-automatically  selected,  yielding  the  greatest  available throughput, while
-requiring no manual configuration. The \fBigb\fR driver also allows you to
-configure the advertised capabilities to less than the maximum (where the full
-speed  of  the interface is not required), or to force a specific mode of
-operation, irrespective of  the  link  partner's  advertised capabilities.
-.SH APPLICATION PROGRAMMING INTERFACE
-.sp
-.LP
-The cloning character-special device, \fB /dev/igb\fR, is used to access all
-Intel 82575 Gigabit devices installed within the system.
-.sp
-.LP
-The igb driver is managed  by the \fBdladm\fR(1M) command  line utility, which
-allows  VLANs to be defined on top of \fBigb\fR instances and  for \fBigb\fR
-instances to be aggregated.  See \fBdladm\fR(1M) for more details.
-.sp
-.LP
-You must send an explicit DL_ATTACH_REQ message to associate the opened stream
-with a particular device (PPA). The PPA ID is interpreted as an unsigned
-integer data type and  indicates the corresponding device instance (unit)
-number. The driver returns an error (DL_ERROR_ACK) if  the PPA field value does
-not correspond to a valid device instance number for the system. The device is
-initialized on first attach and de-initialized (stopped) at last detach.
-.sp
-.LP
-The values returned by the driver in the DL_INFO_ACK primitive in response to
-your DL_INFO_REQ are:
-.RS +4
-.TP
-.ie t \(bu
-.el o
-Maximum SDU is 9000.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-Minimum SDU is 0.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-DLSAP address length is 8.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-MAC type is DL_ETHER.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-SAP (Service Access Point) length value is -2, meaning the physical address
-component is followed immediately by a 2-byte SAP component within the DLSAP
-address.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-Broadcast address value is the Ethernet/IEEE broadcast address
-(FF:FF:FF:FF:FF:FF).
-.sp
-Once in the DL_ATTACHED state, you must send a DL_BIND_REQ to associate a
-particular SAP with the stream.
-.RE
-.SH CONFIGURATION
-.sp
-.LP
-By default, the  igb driver performs auto-negotiation to select the link speed
-and mode. Link speed and mode can be any one of the following, (as described
-in  the \fIIEEE803.2\fR standard):
-.sp
-.LP
-1000 Mbps, full-duplex.
-.sp
-.LP
-100 Mbps, full-duplex.
-.sp
-.LP
-100 Mbps, half-duplex.
-.sp
-.LP
-10 Mbps, full-duplex.
-.sp
-.LP
-10 Mbps, half-duplex.
-.sp
-.LP
-The auto-negotiation protocol automatically selects speed (1000 Mbps, 100 Mbps,
-or 10 Mbps) and operation mode (full-duplex or half-duplex) as the highest
-common denominator supported by both link partners.
-.sp
-.LP
-Alternatively, you can set the capabilities advertised by the \fBigb\fR device
-using \fBndd\fR(1M). The driver supports a number of parameters whose names
-begin with \fIadv_\fR (see below). Each of these parameters contains a boolean
-value that determines if the device advertises that mode of operation. For
-example,  the \fIadv_1000fdx_cap\fR parameter indicates if 1000M full duplex is
-advertised to link partner. The  \fIadv_autoneg\fR cap parameter controls
-whether auto-negotiation is performed. If \fIadv_autoneg_cap\fR is set to 0,
-the driver forces the mode of operation  selected by the first  non-zero
-parameter in priority order as shown below:
-.sp
-.in +2
-.nf
-                        (highest priority/greatest throughput)
-        adv_1000fdx_cap         1000Mbps full duplex
-        adv_100fdx_cap          100Mbps full duplex
-        adv_100hdx_cap          100Mbps half duplex
-        adv_10fdx_cap           10Mbps full duplex
-        adv_10hdx_cap           10Mbps half duplex
-                                (lowest priority/least throughput)
-.fi
-.in -2
-
-.sp
-.LP
-All capabilities default to enabled. Note that changing any capability
-parameter causes the link to go down while the link partners renegotiate the
-link speed/duplex using the newly changed capabilities.
-.SH FILES
-.sp
-.ne 2
-.na
-\fB\fB/dev/igb*\fR\fR
-.ad
-.RS 27n
-Special character device.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB/kernel/drv/igb\fR\fR
-.ad
-.RS 27n
-32-bit device driver (x86).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB/kernel/drv/amd64/igb\fR\fR
-.ad
-.RS 27n
-64-bit device driver (x86).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB/kernel/drv/sparcv9/igb\fR\fR
-.ad
-.RS 27n
-64-bit device driver (SPARC).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB/kernel/drv/igb.conf\fR\fR
-.ad
-.RS 27n
+.\"
+.\" This file and its contents are supplied under the terms of the
+.\" Common Development and Distribution License ("CDDL"), version 1.0.
+.\" You may only use this file in accordance with the terms of version
+.\" 1.0 of the CDDL.
+.\"
+.\" A full copy of the text of the CDDL should have accompanied this
+.\" source.  A copy of the CDDL is also available via the Internet at
+.\" http://www.illumos.org/license/CDDL.
+.\"
+.\"
+.\" Copyright 2020 Oxide Computer Company
+.\"
+.Dd September 14, 2020
+.Dt IGB 7D
+.Os
+.Sh NAME
+.Nm igb
+.Nd Intel 1 GbE Server NIC Driver
+.Sh SYNOPSIS
+.Pa /dev/net/igb*
+.Sh DESCRIPTION
+The
+.Nm
+driver is a GLDv3 NIC driver for Intel 1 Gigabit Ethernet PCIe
+controllers which are built-in to motherboards and discrete PCIe
+devices.
+.Pp
+The driver supports the following device families:
+.Bl -dash
+.It
+Intel 82575 Gigabit Ethernet Controller
+.It
+Intel 82576 Gigabit Ethernet Controller
+.It
+Intel 82580 Gigabit Ethernet Controller
+.It
+Intel Ethernet Controller I210
+.It
+Intel Ethernet Controller I211
+.It
+Intel Ethernet Controller I350
+.El
+.Pp
+Many other Intel 1 GbE devices are supported by the
+.Xr e1000g 7D
+driver.
+.Pp
+The driver supports the following functionality depending on the
+controller generation:
+.Bl -dash
+.It
+Jumbo frames up to 9000 bytes.
+.It
+Checksum offload for TCP and UDP on IPv4 and IPv6.
+Checksum offload for IPv4 headers.
+.It
+TCP Segmentation Offload
+.Pq TSO
+over IPv4 and IPv6.
+.It
+Support for multiple hardware rings, enabling receive-side steering
+.Pq RSS
+and multiple MAC address filters.
+.It
+Promiscuous access via
+.Xr snoop 1M
+and
+.Xr dlpi 7P .
+.It
+LED control.
+.It
+Link auto-negotiation, manual link controls, and IEEE 802.3x flow
+control.
+.El
+.Sh APPLICATION PROGRAMMING INTERFACE
+For each supported device instance, which corresponds to a port, a
+character-special file is created.
+This device can be used with the Data Link Provider Interface
+.Pq DLPI
+through either
+.Xr libdlpi 3LIB
+or
+.Xr dlpi 7P .
+.Pp
+Each instance is assigned a unique ascending integer identifier starting
+from zero.
+The first instance in the system would be enumerated with the id 0 and
+be named
+.Sy igb0
+and be found in the file system at
+.Pa /dev/net/igb0 .
+.Sh CONFIGURATION
+The
+.Nm
+driver supports operating at 1 Gbps full-duplex, 100 Mbps full and
+half-duplex, and 10 Mbps full and half-duplex.
+By default, the device will use auto-negotiation and prefer the highest
+compatible speed.
+The advertised speeds and broader configuration can be observed and
+modified with
+.Xr dladm 1M .
+While
+.Xr driver.conf 4
+based configuration is possible, it is recommended that
+.Xr dladm 1M
+is used wherever possible.
+.Sh FILES
+.Bl -tag -width Pa
+.It Pa /dev/net/igb*
+.Nm
+special character device.
+.It Pa /kernel/drv/amd64/igb
+x86 device driver.
+.It Pa /kernel/drv/sparcv9/igb
+SPARC device driver
+.It Pa /kernel/drv/igb.conf
 Configuration file.
-.RE
-
-.SH SEE ALSO
-.sp
-.LP
-\fBdladm\fR(1M), \fBndd\fR(1M), \fBnetstat\fR(1M), \fBdriver.conf\fR(4),
-\fBattributes\fR(5), \fBstreamio\fR(7I), \fBdlpi\fR(7P),
-.sp
-.LP
-\fIWriting Device Drivers\fR
-.sp
-.LP
-\fISTREAMS Programming Guide\fR
-.sp
-.LP
-\fINetwork Interfaces Programmer's Guide\fR
+.El
+.Sh SEE ALSO
+.Xr dladm 1M ,
+.Xr libdlpi 3LIB ,
+.Xr driver.conf 4 ,
+.Xr e1000g 7D ,
+.Xr dlpi 7P ,
+.Xr mac 9E

--- a/usr/src/test/os-tests/runfiles/default.run
+++ b/usr/src/test/os-tests/runfiles/default.run
@@ -75,6 +75,9 @@ tests = ['conn', 'dgram', 'drop_priv', 'nosignal', 'rights.32', 'rights.64',
 [/opt/os-tests/tests/syscall]
 tests = ['open.32', 'open.64']
 
+[/opt/os-tests/tests/syscall]
+tests = ['open.32', 'open.64']
+
 [/opt/os-tests/tests/pf_key]
 user = root
 timeout = 180

--- a/usr/src/uts/common/brand/lx/syscall/lx_futex.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_futex.c
@@ -1401,9 +1401,20 @@ lx_futex(uintptr_t addr, int op, int val, uintptr_t lx_timeout,
 		break;
 
 	case FUTEX_CMP_REQUEUE:
-	case FUTEX_REQUEUE:
 		rval = futex_requeue(&memid, &memid2, val,
 		    val2, (void *)addr2, &val3);
+
+		break;
+
+	case FUTEX_REQUEUE:
+		/*
+		 * Per Linux futex(2), FUTEX_REQUEUE is the same as
+		 * FUTEX_CMP_REQUEUE, except val3 is ignored. futex_requeue()
+		 * will elide the val3 check if cmpval (the last argument) is
+		 * NULL.
+		 */
+		rval = futex_requeue(&memid, &memid2, val,
+		    val2, (void *)addr2, NULL);
 
 		break;
 

--- a/usr/src/uts/common/inet/squeue.c
+++ b/usr/src/uts/common/inet/squeue.c
@@ -599,11 +599,11 @@ static void
 squeue_drain(squeue_t *sqp, uint_t proc_type, hrtime_t expire)
 {
 	mblk_t		*mp;
-	mblk_t 		*head;
-	sqproc_t 	proc;
+	mblk_t		*head;
+	sqproc_t	proc;
 	conn_t		*connp;
 	ill_rx_ring_t	*sq_rx_ring = sqp->sq_rx_ring;
-	hrtime_t 	now;
+	hrtime_t	now;
 	boolean_t	sq_poll_capable;
 	ip_recv_attr_t	*ira, iras;
 

--- a/usr/src/uts/common/inet/tcp/tcp_socket.c
+++ b/usr/src/uts/common/inet/tcp/tcp_socket.c
@@ -199,7 +199,7 @@ static int
 tcp_bind(sock_lower_handle_t proto_handle, struct sockaddr *sa,
     socklen_t len, cred_t *cr)
 {
-	int 		error;
+	int		error;
 	conn_t		*connp = (conn_t *)proto_handle;
 
 	/* All Solaris components should pass a cred for this operation. */
@@ -240,7 +240,7 @@ tcp_listen(sock_lower_handle_t proto_handle, int backlog, cred_t *cr)
 {
 	conn_t	*connp = (conn_t *)proto_handle;
 	tcp_t	*tcp = connp->conn_tcp;
-	int 	error;
+	int	error;
 
 	ASSERT(connp->conn_upper_handle != NULL);
 
@@ -660,7 +660,7 @@ static int
 tcp_ioctl(sock_lower_handle_t proto_handle, int cmd, intptr_t arg,
     int mode, int32_t *rvalp, cred_t *cr)
 {
-	conn_t  	*connp = (conn_t *)proto_handle;
+	conn_t		*connp = (conn_t *)proto_handle;
 	int		error;
 
 	ASSERT(connp->conn_upper_handle != NULL);
@@ -825,7 +825,7 @@ tcp_fallback_noneager(tcp_t *tcp, mblk_t *stropt_mp, queue_t *q,
 	struct stroptions	*stropt;
 	struct T_capability_ack tca;
 	struct sockaddr_in6	laddr, faddr;
-	socklen_t 		laddrlen, faddrlen;
+	socklen_t		laddrlen, faddrlen;
 	short			opts;
 	int			error;
 	mblk_t			*mp, *mpnext;
@@ -999,7 +999,7 @@ tcp_fallback(sock_lower_handle_t proto_handle, queue_t *q,
     sock_quiesce_arg_t *arg)
 {
 	tcp_t			*tcp;
-	conn_t 			*connp = (conn_t *)proto_handle;
+	conn_t			*connp = (conn_t *)proto_handle;
 	int			error;
 	mblk_t			*stropt_mp;
 	mblk_t			*ordrel_mp;

--- a/usr/src/uts/common/io/i40e/core/i40e_common.c
+++ b/usr/src/uts/common/io/i40e/core/i40e_common.c
@@ -1761,6 +1761,8 @@ enum i40e_status_code i40e_set_fc(struct i40e_hw *hw, u8 *aq_failures,
 		config.eee_capability = abilities.eee_capability;
 		config.eeer = abilities.eeer_val;
 		config.low_power_ctrl = abilities.d3_lpan;
+		config.fec_config = abilities.fec_cfg_curr_mod_ext_info &
+				    I40E_AQ_PHY_FEC_CONFIG_MASK;
 		status = i40e_aq_set_phy_config(hw, &config, NULL);
 
 		if (status)
@@ -1920,6 +1922,8 @@ enum i40e_status_code i40e_aq_get_link_info(struct i40e_hw *hw,
 	hw_link_info->link_speed = (enum i40e_aq_link_speed)resp->link_speed;
 	hw_link_info->link_info = resp->link_info;
 	hw_link_info->an_info = resp->an_info;
+	hw_link_info->fec_info = resp->config & (I40E_AQ_CONFIG_FEC_KR_ENA |
+						 I40E_AQ_CONFIG_FEC_RS_ENA);
 	hw_link_info->ext_info = resp->ext_info;
 	hw_link_info->loopback = resp->loopback & I40E_AQ_LOOPBACK_MASK;
 	hw_link_info->max_frame_size = LE16_TO_CPU(resp->max_frame_size);

--- a/usr/src/uts/common/io/i40e/i40e_sw.h
+++ b/usr/src/uts/common/io/i40e/i40e_sw.h
@@ -867,6 +867,7 @@ typedef struct i40e {
 	link_state_t		i40e_link_state;
 	uint32_t		i40e_link_speed;	/* In Mbps */
 	link_duplex_t		i40e_link_duplex;
+	link_fec_t		i40e_fec_requested;
 	uint_t			i40e_sdu;
 	uint_t			i40e_frame_max;
 

--- a/usr/src/uts/common/mapfiles/mac.mapfile
+++ b/usr/src/uts/common/mapfiles/mac.mapfile
@@ -11,6 +11,7 @@
 
 #
 # Copyright (c) 2017, Joyent, Inc.
+# Copyright 2020 RackTop Systems, Inc.
 #
 
 #
@@ -42,6 +43,7 @@ SYMBOL_SCOPE {
 	mac_lso_get				{ FLAGS = EXTERN };
 	mac_maxsdu_update			{ FLAGS = EXTERN };
 	mac_prop_info_set_default_link_flowctrl	{ FLAGS = EXTERN };
+	mac_prop_info_set_default_fec		{ FLAGS = EXTERN };
 	mac_prop_info_set_default_str		{ FLAGS = EXTERN };
 	mac_prop_info_set_default_uint8		{ FLAGS = EXTERN };
 	mac_prop_info_set_perm			{ FLAGS = EXTERN };


### PR DESCRIPTION
Weekly upstream for upstream_merge/2020093001

## Backports

None

## onu

```
OmniOS r151035  omnios-upstream_merge-2020093001-fa44213720     September 2020
illumos development build: 2020-Sep-30 [illumos]
You have new mail.
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2020093001-fa44213720 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Wed Sep 30 09:53:20 UTC 2020 ====
==== Nightly distributed build completed: Wed Sep 30 11:07:04 UTC 2020 ====

==== Total build time ====

real    1:13:43

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-b7ba24aaa1 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.8+10-omnios-151035"

/usr/bin/openssl
OpenSSL 1.1.1h  22 Sep 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   77

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020093001-fa44213720

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:20.5
user  3:58:54.8
sys   1:06:08.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    23:19.9
user  3:23:53.5
sys   1:00:06.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
