### PR TITLE
LX: Use sensible defaults for RLIMIT_NPROC and max-threads

### DIFF
--- a/usr/src/uts/common/brand/lx/syscall/lx_rlimit.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_rlimit.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2017 Joyent, Inc.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/systm.h>
@@ -20,6 +21,8 @@
 #include <sys/cmn_err.h>
 #include <sys/lx_impl.h>
 #include <sys/lx_brand.h>
+#include <sys/sysmacros.h>
+#include <sys/var.h>
 
 #define	LX_RLIMIT_CPU		0
 #define	LX_RLIMIT_FSIZE		1
@@ -166,8 +169,15 @@ lx_getrlimit_common(int lx_resource, uint64_t *rlim_curp, uint64_t *rlim_maxp)
 		break;
 
 	case LX_RLIMIT_NPROC:
-		/*  zone.max-lwps */
-		rlim64.rlim_cur = rlim64.rlim_max = curzone->zone_nlwps_ctl;
+		/*
+		 * This is a limit on the number of processes for a
+		 * real user ID (not enforced for privileged processes).
+		 *
+		 * This is analagous to v.v_maxup but is further capped
+		 * by zone.max-lwps
+		 */
+		rlim64.rlim_cur = rlim64.rlim_max =
+		    MIN(v.v_maxup, curzone->zone_nlwps_ctl);
 		break;
 
 	case LX_RLIMIT_MEMLOCK:


### PR DESCRIPTION
At present, if an lx zone is configured without a cap on the number of LWPs, the emulated Linux `max-threads` and `RLIMIT_NPROC`/`CHILD_MAX` values are set to INT_MAX. This is much higher than would be returned on a real Linux system and is sometimes used directly by software in order to determine how much memory to allocate, which usually causes it to fail.

(For example, debugging a crash here https://github.com/illumos/ast/blob/illumos/2012-08-01/src/cmd/ksh93/sh/jobs.c#L1341 led me to this)

Here's some output from a zone which has no caps set, on a host with 16GB of RAM:

```
# prlimit -m
RESOURCE DESCRIPTION                  SOFT        HARD UNITS
RSS      max resident set size 17142702080 17142702080 bytes

# prlimit -u
RESOURCE DESCRIPTION                   SOFT       HARD UNITS
NPROC    max number of processes 2147483647 2147483647 processes

# getconf CHILD_MAX
2147483647

# sysctl kernel.threads-max
kernel.threads-max = 2147483647
```

There's another problem here. Linux sets RLIMIT_NPROC/CHILD_MAX to half of threads-max, whereas the lx brand uses the same value for both - either INT_MAX or the max-lwps zone cap.

Linux sets `max-threads` to be half the number of physical memory pages, it seems reasonable that we should do the same in the absence of a configured cap, using either the physical memory cap from the zone configuration or otherwise from the host. There's no additional information leakage here since, in the absence of a physical memory cap, the host memory size is already exposed to the zone.

With this change in place, a zone with no caps on a 16GB host shows:

```
root@lx:~# prlimit -m
RESOURCE DESCRIPTION                  SOFT        HARD UNITS
RSS      max resident set size 17161994240 17161994240 bytes
root@lx:~# prlimit -u
RESOURCE DESCRIPTION               SOFT   HARD UNITS
NPROC    max number of processes 523742 523742 processes
root@lx:~# getconf CHILD_MAX
523742
root@lx:~# sysctl kernel.threads-max
kernel.threads-max = 1047485
```

With a max-lwps cap of 8192:

```
root@lx:~# prlimit -u
RESOURCE DESCRIPTION             SOFT HARD UNITS
NPROC    max number of processes 4096 4096 processes
root@lx:~# getconf CHILD_MAX
4096
root@lx:~# sysctl kernel.threads-max
kernel.threads-max = 8192
```

With a max-lwps cap of 8192, and a memory cap of 2GB:

```
root@lx:~# prlimit -m
RESOURCE DESCRIPTION                 SOFT       HARD UNITS
RSS      max resident set size 2147483648 2147483648 bytes
root@lx:~# prlimit -u
RESOURCE DESCRIPTION             SOFT HARD UNITS
NPROC    max number of processes 4096 4096 processes
root@lx:~# sysctl kernel.threads-max
kernel.threads-max = 8192
```

and just with the memory cap of 2GB (no LWP cap):

```
root@lx:~# prlimit -m
RESOURCE DESCRIPTION                 SOFT       HARD UNITS
RSS      max resident set size 2147483648 2147483648 bytes
root@lx:~# prlimit -u
RESOURCE DESCRIPTION              SOFT  HARD UNITS
NPROC    max number of processes 65536 65536 processes
root@lx:~# getconf CHILD_MAX
65536
root@lx:~# sysctl kernel.threads-max
kernel.threads-max = 131072
```
