### PR TITLE
LX: Incorrect RLIMIT_NPROC causing some software to fail

### DIFF
--- a/usr/src/cmd/zoneadmd/vplat.c
+++ b/usr/src/cmd/zoneadmd/vplat.c
@@ -1085,23 +1085,10 @@ mount_one_dev_symlink_cb(void *arg, const char *source, const char *target)
 int
 vplat_get_iptype(zlog_t *zlogp, zone_iptype_t *iptypep)
 {
-	zone_dochandle_t handle;
-
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
-	if (zonecfg_get_iptype(handle, iptypep) != Z_OK) {
+	if (zonecfg_get_iptype(snap_hndl, iptypep) != Z_OK) {
 		zerror(zlogp, B_FALSE, "invalid ip-type configuration");
-		zonecfg_fini_handle(handle);
 		return (-1);
 	}
-	zonecfg_fini_handle(handle);
 	return (0);
 }
 
@@ -1114,7 +1101,6 @@ static int
 mount_one_dev(zlog_t *zlogp, char *devpath, zone_mnt_t mount_cmd)
 {
 	char			brand[MAXNAMELEN];
-	zone_dochandle_t	handle = NULL;
 	brand_handle_t		bh = NULL;
 	struct zone_devtab	ztab;
 	di_prof_t		prof = NULL;
@@ -1170,28 +1156,19 @@ mount_one_dev(zlog_t *zlogp, char *devpath, zone_mnt_t mount_cmd)
 	}
 
 	/* Add user-specified devices and directories */
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_FALSE, "can't initialize zone handle");
-		goto cleanup;
-	}
-	if ((err = zonecfg_get_handle(zone_name, handle)) != 0) {
-		zerror(zlogp, B_FALSE, "can't get handle for zone "
-		    "%s: %s", zone_name, zonecfg_strerror(err));
-		goto cleanup;
-	}
-	if ((err = zonecfg_setdevent(handle)) != 0) {
+	if ((err = zonecfg_setdevent(snap_hndl)) != 0) {
 		zerror(zlogp, B_FALSE, "%s: %s", zone_name,
 		    zonecfg_strerror(err));
 		goto cleanup;
 	}
-	while (zonecfg_getdevent(handle, &ztab) == Z_OK) {
+	while (zonecfg_getdevent(snap_hndl, &ztab) == Z_OK) {
 		if (di_prof_add_dev(prof, ztab.zone_dev_match)) {
 			zerror(zlogp, B_TRUE, "failed to add "
 			    "user-specified device");
 			goto cleanup;
 		}
 	}
-	(void) zonecfg_enddevent(handle);
+	(void) zonecfg_enddevent(snap_hndl);
 
 	/* Send profile to kernel */
 	if (di_prof_commit(prof)) {
@@ -1204,8 +1181,6 @@ mount_one_dev(zlog_t *zlogp, char *devpath, zone_mnt_t mount_cmd)
 cleanup:
 	if (bh != NULL)
 		brand_close(bh);
-	if (handle != NULL)
-		zonecfg_fini_handle(handle);
 	if (prof)
 		di_prof_fini(prof);
 	return (retval);
@@ -1700,7 +1675,6 @@ mount_filesystems(zlog_t *zlogp, zone_mnt_t mount_cmd)
 	char luroot[MAXPATHLEN];
 	int i, num_fs = 0;
 	struct zone_fstab *fs_ptr = NULL;
-	zone_dochandle_t handle = NULL;
 	zone_state_t zstate;
 	brand_handle_t bh;
 	plat_gmount_cb_data_t cb;
@@ -1719,12 +1693,7 @@ mount_filesystems(zlog_t *zlogp, zone_mnt_t mount_cmd)
 		goto bad;
 	}
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		goto bad;
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK ||
-	    zonecfg_setfsent(handle) != Z_OK) {
+	if (zonecfg_setfsent(snap_hndl) != Z_OK) {
 		zerror(zlogp, B_FALSE, "invalid configuration");
 		goto bad;
 	}
@@ -1742,7 +1711,6 @@ mount_filesystems(zlog_t *zlogp, zone_mnt_t mount_cmd)
 	/* Get a handle to the brand info for this zone */
 	if ((bh = brand_open(brand)) == NULL) {
 		zerror(zlogp, B_FALSE, "unable to determine zone brand");
-		zonecfg_fini_handle(handle);
 		return (-1);
 	}
 
@@ -1757,7 +1725,6 @@ mount_filesystems(zlog_t *zlogp, zone_mnt_t mount_cmd)
 	    plat_gmount_cb, &cb) != 0) {
 		zerror(zlogp, B_FALSE, "unable to mount filesystems");
 		brand_close(bh);
-		zonecfg_fini_handle(handle);
 		return (-1);
 	}
 	brand_close(bh);
@@ -1768,12 +1735,9 @@ mount_filesystems(zlog_t *zlogp, zone_mnt_t mount_cmd)
 	 * higher level directories (e.g., /usr) get mounted before
 	 * any beneath them (e.g., /usr/local).
 	 */
