### PR TITLE
Upstream merge/2020121301

### DIFF
--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -34,4 +34,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2020.12.04.1
+BOOT_VERSION = $(LOADER_VERSION)-2020.12.07.1

--- a/usr/src/boot/lib/libstand/zfs/nvlist.c
+++ b/usr/src/boot/lib/libstand/zfs/nvlist.c
@@ -90,6 +90,38 @@ _putuint(struct xdr *xdr, unsigned i)
 	return (sizeof (int));
 }
 
+static int
+_getint_mem(struct xdr *xdr, int *ip)
+{
+	*ip = *(int *)xdr->xdr_idx;
+	return (sizeof (int));
+}
+
+static int
+_putint_mem(struct xdr *xdr, int i)
+{
+	int *ip = (int *)xdr->xdr_idx;
+
+	*ip = i;
+	return (sizeof (int));
+}
+
+static int
+_getuint_mem(struct xdr *xdr, unsigned *ip)
+{
+	*ip = *(unsigned *)xdr->xdr_idx;
+	return (sizeof (unsigned));
+}
+
+static int
+_putuint_mem(struct xdr *xdr, unsigned i)
+{
+	unsigned *up = (unsigned *)xdr->xdr_idx;
+
+	*up = i;
+	return (sizeof (int));
+}
+
 /*
  * XDR data translations.
  */
