### PR TITLE
Upstream merge/2020100801

### DIFF
--- a/usr/src/boot/lib/libstand/pager.c
+++ b/usr/src/boot/lib/libstand/pager.c
@@ -46,18 +46,18 @@ static char *pager_blank   = \
 void
 pager_open(void)
 {
-    int		nlines;
-    char	*cp, *lp;
+	int	nlines;
+	char	*cp, *lp;
 
-    nlines = 24;		/* sensible default */
-    if ((cp = getenv("screen-#rows")) != NULL) {
-	nlines = strtol(cp, &lp, 0);
-    }
+	nlines = 24;		/* sensible default */
+	if ((cp = getenv("screen-#rows")) != NULL) {
+		nlines = strtol(cp, &lp, 0);
+	}
 
-    p_maxlines = nlines - 1;
-    if (p_maxlines < 1)
-	p_maxlines = 1;
-    p_freelines = p_maxlines;
+	p_maxlines = nlines - 1;
+	if (p_maxlines < 1)
+		p_maxlines = 1;
+	p_freelines = p_maxlines;
 }
 
 /*
@@ -66,7 +66,7 @@ pager_open(void)
 void
 pager_close(void)
 {
-    p_maxlines = -1;
+	p_maxlines = -1;
 }
 
 /*
@@ -82,47 +82,47 @@ pager_close(void)
 int
 pager_output(const char *cp)
 {
-    int		action;
+	int	action;
 
-    if (cp == NULL)
-	return(0);
+	if (cp == NULL)
+		return (0);
 
-    for (;;) {
-	if (*cp == 0)
-	    return(0);
+	for (;;) {
+		if (*cp == 0)
+			return (0);
 
-	putchar(*cp);			/* always emit character */
+		putchar(*cp);			/* always emit character */
 
-	if (*(cp++) == '\n') {		/* got a newline? */
-	    p_freelines--;
-	    if (p_freelines <= 0) {
-		printf("%s", pager_prompt1);
-		action = 0;
-		while (action == 0) {
-		    switch(getchar()) {
-		    case '\r':
-		    case '\n':
-			p_freelines = 1;
-			action = 1;
-			break;
-		    case ' ':
-			p_freelines = p_maxlines;
-			action = 1;
-			break;
-		    case 'q':
-		    case 'Q':
-			action = 2;
-			break;
-		    default:
-			break;
-		    }
+		if (*(cp++) == '\n') {		/* got a newline? */
+			p_freelines--;
+			if (p_freelines <= 0) {
+				printf("%s", pager_prompt1);
+				action = 0;
+				while (action == 0) {
+					switch (getchar()) {
+					case '\r':
+					case '\n':
+						p_freelines = 1;
+						action = 1;
+						break;
+					case ' ':
+						p_freelines = p_maxlines;
+						action = 1;
+						break;
+					case 'q':
+					case 'Q':
+						action = 2;
+						break;
+					default:
+						break;
+					}
+				}
+				printf("\r%s\r", pager_blank);
+				if (action == 2)
+					return (1);
+			}
 		}
-		printf("\r%s\r", pager_blank);
-		if (action == 2)
-		    return(1);
-	    }
 	}
-    }
 }
 
 /*
@@ -131,32 +131,32 @@ pager_output(const char *cp)
 int
 pager_file(const char *fname)
 {
-    char	buf[80];
-    size_t	hmuch;
-    int		fd;
-    int		result;
+	char	buf[80];
+	size_t	hmuch;
+	int	fd;
+	int	result;
 
-    if ((fd = open(fname, O_RDONLY)) == -1) {
-	printf("can't open '%s': %s\n", fname, strerror(errno));
-	return(-1);
-    }
+	if ((fd = open(fname, O_RDONLY)) == -1) {
+		printf("can't open '%s': %s\n", fname, strerror(errno));
+		return (-1);
+	}
 
-    for (;;) {
-	hmuch = read(fd, buf, sizeof(buf) - 1);
-	if (hmuch == -1) {
-	    result = -1;
-	    break;
+	for (;;) {
+		hmuch = read(fd, buf, sizeof (buf) - 1);
+		if (hmuch == -1) {
+			result = -1;
+			break;
+		}
+		if (hmuch == 0) {
+			result = 0;
+			break;
+		}
+		buf[hmuch] = 0;
+		if (pager_output(buf)) {
+			result = 1;
+			break;
+		}
 	}
-	if (hmuch == 0) {
-	    result = 0;
-	    break;
-	}
-	buf[hmuch] = 0;
-	if (pager_output(buf)) {
-	    result = 1;
-	    break;
-	}
-    }
-    close(fd);
-    return(result);
+	close(fd);
+	return (result);
 }

--- a/usr/src/boot/sys/boot/common/gfx_fb.h
+++ b/usr/src/boot/sys/boot/common/gfx_fb.h
@@ -93,15 +93,21 @@ struct vesa_edid_info {
 	uint8_t checksum;
 } __packed;
 
+/*
+ * Number of pixels and lines is 12-bit int, valid values 0-4095.
+ */
+#define	EDID_MAX_PIXELS	4095
+#define	EDID_MAX_LINES	4095
+
 #define	GET_EDID_INFO_WIDTH(edid_info, timings_num) \
