### PR TITLE
lx brand updates to support systemd >= v247

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,11 +91,6 @@ usr/src/boot/sys/boot/i386/pmbr/pmbr
 usr/src/boot/sys/boot/i386/pxeldr/loader
 usr/src/boot/sys/boot/i386/pxeldr/pxeboot
 usr/src/boot/sys/boot/i386/pxeldr/pxeldr
-usr/src/boot/sys/boot/libcrypto/amd64/machine
-usr/src/boot/sys/boot/libcrypto/amd64/sha1-x86_64.s
-usr/src/boot/sys/boot/libcrypto/amd64/x86
-usr/src/boot/sys/boot/libcrypto/i386/machine
-usr/src/boot/sys/boot/libcrypto/i386/x86
 usr/src/boot/sys/boot/libficl/amd64/machine
 usr/src/boot/sys/boot/libficl/amd64/x86
 usr/src/boot/sys/boot/libficl/i386/machine
@@ -115,6 +110,7 @@ usr/src/boot/sys/boot/libstand/amd64/libstand_bzlib_private.h
 usr/src/boot/sys/boot/libstand/amd64/libstand_gzguts.h
 usr/src/boot/sys/boot/libstand/amd64/libstand_zutil.h
 usr/src/boot/sys/boot/libstand/amd64/machine
+usr/src/boot/sys/boot/libstand/amd64/sha1-x86_64.s
 usr/src/boot/sys/boot/libstand/amd64/x86
 usr/src/boot/sys/boot/libstand/i386/_bzlib.c
 usr/src/boot/sys/boot/libstand/i386/_crctable.c
@@ -4058,7 +4054,9 @@ usr/src/man/man9f/ddi_ufm_slot_set_imgsize.9f
 usr/src/man/man9f/ddi_ufm_slot_set_misc.9f
 usr/src/man/man9f/ddi_ufm_slot_set_version.9f
 usr/src/man/man9f/ddi_ufm_update.9f
+usr/src/man/man9f/desballoca.9f
 usr/src/man/man9f/dev_err.9f
+usr/src/man/man9f/esballoca.9f
 usr/src/man/man9f/firmware_close.9f
 usr/src/man/man9f/firmware_free.9f
 usr/src/man/man9f/firmware_get_size.9f

--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,4 +1,4 @@
 This README is here to keep track of merges from Joyent's illumos-joyent
 
-Last illumos-joyent commit: 7e5cd87005240f2e0f5ae527ae003c420a0c10f3
+Last illumos-joyent commit: 43e443cf314f0181bdd958df4333caa1aee086c8
 

