### PR TITLE
Backports to r151038

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1491,6 +1491,7 @@ usr/src/cmd/pathchk/pathchk
 usr/src/cmd/pbind/amd64/pbind
 usr/src/cmd/pcidb/pcidb
 usr/src/cmd/pcidr/pcidr
+usr/src/cmd/pcieadm/pcieadm
 usr/src/cmd/pcieb/pcieb
 usr/src/cmd/pcitool/i386/pcitool
 usr/src/cmd/perl/contrib/Sun/Solaris/Intrs/amd64/

--- a/usr/src/cmd/pcieadm/pcieadm.h
+++ b/usr/src/cmd/pcieadm/pcieadm.h
@@ -71,7 +71,6 @@ extern void pcieadm_init_cfgspace_file(pcieadm_t *, const char *,
 extern void pcieadm_fini_cfgspace_file(void *);
 extern void pcieadm_find_nexus(pcieadm_t *);
 extern void pcieadm_find_dip(pcieadm_t *, const char *);
-extern boolean_t pcieadm_di_node_is_pci(di_node_t);
 
 /*
  * Output related

--- a/usr/src/pkg/manifests/system-test-utiltest.mf
+++ b/usr/src/pkg/manifests/system-test-utiltest.mf
@@ -1695,6 +1695,7 @@ file path=opt/util-tests/tests/pci/igb-ltr-p.out mode=0444
 file path=opt/util-tests/tests/pci/igb-ltr.out mode=0444
 file path=opt/util-tests/tests/pci/igb.pci mode=0444
 file path=opt/util-tests/tests/pcidbtest mode=0555
+file path=opt/util-tests/tests/pcieadm-priv mode=0555
 file path=opt/util-tests/tests/pcieadmtest mode=0555
 file path=opt/util-tests/tests/printf_test mode=0555
 file path=opt/util-tests/tests/sed/multi_test mode=0555

--- a/usr/src/test/util-tests/runfiles/default.run
+++ b/usr/src/test/util-tests/runfiles/default.run
@@ -86,3 +86,5 @@ tests = ['sed_addr', 'multi_test']
 
 [/opt/util-tests/tests/pcidbtest]
 [/opt/util-tests/tests/pcieadmtest]
+[/opt/util-tests/tests/pcieadm-priv]
+user = root

--- a/usr/src/test/util-tests/tests/demangle/rust.c
+++ b/usr/src/test/util-tests/tests/demangle/rust.c
@@ -27,6 +27,7 @@
  */
 /*
  * Copyright 2019, Joyent, Inc.
+ * Copyright 2021 Jason King
  */
 
 /*
@@ -84,25 +85,25 @@ GROUP(demangle_osx,
     "<core::option::Option<T>>::unwrap::_MSG_FILE_LINE_COL::haf7cb8d5824ee659"),
     T("__ZN4core5slice89_$LT$impl$u20$core..iter..traits..IntoIterator$u20$for$u20$$RF$$u27$a$u20$$u5b$T$u5d$$GT$9into_iter17h450e234d27262170E",
     "core::slice::<impl core::iter::traits::IntoIterator for &'a [T]>::into_iter::h450e234d27262170"));
-/* END CSTYLED */
 
 GROUP(demangle_elements_beginning_with_underscore,
     T("_ZN13_$LT$test$GT$E", "<test>"),
     T("_ZN28_$u7b$$u7b$closure$u7d$$u7d$E", "{{closure}}"),
     T("_ZN15__STATIC_FMTSTRE", "__STATIC_FMTSTR"));
 
-/* BEGIN CSTYLED */
 GROUP(demangle_trait_impls,
     T("_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE",
     "<Test + 'static as foo::Bar<Test>>::bar"));
-/* END CSTYLED */
 
 GROUP(invalid_no_chop, T_ERR("_ZNfooE"));
 
-/* BEGIN CSTYLED */
 GROUP(handle_assoc_types,
     T("_ZN151_$LT$alloc..boxed..Box$LT$alloc..boxed..FnBox$LT$A$C$$u20$Output$u3d$R$GT$$u20$$u2b$$u20$$u27$a$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$9call_once17h69e8f44b3723e1caE",
     "<alloc::boxed::Box<alloc::boxed::FnBox<A, Output=R> + 'a> as core::ops::function::FnOnce<A>>::call_once::h69e8f44b3723e1ca"));
+
+/* C++ mangled names that aren't valid rust names */
+GROUP(cplusplus_as_rust, T_ERR("_ZN7mozilla3dom13BrowserParent22RecvUpdateContentCacheERKNS_12ContentCacheE"));
+
 /* END CSTYLED */
 
 static rust_test_grp_t *rust_tests[] = {
@@ -113,7 +114,8 @@ static rust_test_grp_t *rust_tests[] = {
 	&demangle_elements_beginning_with_underscore,
 	&demangle_trait_impls,
 	&invalid_no_chop,
-	&handle_assoc_types
+	&handle_assoc_types,
+	&cplusplus_as_rust,
 };
 
 static const size_t n_rust_tests = ARRAY_SIZE(rust_tests);

--- a/usr/src/test/util-tests/tests/pcieadm/Makefile
+++ b/usr/src/test/util-tests/tests/pcieadm/Makefile
@@ -18,7 +18,7 @@ include $(SRC)/test/Makefile.com
 
 ROOTOPTPKG = $(ROOT)/opt/util-tests/tests
 ROOTOPTPCI = $(ROOT)/opt/util-tests/tests/pci
-PROG = pcieadmtest
+PROG = pcieadmtest pcieadm-priv
 DATAFILES = bridge.pci igb.pci \
 	header0-basic.out \
 	header0-basic-L.out \

--- a/usr/src/test/util-tests/tests/pcieadm/pcieadm-priv.ksh
+++ b/usr/src/test/util-tests/tests/pcieadm/pcieadm-priv.ksh
@@ -1,0 +1,130 @@
+#!/usr/bin/ksh
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Oxide Computer Company
+#
+
+#
+# Additional testing for pcieadm that requires us to actually have
+# privileges rather than relying on existing pieces.
+#
+
+unalias -a
+set -o pipefail
+
+pcieadm_arg0="$(basename $0)"
+pcieadm_prog="/usr/lib/pci/pcieadm"
+pcieadm_tmp="/tmp/pcieadm-priv.$$"
+pcieadm_bdf=""
+pcieadm_dev=""
+pcieadm_path=""
+
+warn()
+{
+	typeset msg="$*"
+	[[ -z "$msg" ]] && msg="failed"
+	echo "TEST FAILED: $pcieadm_arg0: $msg" >&2
+	pcieadm_exit=1
+}
+
+pcieadm_validate_filter()
+{
+	typeset filter="$1"
+
+	if ! $pcieadm_prog show-devs $filter >/dev/null; then
+		warn "failed to show-devs with filter $filter"
+	else
+		printf "TEST PASSED: show-devs $filter\n"
+	fi
+
+	if ! $pcieadm_prog show-cfgspace -d $filter >/dev/null; then
+		warn "failed to show-cfgspace with filter $filter"
+	else
+		printf "TEST PASSED: show-cfgspace -d $filter\n"
+	fi
+
+	if ! $pcieadm_prog save-cfgspace -d $filter "$pcieadm_tmp/out.bin"; then
+		warn "failed to use save-cfgspace -d $filter"
+	else
+		printf "TEST PASSED: save-cfgspace -d $filter\n"
+	fi
+}
+
+#
+# Before we begin execution, set up the environment such that we have a
+# standard locale and that umem will help us catch mistakes.
+#
+export LC_ALL=C.UTF-8
+export LD_PRELOAD=libumem.so
+export UMEM_DEBUG=default
+
+if [[ -n $PCIEADM ]]; then
+	pcieadm_prog=$PCIEADM
+fi
+
+if ! $pcieadm_prog show-devs >/dev/null; then
+	warn "failed to show devices"
+else
+	printf "successfully listed devices\n"
+fi
+
+if ! mkdir "$pcieadm_tmp"; then
+	warn "failed to create temporary directory"
+	exit $pcieadm_exit
+fi
+
+#
+# Verify that we can grab things based on bdf
+#
+pcieadm_bdf=$($pcieadm_prog show-devs -p -o bdf | \
+    awk '{ print $1; exit 0 }')
+if [[ -z "$pcieadm_bdf" ]]; then
+	warn "failed to obtain bdf based filter"
+else
+	pcieadm_validate_filter "$pcieadm_bdf"
+fi
+
+#
+# Verify based on device.
+#
+pcieadm_path=$($pcieadm_prog show-devs -p -o path | \
+    awk '{ print $1; exit 0 }')
+if [[ -z "$pcieadm_path" ]]; then
+	warn "failed to obtain path based filter"
+else
+	pcieadm_validate_filter "$pcieadm_path"
+fi
+
+#
+# Do the same based on the device name
+#
+pcieadm_dev=$($pcieadm_prog show-devs -p -o driver | \
+    awk '{ if ($1 != "--") { print $1; exit 0 } }')
+if [[ -z "$pcieadm_dev" ]]; then
+	warn "failed to obtain driver based filter"
+else
+	pcieadm_validate_filter "$pcieadm_dev"
+fi
+
+if ! $pcieadm_prog save-cfgspace -a "$pcieadm_tmp" > /dev/null; then
+	warn "failed to save all devices"
+else
+	printf "TEST PASSED: save-cfgspace -a\n"
+fi
+
+if (( pcieadm_exit == 0 )); then
+	printf "All tests passed successfully!\n"
+fi
+rm -rf "$pcieadm_tmp"
+exit $pcieadm_exit

--- a/usr/src/uts/common/os/logsubr.c
+++ b/usr/src/uts/common/os/logsubr.c
@@ -216,7 +216,7 @@ log_init(void)
 	log_intrq = log_makeq(0, LOG_HIWAT, (void *)ipltospl(SPL8));
 
 	/*
-	 * Create a queue to hold the most recent 8K of console messages.
+	 * Create a queue to hold the most recent 64K of console messages.
 	 * Useful for debugging.  Required by the "$<msgbuf" adb macro.
 	 */
 	log_recentq = log_makeq(0, LOG_RECENTSIZE, NULL);

--- a/usr/src/uts/common/sys/log.h
+++ b/usr/src/uts/common/sys/log.h
@@ -30,8 +30,6 @@
 #ifndef _SYS_LOG_H
 #define	_SYS_LOG_H
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #include <sys/types.h>
 #include <sys/strlog.h>
 #include <sys/stream.h>
@@ -55,7 +53,7 @@ extern "C" {
 #define	LOG_HIWAT	1048576		/* threshold for tossing messages */
 
 #define	LOG_MAGIC	0xf00d4109U	/* "food for log" - unsent msg magic */
-#define	LOG_RECENTSIZE	8192		/* queue of most recent messages */
+#define	LOG_RECENTSIZE	65536		/* queue of most recent messages */
 #define	LOG_MINFREE	4096		/* message cache low water mark */
 #define	LOG_MAXFREE	8192		/* message cache high water mark */
 

--- a/usr/src/uts/common/syscall/open.c
+++ b/usr/src/uts/common/syscall/open.c
@@ -24,10 +24,11 @@
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 /*
  * Copyright (c) 2013, OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  */
 /*
  * Portions of this source code were derived from Berkeley 4.3 BSD
@@ -116,11 +117,11 @@ copen(int startfd, char *fname, int filemode, int createmode)
 	if (filemode & FXATTRDIROPEN) {
 		if (auditing && startvp != NULL)
 			audit_setfsat_path(1);
-		if (error = lookupnameat(fname, seg, FOLLOW,
-		    NULLVPP, &vp, startvp))
-			return (set_errno(error));
+		error = lookupnameat(fname, seg, FOLLOW, NULLVPP, &vp, startvp);
 		if (startvp != NULL)
 			VN_RELE(startvp);
+		if (error != 0)
+			return (set_errno(error));
 
 		startvp = vp;
 	}


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Sun Apr 25 19:55:16 UTC 2021 ====
==== Nightly distributed build completed: Sun Apr 25 21:13:12 UTC 2021 ====

==== Total build time ====

real    1:17:56

==== Build environment ====

/usr/bin/uname
SunOS r151038 5.11 omnios-r151038-3605dfceff i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151038/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151038/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.10+9-omnios-151038"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1765 (illumos)

Build project:  default
Build taskid:   100

==== Nightly argument issues ====


==== Build version ====

omnios-r38bp-c3cd7568a9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:36.6
user  4:05:13.3
sys   1:16:44.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:47.9
user  3:29:54.0
sys   1:08:18.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