@@ -182,8 +214,6 @@ xdr_u_int(xdr_t *xdr, unsigned *ip)
 static bool
 xdr_int64(xdr_t *xdr, int64_t *lp)
 {
-	int hi;
-	unsigned lo;
 	bool rv = false;
 
 	if (xdr->xdr_idx + sizeof (int64_t) > xdr->xdr_buf + xdr->xdr_buf_size)
@@ -192,18 +222,21 @@ xdr_int64(xdr_t *xdr, int64_t *lp)
 	switch (xdr->xdr_op) {
 	case XDR_OP_ENCODE:
 		/* Encode value *lp, store to buf */
-		hi = *lp >> 32;
-		lo = *lp & UINT32_MAX;
-		xdr->xdr_idx += xdr->xdr_putint(xdr, hi);
-		xdr->xdr_idx += xdr->xdr_putint(xdr, lo);
+		if (xdr->xdr_putint == _putint)
+			*(int64_t *)xdr->xdr_idx = htobe64(*lp);
+		else
+			*(int64_t *)xdr->xdr_idx = *lp;
+		xdr->xdr_idx += sizeof (int64_t);
 		rv = true;
 		break;
 
 	case XDR_OP_DECODE:
 		/* Decode buf, return value to *ip */
-		xdr->xdr_idx += xdr->xdr_getint(xdr, &hi);
-		xdr->xdr_idx += xdr->xdr_getuint(xdr, &lo);
-		*lp = (((int64_t)hi) << 32) | lo;
+		if (xdr->xdr_getint == _getint)
+			*lp = be64toh(*(int64_t *)xdr->xdr_idx);
+		else
+			*lp = *(int64_t *)xdr->xdr_idx;
+		xdr->xdr_idx += sizeof (int64_t);
 		rv = true;
 	}
 	return (rv);
@@ -212,7 +245,6 @@ xdr_int64(xdr_t *xdr, int64_t *lp)
 static bool
 xdr_uint64(xdr_t *xdr, uint64_t *lp)
 {
-	unsigned hi, lo;
 	bool rv = false;
 
 	if (xdr->xdr_idx + sizeof (uint64_t) > xdr->xdr_buf + xdr->xdr_buf_size)
@@ -221,18 +253,21 @@ xdr_uint64(xdr_t *xdr, uint64_t *lp)
 	switch (xdr->xdr_op) {
 	case XDR_OP_ENCODE:
 		/* Encode value *ip, store to buf */
-		hi = *lp >> 32;
-		lo = *lp & UINT32_MAX;
-		xdr->xdr_idx += xdr->xdr_putint(xdr, hi);
-		xdr->xdr_idx += xdr->xdr_putint(xdr, lo);
+		if (xdr->xdr_putint == _putint)
+			*(uint64_t *)xdr->xdr_idx = htobe64(*lp);
+		else
+			*(uint64_t *)xdr->xdr_idx = *lp;
+		xdr->xdr_idx += sizeof (uint64_t);
 		rv = true;
 		break;
 
 	case XDR_OP_DECODE:
 		/* Decode buf, return value to *ip */
-		xdr->xdr_idx += xdr->xdr_getuint(xdr, &hi);
-		xdr->xdr_idx += xdr->xdr_getuint(xdr, &lo);
-		*lp = (((uint64_t)hi) << 32) | lo;
+		if (xdr->xdr_getuint == _getuint)
+			*lp = be64toh(*(uint64_t *)xdr->xdr_idx);
+		else
+			*lp = *(uint64_t *)xdr->xdr_idx;
+		xdr->xdr_idx += sizeof (uint64_t);
 		rv = true;
 	}
 	return (rv);
@@ -288,6 +323,10 @@ static bool
 xdr_array(xdr_t *xdr, const unsigned nelem, const xdrproc_t elproc)
 {
 	bool rv = true;
+	unsigned c = nelem;
+
+	if (!xdr_u_int(xdr, &c))
+		return (false);
 
 	for (unsigned i = 0; i < nelem; i++) {
 		if (!elproc(xdr, xdr->xdr_idx))
@@ -1119,15 +1158,19 @@ nvlist_add_common(nvlist_t *nvl, const char *name, data_type_t type,
 	uint8_t *ptr;
 	size_t namelen;
 	int decoded_size, encoded_size;
-	xdr_t xdr;
+	xdr_t xdr = {
+		.xdr_op = XDR_OP_ENCODE,
+		.xdr_putint = _putint_mem,
+		.xdr_putuint = _putuint_mem,
+		.xdr_buf = nvl->nv_data,
+		.xdr_idx = nvl->nv_data,
+		.xdr_buf_size = nvl->nv_size
+	};
 
 	nvs = (nvs_data_t *)nvl->nv_data;
 	if (nvs->nvl_nvflag & NV_UNIQUE_NAME)
 		(void) nvlist_remove(nvl, name, type);
 
-	xdr.xdr_buf = nvl->nv_data;
-	xdr.xdr_idx = nvl->nv_data;
-	xdr.xdr_buf_size = nvl->nv_size;
 	if (!nvlist_size_native(&xdr, &nvl->nv_size))
 		return (EINVAL);
 
@@ -1164,83 +1207,129 @@ nvlist_add_common(nvlist_t *nvl, const char *name, data_type_t type,
 	hp = (nvp_header_t *)nvl->nv_idx;
 	*hp = head;
 	nvl->nv_idx += sizeof (*hp);
-	*(unsigned *)nvl->nv_idx = namelen;
-	nvl->nv_idx += sizeof (unsigned);
-	strlcpy((char *)nvl->nv_idx, name, namelen + 1);
-	nvl->nv_idx += NV_ALIGN4(namelen);
-	*(unsigned *)nvl->nv_idx = type;
-	nvl->nv_idx += sizeof (unsigned);
-	*(unsigned *)nvl->nv_idx = nelem;
-	nvl->nv_idx += sizeof (unsigned);
+
+	xdr.xdr_buf = nvl->nv_data;
+	xdr.xdr_idx = nvl->nv_idx;
+
+	xdr.xdr_idx += xdr.xdr_putuint(&xdr, namelen);
+	strlcpy((char *)xdr.xdr_idx, name, namelen + 1);
+	xdr.xdr_idx += NV_ALIGN4(namelen);
+	xdr.xdr_idx += xdr.xdr_putuint(&xdr, type);
+	xdr.xdr_idx += xdr.xdr_putuint(&xdr, nelem);
 
 	switch (type) {
 	case DATA_TYPE_BOOLEAN:
 		break;
+
 	case DATA_TYPE_BYTE_ARRAY:
-		*(unsigned *)nvl->nv_idx = encoded_size;
-		nvl->nv_idx += sizeof (unsigned);
-		bcopy(data, nvl->nv_idx, nelem);
-		nvl->nv_idx += encoded_size;
+		xdr.xdr_idx += xdr.xdr_putuint(&xdr, encoded_size);
+		bcopy(data, xdr.xdr_idx, nelem);
+		xdr.xdr_idx += NV_ALIGN4(encoded_size);
 		break;
+
 	case DATA_TYPE_STRING:
 		encoded_size = strlen(data);
-		*(unsigned *)nvl->nv_idx = encoded_size;
-		nvl->nv_idx += sizeof (unsigned);
-		strlcpy((char *)nvl->nv_idx, data, encoded_size + 1);
-		nvl->nv_idx += NV_ALIGN4(encoded_size);
+		xdr.xdr_idx += xdr.xdr_putuint(&xdr, encoded_size);
+		strlcpy((char *)xdr.xdr_idx, data, encoded_size + 1);
+		xdr.xdr_idx += NV_ALIGN4(encoded_size);
 		break;
+
 	case DATA_TYPE_STRING_ARRAY:
 		for (uint32_t i = 0; i < nelem; i++) {
 			encoded_size = strlen(((char **)data)[i]);
-			*(unsigned *)nvl->nv_idx = encoded_size;
-			nvl->nv_idx += sizeof (unsigned);
-			strlcpy((char *)nvl->nv_idx, ((char **)data)[i],
+			xdr.xdr_idx += xdr.xdr_putuint(&xdr, encoded_size);
+			strlcpy((char *)xdr.xdr_idx, ((char **)data)[i],
 			    encoded_size + 1);
-			nvl->nv_idx += NV_ALIGN4(encoded_size);
+			xdr.xdr_idx += NV_ALIGN4(encoded_size);
 		}
 		break;
+
 	case DATA_TYPE_BYTE:
 	case DATA_TYPE_INT8:
 	case DATA_TYPE_UINT8:
+		xdr_char(&xdr, (char *)data);
+		break;
+
 	case DATA_TYPE_INT8_ARRAY:
 	case DATA_TYPE_UINT8_ARRAY:
-		for (uint32_t i = 0; i < nelem; i++) {
-			*(unsigned *)nvl->nv_idx = ((uint8_t *)data)[i];
-			nvl->nv_idx += sizeof (unsigned);
-		}
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_char);
 		break;
+
 	case DATA_TYPE_INT16:
+		xdr_short(&xdr, (short *)data);
+		break;
+
 	case DATA_TYPE_UINT16:
+		xdr_u_short(&xdr, (unsigned short *)data);
+		break;
+
 	case DATA_TYPE_INT16_ARRAY:
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_short);
+		break;
+
 	case DATA_TYPE_UINT16_ARRAY:
-		for (uint32_t i = 0; i < nelem; i++) {
-			*(unsigned *)nvl->nv_idx = ((uint16_t *)data)[i];
-			nvl->nv_idx += sizeof (unsigned);
-		}
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_u_short);
 		break;
+
+	case DATA_TYPE_BOOLEAN_VALUE:
+	case DATA_TYPE_INT32:
+		xdr_int(&xdr, (int *)data);
+		break;
+
+	case DATA_TYPE_UINT32:
+		xdr_u_int(&xdr, (unsigned int *)data);
+		break;
+
+	case DATA_TYPE_BOOLEAN_ARRAY:
+	case DATA_TYPE_INT32_ARRAY:
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_int);
+		break;
+
+	case DATA_TYPE_UINT32_ARRAY:
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_u_int);
+		break;
+
+	case DATA_TYPE_INT64:
+		xdr_int64(&xdr, (int64_t *)data);
+		break;
+
+	case DATA_TYPE_UINT64:
+		xdr_uint64(&xdr, (uint64_t *)data);
+		break;
+
+	case DATA_TYPE_INT64_ARRAY:
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_int64);
+		break;
+
+	case DATA_TYPE_UINT64_ARRAY:
+		xdr_array(&xdr, nelem, (xdrproc_t)xdr_uint64);
+		break;
+
 	case DATA_TYPE_NVLIST:
-		bcopy(((nvlist_t *)data)->nv_data, nvl->nv_idx, encoded_size);
+		bcopy(((nvlist_t *)data)->nv_data, xdr.xdr_idx, encoded_size);
 		break;
+
 	case DATA_TYPE_NVLIST_ARRAY: {
-		uint8_t *buf = nvl->nv_idx;
 		size_t size;
-		xdr_t xdr;
+		xdr_t xdr_nv;
 
 		for (uint32_t i = 0; i < nelem; i++) {
-			xdr.xdr_idx = ((nvlist_t **)data)[i]->nv_data;
-			xdr.xdr_buf = xdr.xdr_idx;
-			xdr.xdr_buf_size = ((nvlist_t **)data)[i]->nv_size;
+			xdr_nv.xdr_idx = ((nvlist_t **)data)[i]->nv_data;
+			xdr_nv.xdr_buf = xdr_nv.xdr_idx;
+			xdr_nv.xdr_buf_size = ((nvlist_t **)data)[i]->nv_size;
 
-			if (!nvlist_size_native(&xdr, &size))
+			if (!nvlist_size_native(&xdr_nv, &size))
 				return (EINVAL);
 
-			bcopy(((nvlist_t **)data)[i]->nv_data, buf, size);
-			buf += size;
+			bcopy(((nvlist_t **)data)[i]->nv_data, xdr.xdr_idx,
+			    size);
+			xdr.xdr_idx += size;
 		}
 		break;
 	}
+
 	default:
-		bcopy(data, nvl->nv_idx, encoded_size);
+		bcopy(data, xdr.xdr_idx, encoded_size);
 	}
 
 	nvl->nv_size += head.encoded_size;
@@ -1464,9 +1553,15 @@ nvpair_print(nvp_header_t *nvp, unsigned int indent)
 	nv_string_t *nvp_name;
 	nv_pair_data_t *nvp_data;
 	nvlist_t nvlist;
-	xdr_t xdr;
-	unsigned i, j, u;
-	uint64_t u64;
+	unsigned i, j;
+	xdr_t xdr = {
+		.xdr_op = XDR_OP_DECODE,
+		.xdr_getint = _getint_mem,
+		.xdr_getuint = _getuint_mem,
+		.xdr_buf = (const uint8_t *)nvp,
+		.xdr_idx = NULL,
+		.xdr_buf_size = nvp->encoded_size
+	};
 
 	nvp_name = (nv_string_t *)((uintptr_t)nvp + sizeof (*nvp));
 	nvp_data = (nv_pair_data_t *)
@@ -1478,32 +1573,60 @@ nvpair_print(nvp_header_t *nvp, unsigned int indent)
 	printf("%s [%d] %.*s", typenames[nvp_data->nv_type],
 	    nvp_data->nv_nelem, nvp_name->nv_size, nvp_name->nv_data);
 
+	xdr.xdr_idx = nvp_data->nv_data;
 	switch (nvp_data->nv_type) {
 	case DATA_TYPE_BYTE:
 	case DATA_TYPE_INT8:
-	case DATA_TYPE_UINT8:
-		bcopy(nvp_data->nv_data, &u, sizeof (u));
-		printf(" = 0x%x\n", (unsigned char)u);
+	case DATA_TYPE_UINT8: {
+		char c;
+
+		if (xdr_char(&xdr, &c))
+			printf(" = 0x%x\n", c);
 		break;
+	}
 
 	case DATA_TYPE_INT16:
-	case DATA_TYPE_UINT16:
-		bcopy(nvp_data->nv_data, &u, sizeof (u));
-		printf(" = 0x%hx\n", (unsigned short)u);
+	case DATA_TYPE_UINT16: {
+		unsigned short u;
+
+		if (xdr_u_short(&xdr, &u))
+			printf(" = 0x%hx\n", u);
 		break;
+	}
 
 	case DATA_TYPE_BOOLEAN_VALUE:
 	case DATA_TYPE_INT32:
-	case DATA_TYPE_UINT32:
-		bcopy(nvp_data->nv_data, &u, sizeof (u));
-		printf(" = 0x%x\n", u);
+	case DATA_TYPE_UINT32: {
+		unsigned u;
+
+		if (xdr_u_int(&xdr, &u))
+			printf(" = 0x%x\n", u);
 		break;
+	}
 
 	case DATA_TYPE_INT64:
-	case DATA_TYPE_UINT64:
-		bcopy(nvp_data->nv_data, &u64, sizeof (u64));
-		printf(" = 0x%jx\n", (uintmax_t)u64);
+	case DATA_TYPE_UINT64: {
+		uint64_t u;
+
+		if (xdr_uint64(&xdr, &u))
+			printf(" = 0x%jx\n", (uintmax_t)u);
 		break;
+	}
+
+	case DATA_TYPE_INT64_ARRAY:
+	case DATA_TYPE_UINT64_ARRAY: {
+		uint64_t *u;
+
+		if (xdr_array(&xdr, nvp_data->nv_nelem,
+		    (xdrproc_t)xdr_uint64)) {
+			u = (uint64_t *)(nvp_data->nv_data + sizeof (unsigned));
+			for (i = 0; i < nvp_data->nv_nelem; i++)
+				printf(" [%u] = 0x%jx", i, (uintmax_t)u[i]);
+			printf("\n");
+		}
+
+		break;
+	}
 
 	case DATA_TYPE_STRING:
 	case DATA_TYPE_STRING_ARRAY:

--- a/usr/src/boot/sys/boot/i386/libi386/vbe.h
+++ b/usr/src/boot/sys/boot/i386/libi386/vbe.h
@@ -142,6 +142,7 @@ struct flatpanelinfo
 
 #define	CMAP_SIZE		256	/* Number of colors in palette */
 
+extern struct paletteentry pe8[CMAP_SIZE];
 extern int palette_format;
 
 /* high-level VBE helpers, from vbe.c */

--- a/usr/src/boot/sys/boot/i386/libi386/vidconsole.c
+++ b/usr/src/boot/sys/boot/i386/libi386/vidconsole.c
@@ -78,6 +78,9 @@ static vis_modechg_cb_t modechg_cb;
 static struct vis_modechg_arg *modechg_arg;
 static tem_vt_state_t tem;
 
+/* RGB colors for 8-bit depth */
+struct paletteentry pe8[CMAP_SIZE];
+
 #define	KEYBUFSZ	10
 #define	DEFAULT_FGCOLOR	7
 #define	DEFAULT_BGCOLOR	0
@@ -542,7 +545,6 @@ static int
 vidc_vbe_cons_put_cmap(struct vis_cmap *cm)
 {
 	int i, rc;
-	struct paletteentry pe;
 	rgb_t rgb;
 	uint32_t c;
 
@@ -568,8 +570,6 @@ vidc_vbe_cons_put_cmap(struct vis_cmap *cm)
 	rgb.blue.pos = gfx_fb.u.fb2.framebuffer_blue_field_position;
 	rgb.blue.size = gfx_fb.u.fb2.framebuffer_blue_mask_size;
 
-	pe.Alignment = 0;
-
 	/*
 	 * The first 16 colors need to be in VGA color order.
 	 */
@@ -582,10 +582,12 @@ vidc_vbe_cons_put_cmap(struct vis_cmap *cm)
 		} else {
 			c = rgb_color_map(&rgb, i);
 		}
-		pe.Red = (c >> rgb.red.pos) & ((1 << rgb.red.size) - 1);
-		pe.Green = (c >> rgb.green.pos) & ((1 << rgb.green.size) - 1);
-		pe.Blue = (c >> rgb.blue.pos) & ((1 << rgb.blue.size) - 1);
-		rc = vbe_set_palette(&pe, i);
+		pe8[i].Red = (c >> rgb.red.pos) & ((1 << rgb.red.size) - 1);
+		pe8[i].Green =
+		    (c >> rgb.green.pos) & ((1 << rgb.green.size) - 1);
+		pe8[i].Blue = (c >> rgb.blue.pos) & ((1 << rgb.blue.size) - 1);
+		pe8[i].Alignment = 0;
+		rc = vbe_set_palette(&pe8[i], i);
 	}
 	return (rc);
 }