--- a/usr/src/uts/common/brand/lx/autofs/lx_autofs.c
+++ b/usr/src/uts/common/brand/lx/autofs/lx_autofs.c
@@ -2210,6 +2210,9 @@ lx_autofs_lookup(vnode_t *dvp, char *nm, vnode_t **vpp, struct pathname *pnp,
 	if (error != ENOENT)
 		return (error);
 
+	if (flags & __FLXNOAUTO)
+		return (ENOENT);
+
 	if (data->lav_catatonic)
 		return (ENOENT);
 

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -753,13 +753,14 @@ lxpr_open(vnode_t **vpp, int flag, cred_t *cr, caller_context_t *ct)
 
 	/*
 	 * If we are opening an underlying file only allow regular files,
-	 * fifos or sockets; reject the open for anything else.
+	 * directories, fifos or sockets; reject the open for anything else.
 	 * Just do it if we are opening the current or root directory.
 	 */
 	if (lxpnp->lxpr_realvp != NULL) {
 		rvp = lxpnp->lxpr_realvp;
 
-		if (type == LXPR_PID_FD_FD && rvp->v_type != VREG &&
+		if (type == LXPR_PID_FD_FD &&
+		    rvp->v_type != VREG && rvp->v_type != VDIR &&
 		    rvp->v_type != VFIFO && rvp->v_type != VSOCK) {
 			error = EACCES;
 		} else {
@@ -6428,16 +6429,8 @@ lxpr_lookup(vnode_t *dp, char *comp, vnode_t **vpp, pathname_t *pathp,
 	 * we should never get here because the lookup
 	 * is done on the realvp for these nodes
 	 */
-	ASSERT(type != LXPR_PID_FD_FD &&
-	    type != LXPR_PID_CURDIR &&
+	ASSERT(type != LXPR_PID_CURDIR &&
 	    type != LXPR_PID_ROOTDIR);
-
-	/*
-	 * restrict lookup permission to owner or root
-	 */
-	if ((error = lxpr_access(dp, VEXEC, 0, cr, ct)) != 0) {
-		return (error);
-	}
 
 	/*
 	 * Just return the parent vnode if that's where we are trying to go.
@@ -6446,6 +6439,35 @@ lxpr_lookup(vnode_t *dp, char *comp, vnode_t **vpp, pathname_t *pathp,
 		VN_HOLD(lxpnp->lxpr_parent);
 		*vpp = lxpnp->lxpr_parent;
 		return (0);
+	}
+
+	switch (type) {
+	case LXPR_PID_FD_FD:
+	case LXPR_PID_TID_FD_FD:
+		/*
+		 * Performing a VOP_LOOKUP on the underlying vnode and emitting
+		 * the resulting vnode, without encapsulation, as our own is a
+		 * very special case when it comes to the assumptions built
+		 * into VFS.
+		 *
+		 * Since the resulting vnode is highly likely to be at some
+		 * abitrary position in another filesystem, we insist that the
+		 * VTRAVERSE flag is set on the parent.  This prevents things
+		 * such as the v_path freshness logic from mistaking the
+		 * resulting vnode as a "real" child of the parent, rather than
+		 * a consequence of this "procfs wormhole".
+		 *
+		 * Failure to establish such protections can lead to
+		 * incorrectly calculated v_paths being set on nodes reached
+		 * through these lookups.
+		 */
+		ASSERT((dp->v_flag & VTRAVERSE) != 0);
+
+		dp = lxpnp->lxpr_realvp;
+		return (VOP_LOOKUP(dp, comp, vpp, pathp, flags, rdir, cr, ct,
+                    direntflags, realpnp));
+	default:
+		break;
 	}
 
 	/*
@@ -6457,6 +6479,12 @@ lxpr_lookup(vnode_t *dp, char *comp, vnode_t **vpp, pathname_t *pathp,
 		*vpp = dp;
 		return (0);
 	}
+
+	/*
+	 * restrict lookup permission to owner or root
+	 */
+	if ((error = lxpr_access(dp, VEXEC, 0, cr, ct)) != 0)
+		return (error);
 
 	*vpp = (lxpr_lookup_function[type](dp, comp));
 	return ((*vpp == NULL) ? ENOENT : 0);

--- a/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
+++ b/usr/src/uts/common/brand/lx/procfs/lx_prvnops.c
@@ -5714,6 +5714,8 @@ typedef enum {
 	LXCS_CPUID1_ECX,
 	LXCS_CPUID1_EDX,
 	LXCS_CPUID7_EBX,
+	LXCS_CPUID7_ECX,
+	LXCS_CPUID7_EDX,
 	LXCS_CPUIDD1_EAX,
 	LXCS_CPUIDX1_ECX,
 	LXCS_CPUIDX1_EDX,
@@ -5907,37 +5909,55 @@ lx_cpuinfo_mapping_t lx_cpuinfo_mappings[] = {
 	{ LXCS_CPUID7_EBX, 0x00000001,			"fsgsbase" },
 	{ LXCS_CPUID7_EBX, 0x00000002,			"tsc_adjust" },
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_BMI1,	"bmi1" },
-	{ LXCS_CPUID7_EBX, 0x00000010,			"hle" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_HLE,	"hle" },
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX2,	"avx2" },
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_SMEP,	"smep" },
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_BMI2,	"bmi2" },
 	{ LXCS_CPUID7_EBX, 0x00000200,			"erms" },
 	{ LXCS_CPUID7_EBX, 0x00000400,			"invpcid" },
 	{ LXCS_CPUID7_EBX, 0x00000800,			"rtm" },
-	{ LXCS_CPUID7_EBX, 0x00000000,			"cqm" },
-	{ LXCS_CPUID7_EBX, 0x00004000,			"mpx" },
-	{ LXCS_CPUID7_EBX, 0x00010000,			"avx512f" },
+	{ LXCS_CPUID7_EBX, 0x00001000,			"cqm" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_MPX,	"mpx" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512F,	"avx512f" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512DQ,	"avx512dq" },
 
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_RDSEED,	"rdseed" },
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_ADX,	"adx" },
 	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_SMAP,	"smap" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512IFMA, "avx512ifma" },
 
 	{ LXCS_CPUID7_EBX, 0x00400000,			"pcommit" },
 	{ LXCS_CPUID7_EBX, 0x00800000,			"clflushopt" },
