### PR TITLE
Clean up gexec calls with EBA_NONE

### DIFF
--- a/usr/src/uts/common/exec/java/java.c
+++ b/usr/src/uts/common/exec/java/java.c
@@ -89,7 +89,7 @@ javaexec(vnode_t *vp, struct execa *uap, struct uarg *args,
     caddr_t execfile, cred_t *cred, int *brand_action)
 {
 	struct intpdata idata;
-	int error;
+	int error, eba;
 	ssize_t resid;
 	vnode_t *nvp;
 	off_t xoff, xoff_end;
@@ -160,8 +160,9 @@ javaexec(vnode_t *vp, struct execa *uap, struct uarg *args,
 	args->pathname = resolvepn.pn_path;
 	/* don't free resolvepn until we are done with args */
 	pn_free(&lookpn);
-	error = gexec(&nvp, uap, args, &idata, level + 1, execsz, execfile,
-	    cred, EBA_NONE);
+	eba = EBA_NONE;
+	error = gexec(&nvp, uap, args, &idata, level + 1, execsz,
+	    execfile, cred, &eba);
 
 	if (!error) {
 		/*

--- a/usr/src/uts/common/exec/shbin/shbin.c
+++ b/usr/src/uts/common/exec/shbin/shbin.c
@@ -167,7 +167,7 @@ shbinexec(
 {
 	_NOTE(ARGUNUSED(brand_action))
 	vnode_t *nvp;
-	int error = 0;
+	int error = 0, eba;
 	struct intpdata idata;
 	struct pathname intppn;
 	struct pathname resolvepn;
@@ -246,8 +246,9 @@ shbinexec(
 		args->fname = devfd;
 	}
 
+	eba = EBA_NONE;
 	error = gexec(&nvp, uap, args, &idata, ++level, execsz, exec_file, cred,
-	    EBA_NONE);
+	    &eba);
 
 	if (!error) {
 		/*


### PR DESCRIPTION
8c602d87c1bc4bcf5f1c0cecae5814216f42b473 changed the format of gexec()'s `brand_action` parameter.
This fixes a couple of places which were missed at the time.