### PR TITLE
lx_boot_zone_ubuntu should check for non empty val

### DIFF
--- a/usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.ksh
@@ -33,7 +33,7 @@ safe_dir /etc/systemd
 
 # Populate resolv.conf setup files IFF we have resolvers information.
 resolvers=`zone_attr resolvers`
-if [[ $? == 0 ]]; then
+if [ -n "$resolvers" ]; then
 
     echo "# AUTOMATIC ZONE CONFIG" > $tmpfile
     _IFS=$IFS; IFS=,; for r in $resolvers; do
@@ -41,7 +41,7 @@ if [[ $? == 0 ]]; then
     done >> $tmpfile
     IFS=$_IFS
     domain=`zone_attr dns-domain`
-    [[ $? == 0 ]] && echo "search $domain" >> $tmpfile
+    [ -n "$domain" ] && echo "search $domain" >> $tmpfile
 
     if [ -f $ZONEROOT/etc/systemd/resolved.conf ]; then
         cf=$ZONEROOT/etc/systemd/resolved.conf

--- a/usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.ksh
@@ -33,7 +33,7 @@ safe_dir /etc/systemd
 
 # Populate resolv.conf setup files IFF we have resolvers information.
 resolvers=`zone_attr resolvers`
-if [ -n "$resolvers" ]; then
+if [[ -n "$resolvers" ]]; then
 
     echo "# AUTOMATIC ZONE CONFIG" > $tmpfile
     _IFS=$IFS; IFS=,; for r in $resolvers; do
@@ -41,7 +41,7 @@ if [ -n "$resolvers" ]; then
     done >> $tmpfile
     IFS=$_IFS
     domain=`zone_attr dns-domain`
-    [ -n "$domain" ] && echo "search $domain" >> $tmpfile
+    [[ -n "$domain" ]] && echo "search $domain" >> $tmpfile
 
     if [ -f $ZONEROOT/etc/systemd/resolved.conf ]; then
         cf=$ZONEROOT/etc/systemd/resolved.conf


### PR DESCRIPTION
Currently `lx_boot_zone_ubuntu` manages /etc/resolv.conf if the user opts to manual manage the file, and not set resolvers and dns-domain in the zonecfg.

This is because `zone_attr()` will exit 0 even if the value is incorrect, `lx_boot` does not have this issue as it checks for a non empty value in stead. Applying the same change here makes ubuntu lx zones behave properly.

I tested by:
- boot a lx zone with resolvers and dns-domain set, copy /etc/resolv.conf
- replace lx_boot_zone_ubuntu
- boot a lx zone with resolvers and dns-domain set, diff /etc/resolv.conf /etc/resolv.conf.old --> no diff
- remove both resolvers and dns-domain from the zonecfg
- remove /etc/resolv.conf in the zone
- stop + boot the zone
- verify there is no /etc/resolv.conf create

The behavior before was a file with just the 'search ' line.