-	{ LXCS_CPUID7_EBX, 0x01000000,			"clwb" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_CLWB,	"clwb" },
 
-	{ LXCS_CPUID7_EBX, 0x04000000,			"avx512pf" },
-	{ LXCS_CPUID7_EBX, 0x08000000,			"avx512er" },
-	{ LXCS_CPUID7_EBX, 0x10000000,			"avx512cd" },
-	{ LXCS_CPUID7_EBX, 0x20000000,			"sha_ni" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512PF,	"avx512pf" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512ER,	"avx512er" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512CD,	"avx512cd" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_SHA,	"sha_ni" },
+
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512BW,	"avx512bw" },
+	{ LXCS_CPUID7_EBX, CPUID_INTC_EBX_7_0_AVX512VL,	"avx512vl" },
+
+	/*
+	 * Intel-defined CPU features, CPUID level 0x00000007:0 (ecx)
+	 */
+	{ LXCS_CPUID7_ECX, CPUID_INTC_ECX_7_0_AVX512VBMI, "avx512vbmi" },
+	{ LXCS_CPUID7_ECX, CPUID_INTC_ECX_7_0_AVX512VPOPCDQ,
+	    "avx512_vpopcntdq" },
+
+	/*
+	 * Intel-defined CPU features, CPUID level 0x00000007:0 (edx)
+	 */
+	{ LXCS_CPUID7_EDX, CPUID_INTC_EDX_7_0_AVX5124NNIW, "avx512_4nniw" },
+	{ LXCS_CPUID7_EDX, CPUID_INTC_EDX_7_0_AVX5124FMAPS, "avx512_4fmaps" },
 
 	/*
 	 * Extended state features, CPUID level 0x0000000d:1 (eax)
 	 */
-	{ LXCS_CPUIDD1_EAX, 0x00000001,			"xsaveopt" },
-	{ LXCS_CPUIDD1_EAX, 0x00000002,			"xsavec" },
+	{ LXCS_CPUIDD1_EAX, CPUID_INTC_EAX_D_1_XSAVEOPT, "xsaveopt" },
+	{ LXCS_CPUIDD1_EAX, CPUID_INTC_EAX_D_1_XSAVEC,	"xsavec" },
 	{ LXCS_CPUIDD1_EAX, 0x00000004,			"xgetbv1" },
-	{ LXCS_CPUIDD1_EAX, 0x00000008,			"xsaves" },
+	{ LXCS_CPUIDD1_EAX, CPUID_INTC_EAX_D_1_XSAVES,	"xsaves" },
 
 	/*
 	 * Skipped:
@@ -6015,6 +6035,8 @@ lxpr_read_cpuinfo(lxpr_node_t *lxpnp, lxpr_uiobuf_t *uiobuf)
 			cpr.cp_eax = 7;
 			(void) cpuid_insn(cp, &cpr);
 			cpuid_res[LXCS_CPUID7_EBX] = cpr.cp_ebx;
+			cpuid_res[LXCS_CPUID7_ECX] = cpr.cp_ecx;
+			cpuid_res[LXCS_CPUID7_EDX] = cpr.cp_edx;
 		}
 		if (maxeax >= 0xd) {
 			cpr.cp_eax = 0xd;

--- a/usr/src/uts/common/brand/lx/syscall/lx_prctl.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_prctl.c
@@ -278,6 +278,16 @@ lx_prctl(int opt, uintptr_t data)
 		return (0);
 	}
 
+	case LX_PR_SET_NO_NEW_PRIVS: {
+		/*
+		 * On recent versions of Linux more services are starting to set
+		 * NoNewPrivs=yes in their systemd unit file. Since we currently
+		 * just return success for LX_PR_CAPBSET_DROP there is currently
+		 * no need to map this to the illumos privileges.
+		 */
+		return (0);
+	}
+
 	default:
 		break;
 	}

