### PR TITLE
r151038 backports

### DIFF
--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -225,6 +225,7 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_KERNEL_RANDDIR,	/* /proc/sys/kernel/random */
 	LXPR_SYS_KERNEL_RAND_BOOTID, /* /proc/sys/kernel/random/boot_id */
 	LXPR_SYS_KERNEL_RAND_ENTAVL, /* /proc/sys/kernel/random/entropy_avail */
+	LXPR_SYS_KERNEL_RAND_UUID, /* /proc/sys/kernel/random/uuid */
 	LXPR_SYS_KERNEL_SEM,		/* /proc/sys/kernel/sem		*/
 	LXPR_SYS_KERNEL_SHMALL,		/* /proc/sys/kernel/shmall	*/
 	LXPR_SYS_KERNEL_SHMMAX,		/* /proc/sys/kernel/shmmax	*/

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -248,6 +248,7 @@ static void lxpr_read_sys_kernel_osrel(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_pid_max(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_rand_bootid(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_rand_entavl(lxpr_node_t *, lxpr_uiobuf_t *);
+static void lxpr_read_sys_kernel_rand_uuid(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_sem(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_shmall(lxpr_node_t *, lxpr_uiobuf_t *);
 static void lxpr_read_sys_kernel_shmmax(lxpr_node_t *, lxpr_uiobuf_t *);
@@ -590,6 +591,7 @@ static lxpr_dirent_t sys_kerneldir[] = {
 static lxpr_dirent_t sys_randdir[] = {
 	{ LXPR_SYS_KERNEL_RAND_BOOTID,	"boot_id" },
 	{ LXPR_SYS_KERNEL_RAND_ENTAVL,	"entropy_avail" },
+	{ LXPR_SYS_KERNEL_RAND_UUID,	"uuid" },
 };
 
 #define	SYS_RANDDIRFILES (sizeof (sys_randdir) / sizeof (sys_randdir[0]))
@@ -932,6 +934,7 @@ static void (*lxpr_read_function[])() = {
 	lxpr_read_invalid,		/* /proc/sys/kernel/random */
 	lxpr_read_sys_kernel_rand_bootid, /* /proc/sys/kernel/random/boot_id */
 	lxpr_read_sys_kernel_rand_entavl, /* .../kernel/random/entropy_avail */
+	lxpr_read_sys_kernel_rand_uuid, /* .../kernel/random/uuid */
 	lxpr_read_sys_kernel_sem,	/* /proc/sys/kernel/sem */
 	lxpr_read_sys_kernel_shmall,	/* /proc/sys/kernel/shmall */
 	lxpr_read_sys_kernel_shmmax,	/* /proc/sys/kernel/shmmax */
@@ -1101,6 +1104,7 @@ static vnode_t *(*lxpr_lookup_function[])() = {
 	lxpr_lookup_sys_kdir_randdir,	/* /proc/sys/kernel/random */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/random/boot_id */
 	lxpr_lookup_not_a_dir,		/* .../kernel/random/entropy_avail */
+	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/random/uuid */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/sem */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/shmall */
 	lxpr_lookup_not_a_dir,		/* /proc/sys/kernel/shmmax */
@@ -1270,6 +1274,7 @@ static int (*lxpr_readdir_function[])() = {
 	lxpr_readdir_sys_kdir_randdir,	/* /proc/sys/kernel/random */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/random/boot_id */
 	lxpr_readdir_not_a_dir,		/* .../kernel/random/entropy_avail */
+	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/random/uuid */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/sem */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/shmall */
 	lxpr_readdir_not_a_dir,		/* /proc/sys/kernel/shmmax */
@@ -4923,7 +4928,26 @@ lxpr_read_sys_kernel_pid_max(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	lxpr_uiobuf_printf(uiobuf, "%d\n", maxpid);
 }
 
-/* ARGSUSED */
+static void
+lxpr_gen_uuid(char *uuid, size_t size)
+{
+	uint8_t r[16];
+
+	if (random_get_bytes(r, sizeof (r)) != 0)
+		(void) random_get_pseudo_bytes(r, sizeof (r));
+
+	/* Set UUID version to 4 (random) */
+	r[6] = 0x40 | (r[6] & 0x0f);
+	/* Set UUID variant to 1 */
+	r[8] = 0x80 | (r[8] & 0x3f);
+
+	(void) snprintf(uuid, size,
+	    "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x"
+	    "-%02x%02x%02x%02x%02x%02x",
+	    r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8],
+	    r[9], r[10], r[11], r[12], r[13], r[14], r[15]);
+}
+
 static void
 lxpr_read_sys_kernel_rand_bootid(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 {
@@ -4937,9 +4961,7 @@ lxpr_read_sys_kernel_rand_bootid(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	 *    safe choice if you need to identify a specific boot on a specific
 	 *    booted kernel.
 	 *
-	 * We'll just generate a random ID if necessary. On Linux the format
-	 * appears to resemble a uuid but since it is not documented to be a
-	 * uuid, we don't worry about that.
+	 * On Linux the format appears to resemble a uuid so stick with that.
 	 */
 	zone_t *zone = LXPTOZ(lxpnp);
 	lx_zone_data_t *lxzd = ztolxzd(zone);
@@ -4950,32 +4972,8 @@ lxpr_read_sys_kernel_rand_bootid(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	ASSERT(lxzd != NULL);
 
 	mutex_enter(&lxzd->lxzd_lock);
-	if (lxzd->lxzd_bootid[0] == '\0') {
-		int i;
-
-		for (i = 0; i < 5; i++) {
-			u_longlong_t n;
-			char s[32];
-
-			(void) random_get_bytes((uint8_t *)&n, sizeof (n));
-			switch (i) {
-			case 0:	(void) snprintf(s, sizeof (s), "%08llx", n);
-				s[8] = '\0';
-				break;
-			case 4:	(void) snprintf(s, sizeof (s), "%012llx", n);
-				s[12] = '\0';
-				break;
-			default: (void) snprintf(s, sizeof (s), "%04llx", n);
-				s[4] = '\0';
-				break;
-			}
-			if (i > 0)
-				(void) strlcat(lxzd->lxzd_bootid, "-",
-				    sizeof (lxzd->lxzd_bootid));
-			(void) strlcat(lxzd->lxzd_bootid, s,
-			    sizeof (lxzd->lxzd_bootid));
-		}
-	}
+	if (lxzd->lxzd_bootid[0] == '\0')
+		lxpr_gen_uuid(lxzd->lxzd_bootid, sizeof (lxzd->lxzd_bootid));
 	(void) strlcpy(bootid, lxzd->lxzd_bootid, sizeof (bootid));
 	mutex_exit(&lxzd->lxzd_lock);
 
@@ -4993,6 +4991,24 @@ lxpr_read_sys_kernel_rand_entavl(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 	ASSERT(LXPTOZ(lxpnp)->zone_brand == &lx_brand);
 
 	lxpr_uiobuf_printf(uiobuf, "%d\n", swrand_stats.ss_entEst);
+}
+
+static void
+lxpr_read_sys_kernel_rand_uuid(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
+{
+	/*
+	 * Each read from this read-only file should return a new
+	 * random 128-bit UUID string in the standard UUID format.
+	 */
+	zone_t *zone = LXPTOZ(lxpnp);
+	char uuid[LX_BOOTID_LEN];
+
+	ASSERT(lxpnp->lxpr_type == LXPR_SYS_KERNEL_RAND_UUID);
+	ASSERT(zone->zone_brand == &lx_brand);
+
+	lxpr_gen_uuid(uuid, sizeof (uuid));
+
+	lxpr_uiobuf_printf(uiobuf, "%s\n", uuid);
 }
 
 /* ARGSUSED */

--- a/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
+++ b/usr/src/uts/i86pc/io/vmm/vmm_sol_dev.c
@@ -1873,12 +1873,12 @@ vmm_do_vm_destroy_locked(vmm_softc_t *sc, boolean_t clean_zsd,
 
 	*hma_release = B_FALSE;
 
-	if (clean_zsd) {
-		vmm_zsd_rem_vm(sc);
-	}
-
 	if (vmm_drv_purge(sc) != 0) {
 		return (EINTR);
+	}
+
+	if (clean_zsd) {
+		vmm_zsd_rem_vm(sc);
 	}
 
 	/* Clean up devmem entries */


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Sun Apr  4 00:05:55 UTC 2021 ====
==== Nightly distributed build completed: Sun Apr  4 01:21:34 UTC 2021 ====

==== Total build time ====

real    1:15:38

==== Build environment ====

/usr/bin/uname
SunOS r151038 5.11 omnios-r151038-c83a8f9e0b i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151038/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151038/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.10+9-omnios-151038"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1764 (illumos)

Build project:  default
Build taskid:   75

==== Nightly argument issues ====


==== Build version ====

omnios-bpr38-f6dfc21feb

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:03.8
user  4:05:01.4
sys   1:10:59.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    23:44.5
user  3:25:15.2
sys   1:03:08.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