--- a/usr/src/head/grp.h
+++ b/usr/src/head/grp.h
@@ -28,6 +28,8 @@
  *
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2020 Joyent, Inc.
  */
 
 #ifndef _GRP_H
@@ -62,6 +64,7 @@ extern struct group *fgetgrent_r(FILE *, struct group *, char *, int);
 
 extern struct group *fgetgrent(FILE *);		/* MT-unsafe */
 extern int initgroups(const char *, gid_t);
+extern int getgrouplist(const char *, gid_t, gid_t *, int *);
 #endif /* defined(__EXTENSIONS__) || !defined(__XOPEN_OR_POSIX) */
 
 #if defined(__EXTENSIONS__) || !defined(__XOPEN_OR_POSIX) || defined(_XPG4_2)
@@ -125,13 +128,6 @@ extern int __posix_getgrgid_r(gid_t, struct group *, char *, size_t,
 extern int __posix_getgrnam_r(const char *, struct group *, char *, size_t,
     struct group **);
 
-#ifdef __lint
-
-#define	getgrgid_r __posix_getgrgid_r
-#define	getgrnam_r __posix_getgrnam_r
-
-#else	/* !__lint */
-
 static int
 getgrgid_r(gid_t __gid, struct group *__grp, char *__buf, size_t __len,
     struct group **__res)
@@ -145,7 +141,6 @@ getgrnam_r(const char *__cb, struct group *__grp, char *__buf, size_t __len,
 	return (__posix_getgrnam_r(__cb, __grp, __buf, __len, __res));
 }
 
-#endif /* !__lint */
 #endif /* __PRAGMA_REDEFINE_EXTNAME */
 
 #else  /* (_POSIX_C_SOURCE - 0 >= 199506L) || ... */

--- a/usr/src/lib/libc/port/gen/initgroups.c
+++ b/usr/src/lib/libc/port/gen/initgroups.c
@@ -22,19 +22,20 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*	Copyright (c) 1988 AT&T	*/
 /*	  All Rights Reserved  	*/
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #pragma weak _initgroups = initgroups
 
-#include "lint.h"
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <grp.h>
+#include <limits.h>
+#include <sys/debug.h>
 #include <sys/types.h>
 #include <sys/param.h>
 #include <unistd.h>
@@ -83,4 +84,126 @@ initgroups(const char *uname, gid_t agroup)
 
 	errno = errsave;
 	return (retsave);
+}
+
+int
+getgrouplist(const char *uname, gid_t agroup, gid_t *groups, int *ngroups)
+{
+	gid_t *grouplist = NULL;
+	gid_t *grpptr;
+	long ngroups_max;
+	int sz, ret;
+
+	/*
+	 * We require sysconf(_SC_NGROUPS_MAX) either returns a sane value (>0)
+	 * or fails. If it returns 0, something has gone horribly, horribly
+	 * wrong.
+	 */
+	ngroups_max = sysconf(_SC_NGROUPS_MAX);
+	if (ngroups_max > INT_MAX)
+		ngroups_max = INT_MAX;
+	else if (ngroups_max < 0)
+		return (-1);
+	VERIFY3S(ngroups_max, >, 0);
+
+	/*
+	 * The documented behavior of getgrouplist(3C) on other platforms
+	 * (e.g. Linux and FreeBSD) do not list any failures other than
+	 * 'groups is too small'. However, examination of some popular
+	 * implementations of getgrouplist on those platforms (e.g. glibc and
+	 * musl -- both appear to share the same man page for getgrouplist(3))
+	 * show that they can in fact fail for other reasons (e.g. ENOMEM,
+	 * EIO).
+	 *
+	 * As such, we don't attempt to catch and deal with any underlying
+	 * errors here. Instead, any underlying errors cause getgrouplist(3C)
+	 * to fail, and any errno value set is left unmodified for examination
+	 * by the caller.
+	 *
+	 * One small complication is that the internal _getgroupsbymember()
+	 * itself doesn't provide any way to report back if the buffer supplied
+	 * to _getgroupsbymember() is too small. Instead, we always supply
+	 * a buffer large enough to hold _SC_NGROUPS_MAX entries -- either
+	 * by allocating one ourselves or using the user supplied buffer if
+	 * sufficiently large.
+	 *
+	 * The system behavior is undefined for any user in more groups than
+	 * _SC_NGROUPS_MAX -- initgroups(3C) for example just ignores any
+	 * excess groups (and which _SC_NGROUPS_MAX sized subset of groups end
+	 * up being set as the secondary groups is non-deterministic), so this
+	 * seems reasonable. Modifying _getgroupsbymember() would require
+	 * modification of the NSS code (due to the pervasive special handling
+	 * of _getgroupsbymember() in the NSS code) as well as modification of
+	 * all NSS backends that implement it. As there are at least a few
+	 * known third party NSS backends, we've opted to avoid doing this
+	 * for now.
+	 */
+
+	if ((ngroups == NULL) || (*ngroups <= 0) || (groups == NULL)) {
+		*ngroups = ngroups_max;
+		errno = EINVAL;
+		return (-1);
+	}
+
+	if (*ngroups < ngroups_max) {
+		/*
+		 * The caller's buffer might be too small, try to use our own
+		 * buffer instead.
+		 */
+		grouplist = calloc(ngroups_max, sizeof (gid_t));
+		if (grouplist == NULL)
+			return (-1);
+
+		grpptr = grouplist;
+		sz = ngroups_max;
+	} else {
+		/* The caller's buffer is large enough, so use it */
+		grpptr = groups;
+		sz = *ngroups;
+	}
+
+	/*
+	 * Always add agroup as the first member -- it should always appear
+	 * in the resulting list of groups, and this allows the backends to
+	 * skip adding it.
+	 */
+	grpptr[0] = agroup;
+
+	ret = _getgroupsbymember(uname, grpptr, sz, 1);
+
+	/*
+	 * We passed in 1 group entry. We should at minimum get 1 entry back
+	 * from _getgroupsbymember(). If we don't, there is a bug in the NSS
+	 * code or a backend. Since the return value is used to size a copy
+	 * further below, we hard fail (abort) here if we get back an
+	 * impossible value so we're not traipsing all over memory (which would
+	 * just make debugging any such problem all the more difficult).
+	 */
+	VERIFY3S(ret, >, 0);
+
+	/*
+	 * If we used the caller's buffer, it means its size was >= ngroups_max
+	 * entries, and we're done.
+	 */
+	if (grpptr == groups) {
+		/* Set *ngroups to the number of entries in groups */
+		*ngroups = ret;
+		return (ret);
+	}
+
+	/* We verified earlier *ngroups > 0 */
+	if (ret < *ngroups) {
+		/* Copy as many gids that will fit */
+		(void) memcpy(groups, grpptr, *ngroups * sizeof (gid_t));
+
+		*ngroups = ret;
+		ret = -1;
+		errno = ERANGE;
+	} else {
+		(void) memcpy(groups, grpptr, ret * sizeof (gid_t));
+		*ngroups = ret;
+	}
+
+	free(grouplist);
+	return (ret);
 }

