### PR TITLE
Add privilege management to bhyve

### DIFF
--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -1060,6 +1060,7 @@ ZVERBOSE=	-Wl,-zverbose
 ZASSERTDEFLIB=	-Wl,-zassert-deflib
 ZGUIDANCE=	-Wl,-zguidance
 ZFATALWARNINGS=	-Wl,-zfatal-warnings
+ZASLR=		-Wl,-zaslr
 
 GSHARED=	-shared
 CCMT=		-mt

--- a/usr/src/cmd/bhyve/Makefile
+++ b/usr/src/cmd/bhyve/Makefile
@@ -64,6 +64,7 @@ SRCS =	acpi.c			\
 	pctestdev.c		\
 	pm.c			\
 	post.c			\
+	privileges.c		\
 	ps2kbd.c		\
 	ps2mouse.c		\
 	rfb.c			\

--- a/usr/src/cmd/bhyve/Makefile
+++ b/usr/src/cmd/bhyve/Makefile
@@ -151,6 +151,7 @@ $(PROG) := LDLIBS += \
 	-lz
 NATIVE_LIBS += libz.so libcrypto.so
 $(MEVENT_TEST_PROG) := LDLIBS += -lsocket
+$(PROG) := LDFLAGS += $(ZASLR)
 
 .KEEP_STATE:
 

--- a/usr/src/cmd/bhyve/bhyverun.c
+++ b/usr/src/cmd/bhyve/bhyverun.c
@@ -110,6 +110,9 @@ __FBSDID("$FreeBSD$");
 #include "rtc.h"
 #include "vga.h"
 #include "vmgenc.h"
+#ifndef __FreeBSD__
+#include "privileges.h"
+#endif
 
 #define GUEST_NIO_PORT		0x488	/* guest upcalls via i/o port */
 
@@ -1519,6 +1522,10 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
+#ifndef __FreeBSD__
+	illumos_priv_init();
+#endif
+
 	calc_topolopgy();
 #ifdef __FreeBSD__
 	build_vcpumaps();
@@ -1685,6 +1692,10 @@ main(int argc, char *argv[])
 
 	if (caph_enter() == -1)
 		errx(EX_OSERR, "cap_enter() failed");
+#endif
+
+#ifndef __FreeBSD__
+	illumos_priv_lock();
 #endif
 
 #ifdef __FreeBSD__

--- a/usr/src/cmd/bhyve/privileges.c
+++ b/usr/src/cmd/bhyve/privileges.c
@@ -1,0 +1,177 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+ */
+
+/*
+ * Two privilege sets are maintained. One which is the minimal privileges
+ * necessary to run bhyve - 'bhyve_priv_min' - and one which is the maximum
+ * privileges required - 'bhyve_priv_max'. This second set starts off identical
+ * to the first, and is added to by modules during initialisation depending on
+ * their requirements and their configuration.
+ * Once all modules are initialised, and before the VM is set running, the
+ * privileges are locked by setting the 'Permitted' privilege set from the
+ * contents of the maximum set, which is now the upper bound, and dropping back
+ * to the minimum set.
+ *
+ * Privileges are process wide, and this framework does not support threaded
+ * access. The ID of the thread that first initialises privileges is recorded,
+ * and all subsequent privilege operations must be done by the same thread.
+ */
+
+#include <err.h>
+#include <pthread.h>
+#include <priv.h>
+#include <stdlib.h>
+#include <string.h>
+#include <upanic.h>
+#include <sys/debug.h>
+#include "config.h"
+#include "debug.h"
+#include "privileges.h"
+
+static pthread_t priv_thread;
+static priv_set_t *bhyve_priv_init;
+static priv_set_t *bhyve_priv_min;
+static priv_set_t *bhyve_priv_max;
+static bool priv_debug = false;
+
+#define	DPRINTF(params) \
+    if (priv_debug) do { PRINTLN params; fflush(stdout); } while(0)
+
+static void
+illumos_priv_printset(char *tag, priv_set_t *set)
+{
+	char *s;
+
+	s = priv_set_to_str(set, ',', PRIV_STR_LIT);
+	if (s == NULL) {
+		warn("priv_set_to_str(%s) failed", tag);
+		return;
+	}
+	DPRINTF((" + %s: %s", tag, s));
+	free(s);
+}
+
+void
+illumos_priv_reduce(void)
+{
+	VERIFY3S(pthread_equal(pthread_self(), priv_thread), !=, 0);
+	DPRINTF((" + Reducing privileges to minimum"));
+	if (setppriv(PRIV_SET, PRIV_EFFECTIVE, bhyve_priv_min) != 0)
+		err(4, "failed to reduce privileges");
+}
+
+static void
+illumos_priv_add_set(priv_set_t *set, const char *priv, const char *src)
+{
+	VERIFY3S(pthread_equal(pthread_self(), priv_thread), !=, 0);
+	DPRINTF((" + Adding privilege %s (%s)", priv, src));
+	if (!priv_ismember(bhyve_priv_init, priv))
+		err(4, "Privilege %s (for %s) not in initial set", priv, src);
+	if (priv_addset(set, priv) != 0)
+		err(4, "Failed to add %s privilege for %s", priv, src);
+}
+void
+illumos_priv_add(const char *priv, const char *src)
+{
+	illumos_priv_add_set(bhyve_priv_max, priv, src);
+}
+
+void
+illumos_priv_add_min(const char *priv, const char *src)
+{
+	illumos_priv_add_set(bhyve_priv_min, priv, src);
+	illumos_priv_add_set(bhyve_priv_max, priv, src);
+}
+
+void
+illumos_priv_init(void)
+{
+	priv_debug = get_config_bool_default("privileges.debug", false);
+
+	DPRINTF((" + Initialising privileges."));
+
+	if (priv_debug)
+		(void) setpflags(PRIV_DEBUG, 1);
+
+	priv_thread = pthread_self();
+
+	if ((bhyve_priv_init = priv_allocset()) == NULL)
+		err(4, "failed to allocate memory for initial priv set");
+	if ((bhyve_priv_min = priv_allocset()) == NULL)
+		err(4, "failed to allocate memory for minimum priv set");
+	if ((bhyve_priv_max = priv_allocset()) == NULL)
+		err(4, "failed to allocate memory for maximum priv set");
+
+	if (getppriv(PRIV_EFFECTIVE, bhyve_priv_init) != 0)
+		err(4, "failed to fetch current privileges");
+
+	if (priv_debug)
+		illumos_priv_printset("initial", bhyve_priv_init);
+
+	/*
+	 * file_read is left in the minimum set to allow for lazy library
+	 * loading.
+	 */
+	priv_basicset(bhyve_priv_min);
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_FILE_LINK_ANY));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_FILE_WRITE));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_NET_ACCESS));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_PROC_EXEC));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_PROC_FORK));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_PROC_INFO));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_PROC_SECFLAGS));
+	VERIFY0(priv_delset(bhyve_priv_min, PRIV_PROC_SESSION));
+
+	priv_intersect(bhyve_priv_init, bhyve_priv_min);
+	priv_copyset(bhyve_priv_min, bhyve_priv_max);
+
+	/*
+	 * These are privileges that we know will always be needed.
+	 * Other privileges may be added by modules as necessary during
+	 * initialisation.
+	 */
+	illumos_priv_add_min(PRIV_PROC_CLOCK_HIGHRES, "init");
+	illumos_priv_add(PRIV_FILE_WRITE, "init");
+}
+
+void
+illumos_priv_lock(void)
+{
+	VERIFY3S(pthread_equal(pthread_self(), priv_thread), !=, 0);
+
+	if (bhyve_priv_init == NULL) {
+		const char *msg = "attempted to re-lock privileges";
+		upanic(msg, strlen(msg));
+	}
+
+	priv_intersect(bhyve_priv_init, bhyve_priv_max);
+
+	if (priv_debug) {
+		DPRINTF((" + Locking privileges"));
+
+		illumos_priv_printset("min", bhyve_priv_min);
+		illumos_priv_printset("max", bhyve_priv_max);
+	}
+
+	if (setppriv(PRIV_SET, PRIV_PERMITTED, bhyve_priv_max) != 0) {
+		const char *fail = "failed to reduce permitted privileges";
+		upanic(fail, strlen(fail));
+	}
+
+	illumos_priv_reduce();
+
+	priv_freeset(bhyve_priv_init);
+	bhyve_priv_init = NULL;
+}

