### PR TITLE
 Allow brands to control their init restart behaviour

### DIFF
--- a/usr/src/cmd/zoneadmd/zoneadmd.c
+++ b/usr/src/cmd/zoneadmd/zoneadmd.c
@@ -991,7 +991,7 @@ zone_bootup(zlog_t *zlogp, const char *bootargs, int zstate)
 	dladm_status_t status;
 	char errmsg[DLADM_STRSIZE];
 	int err;
-	boolean_t restart_init;
+	boolean_t restart_init, restart_init0, restart_initreboot;
 	boolean_t app_svc_dep;
 
 	if (brand_prestatechg(zlogp, zstate, Z_BOOT) != 0)
@@ -1046,6 +1046,8 @@ zone_bootup(zlog_t *zlogp, const char *bootargs, int zstate)
 
 	/* See if this zone's brand should restart init if it dies. */
 	restart_init = brand_restartinit(bh);
+	restart_init0 = brand_restartinit0(bh);
+	restart_initreboot = brand_restartinitreboot(bh);
 
 	/*
 	 * See if we need to setup contract dependencies between the zone's
@@ -1125,6 +1127,16 @@ zone_bootup(zlog_t *zlogp, const char *bootargs, int zstate)
 	if (!restart_init && zone_setattr(zoneid, ZONE_ATTR_INITNORESTART,
 	    NULL, 0) == -1) {
 		zerror(zlogp, B_TRUE, "could not set zone init-no-restart");
+		goto bad;
+	}
+	if (restart_init0 && zone_setattr(zoneid, ZONE_ATTR_INITRESTART0,
+	    NULL, 0) == -1) {
+		zerror(zlogp, B_TRUE, "could not set zone init-no-restart-0");
+		goto bad;
+	}
+	if (restart_initreboot && zone_setattr(zoneid, ZONE_ATTR_INITREBOOT,
+	    NULL, 0) == -1) {
+		zerror(zlogp, B_TRUE, "could not set zone init-reboot");
 		goto bad;
 	}
 

--- a/usr/src/lib/libbrand/common/libbrand.c
+++ b/usr/src/lib/libbrand/common/libbrand.c
@@ -63,6 +63,8 @@
 #define	DTD_ELEM_MODNAME	((const xmlChar *) "modname")
 #define	DTD_ELEM_MOUNT		((const xmlChar *) "mount")
 #define	DTD_ELEM_RESTARTINIT	((const xmlChar *) "restartinit")
+#define	DTD_ELEM_RESTARTINIT0	((const xmlChar *) "restartinit0")
+#define	DTD_ELEM_RESTARTINITREBOOT	((const xmlChar *) "restartinitreboot")
 #define	DTD_ELEM_POSTATTACH	((const xmlChar *) "postattach")
 #define	DTD_ELEM_POSTCLONE	((const xmlChar *) "postclone")
 #define	DTD_ELEM_POSTINSTALL	((const xmlChar *) "postinstall")
@@ -535,6 +537,34 @@ brand_restartinit(brand_handle_t bh)
 	if (strcmp(val, "false") == 0)
 		return (B_FALSE);
 	return (B_TRUE);
+}
+
+boolean_t
+brand_restartinit0(brand_handle_t bh)
+{
+	struct brand_handle *bhp = (struct brand_handle *)bh;
+	char val[80];
+
+	if (brand_get_value(bhp, NULL, NULL, NULL, NULL,
+	    val, sizeof (val), DTD_ELEM_RESTARTINIT0, B_FALSE, B_FALSE) == 0 &&
+	    strcmp(val, "true") == 0) {
+		return (B_TRUE);
+	}
+	return (B_FALSE);
+}
+
+boolean_t
+brand_restartinitreboot(brand_handle_t bh)
+{
+	struct brand_handle *bhp = (struct brand_handle *)bh;
+	char val[80];
+
+	if (brand_get_value(bhp, NULL, NULL, NULL, NULL,
+	    val, sizeof (val), DTD_ELEM_RESTARTINITREBOOT,
+	    B_FALSE, B_FALSE) == 0 && strcmp(val, "true") == 0) {
+		return (B_TRUE);
+	}
+	return (B_FALSE);
 }
 
 int

--- a/usr/src/lib/libbrand/common/libbrand.h
+++ b/usr/src/lib/libbrand/common/libbrand.h
@@ -62,6 +62,8 @@ extern int brand_get_halt(brand_handle_t, const char *, const char *,
     char *, size_t);
 extern int brand_get_initname(brand_handle_t, char *, size_t);
 extern boolean_t brand_restartinit(brand_handle_t);
+extern boolean_t brand_restartinit0(brand_handle_t);
+extern boolean_t brand_restartinitreboot(brand_handle_t);
 extern int brand_get_install(brand_handle_t, const char *, const char *,
     char *, size_t);
 extern int brand_get_installopts(brand_handle_t, char *, size_t);

--- a/usr/src/lib/libbrand/common/mapfile-vers
+++ b/usr/src/lib/libbrand/common/mapfile-vers
@@ -80,6 +80,8 @@ SYMBOL_VERSION SUNWprivate {
 	brand_platform_iter_link;
 	brand_platform_iter_mounts;
 	brand_restartinit;
+	brand_restartinit0;
+	brand_restartinitreboot;
     local:
 	*;
 };

--- a/usr/src/lib/libbrand/dtd/brand.dtd.1
+++ b/usr/src/lib/libbrand/dtd/brand.dtd.1
@@ -225,6 +225,28 @@
 <!ATTLIST restartinit>
 
 <!--
+  restartinit0
+
+    Boolean indicating that the program specified by the initname attr
+    should be restarted only if it exits 0. This defaults to false.
+
+    It has no attributes.
+-->
+<!ELEMENT restartinit0	(#PCDATA) >
+<!ATTLIST restartinit0>
+
+<!--
+  restartinitreboot
+
+    Boolean indicating that, when the program specified by the initname attr
+    exits, the zone should be rebooted. This defaults to false.
+
+    It has no attributes.
+-->
+<!ELEMENT restartinitreboot	(#PCDATA) >
+<!ATTLIST restartinitreboot>
+
+<!--
   login_cmd
 
     Path to the initial login binary that should be executed when
@@ -642,7 +664,9 @@
 		directory in which the configuration file is stored.
 -->
 
-<!ELEMENT brand		(modname?, initname, restartinit?, login_cmd,
+<!ELEMENT brand		(modname?, initname, restartinit?,
+			restartinit0?, restartinitreboot?,
+			login_cmd,
 			forcedlogin_cmd, user_cmd, install,
 			installopts?, boot?, sysboot?, halt?, shutdown?,
 			verify_cfg?, verify_adm?, postattach?, postclone?,

--- a/usr/src/tools/scripts/onu.sh.in
+++ b/usr/src/tools/scripts/onu.sh.in
@@ -141,6 +141,8 @@ finalise_image()
 		' $root/etc/zones/*.xml
 		cp /usr/lib/brand/shared/common.ksh \
 		    $root/usr/lib/brand/shared/common.ksh
+		cp /usr/share/lib/xml/dtd/brand.dtd.1 \
+		    $root/usr/share/lib/xml/dtd/brand.dtd.1
 	fi
 }
 

--- a/usr/src/uts/common/os/exit.c
+++ b/usr/src/uts/common/os/exit.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2018 Joyent, Inc.
  * Copyright 2020 Oxide Computer Company
  */
 
