### PR TITLE
lx can use O_DIRECTORY directly & O_PATH improvement.

### DIFF
--- a/usr/src/cmd/ptools/pfiles/pfiles.c
+++ b/usr/src/cmd/ptools/pfiles/pfiles.c
@@ -25,7 +25,7 @@
  */
 /*
  * Copyright (c) 2017 Joyent, Inc.  All Rights reserved.
- * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <stdio.h>
@@ -44,6 +44,7 @@
 #include <sys/mkdev.h>
 #include <sys/stropts.h>
 #include <sys/timod.h>
+#include <sys/file.h>
 #include <sys/un.h>
 #include <libproc.h>
 #include <netinet/in.h>
@@ -364,7 +365,8 @@ dofcntl(struct ps_prochandle *Pr, const prfdinfo_t *info, int mandatory,
 
 #define	ALL_O_FLAGS	O_ACCMODE | O_NDELAY | O_NONBLOCK | O_APPEND | \
 			O_SYNC | O_DSYNC | O_RSYNC | O_XATTR | \
-			O_CREAT | O_TRUNC | O_EXCL | O_NOCTTY | O_LARGEFILE
+			O_CREAT | O_TRUNC | O_EXCL | O_NOCTTY | O_LARGEFILE | \
+			__FLXPATH
 
 static void
 show_fileflags(int flags)
@@ -417,6 +419,8 @@ show_fileflags(int flags)
 		(void) strcat(str, "|O_LARGEFILE");
 	if (flags & O_XATTR)
 		(void) strcat(str, "|O_XATTR");
+	if (flags & __FLXPATH)
+		(void) strcat(str, "|__FLXPATH");
 	if (flags & ~(ALL_O_FLAGS))
 		(void) sprintf(str + strlen(str), "|0x%x",
 		    flags & ~(ALL_O_FLAGS));

--- a/usr/src/cmd/sgs/libconv/common/corenote.c
+++ b/usr/src/cmd/sgs/libconv/common/corenote.c
@@ -27,6 +27,7 @@
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
  * Copyright (c) 2018 Joyent, Inc.
  * Copyright 2020 Oxide Computer Company
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -2480,6 +2481,7 @@ conv_cnote_fileflags(uint32_t fileflags, Conv_fmt_flags_t fmt_flags,
 		{ 0x2000,	MSG_PR_O_LARGEFILE },
 		{ 0x20000,	MSG_PR_O_NOFOLLOW },
 		{ 0x40000,	MSG_PR_O_NOLINKS },
+		{ 0x80000000,	MSG_PR___FLXPATH },
 		{ 0, 0 },
 	};
 

--- a/usr/src/cmd/sgs/libconv/common/corenote.msg
+++ b/usr/src/cmd/sgs/libconv/common/corenote.msg
@@ -26,6 +26,7 @@
 # Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
 # Copyright (c) 2018 Joyent, Inc.
 # Copyright 2020 Oxide Computer Company
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 #
 
 @ MSG_NT_PRSTATUS		"[ NT_PRSTATUS ]"
@@ -1115,6 +1116,7 @@
 @ MSG_PR_O_XATTR			"O_XATTR"
 @ MSG_PR_O_NOFOLLOW			"O_NOFOLLOW"
 @ MSG_PR_O_NOLINKS			"O_NOLINKS"
+@ MSG_PR___FLXPATH			"__FLXPATH"
 
 @ MSG_S_IFIFO				"S_IFIFO"
 @ MSG_S_IFCHR				"S_IFCHR"

--- a/usr/src/cmd/truss/codes.c
+++ b/usr/src/cmd/truss/codes.c
@@ -25,6 +25,7 @@
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2020 Joyent, Inc.
  * Copyright (c) 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1966,7 +1967,7 @@ pathconfname(int code)
 #define	ALL_O_FLAGS \
 	(O_NDELAY|O_APPEND|O_SYNC|O_DSYNC|O_NONBLOCK|O_CREAT|O_TRUNC\
 	|O_EXCL|O_NOCTTY|O_LARGEFILE|O_RSYNC|O_XATTR|O_NOFOLLOW|O_NOLINKS\
-	|O_CLOEXEC|O_DIRECTORY|O_DIRECT|FXATTRDIROPEN)
+	|O_CLOEXEC|O_DIRECTORY|O_DIRECT|FXATTRDIROPEN|__FLXPATH)
 
 const char *
 openarg(private_t *pri, int arg)
@@ -2032,6 +2033,8 @@ openarg(private_t *pri, int arg)
 		(void) strlcat(str, "|O_DIRECT", sizeof (pri->code_buf));
 	if (arg & FXATTRDIROPEN)
 		(void) strlcat(str, "|FXATTRDIROPEN", sizeof (pri->code_buf));
+	if (arg & __FLXPATH)
+		(void) strlcat(str, "|__FLXPATH", sizeof (pri->code_buf));
 
 	return ((const char *)str);
 }

--- a/usr/src/uts/common/brand/lx/syscall/lx_open.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_open.c
@@ -54,17 +54,17 @@ ltos_open_flags(int input)
 {
 	int flags;
 
-	if (input & LX_O_PATH) {
+	if (input & LX_O_PATH)
 		input &= (LX_O_DIRECTORY | LX_O_NOFOLLOW | LX_O_CLOEXEC);
-	}
 
-	/* This depends on the Linux ACCMODE flags being the same as SunOS. */
+	/*
+	 * The illumos O_ACCMODE also includes O_SEARCH|O_EXEC
+	 * so this has the effect of stripping those here.
+	 */
 	flags = (input & LX_O_ACCMODE);
 