--- a/usr/src/lib/libc/port/mapfile-vers
+++ b/usr/src/lib/libc/port/mapfile-vers
@@ -23,7 +23,7 @@
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2018 Nexenta Systems, Inc.
 # Copyright (c) 2012 by Delphix. All rights reserved.
-# Copyright 2018 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 # Copyright (c) 2013, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright (c) 2013 Gary Mills
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
@@ -77,6 +77,11 @@ $endif
 $if _x86 && _ELF64
 $add amd64
 $endif
+
+SYMBOL_VERSION ILLUMOS_0.38 {
+    protected:
+	getgrouplist;
+} ILLUMOS_0.37;
 
 SYMBOL_VERSION ILLUMOS_0.37 {
    global:

--- a/usr/src/man/man3c/Makefile
+++ b/usr/src/man/man3c/Makefile
@@ -14,7 +14,7 @@
 # Copyright 2018 Nexenta Systems, Inc.
 # Copyright 2013, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
-# Copyright 2018 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 # Copyright 2018 Jason King
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
@@ -172,6 +172,7 @@ MANFILES=	__fbufsize.3c					\
 		getenv.3c					\
 		getexecname.3c					\
 		getgrnam.3c					\
+		getgrouplist.3c					\
 		gethostid.3c					\
 		gethostname.3c					\
 		gethrtime.3c					\

--- a/usr/src/man/man3c/getgrouplist.3c
+++ b/usr/src/man/man3c/getgrouplist.3c
@@ -1,0 +1,207 @@
+.\"
+.\" This file and its contents are supplied under the terms of the
+.\" Common Development and Distribution License ("CDDL"), version 1.0.
+.\" You may only use this file in accordance with the terms of version
+.\" 1.0 of the CDDL.
+.\"
+.\" A full copy of the text of the CDDL should have accompanied this
+.\" source.  A copy of the CDDL is also available via the Internet at
+.\" http://www.illumos.org/license/CDDL.
+.\"
+.\"
+.\" Copyright 2020 Joyent, Inc.
+.\"
+.Dd November 22, 2020
+.Dt GETGROUPLIST 3C
+.Os
+.Sh NAME
+.Nm getgrouplist
+.Nd calculate group access list
+.Sh SYNOPSIS
+.In grp.h
+.Ft int
+.Fo getgrouplist
+.Fa "const char *user"
+.Fa "gid_t agroup"
+.Fa "gid_t *groups"
+.Fa "int *ngroups"
+.Fc
+.Sh DESCRIPTION
+The
+.Fn getgrouplist
+function queries the group database to obtain the list of groups that
+.Fa user
+belongs to.
+The
+.Fa agroup
+group is always added to the resulting group list.
+This value is typically the primary gid of the user from the
+.Sy passwd
+database.
+.Pp
+When calling
+.Fn getgrouplist ,
+the caller should set the maximum number of groups that
+.Fa groups
+can hold in
+.Fa *ngroups .
+The value of
+.Dv NGROUPS_MAX
+can be used to size
+.Fa groups
+to ensure it can hold any number of groups supported by the system.
+.Pp
+Upon return,
+.Fn getgrouplist
+stores the list of groups that
+.Fa user
+belongs to in
+.Fa groups
+and stores the number of groups
+.Fa user
+belongs to in
+.Fa *ngroups
+.Po
+this may be a smaller than the value passed in when
+calling
+.Fn getgrouplist
+.Pc .
+If
+.Fa groups
+is too small to hold all of the groups
+.Fa user
+belongs to,
+.Fn getgrouplist
+fails and sets
+.Fa *ngroups
+to a value large enough to hold the full result.
+.Sh RETURN VALUES
+On success,
+.Fn getgrouplist
+returns the number of groups
+.Fa user
+belongs to, fills in
+.Fa groups
+with the gids of the groups
+.Fa user
+belongs to, and also sets
+.Fa *ngroups
+to the number of groups
+.Fa user
+belongs to.
+.Pp
+On failure,
+.Fn getgrouplist
+returns -1 and
+.Va errno
+is set.
+.Pp
+The behavior of
+.Fn getgrouplist
+is undefined if the total number of groups a user belongs to exceeds
+.Dv NGROUPS_MAX .
+.Pp
+Note that on
+.Fx ,
+.Fn getgrouplist
+always returns -1 on failure or 0 on success.
+A caller must rely on the value set in
+.Fa *ngroups
+upon return to determine the number of entries in
+.Fa groups .
+.Pp
+On Linux, both glibc and musl return the number of groups
+.Fa user
+belongs to on success and returns -1 on failure.
+.Pp
+None of these other implementations document any
+.Va errno
+values on failure, however their implementations show that
+.Va errno
+may be set on failure.
+Software using
+.Fn getgrouplist
+should be aware of these differences when attemping to write portable
+software.
+.Sh EXAMPLES
+.Sy Example 1
+Print all the groups for a user.
+.Bd -literal
+#include <pwd.h>
+#include <grp.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+#include <err.h>
+
+void
+printgroups(const char *user)
+{
+    struct passwd *pw;
+    gid_t *groups;
+    int ngroups, ret;
+
+    if ((groups = calloc(NGROUPS_MAX, sizeof (gid_t))) == NULL)
+        err(EXIT_FAILURE, "calloc");
+
+    if ((pw = getpwnam(user)) == NULL)
+        err(EXIT_FAILURE, "getpwname");
+
+    ngroups = NGROUPS_MAX;
+    ret = getgrouplist(user, pw->pw_gid, groups, &ngroups);
+    if (ret < 0)
+        err(EXIT_FAILURE, "getgrouplist");
+
+    for (int i = 0; i < ret; i++) {
+        struct group *gr = getgrgid(groups[i]);
+
+        (void) printf("%s ", gr->gr_name);
+    }
+    (void) fputc('\\n', stdout);
+
+    free(groups);
+}
+.Ed
+.Sh ERRORS
+On failure,
+.Fn getgrouplist
+returns -1, and will set errno to one one of the following values:
+.Bl -tag -width Dv
+.It Er ENOMEM
+Not enough memory to complete the request.
+.It Er EINVAL
+One of the parameters is invalid
+.Po
+for example,
+.Fa ngroups
+is
+.Dv NULL
+.Pc .
+.It Dv ERANGE
+The supplied value of
+.Fa *ngroups
+is too small to hold the results.
+.Fa *ngroups
+is set
+.Po
+upon return
+.Pc
+to a value large enough to hold the results, and a partial set of
+results is written to
+.Fa groups .
+The value written to
+.Fa *ngroups
+may be larger than the value returned by a successful call to
+.Fn getgrouplist .
+.El
+.Sh INTERFACE STABILITY
+.Sy Uncommitted
+.Sh MT-LEVEL
+.Sy MT-Safe
+.Sh SEE ALSO
+.Xr groups 1 ,
+.Xr getuid 2 ,
+.Xr getgrnam 3C ,
+.Xr getgroups 3C ,
+.Xr initgroups 3C ,
+.Xr limits.h 3HEAD

--- a/usr/src/pkg/manifests/system-library.man3c.inc
+++ b/usr/src/pkg/manifests/system-library.man3c.inc
@@ -15,7 +15,7 @@
 # Copyright 2013 OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
 # Copyright 2018 Jason King
-# Copyright 2018, Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
@@ -168,6 +168,7 @@ file path=usr/share/man/man3c/getentropy.3c
 file path=usr/share/man/man3c/getenv.3c
 file path=usr/share/man/man3c/getexecname.3c
 file path=usr/share/man/man3c/getgrnam.3c
+file path=usr/share/man/man3c/getgrouplist.3c
 file path=usr/share/man/man3c/gethostid.3c
 file path=usr/share/man/man3c/gethostname.3c
 file path=usr/share/man/man3c/gethrtime.3c

--- a/usr/src/uts/common/io/aggr/aggr_grp.c
+++ b/usr/src/uts/common/io/aggr/aggr_grp.c
@@ -607,6 +607,8 @@ aggr_grp_add_port(aggr_grp_t *grp, datalink_id_t port_linkid, boolean_t force,
 	port->lp_grp = grp;
 	AGGR_GRP_REFHOLD(grp);
 	grp->lg_nports++;
+	if (grp->lg_nports > grp->lg_nports_high)
+		grp->lg_nports_high = grp->lg_nports;
 
 	aggr_lacp_init_port(port);
 	mac_perim_exit(mph);
@@ -675,7 +677,7 @@ aggr_add_pseudo_rx_ring(aggr_port_t *port,
 	 * No slot for this new RX ring.
 	 */
 	if (j == MAX_RINGS_PER_GROUP)
-		return (EIO);
+		return (ENOSPC);
 
 	ring->arr_flags |= MAC_PSEUDO_RING_INUSE;
 	ring->arr_hw_rh = hw_rh;
@@ -884,7 +886,7 @@ aggr_add_pseudo_tx_ring(aggr_port_t *port,
 	 * No slot for this new TX ring.
 	 */
 	if (i == MAX_RINGS_PER_GROUP)
-		return (EIO);
+		return (ENOSPC);
 	/*
 	 * The following 4 statements needs to be done before
 	 * calling mac_group_add_ring(). Otherwise it will
@@ -948,13 +950,17 @@ aggr_rem_pseudo_tx_ring(aggr_pseudo_tx_group_t *tx_grp,
  * rings of the aggr and the hardware rings of the underlying port.
  */
 static int
-aggr_add_pseudo_tx_group(aggr_port_t *port, aggr_pseudo_tx_group_t *tx_grp)
+aggr_add_pseudo_tx_group(aggr_port_t *port, aggr_pseudo_tx_group_t *tx_grp,
+    uint_t limit)
 {
 	aggr_grp_t		*grp = port->lp_grp;
 	mac_ring_handle_t	hw_rh[MAX_RINGS_PER_GROUP], pseudo_rh;
 	mac_perim_handle_t	pmph;
 	int			hw_rh_cnt, i = 0, j;
 	int			err = 0;
+
+	if (limit == 0)
+		return (ENOSPC);
 
 	ASSERT(MAC_PERIM_HELD(grp->lg_mh));
 	mac_perim_enter_by_mh(port->lp_mh, &pmph);
@@ -973,12 +979,13 @@ aggr_add_pseudo_tx_group(aggr_port_t *port, aggr_pseudo_tx_group_t *tx_grp)
 	if (hw_rh_cnt == 0)
 		port->lp_tx_ring_cnt = 1;
 	else
-		port->lp_tx_ring_cnt = hw_rh_cnt;
+		port->lp_tx_ring_cnt = MIN(hw_rh_cnt, limit);
 
+	port->lp_tx_ring_alloc = port->lp_tx_ring_cnt;
 	port->lp_tx_rings = kmem_zalloc((sizeof (mac_ring_handle_t *) *
-	    port->lp_tx_ring_cnt), KM_SLEEP);
+	    port->lp_tx_ring_alloc), KM_SLEEP);
 	port->lp_pseudo_tx_rings = kmem_zalloc((sizeof (mac_ring_handle_t *) *
-	    port->lp_tx_ring_cnt), KM_SLEEP);
+	    port->lp_tx_ring_alloc), KM_SLEEP);
 
 	if (hw_rh_cnt == 0) {
 		if ((err = aggr_add_pseudo_tx_ring(port, tx_grp,
@@ -987,7 +994,7 @@ aggr_add_pseudo_tx_group(aggr_port_t *port, aggr_pseudo_tx_group_t *tx_grp)
 			port->lp_pseudo_tx_rings[0] = pseudo_rh;
 		}
 	} else {
-		for (i = 0; err == 0 && i < hw_rh_cnt; i++) {
+		for (i = 0; err == 0 && i < port->lp_tx_ring_cnt; i++) {
 			err = aggr_add_pseudo_tx_ring(port,
 			    tx_grp, hw_rh[i], &pseudo_rh);
 			if (err != 0)
@@ -1005,10 +1012,11 @@ aggr_add_pseudo_tx_group(aggr_port_t *port, aggr_pseudo_tx_group_t *tx_grp)
 			}
 		}
 		kmem_free(port->lp_tx_rings,
-		    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_cnt));
+		    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_alloc));
 		kmem_free(port->lp_pseudo_tx_rings,
-		    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_cnt));
+		    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_alloc));
 		port->lp_tx_ring_cnt = 0;
