### PR TITLE
Upstream merge/2021071801

### DIFF
--- a/usr/src/cmd/csh/sh.c
+++ b/usr/src/cmd/csh/sh.c
@@ -4,7 +4,7 @@
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 /*
  * Copyright (c) 1980 Regents of the University of California.
@@ -125,7 +125,7 @@ main(int c, char **av)
 	tchar s_prompt[MAXHOSTNAMELEN+3];
 	char *c_max_var_len;
 	int c_max_var_len_size;
-	bool intact;
+	bool intact = 0;
 
 	/*
 	 * set up the error exit, if there is an error before
@@ -322,7 +322,7 @@ main(int c, char **av)
 			nofile++;
 			break;
 #ifdef TRACE
-		case 'T':		/* -T 	trace switch on */
+		case 'T':		/* -T	trace switch on */
 			trace_init();
 			break;
 #endif
@@ -632,7 +632,7 @@ srccat(tchar *cp, tchar *dp)
 
 /*
  * Source to the file which is the catenation of the argument names.
- * 	This one does not check the ownership.
+ *	This one does not check the ownership.
  */
 void
 srccat_inlogin(tchar *cp, tchar *dp)

--- a/usr/src/cmd/prtvtoc/prtvtoc.c
+++ b/usr/src/cmd/prtvtoc/prtvtoc.c
@@ -29,6 +29,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2021 Jason King
  */
 
 /*
@@ -563,6 +564,9 @@ puttable(struct dk_geom *geom, struct extvtoc *vtoc, freemap_t *freemap,
 
 	cylsize = (geom->dkg_nsect) * (geom->dkg_nhead);
 	if (!hflag && !sflag) {
+		u_longlong_t asectors = (u_longlong_t)cylsize * geom->dkg_ncyl;
+		u_longlong_t sectors = (u_longlong_t)cylsize * geom->dkg_pcyl;
+
 		(void) printf("* %s", name);
 		if (vtoc->v_volume[0] != '\0')
 			(void) printf(" (volume \"%.8s\")", vtoc->v_volume);
@@ -575,6 +579,8 @@ puttable(struct dk_geom *geom, struct extvtoc *vtoc, freemap_t *freemap,
 		(void) printf("* %11lu sectors/cylinder\n", cylsize);
 		(void) printf("* %11u cylinders\n", geom->dkg_pcyl);
 		(void) printf("* %11u accessible cylinders\n", geom->dkg_ncyl);
+		(void) printf("* %11llu sectors\n", sectors);
+		(void) printf("* %11llu accessible sectors\n", asectors);
 		(void) printf("*\n* Flags:\n");
 		(void) printf("*   1: unmountable\n");
 		(void) printf("*  10: read-only\n*\n");

--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -6004,9 +6004,6 @@ zfs_do_holds(int argc, char **argv)
 	 */
 	print_holds(scripted, cb.cb_max_namelen, cb.cb_max_taglen, nvl);
 
-	if (nvlist_empty(nvl))
-		(void) printf(gettext("no datasets available\n"));
-
 	nvlist_free(nvl);
 
 	return (0 != errors);

--- a/usr/src/man/man1m/bhyve.1m
+++ b/usr/src/man/man1m/bhyve.1m
@@ -297,7 +297,7 @@ If
 is not specified, the device emulation has no backend and can be
 considered unconnected.
 .Pp
-Host Bridge Devices
+.Sy Host Bridge Devices
 .Bl -tag -width 10n
 .It Cm model Ns = Ns Ar model
 Specify a hostbridge model to emulate.
@@ -326,7 +326,7 @@ and
 .Va devid
 must be specified.
 .Pp
-Network backends:
+.Sy Accelerated Virtio Network Backends :
 .Bl -tag -width 10n
 .It Oo Cm vnic Ns = Oc Ns Ar vnic Ns Oo , Ns Cm feature_mask Ns = Ns Ar mask Oc
 .Pp
@@ -339,7 +339,30 @@ Bits set in the
 value are removed from the advertised features.
 .El
 .Pp
-Block storage devices:
+.Sy Other Network Backends :
+.Bl -tag -width 10n
+.It Oo Cm vnic Ns = Oc Ns Ar vnic Ns Oo , Ns Ar network-backend-options Oc
+.Pp
+.Ar vnic
+is the name of a configured virtual NIC on the system.
+.El
+.Pp
+The
+.Ar network-backend-options
+are:
+.Bl -tag -width 8n
+.It Cm promiscphys
+Enable promiscuous mode at the physical level (default: false)
+.It Cm promiscsap
+Enable promiscuous mode at the SAP level (default: true)
+.It Cm promiscmulti
+Enable promiscuous mode for all multicast addresses (default: true)
+.It Cm promiscrxonly
+The selected promiscuous modes are only enabled for received traffic
+(default: true).
+.El
+.Pp
+.Sy Block storage devices :
 .Bl -tag -width 10n
 .It Pa /filename Ns Oo , Ns Ar block-device-options Oc
 .It Pa /dev/xxx Ns Oo , Ns Ar block-device-options Oc
@@ -378,7 +401,7 @@ process.
 Use the host TTY device for serial port I/O.
 .El
 .Pp
-Boot ROM device:
+.Sy Boot ROM device :
 .Bl -tag -width 10n
 .It Pa romfile
 Map