--- a/usr/src/uts/common/brand/lx/syscall/lx_stat.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_stat.c
@@ -393,7 +393,7 @@ lx_fstatat64(int fd, char *name, void *outp, int flag)
 	vnode_t *vp = NULL;
 	cred_t *cr = NULL;
 	model_t model = get_udatamodel();
-	enum symfollow follow = FOLLOW;
+	int follow = FOLLOW;
 	int error;
 	char c;
 
@@ -403,17 +403,12 @@ lx_fstatat64(int fd, char *name, void *outp, int flag)
 	if ((flag & ~LX_FSTATAT_ALLOWED) != 0) {
 		return (set_errno(EINVAL));
 	}
-	if ((flag & LX_AT_NO_AUTOMOUNT) != 0) {
-		/*
-		 * While AT_NO_AUTOMOUNT is a legal flag for fstatat64, it is
-		 * not yet supported by lx_autofs.
-		 */
-		lx_unsupported("fstatat(AT_NO_AUTOMOUNT)");
-		return (set_errno(EINVAL));
-	}
 	if ((flag & LX_AT_SYMLINK_NOFOLLOW) != 0) {
 		follow = NO_FOLLOW;
 	}
+
+	if ((flag & LX_AT_NO_AUTOMOUNT) != 0)
+		follow |= __FLXNOAUTO;
 
 	if (copyin(name, &c, sizeof (c)) != 0) {
 		return (set_errno(EFAULT));

--- a/usr/src/uts/common/fs/lookup.c
+++ b/usr/src/uts/common/fs/lookup.c
@@ -246,6 +246,9 @@ lookuppnvp(
 		pp = &presrvd;
 	}
 
+	if (flags & __FLXNOAUTO)
+		lookup_flags |= __FLXNOAUTO;
+
 	if (auditing)
 		audit_anchorpath(pnp, vp == rootvp);
 

--- a/usr/src/uts/common/sys/file.h
+++ b/usr/src/uts/common/sys/file.h
@@ -125,6 +125,11 @@ typedef struct fpollinfo {
  * Private interface for lx O_PATH|O_NOFOLLOW emulation for symlinks.
  */
 #define	__FLXPATH	0x80000000
+/*
+ * Private interface for lx fstatat(AT_NO_AUTOMOUNT) emulation.
+ * Since usage is disjoint, the __FLXPATH bit is re-used.
+ */
+#define	__FLXNOAUTO	0x80000000
 
 #if defined(_KERNEL) || defined(_FAKE_KERNEL)
 


### PR DESCRIPTION
Fixes #1011 

Tested booting various lx images including fedora34 which uses systemd v248. It does not start without the changes in this PR but does after.

```
# zadm boot -c fedira34
[Connected to zone 'fedira34' console]

[NOTICE: Zone booting up]
systemd v248-2.fc34 running in system mode. (+PAM +AUDIT +SELINUX -APPARMOR +IMA +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified)
Detected virtualization container-other.
Detected architecture x86-64.

Welcome to Fedora 34 (Container Image)!

Hostname set to <LXCNAME>.
...
Fedora 34 (Container Image)
Kernel 4.4 on an x86_64 (console)

LXCNAME login:
```

## mail_msg

```

==== Nightly distributed build started:   Mon Jun 14 09:19:33 UTC 2021 ====
==== Nightly distributed build completed: Mon Jun 14 10:33:52 UTC 2021 ====

==== Total build time ====

real    1:14:18

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-832782e136 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151039/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.11+9-omnios-151039"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1767 (illumos)

Build project:  default
Build taskid:   83

==== Nightly argument issues ====


==== Build version ====

omnios-lx_statat_noauto-ff699bdac4

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    27:15.4
user  3:59:33.3
sys   1:06:23.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    23:46.5
user  3:26:06.0
sys   1:01:58.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
