### PR TITLE
fix dtrace manifest following java update

### DIFF
--- a/usr/src/pkg/manifests/developer-dtrace.mf
+++ b/usr/src/pkg/manifests/developer-dtrace.mf
@@ -299,10 +299,7 @@ $(JAVA_11_ONLY)file \
     path=usr/share/lib/java/javadoc/dtrace/api/jquery/images/ui-icons_cd0a0a_256x240.png \
     group=other
 $(JAVA_11_ONLY)file \
-    path=usr/share/lib/java/javadoc/dtrace/api/jquery/jquery-3.3.1.js \
-    group=other
-$(JAVA_11_ONLY)file \
-    path=usr/share/lib/java/javadoc/dtrace/api/jquery/jquery-migrate-3.0.1.js \
+    path=usr/share/lib/java/javadoc/dtrace/api/jquery/jquery-3.5.1.js \
     group=other
 $(JAVA_11_ONLY)file \
     path=usr/share/lib/java/javadoc/dtrace/api/jquery/jquery-ui.css \

--- a/usr/src/tools/env/omnios-illumos-gate.sh
+++ b/usr/src/tools/env/omnios-illumos-gate.sh
@@ -10,9 +10,10 @@ export PERL_PKGVERS=
 export PERL_VARIANT=-thread-multi
 export BUILDPERL32='#'
 
-export JAVA_ROOT=/usr/jdk/openjdk11.0
+export JAVA_ROOT=/usr/jdk/openjdk1.8.0
 export JAVA_HOME=$JAVA_ROOT
-export BLD_JAVA_11=
+export BLD_JAVA_7='#'
+export BLD_JAVA_8=
 
 export BUILDPY2=
 export BUILDPY3=


### PR DESCRIPTION
Following the recent OpenJDK11 update, some manifests also need updates.
Revert to using OpenJDK8 for gate builds until this is resolved upstream.