### PR TITLE
system-log:default does not import properly alongside system-log:rsyslog

### DIFF
--- a/usr/src/cmd/syslogd/system-log.xml
+++ b/usr/src/cmd/syslogd/system-log.xml
@@ -2,28 +2,29 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
     CDDL HEADER START
-   
+
     The contents of this file are subject to the terms of the
     Common Development and Distribution License (the "License").
     You may not use this file except in compliance with the License.
-   
+
     You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
     or http://www.opensolaris.org/os/licensing.
     See the License for the specific language governing permissions
     and limitations under the License.
-   
+
     When distributing Covered Code, include this CDDL HEADER in each
     file and include the License file at usr/src/OPENSOLARIS.LICENSE.
     If applicable, add the following below this CDDL HEADER, with the
     fields enclosed by brackets "[]" replaced with your own identifying
     information: Portions Copyright [yyyy] [name of copyright owner]
-   
+
     CDDL HEADER END
-   
+
     Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 
     Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+    Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
     NOTE:  This service manifest is not editable; its contents will
     be overwritten by package or patch operations, including
@@ -32,15 +33,9 @@
 -->
 
 <service_bundle type='manifest' name='SUNWcsr:syslog'>
+<service name='system/system-log' type='service' version='1'>
 
-<service
-	name='system/system-log'
-	type='service'
-	version='1'>
-
-	<create_default_instance enabled='false' />
-
-	<single_instance/>
+<instance name='default' enabled='false'>
 
 	<dependency
 		name='milestone'
@@ -154,18 +149,19 @@
 			value='solaris.smf.value.firewall.config' />
 	</property_group>
 
-	<stability value='Unstable' />
-
 	<template>
 		<common_name>
-			<loctext xml:lang='C'> system log
-			</loctext>
+			<loctext xml:lang='C'> system log </loctext>
 		</common_name>
 		<documentation>
 			<manpage title='syslogd' section='1M'
 				manpath='/usr/share/man' />
 		</documentation>
 	</template>
-</service>
 
+</instance>
+
+<stability value='Unstable' />
+
+</service>
 </service_bundle>


### PR DESCRIPTION
When importing both `system-log` services on a newly booting system such as an ipkg or lipkg branded zone, `system-log:default` was ending up without a start or stop method, or any of the other properties.

```
bloody# zadm boot -c ipkg
[Connected to zone 'ipkg' console]

[NOTICE: Zone booting up]


OmniOS r151039 Version omnios-master-0721c7dd962 64-bit
Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
Copyright (c) 2017-2021 OmniOS Community Edition (OmniOSce) Association.
Loading smf(5) service descriptions: 113/113
Hostname: ipkg

ipkg console login: root
Password:
OmniOS r151039  omnios-master-0721c7dd962       May 2021
root@ipkg:~# svcs -p system-log
STATE          STIME    FMRI
disabled       10:58:22 svc:/system/system-log:rsyslog
online         10:58:29 svc:/system/system-log:default
root@ipkg:~# ps -ef | grep syslog
    root 12713 12704   0 10:58:50 console     0:00 grep syslog
```

```
root@ipkg:~# cat `svcs -L system-log`
[ May 16 10:58:22 Enabled. ]
[ May 16 10:58:23 Method property group 'start' is not present. ]
```