+		port->lp_tx_ring_alloc = 0;
 	} else {
 		port->lp_tx_grp_added = B_TRUE;
 		port->lp_tx_notify_mh = mac_client_tx_notify(port->lp_mch,
@@ -1042,9 +1050,9 @@ aggr_rem_pseudo_tx_group(aggr_port_t *port, aggr_pseudo_tx_group_t *tx_grp)
 		aggr_rem_pseudo_tx_ring(tx_grp, port->lp_pseudo_tx_rings[i]);
 
 	kmem_free(port->lp_tx_rings,
-	    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_cnt));
+	    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_alloc));
 	kmem_free(port->lp_pseudo_tx_rings,
-	    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_cnt));
+	    (sizeof (mac_ring_handle_t *) * port->lp_tx_ring_alloc));
 
 	port->lp_tx_ring_cnt = 0;
 	(void) mac_client_tx_notify(port->lp_mch, NULL, port->lp_tx_notify_mh);
@@ -1111,6 +1119,48 @@ aggr_pseudo_stop_rx_ring(mac_ring_driver_t arg)
 }
 
 /*
+ * Trim each port in a group to ensure it uses no more than tx_ring_limit
+ * rings.
+ */
+static void
+aggr_grp_balance_tx(aggr_grp_t *grp, uint_t tx_ring_limit)
+{
+	aggr_port_t *port;
+	mac_perim_handle_t mph;
+	uint_t i, tx_ring_cnt;
+
+	ASSERT(tx_ring_limit > 0);
+	ASSERT(MAC_PERIM_HELD(grp->lg_mh));
+
+	for (port = grp->lg_ports; port != NULL; port = port->lp_next) {
+		mac_perim_enter_by_mh(port->lp_mh, &mph);
+
+		/*
+		 * Reduce the Tx ring count first to prevent rings being
+		 * used as they are removed.
+		 */
+		rw_enter(&grp->lg_tx_lock, RW_WRITER);
+		if (port->lp_tx_ring_cnt <= tx_ring_limit) {
+			rw_exit(&grp->lg_tx_lock);
+			mac_perim_exit(mph);
+			continue;
+		}
+
+		tx_ring_cnt = port->lp_tx_ring_cnt;
+		port->lp_tx_ring_cnt = tx_ring_limit;
+		rw_exit(&grp->lg_tx_lock);
+
+		for (i = tx_ring_cnt - 1; i >= tx_ring_limit; i--) {
+			aggr_rem_pseudo_tx_ring(&grp->lg_tx_group,
+			    port->lp_pseudo_tx_rings[i]);
+
+		}
+
+		mac_perim_exit(mph);
+	}
+}
+
+/*
  * Add one or more ports to an existing link aggregation group.
  */
 int
