### PR TITLE
Upstream merge upstream_merge/2021092301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3409,6 +3409,8 @@ usr/src/man/man3c/cnd_wait.3c
 usr/src/man/man3c/duplocale.3c
 usr/src/man/man3c/epoll_create1.3c
 usr/src/man/man3c/epoll_pwait.3c
+usr/src/man/man3c/eventfd_read.3c
+usr/src/man/man3c/eventfd_write.3c
 usr/src/man/man3c/explicit_bzero.3c
 usr/src/man/man3c/ffsl.3c
 usr/src/man/man3c/ffsll.3c
@@ -4345,6 +4347,8 @@ usr/src/test/libmlrpc-tests/tests/netrlogon/samlogon_tests/samlogon
 usr/src/test/os-tests/tests/ddi_ufm/ufm-test
 usr/src/test/os-tests/tests/ddi_ufm/ufm-test-cleanup
 usr/src/test/os-tests/tests/ddi_ufm/ufm-test-setup
+usr/src/test/os-tests/tests/eventfd.32
+usr/src/test/os-tests/tests/eventfd.64
 usr/src/test/os-tests/tests/file-locking/acquire-lock.32
 usr/src/test/os-tests/tests/file-locking/acquire-lock.64
 usr/src/test/os-tests/tests/file-locking/runtests.32

--- a/usr/src/lib/krb5/plugins/kdb/ldap/Makefile.com
+++ b/usr/src/lib/krb5/plugins/kdb/ldap/Makefile.com
@@ -66,7 +66,8 @@ CERRWARN +=	-_gcc=-Wno-unused-function
 
 DYNFLAGS +=	$(KERBRUNPATH)
 # setting -L $(ROOT)/usr/lib/gss because libkdb_ldap needs mech_krb5
-LDLIBS +=	-L $(ROOT)/usr/lib/gss -L $(ROOTLIBDIR) -lkdb_ldap -lc
+LDLIBS +=	-L $(ROOT)/usr/lib/gss -L $(ROOTLIBDIR) -lkdb_ldap
+$(SPARC_BLD)LDLIBS += -lc
 
 .KEEP_STATE:
 

--- a/usr/src/uts/common/sys/sunldi_impl.h
+++ b/usr/src/uts/common/sys/sunldi_impl.h
@@ -72,8 +72,8 @@ void ldi_init(void);
  * LDI streams linking interfaces
  */
 extern int ldi_mlink_lh(vnode_t *, int, intptr_t, cred_t *, int *);
-extern void ldi_mlink_fp(struct stdata *, struct file *, int, int);
-extern void ldi_munlink_fp(struct stdata *, struct file *, int);
+extern int ldi_mlink_fp(struct stdata *, struct file *, int, int);
+extern int ldi_munlink_fp(struct stdata *, struct file *, int);
 
 /*
  * LDI module identifier

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -26,6 +26,7 @@
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 # Copyright 2020 Joyent, Inc.
 # Copyright 2021 Oxide Computer Company
+# Copyright 2021 Jason King
 #
 #	This Makefile defines file modules in the directory uts/i86pc
 #	and its children. These are the source files which are i86pc
@@ -124,6 +125,7 @@ CORE_OBJS +=			\
 	todpc_subr.o		\
 	tscc_hpet.o		\
 	tscc_pit.o		\
+	tscc_vmware.o		\
 	trap.o			\
 	turbo.o			\
 	vm_machdep.o		\

--- a/usr/src/uts/i86pc/os/tscc_vmware.c
+++ b/usr/src/uts/i86pc/os/tscc_vmware.c
@@ -1,0 +1,67 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2021 Jason King
+ */
+
+#include <sys/x86_archext.h>
+#include <sys/tsc.h>
+
+/* For VMs, this leaf will contain the largest VM leaf supported in EAX */
+#define	CPUID_VM_LEAF_MAX	0x40000000
+
+/*
+ * From https://lwn.net/Articles/301888/, CPUID leaf 0x40000010 (when present)
+ * on VMware will contain the TSC frequency in kHz. While it would have been
+ * nice to locate an official bit of documentation from VMware, implementations
+ * in both Linux and FreeBSD agree with the above link, so it seems reasonable
+ * to use it as well.
+ */
+#define	CPUID_VM_LEAF_FREQ	0x40000010
+
+static boolean_t
+tsc_calibrate_vmware(uint64_t *freqp)
+{
+	if (get_hwenv() != HW_VMWARE)
+		return (B_FALSE);
+
+	struct cpuid_regs regs = { 0 };
+
+	/* First determine the largest VM leaf supported */
+	regs.cp_eax = CPUID_VM_LEAF_MAX;
+	__cpuid_insn(&regs);
+
+	if (regs.cp_eax < CPUID_VM_LEAF_FREQ)
+		return (B_FALSE);
+
+	regs.cp_eax = CPUID_VM_LEAF_FREQ;
+	__cpuid_insn(&regs);
+
+	/*
+	 * While not observed in the wild, as a precautionary measure,
+	 * we treat a value of 0 as a failure out of an excess of caution.
+	 */
+	if (regs.cp_eax == 0)
+		return (B_FALSE);
+
+	/* Convert from kHz to Hz */
+	*freqp = (uint64_t)regs.cp_eax * 1000;
+
+	return (B_TRUE);
+}
+
+static tsc_calibrate_t tsc_calibration_vmware = {
+	.tscc_source = "VMware",
+	.tscc_preference = 100,
+	.tscc_calibrate = tsc_calibrate_vmware,
+};
+TSC_CALIBRATION_SOURCE(tsc_calibration_vmware);


### PR DESCRIPTION
Weekly upstream for upstream_merge/2021092301

## Backports

To all releases:

* 14098 handle failure when muxing non-device streams

(getting ready for upcoming wireguard improvements)

## onu

```
OmniOS r151039  omnios-upstream_merge-2021092301-90190fd5ac     September 2021
illumos development build: 2021-Sep-23 [illumos]
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2021092301-90190fd5ac i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Sep 23 08:55:53 UTC 2021 ====
==== Nightly distributed build completed: Thu Sep 23 10:30:41 UTC 2021 ====

==== Total build time ====

real    1:34:48

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-8d191514879 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151039/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-10/bin/gcc
gcc (OmniOS 151039/10.3.0-il-0) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.12+7-omnios-151039"

/usr/bin/openssl
OpenSSL 1.1.1l  24 Aug 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1767 (illumos)

Build project:  default
Build taskid:   112

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2021092301-90190fd5ac

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    37:58.5
user  5:57:30.1
sys   1:39:10.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    32:05.2
user  5:03:19.8
sys   1:27:49.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