-	if (mount_filesystems_fsent(handle, zlogp, &fs_ptr, &num_fs,
+	if (mount_filesystems_fsent(snap_hndl, zlogp, &fs_ptr, &num_fs,
 	    mount_cmd) != 0)
 		goto bad;
-
-	zonecfg_fini_handle(handle);
-	handle = NULL;
 
 	/*
 	 * Normally when we mount a zone all the zone filesystems
@@ -1870,8 +1834,6 @@ mount_filesystems(zlog_t *zlogp, zone_mnt_t mount_cmd)
 	return (0);
 
 bad:
-	if (handle != NULL)
-		zonecfg_fini_handle(handle);
 	free_fs_data(fs_ptr, num_fs);
 	return (-1);
 }
@@ -2446,7 +2408,6 @@ bad:
 static int
 configure_shared_network_interfaces(zlog_t *zlogp)
 {
-	zone_dochandle_t handle;
 	struct zone_nwiftab nwiftab, loopback_iftab;
 	zoneid_t zoneid;
 
@@ -2455,29 +2416,18 @@ configure_shared_network_interfaces(zlog_t *zlogp)
 		return (-1);
 	}
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
-	if (zonecfg_setnwifent(handle) == Z_OK) {
+	if (zonecfg_setnwifent(snap_hndl) == Z_OK) {
 		for (;;) {
-			if (zonecfg_getnwifent(handle, &nwiftab) != Z_OK)
+			if (zonecfg_getnwifent(snap_hndl, &nwiftab) != Z_OK)
 				break;
 			if (configure_one_interface(zlogp, zoneid, &nwiftab) !=
 			    Z_OK) {
-				(void) zonecfg_endnwifent(handle);
-				zonecfg_fini_handle(handle);
+				(void) zonecfg_endnwifent(snap_hndl);
 				return (-1);
 			}
 		}
-		(void) zonecfg_endnwifent(handle);
+		(void) zonecfg_endnwifent(snap_hndl);
 	}
-	zonecfg_fini_handle(handle);
 	if (is_system_labeled()) {
 		/*
 		 * Labeled zones share the loopback interface
@@ -2950,7 +2900,6 @@ get_brand_dev(void)
 static int
 configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 {
-	zone_dochandle_t handle;
 	struct zone_nwiftab nwiftab;
 	char rootpath[MAXPATHLEN];
 	char path[MAXPATHLEN];
@@ -2959,30 +2908,17 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 	boolean_t added = B_FALSE;
 	zone_addr_list_t *zalist = NULL, *new;
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
-
-	if (zonecfg_setnwifent(handle) != Z_OK) {
-		zonecfg_fini_handle(handle);
+	if (zonecfg_setnwifent(snap_hndl) != Z_OK)
 		return (0);
-	}
 
 	for (;;) {
-		if (zonecfg_getnwifent(handle, &nwiftab) != Z_OK)
+		if (zonecfg_getnwifent(snap_hndl, &nwiftab) != Z_OK)
 			break;
 
 		if (prof == NULL) {
 			if (zone_get_devroot(zone_name, rootpath,
 			    sizeof (rootpath)) != Z_OK) {
-				(void) zonecfg_endnwifent(handle);
-				zonecfg_fini_handle(handle);
+				(void) zonecfg_endnwifent(snap_hndl);
 				zerror(zlogp, B_TRUE,
 				    "unable to determine dev root");
 				return (-1);
@@ -2990,8 +2926,7 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 			(void) snprintf(path, sizeof (path), "%s%s", rootpath,
 			    get_brand_dev());
 			if (di_prof_init(path, &prof) != 0) {
-				(void) zonecfg_endnwifent(handle);
-				zonecfg_fini_handle(handle);
+				(void) zonecfg_endnwifent(snap_hndl);
 				zerror(zlogp, B_TRUE,
 				    "failed to initialize profile");
 				return (-1);
@@ -3015,8 +2950,7 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 		    nwiftab.zone_nwif_physical) == 0) {
 			added = B_TRUE;
 		} else {
-			(void) zonecfg_endnwifent(handle);
-			zonecfg_fini_handle(handle);
+			(void) zonecfg_endnwifent(snap_hndl);
 			zerror(zlogp, B_TRUE, "failed to add network device");
 			return (-1);
 		}
@@ -3025,7 +2959,6 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 		if (new == NULL) {
 			zerror(zlogp, B_TRUE, "no memory for %s",
 			    nwiftab.zone_nwif_physical);
-			zonecfg_fini_handle(handle);
 			free_ip_interface(zalist);
 		}
 		bzero(new, sizeof (*new));
@@ -3035,16 +2968,14 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 	}
 	if (zalist != NULL) {
 		if ((errno = add_net(zlogp, zoneid, zalist)) != 0) {
-			(void) zonecfg_endnwifent(handle);
-			zonecfg_fini_handle(handle);
+			(void) zonecfg_endnwifent(snap_hndl);
 			zerror(zlogp, B_TRUE, "failed to add address");
 			free_ip_interface(zalist);
 			return (-1);
 		}
 		free_ip_interface(zalist);
 	}
-	(void) zonecfg_endnwifent(handle);
-	zonecfg_fini_handle(handle);
+	(void) zonecfg_endnwifent(snap_hndl);
 
 	if (prof != NULL && added) {
 		if (di_prof_commit(prof) != 0) {
@@ -3303,26 +3234,14 @@ static int
 get_privset(zlog_t *zlogp, priv_set_t *privs, zone_mnt_t mount_cmd)
 {
 	int error = -1;
-	zone_dochandle_t handle;
 	char *privname = NULL;
-
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
 
 	if (ALT_MOUNT(mount_cmd)) {
 		zone_iptype_t	iptype;
 		const char	*curr_iptype;
 
-		if (zonecfg_get_iptype(handle, &iptype) != Z_OK) {
+		if (zonecfg_get_iptype(snap_hndl, &iptype) != Z_OK) {
 			zerror(zlogp, B_TRUE, "unable to determine ip-type");
-			zonecfg_fini_handle(handle);
 			return (-1);
 		}
 
@@ -3335,17 +3254,15 @@ get_privset(zlog_t *zlogp, priv_set_t *privs, zone_mnt_t mount_cmd)
 			break;
 		}
 
-		if (zonecfg_default_privset(privs, curr_iptype) == Z_OK) {
-			zonecfg_fini_handle(handle);
+		if (zonecfg_default_privset(privs, curr_iptype) == Z_OK)
 			return (0);
-		}
+
 		zerror(zlogp, B_FALSE,
 		    "failed to determine the zone's default privilege set");
-		zonecfg_fini_handle(handle);
 		return (-1);
 	}
 
-	switch (zonecfg_get_privset(handle, privs, &privname)) {
+	switch (zonecfg_get_privset(snap_hndl, privs, &privname)) {
 	case Z_OK:
 		error = 0;
 		break;
@@ -3368,7 +3285,6 @@ get_privset(zlog_t *zlogp, priv_set_t *privs, zone_mnt_t mount_cmd)
 	}
 
 	free(privname);
-	zonecfg_fini_handle(handle);
 	return (error);
 }
 
@@ -3394,7 +3310,6 @@ get_rctls(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 	nvlist_t **nvlv = NULL;
 	int rctlcount = 0;
 	int error = -1;
-	zone_dochandle_t handle;
 	struct zone_rctltab rctltab;
 	rctlblk_t *rctlblk = NULL;
 	uint64_t maxlwps;
@@ -3403,16 +3318,6 @@ get_rctls(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 
 	*bufp = NULL;
 	*bufsizep = 0;
-
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
 
 	rctltab.zone_rctl_valptr = NULL;
 	if (nvlist_alloc(&nvl, NV_UNIQUE_NAME, 0) != 0) {
@@ -3446,7 +3351,7 @@ get_rctls(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 		}
 	}
 
-	if (zonecfg_setrctlent(handle) != Z_OK) {
+	if (zonecfg_setrctlent(snap_hndl) != Z_OK) {
 		zerror(zlogp, B_FALSE, "%s failed", "zonecfg_setrctlent");
 		goto out;
 	}
@@ -3455,7 +3360,7 @@ get_rctls(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 		zerror(zlogp, B_TRUE, "memory allocation failed");
 		goto out;
 	}
-	while (zonecfg_getrctlent(handle, &rctltab) == Z_OK) {
+	while (zonecfg_getrctlent(snap_hndl, &rctltab) == Z_OK) {
 		struct zone_rctlvaltab *rctlval;
 		uint_t i, count;
 		const char *name = rctltab.zone_rctl_name;
@@ -3558,7 +3463,7 @@ get_rctls(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 		nvlv = NULL;
 		rctlcount++;
 	}
-	(void) zonecfg_endrctlent(handle);
+	(void) zonecfg_endrctlent(snap_hndl);
 
 	if (rctlcount == 0) {
 		error = 0;
@@ -3582,8 +3487,6 @@ out:
 	nvlist_free(nvl);
 	if (nvlv != NULL)
 		free(nvlv);
-	if (handle != NULL)
-		zonecfg_fini_handle(handle);
 	return (error);
 }
 
@@ -3608,7 +3511,6 @@ get_implicit_datasets(zlog_t *zlogp, char **retstr)
 static int
 get_datasets(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 {
-	zone_dochandle_t handle;
 	struct zone_dstab dstab;
 	size_t total, offset, len;
 	int error = -1;
@@ -3619,30 +3521,20 @@ get_datasets(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 	*bufp = NULL;
 	*bufsizep = 0;
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
-
 	if (get_implicit_datasets(zlogp, &implicit_datasets) != 0) {
 		zerror(zlogp, B_FALSE, "getting implicit datasets failed");
 		goto out;
 	}
 
-	if (zonecfg_setdsent(handle) != Z_OK) {
+	if (zonecfg_setdsent(snap_hndl) != Z_OK) {
 		zerror(zlogp, B_FALSE, "%s failed", "zonecfg_setdsent");
 		goto out;
 	}
 
 	total = 0;
-	while (zonecfg_getdsent(handle, &dstab) == Z_OK)
+	while (zonecfg_getdsent(snap_hndl, &dstab) == Z_OK)
 		total += strlen(dstab.zone_dataset_name) + 1;
-	(void) zonecfg_enddsent(handle);
+	(void) zonecfg_enddsent(snap_hndl);
 
 	if (implicit_datasets != NULL)
 		implicit_len = strlen(implicit_datasets);
@@ -3659,12 +3551,12 @@ get_datasets(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 		goto out;
 	}
 
-	if (zonecfg_setdsent(handle) != Z_OK) {
+	if (zonecfg_setdsent(snap_hndl) != Z_OK) {
 		zerror(zlogp, B_FALSE, "%s failed", "zonecfg_setdsent");
 		goto out;
 	}
 	offset = 0;
-	while (zonecfg_getdsent(handle, &dstab) == Z_OK) {
+	while (zonecfg_getdsent(snap_hndl, &dstab) == Z_OK) {
 		len = strlen(dstab.zone_dataset_name);
 		(void) strlcpy(str + offset, dstab.zone_dataset_name,
 		    total - offset);
@@ -3672,7 +3564,7 @@ get_datasets(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 		if (offset < total - 1)
 			str[offset++] = ',';
 	}
-	(void) zonecfg_enddsent(handle);
+	(void) zonecfg_enddsent(snap_hndl);
 
 	if (implicit_len > 0)
 		(void) strlcpy(str + offset, implicit_datasets, total - offset);
@@ -3684,8 +3576,6 @@ get_datasets(zlog_t *zlogp, char **bufp, size_t *bufsizep)
 out:
 	if (error != 0 && str != NULL)
 		free(str);
-	if (handle != NULL)
-		zonecfg_fini_handle(handle);
 	if (implicit_datasets != NULL)
 		free(implicit_datasets);
 
@@ -3695,40 +3585,26 @@ out:
 static int
 validate_datasets(zlog_t *zlogp)
 {
-	zone_dochandle_t handle;
 	struct zone_dstab dstab;
 	zfs_handle_t *zhp;
 	libzfs_handle_t *hdl;
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (-1);
-	}
-	if (zonecfg_get_snapshot_handle(zone_name, handle) != Z_OK) {
+	if (zonecfg_setdsent(snap_hndl) != Z_OK) {
 		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (-1);
-	}
-
-	if (zonecfg_setdsent(handle) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
 		return (-1);
 	}
 
 	if ((hdl = libzfs_init()) == NULL) {
 		zerror(zlogp, B_FALSE, "opening ZFS library");
-		zonecfg_fini_handle(handle);
 		return (-1);
 	}
 
-	while (zonecfg_getdsent(handle, &dstab) == Z_OK) {
+	while (zonecfg_getdsent(snap_hndl, &dstab) == Z_OK) {
 
 		if ((zhp = zfs_open(hdl, dstab.zone_dataset_name,
 		    ZFS_TYPE_FILESYSTEM)) == NULL) {
 			zerror(zlogp, B_FALSE, "cannot open ZFS dataset '%s'",
 			    dstab.zone_dataset_name);
-			zonecfg_fini_handle(handle);
 			libzfs_fini(hdl);
 			return (-1);
 		}
@@ -3743,7 +3619,6 @@ validate_datasets(zlog_t *zlogp)
 			zerror(zlogp, B_FALSE, "cannot set 'zoned' "
 			    "property for ZFS dataset '%s'\n",
 			    dstab.zone_dataset_name);
-			zonecfg_fini_handle(handle);
 			zfs_close(zhp);
 			libzfs_fini(hdl);
 			return (-1);
@@ -3751,9 +3626,8 @@ validate_datasets(zlog_t *zlogp)
 
 		zfs_close(zhp);
 	}
-	(void) zonecfg_enddsent(handle);
+	(void) zonecfg_enddsent(snap_hndl);
 
-	zonecfg_fini_handle(handle);
 	libzfs_fini(hdl);
 
 	return (0);
@@ -4490,22 +4364,10 @@ setup_zone_rm(zlog_t *zlogp, char *zone_name, zoneid_t zoneid)
 	int res;
 	uint64_t tmp;
 	char sched[MAXNAMELEN];
-	zone_dochandle_t handle = NULL;
 	char pool_err[128];
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (Z_BAD_HANDLE);
-	}
-
-	if ((res = zonecfg_get_snapshot_handle(zone_name, handle)) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		zonecfg_fini_handle(handle);
-		return (res);
-	}
-
 	/* Get the scheduling class set in the zone configuration. */
-	if (zonecfg_get_sched_class(handle, sched, sizeof (sched)) == Z_OK &&
+	if (zonecfg_get_sched_class(snap_hndl, sched, sizeof (sched)) == Z_OK &&
 	    strlen(sched) > 0) {
 		if (zone_setattr(zoneid, ZONE_ATTR_SCHED_CLASS, sched,
 		    strlen(sched)) == -1)
@@ -4550,7 +4412,7 @@ setup_zone_rm(zlog_t *zlogp, char *zone_name, zoneid_t zoneid)
 		 */
 		char class_name[PC_CLNMSZ];
 
-		if (zonecfg_get_dflt_sched_class(handle, class_name,
+		if (zonecfg_get_dflt_sched_class(snap_hndl, class_name,
 		    sizeof (class_name)) != Z_OK) {
 			zerror(zlogp, B_FALSE, "WARNING: unable to determine "
 			    "the zone's scheduling class");
@@ -4583,7 +4445,7 @@ setup_zone_rm(zlog_t *zlogp, char *zone_name, zoneid_t zoneid)
 	 * right thing in all cases (reuse or create) based on the current
 	 * zonecfg.
 	 */
-	if ((res = zonecfg_bind_tmp_pool(handle, zoneid, pool_err,
+	if ((res = zonecfg_bind_tmp_pool(snap_hndl, zoneid, pool_err,
 	    sizeof (pool_err))) != Z_OK) {
 		if (res == Z_POOL || res == Z_POOL_CREATE || res == Z_POOL_BIND)
 			zerror(zlogp, B_FALSE, "%s: %s\ndedicated-cpu setting "
@@ -4592,14 +4454,13 @@ setup_zone_rm(zlog_t *zlogp, char *zone_name, zoneid_t zoneid)
 		else
 			zerror(zlogp, B_FALSE, "could not bind zone to "
 			    "temporary pool: %s", zonecfg_strerror(res));
-		zonecfg_fini_handle(handle);
 		return (Z_POOL_BIND);
 	}
 
 	/*
 	 * Check if we need to warn about poold not being enabled.
 	 */
-	if (zonecfg_warn_poold(handle)) {
+	if (zonecfg_warn_poold(snap_hndl)) {
 		zerror(zlogp, B_FALSE, "WARNING: A range of dedicated-cpus has "
 		    "been specified\nbut the dynamic pool service is not "
 		    "enabled.\nThe system will not dynamically adjust the\n"
@@ -4609,7 +4470,7 @@ setup_zone_rm(zlog_t *zlogp, char *zone_name, zoneid_t zoneid)
 	}
 
 	/* The following is a warning, not an error. */
-	if ((res = zonecfg_bind_pool(handle, zoneid, pool_err,
+	if ((res = zonecfg_bind_pool(snap_hndl, zoneid, pool_err,
 	    sizeof (pool_err))) != Z_OK) {
 		if (res == Z_POOL_BIND)
 			zerror(zlogp, B_FALSE, "WARNING: unable to bind to "
@@ -4623,10 +4484,9 @@ setup_zone_rm(zlog_t *zlogp, char *zone_name, zoneid_t zoneid)
 	}
 
 	/* Update saved pool name in case it has changed */
-	(void) zonecfg_get_poolname(handle, zone_name, pool_name,
+	(void) zonecfg_get_poolname(snap_hndl, zone_name, pool_name,
 	    sizeof (pool_name));
 
-	zonecfg_fini_handle(handle);
 	return (Z_OK);
 }
 
@@ -4817,31 +4677,20 @@ setup_zone_fs_allowed(zone_dochandle_t handle, zlog_t *zlogp, zoneid_t zoneid)
 }
 
 static int
-setup_zone_attrs(zlog_t *zlogp, char *zone_namep, zoneid_t zoneid)
+setup_zone_attrs(zlog_t *zlogp, zoneid_t zoneid)
 {
-	zone_dochandle_t handle;
 	int res = Z_OK;
 
-	if ((handle = zonecfg_init_handle()) == NULL) {
-		zerror(zlogp, B_TRUE, "getting zone configuration handle");
-		return (Z_BAD_HANDLE);
-	}
-	if ((res = zonecfg_get_snapshot_handle(zone_namep, handle)) != Z_OK) {
-		zerror(zlogp, B_FALSE, "invalid configuration");
-		goto out;
-	}
-
-	if ((res = setup_zone_hostid(handle, zlogp, zoneid)) != Z_OK)
+	if ((res = setup_zone_hostid(snap_hndl, zlogp, zoneid)) != Z_OK)
 		goto out;
 
-	if ((res = setup_zone_fs_allowed(handle, zlogp, zoneid)) != Z_OK)
+	if ((res = setup_zone_fs_allowed(snap_hndl, zlogp, zoneid)) != Z_OK)
 		goto out;
 
-	if ((res = setup_zone_secflags(handle, zlogp, zoneid)) != Z_OK)
+	if ((res = setup_zone_secflags(snap_hndl, zlogp, zoneid)) != Z_OK)
 		goto out;
 
 out:
-	zonecfg_fini_handle(handle);
 	return (res);
 }
 
@@ -5039,7 +4888,7 @@ vplat_create(zlog_t *zlogp, zone_mnt_t mount_cmd, zoneid_t zone_did)
 		struct brand_attr attr;
 		char modname[MAXPATHLEN];
 
-		if (setup_zone_attrs(zlogp, zone_name, zoneid) != Z_OK)
+		if (setup_zone_attrs(zlogp, zoneid) != Z_OK)
 			goto error;
 
 		if ((bh = brand_open(brand_name)) == NULL) {
@@ -5465,14 +5314,9 @@ vplat_teardown(zlog_t *zlogp, boolean_t unmount_cmd, boolean_t rebooting)
 
 		if (rebooting) {
 			struct zone_psettab pset_tab;
-			zone_dochandle_t handle;
 
-			if ((handle = zonecfg_init_handle()) != NULL &&
-			    zonecfg_get_handle(zone_name, handle) == Z_OK &&
-			    zonecfg_lookup_pset(handle, &pset_tab) == Z_OK)
+			if (zonecfg_lookup_pset(snap_hndl, &pset_tab) == Z_OK)
 				destroy_tmp_pool = B_FALSE;
-
-			zonecfg_fini_handle(handle);
 		}
 
 		if (destroy_tmp_pool) {

--- a/usr/src/man/man1/prctl.1
+++ b/usr/src/man/man1/prctl.1
@@ -1,9 +1,10 @@
 '\" te
 .\" Copyright (c) 2009 Sun Microsystems, Inc. All Rights Reserved
+.\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\"  See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with
 .\" the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH PRCTL 1 "April 9, 2016"
+.TH PRCTL 1 "Jan 23, 2021"
 .SH NAME
 prctl \- get or set the resource controls of running processes, tasks, and
 projects
@@ -270,6 +271,9 @@ NAME    PRIVILEGE       VALUE    FLAG   ACTION             RECIPIENT
 task.max-cpu-time
         usage            8s
         system          18.4Es    inf   none                -
+task.max-processes
+        usage              30
+        system          2.15G     max   deny                -
 task.max-lwps
         usage              39
         system          2.15G     max   deny                -
@@ -294,6 +298,9 @@ privileged       508MB      -   deny                -
 project.max-tasks
         usage               2
         system          2.15G     max   deny                -
+project.max-processes
+         usage             30
+        system          2.15G     max   deny                -
 project.max-lwps
          usage             39
         system          2.15G     max   deny                -
@@ -308,6 +315,8 @@ zone.max-sem-ids
         system          16.8M     max   deny                -
 zone.max-msg-ids
         system          16.8M     max   deny                -
+zone.max-processes
+        system          2.15G     max   deny                -
 zone.max-lwps
         system          2.15G     max   deny                -
 zone.cpu-shares

--- a/usr/src/man/man1m/zonecfg.1m
+++ b/usr/src/man/man1m/zonecfg.1m
@@ -2,10 +2,11 @@
 .\" Copyright (c) 2004, 2009 Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 2015 Joyent, Inc.
 .\" Copyright 2017 Peter Tribble
+.\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License"). You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\" See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE. If applicable, add the following below this CDDL HEADER, with the
 .\" fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH ZONECFG 1M "Feb 13, 2019"
+.TH ZONECFG 1M "Jan 23, 2021"
 .SH NAME
 zonecfg \- set up zone configuration
 .SH SYNOPSIS
@@ -300,6 +301,16 @@ The following properties are supported:
 .sp .6
 .RS 4n
 \fBmax-msg-ids\fR
+.RE
+
+.sp
+.ne 2
+.na
+\fB(global)\fR
+.ad
+.sp .6
+.RS 4n
+\fBmax-processes\fR
 .RE
 
 .sp
@@ -769,6 +780,8 @@ is the preferred way to set the \fBzone.cpu-shares\fR rctl.
 .RS 4n
 The maximum number of LWPs simultaneously available to this zone. This property
 is the preferred way to set the \fBzone.max-lwps\fR rctl.
+If \fBmax-processes\fR is not explicitly set then it will be set to the
+same value as \fBmax-lwps\fR.
 .RE
 
 .sp
@@ -780,6 +793,19 @@ is the preferred way to set the \fBzone.max-lwps\fR rctl.
 .RS 4n
 The maximum number of message queue IDs allowed for this zone. This property is
 the preferred way to set the \fBzone.max-msg-ids\fR rctl.
+.RE
+
+.sp
+.ne 2
+.na
+\fBglobal: \fBmax-processes\fR\fR
+.ad
+.sp .6
+.RS 4n
+The maximum number of processes simultaneously available to this zone. This
+property is the preferred way to set the \fBzone.max-processes\fR rctl.
+If \fBmax-lwps\fR is not explicitly set, then setting this property will
+automatically set \fBmax-lwps\fR to 10 times the value of \fBmax-processes\fR.
 .RE
 
 .sp
@@ -982,6 +1008,7 @@ resource          property-name   type
 (global)          cpu-shares      simple
 (global)          max-lwps        simple
 (global)          max-msg-ids     simple
+(global)          max-processes   simple
 (global)          max-sem-ids     simple
 (global)          max-shm-ids     simple
 (global)          max-shm-memory  simple

--- a/usr/src/man/man5/resource_controls.5
+++ b/usr/src/man/man5/resource_controls.5
@@ -1,10 +1,11 @@
 '\" te
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 2017, Joyent, Inc.
+.\" Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH RESOURCE_CONTROLS 5 "April 28, 2017"
+.TH RESOURCE_CONTROLS 5 "Jan 23, 2021"
 .SH NAME
 resource_controls \- resource controls available through project database
 .SH DESCRIPTION
@@ -51,7 +52,7 @@ The following are the resource controls are available:
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-address-space\fR\fR
+\fBprocess.max-address-space\fR
 .ad
 .sp .6
 .RS 4n
@@ -62,7 +63,7 @@ available to this process, expressed as a number of bytes.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-core-size\fR\fR
+\fBprocess.max-core-size\fR
 .ad
 .sp .6
 .RS 4n
@@ -73,7 +74,7 @@ bytes.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-cpu-time\fR\fR
+\fBprocess.max-cpu-time\fR
 .ad
 .sp .6
 .RS 4n
@@ -84,7 +85,7 @@ seconds.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-data-size\fR\fR
+\fBprocess.max-data-size\fR
 .ad
 .sp .6
 .RS 4n
@@ -94,7 +95,7 @@ Maximum heap memory available to this process, expressed as a number of bytes.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-file-descriptor\fR\fR
+\fBprocess.max-file-descriptor\fR
 .ad
 .sp .6
 .RS 4n
@@ -105,7 +106,7 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-file-size\fR\fR
+\fBprocess.max-file-size\fR
 .ad
 .sp .6
 .RS 4n
@@ -116,14 +117,14 @@ number of bytes.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-locked-memory\fR\fR
+\fBprocess.max-locked-memory\fR
 .ad
 .sp .6
 .RS 4n
 Total amount of physical memory that can be locked by this process, expressed
 as a number of bytes. This limit is not enforced for a process with the
-\fB\fBPRIV_PROC_LOCK_MEMORY\fR\fR privilege. Because the ability to lock memory
-is controlled by the \fB\fBPRIV_PROC_LOCK_MEMORY\fR\fR privilege within native
+\fBPRIV_PROC_LOCK_MEMORY\fR privilege. Because the ability to lock memory
+is controlled by the \fBPRIV_PROC_LOCK_MEMORY\fR privilege within native
 zones, this resource control is only useful within branded zones which might
 support a different policy for locking memory.
 .RE
@@ -131,7 +132,7 @@ support a different policy for locking memory.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-msg-messages\fR\fR
+\fBprocess.max-msg-messages\fR
 .ad
 .sp .6
 .RS 4n
@@ -142,7 +143,7 @@ control at \fBmsgget()\fR time), expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-msg-qbytes\fR\fR
+\fBprocess.max-msg-qbytes\fR
 .ad
 .sp .6
 .RS 4n
@@ -153,7 +154,7 @@ resource control at \fBmsgget()\fR time), expressed as a number of bytes.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-port-events\fR\fR
+\fBprocess.max-port-events\fR
 .ad
 .sp .6
 .RS 4n
@@ -163,7 +164,7 @@ Maximum allowable number of events per event port, expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-sem-nsems\fR\fR
+\fBprocess.max-sem-nsems\fR
 .ad
 .sp .6
 .RS 4n
@@ -174,7 +175,7 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-sem-ops\fR\fR
+\fBprocess.max-sem-ops\fR
 .ad
 .sp .6
 .RS 4n
@@ -186,7 +187,7 @@ integer, specifying the number of operations.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-sigqueue-size\fR\fR
+\fBprocess.max-sigqueue-size\fR
 .ad
 .sp .6
 .RS 4n
@@ -196,7 +197,7 @@ Maximum number of outstanding queued signals.
 .sp
 .ne 2
 .na
-\fB\fBprocess.max-stack-size\fR\fR
+\fBprocess.max-stack-size\fR
 .ad
 .sp .6
 .RS 4n
@@ -207,7 +208,7 @@ of bytes.
 .sp
 .ne 2
 .na
-\fB\fBproject.cpu-cap\fR\fR
+\fBproject.cpu-cap\fR
 .ad
 .sp .6
 .RS 4n
@@ -221,7 +222,7 @@ action.
 .sp
 .ne 2
 .na
-\fB\fBproject.cpu-shares\fR\fR
+\fBproject.cpu-shares\fR
 .ad
 .sp .6
 .RS 4n
@@ -233,7 +234,7 @@ resource control does not support the \fBsyslog\fR action.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-contracts\fR\fR
+\fBproject.max-contracts\fR
 .ad
 .sp .6
 .RS 4n
@@ -243,7 +244,7 @@ Maximum number of contracts allowed in a project, expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-crypto-memory\fR\fR
+\fBproject.max-crypto-memory\fR
 .ad
 .sp .6
 .RS 4n
@@ -255,7 +256,7 @@ charged against this resource control.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-locked-memory\fR\fR
+\fBproject.max-locked-memory\fR
 .ad
 .sp .6
 .RS 4n
@@ -266,7 +267,7 @@ Total amount of physical memory locked by device drivers and user processes
 .sp
 .ne 2
 .na
-\fB\fBproject.max-lwps\fR\fR
+\fBproject.max-lwps\fR
 .ad
 .sp .6
 .RS 4n
@@ -277,7 +278,7 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-msg-ids\fR\fR
+\fBproject.max-msg-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -288,7 +289,18 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-port-ids\fR\fR
+\fBproject.max-processes\fR
+.ad
+.sp .6
+.RS 4n
+Maximum number of processes simultaneously available to a project, expressed as
+an integer.
+.RE
+
+.sp
+.ne 2
+.na
+\fBproject.max-port-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -298,7 +310,7 @@ Maximum allowable number of event ports, expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-sem-ids\fR\fR
+\fBproject.max-sem-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -308,7 +320,7 @@ Maximum number of semaphore IDs allowed for a project, expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-shm-ids\fR\fR
+\fBproject.max-shm-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -319,7 +331,7 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-shm-memory\fR\fR
+\fBproject.max-shm-memory\fR
 .ad
 .sp .6
 .RS 4n
@@ -330,7 +342,7 @@ bytes.
 .sp
 .ne 2
 .na
-\fB\fBproject.max-tasks\fR\fR
+\fBproject.max-tasks\fR
 .ad
 .sp .6
 .RS 4n
@@ -340,7 +352,7 @@ Maximum number of tasks allowable in a project, expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBproject.pool\fR\fR
+\fBproject.pool\fR
 .ad
 .sp .6
 .RS 4n
@@ -350,7 +362,7 @@ Binds a specified resource pool with a project.
 .sp
 .ne 2
 .na
-\fB\fBrcap.max-rss\fR\fR
+\fBrcap.max-rss\fR
 .ad
 .sp .6
 .RS 4n
@@ -361,7 +373,7 @@ in a project.
 .sp
 .ne 2
 .na
-\fB\fBtask.max-cpu-time\fR\fR
+\fBtask.max-cpu-time\fR
 .ad
 .sp .6
 .RS 4n
@@ -372,11 +384,22 @@ number of seconds.
 .sp
 .ne 2
 .na
-\fB\fBtask.max-lwps\fR\fR
+\fBtask.max-lwps\fR
 .ad
 .sp .6
 .RS 4n
 Maximum number of LWPs simultaneously available to this task's processes,
+expressed as an integer.
+.RE
+
+.sp
+.ne 2
+.na
+\fBtask.max-processes\fR
+.ad
+.sp .6
+.RS 4n
+Maximum number of processes simultaneously available to this task,
 expressed as an integer.
 .RE
 
@@ -386,7 +409,7 @@ The following zone-wide resource controls are available:
 .sp
 .ne 2
 .na
-\fB\fBzone.cpu-cap\fR\fR
+\fBzone.cpu-cap\fR
 .ad
 .sp .6
 .RS 4n
@@ -400,7 +423,7 @@ not support the \fBsyslog\fR action.
 .sp
 .ne 2
 .na
-\fB\fBzone.cpu-shares\fR\fR
+\fBzone.cpu-shares\fR
 .ad
 .sp .6
 .RS 4n
@@ -414,7 +437,7 @@ Expressed as an integer. This resource control does not support the
 .sp
 .ne 2
 .na
-\fB\fBzone.max-locked-memory\fR\fR
+\fBzone.max-locked-memory\fR
 .ad
 .sp .6
 .RS 4n
@@ -424,7 +447,7 @@ Total amount of physical locked memory available to a zone.
 .sp
 .ne 2
 .na
-\fB\fBzone.max-lwps\fR\fR
+\fBzone.max-lwps\fR
 .ad
 .sp .6
 .RS 4n
@@ -437,7 +460,7 @@ entries. Expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBzone.max-msg-ids\fR\fR
+\fBzone.max-msg-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -448,7 +471,20 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBzone.max-sem-ids\fR\fR
+\fBzone.max-processes\fR
+.ad
+.sp .6
+.RS 4n
+Enhances resource isolation by preventing too many processes in one zone from
+affecting other zones. A zone's total processes can be further subdivided among
+projects within the zone within the zone by using \fBproject.max-processes\fR
+entries. Expressed as an integer.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzone.max-sem-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -458,7 +494,7 @@ Maximum number of semaphore IDs allowed for a zone, expressed as an integer.
 .sp
 .ne 2
 .na
-\fB\fBzone.max-shm-ids\fR\fR
+\fBzone.max-shm-ids\fR
 .ad
 .sp .6
 .RS 4n
@@ -469,7 +505,7 @@ integer.
 .sp
 .ne 2
 .na
-\fB\fBzone.max-shm-memory\fR\fR
+\fBzone.max-shm-memory\fR
 .ad
 .sp .6
 .RS 4n
@@ -480,7 +516,7 @@ bytes.
 .sp
 .ne 2
 .na
-\fB\fBzone.max-swap\fR\fR
+\fBzone.max-swap\fR
 .ad
 .sp .6
 .RS 4n
@@ -587,7 +623,7 @@ level. The privilege level must be one of the following three types:
 .sp
 .ne 2
 .na
-\fB\fBbasic\fR\fR
+\fBbasic\fR
 .ad
 .sp .6
 .RS 4n
@@ -597,7 +633,7 @@ Can be modified by the owner of the calling process.
 .sp
 .ne 2
 .na
-\fB\fBprivileged\fR\fR
+\fBprivileged\fR
 .ad
 .sp .6
 .RS 4n
@@ -608,7 +644,7 @@ or by \fBprctl\fR(1) (requiring \fBproc_owner\fR privilege).
 .sp
 .ne 2
 .na
-\fB\fBsystem\fR\fR
+\fBsystem\fR
 .ad
 .sp .6
 .RS 4n
@@ -731,7 +767,7 @@ follows:
 .sp
 .ne 2
 .na
-\fB\fBnone\fR\fR
+\fBnone\fR
 .ad
 .sp .6
 .RS 4n
@@ -745,7 +781,7 @@ the process exceeding the threshold is not affected.
 .sp
 .ne 2
 .na
-\fB\fBdeny\fR\fR
+\fBdeny\fR
 .ad
 .sp .6
 .RS 4n
@@ -758,7 +794,7 @@ control value. See the \fBfork\fR(2).
 .sp
 .ne 2
 .na
-\fB\fBsignal=\fR\fR
+\fBsignal=\fR
 .ad
 .sp .6
 .RS 4n
@@ -787,7 +823,7 @@ The following are the signals available to resource control values:
 .sp
 .ne 2
 .na
-\fB\fBSIGABRT\fR\fR
+\fBSIGABRT\fR
 .ad
 .sp .6
 .RS 4n
@@ -797,7 +833,7 @@ Terminate the process.
 .sp
 .ne 2
 .na
-\fB\fBSIGHUP\fR\fR
+\fBSIGHUP\fR
 .ad
 .sp .6
 .RS 4n
@@ -808,7 +844,7 @@ the process group that controls the terminal.
 .sp
 .ne 2
 .na
-\fB\fBSIGTERM\fR\fR
+\fBSIGTERM\fR
 .ad
 .sp .6
 .RS 4n
@@ -818,7 +854,7 @@ Terminate the process. Termination signal sent by software.
 .sp
 .ne 2
 .na
-\fB\fBSIGKILL\fR\fR
+\fBSIGKILL\fR
 .ad
 .sp .6
 .RS 4n
@@ -828,7 +864,7 @@ Terminate the process and kill the program.
 .sp
 .ne 2
 .na
-\fB\fBSIGSTOP\fR\fR
+\fBSIGSTOP\fR
 .ad
 .sp .6
 .RS 4n
@@ -838,7 +874,7 @@ Stop the process. Job control signal.
 .sp
 .ne 2
 .na
-\fB\fBSIGXRES\fR\fR
+\fBSIGXRES\fR
 .ad
 .sp .6
 .RS 4n
@@ -848,7 +884,7 @@ Resource control limit exceeded. Generated by resource control facility.
 .sp
 .ne 2
 .na
-\fB\fBSIGXFSZ\fR\fR
+\fBSIGXFSZ\fR
 .ad
 .sp .6
 .RS 4n
@@ -860,7 +896,7 @@ controls with the \fBRCTL_GLOBAL_FILE_SIZE\fR property
 .sp
 .ne 2
 .na
-\fB\fBSIGXCPU\fR\fR
+\fBSIGXCPU\fR
 .ad
 .sp .6
 .RS 4n
@@ -910,7 +946,7 @@ The global flags indicate the following:
 .sp
 .ne 2
 .na
-\fB\fBlowerable\fR\fR
+\fBlowerable\fR
 .ad
 .sp .6
 .RS 4n
@@ -921,7 +957,7 @@ control.
 .sp
 .ne 2
 .na
-\fB\fBno-deny\fR\fR
+\fBno-deny\fR
 .ad
 .sp .6
 .RS 4n
@@ -932,7 +968,7 @@ denied.
 .sp
 .ne 2
 .na
-\fB\fBcpu-time\fR\fR
+\fBcpu-time\fR
 .ad
 .sp .6
 .RS 4n
@@ -943,7 +979,7 @@ are reached.
 .sp
 .ne 2
 .na
-\fB\fBseconds\fR\fR
+\fBseconds\fR
 .ad
 .sp .6
 .RS 4n

--- a/usr/src/uts/common/brand/lx/syscall/lx_rlimit.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_rlimit.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2017 Joyent, Inc.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/systm.h>
@@ -20,6 +21,8 @@
 #include <sys/cmn_err.h>
 #include <sys/lx_impl.h>
 #include <sys/lx_brand.h>
+#include <sys/sysmacros.h>
+#include <sys/var.h>
 
 #define	LX_RLIMIT_CPU		0
 #define	LX_RLIMIT_FSIZE		1
@@ -166,8 +169,15 @@ lx_getrlimit_common(int lx_resource, uint64_t *rlim_curp, uint64_t *rlim_maxp)
 		break;
 
 	case LX_RLIMIT_NPROC:
-		/*  zone.max-lwps */
-		rlim64.rlim_cur = rlim64.rlim_max = curzone->zone_nlwps_ctl;
+		/*
+		 * This is a limit on the number of processes for a
+		 * real user ID (not enforced for privileged processes).
+		 *
+		 * This is analagous to v.v_maxup but is further capped
+		 * by zone.max-processes
+		 */
+		rlim64.rlim_cur = rlim64.rlim_max =
+		    MIN(v.v_maxup, curzone->zone_nprocs_ctl);
 		break;
 
 	case LX_RLIMIT_MEMLOCK:
@@ -415,7 +425,7 @@ lx_setrlimit_common(int lx_resource, uint64_t rlim_cur, uint64_t rlim_max)
 
 	case LX_RLIMIT_NPROC:
 		/*
-		 * zone.max-lwps
+		 * zone.max-processes
 		 * Since we're emulating the value via a zone rctl, we can't
 		 * set that from within the zone. Lie and say we set the value.
 		 */


### PR DESCRIPTION
I started this by debugging a problem with running certain pieces of software in an lx zone. That turned out to be that `getconf CHILD_MAX` was returning INT_MAX, a number far in excess of the number of children a process can have. The software was trying and failing to allocate memory to hold the PIDs of all potential children.

In fixing that, I found that the `max-processes` zone control was not documented, so I've updated the man pages to include that. Further testing showed that the automatic inference that should occur when setting only one of the max-lwps or max-processes resource limits on a zone was not working. This turns out to be a mismerge of OS-5292 in the past. Rather than fix that directly, I've brought over OS-1179 which improves zone startup time by reducing the number of times the zone configuration is loaded and parsed. This also makes the OS-5292 changes work correctly.