@@ -1120,6 +1170,7 @@ aggr_grp_add_ports(datalink_id_t linkid, uint_t nports, boolean_t force,
 	int rc;
 	uint_t port_added = 0;
 	uint_t grp_added;
+	uint_t nports_high, tx_ring_limit;
 	aggr_grp_t *grp = NULL;
 	aggr_port_t *port;
 	boolean_t link_state_changed = B_FALSE;
@@ -1139,6 +1190,24 @@ aggr_grp_add_ports(datalink_id_t linkid, uint_t nports, boolean_t force,
 	 */
 	mac_perim_enter_by_mh(grp->lg_mh, &mph);
 	rw_exit(&aggr_grp_lock);
+
+	/*
+	 * Limit the number of Tx rings per port. When determining the
+	 * number of ports take into consideration the existing high
+	 * value, and what the new high value may be after this request.
+	 */
+	nports_high = MAX(grp->lg_nports_high, grp->lg_nports + nports);
+	tx_ring_limit = MAX_RINGS_PER_GROUP / nports_high;
+
+	if (tx_ring_limit == 0) {
+		rc = ENOSPC;
+		goto bail;
+	}
+
+	/*
+	 * Balance the Tx rings so each port has a fair share of rings.
+	 */
+	aggr_grp_balance_tx(grp, tx_ring_limit);
 
 	/* Add the specified ports to the aggr. */
 	for (uint_t i = 0; i < nports; i++) {
@@ -1164,7 +1233,8 @@ aggr_grp_add_ports(datalink_id_t linkid, uint_t nports, boolean_t force,
 		 * Create the pseudo ring for each HW ring of the underlying
 		 * port.
 		 */
-		rc = aggr_add_pseudo_tx_group(port, &grp->lg_tx_group);
+		rc = aggr_add_pseudo_tx_group(port, &grp->lg_tx_group,
+		    tx_ring_limit);
 		if (rc != 0)
 			goto bail;
 
@@ -1374,11 +1444,15 @@ aggr_grp_create(datalink_id_t linkid, uint32_t key, uint_t nports,
 {
 	aggr_grp_t *grp = NULL;
 	aggr_port_t *port;
+	aggr_port_t *last_attached = NULL;
 	mac_register_t *mac;
 	boolean_t link_state_changed;
-	mac_perim_handle_t mph;
+	mac_perim_handle_t mph, pmph;
+	datalink_id_t tempid;
+	boolean_t mac_registered = B_FALSE;
+	uint_t tx_ring_limit;
 	int err;
-	int i;
+	int i, j;
 	kt_did_t tid = 0;
 
 	/* need at least one port */
@@ -1525,6 +1599,8 @@ aggr_grp_create(datalink_id_t linkid, uint32_t key, uint_t nports,
 		goto bail;
 	}
 
+	mac_registered = B_TRUE;
+
 	mac_perim_enter_by_mh(grp->lg_mh, &mph);
 
 	/*
@@ -1546,6 +1622,25 @@ aggr_grp_create(datalink_id_t linkid, uint32_t key, uint_t nports,
 	aggr_lacp_set_mode(grp, lacp_mode, lacp_timer);
 
 	/*
+	 * The pseudo Tx group holds a maximum of MAX_RINGS_PER_GROUP
+	 * rings, when all the Tx rings of all the ports are accumulated
+	 * it is conceivable this limit is exceeded. We try and prevent
+	 * this by limiting the number of rings an individual port will use.
+	 *
+	 * - When an aggr is first created, we will not let an
+	 *   individual port use more than MAX_RINGS_PER_GROUP/nports
+	 *   rings.
+	 * - As ports are added to an existing aggr, each of the
+	 *   ports will not use more than MAX_RINGS_PER_GROUP/nports_high.
+	 *   Where nports_high is the highest number of ports the aggr has
+	 *   held (including any ports being added). This may involve
+	 *   trimming rings from existing ports.
+	 */
+
+	/* Leave room for 4 ports */
+	tx_ring_limit = MAX_RINGS_PER_GROUP / MAX(4, nports);
+
+	/*
 	 * Attach each port if necessary.
 	 */
 	for (port = grp->lg_ports; port != NULL; port = port->lp_next) {
@@ -1554,12 +1649,34 @@ aggr_grp_create(datalink_id_t linkid, uint32_t key, uint_t nports,
 		 * underlying port. Note that this is done after the
 		 * aggr registers its MAC.
 		 */
-		VERIFY3S(aggr_add_pseudo_tx_group(port, &grp->lg_tx_group),
-		    ==, 0);
+		err = aggr_add_pseudo_tx_group(port, &grp->lg_tx_group,
+		    tx_ring_limit);
+
+		if (err != 0) {
+			mac_perim_exit(mph);
+			goto bail;
+		}
 
 		for (i = 0; i < grp->lg_rx_group_count; i++) {
-			VERIFY3S(aggr_add_pseudo_rx_group(port,
-			    &grp->lg_rx_groups[i]), ==, 0);
+			err = aggr_add_pseudo_rx_group(port,
+			    &grp->lg_rx_groups[i]);
+
+			if (err != 0) {
+				/*
+				 * Undo what we have added for the current
+				 * port.
+				 */
+				aggr_rem_pseudo_tx_group(port,
+				    &grp->lg_tx_group);
+
+				for (j = 0; j < i; j++) {
+					aggr_rem_pseudo_rx_group(port,
+					    &grp->lg_rx_groups[j]);
+				}
+
+				mac_perim_exit(mph);
+				goto bail;
+			}
 		}
 
 		if (aggr_port_notify_link(grp, port))
@@ -1569,6 +1686,8 @@ aggr_grp_create(datalink_id_t linkid, uint32_t key, uint_t nports,
 		 * Initialize the callback functions for this port.
 		 */
 		aggr_port_init_callbacks(port);
+
+		last_attached = port;
 	}
 
 	if (link_state_changed)
@@ -1585,17 +1704,7 @@ aggr_grp_create(datalink_id_t linkid, uint32_t key, uint_t nports,
 	return (0);
 
 bail:
-
 	grp->lg_closing = B_TRUE;
-
-	port = grp->lg_ports;
-	while (port != NULL) {
-		aggr_port_t *cport;
-
-		cport = port->lp_next;
-		aggr_port_delete(port);
-		port = cport;
-	}
 
 	/*
 	 * Inform the lacp_rx thread to exit.
@@ -1618,6 +1727,47 @@ bail:
 	mutex_exit(&grp->lg_tx_flowctl_lock);
 	if (tid != 0)
 		thread_join(tid);
+
+	if (mac_registered) {
+		(void) dls_devnet_destroy(grp->lg_mh, &tempid, B_TRUE);
+		(void) mac_disable(grp->lg_mh);
+
+		if (last_attached != NULL) {
+			/*
+			 * Detach and clean up ports added.
+			 */
+			mac_perim_enter_by_mh(grp->lg_mh, &mph);
+
+			for (port = grp->lg_ports; ; port = port->lp_next) {
+				mac_perim_enter_by_mh(port->lp_mh, &pmph);
+				(void) aggr_grp_detach_port(grp, port);
+				mac_perim_exit(pmph);
+
+				aggr_rem_pseudo_tx_group(port,
+				    &grp->lg_tx_group);
+
+				for (i = 0; i < grp->lg_rx_group_count; i++) {
+					aggr_rem_pseudo_rx_group(port,
+					    &grp->lg_rx_groups[i]);
+				}
+				if (port == last_attached)
+					break;
+			}
+
+			mac_perim_exit(mph);
+		}
+
+		(void) mac_unregister(grp->lg_mh);
+	}
+
+	port = grp->lg_ports;
+	while (port != NULL) {
+		aggr_port_t *cport;
+
+		cport = port->lp_next;
+		aggr_port_delete(port);
+		port = cport;
+	}
 
 	kmem_free(grp->lg_tx_blocked_rings,
 	    (sizeof (mac_ring_handle_t *) * MAX_RINGS_PER_GROUP));

--- a/usr/src/uts/common/io/mlxcx/mlxcx.c
+++ b/usr/src/uts/common/io/mlxcx/mlxcx.c
@@ -2874,10 +2874,14 @@ mlxcx_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	}
 	mlxp->mlx_attach |= MLXCX_ATTACH_CHKTIMERS;
 
-	if (!mlxcx_setup_sensors(mlxp)) {
-		goto err;
+	/*
+	 * Some devices may not have a working temperature sensor; however,
+	 * there isn't a great way for us to know. We shouldn't fail attach if
+	 * this doesn't work.
+	 */
+	if (mlxcx_setup_sensors(mlxp)) {
+		mlxp->mlx_attach |= MLXCX_ATTACH_SENSORS;
 	}
-	mlxp->mlx_attach |= MLXCX_ATTACH_SENSORS;
 
 	/*
 	 * Finally, tell MAC that we exist!

--- a/usr/src/uts/common/sys/aggr_impl.h
+++ b/usr/src/uts/common/sys/aggr_impl.h
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  * Copyright 2012 OmniTI Computer Consulting, Inc  All rights reserved.
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2020 RackTop Systems, Inc.
  */
 
 #ifndef	_SYS_AGGR_IMPL_H
@@ -161,7 +162,8 @@ typedef struct aggr_port_s {
 	 */
 	mac_group_handle_t	lp_hwghs[MAX_GROUPS_PER_PORT];
 
-	int			lp_tx_ring_cnt;
+	uint_t			lp_tx_ring_alloc;
+	uint_t			lp_tx_ring_cnt;
 	/* handles of the underlying HW TX rings */
 	mac_ring_handle_t	*lp_tx_rings;
 	/*
@@ -195,6 +197,7 @@ typedef struct aggr_grp_s {
 	uint16_t	lg_key;			/* key (group port number) */
 	uint32_t	lg_refs;		/* refcount */
 	uint16_t	lg_nports;		/* number of MAC ports */
+	uint16_t	lg_nports_high;		/* highest no. of MAC ports */
 	uint8_t		lg_addr[ETHERADDRL];	/* group MAC address */
 	uint16_t
 			lg_closing : 1,

--- a/usr/src/uts/i86pc/io/vmm/vmm_lapic.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_lapic.c
@@ -38,6 +38,7 @@
  * http://www.illumos.org/license/CDDL.
  *
  * Copyright 2014 Pluribus Networks Inc.
+ * Copyright 2020 Oxide Computer Company
  */
 
 #include <sys/cdefs.h>
@@ -127,19 +128,18 @@ lapic_intr_msi(struct vm *vm, uint64_t addr, uint64_t msg)
 	}
 
 	/*
-	 * Extract the x86-specific fields from the MSI addr/msg
-	 * params according to the Intel Arch spec, Vol3 Ch 10.
+	 * Extract the x86-specific fields from the MSI addr/msg params
+	 * according to the Intel Arch spec, Vol3 Ch 10.
 	 *
-	 * The PCI specification does not support level triggered
-	 * MSI/MSI-X so ignore trigger level in 'msg'.
+	 * The PCI specification does not support level triggered MSI/MSI-X so
+	 * ignore trigger level in 'msg'.
 	 *
-	 * The 'dest' is interpreted as a logical APIC ID if both
-	 * the Redirection Hint and Destination Mode are '1' and
-	 * physical otherwise.
+	 * Certain kinds of interrupt broadcasts (physical or logical-clustered
+	 * for destination 0xff) are prohibited when the redirection hint bit is
+	 * set for a given message.  Those edge cases are ignored for now.
 	 */
 	dest = (addr >> 12) & 0xff;
-	phys = ((addr & (MSI_X86_ADDR_RH | MSI_X86_ADDR_LOG)) !=
-	    (MSI_X86_ADDR_RH | MSI_X86_ADDR_LOG));
+	phys = (addr & MSI_X86_ADDR_LOG) == 0;
 	delmode = msg & APIC_DELMODE_MASK;
 	vec = msg & 0xff;
 


### PR DESCRIPTION
Weekly upstream merge from illumos-gate

## Backports to r36

* 13207 Creating an aggr with more than 128 Tx or Rx rings panics
* 13208 Create aggr fails when underlying links have more than 128 Tx

## onu

```
OmniOS r151037  omnios-upstream_merge-2020121301-caba67bdea     December 2020
illumos development build: 2020-Dec-13 [illumos-omnios]
You have new mail.
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2020121301-caba67bdea i86pc i386 i86pc
```

## mail_msg

```
==== Nightly distributed build started:   Sun Dec 13 12:26:18 CET 2020 ====
==== Nightly distributed build completed: Sun Dec 13 13:45:09 CET 2020 ====

==== Total build time ====

real    1:18:51

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-0d048edc02 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151037/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.9+11-omnios-151037"

/usr/bin/openssl
OpenSSL 1.1.1i  8 Dec 2020
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1763 (illumos)

Build project:  default
Build taskid:   82

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2020121301-caba67bdea

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    35:43.5
user  3:30:56.9
sys     38:49.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    30:39.5
user  2:59:43.9
sys     33:48.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```