-    ((edid_info)->detailed_timings[(timings_num)].horizontal_active_lo | \
-    (((uint_t)(edid_info)->detailed_timings[(timings_num)].horizontal_hi & \
-    0xf0) << 4))
+	((edid_info)->detailed_timings[(timings_num)].horizontal_active_lo | \
+	(((uint_t)(edid_info)->detailed_timings[(timings_num)].horizontal_hi & \
+	0xf0) << 4))
 
 #define	GET_EDID_INFO_HEIGHT(edid_info, timings_num) \
-    ((edid_info)->detailed_timings[(timings_num)].vertical_active_lo | \
-    (((uint_t)(edid_info)->detailed_timings[(timings_num)].vertical_hi & \
-    0xf0) << 4))
+	((edid_info)->detailed_timings[(timings_num)].vertical_active_lo | \
+	(((uint_t)(edid_info)->detailed_timings[(timings_num)].vertical_hi & \
+	0xf0) << 4))
 
 extern multiboot_tag_framebuffer_t gfx_fb;
 

--- a/usr/src/boot/sys/boot/i386/libi386/vbe.h
+++ b/usr/src/boot/sys/boot/i386/libi386/vbe.h
@@ -33,7 +33,10 @@
  * VESA disabled.
  */
 
-#define VBE_DEFAULT_MODE	"800x600"
+#ifndef _VBE_H
+#define	_VBE_H
+
+#define	VBE_DEFAULT_MODE	"800x600"
 
 struct vbeinfoblock {
 	char VbeSignature[4];
@@ -61,8 +64,10 @@ struct modeinfoblock {
 	uint8_t XCharSize, YCharSize, NumberOfPlanes, BitsPerPixel;
 	uint8_t NumberOfBanks, MemoryModel, BankSize, NumberOfImagePages;
 	uint8_t Reserved1;
-	/* Direct Color fields
-	   (required for direct/6 and YUV/7 memory models) */
+	/*
+	 * Direct Color fields
+	 * (required for direct/6 and YUV/7 memory models)
+	 */
 	uint8_t RedMaskSize, RedFieldPosition;
 	uint8_t GreenMaskSize, GreenFieldPosition;
 	uint8_t BlueMaskSize, BlueFieldPosition;
@@ -108,17 +113,16 @@ struct paletteentry {
 
 struct flatpanelinfo
 {
-	uint16_t HorizontalSize;
-	uint16_t VerticalSize;
-	uint16_t PanelType;
-	uint8_t RedBPP;
-	uint8_t GreenBPP;
-	uint8_t BlueBPP;
-	uint8_t ReservedBPP;
-	uint32_t ReservedOffScreenMemSize;
-	uint32_t ReservedOffScreenMemPtr;
-
-	uint8_t Reserved[14];
+	uint16_t HorizontalSize;	/* Horizontal Size in Pixels */
+	uint16_t VerticalSize;		/* Vertical Size in Lines */
+	uint16_t PanelType;		/* Flat Panel Type */
+	uint8_t RedBPP;			/* Red Bits Per Primary */
+	uint8_t GreenBPP;		/* Green Bits Per Primary */
+	uint8_t BlueBPP;		/* Blue Bits Per Primary */
+	uint8_t ReservedBPP;		/* Reserved Bits Per Primary */
+	uint32_t RsvdOffScreenMemSize;	/* Size in KB of Offscreen Memory */
+	uint32_t RsvdOffScreenMemPtr; /* Pointer to reserved offscreen memory */
+	uint8_t Reserved[14];		/* remainder of FPInfo */
 } __packed;
 
 #define	VBE_BASE_MODE		(0x100)		/* VBE 3.0 page 18 */
@@ -143,3 +147,5 @@ int vbe_set_mode(int);
 int vbe_get_mode(void);
 int vbe_set_palette(const struct paletteentry *, size_t);
 void vbe_modelist(int);
+
+#endif /* _VBE_H */

--- a/usr/src/man/man2/rename.2
+++ b/usr/src/man/man2/rename.2
@@ -4,11 +4,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH RENAME 2 "Oct 4, 2007"
+.TH RENAME 2 "Sep 29, 2020"
 .SH NAME
 rename, renameat \- change the name of a file
 .SH SYNOPSIS
-.LP
 .nf
 #include <stdio.h>
 
@@ -24,7 +23,6 @@ rename, renameat \- change the name of a file
 .fi
 
 .SS "XPG3"
-.LP
 .nf
 #include <unistd.h>
 
@@ -32,8 +30,6 @@ rename, renameat \- change the name of a file
 .fi
 
 .SH DESCRIPTION
-.sp
-.LP
 The  \fBrename()\fR function changes the name of a file. The \fIold\fR argument
 points to the pathname of the file to be renamed. The \fInew\fR argument points
 to the new path name of the file.
@@ -155,14 +151,10 @@ Upon successful completion, the \fBrename()\fR and \fBrenameat()\fR functions
 will mark for update the \fBst_ctime\fR and \fBst_mtime\fR fields of the parent
 directory of each file.
 .SH RETURN VALUES
-.sp
-.LP
 Upon successful completion, \fB0\fR is returned. Otherwise, \fB\(mi1\fR is
 returned and \fBerrno\fR is set to indicate an error.
 .SH ERRORS
-.sp
-.LP
-The \fBrename()\fR function will fail if:
+The \fBrename()\fR and \fBrenameat()\fR functions will fail if:
 .sp
 .ne 2
 .na
@@ -335,7 +327,7 @@ The links named by \fIold\fR and \fInew\fR are on different file systems.
 
 .sp
 .LP
-The \fBrenameat()\fR functions will fail if:
+The \fBrenameat()\fR function will fail if:
 .sp
 .ne 2
 .na
@@ -347,8 +339,6 @@ an attribute file as a regular file.
 .RE
 
 .SH ATTRIBUTES
-.sp
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -367,13 +357,9 @@ Standard	For \fBrename()\fR, see \fBstandards\fR(5).
 .TE
 
 .SH SEE ALSO
-.sp
-.LP
 \fBchmod\fR(2), \fBlink\fR(2), \fBunlink\fR(2), \fBattributes\fR(5),
 \fBfsattr\fR(5), \fBstandards\fR(5)
 .SH NOTES
-.sp
-.LP
 The system can deadlock if there is a loop in the file system graph. Such a
 loop can occur if there is an entry in directory \fBa\fR, \fBa/name1\fR, that
 is a hard link to directory \fBb\fR, and an entry in directory \fBb\fR,

--- a/usr/src/man/man2/statvfs.2
+++ b/usr/src/man/man2/statvfs.2
@@ -3,11 +3,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH STATVFS 2 "Mar 22, 2004"
+.TH STATVFS 2 "Oct 3, 2020"
 .SH NAME
 statvfs, fstatvfs \- get file system information
 .SH SYNOPSIS
-.LP
 .nf
 #include <sys/types.h>
 #include <sys/statvfs.h>
@@ -21,8 +20,6 @@ statvfs, fstatvfs \- get file system information
 .fi
 
 .SH DESCRIPTION
-.sp
-.LP
 The \fBstatvfs()\fR function returns a "generic superblock" describing a file
 system; it can be used to acquire information about mounted  file systems.  The
 \fIbuf\fR argument is a pointer to a structure (described below) that is filled
@@ -86,13 +83,9 @@ file named by \fIpath\fR in \fBstatvfs()\fR is instead identified by an open
 file descriptor \fIfildes\fR obtained from a successful \fBopen\fR(2),
 \fBcreat\fR(2), \fBdup\fR(2), \fBfcntl\fR(2), or \fBpipe\fR(2) function call.
 .SH RETURN VALUES
-.sp
-.LP
 Upon successful completion, \fB0\fR is returned. Otherwise, \fB\(mi1\fR is
 returned and \fBerrno\fR is set to indicate the error.
 .SH ERRORS
-.sp
-.LP
 The \fBstatvfs()\fR and \fBfstatvfs()\fR functions will fail if:
 .sp
 .ne 2
@@ -159,7 +152,7 @@ Too many symbolic links were encountered in translating \fIpath\fR.
 .ad
 .RS 16n
 The length of a \fIpath\fR component exceeds \fBNAME_MAX\fR characters, or the
-length of \fIpath\fR The exceeds \fBPATH_MAX\fR characters.
+length of \fIpath\fR exceeds \fBPATH_MAX\fR characters.
 .RE
 
 .sp
@@ -231,13 +224,9 @@ An I/O error occurred while reading the file system.
 .RE
 
 .SH USAGE
-.sp
-.LP
 The \fBstatvfs()\fR and \fBfstatvfs()\fR functions have transitional interfaces
 for 64-bit file offsets.  See \fBlf64\fR(5).
 .SH ATTRIBUTES
-.sp
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -252,14 +241,10 @@ Interface Stability	Standard
 .TE
 
 .SH SEE ALSO
-.sp
-.LP
 \fBchmod\fR(2), \fBchown\fR(2), \fBcreat\fR(2), \fBdup\fR(2), \fBfcntl\fR(2),
 \fBlink\fR(2), \fBmknod\fR(2), \fBopen\fR(2), \fBpipe\fR(2), \fBread\fR(2),
 \fBtime\fR(2), \fBunlink\fR(2), \fButime\fR(2), \fBwrite\fR(2),
 \fBattributes\fR(5), \fBlf64\fR(5), \fBstandards\fR(5)
 .SH BUGS
-.sp
-.LP
 The values returned for \fBf_files\fR, \fBf_ffree\fR, and \fBf_favail\fR may
 not be valid for \fBNFS\fR mounted file systems.

--- a/usr/src/man/man7d/pchtemp.7d
+++ b/usr/src/man/man7d/pchtemp.7d
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2019 Joyent, Inc.
 .\"
-.Dd January 10, 2020
+.Dd September 30, 2020
 .Dt PCHTEMP 7D
 .Os
 .Sh NAME
@@ -44,6 +44,8 @@ Intel 7th/8th Generation Processor Family U/Y Platforms
 .It
 Intel 300 Series and Intel C240 Series Chipset Family Platform
 Controller Hub
+.It
+Intel 400 Series Chipset Family On-Package Platform Controller Hub
 .El
 .Pp
 Temperature information is available to the system via the fault

--- a/usr/src/pkg/manifests/driver-cpu-sensor.mf
+++ b/usr/src/pkg/manifests/driver-cpu-sensor.mf
@@ -44,6 +44,7 @@ driver name=amdnbtemp \
     alias=pci1022,1703,p
 driver name=coretemp
 driver name=pchtemp \
+    alias=pci8086,2f9,p \
     alias=pci8086,8c24,p \
     alias=pci8086,8ca4,p \
     alias=pci8086,8d24,p \

--- a/usr/src/test/net-tests/tests/net_common.ksh
+++ b/usr/src/test/net-tests/tests/net_common.ksh
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2019 Joyent, Inc.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #

--- a/usr/src/test/os-tests/runfiles/default.run
+++ b/usr/src/test/os-tests/runfiles/default.run
@@ -75,9 +75,6 @@ tests = ['conn', 'dgram', 'drop_priv', 'nosignal', 'rights.32', 'rights.64',
 [/opt/os-tests/tests/syscall]
 tests = ['open.32', 'open.64']
 
-[/opt/os-tests/tests/syscall]
-tests = ['open.32', 'open.64']
-
 [/opt/os-tests/tests/pf_key]
 user = root
 timeout = 180

--- a/usr/src/uts/common/inet/ipclassifier.h
+++ b/usr/src/uts/common/inet/ipclassifier.h
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*

--- a/usr/src/uts/i86pc/io/rootnex.c
+++ b/usr/src/uts/i86pc/io/rootnex.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2011 Bayard G. Bell.  All rights reserved.
  * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
  * Copyright 2017 Joyent, Inc.
+ * Copyright 2020 Ryan Zezeski
  */
 
 /*
@@ -3130,10 +3131,10 @@ rootnex_get_sgl(ddi_dma_obj_t *dmar_object, ddi_dma_cookie_t *sgl,
 			sgl[cnt].dmac_size += psize;
 
 			/*
-			 * if this exactly ==  the maximum cookie size, and
-			 * it isn't the last cookie, go to the next cookie.
+			 * If this cookie is used up, and more cookies
+			 * are available, then move onto the next one.
 			 */
-			if (((sgl[cnt].dmac_size + psize) == maxseg) &&
+			if ((sgl[cnt].dmac_size == maxseg) &&
 			    ((cnt + 1) < sglinfo->si_max_pages)) {
 				cnt++;
 				sgl[cnt].dmac_laddress = 0;
@@ -3230,10 +3231,10 @@ rootnex_dvma_get_sgl(ddi_dma_obj_t *dmar_object, ddi_dma_cookie_t *sgl,
 			sgl[cnt].dmac_size += psize;
 
 			/*
-			 * if this exactly ==  the maximum cookie size, and
-			 * it isn't the last cookie, go to the next cookie.
+			 * If this cookie is used up, and more cookies
+			 * are available, then move onto the next one.
 			 */
-			if (((sgl[cnt].dmac_size + psize) == maxseg) &&
+			if ((sgl[cnt].dmac_size == maxseg) &&
 			    ((cnt + 1) < sglinfo->si_max_pages)) {
 				cnt++;
 				sgl[cnt].dmac_laddress = 0;

--- a/usr/src/uts/intel/io/pchtemp/pchtemp.c
+++ b/usr/src/uts/intel/io/pchtemp/pchtemp.c
@@ -42,6 +42,7 @@
  *  - Intel Sunrise Point-LP (Kaby Lake-U) PCH
  *  - Intel Cannon Lake (Whiskey Lake-U) PCH
  *  - Intel 300 Series and C240 Chipset
+ *  - Intel 400 Series (On-Package) PCH
  *
  * The following chipsets use a different format and are not currently
  * supported:


### PR DESCRIPTION
Weekly upstream merge

## Backports

To r151036

* 13193 pchtemp could support Intel 400 series chipset 

## onu

```
OmniOS r151035  omnios-upstream_merge-2020100801-d42ecce3ae     October 2020
illumos development build: 2020-Oct-08 [illumos-omnios]
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2020100801-d42ecce3ae i86pc i386 i86pc
```
## mail_msg

```
==== Nightly distributed build started:   Thu Oct  8 17:26:33 CEST 2020 ====
==== Nightly distributed build completed: Thu Oct  8 18:48:00 CEST 2020 ====

==== Total build time ====

real    1:21:27

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-b7ba24aaa1 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151035/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.8+10-omnios-151035"

/usr/bin/openssl
OpenSSL 1.1.1h  22 Sep 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   76

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020100801-d42ecce3ae

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    36:23.0
user  3:33:42.7
sys     40:48.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    31:42.2
user  3:04:44.3
sys     36:29.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