-	if (input & LX_O_CREAT) {
+	if (input & LX_O_CREAT)
 		flags |= O_CREAT;
-	}
-
 	if (input & LX_O_EXCL)
 		flags |= O_EXCL;
 	if (input & LX_O_NOCTTY)
@@ -83,6 +83,8 @@ ltos_open_flags(int input)
 		flags |= O_NOFOLLOW;
 	if (input & LX_O_CLOEXEC)
 		flags |= O_CLOEXEC;
+	if (input & LX_O_DIRECTORY)
+		flags |= O_DIRECTORY;
 
 	/*
 	 * Linux uses the LX_O_DIRECT flag to do raw, synchronous I/O to the
@@ -169,78 +171,13 @@ lx_openat(int atfd, char *path, int fmode, int cmode)
 
 	flags = ltos_open_flags(fmode);
 
-	/*
-	 * We use the FSEARCH flag to make sure this is a directory. We have to
-	 * explicitly add 1 to emulate the FREAD/FWRITE mapping of the OPENMODE
-	 * macro since it won't get set via OPENMODE when FSEARCH is used.
-	 */
-	if (fmode & LX_O_DIRECTORY) {
-		flags |= FSEARCH;
-		flags++;
-	}
-
 	if (flags & O_CREAT)
 		mode = (mode_t)cmode;
 
 	ttolwp(curthread)->lwp_errno = 0;
 	fd = openat(atfd, path, flags, mode);
 	if (ttolwp(curthread)->lwp_errno != 0) {
-		if ((fmode & LX_O_DIRECTORY) &&
-		    ttolwp(curthread)->lwp_errno != ENOTDIR) {
-			/*
-			 * We got an error trying to open a file as a directory.
-			 * We need to determine if we should return the original
-			 * error or ENOTDIR.
-			 */
-			vnode_t *startvp;
-			vnode_t *vp;
-			int oerror, error = 0;
-
-			oerror = ttolwp(curthread)->lwp_errno;
-
-			if (atfd == AT_FDCWD) {
-				/* regular open */
-				startvp = NULL;
-			} else {
-				char startchar;
-
-				if (copyin(path, &startchar, sizeof (char)))
-					return (set_errno(oerror));
-
-				/* if startchar is / then startfd is ignored */
-				if (startchar == '/') {
-					startvp = NULL;
-				} else {
-					file_t *startfp;
-
-					if ((startfp = getf(atfd)) == NULL)
-						return (set_errno(oerror));
-					startvp = startfp->f_vnode;
-					VN_HOLD(startvp);
-					releasef(atfd);
-				}
-			}
-
-			if (lookupnameat(path, UIO_USERSPACE,
-			    (fmode & LX_O_NOFOLLOW) ?  NO_FOLLOW : FOLLOW,
-			    NULLVPP, &vp, startvp) != 0) {
-				if (startvp != NULL)
-					VN_RELE(startvp);
-				return (set_errno(oerror));
-			}
-
-			if (startvp != NULL)
-				VN_RELE(startvp);
-
-			if (vp->v_type != VDIR)
-				error = ENOTDIR;
-
-			VN_RELE(vp);
-			if (error != 0)
-				return (set_errno(ENOTDIR));
-
-			(void) set_errno(oerror);
-		} else if ((fmode & LX_O_NOFOLLOW) && (fmode & LX_O_PATH) &&
+		if ((fmode & LX_O_NOFOLLOW) && (fmode & LX_O_PATH) &&
 		    ttolwp(curthread)->lwp_errno == ELOOP) {
 			/*
 			 * On Linux, if O_NOFOLLOW and O_PATH are set together

--- a/usr/src/uts/common/fs/vnode.c
+++ b/usr/src/uts/common/fs/vnode.c
@@ -24,6 +24,7 @@
  * Copyright 2020 Joyent, Inc.
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1164,7 +1165,20 @@ top:
 	 * Do remaining checks for FNOFOLLOW and FNOLINKS.
 	 */
 	if ((filemode & FNOFOLLOW) && vp->v_type == VLNK) {
-		error = ELOOP;
+		/*
+		 * The __FLXPATH flag is a private interface for use by the lx
+		 * brand in order to emulate open(O_NOFOLLOW|O_PATH) which,
+		 * when a symbolic link is encountered, returns a file
+		 * descriptor which references it.
+		 * See uts/common/brand/lx/syscall/lx_open.c
+		 *
+		 * When this flag is set, VOP_OPEN() is not called (for a
+		 * symlink, most filesystems will return ENOSYS anyway)
+		 * and the link's vnode is returned to be linked to the
+		 * file descriptor.
+		 */
+		if ((filemode & __FLXPATH) == 0)
+			error = ELOOP;
 		goto out;
 	}
 	if (filemode & FNOLINKS) {

--- a/usr/src/uts/common/os/fio.c
+++ b/usr/src/uts/common/os/fio.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017, Joyent Inc.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -958,7 +959,22 @@ closef(file_t *fp)
 
 	vp = fp->f_vnode;
 
-	error = VOP_CLOSE(vp, flag, count, offset, fp->f_cred, NULL);
+	/*
+	 * The __FLXPATH flag is a private interface for use by the lx
+	 * brand in order to emulate open(O_NOFOLLOW|O_PATH) which,
+	 * when a symbolic link is encountered, returns a file
+	 * descriptor which references it.
+	 * See uts/common/brand/lx/syscall/lx_open.c
+	 *
+	 * When this flag is set, VOP_OPEN() will not have been called when
+	 * this file descriptor was opened, and VOP_CLOSE() should not be
+	 * called here (for a symlink, most filesystems would return ENOSYS
+	 * anyway)
+	 */
+	if (fp->f_flag2 & (__FLXPATH >> 16))
+		error = 0;
+	else
+		error = VOP_CLOSE(vp, flag, count, offset, fp->f_cred, NULL);
 
 	if (count > 1) {
 		mutex_exit(&fp->f_tlock);
@@ -1118,7 +1134,7 @@ falloc(vnode_t *vp, int flag, file_t **fpp, int *fdp)
 	mutex_enter(&fp->f_tlock);
 	fp->f_count = 1;
 	fp->f_flag = (ushort_t)flag;
-	fp->f_flag2 = (flag & (FSEARCH|FEXEC)) >> 16;
+	fp->f_flag2 = (flag & (FSEARCH|FEXEC|__FLXPATH)) >> 16;
 	fp->f_vnode = vp;
 	fp->f_offset = 0;
 	fp->f_audit_data = 0;

--- a/usr/src/uts/common/sys/file.h
+++ b/usr/src/uts/common/sys/file.h
@@ -28,6 +28,7 @@
 
 /* Copyright (c) 2013, OmniTI Computer Consulting, Inc. All rights reserved. */
 /* Copyright 2020 Joyent, Inc. */
+/* Copyright 2021 OmniOS Community Edition (OmniOSce) Association. */
 
 #ifndef _SYS_FILE_H
 #define	_SYS_FILE_H
@@ -120,6 +121,10 @@ typedef struct fpollinfo {
 #define	FCLOEXEC	0x800000	/* O_CLOEXEC = 0x800000 */
 #define	FDIRECTORY	0x1000000	/* O_DIRECTORY = 0x1000000 */
 #define	FDIRECT		0x2000000	/* O_DIRECT = 0x2000000 */
+/*
+ * Private interface for lx O_PATH|O_NOFOLLOW emulation for symlinks.
+ */
+#define	__FLXPATH	0x80000000
 
 #if defined(_KERNEL) || defined(_FAKE_KERNEL)
 


### PR DESCRIPTION
Same results for the ltp open syscall tests before and after this change, and I verified that O_DIRECTORY was being exercised. For example, running specific open tests which use O_DIRECTORY:

```
root@lx:~/ltp/testcases/kernel/syscalls/open# grep -l O_DIRECTORY *.c
open01.c
open08.c
open11.c

root@lx:~/ltp/testcases/kernel/syscalls/open# ./open01
tst_test.c:1289: TINFO: Timeout per run is 0h 05m 00s
open01.c:57: TFAIL: sticky bit is cleared unexpectedly
open01.c:59: TPASS: sirectory bit is set as expected

root@lx:~/ltp/testcases/kernel/syscalls/open# ./open08
tst_test.c:1289: TINFO: Timeout per run is 0h 05m 00s
open08.c:82: TPASS: expected failure - errno = 17 : File exists
open08.c:82: TPASS: expected failure - errno = 21 : Is a directory
open08.c:82: TPASS: expected failure - errno = 20 : Not a directory
open08.c:82: TPASS: expected failure - errno = 36 : File name too long
open08.c:82: TPASS: expected failure - errno = 13 : Permission denied
open08.c:82: TPASS: expected failure - errno = 14 : Bad address

root@lx:~/ltp/testcases/kernel/syscalls/open# ./open11
tst_test.c:1289: TINFO: Timeout per run is 0h 05m 00s
open11.c:284: TPASS: Open regular file O_RDONLY returned fd 3
open11.c:284: TPASS: Open regular file O_WRONLY returned fd 3
open11.c:284: TPASS: Open regular file O_RDWR returned fd 3
open11.c:284: TPASS: Open regular file O_RDWR | O_SYNC returned fd 3
open11.c:284: TPASS: Open regular file O_RDWR | O_TRUNC returned fd 3
open11.c:284: TPASS: Open dir O_RDONLY returned fd 3
open11.c:281: TPASS: Open dir O_RDWR, expect EISDIR: EISDIR (21)
open11.c:281: TPASS: Open regular file O_DIRECTORY, expect ENOTDIR: ENOTDIR (20)
open11.c:284: TPASS: Open hard link file O_RDONLY returned fd 3
open11.c:284: TPASS: Open hard link file O_WRONLY returned fd 3
open11.c:284: TPASS: Open hard link file O_RDWR returned fd 3
open11.c:284: TPASS: Open sym link file O_RDONLY returned fd 3
open11.c:284: TPASS: Open sym link file O_WRONLY returned fd 3
open11.c:284: TPASS: Open sym link file O_RDWR returned fd 3
open11.c:284: TPASS: Open sym link dir O_RDONLY returned fd 3
open11.c:281: TPASS: Open sym link dir O_WRONLY, expect EISDIR: EISDIR (21)
open11.c:281: TPASS: Open sym link dir O_RDWR, expect EISDIR: EISDIR (21)
open11.c:284: TFAIL: Open device special file O_RDONLY failed: ENOENT (2)
open11.c:284: TFAIL: Open device special file O_WRONLY failed: ENOENT (2)
open11.c:284: TFAIL: Open device special file O_RDWR failed: ENOENT (2)
open11.c:284: TPASS: Open non-existing regular file in existing dir returned fd 3
open11.c:284: TPASS: Open link file O_RDONLY | O_CREAT returned fd 3
open11.c:284: TPASS: Open symlink file O_RDONLY | O_CREAT returned fd 3
open11.c:284: TPASS: Open regular file O_RDONLY | O_CREAT returned fd 3
open11.c:281: TFAIL: Open symlink dir O_RDONLY | O_CREAT, expect EISDIR invalid retval 3: SUCCESS (0)
open11.c:281: TFAIL: Open dir O_RDONLY | O_CREAT, expect EISDIR invalid retval 3: SUCCESS (0)
open11.c:288: TPASS: Open regular file O_RDONLY | O_TRUNC, behaviour is undefined but should not oops or hang
open11.c:288: TPASS: Open regular file(non-empty) O_RDONLY | O_TRUNC, behaviour is undefined but should not oops or hang
```