### PR TITLE
assert-deflib fixes (r151034)

### DIFF
--- a/usr/src/cmd/cdpadm/Makefile
+++ b/usr/src/cmd/cdpadm/Makefile
@@ -23,7 +23,7 @@ include ../Makefile.cmd.64
 
 .KEEP_STATE:
 
-LDLIBS=-lsocket
+LDLIBS += -lsocket
 
 all: $(PROG)
 

--- a/usr/src/test/crypto-tests/tests/Makefile.crypto
+++ b/usr/src/test/crypto-tests/tests/Makefile.crypto
@@ -42,6 +42,7 @@ $(PROGS_32) := OBJS += $(BASEPROG:%=%.32.o) $(COMMON_OBJS_32)
 $(PROGS_64) := OBJS += $(BASEPROG:%=%.64.o) $(COMMON_OBJS_64)
 $(PROGS_32) := OBJS += $(COMMONDIR)/testfuncs.32.o
 $(PROGS_64) := OBJS += $(COMMONDIR)/testfuncs.64.o
+$(PROGS_64) := LDLIBS.cmd = $(LDLIBS64)
 $(CRYPTO_pkcs)$(BASEPROG)_32_pkcs := OBJS += $(COMMONDIR)/cryptotest_pkcs.32.o
 $(CRYPTO_pkcs)$(BASEPROG)_64_pkcs := OBJS += $(COMMONDIR)/cryptotest_pkcs.64.o
 $(CRYPTO_kcf)$(BASEPROG)_32_kcf	:= OBJS += $(COMMONDIR)/cryptotest_kcf.32.o

--- a/usr/src/test/os-tests/tests/secflags/Makefile
+++ b/usr/src/test/os-tests/tests/secflags/Makefile
@@ -43,7 +43,7 @@ addrs-32: addrs.c
 	$(POST_PROCESS)
 
 addrs-64: addrs.c
-	$(LINK64.c) addrs.c -o $@ $(LDLIBS)
+	$(LINK64.c) addrs.c -o $@ $(LDLIBS64)
 	$(POST_PROCESS)
 
 stacky := MAPFILE.NES=			# Will foil the test, clearly


### PR DESCRIPTION
These fixes are required following the recent fix to gcc that made `-zassert-deflib` work properly in 64-bit.