@@ -322,6 +322,119 @@ proc_is_exiting(proc_t *p)
 }
 
 /*
+ * Return true if zone's init is restarted, false if exit processing should
+ * proceeed.
+ */
+static boolean_t
+zone_init_exit(zone_t *z, int why, int what)
+{
+	/*
+	 * Typically we don't let the zone's init exit unless zone_start_init()
+	 * failed its exec, or we are shutting down the zone or the machine,
+	 * although the various flags handled within this function will control
+	 * the behavior.
+	 *
+	 * Since we are single threaded, we don't need to lock the following
+	 * accesses to zone_proc_initpid.
+	 */
+	if (z->zone_boot_err != 0 ||
+	    zone_status_get(z) >= ZONE_IS_SHUTTING_DOWN ||
+	    zone_status_get(global_zone) >= ZONE_IS_SHUTTING_DOWN) {
+		/*
+		 * Clear the zone's init pid and proceed with exit processing.
+		 */
+		z->zone_proc_initpid = -1;
+		return (B_FALSE);
+	}
+
+	/*
+	 * There are a variety of configuration flags on the zone to control
+	 * init exit behavior.
+	 *
+	 * If the init process should be restarted, the "zone_restart_init"
+	 * member will be set.
+	 */
+	if (!z->zone_restart_init) {
+		/*
+		 * The zone has been setup to halt when init exits.
+		 */
+		z->zone_init_status = wstat(why, what);
+		(void) zone_kadmin(A_SHUTDOWN, AD_HALT, NULL, zone_kcred());
+		z->zone_proc_initpid = -1;
+		return (B_FALSE);
+	}
+
+	/*
+	 * At this point we know we're configured to restart init, but there
+	 * are various modifiers to that behavior.
+	 */
+
+	if (z->zone_reboot_on_init_exit) {
+		/*
+		 * Some init programs in branded zones do not tolerate a
+		 * restart in the traditional manner; setting
+		 * "zone_reboot_on_init_exit" will cause the entire zone to be
+		 * rebooted instead.
+		 */
+
+		if (z->zone_restart_init_0) {
+			/*
+			 * Some init programs in branded zones only want to
+			 * restart if they exit 0, otherwise the zone should
+			 * shutdown. Setting the "zone_restart_init_0" member
+			 * controls this behavior.
+			 */
+			if (why == CLD_EXITED && what == 0) {
+				/* Trigger a zone reboot */
+				(void) zone_kadmin(A_REBOOT, 0, NULL,
+				    zone_kcred());
+			} else {
+				/* Shutdown instead of reboot */
+				(void) zone_kadmin(A_SHUTDOWN, AD_HALT, NULL,
+				    zone_kcred());
+			}
+		} else {
+			/* Trigger a zone reboot */
+			(void) zone_kadmin(A_REBOOT, 0, NULL, zone_kcred());
+		}
+
+		z->zone_init_status = wstat(why, what);
+		z->zone_proc_initpid = -1;
+		return (B_FALSE);
+	}
+
+	if (z->zone_restart_init_0) {
+		/*
+		 * Some init programs in branded zones only want to restart if
+		 * they exit 0, otherwise the zone should shutdown. Setting the
+		 * "zone_restart_init_0" member controls this behavior.
+		 *
+		 * In this case we only restart init if it exited successfully.
+		 */
+		if (why == CLD_EXITED && what == 0 &&
+		    restart_init(what, why) == 0) {
+			return (B_TRUE);
+		}
+	} else {
+		/*
+		 * No restart modifiers on the zone, attempt to restart init.
+		 */
+		if (restart_init(what, why) == 0) {
+			return (B_TRUE);
+		}
+	}
+
+
+	/*
+	 * The restart failed, the zone will shut down.
+	 */
+	z->zone_init_status = wstat(why, what);
+	(void) zone_kadmin(A_SHUTDOWN, AD_HALT, NULL, zone_kcred());
+	z->zone_proc_initpid = -1;
+	return (B_FALSE);
+}
+
+/*
  * Return value:
  *   1 - exitlwps() failed, call (or continue) lwp_exit()
  *   0 - restarting init.  Return through system call path
@@ -368,55 +481,10 @@ proc_exit(int why, int what)
 	}
 	mutex_exit(&p->p_lock);
 
-	/*
-	 * Don't let init exit unless zone_start_init() failed its exec, or
-	 * we are shutting down the zone or the machine.
-	 *
-	 * Since we are single threaded, we don't need to lock the
-	 * following accesses to zone_proc_initpid.
-	 */
 	if (p->p_pid == z->zone_proc_initpid) {
-		if (z->zone_boot_err == 0 &&
-		    zone_status_get(z) < ZONE_IS_SHUTTING_DOWN &&
-		    zone_status_get(global_zone) < ZONE_IS_SHUTTING_DOWN) {
-
-			/*
-			 * If the init process should be restarted, the
-			 * "zone_restart_init" member will be set.  Some init
-			 * programs in branded zones do not tolerate a restart
-			 * in the traditional manner; setting the
-			 * "zone_reboot_on_init_exit" member will cause the
-			 * entire zone to be rebooted instead.  If neither of
-			 * these flags is set the zone will shut down.
-			 */
-			if (z->zone_reboot_on_init_exit == B_TRUE &&
-			    z->zone_restart_init == B_TRUE) {
-				/*
-				 * Trigger a zone reboot and continue
-				 * with exit processing.
-				 */
-				z->zone_init_status = wstat(why, what);
-				(void) zone_kadmin(A_REBOOT, 0, NULL,
-				    zone_kcred());
-
-			} else {
-				if (z->zone_restart_init == B_TRUE) {
-					if (restart_init(what, why) == 0)
-						return (0);
-				}
-
-				z->zone_init_status = wstat(why, what);
-				(void) zone_kadmin(A_SHUTDOWN, AD_HALT, NULL,
-				    zone_kcred());
-			}
-		}
-
-		/*
-		 * Since we didn't or couldn't restart init, we clear
-		 * the zone's init state and proceed with exit
-		 * processing.
-		 */
-		z->zone_proc_initpid = -1;
+		/* If zone's init restarts, we're done here. */
+		if (zone_init_exit(z, why, what))
+			return (0);
 	}
 
 	/*

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -2690,6 +2690,7 @@ zone_init(void)
 	mutex_exit(&p0.p_lock);
 	zone0.zone_restart_init = B_TRUE;
 	zone0.zone_reboot_on_init_exit = B_FALSE;
+	zone0.zone_restart_init_0 = B_FALSE;
 	zone0.zone_init_status = -1;
 	zone0.zone_brand = &native_brand;
 	rctl_prealloc_destroy(gp);
@@ -4965,6 +4966,7 @@ zone_create(const char *zone_name, const char *zone_root,
 	zone->zone_ncpus_online = 0;
 	zone->zone_restart_init = B_TRUE;
 	zone->zone_reboot_on_init_exit = B_FALSE;
+	zone->zone_restart_init_0 = B_FALSE;
 	zone->zone_init_status = -1;
 	zone->zone_brand = &native_brand;
 	zone->zone_initname = NULL;
@@ -6243,6 +6245,14 @@ zone_setattr(zoneid_t zoneid, int attr, void *buf, size_t bufsize)
 		break;
 	case ZONE_ATTR_INITNORESTART:
 		zone->zone_restart_init = B_FALSE;
+		err = 0;
+		break;
+	case ZONE_ATTR_INITRESTART0:
+		zone->zone_restart_init_0 = B_TRUE;
+		err = 0;
+		break;
+	case ZONE_ATTR_INITREBOOT:
+		zone->zone_reboot_on_init_exit = B_TRUE;
 		err = 0;
 		break;
 	case ZONE_ATTR_BOOTARGS:

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -131,6 +131,8 @@ extern "C" {
 #define	ZONE_ATTR_APP_SVC_CT	19
 #define	ZONE_ATTR_SCHED_FIXEDHI	20
 #define	ZONE_ATTR_SECFLAGS	21
+#define	ZONE_ATTR_INITRESTART0	22
+#define	ZONE_ATTR_INITREBOOT	23
 
 /* Start of the brand-specific attribute namespace */
 #define	ZONE_ATTR_BRAND_ATTRS	32768
@@ -622,6 +624,7 @@ typedef struct zone {
 
 	boolean_t	zone_restart_init;	/* Restart init if it dies? */
 	boolean_t	zone_reboot_on_init_exit; /* Reboot if init dies? */
+	boolean_t	zone_restart_init_0;	/* Restart only if it exits 0 */
 	boolean_t	zone_setup_app_contract; /* setup contract? */
 	struct brand	*zone_brand;		/* zone's brand */
 	void		*zone_brand_data;	/* store brand specific data */


### PR DESCRIPTION

## mail_msg

```

==== Nightly distributed build started:   Sun Apr 18 10:14:34 UTC 2021 ====
==== Nightly distributed build completed: Sun Apr 18 11:32:48 UTC 2021 ====

==== Total build time ====

real    1:18:13

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-cc133161da i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151037/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.10+9-omnios-151037"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1765 (illumos)

Build project:  default
Build taskid:   125

==== Nightly argument issues ====


==== Build version ====

omnios-zoneinit-c511fb5a543

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:54.0
user  4:05:14.2
sys   1:17:01.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:58.9
user  3:30:55.6
sys   1:09:40.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
