### PR TITLE
Upstream merge upstream_merge/2021030401

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3484,6 +3484,7 @@ usr/src/man/man3c/iswspecial_l.3c
 usr/src/man/man3c/iswupper_l.3c
 usr/src/man/man3c/iswxdigit_l.3c
 usr/src/man/man3c/isxdigit_l.3c
+usr/src/man/man3c/l
 usr/src/man/man3c/le16toh.3c
 usr/src/man/man3c/le32toh.3c
 usr/src/man/man3c/le64toh.3c
@@ -4073,6 +4074,7 @@ usr/src/man/man9f/kcred.9f
 usr/src/man/man9f/mac_fini_ops.9f
 usr/src/man/man9f/mac_free.9f
 usr/src/man/man9f/mac_hcksum_set.9f
+usr/src/man/man9f/mac_prop_info_set_default_fec.9f
 usr/src/man/man9f/mac_prop_info_set_default_link_flowctrl.9f
 usr/src/man/man9f/mac_prop_info_set_default_str.9f
 usr/src/man/man9f/mac_prop_info_set_default_uint32.9f

--- a/usr/src/Makefile
+++ b/usr/src/Makefile
@@ -74,16 +74,6 @@ CHKMFSTSUBDIRS=	cmd
 CHKMANSUBDIRS = man
 
 MSGSUBDIRS=	cmd ucbcmd lib data
-DOMAINS= \
-	SUNW_OST_ADMIN \
-	SUNW_OST_NETRPC \
-	SUNW_OST_OSCMD \
-	SUNW_OST_OSLIB \
-	SUNW_OST_UCBCMD \
-	SUNW_OST_ZONEINFO
-
-MSGDDIRS=       $(DOMAINS:%=$(MSGROOT)/%)
-MSGDIRS=        $(MSGROOT) $(MSGDDIRS) $(MSGROOT)/LC_TIME
 
 all :=			TARGET= all
 install :=		TARGET= install
@@ -126,7 +116,7 @@ install1: mapfiles closedbins sgs
 
 install2: install1 .WAIT $(SUBDIRS)
 
-_msg: _msgdirs rootdirs FRC
+_msg: rootdirs FRC
 	@for m in $(MSGSUBDIRS); do \
 		cd $$m; pwd; $(MAKE) _msg; cd ..; \
 	done
@@ -212,9 +202,7 @@ bldtools:
 rootdirs: $(ROOTDIRS)
 	$(INS) -d -m 775 $(ROOT)/var/mail/:saved
 
-_msgdirs:       $(MSGDIRS)
-
-$(ROOTDIRS) $(MSGDIRS):
+$(ROOTDIRS):
 	$(INS.dir)
 
 userheaders: FRC

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.h
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.h
@@ -101,7 +101,7 @@ extern void del_transient(int port);
  * argument is interpreted.
  */
 #define	XID_CACHE_SIZE 256
