### PR TITLE
Upstream merge upstream_merge/2021032601

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1489,6 +1489,7 @@ usr/src/cmd/passmgmt/passmgmt
 usr/src/cmd/passwd/passwd
 usr/src/cmd/pathchk/pathchk
 usr/src/cmd/pbind/amd64/pbind
+usr/src/cmd/pcidb/pcidb
 usr/src/cmd/pcidr/pcidr
 usr/src/cmd/pcieb/pcieb
 usr/src/cmd/pcitool/i386/pcitool

--- a/exception_lists/packaging.deps
+++ b/exception_lists/packaging.deps
@@ -25,6 +25,8 @@ pkg:/library/nspr
 pkg:/library/nspr/header-nspr
 pkg:/library/perl-5/xml-parser
 pkg:/library/security/openssl
+pkg:/library/security/openssl-10
+pkg:/library/security/openssl-11
 pkg:/library/security/trousers
 pkg:/library/zlib
 pkg:/ooce/runtime/expect

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -305,6 +305,7 @@ COMMON_SUBDIRS=		\
 	passwd		\
 	pathchk		\
 	pbind		\
+	pcidb		\
 	pcidr		\
 	pcieb		\
 	pcitool		\

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.c
@@ -22,6 +22,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2021 Joyent, Inc.
  */
 
 #include <stdio.h>
@@ -79,6 +81,7 @@ int x_length = 0x7fffffff;
 FILE *namefile;
 boolean_t Pflg;
 boolean_t Iflg;
+boolean_t fflg;
 boolean_t qflg;
 boolean_t rflg;
 #ifdef	DEBUG
@@ -227,7 +230,7 @@ main(int argc, char **argv)
 	}
 	(void) setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 
