### PR TITLE
13643 smb share of lofs mount fails

### DIFF
--- a/usr/src/uts/common/fs/smbsrv/smb_tree.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_tree.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2021 Tintri by DDN, Inc. All rights reserved.
  */
 
 /*
@@ -917,10 +918,6 @@ smb_tree_alloc(smb_request_t *sr, const smb_kshare_t *si,
 	tree->t_session = session;
 	tree->t_server = session->s_server;
 
-	/* grab a ref for tree->t_owner */
-	smb_user_hold_internal(sr->uid_user);
-	tree->t_owner = sr->uid_user;
-
 	if (STYPE_ISDSK(stype) || STYPE_ISPRN(stype)) {
 		if (smb_tree_getattr(si, snode, tree) != 0) {
 			smb_idpool_free(&session->s_tid_pool, tid);
@@ -963,6 +960,10 @@ smb_tree_alloc(smb_request_t *sr, const smb_kshare_t *si,
 	tree->t_access = access;
 	tree->t_connect_time = gethrestime_sec();
 	tree->t_execflags = execflags;
+
+	/* grab a ref for tree->t_owner */
+	smb_user_hold_internal(sr->uid_user);
+	tree->t_owner = sr->uid_user;
 
 	/* if FS is readonly, enforce that here */
 	if (tree->t_flags & SMB_TREE_READONLY)
@@ -1099,15 +1100,28 @@ static int
 smb_tree_getattr(const smb_kshare_t *si, smb_node_t *node, smb_tree_t *tree)
 {
 	vfs_t *vfsp = SMB_NODE_VFS(node);
+	vfs_t *realvfsp;
 	smb_cfg_val_t srv_encrypt;
 
 	ASSERT(vfsp);
 
-	if (getvfs(&vfsp->vfs_fsid) != vfsp)
-		return (ESTALE);
-
 	smb_tree_get_volname(vfsp, tree);
-	smb_tree_get_flags(si, vfsp, tree);
+
+	/*
+	 * In the case of an lofs mount, we need to ask the (real)
+	 * underlying filesystem about capabilities, where the
+	 * passed in vfs_t will be from lofs.
+	 */
+	realvfsp = getvfs(&vfsp->vfs_fsid);
+	if (realvfsp != NULL) {
+		smb_tree_get_flags(si, realvfsp, tree);
+		VFS_RELE(realvfsp);
+	} else {
+		cmn_err(CE_NOTE, "Failed getting info for share: %s",
+			si->shr_name);
+		/* do the best we can without realvfsp */
+		smb_tree_get_flags(si, vfsp, tree);
+	}
 
 	srv_encrypt = tree->t_session->s_server->sv_cfg.skc_encrypt;
 	if (tree->t_session->dialect >= SMB_VERS_3_0) {
@@ -1122,7 +1136,6 @@ smb_tree_getattr(const smb_kshare_t *si, smb_node_t *node, smb_tree_t *tree)
 	} else
 		tree->t_encrypt = SMB_CONFIG_DISABLED;
 
-	VFS_RELE(vfsp);
 	return (0);
 }
 


### PR DESCRIPTION
This worked OK in a global zone.
I'm trying to setup a zone to test it in a NGZ...

Here's the same change for illumos.
https://code.illumos.org/c/illumos-gate/+/1347