@@ -386,7 +409,7 @@ Map
 in the guest address space reserved for boot firmware.
 .El
 .Pp
-Pass-through devices:
+.Sy Pass-through devices :
 .Bl -tag -width 10n
 .It Pa /dev/ppt Ns Ar N
 Connect to a PCI device on the host identified by the specificed path.
@@ -400,7 +423,7 @@ The host device must have been previously attached to the
 .Sy ppt
 driver.
 .Pp
-Virtio console devices:
+.Sy Virtio console devices :
 .Bl -tag -width 10n
 .It Li port1= Ns Pa /path/to/port1.sock Ns ,anotherport= Ns Pa ...
 A maximum of 16 ports per device can be created.
@@ -425,7 +448,7 @@ Emergency write is advertised, but no-op at present.
 .El
 .El
 .Pp
-Framebuffer devices:
+.Sy Framebuffer devices :
 .Bl -tag -width 10n
 .It Xo
 .Sm off
@@ -505,14 +528,14 @@ the session over an encrypted channel provided by IPsec or SSH.
 .El
 .El
 .Pp
-xHCI USB devices:
+.Sy xHCI USB devices :
 .Bl -tag -width 10n
 .It Li tablet
 A USB tablet device which provides precise cursor synchronization
 when using VNC.
 .El
 .Pp
-NVMe devices:
+.Sy NVMe devices :
 .Bl -tag -width 10n
 .It Li path
 Accepted device paths are:
@@ -533,7 +556,7 @@ Sector size (defaults to blockif sector size).
 Serial number with maximum 20 characters.
 .El
 .Pp
-AHCI devices:
+.Sy AHCI devices :
 .Bl -tag -width 10n
 .It Li nmrr
 Nominal Media Rotation Rate, known as RPM. value 1 will indicate device as Solid State Disk. default value is 0, not report.

--- a/usr/src/man/man4/bhyve_config.4
+++ b/usr/src/man/man4/bhyve_config.4
@@ -222,7 +222,9 @@ VirtIO block storage interface.
 .It Li virtio-console
 VirtIO console interface.
 .It Li virtio-net-viona
-VirtIO network interface.
+Accelerated VirtIO network interface.
+.It Li net-viona
+Legacy VirtIO network interface.
 .It Li virtio-rnd
 VirtIO random number generator interface.
 .It Li xhci
@@ -272,7 +274,7 @@ Specify the logical and physical sector size of the emulated disk.
 If the physical size is not specified, it is set to be equal to the logical
 size.
 .El
-.Ss virtio-net-viona Settings
+.Ss virtio-net-viona Network Backend Settings
 Viona network devices use the following settings to configure their backend.
 .Bl -column "feature_flags" "string" "Default"
 .It Sy Name Ta Sy Format Ta Sy Default Ta Sy Description
@@ -280,6 +282,21 @@ Viona network devices use the following settings to configure their backend.
 The VNIC to use for the network connection.
 .It feature_mask Ta integer Ta 0 Ta
 Specify a mask to apply to the virtio features advertised to the guest.
+.El
+.Ss Other Network Backend Settings
+Other network devices use the following settings to configure their backend.
+.Bl -column "feature_flags" "string" "Default"
+.It Sy Name Ta Sy Format Ta Sy Default Ta Sy Description
+.It vnic Ta string Ta Ta
+The VNIC to use for the network connection.
+.It promiscphys Ta bool Ta false Ta
+Enable promiscuous mode at the physical level.
+.It promiscsap Ta bool Ta true Ta
+Enable promiscuous mode at the SAP level.
+.It promiscmulti Ta bool Ta true Ta
+Enable promiscuous mode for all multicast addresses.
+.It promiscrxonly Ta bool Ta true Ta
+The selected promiscuous modes are only enabled for received traffic.
 .El
 .Ss UART Device Settings
 .Bl -column "Name" "Format" "Default"

--- a/usr/src/uts/common/fs/smbsrv/smb_user.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_user.c
@@ -1000,6 +1000,9 @@ smb_is_same_user(cred_t *cr1, cred_t *cr2)
 	ksid_t *ks1 = crgetsid(cr1, KSID_USER);
 	ksid_t *ks2 = crgetsid(cr2, KSID_USER);
 
+	if (ks1 == NULL || ks2 == NULL) {
+		return (B_FALSE);
+	}
 	return (ks1->ks_rid == ks2->ks_rid &&
 	    strcmp(ks1->ks_domain->kd_name, ks2->ks_domain->kd_name) == 0);
 }


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151039  omnios-upstream_merge-2021071801-e49f3274aa     July 2021
illumos development build: 2021-Jul-18 [illumos-omnios]
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2021071801-e49f3274aa i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Sun Jul 18 12:25:20 CEST 2021 ====
==== Nightly distributed build completed: Sun Jul 18 13:47:09 CEST 2021 ====

==== Total build time ====

real    1:21:49

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-c2ced650b5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151039/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.11+9-omnios-151039"

/usr/bin/openssl
OpenSSL 1.1.1k  25 Mar 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1767 (illumos)

Build project:  default
Build taskid:   80

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2021071801-e49f3274aa

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    36:24.4
user  3:31:46.6
sys     39:58.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    31:37.7
user  3:02:05.6
sys     35:44.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