-struct cache_struct {
+extern struct cache_struct {
 	int xid_num;	/* RPC transaction id */
 	int xid_frame;	/* Packet number */
 	int xid_prog;	/* RPC program number */
@@ -111,6 +111,26 @@ struct cache_struct {
 	int xid_gss_service; /* none, integ, priv */
 } xid_cache[XID_CACHE_SIZE];
 
+extern char *tkp, *sav_tkp;
+extern char *token;
+extern enum tokentype {
+	EOL,
+	ALPHA,
+	NUMBER,
+	FIELD,
+	ADDR_IP,
+	ADDR_ETHER,
+	SPECIAL,
+	ADDR_IP6,
+	ADDR_AT
+} tokentype;
+extern uint_t tokenval;
+
+enum direction { ANY, TO, FROM };
+extern enum direction dir;
+
+extern int eaddr;	/* need ethernet addr */
+extern int opstack;	/* operand stack depth */
 
 /*
  * The following macros advance the pointer passed to them.  They

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_filter.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_filter.c
@@ -499,31 +499,34 @@ static int slp_index	= 0;
  * Returns the index of dport in the table if found, otherwise -1.
  */
 static int
-find_slp(uint_t dport) {
-    int i;
+find_slp(uint_t dport)
+{
+	int i;
 
-    if (!dport)
-	return (0);
+	if (!dport)
+		return (0);
 
-    for (i = slp_index; i >= 0; i--)
-	if (slp_table[i] == dport) {
-	    return (i);
-	}
-    for (i = SLP_CACHE_SIZE - 1; i > slp_index; i--)
-	if (slp_table[i] == dport) {
-	    return (i);
-	}
-    return (-1);
+	for (i = slp_index; i >= 0; i--)
+		if (slp_table[i] == dport) {
+			return (i);
+		}
+	for (i = SLP_CACHE_SIZE - 1; i > slp_index; i--)
+		if (slp_table[i] == dport) {
+			return (i);
+		}
+	return (-1);
 }
 
-static void stash_slp(uint_t sport) {
-    if (slp_table[slp_index - 1] == sport)
-	/* avoid redundancy due to multicast retransmissions */
-	return;
+static void
+stash_slp(uint_t sport)
+{
+	if (slp_table[slp_index - 1] == sport)
+		/* avoid redundancy due to multicast retransmissions */
+		return;
 
-    slp_table[slp_index++] = sport;
-    if (slp_index == SLP_CACHE_SIZE)
-	slp_index = 0;
+	slp_table[slp_index++] = sport;
+	if (slp_index == SLP_CACHE_SIZE)
+		slp_index = 0;
 }
 
 /*
@@ -1123,8 +1126,7 @@ resolve_chain(uint_t p)
 
 char *tkp, *sav_tkp;
 char *token;
-enum { EOL, ALPHA, NUMBER, FIELD, ADDR_IP, ADDR_ETHER, SPECIAL,
-	ADDR_IP6, ADDR_AT } tokentype;
+enum tokentype tokentype;
 uint_t tokenval;
 
 /*
@@ -1134,7 +1136,7 @@ uint_t tokenval;
  * ALPHA:	A name that begins with a letter and contains
  *		letters or digits, hyphens or underscores.
  * NUMBER:	A number.  The value can be represented as
- * 		a decimal value (1234) or an octal value
+ *		a decimal value (1234) or an octal value
  *		that begins with zero (066) or a hex value
  *		that begins with 0x or 0X (0xff).
  * FIELD:	A name followed by a left square bracket.
@@ -1460,7 +1462,6 @@ comparison(char *s)
 	return (n_checks > 0);
 }
 
-enum direction { ANY, TO, FROM };
 enum direction dir;
 
 /*

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpc.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpc.c
@@ -61,6 +61,7 @@ static void rpc_detail_reply(int, int, struct cache_struct *, char *, int len);
 static void print_creds(int);
 static void print_verif(int);
 static void stash_xid(ulong_t, int, int, int, int);
+struct cache_struct xid_cache[XID_CACHE_SIZE];
 
 #define	LAST_FRAG ((ulong_t)1 << 31)
 
@@ -257,8 +258,7 @@ rpc_detail_call(int flags, int xid, int rpcvers, int prog, int vers, int proc,
 }
 
 char *
-nameof_flavor(flavor)
-	int flavor;
+nameof_flavor(int flavor)
 {
 	switch (flavor) {
 	case AUTH_NONE : return ("None");
@@ -545,15 +545,13 @@ struct rpcnames {
 };
 
 int
-compare(a, b)
-	register struct rpcnames *a, *b;
+compare(struct rpcnames *a, struct rpcnames *b)
 {
 	return (a->rp_prog - b->rp_prog);
 }
 
 char *
-nameof_prog(prog)
-	int prog;
+nameof_prog(int prog)
 {
 	struct rpcnames *r;
 	struct rpcnames *bsearch();
@@ -570,8 +568,7 @@ nameof_prog(prog)
 }
 
 char *
-nameof_astat(status)
-	int status;
+nameof_astat(int status)
 {
 	switch (status) {
 	case SUCCESS	  : return ("Success");
@@ -585,8 +582,7 @@ nameof_astat(status)
 }
 
 char *
-nameof_why(why)
-	int why;
+nameof_why(int why)
 {
 	switch (why) {
 	case AUTH_BADCRED:	return ("bogus credentials (seal broken)");
@@ -723,8 +719,7 @@ struct cache_struct *xcp	= &xid_cache[0];
 struct cache_struct *xcplast	= &xid_cache[XID_CACHE_SIZE - 1];
 
 struct cache_struct *
-find_xid(xid)
-	ulong_t xid;
+find_xid(ulong_t xid)
 {
 	struct cache_struct *x;
 
@@ -758,9 +753,7 @@ stash_xid(ulong_t xid, int frame, int prog, int vers, int proc)
 }
 
 void
-check_retransmit(line, xid)
-	char *line;
-	ulong_t xid;
+check_retransmit(char *line, ulong_t xid)
 {
 	struct cache_struct *x;
 	extern int pi_frame;

--- a/usr/src/cmd/logadm/err.c
+++ b/usr/src/cmd/logadm/err.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include "err.h"
 
+jmp_buf Err_env;
 jmp_buf	*Err_env_ptr;
 static const char *Myname;
 static int Exitcode;

--- a/usr/src/cmd/logadm/err.h
+++ b/usr/src/cmd/logadm/err.h
@@ -50,7 +50,7 @@ void err_mailto(const char *recipient);
 #define	EF_JMP	0x08	/* longjmp through Error_env after printing error */
 #define	EF_RAW	0x10	/* don't prepend/append anything to message */
 
-jmp_buf Err_env;
+extern jmp_buf Err_env;
 extern jmp_buf *Err_env_ptr;
 
 #define	SETJMP	setjmp(*(Err_env_ptr = &Err_env))
@@ -70,7 +70,7 @@ void err_free(void *ptr, const char *fname, int line);
 #define	STRDUP(ptr) err_strdup(ptr, __FILE__, __LINE__)
 char *err_strdup(const char *ptr, const char *fname, int line);
 
-int Debug;	/* replace with #define to zero to compile out Debug code */
+extern int Debug; /* replace with #define to zero to compile out Debug code */
 
 #ifdef	__cplusplus
 }

--- a/usr/src/cmd/logadm/main.c
+++ b/usr/src/cmd/logadm/main.c
@@ -82,6 +82,8 @@ static char *Chown = "/bin/chown";
 static char *Gzip = "/bin/gzip";
 static char *Mkdir = "/bin/mkdir";
 
+int Debug;
+
 /* return from time(0), gathered early on to avoid slewed timestamps */
 time_t Now;
 

--- a/usr/src/cmd/make/lib/mksh/Makefile
+++ b/usr/src/cmd/make/lib/mksh/Makefile
@@ -26,7 +26,7 @@ include $(SRC)/lib/Makefile.lib
 include ../../Makefile.com
 
 POFILE = libmksh.po
-POFILES = $(OBJECTS:%.o=%.po)
+MSGFILES = $(OBJECTS:%.o=%.cc)
 
 LIBS = $(LIBRARY)
 SRCDIR = ../
@@ -42,11 +42,9 @@ all: $(LIBS)
 
 install: all
 
-$(POFILE): $(POFILES)
-	$(CAT) $(POFILES) > $@
+$(POFILE): pofile_MSGFILES
 
-_msg: $(MSGDOMAIN) $(POFILE)
-	$(RM) $(MSGDOMAIN)/$(POFILE)
-	$(CP) $(POFILE) $(MSGDOMAIN)
+_msg: $(MSGDOMAINPOFILE)
 
 include $(SRC)/lib/Makefile.targ
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/cmd/powertop/common/powertop.c
+++ b/usr/src/cmd/powertop/common/powertop.c
@@ -72,7 +72,6 @@ state_info_t		g_cstate_info[NSTATES];
 freq_state_info_t	g_pstate_info[NSTATES];
 cpu_power_info_t	*g_cpu_power_states;
 
-boolean_t		g_turbo_supported;
 boolean_t		g_sig_resize;
 
 uint_t			g_argc;

--- a/usr/src/cmd/powertop/common/turbo.c
+++ b/usr/src/cmd/powertop/common/turbo.c
@@ -62,9 +62,9 @@ static turbo_info_t	*t_new = NULL;
 static int
 pt_turbo_init(void)
 {
-	kstat_ctl_t 		*kc;
-	kstat_t 		*ksp;
-	kstat_named_t 		*knp;
+	kstat_ctl_t		*kc;
+	kstat_t			*ksp;
+	kstat_named_t		*knp;
 
 	/*
 	 * check if the CPU turbo is supported
@@ -111,10 +111,10 @@ pt_turbo_init(void)
 static int
 pt_turbo_snapshot(turbo_info_t *turbo_snapshot)
 {
-	kstat_ctl_t 		*kc;
-	kstat_t 		*ksp;
-	kstat_named_t 		*knp;
-	int 			cpu;
+	kstat_ctl_t		*kc;
+	kstat_t			*ksp;
+	kstat_named_t		*knp;
+	int			cpu;
 	turbo_info_t		*turbo_info;
 
 	if ((kc = kstat_open()) == NULL)

--- a/usr/src/cmd/ptools/Makefile
+++ b/usr/src/cmd/ptools/Makefile
@@ -96,10 +96,12 @@ $(LEGACY_SUBDIRS): FRC
 # Combine all messages files into a single file and copy it to
 # MSGDOMAIN directory
 #
-_msg: ${POFILES}
+_msg: $(MSGDOMAIN) $(POFILES)
 	$(RM) $(POFILE)
 	$(CAT) $(POFILES) > $(POFILE)
 	$(RM)  $(MSGDOMAIN)/$(POFILE)
 	$(CP) $(POFILE) $(MSGDOMAIN)
 
 FRC:
+
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/cmd/smbsrv/test-msgbuf/test_mbmarshal.c
+++ b/usr/src/cmd/smbsrv/test-msgbuf/test_mbmarshal.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -139,7 +139,7 @@ out:
 }
 
 static void
-mbm_put_atrunc()
+mbm_put_atrunc1()
 {
 	uint8_t wire[] = { 'o', 'n', 'e', 't', };
 	mbuf_chain_t *mbc;
@@ -150,23 +150,57 @@ mbm_put_atrunc()
 	/* Encode with wire length < strlen */
 	rc = smb_mbc_encodef(mbc, "4s", "onetwo");
 	if (rc != 0) {
-		printf("Fail: mbm_put_atrunc encode\n");
+		printf("Fail: mbm_put_atrunc1 encode\n");
 		goto out;
 	}
 	/* Trunc should put exactly 4 */
 	if (mbc->chain->m_len != 4) {
-		printf("Fail: mbm_put_atrunc len=%d\n",
+		printf("Fail: mbm_put_atrunc1 len=%d\n",
 		    mbc->chain->m_len);
 		return;
 	}
 
 	if (memcmp(mbc->chain->m_data, wire, 4)) {
-		printf("Fail: mbm_put_atrunc cmp:\n");
+		printf("Fail: mbm_put_atrunc1 cmp:\n");
 		hexdump((uchar_t *)mbc->chain->m_data, 4);
 		return;
 	}
 
-	printf("Pass: mbm_put_atrunc\n");
+	printf("Pass: mbm_put_atrunc1\n");
+
+out:
+	smb_mbc_free(mbc);
+}
+
+static void
+mbm_put_atrunc2()
+{
+	uint8_t wire[] = { 'o', 'n', 'e', 't', 0 };
+	mbuf_chain_t *mbc;
+	int rc;
+
+	mbc = smb_mbc_alloc(4);
+
+	/* Encode with wire length < strlen */
+	rc = smb_mbc_encodef(mbc, "s", "onetwo");
+	if (rc != 1) {
+		printf("Fail: mbm_put_atrunc2 encode rc=%d\n", rc);
+		goto out;
+	}
+	/* Trunc should put exactly 4 */
+	if (mbc->chain->m_len != 4) {
+		printf("Fail: mbm_put_atrunc2 len=%d\n",
+		    mbc->chain->m_len);
+		return;
+	}
+
+	if (memcmp(mbc->chain->m_data, wire, 5)) {
+		printf("Fail: mbm_put_atrunc2 cmp:\n");
+		hexdump((uchar_t *)mbc->chain->m_data, 4);
+		return;
+	}
+
+	printf("Pass: mbm_put_atrunc2\n");
 
 out:
 	smb_mbc_free(mbc);
@@ -338,7 +372,7 @@ out:
 }
 
 static void
-mbm_put_utrunc()
+mbm_put_utrunc1()
 {
 	uint16_t wire[] = { 'o', 'n', 'e', 't' };
 	mbuf_chain_t *mbc;
@@ -349,23 +383,57 @@ mbm_put_utrunc()
 	/* Encode with wire length < strlen */
 	rc = smb_mbc_encodef(mbc, "8U", "onetwo");
 	if (rc != 0) {
-		printf("Fail: mbm_put_utrunc encode\n");
+		printf("Fail: mbm_put_utrunc1 encode\n");
 		goto out;
 	}
 	/* Trunc should put exactly 8 */
 	if (mbc->chain->m_len != 8) {
-		printf("Fail: mbm_put_utrunc len=%d\n",
+		printf("Fail: mbm_put_utrunc1 len=%d\n",
 		    mbc->chain->m_len);
 		return;
 	}
 
 	if (memcmp(mbc->chain->m_data, wire, 8)) {
-		printf("Fail: mbm_put_utrunc cmp:\n");
+		printf("Fail: mbm_put_utrunc1 cmp:\n");
 		hexdump((uchar_t *)mbc->chain->m_data, 8);
 		return;
 	}
 
-	printf("Pass: mbm_put_utrunc\n");
+	printf("Pass: mbm_put_utrunc1\n");
+
+out:
+	smb_mbc_free(mbc);
+}
+
+static void
+mbm_put_utrunc2()
+{
+	uint16_t wire[] = { 'o', 'n', 'e', 't', 0 };
+	mbuf_chain_t *mbc;
+	int rc;
+
+	mbc = smb_mbc_alloc(8);
+
+	/* Encode with wire length < strlen */
+	rc = smb_mbc_encodef(mbc, "U", "onetwo");
+	if (rc != 1) {
+		printf("Fail: mbm_put_utrunc2 encode rc=%d\n", rc);
+		goto out;
+	}
+	/* Trunc should put exactly 8 */
+	if (mbc->chain->m_len != 8) {
+		printf("Fail: mbm_put_utrunc2 len=%d\n",
+		    mbc->chain->m_len);
+		return;
+	}
+
+	if (memcmp(mbc->chain->m_data, wire, 10)) {
+		printf("Fail: mbm_put_utrunc2 cmp:\n");
+		hexdump((uchar_t *)mbc->chain->m_data, 8);
+		return;
+	}
+
+	printf("Pass: mbm_put_utrunc2\n");
 
 out:
 	smb_mbc_free(mbc);
@@ -657,14 +725,16 @@ test_mbmarshal()
 	mbm_put_a0();
 	mbm_put_a1();
 	mbm_put_apad();
-	mbm_put_atrunc();
+	mbm_put_atrunc1();
+	mbm_put_atrunc2();
 
 	mbm_put_u0();
 	mbm_put_u1();
 	mbm_put_u3();
 	mbm_put_u4();
 	mbm_put_upad();
-	mbm_put_utrunc();
+	mbm_put_utrunc1();
+	mbm_put_utrunc2();
 
 	mbm_get_a0();
 	mbm_get_a1();

--- a/usr/src/cmd/troff/Makefile
+++ b/usr/src/cmd/troff/Makefile
@@ -20,11 +20,7 @@
 # CDDL HEADER END
 #
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
-#
 # Copyright (c) 1989 by Sun Microsystems, Inc.
-#
-# cmd/troff/Makefile
 #
 
 include ../Makefile.cmd
@@ -47,11 +43,11 @@ POFILES= $(SUBDIRS:%=%/%.po)
 POFILE= troff.po
 
 
-.KEEP_STATE :
+.KEEP_STATE:
 
-all :		$(SUBDIRS)
+all:		$(SUBDIRS)
 
-install clean lint strip :	$(SUBDIRS)
+install clean lint strip:	$(SUBDIRS)
 
 clobber: $(SUBDIRS) local_clobber
 
@@ -60,14 +56,16 @@ local_clobber:
 
 $(POFILE):      $(SUBDIRS) $(POFILES2)
 	cat     $(POFILES) $(POFILES2)  >       $@
-	 
-_msg:   $(SUBDIRS)
+
+_msg:   $(MSGDOMAIN) $(SUBDIRS)
 	  $(RM)	$(POFILE)
 	  cat    $(POFILES)      > $(POFILE)
 	  $(RM) $(MSGDOMAIN)/$(POFILE)
 	  cp $(POFILE) $(MSGDOMAIN)
 
-$(SUBDIRS) :	FRC
-		@cd $@; pwd; $(MAKE) $(TARGET)
+$(SUBDIRS):	FRC
+	@cd $@; pwd; $(MAKE) $(TARGET)
 
 FRC:
+
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/contrib/ast/src/cmd/ksh93/sh/main.c
+++ b/usr/src/contrib/ast/src/cmd/ksh93/sh/main.c
@@ -580,13 +580,6 @@ static void	exfile(register Shell_t *shp, register Sfio_t *iop,register int fno)
 		if(t)
 		{
 			execflags = sh_state(SH_ERREXIT)|sh_state(SH_INTERACTIVE);
-			/* The last command may not have to fork */
-			if(!sh_isstate(SH_PROFILE) && sh_isoption(SH_CFLAG) &&
-				(fno<0 || !(shp->fdstatus[fno]&(IOTTY|IONOSEEK)))
-				&& !sfreserve(iop,0,0))
-			{
-					execflags |= sh_state(SH_NOFORK);
-			}
 			shp->st.execbrk = 0;
 			sh_exec(t,execflags);
 			if(shp->forked)

--- a/usr/src/contrib/ast/src/cmd/ksh93/tests/io.sh
+++ b/usr/src/contrib/ast/src/cmd/ksh93/tests/io.sh
@@ -496,4 +496,18 @@ done	{n}< /dev/null
 n=$( exec {n}< /dev/null; print -r -- $n)
 [[ -r /dev/fd/$n ]] && err_exit "file descriptor n=$n left open after subshell"
 
+# ==========
+# https://github.com/att/ast/issues/9
+tf=`mktemp`
+echo foo bar > $tf
+$SHELL -c 'echo xxx 1<>; '$tf
+actual=$(cat $tf)
+expect="xxx"
+[[ "$actual" = "$expect" ]] || err_exit "<>; does not truncate files - $expect - $actual"
+rm -f $tf
+
+cp /dev/null $tf
+$SHELL -c '{ echo "Foo"; echo "bar"; uname; } >; '$tf
+[[ -s "$tf" ]] || err_exit ">; does not work with -c"
+rm -f $tf
 exit $((Errors<125?Errors:125))

--- a/usr/src/lib/brand/shared/brand/Makefile.com
+++ b/usr/src/lib/brand/shared/brand/Makefile.com
@@ -55,6 +55,11 @@ CPPFLAGS +=	-D_REENTRANT -U_ASM -I. -I../sys
 CFLAGS +=	$(CCVERBOSE)
 ASFLAGS =	-P $(ASFLAGS_$(CURTYPE)) -D_ASM -I. -I../sys
 
+#
+# Disable stack protection as this code might be running in an s10 context.
+#
+STACKPROTECT = none
+
 # intentional code after abort()
 SMOFF += unreachable
 

--- a/usr/src/lib/brand/solaris10/s10_brand/Makefile.com
+++ b/usr/src/lib/brand/solaris10/s10_brand/Makefile.com
@@ -84,6 +84,11 @@ DYNFLAGS +=	$(DYNFLAGS_$(CLASS))
 DYNFLAGS +=	$(BLOCAL) $(ZNOVERSION) -Wl,-e_start
 LDLIBS +=	-lmapmalloc -lc
 
+#
+# Disable stack protection as we're running in an s10 context.
+#
+STACKPROTECT = none
+
 CERRWARN +=	$(CNOWARN_UNINIT)
 
 $(LIBS):= PICS += $(SHAREDOBJS)

--- a/usr/src/lib/cfgadm_plugins/scsi/Makefile
+++ b/usr/src/lib/cfgadm_plugins/scsi/Makefile
@@ -71,3 +71,5 @@ $(POFILES):
 	$(RM) messages.po
 
 FRC:
+
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/lib/libc/i386/fp/_D_cplx_lr_div.c
+++ b/usr/src/lib/libc/i386/fp/_D_cplx_lr_div.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _D_cplx_lr_div(z, w) returns z / w computed by the textbook
  * formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 double _Complex
 _D_cplx_lr_div(double _Complex z, double _Complex w)
 {
-	double _Complex	v;
+	double _Complex	v = 0;
 	long double	a, b, c, d, r;
 
 	/* LINTED alignment */

--- a/usr/src/lib/libc/i386/fp/_D_cplx_lr_div_ix.c
+++ b/usr/src/lib/libc/i386/fp/_D_cplx_lr_div_ix.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _D_cplx_div_ix(b, w) returns (I * b) / w computed by the text-
  * book formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 double _Complex
 _D_cplx_lr_div_ix(double b, double _Complex w)
 {
-	double _Complex	v;
+	double _Complex	v = 0;
 	long double	c, d, r;
 
 	/* LINTED alignment */

--- a/usr/src/lib/libc/i386/fp/_D_cplx_lr_div_rx.c
+++ b/usr/src/lib/libc/i386/fp/_D_cplx_lr_div_rx.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _D_cplx_lr_div_rx(a, w) returns a / w computed by the textbook
  * formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 double _Complex
 _D_cplx_lr_div_rx(double a, double _Complex w)
 {
-	double _Complex	v;
+	double _Complex	v = 0;
 	long double	c, d, r;
 
 	/* LINTED alignment */

--- a/usr/src/lib/libc/i386/fp/_D_cplx_mul.c
+++ b/usr/src/lib/libc/i386/fp/_D_cplx_mul.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _D_cplx_mul(z, w) returns z * w with infinities handled according
  * to C99.
@@ -74,13 +72,13 @@ testinf(double x)
 
 	xx.d = x;
 	return (((((xx.i[1] << 1) - 0xffe00000) | xx.i[0]) == 0)?
-		(1 | (xx.i[1] >> 31)) : 0);
+	    (1 | (xx.i[1] >> 31)) : 0);
 }
 
 double _Complex
 _D_cplx_mul(double _Complex z, double _Complex w)
 {
-	double _Complex	v;
+	double _Complex	v = 0;
 	double		a, b, c, d;
 	long double	x, y;
 	int		recalc, i, j;

--- a/usr/src/lib/libc/i386/fp/_F_cplx_lr_div.c
+++ b/usr/src/lib/libc/i386/fp/_F_cplx_lr_div.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _F_cplx_lr_div(z, w) returns z / w computed by the textbook
  * formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 float _Complex
 _F_cplx_lr_div(float _Complex z, float _Complex w)
 {
-	float _Complex	v;
+	float _Complex	v = 0;
 	long double	a, b, c, d, r;
 
 	a = ((float *)&z)[0];

--- a/usr/src/lib/libc/i386/fp/_F_cplx_lr_div_ix.c
+++ b/usr/src/lib/libc/i386/fp/_F_cplx_lr_div_ix.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _F_cplx_div_ix(b, w) returns (I * b) / w computed by the text-
  * book formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 float _Complex
 _F_cplx_lr_div_ix(float b, float _Complex w)
 {
-	float _Complex	v;
+	float _Complex	v = 0;
 	long double	c, d, r;
 
 	c = ((float *)&w)[0];

--- a/usr/src/lib/libc/i386/fp/_F_cplx_lr_div_rx.c
+++ b/usr/src/lib/libc/i386/fp/_F_cplx_lr_div_rx.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _F_cplx_lr_div_rx(a, w) returns a / w computed by the textbook
  * formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 float _Complex
 _F_cplx_lr_div_rx(float a, float _Complex w)
 {
-	float _Complex	v;
+	float _Complex	v = 0;
 	long double	c, d, r;
 
 	c = ((float *)&w)[0];

--- a/usr/src/lib/libc/i386/fp/_F_cplx_mul.c
+++ b/usr/src/lib/libc/i386/fp/_F_cplx_mul.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _F_cplx_mul(z, w) returns z * w with infinities handled according
  * to C99.
@@ -79,7 +77,7 @@ testinff(float x)
 float _Complex
 _F_cplx_mul(float _Complex z, float _Complex w)
 {
-	float _Complex	v;
+	float _Complex	v = 0;
 	float		a, b, c, d;
 	long double	x, y;
 	int		recalc, i, j;

--- a/usr/src/lib/libc/i386/fp/_X_cplx_lr_div.c
+++ b/usr/src/lib/libc/i386/fp/_X_cplx_lr_div.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _X_cplx_lr_div(z, w) returns z / w computed by the textbook
  * formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 long double _Complex
 _X_cplx_lr_div(long double _Complex z, long double _Complex w)
 {
-	long double _Complex	v;
+	long double _Complex	v = 0;
 	long double		a, b, c, d, r;
 
 	a = ((long double *)&z)[0];

--- a/usr/src/lib/libc/i386/fp/_X_cplx_lr_div_ix.c
+++ b/usr/src/lib/libc/i386/fp/_X_cplx_lr_div_ix.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _X_cplx_div_ix(b, w) returns (I * b) / w computed by the text-
  * book formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 long double _Complex
 _X_cplx_lr_div_ix(long double b, long double _Complex w)
 {
-	long double _Complex	v;
+	long double _Complex	v = 0;
 	long double		c, d, r;
 
 	c = ((long double *)&w)[0];

--- a/usr/src/lib/libc/i386/fp/_X_cplx_lr_div_rx.c
+++ b/usr/src/lib/libc/i386/fp/_X_cplx_lr_div_rx.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _X_cplx_lr_div_rx(a, w) returns a / w computed by the textbook
  * formula without regard to exceptions or special cases.
@@ -41,7 +39,7 @@
 long double _Complex
 _X_cplx_lr_div_rx(long double a, long double _Complex w)
 {
-	long double _Complex	v;
+	long double _Complex	v = 0;
 	long double		c, d, r;
 
 	c = ((long double *)&w)[0];

--- a/usr/src/lib/libc/i386/fp/_X_cplx_mul.c
+++ b/usr/src/lib/libc/i386/fp/_X_cplx_mul.c
@@ -24,8 +24,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 /*
  * _X_cplx_mul(z, w) returns z * w with infinities handled according
  * to C99.
@@ -83,7 +81,7 @@ testinfl(long double x)
 long double _Complex
 _X_cplx_mul(long double _Complex z, long double _Complex w)
 {
-	long double _Complex	v;
+	long double _Complex	v = 0;
 	long double		a, b, c, d, x, y;
 	int			recalc, i, j;
 

--- a/usr/src/lib/libcurses/Makefile
+++ b/usr/src/lib/libcurses/Makefile
@@ -134,3 +134,4 @@ generic.po:
 FRC:
 
 include ../Makefile.targ
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/lib/libmlrpc/common/ndr_marshal.c
+++ b/usr/src/lib/libmlrpc/common/ndr_marshal.c
@@ -20,12 +20,13 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2021 Tintri by DDN, Inc. All rights reserved.
  */
 
 #include <assert.h>
 #include <strings.h>
 #include <sys/param.h>
+#include <sys/debug.h>
 
 #include <libmlrpc.h>
 
@@ -419,6 +420,8 @@ ndr_decode_pac_hdr(ndr_stream_t *nds, ndr_pac_hdr_t *hdr)
 	return (NDR_DRC_PTYPE_RPCHDR(rc));
 }
 
+CTASSERT(sizeof (ndr_common_header_t) >= NDR_CMN_HDR_SIZE);
+
 /*
  * Decode an RPC fragment header.  Use ndr_decode_pdu_hdr() to process
  * the first fragment header then this function to process additional
@@ -432,7 +435,7 @@ ndr_decode_frag_hdr(ndr_stream_t *nds, ndr_common_header_t *hdr)
 	int byte_order;
 
 	pdu = (uint8_t *)nds->pdu_base_offset + nds->pdu_scan_offset;
-	bcopy(pdu, hdr, NDR_RSP_HDR_SIZE);
+	bcopy(pdu, hdr, NDR_CMN_HDR_SIZE);
 
 	/*
 	 * Swap non-byte fields if the PDU byte-order

--- a/usr/src/lib/libmlrpc/common/rpcpdu.ndl
+++ b/usr/src/lib/libmlrpc/common/rpcpdu.ndl
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2021 Tintri by DDN, Inc. All rights reserved.
  */
 
 #ifndef _RPCPDU_NDL_
@@ -557,9 +557,11 @@ struct ndr_request_hdr_with_object {
 
 /*
  * Convenient for response header sizing and multi-fragment responses.
- * We know the header is going to be 24 bytes.
+ * We know the header is going to be 24 bytes, and the 'common' part
+ * is 16 bytes.
  */
-#define NDR_RSP_HDR_SIZE			24
+#define	NDR_CMN_HDR_SIZE			16
+#define	NDR_RSP_HDR_SIZE			24
 
 
 /*

--- a/usr/src/lib/libslp/Makefile
+++ b/usr/src/lib/libslp/Makefile
@@ -75,3 +75,5 @@ $(SUBDIRS):	FRC
 	@cd $@; pwd; $(MAKE) $(TARGET)
 
 FRC:
+
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/lib/libsmedia/plugins/Makefile.plugin
+++ b/usr/src/lib/libsmedia/plugins/Makefile.plugin
@@ -62,3 +62,5 @@ $(POFILE) : $(POFILE_SRCS)
 	$(SED) -e '/^domain/d' messages.po > $@
 	$(RM) messages.po
 
+
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/lib/libsmedia/plugins/blkdev/Makefile
+++ b/usr/src/lib/libsmedia/plugins/blkdev/Makefile
@@ -21,9 +21,9 @@
 #
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
 #
-#
-# lib/libsmedia/plugins/bd/Makefile
 
 include		../../../Makefile.lib
 include		Makefile.targ
 include		../Makefile.plugin
+
+include $(SRC)/Makefile.msg.targ

--- a/usr/src/man/man2/chown.2
+++ b/usr/src/man/man2/chown.2
@@ -4,11 +4,10 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH CHOWN 2 "Oct 9, 2008"
+.TH CHOWN 2 "Mar 2, 2021"
 .SH NAME
 chown, lchown, fchown, fchownat \- change owner and group of a file
 .SH SYNOPSIS
-.LP
 .nf
 #include <unistd.h>
 #include <sys/types.h>
@@ -33,8 +32,6 @@ chown, lchown, fchown, fchownat \- change owner and group of a file
 .fi
 
 .SH DESCRIPTION
-.sp
-.LP
 The \fBchown()\fR function sets the owner \fBID\fR and group \fBID\fR of the
 file specified by \fIpath\fR or referenced by the open file descriptor
 \fIfildes\fR to \fIowner\fR and \fIgroup\fR respectively. If \fIowner\fR or
@@ -54,7 +51,7 @@ in the same manner as \fBchown()\fR. If, however, the \fIpath\fR argument is
 relative, the path is resolved relative to the \fIfildes\fR argument rather
 than the current working directory.  If the \fIfildes\fR argument has the
 special value \fBAT_FDCWD\fR, the path resolution reverts back to current
-working directory relative.  If the \fIflag\fR argument is set to \fBSYMLNK\fR,
+working directory relative.  If the \fIflag\fR argument is set to \fBAT_SYMLINK_NOFOLLOW\fR,
 the function behaves like \fBlchown()\fR with respect to symbolic links. If the
 \fIpath\fR argument is absolute, the \fIfildes\fR argument is ignored.  If the
 \fIpath\fR argument is a null pointer, the function behaves like
@@ -105,14 +102,10 @@ See \fBsystem\fR(4) and  \fBfpathconf\fR(2).
 Upon successful completion, \fBchown()\fR, \fBfchown()\fR and \fBlchown()\fR
 mark for update the \fBst_ctime\fR field of the file.
 .SH RETURN VALUES
-.sp
-.LP
 Upon successful completion, \fB0\fR is returned. Otherwise, \fB\(mi1\fR is
 returned, the owner and group of the named file remain unchanged, and
 \fBerrno\fR is set to indicate the error.
 .SH ERRORS
-.sp
-.LP
 All of these functions will fail if:
 .sp
 .ne 2
@@ -299,8 +292,6 @@ The named file referred to by \fIfildes\fR resides on a read-only file system.
 .RE
 
 .SH ATTRIBUTES
-.sp
-.LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
 
@@ -324,7 +315,5 @@ The \fBfchownat()\fR function is Evolving.
 .LP
 The \fBchown()\fR and \fBfchownat()\fR functions are Async-Signal-Safe.
 .SH SEE ALSO
-.sp
-.LP
 \fBchgrp\fR(1), \fBchown\fR(1), \fBchmod\fR(2), \fBfpathconf\fR(2),
 \fBsystem\fR(4), \fBattributes\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man9e/mc_getprop.9e
+++ b/usr/src/man/man9e/mc_getprop.9e
@@ -62,7 +62,7 @@ When the
 .Fn mc_getprop
 entry point is called, the driver needs to first identify the property.
 The set of possible properties and their meaning is listed in the
-.Sx PROPERTIES
+.Sy PROPERTIES
 section of
 .Xr mac 9E .
 It should identify the property based on the value of

--- a/usr/src/man/man9e/mc_propinfo.9e
+++ b/usr/src/man/man9e/mc_propinfo.9e
@@ -68,7 +68,7 @@ When the
 .Fn mc_propinfo
 entry point is called, the driver needs to first identify the property.
 The set of possible properties and their meaning is listed in the
-.Sx PROPERTIES
+.Sy PROPERTIES
 section of
 .Xr mac 9E .
 It should identify the property based on the value of

--- a/usr/src/man/man9e/mc_setprop.9e
+++ b/usr/src/man/man9e/mc_setprop.9e
@@ -62,7 +62,7 @@ When the
 .Fn mc_setprop
 entry point is called, the driver needs to first identify the property.
 The set of possible properties and their meaning is listed in the
-.Sx PROPERTIES
+.Sy PROPERTIES
 section of
 .Xr mac 9E .
 It should identify the property based on the value of

--- a/usr/src/man/man9f/Makefile
+++ b/usr/src/man/man9f/Makefile
@@ -1026,6 +1026,7 @@ MANLINKS=	AVL_NEXT.9f					\
 		mac_fini_ops.9f					\
 		mac_free.9f					\
 		mac_hcksum_set.9f				\
+		mac_prop_info_set_default_fec.9f		\
 		mac_prop_info_set_default_link_flowctrl.9f	\
 		mac_prop_info_set_default_str.9f		\
 		mac_prop_info_set_default_uint32.9f		\
@@ -1908,6 +1909,8 @@ list_tail.9f				:= LINKSRC = list_create.9f
 mac_free.9f				:= LINKSRC = mac_alloc.9f
 mac_hcksum_set.9f			:= LINKSRC = mac_hcksum_get.9f
 mac_fini_ops.9f				:= LINKSRC = mac_init_ops.9f
+
+mac_prop_info_set_default_fec.9f	:= LINKSRC = mac_prop_info.9f
 mac_prop_info_set_default_link_flowctrl.9f	:= LINKSRC = mac_prop_info.9f
 mac_prop_info_set_default_str.9f	:= LINKSRC = mac_prop_info.9f
 mac_prop_info_set_default_uint8.9f	:= LINKSRC = mac_prop_info.9f

--- a/usr/src/man/man9f/mac_link_update.9f
+++ b/usr/src/man/man9f/mac_link_update.9f
@@ -36,7 +36,7 @@ The current state of the link.
 For valid link states see the discussion of
 .Sy MAC_PROP_STATUS
 in the
-.Sx PROPERTIES
+.Sy PROPERTIES
 section of
 .Xr mac 9E .
 .El
@@ -46,7 +46,7 @@ The
 function is used by device drivers to inform the MAC layer that the
 state of a link has changed.
 As discussed in the
-.Sx Link Updates
+.Sy Link Updates
 section of
 .Xr mac 9E ,
 the driver should call this whenever it detects that the state of the

--- a/usr/src/man/man9f/mac_prop_info.9f
+++ b/usr/src/man/man9f/mac_prop_info.9f
@@ -10,12 +10,14 @@
 .\"
 .\"
 .\" Copyright 2016 Joyent, Inc.
+.\" Copyright 2021 Oxide Computer Company
 .\"
-.Dd May 31, 2016
+.Dd February 25, 2021
 .Dt MAC_PROP_INFO 9F
 .Os
 .Sh NAME
 .Nm mac_prop_info ,
+.Nm mac_prop_info_set_default_fec ,
 .Nm mac_prop_info_set_default_link_flowctrl ,
 .Nm mac_prop_info_set_default_str ,
 .Nm mac_prop_info_set_default_uint8 ,
@@ -26,6 +28,11 @@
 .Nd mac property information functions
 .Sh SYNOPSIS
 .In sys/mac_provider.h
+.Ft void
+.Fo mac_prop_info_set_default_fec
+.Fa "mac_prop_info_handle_t hdl"
+.Fa "link_fec_t fec"
+.Fc
 .Ft void
 .Fo mac_prop_info_set_default_link_flowctrl
 .Fa "mac_prop_info_handle_t hdl"
@@ -66,26 +73,36 @@
 illumos DDI specific
 .Sh PARAMETERS
 .Bl -tag -width Ds
-.It Ft hdl
+.It Fa hdl
 A pointer to the MAC property information handle.
-.It Ft fctl
+.It Fa fctl
 A valid link flow control entry.
 Valid values are documented in the
 .Sy MAC_PROP_FLOWCTRL
 property description in the
-.Sx PROPERTIES
+.Sy PROPERTIES
 section of
 .Xr mac 9E .
-.It Ft str
+.It Fa fec
+A valid link forward error correction
+.Pq fec
+scheme.
+Valid values are documented in the
+.Sy MAC_PROP_EN_FEC_CAP
+property description in the
+.Sy PROPERTIES
+section of
+.Xr mac 9E .
+.It Fa str
 A null-terminated ASCII character string that describes that contains a
 value of a property.
-.It Ft u8
+.It Fa u8
 An 8-bit unsigned value.
-.It Ft u16
+.It Fa u16
 An 16-bit unsigned value.
-.It Ft u32
+.It Fa u32
 An 32-bit unsigned value.
-.It Ft perm
+.It Fa perm
 An 8-bit unsigned value which is the bitwise inclusive OR of the
 following values:
 .Bl -tag -width Ds
@@ -105,10 +122,10 @@ This is equivalent to specifying both
 and
 .Sy MAC_PROP_PERM_WRITE .
 .El
-.It Ft low
+.It Fa low
 A 32-bit unsigned value that represents the lowest possible value of an
 integer property, generally inclusive.
-.It Ft high
+.It Fa high
 A 32-bit unsigned value that represents the highest possible value an
 integer property, generally inclusive.
 .El
@@ -156,6 +173,7 @@ function is called, a new property range is added, allowing for multiple
 disjoint ranges to be specified for a given property.
 .Pp
 The remaining functions,
+.Fn mac_prop_info_set_default_fec ,
 .Fn mac_prop_info_set_default_link_flowctrl ,
 .Fn mac_prop_info_set_default_str ,
 .Fn mac_prop_info_set_uint8 ,
@@ -193,6 +211,18 @@ and
 .Fn mac_prop_info_set_default_uint32
 functions set the default value for values whose properties are 8-, 16-,
 and 32-bit unsigned values respectively.
+.Pp
+The
+.Fn mac_prop_info_set_default_fec
+function is used for properties that describe link forward error
+correction values such as
+.Dv MAC_PROP_EN_FEC_CAP
+and
+.Dv MAC_PROP_ADV_FEC_CAP .
+The various values of a
+.Ft link_fec_t
+are documented in
+.Xr mac 9E .
 .Sh CONTEXT
 These functions are generally called on a handle passed into the
 .Xr mc_propinfo 9E

--- a/usr/src/pkg/manifests/system-kernel.man9f.inc
+++ b/usr/src/pkg/manifests/system-kernel.man9f.inc
@@ -1036,6 +1036,8 @@ link path=usr/share/man/man9f/list_tail.9f target=list_create.9f
 link path=usr/share/man/man9f/mac_fini_ops.9f target=mac_init_ops.9f
 link path=usr/share/man/man9f/mac_free.9f target=mac_alloc.9f
 link path=usr/share/man/man9f/mac_hcksum_set.9f target=mac_hcksum_get.9f
+link path=usr/share/man/man9f/mac_prop_info_set_default_fec.9f \
+    target=mac_prop_info.9f
 link path=usr/share/man/man9f/mac_prop_info_set_default_link_flowctrl.9f \
     target=mac_prop_info.9f
 link path=usr/share/man/man9f/mac_prop_info_set_default_str.9f \

--- a/usr/src/tools/scripts/wsdiff.py
+++ b/usr/src/tools/scripts/wsdiff.py
@@ -303,10 +303,12 @@ def str_prefix_trunc(s, prefix) :
 def fnFormat(fn) :
 	global baseWsRoot, ptchWsRoot
 
-	if len(os.path.commonprefix([fn, baseWsRoot])) == len(baseWsRoot):
+	if (baseWsRoot and
+	    len(os.path.commonprefix([fn, baseWsRoot])) == len(baseWsRoot)):
 		return fn[len(baseWsRoot) + 1:]
 
-	if len(os.path.commonprefix([fn, ptchWsRoot])) == len(ptchWsRoot):
+	if (ptchWsRoot and
+	    len(os.path.commonprefix([fn, ptchWsRoot])) == len(ptchWsRoot)):
 		return fn[len(ptchWsRoot) + 1:]
 
 	# Fall back to looking for the expected root_<arch>[-nd] string

--- a/usr/src/uts/common/fs/smbsrv/smb2_qinfo_file.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_qinfo_file.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -240,10 +240,11 @@ static uint32_t
 smb2_qif_basic(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	smb_attr_t *sa = &qi->qi_attr;
+	int rc;
 
 	ASSERT((sa->sa_mask & SMB_AT_BASIC) == SMB_AT_BASIC);
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "TTTTll",
 	    &sa->sa_crtime,		/* T */
 	    &sa->sa_vattr.va_atime,	/* T */
@@ -251,6 +252,8 @@ smb2_qif_basic(smb_request_t *sr, smb_queryinfo_t *qi)
 	    &sa->sa_vattr.va_ctime,	/* T */
 	    sa->sa_dosattr,		/* l */
 	    0); /* reserved */		/* l */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -265,10 +268,11 @@ static uint32_t
 smb2_qif_standard(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	smb_attr_t *sa = &qi->qi_attr;
+	int rc;
 
 	ASSERT((sa->sa_mask & SMB_AT_STANDARD) == SMB_AT_STANDARD);
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "qqlbbw",
 	    sa->sa_allocsz,		/* q */
 	    sa->sa_vattr.va_size,	/* q */
@@ -276,6 +280,8 @@ smb2_qif_standard(smb_request_t *sr, smb_queryinfo_t *qi)
 	    qi->qi_delete_on_close,	/* b */
 	    qi->qi_isdir,		/* b */
 	    0); /* reserved */		/* w */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -290,6 +296,7 @@ smb2_qif_internal(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	smb_attr_t *sa = &qi->qi_attr;
 	u_longlong_t nodeid;
+	int rc;
 
 	ASSERT((sa->sa_mask & SMB_AT_NODEID) == SMB_AT_NODEID);
 	nodeid = sa->sa_vattr.va_nodeid;
@@ -298,9 +305,11 @@ smb2_qif_internal(smb_request_t *sr, smb_queryinfo_t *qi)
 	    (sr->session->s_flags & SMB_SSN_AAPL_CCEXT) != 0)
 		nodeid = 0;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "q",
 	    nodeid);	/* q */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -315,9 +324,12 @@ static uint32_t
 smb2_qif_ea_size(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	_NOTE(ARGUNUSED(qi))
+	int rc;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "l", 0);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -341,10 +353,13 @@ smb2_qif_access(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	_NOTE(ARGUNUSED(qi))
 	smb_ofile_t *of = sr->fid_ofile;
+	int rc;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "l",
 	    of->f_granted_access);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -358,14 +373,17 @@ smb2_qif_access(smb_request_t *sr, smb_queryinfo_t *qi)
 static uint32_t
 smb2_qif_name(smb_request_t *sr, smb_queryinfo_t *qi)
 {
+	int rc;
 
 	ASSERT(qi->qi_namelen > 0);
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "llU",
 	    0, /* FileIndex	 (l) */
 	    qi->qi_namelen,	/* l */
 	    qi->qi_name);	/* U */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -379,13 +397,16 @@ smb2_qif_position(smb_request_t *sr, smb_queryinfo_t *qi)
 	_NOTE(ARGUNUSED(qi))
 	smb_ofile_t *of = sr->fid_ofile;
 	uint64_t pos;
+	int rc;
 
 	mutex_enter(&of->f_mutex);
 	pos = of->f_seek_pos;
 	mutex_exit(&of->f_mutex);
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "q", pos);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -399,9 +420,12 @@ static uint32_t
 smb2_qif_mode(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	_NOTE(ARGUNUSED(qi))
+	int rc;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "l", 0);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -413,9 +437,12 @@ static uint32_t
 smb2_qif_alignment(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	_NOTE(ARGUNUSED(qi))
+	int rc;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "l", 0);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -430,6 +457,7 @@ static uint32_t
 smb2_qif_altname(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	smb_ofile_t *of = sr->fid_ofile;
+	int rc;
 
 	ASSERT(qi->qi_namelen > 0);
 	ASSERT(qi->qi_attr.sa_mask & SMB_AT_NODEID);
@@ -442,10 +470,12 @@ smb2_qif_altname(smb_request_t *sr, smb_queryinfo_t *qi)
 	/* fill in qi->qi_shortname */
 	smb_query_shortname(of->f_node, qi);
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "%lU", sr,
 	    smb_wcequiv_strlen(qi->qi_shortname),
 	    qi->qi_shortname);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -481,6 +511,7 @@ smb2_qif_pipe(smb_request_t *sr, smb_queryinfo_t *qi)
 	smb_ofile_t *of = sr->fid_ofile;
 	uint32_t	pipe_mode;
 	uint32_t	nonblock;
+	int		rc;
 
 	switch (of->f_ftype) {
 	case SMB_FTYPE_BYTE_PIPE:
@@ -496,9 +527,11 @@ smb2_qif_pipe(smb_request_t *sr, smb_queryinfo_t *qi)
 	}
 	nonblock = 0;	/* XXX todo: Get this from the pipe handle. */
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "ll",
 	    pipe_mode, nonblock);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -532,13 +565,16 @@ smb2_qif_compr(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	smb_attr_t *sa = &qi->qi_attr;
 	uint16_t CompressionFormat = 0;	/* COMPRESSION_FORMAT_NONE */
+	int rc;
 
 	ASSERT(sa->sa_mask & SMB_AT_SIZE);
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "qw6.",
 	    sa->sa_vattr.va_size,	/* q */
 	    CompressionFormat);		/* w */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -550,8 +586,9 @@ static uint32_t
 smb2_qif_opens(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	smb_attr_t *sa = &qi->qi_attr;
+	int rc;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "TTTTqqll",
 	    &sa->sa_crtime,		/* T */
 	    &sa->sa_vattr.va_atime,	/* T */
@@ -561,6 +598,8 @@ smb2_qif_opens(smb_request_t *sr, smb_queryinfo_t *qi)
 	    sa->sa_vattr.va_size,	/* q */
 	    sa->sa_dosattr,		/* l */
 	    0); /* reserved */		/* l */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -578,8 +617,12 @@ static uint32_t
 smb2_qif_tags(smb_request_t *sr, smb_queryinfo_t *qi)
 {
 	_NOTE(ARGUNUSED(qi))
-	(void) smb_mbc_encodef(
+	int rc;
+
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "ll", 0, 0);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }

--- a/usr/src/uts/common/fs/smbsrv/smb2_qinfo_fs.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_qinfo_fs.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -100,6 +100,7 @@ smb2_qfs_volume(smb_request_t *sr)
 	smb_node_t *snode;
 	fsid_t fsid;
 	uint32_t LabelLength;
+	int rc;
 
 	if (!STYPE_ISDSK(tree->t_res_type))
 		return (NT_STATUS_INVALID_PARAMETER);
@@ -112,14 +113,16 @@ smb2_qfs_volume(smb_request_t *sr)
 	/*
 	 * NT has the "supports objects" flag set to 1.
 	 */
-	(void) smb_mbc_encodef(
-	    &sr->raw_data, "qllb.U",
-	    0LL,	/* Volume creation time (q) */
+	rc = smb_mbc_encodef(
+	    &sr->raw_data, "Tllb.U",
+	    &tree->t_create_time,	/*	(T) */
 	    fsid.val[0],	/* serial no.   (l) */
 	    LabelLength,		/*	(l) */
 	    0,		/* Supports objects	(b) */
 	    /* reserved				(.) */
 	    tree->t_volume);		/*	(U) */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -141,12 +144,14 @@ smb2_qfs_size(smb_request_t *sr)
 	if (rc)
 		return (smb_errno2status(rc));
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "qqll",
 	    fssize.fs_caller_units,
 	    fssize.fs_caller_avail,
 	    fssize.fs_sectors_per_unit,
 	    fssize.fs_bytes_per_sector);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -168,13 +173,15 @@ smb2_qfs_fullsize(smb_request_t *sr)
 	if (rc)
 		return (smb_errno2status(rc));
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "qqqll",
 	    fssize.fs_caller_units,
 	    fssize.fs_caller_avail,
 	    fssize.fs_volume_avail,
 	    fssize.fs_sectors_per_unit,
 	    fssize.fs_bytes_per_sector);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -188,6 +195,7 @@ smb2_qfs_device(smb_request_t *sr)
 	smb_tree_t *tree = sr->tid_tree;
 	uint32_t DeviceType;
 	uint32_t Characteristics;
+	int rc;
 
 	if (!STYPE_ISDSK(tree->t_res_type))
 		return (NT_STATUS_INVALID_PARAMETER);
@@ -195,10 +203,12 @@ smb2_qfs_device(smb_request_t *sr)
 	DeviceType = FILE_DEVICE_DISK;
 	Characteristics = FILE_DEVICE_IS_MOUNTED;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "ll",
 	    DeviceType,
 	    Characteristics);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -213,6 +223,7 @@ smb2_qfs_attr(smb_request_t *sr)
 	char *fsname;
 	uint32_t namelen;
 	uint32_t FsAttr;
+	int rc;
 
 	/* This call is OK on all tree types. */
 	switch (tree->t_res_type & STYPE_MASK) {
@@ -247,12 +258,14 @@ smb2_qfs_attr(smb_request_t *sr)
 	if (tree->t_flags & SMB_TREE_SPARSE)
 		FsAttr |= FILE_SUPPORTS_SPARSE_FILES;
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "lllU",
 	    FsAttr,
 	    MAXNAMELEN-1,
 	    namelen,
 	    fsname);
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -264,6 +277,7 @@ uint32_t
 smb2_qfs_control(smb_request_t *sr)
 {
 	smb_tree_t *tree = sr->tid_tree;
+	int rc;
 
 	if (!STYPE_ISDSK(tree->t_res_type))
 		return (NT_STATUS_INVALID_PARAMETER);
@@ -275,7 +289,7 @@ smb2_qfs_control(smb_request_t *sr)
 		return (NT_STATUS_VOLUME_NOT_UPGRADED);
 	}
 
-	(void) smb_mbc_encodef(
+	rc = smb_mbc_encodef(
 	    &sr->raw_data, "qqqqqll",
 	    0,		/* free space start filtering - MUST be 0 */
 	    0,		/* free space threshold - MUST be 0 */
@@ -284,6 +298,8 @@ smb2_qfs_control(smb_request_t *sr)
 	    SMB_QUOTA_UNLIMITED,	/* default quota limit */
 	    FILE_VC_QUOTA_ENFORCE,	/* fs control flag */
 	    0);				/* pad bytes */
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }
@@ -364,7 +380,7 @@ smb2_qfs_sectorsize(smb_request_t *sr)
 	smb_fssize_t		fssize;
 	smb_tree_t *tree = sr->tid_tree;
 	uint32_t lbps, pbps;
-	uint32_t flags;
+	uint32_t flags, unk;
 	int rc;
 
 	if (!STYPE_ISDSK(tree->t_res_type))
@@ -373,23 +389,14 @@ smb2_qfs_sectorsize(smb_request_t *sr)
 	rc = smb_fssize(sr, &fssize);
 	if (rc)
 		return (smb_errno2status(rc));
+
+	// PhysicalBytesPerSector
 	pbps = fssize.fs_bytes_per_sector;
+
+	// LogicalBytesPerSector
 	lbps = fssize.fs_sectors_per_unit * pbps;
 	if (lbps > smb2_max_logical_sector_size)
 		lbps = smb2_max_logical_sector_size;
-
-	// LogicalBytesPerSector
-	(void) smb_mbc_encodef(&sr->raw_data, "l", lbps);
-
-	// PhysicalBytesPerSectorForAtomicity
-	(void) smb_mbc_encodef(&sr->raw_data, "l", pbps);
-
-	// PhysicalBytesPerSectorForPerformance
-	// Using logical size here.
-	(void) smb_mbc_encodef(&sr->raw_data, "l", lbps);
-
-	// FileSystemEffectivePhysicalBytesPerSectorForAtomicity
-	(void) smb_mbc_encodef(&sr->raw_data, "l", pbps);
 
 	// Flags
 	// We include "no seek penalty" because our files are
@@ -398,15 +405,24 @@ smb2_qfs_sectorsize(smb_request_t *sr)
 	flags = SSINFO_FLAGS_ALIGNED_DEVICE |
 		SSINFO_FLAGS_PARTITION_ALIGNED_ON_DEVICE |
 		SSINFO_FLAGS_NO_SEEK_PENALTY;
-	(void) smb_mbc_encodef(&sr->raw_data, "l", flags);
 
 	// ByteOffsetForSectorAlignment
 	// ByteOffsetForPartitionAlignment
 	// Just say "unknown" for these two.
-	(void) smb_mbc_encodef(
-	    &sr->raw_data, "l",
-	    SSINFO_OFFSET_UNKNOWN,
-	    SSINFO_OFFSET_UNKNOWN);
+	unk = SSINFO_OFFSET_UNKNOWN;
+
+	rc = smb_mbc_encodef(
+	    &sr->raw_data,
+	    "lllllll",
+	    lbps, // LogicalBytesPerSector
+	    pbps, // PhysicalBytesPerSectorForAtomicity
+	    lbps, // PhysicalBytesPerSectorForPerformance
+	    pbps, // FileSystemEffectivePhysicalBytesPerSectorForAtomicity
+	    flags,
+	    unk, unk);
+
+	if (rc != 0)
+		return (NT_STATUS_BUFFER_OVERFLOW);
 
 	return (0);
 }

--- a/usr/src/uts/common/io/comstar/stmf/lun_map.c
+++ b/usr/src/uts/common/io/comstar/stmf/lun_map.c
@@ -247,6 +247,7 @@ stmf_session_prepare_report_lun_data(stmf_lun_map_t *sm)
 	stmf_xfer_data_t *xd;
 	uint16_t nluns, ent;
 	uint32_t alloc_size, data_size;
+	uchar_t *buf;
 	int i;
 
 	nluns = sm->lm_nluns;
@@ -272,12 +273,13 @@ stmf_session_prepare_report_lun_data(stmf_lun_map_t *sm)
 
 	ent = 0;
 
+	buf = &(xd->buf[0]);
 	for (i = 0; ((i < sm->lm_nentries) && (ent < nluns)); i++) {
 		if (sm->lm_plus[i] == NULL)
 			continue;
 		/* Fill in the entry */
-		xd->buf[8 + (ent << 3) + 1] = (uchar_t)i;
-		xd->buf[8 + (ent << 3) + 0] = ((uchar_t)(i >> 8));
+		buf[8 + (ent << 3) + 1] = (uchar_t)i;
+		buf[8 + (ent << 3) + 0] = ((uchar_t)(i >> 8));
 		ent++;
 	}
 

--- a/usr/src/uts/common/io/usb/clients/ccid/ccid.c
+++ b/usr/src/uts/common/io/usb/clients/ccid/ccid.c
@@ -3989,7 +3989,7 @@ ccid_ioctl_status(ccid_slot_t *slot, intptr_t arg, int mode)
 
 	if ((slot->cs_flags & CCID_SLOT_F_ACTIVE) != 0) {
 		ucs.ucs_status |= UCCID_STATUS_F_PARAMS_VALID;
-		ucs.ucs_prot = slot->cs_icc.icc_cur_protocol;
+		ucs.ucs_prot = (uccid_prot_t)slot->cs_icc.icc_cur_protocol;
 		ucs.ucs_params = slot->cs_icc.icc_params;
 	}
 

--- a/usr/src/uts/common/mapfiles/ddi.mapfile
+++ b/usr/src/uts/common/mapfiles/ddi.mapfile
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 # Copyright 2020 RackTop Systems, Inc.
 #
 
@@ -77,6 +77,7 @@ SYMBOL_SCOPE {
 	ddi_dev_regsize			{ FLAGS = EXTERN };
 	ddi_dma_addr_bind_handle	{ FLAGS = EXTERN };
 	ddi_dma_alloc_handle		{ FLAGS = EXTERN };
+	ddi_dma_cookie_iter		{ FLAGS = EXTERN };
 	ddi_dma_free_handle		{ FLAGS = EXTERN };
 	ddi_dma_mem_alloc		{ FLAGS = EXTERN };
 	ddi_dma_mem_free		{ FLAGS = EXTERN };

--- a/usr/src/uts/common/smbsrv/smb_ktypes.h
+++ b/usr/src/uts/common/smbsrv/smb_ktypes.h
@@ -1170,6 +1170,7 @@ typedef struct smb_tree {
 	time_t			t_connect_time;
 	volatile uint32_t	t_open_files;
 	smb_cfg_val_t		t_encrypt; /* Share.EncryptData */
+	timestruc_t		t_create_time;
 } smb_tree_t;
 
 #define	SMB_TREE_VFS(tree)	((tree)->t_snode->vp->v_vfsp)

--- a/usr/src/uts/common/sys/usb/clients/ccid/uccid.h
+++ b/usr/src/uts/common/sys/usb/clients/ccid/uccid.h
@@ -83,6 +83,7 @@ typedef struct uccid_cmd_txn_end {
  * Protocol definitions. This should match common/ccid/atr.h.
  */
 typedef enum {
+	UCCID_PROT_NONE = 0,
 	UCCID_PROT_T0	= 1 << 0,
 	UCCID_PROT_T1	= 1 << 1
 } uccid_prot_t;


### PR DESCRIPTION
Weekly upstream for upstream_merge/2021030401

## Backports

None

## onu

```
OmniOS r151037  omnios-upstream_merge-2021030401-bab884c6d85    March 2021
illumos development build: 2021-Mar-04 [illumos]
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2021030401-bab884c6d85 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Mar  4 15:29:17 UTC 2021 ====
==== Nightly distributed build completed: Thu Mar  4 16:42:43 UTC 2021 ====

==== Total build time ====

real    1:13:25

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-bd84f0d4f0 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151037/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.10+9-omnios-151037"

/usr/bin/openssl
OpenSSL 1.1.1j  16 Feb 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1764 (illumos)

Build project:  default
Build taskid:   2083

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2021030401-bab884c6d85

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:16.7
user  4:01:41.3
sys   1:07:36.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    23:20.7
user  3:26:56.6
sys   1:00:33.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
