### PR TITLE
Upstream merge upstream_merge/2021042501

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,4 +1,4 @@
 This README is here to keep track of merges from Joyent's illumos-joyent
 
-Last illumos-joyent commit: d68584140ba989b2a32d625ed4391fc2a93c8b2e
+Last illumos-joyent commit: 7e5cd87005240f2e0f5ae527ae003c420a0c10f3
 

--- a/usr/src/man/man3c/strtod.3c
+++ b/usr/src/man/man3c/strtod.3c
@@ -44,7 +44,7 @@
 .\" Copyright (c) 1992, X/Open Company Limited.  All Rights Reserved.
 .\" Portions Copyright (c) 2006, Sun Microsystems, Inc.  All Rights Reserved.
 .\"
-.TH STRTOD 3C "Aug 25, 2019"
+.TH STRTOD 3C "Apr 21, 2021"
 .SH NAME
 strtod, strtof, strtold, atof \- convert string to floating-point number
 .SH SYNOPSIS
@@ -206,7 +206,8 @@ conversion could be performed, \fB0\fR is returned.
 If the correct value is outside the range of representable values,
 \fB\(+-HUGE_VAL\fR, \fB\(+-HUGE_VALF\fR, or \fB\(+-HUGE_VALL\fR is returned
 (according to the sign of the value), a floating point overflow exception is
-raised, and \fBerrno\fR is set to \fBERANGE\fR.
+raised, and \fBerrno\fR is set to \fBERANGE\fR. \fBHUGE_VAL\fR,
+\fBHUGE_VALF\fR, and \fBHUGE_VALL\fR are described in \fBmath.h\fR(3HEAD).
 .sp
 .LP
 If the correct value would cause an underflow, the correctly rounded result
@@ -326,8 +327,8 @@ MT-Level	MT-Safe with exceptions
 .TE
 
 .SH SEE ALSO
-\fBisspace\fR(3C), \fBlocaleconv\fR(3C), \fBscanf\fR(3C), \fBsetlocale\fR(3C),
-\fBstrtol\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)
+\fBisspace\fR(3C), \fBlocaleconv\fR(3C), \fBmath.h\fR(3HEAD), \fBscanf\fR(3C),
+\fBsetlocale\fR(3C), \fBstrtol\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)
 .SH NOTES
 The \fBstrtod()\fR and \fBatof()\fR functions can be used safely in
 multithreaded applications, as long as \fBsetlocale\fR(3C) is not called to

--- a/usr/src/man/man3c/wcstod.3c
+++ b/usr/src/man/man3c/wcstod.3c
@@ -43,7 +43,7 @@
 .\" Copyright (c) 1992, X/Open Company Limited.  All Rights Reserved.
 .\" Portions Copyright (c) 2003, Sun Microsystems, Inc.  All Rights Reserved
 .\"
-.TH WCSTOD 3C "Aug 25, 2019"
+.TH WCSTOD 3C "Apr 21, 2021"
 .SH NAME
 wcstod, wcstof, wcstold, wstod, watof \- convert wide character string to
 floating-point number
@@ -219,7 +219,8 @@ conversion could be performed, \fB0\fR is returned.
 If the correct value is outside the range of representable values,
 \fB\(+-HUGE_VAL\fR, \fB\(+-HUGE_VALF\fR, or \fB\(+-HUGE_VALL\fR is returned
 (according to the sign of the value), a floating point overflow exception is
-raised, and \fBerrno\fR is set to \fBERANGE\fR.
+raised, and \fBerrno\fR is set to \fBERANGE\fR. \fBHUGE_VAL\fR,
+\fBHUGE_VALF\fR, and \fBHUGE_VALL\fR are described in \fBmath.h\fR(3HEAD).
 .sp
 .LP
 If the correct value would cause an underflow, the correctly rounded result
@@ -272,5 +273,5 @@ MT-Level	MT-Safe
 .TE
 
 .SH SEE ALSO
-\fBiswspace\fR(3C), \fBlocaleconv\fR(3C), \fBscanf\fR(3C), \fBsetlocale\fR(3C),
-\fBwcstol\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)
+\fBiswspace\fR(3C), \fBlocaleconv\fR(3C), \fBmath.h\fR(3HEAD), \fBscanf\fR(3C),
+\fBsetlocale\fR(3C), \fBwcstol\fR(3C), \fBattributes\fR(5), \fBstandards\fR(5)

--- a/usr/src/man/man9f/scsi_hba_attach_setup.9f
+++ b/usr/src/man/man9f/scsi_hba_attach_setup.9f
@@ -4,7 +4,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.Dd Apr 23, 2017
+.Dd April 23, 2021
 .Dt SCSI_HBA_ATTACH_SETUP 9F
 .Os
 .Sh NAME
@@ -81,7 +81,7 @@ If
 is requested in
 .Fa hba_flags ,
 the
-Fa hba_tran
+.Fa hba_tran
 structure is cloned once for each target that is attached to the
 HBA.
 The use of this flag is deprecated, drivers should instead use

--- a/usr/src/test/util-tests/tests/ctf/check-function.c
+++ b/usr/src/test/util-tests/tests/ctf/check-function.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -24,6 +25,13 @@ static const char *two_args[] = { "int", "const char *" };
 static const char *three_args[] = { "int", "const char *", "float" };
 static const char *argument_args[] = { "uintptr_t" };
 static const char *vararg_args[] = { "const char *" };
+static const char *vla1_args[] = { "int", "int *" };
+static const char *vla2_args[] = { "int", "int (*)[0]" };
+static const char *vla3_args[] = { "int", "int (*)[7]" };
+static const char *vla4_args[] = { "int", "int (*)[0]" };
+static const char *vla5_args[] = { "int", "int", "int (*)[3][0]" };
+static const char *vla6_args[] = { "int", "int", "int (*)[0][4]" };
+
 
 static check_function_test_t functions[] = {
 	{ "simple_func", "void", 0, 0, NULL },
@@ -34,6 +42,12 @@ static check_function_test_t functions[] = {
 	{ "argument", "const char *", 1, 0, argument_args },
 	{ "vararg", "void", 1, CTF_FUNC_VARARG, vararg_args },
 	{ "vararg_ret", "uintptr_t", 1, CTF_FUNC_VARARG, vararg_args },
+	{ "vla1", "int", 2, 0, vla1_args },
+	{ "vla2", "int", 2, 0, vla2_args },
+	{ "vla3", "int", 2, 0, vla3_args },
+	{ "vla4", "int", 2, 0, vla4_args },
+	{ "vla5", "int", 3, 0, vla5_args },
+	{ "vla6", "int", 3, 0, vla6_args },
 	{ NULL }
 };
 

--- a/usr/src/test/util-tests/tests/ctf/test-function.c
+++ b/usr/src/test/util-tests/tests/ctf/test-function.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/types.h>
@@ -62,6 +63,42 @@ uintptr_t
 vararg_ret(const char *foo, ...)
 {
 	return ((uintptr_t)foo);
+}
+
+int
+vla1(int n, int arr[n])
+{
+	return (arr[1]);
+}
+
+int
+vla2(int n, int arr[n][n])
+{
+	return (arr[1][2]);
+}
+
+int
+vla3(int n, int arr[n][7])
+{
+	return (arr[1][2]);
+}
+
+int
+vla4(int n, int arr[23][n])
+{
+	return (arr[1][2]);
+}
+
+int
+vla5(int a, int b, int arr[a][3][b])
+{
+	return (arr[1][2][3]);
+}
+
+int
+vla6(int a, int b, int arr[a][b][4])
+{
+	return (arr[1][2][3]);
 }
 
 typedef int (*strfunc_t)(const char *, const char *);

--- a/usr/src/test/util-tests/tests/demangle/rust.c
+++ b/usr/src/test/util-tests/tests/demangle/rust.c
@@ -27,6 +27,7 @@
  */
 /*
  * Copyright 2019, Joyent, Inc.
+ * Copyright 2021 Jason King
  */
 
 /*
@@ -84,25 +85,25 @@ GROUP(demangle_osx,
     "<core::option::Option<T>>::unwrap::_MSG_FILE_LINE_COL::haf7cb8d5824ee659"),
     T("__ZN4core5slice89_$LT$impl$u20$core..iter..traits..IntoIterator$u20$for$u20$$RF$$u27$a$u20$$u5b$T$u5d$$GT$9into_iter17h450e234d27262170E",
     "core::slice::<impl core::iter::traits::IntoIterator for &'a [T]>::into_iter::h450e234d27262170"));
-/* END CSTYLED */
 
 GROUP(demangle_elements_beginning_with_underscore,
     T("_ZN13_$LT$test$GT$E", "<test>"),
     T("_ZN28_$u7b$$u7b$closure$u7d$$u7d$E", "{{closure}}"),
     T("_ZN15__STATIC_FMTSTRE", "__STATIC_FMTSTR"));
 
-/* BEGIN CSTYLED */
 GROUP(demangle_trait_impls,
     T("_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE",
     "<Test + 'static as foo::Bar<Test>>::bar"));
-/* END CSTYLED */
 
 GROUP(invalid_no_chop, T_ERR("_ZNfooE"));
 
-/* BEGIN CSTYLED */
 GROUP(handle_assoc_types,
     T("_ZN151_$LT$alloc..boxed..Box$LT$alloc..boxed..FnBox$LT$A$C$$u20$Output$u3d$R$GT$$u20$$u2b$$u20$$u27$a$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$9call_once17h69e8f44b3723e1caE",
     "<alloc::boxed::Box<alloc::boxed::FnBox<A, Output=R> + 'a> as core::ops::function::FnOnce<A>>::call_once::h69e8f44b3723e1ca"));
+
+/* C++ mangled names that aren't valid rust names */
+GROUP(cplusplus_as_rust, T_ERR("_ZN7mozilla3dom13BrowserParent22RecvUpdateContentCacheERKNS_12ContentCacheE"));
+
 /* END CSTYLED */
 
 static rust_test_grp_t *rust_tests[] = {
@@ -113,7 +114,8 @@ static rust_test_grp_t *rust_tests[] = {
 	&demangle_elements_beginning_with_underscore,
 	&demangle_trait_impls,
 	&invalid_no_chop,
-	&handle_assoc_types
+	&handle_assoc_types,
+	&cplusplus_as_rust,
 };
 
 static const size_t n_rust_tests = ARRAY_SIZE(rust_tests);

--- a/usr/src/uts/common/fs/smbsrv/smb_tree.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_tree.c
@@ -1119,7 +1119,7 @@ smb_tree_getattr(const smb_kshare_t *si, smb_node_t *node, smb_tree_t *tree)
 		VFS_RELE(realvfsp);
 	} else {
 		cmn_err(CE_NOTE, "Failed getting info for share: %s",
-			si->shr_name);
+		    si->shr_name);
 		/* do the best we can without realvfsp */
 		smb_tree_get_flags(si, vfsp, tree);
 	}

--- a/usr/src/uts/common/os/logsubr.c
+++ b/usr/src/uts/common/os/logsubr.c
@@ -216,7 +216,7 @@ log_init(void)
 	log_intrq = log_makeq(0, LOG_HIWAT, (void *)ipltospl(SPL8));
 
 	/*
-	 * Create a queue to hold the most recent 8K of console messages.
+	 * Create a queue to hold the most recent 64K of console messages.
 	 * Useful for debugging.  Required by the "$<msgbuf" adb macro.
 	 */
 	log_recentq = log_makeq(0, LOG_RECENTSIZE, NULL);

--- a/usr/src/uts/common/sys/log.h
+++ b/usr/src/uts/common/sys/log.h
@@ -30,8 +30,6 @@
 #ifndef _SYS_LOG_H
 #define	_SYS_LOG_H
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <sys/types.h>
 #include <sys/strlog.h>
 #include <sys/stream.h>
@@ -55,7 +53,7 @@ extern "C" {
 #define	LOG_HIWAT	1048576		/* threshold for tossing messages */
 
 #define	LOG_MAGIC	0xf00d4109U	/* "food for log" - unsent msg magic */
-#define	LOG_RECENTSIZE	8192		/* queue of most recent messages */
+#define	LOG_RECENTSIZE	65536		/* queue of most recent messages */
 #define	LOG_MINFREE	4096		/* message cache low water mark */
 #define	LOG_MAXFREE	8192		/* message cache high water mark */
 

--- a/usr/src/uts/common/syscall/open.c
+++ b/usr/src/uts/common/syscall/open.c
@@ -24,10 +24,11 @@
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 /*
  * Copyright (c) 2013, OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 /*
  * Portions of this source code were derived from Berkeley 4.3 BSD
@@ -116,11 +117,11 @@ copen(int startfd, char *fname, int filemode, int createmode)
 	if (filemode & FXATTRDIROPEN) {
 		if (auditing && startvp != NULL)
 			audit_setfsat_path(1);
-		if (error = lookupnameat(fname, seg, FOLLOW,
-		    NULLVPP, &vp, startvp))
-			return (set_errno(error));
+		error = lookupnameat(fname, seg, FOLLOW, NULLVPP, &vp, startvp);
 		if (startvp != NULL)
 			VN_RELE(startvp);
+		if (error != 0)
+			return (set_errno(error));
 
 		startvp = vp;
 	}


### PR DESCRIPTION
Weekly upstream for upstream_merge/2021042501

## onu

```
OmniOS r151037  omnios-upstream_merge-2021042501-b0f357568c7    April 2021
illumos development build: 2021-Apr-25 [illumos]

bloody%
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2021042501-b0f357568c7 i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Sun Apr 25 18:10:04 UTC 2021 ====
==== Nightly distributed build completed: Sun Apr 25 19:27:43 UTC 2021 ====

==== Total build time ====

real    1:17:38

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-473317b31a i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151037/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.10+9-omnios-151037"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1767 (illumos)

Build project:  default
Build taskid:   2926

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2021042501-b0f357568c7

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:45.2
user  4:06:02.9
sys   1:15:45.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:43.6
user  3:30:27.4
sys   1:08:04.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
