### PR TITLE
Disable IPS indexing when performing an onu

### DIFF
--- a/usr/src/tools/scripts/onu.sh.in
+++ b/usr/src/tools/scripts/onu.sh.in
@@ -157,7 +157,7 @@ update()
 	prepare_image
 
 	banner "Running image-update"
-	do_cmd pkg -R $root update -fr -C0
+	do_cmd pkg -R $root update --no-index -fr -C0
 
 	finalise_image
 }


### PR DESCRIPTION
This just makes an `onu` take longer than necessary for no benefit in almost all cases.