-	while ((c = getopt(argc, argv, "at:CPDSi:o:Nn:s:d:I:vVp:f:c:x:U?rqz"))
+	while ((c = getopt(argc, argv, "at:CPDSi:o:Nn:s:d:I:vVp:fc:x:U?rqz"))
 	    != EOF) {
 		switch (c) {
 		case 'a':
@@ -305,21 +308,7 @@ main(int argc, char **argv)
 			}
 			break;
 		case 'f':
-			(void) gethostname(self, MAXHOSTNAMELEN);
-			p = strchr(optarg, ':');
-			if (p) {
-				*p = '\0';
-				if (strcmp(optarg, self) == 0 ||
-				    strcmp(p+1, self) == 0)
-				(void) fprintf(stderr,
-				"Warning: cannot capture packets from %s\n",
-				    self);
-				*p = ' ';
-			} else if (strcmp(optarg, self) == 0)
-				(void) fprintf(stderr,
-				"Warning: cannot capture packets from %s\n",
-				    self);
-			argstr = optarg;
+			fflg = B_TRUE;
 			break;
 		case 'x':
 			p = optarg;

--- a/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.h
+++ b/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.h
@@ -24,7 +24,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 #ifndef	_SNOOP_H
@@ -348,7 +348,7 @@ extern char *prot_title;
 extern unsigned int encap_levels, total_encap_levels;
 
 extern int quitting;
-extern boolean_t Iflg, Pflg, rflg;
+extern boolean_t Iflg, Pflg, fflg, rflg;
 
 /*
  * Global error recovery routine: used to reset snoop variables after

--- a/usr/src/cmd/pcidb/Makefile
+++ b/usr/src/cmd/pcidb/Makefile
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Oxide Computer Company
+#
+
+PROG= pcidb
+
+include ../Makefile.cmd
+include ../Makefile.cmd.64
+include ../Makefile.ctf
+
+CFLAGS += $(CCVERBOSE)
+CSTD = $(CSTD_GNU99)
+LDLIBS += -lpcidb -lofmt
+OBJS = pcidb.o
+ROOTCMDDIR = $(ROOTLIB)/pci
+
+.KEEP_STATE:
+
+$(PROG): $(OBJS)
+	$(LINK.c) -o $@ $(OBJS) $(LDLIBS)
+	$(POST_PROCESS)
+
+%.o: %.c
+	$(COMPILE.c) $<
+	$(POST_PROCESS_O)
+
+all: $(PROG)
+
+install: all $(ROOTCMD)
+
+clean:
+	$(RM) $(OBJS)
+
+include ../Makefile.targ

--- a/usr/src/cmd/pcidb/pcidb.c
+++ b/usr/src/cmd/pcidb/pcidb.c
@@ -1,0 +1,884 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2021 Oxide Computer Company
+ */
+
+/*
+ * A tool to interface with the pci.ids database driven by libpcidb.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <pcidb.h>
+#include <err.h>
+#include <libgen.h>
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+#include <ofmt.h>
+#include <errno.h>
+#include <sys/debug.h>
+#include <priv.h>
+
+#define	EXIT_USAGE	2
+
+static char *pcidb_progname;
+
+typedef enum {
+	PCIDB_MODE_UNKNOWN,
+	PCIDB_MODE_LIST,
+	PCIDB_MODE_SEARCH,
+	PCIDB_MODE_LOOKUP
+} pcidb_mode_t;
+
+typedef enum {
+	PCIDB_TABLE_NONE,
+	PCIDB_TABLE_VENDOR,
+	PCIDB_TABLE_DEVICE,
+	PCIDB_TABLE_SUBSYSTEM,
+	PCIDB_TABLE_CLASS,
+	PCIDB_TABLE_SUBCLASS,
+	PCIDB_TABLE_PROGIF
+} pcidb_table_t;
+
+typedef enum {
+	PCIDB_OFMT_VID,
+	PCIDB_OFMT_VENSTR,
+	PCIDB_OFMT_DID,
+	PCIDB_OFMT_DEVSTR,
+	PCIDB_OFMT_SVID,
+	PCIDB_OFMT_SDID,
+	PCIDB_OFMT_SUBVENSTR,
+	PCIDB_OFMT_SUBSYSSTR,
+	PCIDB_OFMT_BCC,
+	PCIDB_OFMT_CLASSSTR,
+	PCIDB_OFMT_SCC,
+	PCIDB_OFMT_SUBCLASSSTR,
+	PCIDB_OFMT_PI,
+	PCIDB_OFMT_PROGIFSTR
+} pcidb_ofmt_t;
+
+typedef struct pcidb_filter {
+	uint32_t pft_vend;
+	uint32_t pft_dev;
+	uint32_t pft_subven;
+	uint32_t pft_subdev;
+	uint32_t pft_class;
+	uint32_t pft_subclass;
+	uint32_t pft_progif;
+} pcidb_filter_t;
+
+#define	PCIDB_NOFILTER	UINT32_MAX
+
+typedef struct pcidb_walk {
+	pcidb_hdl_t *pw_hdl;
+	ofmt_handle_t pw_ofmt;
+	pcidb_vendor_t *pw_vendor;
+	pcidb_device_t *pw_device;
+	pcidb_subvd_t *pw_subvd;
+	pcidb_class_t *pw_class;
+	pcidb_subclass_t *pw_subclass;
+	pcidb_progif_t *pw_progif;
+	boolean_t pw_strcase;
+	uint_t pw_nfilters;
+	pcidb_filter_t *pw_filters;
+} pcidb_walk_t;
+
+static boolean_t
+pcidb_write_vendor(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
+{
+	pcidb_walk_t *walk = ofarg->ofmt_cbarg;
+
+	VERIFY(walk->pw_vendor != NULL);
+	switch (ofarg->ofmt_id) {
+	case PCIDB_OFMT_VID:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_vendor_id(walk->pw_vendor));
+		break;
+	case PCIDB_OFMT_VENSTR:
+		(void) strlcpy(buf, pcidb_vendor_name(walk->pw_vendor), buflen);
+		break;
+	default:
+		abort();
+	}
+	return (B_TRUE);
+}
+
+static boolean_t
+pcidb_write_device(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
+{
+	pcidb_walk_t *walk = ofarg->ofmt_cbarg;
+
+	VERIFY(walk->pw_device != NULL);
+	switch (ofarg->ofmt_id) {
+	case PCIDB_OFMT_DID:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_device_id(walk->pw_device));
+		break;
+	case PCIDB_OFMT_DEVSTR:
+		(void) strlcpy(buf, pcidb_device_name(walk->pw_device), buflen);
+		break;
+	default:
+		abort();
+	}
+	return (B_TRUE);
+}
+
+static boolean_t
+pcidb_write_subsystem(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
+{
+	pcidb_walk_t *walk = ofarg->ofmt_cbarg;
+	pcidb_vendor_t *vendor;
+
+	VERIFY(walk->pw_subvd != NULL);
+	switch (ofarg->ofmt_id) {
+	case PCIDB_OFMT_SVID:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_subvd_svid(walk->pw_subvd));
+		break;
+	case PCIDB_OFMT_SDID:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_subvd_sdid(walk->pw_subvd));
+		break;
+	case PCIDB_OFMT_SUBSYSSTR:
+		(void) strlcpy(buf, pcidb_subvd_name(walk->pw_subvd), buflen);
+		break;
+	case PCIDB_OFMT_SUBVENSTR:
+		vendor = pcidb_lookup_vendor(walk->pw_hdl,
+		    pcidb_subvd_svid(walk->pw_subvd));
+		if (vendor == NULL) {
+			return (B_FALSE);
+		}
+		(void) strlcpy(buf, pcidb_vendor_name(vendor), buflen);
+		break;
+	default:
+		abort();
+	}
+	return (B_TRUE);
+}
+
+static boolean_t
+pcidb_write_class(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
+{
+	pcidb_walk_t *walk = ofarg->ofmt_cbarg;
+
+	VERIFY(walk->pw_class != NULL);
+	switch (ofarg->ofmt_id) {
+	case PCIDB_OFMT_BCC:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_class_code(walk->pw_class));
+		break;
+	case PCIDB_OFMT_CLASSSTR:
+		(void) strlcpy(buf, pcidb_class_name(walk->pw_class), buflen);
+		break;
+	default:
+		abort();
+	}
+	return (B_TRUE);
+}
+
+static boolean_t
+pcidb_write_subclass(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
+{
+	pcidb_walk_t *walk = ofarg->ofmt_cbarg;
+
+	VERIFY(walk->pw_subclass != NULL);
+	switch (ofarg->ofmt_id) {
+	case PCIDB_OFMT_SCC:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_subclass_code(walk->pw_subclass));
+		break;
+	case PCIDB_OFMT_SUBCLASSSTR:
+		(void) strlcpy(buf, pcidb_subclass_name(walk->pw_subclass),
+		    buflen);
+		break;
+	default:
+		abort();
+	}
+	return (B_TRUE);
+}
+
+static boolean_t
+pcidb_write_progif(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
+{
+	pcidb_walk_t *walk = ofarg->ofmt_cbarg;
+
+	VERIFY(walk->pw_progif != NULL);
+	switch (ofarg->ofmt_id) {
+	case PCIDB_OFMT_PI:
+		(void) snprintf(buf, buflen, "%x",
+		    pcidb_progif_code(walk->pw_progif));
+		break;
+	case PCIDB_OFMT_PROGIFSTR:
+		(void) strlcpy(buf, pcidb_progif_name(walk->pw_progif),
+		    buflen);
+		break;
+	default:
+		abort();
+	}
+	return (B_TRUE);
+}
+
+static const char *pcidb_vendor_fields = "vid,vendor";
+static const ofmt_field_t pcidb_vendor_ofmt[] = {
+	{ "VID",	8,	PCIDB_OFMT_VID,		pcidb_write_vendor },
+	{ "VENDOR",	30,	PCIDB_OFMT_VENSTR,	pcidb_write_vendor },
+	{ NULL, 0, 0, NULL }
+};
+
+static const char *pcidb_device_fields = "vid,did,vendor,device";
+static const ofmt_field_t pcidb_device_ofmt[] = {
+	{ "VID",	8,	PCIDB_OFMT_VID,		pcidb_write_vendor },
+	{ "VENDOR",	30,	PCIDB_OFMT_VENSTR,	pcidb_write_vendor },
+	{ "DID",	8,	PCIDB_OFMT_DID,		pcidb_write_device },
+	{ "DEVICE",	30,	PCIDB_OFMT_DEVSTR,	pcidb_write_device },
+	{ NULL, 0, 0, NULL }
+};
+
+static const char *pcidb_subsystem_fields = "vid,did,svid,sdid,subsystem";
+static const ofmt_field_t pcidb_subsystem_ofmt[] = {
+	{ "VID",	8,	PCIDB_OFMT_VID,		pcidb_write_vendor },
+	{ "VENDOR",	30,	PCIDB_OFMT_VENSTR,	pcidb_write_vendor },
+	{ "DID",	8,	PCIDB_OFMT_DID,		pcidb_write_device },
+	{ "DEVICE",	30,	PCIDB_OFMT_DEVSTR,	pcidb_write_device },
+	{ "SVID",	8,	PCIDB_OFMT_SVID,	pcidb_write_subsystem },
+	{ "SDID",	8,	PCIDB_OFMT_SDID,	pcidb_write_subsystem },
+	{ "SUBSYSTEM",	30,	PCIDB_OFMT_SUBSYSSTR,	pcidb_write_subsystem },
+	{ "SUBVENDOR",	30,	PCIDB_OFMT_SUBVENSTR,	pcidb_write_subsystem },
+	{ NULL, 0, 0, NULL }
+};
+
+static const char *pcidb_class_fields = "bcc,class";
+static const ofmt_field_t pcidb_class_ofmt[] = {
+	{ "BCC",	6,	PCIDB_OFMT_BCC,		pcidb_write_class },
+	{ "CLASS",	30,	PCIDB_OFMT_CLASSSTR,	pcidb_write_class },
+	{ NULL, 0, 0, NULL }
+};
+
+static const char *pcidb_subclass_fields = "bcc,scc,class,subclass";
+static const ofmt_field_t pcidb_subclass_ofmt[] = {
+	{ "BCC",	6,	PCIDB_OFMT_BCC,		pcidb_write_class },
+	{ "CLASS",	30,	PCIDB_OFMT_CLASSSTR,	pcidb_write_class },
+	{ "SCC",	6,	PCIDB_OFMT_SCC,		pcidb_write_subclass },
+	{ "SUBCLASS",	30,	PCIDB_OFMT_SUBCLASSSTR,	pcidb_write_subclass },
+	{ NULL, 0, 0, NULL }
+};
+
+static const char *pcidb_progif_fields = "bcc,scc,pi,subclass,interface";
+static const ofmt_field_t pcidb_progif_ofmt[] = {
+	{ "BCC",	6,	PCIDB_OFMT_BCC,		pcidb_write_class },
+	{ "CLASS",	30,	PCIDB_OFMT_CLASSSTR,	pcidb_write_class },
+	{ "SCC",	6,	PCIDB_OFMT_SCC,		pcidb_write_subclass },
+	{ "SUBCLASS",	30,	PCIDB_OFMT_SUBCLASSSTR,	pcidb_write_subclass },
+	{ "PI",		6,	PCIDB_OFMT_PI,		pcidb_write_progif },
+	{ "INTERFACE",	30,	PCIDB_OFMT_PROGIFSTR,	pcidb_write_progif },
+	{ NULL, 0, 0, NULL }
+};
+
+static void
+pcidb_ofmt_errx(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	verrx(EXIT_FAILURE, fmt, ap);
+}
+
+static boolean_t
+pcidb_filter_match(pcidb_walk_t *walk)
+{
+	if (walk->pw_nfilters == 0) {
+		return (B_TRUE);
+	}
+
+	for (uint_t i = 0; i < walk->pw_nfilters; i++) {
+		const pcidb_filter_t *filt = &walk->pw_filters[i];
+		if (filt->pft_vend != PCIDB_NOFILTER &&
+		    (walk->pw_vendor == NULL ||
+		    filt->pft_vend != pcidb_vendor_id(walk->pw_vendor))) {
+			continue;
+		}
+
+		if (filt->pft_dev != PCIDB_NOFILTER &&
+		    (walk->pw_device == NULL ||
+		    filt->pft_dev != pcidb_device_id(walk->pw_device))) {
+			continue;
+		}
+
+		if (filt->pft_subven != PCIDB_NOFILTER &&
+		    (walk->pw_subvd == NULL ||
+		    filt->pft_subven != pcidb_subvd_svid(walk->pw_subvd))) {
+			continue;
+		}
+
+		if (filt->pft_subdev != PCIDB_NOFILTER &&
+		    (walk->pw_subvd == NULL ||
+		    filt->pft_subdev != pcidb_subvd_sdid(walk->pw_subvd))) {
+			continue;
+		}
+
+		if (filt->pft_class != PCIDB_NOFILTER &&
+		    (walk->pw_class == NULL ||
+		    filt->pft_class != pcidb_class_code(walk->pw_class))) {
+			continue;
+		}
+
+		if (filt->pft_subclass != PCIDB_NOFILTER &&
+		    (walk->pw_subclass == NULL ||
+		    filt->pft_subclass !=
+		    pcidb_subclass_code(walk->pw_subclass))) {
+			continue;
+		}
+
+		if (filt->pft_progif != PCIDB_NOFILTER &&
+		    (walk->pw_progif == NULL ||
+		    filt->pft_progif != pcidb_progif_code(walk->pw_progif))) {
+			continue;
+		}
+
+		return (B_TRUE);
+	}
+
+	return (B_FALSE);
+}
+
+static void
+pcidb_walk_vendors(pcidb_walk_t *walk)
+{
+	pcidb_hdl_t *hdl = walk->pw_hdl;
+
+	for (pcidb_vendor_t *vend = pcidb_vendor_iter(hdl); vend != NULL;
+	    vend = pcidb_vendor_iter_next(vend)) {
+		walk->pw_vendor = vend;
+		if (!pcidb_filter_match(walk))
+			continue;
+		ofmt_print(walk->pw_ofmt, walk);
+	}
+}
+
+static void
+pcidb_walk_devices(pcidb_walk_t *walk)
+{
+	pcidb_hdl_t *hdl = walk->pw_hdl;
+
+	for (pcidb_vendor_t *vend = pcidb_vendor_iter(hdl); vend != NULL;
+	    vend = pcidb_vendor_iter_next(vend)) {
+		walk->pw_vendor = vend;
+		for (pcidb_device_t *dev = pcidb_device_iter(vend); dev != NULL;
+		    dev = pcidb_device_iter_next(dev)) {
+			walk->pw_device = dev;
+			if (!pcidb_filter_match(walk))
+				continue;
+			ofmt_print(walk->pw_ofmt, walk);
+		}
+	}
+}
+
+static void
+pcidb_walk_subsystems(pcidb_walk_t *walk)
+{
+	pcidb_hdl_t *hdl = walk->pw_hdl;
+
+	for (pcidb_vendor_t *vend = pcidb_vendor_iter(hdl); vend != NULL;
+	    vend = pcidb_vendor_iter_next(vend)) {
+		walk->pw_vendor = vend;
+		for (pcidb_device_t *dev = pcidb_device_iter(vend); dev != NULL;
+		    dev = pcidb_device_iter_next(dev)) {
+			walk->pw_device = dev;
+			for (pcidb_subvd_t *sub = pcidb_subvd_iter(dev);
+			    sub != NULL; sub = pcidb_subvd_iter_next(sub)) {
+				walk->pw_subvd = sub;
+				if (!pcidb_filter_match(walk))
+					continue;
+				ofmt_print(walk->pw_ofmt, walk);
+			}
+		}
+
+	}
+}
+
+static void
+pcidb_walk_classes(pcidb_walk_t *walk)
+{
+	for (pcidb_class_t *class = pcidb_class_iter(walk->pw_hdl);
+	    class != NULL; class = pcidb_class_iter_next(class)) {
+		walk->pw_class = class;
+		if (!pcidb_filter_match(walk))
+			continue;
+		ofmt_print(walk->pw_ofmt, walk);
+	}
+}
+
+static void
+pcidb_walk_subclasses(pcidb_walk_t *walk)
+{
+	for (pcidb_class_t *class = pcidb_class_iter(walk->pw_hdl);
+	    class != NULL; class = pcidb_class_iter_next(class)) {
+		walk->pw_class = class;
+		for (pcidb_subclass_t *sub = pcidb_subclass_iter(class);
+		    sub != NULL; sub = pcidb_subclass_iter_next(sub)) {
+			walk->pw_subclass = sub;
+			if (!pcidb_filter_match(walk))
+				continue;
+			ofmt_print(walk->pw_ofmt, walk);
+		}
+	}
+}
+
+static void
+pcidb_walk_progifs(pcidb_walk_t *walk)
+{
+	for (pcidb_class_t *class = pcidb_class_iter(walk->pw_hdl);
+	    class != NULL; class = pcidb_class_iter_next(class)) {
+		walk->pw_class = class;
+		for (pcidb_subclass_t *sub = pcidb_subclass_iter(class);
+		    sub != NULL; sub = pcidb_subclass_iter_next(sub)) {
+			walk->pw_subclass = sub;
+			for (pcidb_progif_t *progif = pcidb_progif_iter(sub);
+			    progif != NULL;
+			    progif = pcidb_progif_iter_next(progif)) {
+				walk->pw_progif = progif;
+				if (!pcidb_filter_match(walk))
+					continue;
+				ofmt_print(walk->pw_ofmt, walk);
+			}
+		}
+	}
+}
+
+static void
+pcidb_parse_class_filter(pcidb_filter_t *filter, char *arg, const char *orig)
+{
+	size_t len;
+	unsigned long val;
+	char *eptr;
+
+	filter->pft_vend = filter->pft_dev = PCIDB_NOFILTER;
+	filter->pft_subven = filter->pft_subdev = PCIDB_NOFILTER;
+
+	len = strlen(arg);
+	if (len != 2 && len != 4 && len != 6) {
+		errx(EXIT_FAILURE, "invalid class filter: '%s': bad length",
+		    orig);
+	}
+
+	errno = 0;
+	val = strtoul(arg, &eptr, 16);
+	if (errno != 0 || *eptr != '\0') {
+		errx(EXIT_FAILURE, "invalid class filter: '%s': failed to "
+		    "parse hex string", orig);
+	}
+
+	if (len == 6) {
+		filter->pft_progif = val & 0xff;
+		val = val >> 8;
+	} else {
+		filter->pft_progif = PCIDB_NOFILTER;
+	}
+
+	if (len >= 4) {
+		filter->pft_subclass = val & 0xff;
+		val = val >> 8;
+	} else {
+		filter->pft_subclass = PCIDB_NOFILTER;
+	}
+
+	filter->pft_class = val & 0xff;
+}
+
+static void
+pcidb_parse_device_filter(pcidb_filter_t *filter, char *arg, const char *orig)
+{
+	unsigned long val;
+	uint32_t primary, secondary;
+	char *eptr;
+
+	filter->pft_vend = filter->pft_dev = PCIDB_NOFILTER;
+	filter->pft_subven = filter->pft_subdev = PCIDB_NOFILTER;
+	filter->pft_class = filter->pft_subclass = PCIDB_NOFILTER;
+	filter->pft_progif = PCIDB_NOFILTER;
+
+	errno = 0;
+	val = strtoul(arg, &eptr, 16);
+	if (errno != 0 || (*eptr != '\0' && *eptr != ',')) {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': failed to "
+		    "parse hex string", orig);
+	}
+
+	if (val > UINT16_MAX) {
+		errx(EXIT_FAILURE, "invalid id: %x is larger than 0xffff", val);
+	}
+
+	primary = (uint32_t)val;
+	if (*eptr == '\0') {
+		filter->pft_vend = primary;
+		return;
+	} else if (strcmp(eptr, ",s") == 0) {
+		filter->pft_subven = primary;
+		return;
+	} else if (eptr[1] == '\0') {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': filter "
+		    "terminated early", arg);
+	}
+
+	arg = eptr + 1;
+	val = strtoul(arg, &eptr, 16);
+	if (errno != 0 || (*eptr != '\0' && *eptr != ',' && *eptr != '.')) {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': failed to "
+		    "parse hex string at %s", orig, arg);
+	}
+
+	if (val > UINT16_MAX) {
+		errx(EXIT_FAILURE, "invalid id: %x is larger than 0xffff", val);
+	}
+
+	secondary = (uint32_t)val;
+	if (*eptr == '\0') {
+		filter->pft_vend = primary;
+		filter->pft_dev = secondary;
+		return;
+	} else if (eptr[1] == '\0') {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': filter "
+		    "terminated early", arg);
+	}
+
+	if (*eptr == ',') {
+		if (eptr[1] == 'p' && eptr[2] == '\0') {
+			filter->pft_vend = primary;
+			filter->pft_dev = secondary;
+			return;
+		}
+		if (eptr[1] == 's' && eptr[2] == '\0') {
+			filter->pft_subven = primary;
+			filter->pft_subdev = secondary;
+			return;
+		}
+		errx(EXIT_FAILURE, "invalid device filter: '%s': invalid "
+		    "trailing comma at %s, expected either ,p or ,s",
+		    orig, eptr);
+	}
+
+	filter->pft_vend = primary;
+	filter->pft_dev = secondary;
+
+	arg = eptr + 1;
+	errno = 0;
+	val = strtoul(arg, &eptr, 16);
+	if (errno != 0 || (*eptr != '\0' && *eptr != ',')) {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': failed to "
+		    "parse hex string at %s", orig, arg);
+	}
+
+	if (val > UINT16_MAX) {
+		errx(EXIT_FAILURE, "invalid id: %x is larger than 0xffff", val);
+	}
+
+	filter->pft_subven = (uint32_t)val;
+	if (*eptr == '\0') {
+		return;
+	} else if (eptr[1] == '\0') {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': filter "
+		    "terminated early", arg);
+	}
+
+	arg = eptr + 1;
+	errno = 0;
+	val = strtoul(arg, &eptr, 16);
+	if (errno != 0 || *eptr != '\0') {
+		errx(EXIT_FAILURE, "invalid device filter: '%s': failed to "
+		    "parse hex string at %s", orig, arg);
+	}
+
+	if (val > UINT16_MAX) {
+		errx(EXIT_FAILURE, "invalid id: %x is larger than 0xffff", val);
+	}
+
+	filter->pft_subdev = (uint32_t)val;
+}
+
+
+/*
+ * Process a series of alias style ways of indicating numeric filters. Use the
+ * basic alias format for now.
+ */
+static void
+pcidb_process_filters(int argc, char *argv[], pcidb_walk_t *walkp)
+{
+	if (argc <= 0) {
+		walkp->pw_nfilters = 0;
+		return;
+	}
+
+	walkp->pw_nfilters = argc;
+	walkp->pw_filters = calloc(walkp->pw_nfilters, sizeof (pcidb_filter_t));
+	if (walkp->pw_filters == NULL) {
+		err(EXIT_FAILURE, "failed to allocate memory for filters");
+	}
+
+	for (int i = 0; i < argc; i++) {
+		char *str = strdup(argv[i]);
+
+		if (str == NULL) {
+			errx(EXIT_FAILURE, "failed to duplicate string %s",
+			    argv[i]);
+		}
+
+		if (strncmp(str, "pciexclass,", 11) == 0) {
+			pcidb_parse_class_filter(&walkp->pw_filters[i],
+			    str + 11, argv[i]);
+		} else if (strncmp(str, "pciclass,", 9) == 0) {
+			pcidb_parse_class_filter(&walkp->pw_filters[i], str + 9,
+			    argv[i]);
+		} else if (strncmp(str, "pciex", 5) == 0) {
+			pcidb_parse_device_filter(&walkp->pw_filters[i],
+			    str + 5, argv[i]);
+		} else if (strncmp(str, "pci", 3) == 0) {
+			pcidb_parse_device_filter(&walkp->pw_filters[i],
+			    str + 3, argv[i]);
+		} else {
+			errx(EXIT_FAILURE, "invalid filter string: %s", str);
+		}
+
+		free(str);
+	}
+}
+
+static void
+pcidb_drop_privs(void)
+{
+	priv_set_t *curprivs, *targprivs;
+
+	if ((curprivs = priv_allocset()) == NULL) {
+		err(EXIT_FAILURE, "failed to allocate privilege set to drop "
+		    "privs");
+	}
+
+	if (getppriv(PRIV_EFFECTIVE, curprivs) != 0) {
+		err(EXIT_FAILURE, "failed to get current privileges");
+	}
+
+	if ((targprivs = priv_allocset()) == NULL) {
+		err(EXIT_FAILURE, "failed to allocate privilege set to drop "
+		    "privs");
+	}
+
+	/*
+	 * Set our privileges to the minimum required. Because stdout will have
+	 * already been opened, all we need is the ability to read files from
+	 * basic privileges. We opt to keep FILE_DAC_READ if the caller has it
+	 * just in case there is something weird about the location of the
+	 * pci.ids files.
+	 */
+	priv_basicset(targprivs);
+	VERIFY0(priv_delset(targprivs, PRIV_FILE_LINK_ANY));
+	VERIFY0(priv_delset(targprivs, PRIV_PROC_INFO));
+	VERIFY0(priv_delset(targprivs, PRIV_PROC_SESSION));
+	VERIFY0(priv_delset(targprivs, PRIV_PROC_FORK));
+	VERIFY0(priv_delset(targprivs, PRIV_NET_ACCESS));
+	VERIFY0(priv_delset(targprivs, PRIV_FILE_WRITE));
+	VERIFY0(priv_delset(targprivs, PRIV_PROC_EXEC));
+	VERIFY0(priv_addset(targprivs, PRIV_FILE_DAC_READ));
+
+	priv_intersect(curprivs, targprivs);
+
+	if (setppriv(PRIV_SET, PRIV_EFFECTIVE, targprivs) != 0) {
+		err(EXIT_FAILURE, "failed to reduce privileges");
+	}
+
+	priv_freeset(curprivs);
+	priv_freeset(targprivs);
+}
+
+static int
+pcidb_usage(const char *fmt, ...)
+{
+	if (fmt != NULL) {
+		va_list ap;
+
+		(void) fprintf(stderr, "%s: ", pcidb_progname);
+		va_start(ap, fmt);
+		(void) vfprintf(stderr, fmt, ap);
+		va_end(ap);
+		(void) fprintf(stderr, "\n");
+	}
+
+	(void) fprintf(stderr, "usage:  %s [-v|-d|-s|-c|-S|-i] [-H]"
+	    "[[-p] [-o <field>[,...]] [<filter>]\n\n"
+	    "\t-v\t\tshow vendor table\n"
+	    "\t-d\t\tshow device table\n"
+	    "\t-s\t\tshow subsystem table\n"
+	    "\t-c\t\tshow class table\n"
+	    "\t-S\t\tshow subclass table\n"
+	    "\t-i\t\tshow programming interface table\n"
+	    "\t-H\t\tdo not output column headers\n"
+	    "\t-p\t\toutput in parsable form\n"
+	    "\t-o field\toutput only specified fields\n\n"
+	    "filters take the form of PCI aliases, e.g. pci8086,1522, "
+	    "pci1028,1f44,s, or\n"
+	    "pciex1022,1480.1462,7c37. Classes can be specified in a similar "
+	    "way, e.g.\npciclass,010802 or pciclass,0403.\n", pcidb_progname);
+
+	return (EXIT_USAGE);
+}
+
+int
+main(int argc, char *argv[])
+{
+	pcidb_hdl_t *hdl;
+	int c;
+	uint_t tablecnt = 0;
+	pcidb_table_t table = PCIDB_TABLE_NONE;
+	boolean_t parse = B_FALSE, strcase = B_FALSE;
+	const char *fields = NULL;
+	const char *ofmt_fields_str = NULL;
+	const ofmt_field_t *ofmt_fields = NULL;
+	ofmt_handle_t ofmt;
+	ofmt_status_t oferr;
+	uint_t flags = 0;
+	pcidb_walk_t walk;
+
+	bzero(&walk, sizeof (walk));
+	pcidb_progname = basename(argv[0]);
+
+	pcidb_drop_privs();
+
+	while ((c = getopt(argc, argv, ":vdscSipo:hH")) != -1) {
+		switch (c) {
+		case 'v':
+			tablecnt++;
+			table = PCIDB_TABLE_VENDOR;
+			break;
+		case 'd':
+			tablecnt++;
+			table = PCIDB_TABLE_DEVICE;
+			break;
+		case 's':
+			tablecnt++;
+			table = PCIDB_TABLE_SUBSYSTEM;
+			break;
+		case 'c':
+			tablecnt++;
+			table = PCIDB_TABLE_CLASS;
+			break;
+		case 'S':
+			tablecnt++;
+			table = PCIDB_TABLE_SUBCLASS;
+			break;
+		case 'i':
+			tablecnt++;
+			table = PCIDB_TABLE_PROGIF;
+			break;
+		case 'p':
+			parse = B_TRUE;
+			flags |= OFMT_PARSABLE;
+			break;
+		case 'o':
+			fields = optarg;
+			break;
+		case 'h':
+			return (pcidb_usage(NULL));
+		case 'H':
+			flags |= OFMT_NOHEADER;
+			break;
+		case ':':
+			return (pcidb_usage("Option -%c requires an argument",
+			    optopt));
+		case '?':
+			return (pcidb_usage("unknown option: -%c", optopt));
+		}
+	}
+
+	if (tablecnt > 1) {
+		errx(EXIT_USAGE, "more than one table specified, only one of "
+		    "-v, -d, -s, -c, -S, and -i may be specified");
+	}
+
+	if (parse && fields == NULL) {
+		errx(EXIT_USAGE, "-p requires fields specified with -o");
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	pcidb_process_filters(argc, argv, &walk);
+
+	switch (table) {
+	case PCIDB_TABLE_VENDOR:
+		ofmt_fields = pcidb_vendor_ofmt;
+		ofmt_fields_str = pcidb_vendor_fields;
+		break;
+	case PCIDB_TABLE_NONE:
+	case PCIDB_TABLE_DEVICE:
+		ofmt_fields = pcidb_device_ofmt;
+		ofmt_fields_str = pcidb_device_fields;
+		break;
+	case PCIDB_TABLE_SUBSYSTEM:
+		ofmt_fields = pcidb_subsystem_ofmt;
+		ofmt_fields_str = pcidb_subsystem_fields;
+		break;
+	case PCIDB_TABLE_CLASS:
+		ofmt_fields = pcidb_class_ofmt;
+		ofmt_fields_str = pcidb_class_fields;
+		break;
+	case PCIDB_TABLE_SUBCLASS:
+		ofmt_fields = pcidb_subclass_ofmt;
+		ofmt_fields_str = pcidb_subclass_fields;
+		break;
+	case PCIDB_TABLE_PROGIF:
+		ofmt_fields = pcidb_progif_ofmt;
+		ofmt_fields_str = pcidb_progif_fields;
+		break;
+	}
+
+	if (fields == NULL) {
+		fields = ofmt_fields_str;
+	}
+
+	oferr = ofmt_open(fields, ofmt_fields, flags, 0, &ofmt);
+	ofmt_check(oferr, parse, ofmt, pcidb_ofmt_errx, warnx);
+
+	hdl = pcidb_open(PCIDB_VERSION);
+	if (hdl == NULL) {
+		err(EXIT_FAILURE, "failed to initialize PCI IDs database");
+	}
+
+	walk.pw_hdl = hdl;
+	walk.pw_ofmt = ofmt;
+	walk.pw_strcase = strcase;
+
+	switch (table) {
+	case PCIDB_TABLE_VENDOR:
+		pcidb_walk_vendors(&walk);
+		break;
+	case PCIDB_TABLE_NONE:
+	case PCIDB_TABLE_DEVICE:
+		pcidb_walk_devices(&walk);
+		break;
+	case PCIDB_TABLE_SUBSYSTEM:
+		pcidb_walk_subsystems(&walk);
+		break;
+	case PCIDB_TABLE_CLASS:
+		pcidb_walk_classes(&walk);
+		break;
+	case PCIDB_TABLE_SUBCLASS:
+		pcidb_walk_subclasses(&walk);
+		break;
+	case PCIDB_TABLE_PROGIF:
+		pcidb_walk_progifs(&walk);
+		break;
+	}
+
+	ofmt_close(ofmt);
+	pcidb_close(hdl);
+	return (EXIT_SUCCESS);
+}

--- a/usr/src/contrib/ast/src/cmd/ksh93/tests/builtins.sh
+++ b/usr/src/contrib/ast/src/cmd/ksh93/tests/builtins.sh
@@ -219,6 +219,9 @@ fi
 if	[[ $(printf -- "%s" foo) != foo ]]
 then	err_exit 'printf -- not working'
 fi
+if	[[ $(printf -- --) != -- ]]
+then	err_exit 'printf -- -- ... not working'
+fi
 if	[[ $(printf -- -eexist) != -eexist ]]
 then	err_exit 'printf -- -eexist. not working'
 fi

--- a/usr/src/lib/libpcidb/Makefile.com
+++ b/usr/src/lib/libpcidb/Makefile.com
@@ -24,7 +24,7 @@
 
 LIBRARY = libpcidb.a
 VERS = .1
-OBJECTS = pcidb.o
+OBJECTS = pcidb.o list.o
 
 include ../../Makefile.lib
 
@@ -33,11 +33,16 @@ LIBS = $(DYNLIB)
 SRCDIR = ../common
 
 LDLIBS += -lc
+CSTD = $(CSTD_GNU99)
 
 
 .KEEP_STATE:
 
 all: $(LIBS)
+
+pics/%.o: $(SRC)/common/list/%.c
+	$(COMPILE.c) -o $@ $<
+	$(POST_PROCESS_O)
 
 
 include ../../Makefile.targ

--- a/usr/src/lib/libpcidb/common/mapfile-vers
+++ b/usr/src/lib/libpcidb/common/mapfile-vers
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2012 Joyent, Inc. All rights reserved.
+# Copyright 2021 Oxide Computer Company
 #
 
 #
@@ -40,30 +41,47 @@ $mapfile_version 2
 
 SYMBOL_VERSION SUNWprivate {
     global:
-	pcidb_open;
+	pcidb_class_code;
+	pcidb_class_iter_next;
+	pcidb_class_iter;
+	pcidb_class_name;
 	pcidb_close;
-	pcidb_lookup_vendor;
-	pcidb_vendor_iter;
-	pcidb_vendor_iter_next;
-	pcidb_vendor_name;
-	pcidb_vendor_id;
-	pcidb_lookup_device;
-	pcidb_lookup_device_by_vendor;
-	pcidb_device_iter;
-	pcidb_device_iter_next;
-	pcidb_device_name;
 	pcidb_device_id;
+	pcidb_device_iter_next;
+	pcidb_device_iter;
+	pcidb_device_name;
 	pcidb_device_vendor;
+	pcidb_lookup_class;
+	pcidb_lookup_device_by_vendor;
+	pcidb_lookup_device;
+	pcidb_lookup_progif_by_subclass;
+	pcidb_lookup_progif;
+	pcidb_lookup_subclass_by_class;
+	pcidb_lookup_subclass;
+	pcidb_lookup_subvd_by_device;
+	pcidb_lookup_subvd_by_vendor;
 	pcidb_lookup_subvd;
-	pcidb_lookup_subvd_by_vendor;	
-	pcidb_lookup_subvd_by_device;	
-	pcidb_subvd_iter;
-	pcidb_subvd_iter_next;
-	pcidb_subvd_name;
-	pcidb_subvd_svid;
-	pcidb_subvd_sdid;
+	pcidb_lookup_vendor;
+	pcidb_open;
+	pcidb_progif_code;
+	pcidb_progif_iter_next;
+	pcidb_progif_iter;
+	pcidb_progif_name;
+	pcidb_subclass_code;
+	pcidb_subclass_iter_next;
+	pcidb_subclass_iter;
+	pcidb_subclass_name;
 	pcidb_subvd_device;
+	pcidb_subvd_iter_next;
+	pcidb_subvd_iter;
+	pcidb_subvd_name;
+	pcidb_subvd_sdid;
+	pcidb_subvd_svid;
 	pcidb_subvd_vendor;
+	pcidb_vendor_id;
+	pcidb_vendor_iter_next;
+	pcidb_vendor_iter;
+	pcidb_vendor_name;
     local:
 	*;
 };

--- a/usr/src/lib/libpcidb/common/pcidb.h
+++ b/usr/src/lib/libpcidb/common/pcidb.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright 2021 Oxide Computer Company
  */
 
 /*
@@ -41,6 +42,9 @@ typedef struct pcidb_hdl pcidb_hdl_t;
 typedef struct pcidb_vendor pcidb_vendor_t;
 typedef struct pcidb_device pcidb_device_t;
 typedef struct pcidb_subvd pcidb_subvd_t;
+typedef struct pcidb_class pcidb_class_t;
+typedef struct pcidb_subclass pcidb_subclass_t;
+typedef struct pcidb_progif pcidb_progif_t;
 
 extern pcidb_hdl_t *pcidb_open(int);
 extern void pcidb_close(pcidb_hdl_t *);
@@ -76,6 +80,32 @@ extern uint16_t pcidb_subvd_svid(pcidb_subvd_t *);
 extern uint16_t pcidb_subvd_sdid(pcidb_subvd_t *);
 extern pcidb_device_t *pcidb_subvd_device(pcidb_subvd_t *);
 extern pcidb_vendor_t *pcidb_subvd_vendor(pcidb_subvd_t *);
+
+extern pcidb_class_t *pcidb_lookup_class(pcidb_hdl_t *, uint8_t);
+extern pcidb_class_t *pcidb_class_iter(pcidb_hdl_t *);
+extern pcidb_class_t *pcidb_class_iter_next(pcidb_class_t *);
+
+extern const char *pcidb_class_name(pcidb_class_t *);
+extern uint8_t pcidb_class_code(pcidb_class_t *);
+
+extern pcidb_subclass_t *pcidb_lookup_subclass(pcidb_hdl_t *, uint8_t, uint8_t);
+extern pcidb_subclass_t *pcidb_lookup_subclass_by_class(pcidb_class_t *,
+    uint8_t);
+extern pcidb_subclass_t *pcidb_subclass_iter(pcidb_class_t *);
+extern pcidb_subclass_t *pcidb_subclass_iter_next(pcidb_subclass_t *);
+
+extern const char *pcidb_subclass_name(pcidb_subclass_t *);
+extern uint8_t pcidb_subclass_code(pcidb_subclass_t *);
+
+extern pcidb_progif_t *pcidb_lookup_progif(pcidb_hdl_t *, uint8_t, uint8_t,
+    uint8_t);
+extern pcidb_progif_t *pcidb_lookup_progif_by_subclass(pcidb_subclass_t *,
+    uint8_t);
+extern pcidb_progif_t *pcidb_progif_iter(pcidb_subclass_t *);
+extern pcidb_progif_t *pcidb_progif_iter_next(pcidb_progif_t *);
+
+extern const char *pcidb_progif_name(pcidb_progif_t *);
+extern uint8_t pcidb_progif_code(pcidb_progif_t *);
 
 #ifdef __cplusplus
 }

--- a/usr/src/man/man1m/chroot.1m
+++ b/usr/src/man/man1m/chroot.1m
@@ -1,86 +1,133 @@
 '\" te
 .\" Copyright (c) 2004, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 1989 AT&T
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
-.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
-.\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH CHROOT 1M "Dec 15, 2003"
-.SH NAME
-chroot \- change root directory for a command
-.SH SYNOPSIS
-.LP
-.nf
-\fB/usr/sbin/chroot\fR \fInewroot\fR \fIcommand\fR
-.fi
-
-.SH DESCRIPTION
-.sp
-.LP
-The \fBchroot\fR utility causes \fIcommand\fR to be executed relative to
-\fInewroot\fR. The meaning of any initial slashes (\fB\|/\|\fR) in the path
-names is changed to \fInewroot\fR for \fIcommand\fR and any of its child
-processes. Upon execution, the initial working directory is \fInewroot\fR.
-.sp
-.LP
-Notice that redirecting the output of \fIcommand\fR to a file,
-.sp
-.in +2
-.nf
-chroot\fI newroot \|command\fR >\fBx\fR
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-will create the file \fBx\fR relative to the original root of \fIcommand\fR,
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" Portions Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+.\"
+.Dd March 18, 2021
+.Dt CHROOT 1M
+.Os
+.Sh NAME
+.Nm chroot
+.Nd change root directory for a command
+.Sh SYNOPSIS
+.Nm
+.Ar newroot
+.Ar command
+.Sh DESCRIPTION
+The
+.Nm
+utility causes
+.Ar command
+to be executed relative to
+.Ar newroot .
+The meaning of any initial slash
+.Pq /
+in the path names is changed to
+.Ar newroot
+for
+.Ar command
+and any of its child processes.
+Upon execution, the initial working directory is
+.Ar newroot .
+.Pp
+Notice that redirecting the output of
+.Ar command
+to a file, such as in:
+.Pp
+.D1 Nm chroot Ar newroot Ar command Sy > Pa xyz
+.Pp
+will create the file
+.Pa xyz
+relative to the original root of
+.Ar command ,
 not the new one.
-.sp
-.LP
-The new root path name is always relative to the current root. Even if a
-\fBchroot\fR is currently in effect, the \fInewroot\fR argument is relative to
-the current root of the running process.
-.sp
-.LP
+.Pp
+The new root path name is always relative to the current root.
+Even if a
+.Nm
+is currently in effect, the
+.Ar newroot
+argument is relative to the current root of the running process.
+.Pp
 This command can be run only by the super-user.
-.SH RETURN VALUES
-.sp
-.LP
-The exit status of \fBchroot\fR is the return value of \fIcommand\fR.
-.SH EXAMPLES
-.LP
-\fBExample 1 \fRUsing the \fBchroot\fR Utility
-.sp
-.LP
-The \fBchroot\fR utility provides an easy way to extract \fBtar\fR files (see
-\fBtar\fR(1)) written with absolute filenames to a different location. It is
-necessary to copy the shared libraries used by \fBtar\fR (see \fBldd\fR(1)) to
-the \fInewroot\fR filesystem.
-
-.sp
-.in +2
-.nf
-example# mkdir /tmp/lib; cd /lib
-example# cp ld.so.1 libc.so.1 libcmd.so.1 libdl.so.1 \e
-         libsec.so.1 /tmp/lib
+.Sh EXIT STATUS
+The exit status of
+.Nm
+is the exit status of
+.Ar command .
+.Sh OPERANDS
+The following operands are supported:
+.Bl -tag -width Ar
+.It Ar newroot
+The new root directory.
+.It Ar command
+The command to be executed relative to
+.Ar newroot .
+.El
+.Sh EXAMPLES
+.Sy Example 1
+Using the
+.Nm
+Utility
+.Pp
+The
+.Nm
+utility provides an easy way to extract
+.Sy tar
+files
+.Pq see Xr tar 1
+written with absolute filenames to a different location.
+It is necessary to copy the shared libraries used by
+.Sy tar
+.Pq see Xr ldd 1
+to the
+.Ar newroot
+filesystem.
+.Bd -literal -offset indent
+example# mkdir -p /tmp/lib /tmp/usr/lib
+example# cd /lib && cp ld.so.1 \e
+         libavl.so.1 libc.so.1 libcmdutils.so.1 libcustr.so.1 \e
+         libm.so.2 libmd.so.1 libmp.so.2 libnsl.so.1 \e
+         libnvpair.so.1 libsec.so.1 libsecdb.so.1 libtsol.so.2 \e
+         libuutil.so.1 /tmp/lib/
+example# cp /usr/lib/libidmap.so.1 /tmp/usr/lib/
 example# cp /usr/bin/tar /tmp
 example# dd if=/dev/rmt/0 | chroot /tmp tar xvf -
-.fi
-.in -2
-.sp
-
-.SH SEE ALSO
-.sp
-.LP
-\fBcd\fR(1), \fBtar\fR(1), \fBchroot\fR(2), \fBttyname\fR(3C),
-\fBattributes\fR(5)
-.SH NOTES
-.sp
-.LP
+.Ed
+.Sh SEE ALSO
+.Xr cd 1 ,
+.Xr ldd 1 ,
+.Xr tar 1 ,
+.Xr chroot 2 ,
+.Xr ttyname 3C ,
+.Xr attributes 5
+.Sh NOTES
 Exercise extreme caution when referencing device files in the new root file
 system.
-.sp
-.LP
-References by routines such as \fBttyname\fR(3C) to stdin, stdout, and stderr
+.Pp
+References by routines such as
+.Xr ttyname 3C
+to
+.Dv stdin ,
+.Dv stdout ,
+and
+.Dv stderr
 will find that the device associated with the file descriptor is unknown after
-\fBchroot\fR is run.
+.Nm
+is run.

--- a/usr/src/man/man1m/snoop.1m
+++ b/usr/src/man/man1m/snoop.1m
@@ -1,22 +1,21 @@
 '\" te
+.\" Copyright 2021 Joyent, Inc.
 .\" Copyright (C) 2009, Sun Microsystems, Inc. All Rights Reserved
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH SNOOP 1M "Feb 25, 2017"
+.TH SNOOP 1M "Mar 22, 2021"
 .SH NAME
 snoop \- capture and inspect network packets
 .SH SYNOPSIS
-.LP
 .nf
-\fBsnoop\fR  [\fB-aqrCDINPSvV\fR] [\fB-t\fR [r |  a |  d]] [\fB-c\fR \fImaxcount\fR]
+\fBsnoop\fR  [\fB-afqrCDINPSvV\fR] [\fB-t\fR [r |  a |  d]] [\fB-c\fR \fImaxcount\fR]
  [\fB-d\fR \fIdevice\fR] [\fB-i\fR \fIfilename\fR] [\fB-n\fR \fIfilename\fR] [\fB-o\fR \fIfilename\fR]
  [\fB-p\fR \fIfirst\fR [, \fIlast\fR]] [\fB-s\fR \fIsnaplen\fR] [\fB-x\fR \fIoffset\fR [, \fIlength\fR]]
  [\fIexpression\fR]
 .fi
 
 .SH DESCRIPTION
-.LP
 From a datalink or IP interface, \fBsnoop\fR captures packets and displays
 their contents. If the datalink or IP interface is not specified, \fBsnoop\fR
 will pick a datalink to use, giving priority to datalinks that have been
@@ -163,6 +162,18 @@ Capture link-layer packets from the network using the DLPI datalink specified
 by \fIdatalink\fR, for example, \fBbge0\fR or \fBnet0\fR. The \fBdladm\fR(1M)
 \fBshow-link\fR subcommand can be used to list available datalinks. The
 \fB-d\fR and \fB-I\fR options are mutually exclusive.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fB-f\fR\fR
+.ad
+.sp .6
+.RS 4n
+Ignore any errors when enabling promiscuous mode. Normally any error when
+enabling promiscuous mode on a datalink or IP interface is fatal and causes
+\fBsnoop\fR to exit.
 .RE
 
 .sp
@@ -832,7 +843,6 @@ True if the packet is an \fBOSPF\fR packet.
 .RE
 
 .SH EXAMPLES
-.LP
 \fBExample 1 \fRUsing the \fBsnoop\fR Command
 .sp
 .LP
@@ -1126,7 +1136,6 @@ Internet services and aliases.
 .RE
 
 .SH SEE ALSO
-.LP
 \fBdladm\fR(1M), \fBifconfig\fR(1M), \fBnetstat\fR(1M), \fBhosts\fR(4),
 \fBrpc\fR(4), \fBservices\fR(4), \fBattributes\fR(5), \fBaudio\fR(7I),
 \fBipnet\fR(7D), \fBbufmod\fR(7M), \fBdlpi\fR(7P), \fBpfmod\fR(7M)
@@ -1135,7 +1144,6 @@ Internet services and aliases.
 Callaghan, B. and Gilligan, R. \fIRFC 1761, Snoop Version 2 Packet Capture File
 Format\fR. Network Working Group. February 1995.
 .SH WARNINGS
-.LP
 The processing overhead is much higher for real-time packet interpretation.
 Consequently, the packet drop count may be higher. For more reliable capture,
 output raw packets to a file using the \fB-o\fR option and analyze the packets

--- a/usr/src/pkg/manifests/SUNWcs.mf
+++ b/usr/src/pkg/manifests/SUNWcs.mf
@@ -1733,6 +1733,9 @@ depend fmri=runtime/perl/module/sun-solaris type=require
 # shell/ksh93 provides the system /bin/sh
 depend fmri=shell/ksh93 type=require
 #
+# shell/ksh93 provides the system /bin/sh
+depend fmri=shell/ksh93 type=require
+#
 # The boot loader package
 #
 depend fmri=system/boot/loader type=require

--- a/usr/src/pkg/manifests/diagnostic-pci.mf
+++ b/usr/src/pkg/manifests/diagnostic-pci.mf
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Oxide Computer Company
+#
+
+set name=pkg.fmri value=pkg:/diagnostic/pci@$(PKGVERS)
+set name=pkg.description value="PCI Utilities"
+set name=pkg.summary value="PCI Utilities"
+set name=info.classification \
+    value="org.opensolaris.category.2008:Applications/System Utilities"
+set name=variant.arch value=$(ARCH)
+dir path=usr group=sys
+dir path=usr/lib
+dir path=usr/lib/pci
+file path=usr/lib/pci/pcidb mode=0555
+license lic_CDDL license=lic_CDDL

--- a/usr/src/pkg/manifests/system-test-utiltest.mf
+++ b/usr/src/pkg/manifests/system-test-utiltest.mf
@@ -1678,6 +1678,7 @@ file path=opt/util-tests/tests/mdb/typedef/tst.union.mdb mode=0444
 file path=opt/util-tests/tests/mdb/typedef/tst.union.mdb.out mode=0444
 file path=opt/util-tests/tests/mergeq/mqt mode=0555
 file path=opt/util-tests/tests/mergeq/wqt mode=0555
+file path=opt/util-tests/tests/pcidbtest mode=0555
 file path=opt/util-tests/tests/printf_test mode=0555
 file path=opt/util-tests/tests/sed/multi_test mode=0555
 file path=opt/util-tests/tests/sed/regress.multitest.out/1.1 mode=0444
@@ -1827,6 +1828,7 @@ license usr/src/test/util-tests/tests/demangle/THIRDPARTYLICENSE.rust \
     license=usr/src/test/util-tests/tests/demangle/THIRDPARTYLICENSE.rust
 license usr/src/test/util-tests/tests/sed/bsd/THIRDPARTYLICENSE \
     license=usr/src/test/util-tests/tests/sed/bsd/THIRDPARTYLICENSE
+depend fmri=diagnostic/pci type=require
 depend fmri=locale/de type=require
 depend fmri=system/library/iconv/utf-8 type=require
 depend fmri=system/test/testrunner type=require

--- a/usr/src/test/os-tests/tests/stackalign/stackalign.c
+++ b/usr/src/test/os-tests/tests/stackalign/stackalign.c
@@ -103,7 +103,7 @@ main(int argc, char *argv[])
 	int door_fd, rc;
 
 	if (pthread_create(&tid, NULL,
-	    (void *(*)(void *))get_stack_at_entry, &arg) != 0) {
+	    (void *(*)(void *))(uintptr_t)get_stack_at_entry, &arg) != 0) {
 		perror("pthread_create() failed:");
 		exit(-2);
 	}
@@ -111,7 +111,8 @@ main(int argc, char *argv[])
 
 	arg.text = "thr_create()";
 
-	if (thr_create(NULL, 0, (void *(*)(void *))get_stack_at_entry,
+	if (thr_create(NULL, 0,
+	    (void *(*)(void *))(uintptr_t)get_stack_at_entry,
 	    &arg, 0, &tid) != 0) {
 		perror("thr_create() failed:");
 		exit(-3);
@@ -142,7 +143,7 @@ main(int argc, char *argv[])
 	arg.text = "door_call()";
 
 	if ((door_fd = door_create(
-	    (door_server_procedure_t *)get_stack_at_entry,
+	    (door_server_procedure_t *)(uintptr_t)get_stack_at_entry,
 	    &arg, 0)) < 0) {
 		perror("failed to create door");
 		exit(-7);

--- a/usr/src/test/util-tests/runfiles/default.run
+++ b/usr/src/test/util-tests/runfiles/default.run
@@ -83,3 +83,5 @@ tests = ['custr_remove', 'custr_trunc']
 
 [/opt/util-tests/tests/sed]
 tests = ['sed_addr', 'multi_test']
+
+[/opt/util-tests/tests/pcidbtest]

--- a/usr/src/test/util-tests/tests/Makefile
+++ b/usr/src/test/util-tests/tests/Makefile
@@ -20,7 +20,7 @@
 
 SUBDIRS = date dis dladm iconv libnvpair_json libsff printf xargs grep_xpg4
 SUBDIRS += demangle mergeq workq chown ctf smbios libjedec awk make sleep
-SUBDIRS += libcustr find mdb sed head
+SUBDIRS += libcustr find mdb sed head pcidb
 SUBDIRS += bunyan
 
 include $(SRC)/test/Makefile.com

--- a/usr/src/test/util-tests/tests/pcidb/Makefile
+++ b/usr/src/test/util-tests/tests/pcidb/Makefile
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Oxide Computer Company
+#
+
+include $(SRC)/cmd/Makefile.cmd
+include $(SRC)/test/Makefile.com
+
+ROOTOPTPKG = $(ROOT)/opt/util-tests/tests
+PROG = pcidbtest
+
+ROOTPROG = $(PROG:%=$(ROOTOPTPKG)/%)
+
+all:
+
+install: $(ROOTPROG)
+
+clobber: clean
+
+clean:
+
+$(ROOTOPTPKG):
+	$(INS.dir)
+
+$(ROOTOPTPKG)/%: %.ksh $(ROOTOPTPKG)
+	$(INS.rename)

--- a/usr/src/test/util-tests/tests/pcidb/pcidbtest.ksh
+++ b/usr/src/test/util-tests/tests/pcidb/pcidbtest.ksh
@@ -1,0 +1,223 @@
+#!/usr/bin/ksh
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Oxide Computer Company
+#
+
+unalias -a
+set -o pipefail
+
+pcidb_arg0="$(basename $0)"
+pcidb_prog="/usr/lib/pci/pcidb"
+pcidb_exit=0
+
+warn()
+{
+	typeset msg="$*"
+	[[ -z "$msg" ]] && msg="failed"
+	echo "TEST FAILED: $pcidb_arg0: $msg" >&2
+}
+
+#
+# The following is intended to catch bad filters.
+#
+pcidb_bad_filter()
+{
+	typeset filt="$1"
+
+	if $pcidb_prog $filt 2>/dev/null; then
+		warn "invalid filter $filt erroneously worked"
+		pcidb_exit=1
+		return
+	fi
+
+	printf "TEST PASSED: invalid filter %s\n" "$filt"
+
+}
+
+pcidb_bad_args()
+{
+	if $pcidb_prog $@ 2>/dev/null 1>/dev/null; then
+		warn "should have failed with args "$@", but passed"
+		pcidb_exit=1
+		return
+	fi
+
+	printf "TEST PASSED: invalid arguments %s\n" "$*"
+}
+
+pcidb_match()
+{
+	typeset output
+	typeset match="$1"
+	shift
+
+	output=$($pcidb_prog $@)
+	if (( $? != 0)); then
+		warn "failed to run pcidb with args: $@"
+		pcidb_exit=1
+		return
+	fi
+
+	if [[ "$output" != "$match" ]]; then
+		warn "output mismatch with args: $@\n found:    $output\n" \
+		    "expected: $match"
+		pcidb_exit=1
+		return
+	fi
+
+	printf "TEST PASSED: successfully matched against %s\n" "$*"
+}
+
+if [[ -n $PCIDB ]]; then
+	pcidb_prog=$PCIDB
+fi
+
+#
+# Before we begin execution, set up the environment such that we have a
+# standard locale and that umem will help us catch mistakes.
+#
+export LC_ALL=C.UTF-8
+export LD_PRELOAD=libumem.so
+export UMEM_DEBUG=default
+
+#
+# Validate that filters match either exactly one or at least one line of
+# output using parsable mode. When we match more than one entry, we
+# don't try to assert the count because we expect that it will actually
+# change over time.
+#
+exp="1de
+8086"
+pcidb_match "$exp" -v -p -o vid pci8086 pci1de
+pcidb_match "Advanced Micro Devices, Inc. [AMD]" -v -p -o vendor pci1022
+pcidb_match "1af4:1044:Virtio RNG" -p -o vid,did,device pci1af4,1044
+pcidb_match "Dell:HBA330 Adapter" -s -p -o subvendor,subsystem \
+	pci1000,97.1028,1f45
+pcidb_match "c:3:30:XHCI" -i -p -o bcc,scc,pi,interface pciclass,0c0330
+pcidb_match "I2O" -S -p -o subclass pciexclass,0e
+pcidb_match "Ethernet 1Gb 2-port 368i Adapter" -s -p -o subsystem pci1590,216,s
+
+#
+# We should get no output when we specify a class or device filter and
+# use a different table or we have an over specified filter.
+#
+pcidb_match "" -d pciclass,03
+pcidb_match "" -S pci1000
+pcidb_match "" -v pci8086,1234
+pcidb_match "" -c pciclass,010802
+
+#
+# Run through filter parsing
+#
+pcidb_bad_filter "foo"
+pcidb_bad_filter ";ffvi"
+pcidb_bad_filter "12345"
+pcidb_bad_filter "pc8086"
+pcidb_bad_filter "pciqwer"
+pcidb_bad_filter "pci12345"
+pcidb_bad_filter "pci8086,"
+pcidb_bad_filter "pci8086,locke"
+pcidb_bad_filter "pci8086sigh"
+pcidb_bad_filter "pci8086,p"
+pcidb_bad_filter "pci8086,12345"
+pcidb_bad_filter "pci8086,1234zz"
+pcidb_bad_filter "pci8086,1234."
+pcidb_bad_filter "pci8086,1234,"
+pcidb_bad_filter "pci8086,1234,b"
+pcidb_bad_filter "pci8086,1234,8"
+pcidb_bad_filter "pci8086,1234,wat"
+pcidb_bad_filter "pci8086,1234.terra"
+pcidb_bad_filter "pci8086,1234.terra,celes"
+pcidb_bad_filter "pci8086,1234.fffff"
+pcidb_bad_filter "pci8086,1234.abcd,"
+pcidb_bad_filter "pci8086,1234.abcd."
+pcidb_bad_filter "pci8086,1234.abcdqr"
+pcidb_bad_filter "pci8086,1234.abcd,2,p"
+pcidb_bad_filter "pci8086,1234.abcd,2000000000"
+pcidb_bad_filter "pci8086,1234.abcd,kefka"
+pcidb_bad_filter "pci8086,1234.abcd,34ultros"
+pcidb_bad_filter "pciexqwer"
+pcidb_bad_filter "pciex12345"
+pcidb_bad_filter "pciex8086,"
+pcidb_bad_filter "pciex8086,locke"
+pcidb_bad_filter "pciex8086sigh"
+pcidb_bad_filter "pciex8086,p"
+pcidb_bad_filter "pciex8086,12345"
+pcidb_bad_filter "pciex8086,1234zz"
+pcidb_bad_filter "pciex8086,1234."
+pcidb_bad_filter "pciex8086,1234,"
+pcidb_bad_filter "pciex8086,1234,b"
+pcidb_bad_filter "pciex8086,1234,8"
+pcidb_bad_filter "pciex8086,1234,wat"
+pcidb_bad_filter "pciex8086,1234.terra"
+pcidb_bad_filter "pciex8086,1234.terra,celes"
+pcidb_bad_filter "pciex8086,1234.fffff"
+pcidb_bad_filter "pciex8086,1234.abcd,"
+pcidb_bad_filter "pciex8086,1234.abcd."
+pcidb_bad_filter "pciex8086,1234.abcdqr"
+pcidb_bad_filter "pciex8086,1234.abcd,2,p"
+pcidb_bad_filter "pciex8086,1234.abcd,2000000000"
+pcidb_bad_filter "pciex8086,1234.abcd,kefka"
+pcidb_bad_filter "pciex8086,1234.abcd,34ultros"
+pcidb_bad_filter "pciclas"
+pcidb_bad_filter "pciclassedgar"
+pcidb_bad_filter "pciclass,sabin"
+pcidb_bad_filter "pciclass,0"
+pcidb_bad_filter "pciclass,013"
+pcidb_bad_filter "pciclass,01345"
+pcidb_bad_filter "pciclass,0134567"
+pcidb_bad_filter "pciclass,01,"
+pcidb_bad_filter "pciclass,010,"
+pcidb_bad_filter "pciclass,010aa,"
+pcidb_bad_filter "pciclass,0102as"
+pcidb_bad_filter "pciclass,0102.as"
+pcidb_bad_filter "pciclass,0102@as"
+pcidb_bad_filter "pciclass,010298aa"
+pcidb_bad_filter "pciclass,010298,"
+pcidb_bad_filter "pciclass,010298!"
+pcidb_bad_filter "pciclass,010298!shadow"
+pcidb_bad_filter "pciexclas"
+pcidb_bad_filter "pciexclassedgar"
+pcidb_bad_filter "pciexclass,sabin"
+pcidb_bad_filter "pciexclass,0"
+pcidb_bad_filter "pciexclass,013"
+pcidb_bad_filter "pciexclass,01345"
+pcidb_bad_filter "pciexclass,0134567"
+pcidb_bad_filter "pciexclass,01,"
+pcidb_bad_filter "pciexclass,010,"
+pcidb_bad_filter "pciexclass,010aa,"
+pcidb_bad_filter "pciexclass,0102as"
+pcidb_bad_filter "pciexclass,0102.as"
+pcidb_bad_filter "pciexclass,0102@as"
+pcidb_bad_filter "pciexclass,010298aa"
+pcidb_bad_filter "pciexclass,010298,"
+pcidb_bad_filter "pciexclass,010298!"
+pcidb_bad_filter "pciexclass,010298!shadow"
+
+#
+# Verify that if we ask for bad columns we error
+#
+pcidb_bad_args -p
+pcidb_bad_args -o
+pcidb_bad_args -o -p
+pcidb_bad_args -p -o terra
+pcidb_bad_args -p -o subclass -v
+pcidb_bad_args -v -d -c
+
+if (( pcidb_exit == 0 )); then
+	printf "All tests passed successfully!\n"
+fi
+
+exit $pcidb_exit

--- a/usr/src/tools/onbld/Checks/DbLookups.py
+++ b/usr/src/tools/onbld/Checks/DbLookups.py
@@ -87,7 +87,7 @@ class BugDB(object):
 		try:
 			data = urlopen(req)
 		except HTTPError as e:
-			if e.code == 404:
+			if e.code == 401 or e.code == 404:
 				raise NonExistentBug(cr)
 			else:
 				raise


### PR DESCRIPTION
Weekly upstream for upstream_merge/2021032601

## Backports

None

## onu

```
OmniOS r151037  omnios-upstream_merge-2021032601-b7321237bf     March 2021
illumos development build: 2021-Mar-26 [illumos]
You have new mail.
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2021032601-b7321237bf i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Fri Mar 26 10:20:02 UTC 2021 ====
==== Nightly distributed build completed: Fri Mar 26 11:38:12 UTC 2021 ====

==== Total build time ====

real    1:18:09

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-0401360920 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151037/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.10+9-omnios-151037"

/usr/bin/openssl
OpenSSL 1.1.1j  16 Feb 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1764 (illumos)

Build project:  default
Build taskid:   94

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2021032601-b7321237bf

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:06.7
user  4:07:35.4
sys   1:17:11.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:58.3
user  3:30:32.6
sys   1:09:06.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