--- a/usr/src/cmd/bhyve/privileges.h
+++ b/usr/src/cmd/bhyve/privileges.h
@@ -1,0 +1,28 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+ */
+
+#ifndef _BHYVE_PRIVILEGES_H
+#define	_BHYVE_PRIVILEGES_H
+
+#include <priv.h>
+#include <stdbool.h>
+
+void illumos_priv_init(void);
+void illumos_priv_lock(void);
+void illumos_priv_add(const char *, const char *);
+void illumos_priv_add_min(const char *, const char *);
+void illumos_priv_reduce(void);
+
+#endif /* _BHYVE_PRIVILEGES_H */

--- a/usr/src/man/man4/bhyve_config.4
+++ b/usr/src/man/man4/bhyve_config.4
@@ -25,7 +25,7 @@
 .\"
 .\" Portions Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 .\"
-.Dd March 24, 2021
+.Dd May 6, 2021
 .Dt BHYVE_CONFIG 4
 .Os
 .Sh NAME
@@ -147,8 +147,13 @@ If set to false, MSI interrupts are used instead.
 .It Va config.dump Ta bool Ta false Ta
 If this value is set to true, then
 .Xr bhyve 1M
-will write all of its configuration variables to stdout and exit
-after it has finished parsing command line options.
+will write all of its configuration variables to
+.Dv stdout
+and exit after it has finished parsing command line options.
+.It Va privileges.debug Ta bool Ta false Ta
+Enable debug messages relating to privilege management.
+These messages are sent to
+.Dv stdout .
 .El
 .Ss x86-Specific Settings
 .Bl -column "x86.vmexit_on_pause" "integer" "Default"
@@ -357,7 +362,7 @@ TCP address to listen on for remote connections.
 The IP address must be given as a numeric address.
 IPv6 addresses must be enclosed in square brackets and
 support scoped identifiers as described in
-.Xr getaddrinfo 3socket .
+.Xr getaddrinfo 3SOCKET .
 A bare port number may be given in which case the IPv4
 localhost address is used.
 .It Va unix Ta string Ta Ta
@@ -470,5 +475,5 @@ The path of a UNIX domain socket providing the host connection for the port.
 .El
 .Sh SEE ALSO
 .Xr bhyve 1M ,
-.Xr strtoul 3c ,
-.Xr getaddrinfo 3socket
+.Xr strtoul 3C ,
+.Xr getaddrinfo 3SOCKET


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Tue May 11 14:15:16 UTC 2021 ====
==== Nightly distributed build completed: Tue May 11 15:33:40 UTC 2021 ====

==== Total build time ====

real    1:18:23

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-0721c7dd962 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151039/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.11+9-omnios-151039"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1767 (illumos)

Build project:  default
Build taskid:   262

==== Nightly argument issues ====


==== Build version ====

omnios-bhyve-5b54da68f4e

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:03.3
user  4:03:59.7
sys   1:19:11.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:43.5
user  3:26:52.6
sys   1:10:41.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
