### PR TITLE
Backports to r151038

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -21,6 +21,15 @@ are included in the footer.
 13380 Add virtio-9p (aka VirtFS) filesystem sharing to bhyve
 	system/bhyve
 
+14098 handle failure when muxing non-device streams
+	system/kernel
+
+14089 gfx_private: do not read from WC memory
+	boot/loader
+
+update-man-index should not unecessarily rebuild indices
+	system/man
+
 =======================================================================
 
 =============================

--- a/usr/src/cmd/man/update-man-index
+++ b/usr/src/cmd/man/update-man-index
@@ -9,7 +9,8 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 Richard L. Hamilton <rlhamil@smart.net>
 #
 
 [ -f /lib/svc/share/smf_include.sh ] || exit 1
@@ -46,11 +47,18 @@ IFS="$oIFS"
 
 MANPATH=
 for p in "${!manpath[@]}"; do
+	[ -d "$p" -a -f "$p/whatis" ] && \
+	    [ -z "`find "$p/" -type f -newer "$p/whatis"`" ] && \
+	    continue
 	MANPATH+="${MANPATH:+:}$p"
 done
 
-echo "Rebuilding man page index using $MANPATH"
-export MANPATH
-/usr/bin/man -w
+if [ -n "$MANPATH" ]; then
+	echo "Rebuilding man page index using $MANPATH"
+	export MANPATH
+	/usr/bin/man -w
+else
+	echo "Man pages are up-to-date"
+fi
 
 exit 0

--- a/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
@@ -219,11 +219,13 @@ typedef struct smb2_negotiate_ctx {
 #define	SMB31_PREAUTH_CTX_SALT_LEN	32
 
 /*
- * SMB 3.1.1 specifies the only hashing algorithm - SHA-512 and
+ * SMB 3.1.1 originally specified a single hashing algorithm - SHA-512 - and
  * two encryption ones - AES-128-CCM and AES-128-GCM.
+ * Windows Server 2022 and Windows 11 introduced two further encryption
+ * algorithms - AES-256-CCM and AES-256-GCM.
  */
 #define	MAX_HASHID_NUM	(1)
-#define	MAX_CIPHER_NUM	(2)
+#define	MAX_CIPHER_NUM	(4)
 
 typedef struct smb2_preauth_integrity_caps {
 	uint16_t	picap_hash_count;

--- a/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_negotiate.c
@@ -219,13 +219,11 @@ typedef struct smb2_negotiate_ctx {
 #define	SMB31_PREAUTH_CTX_SALT_LEN	32
 
 /*
- * SMB 3.1.1 originally specified the only hashing algorithm - SHA-512 and
+ * SMB 3.1.1 specifies the only hashing algorithm - SHA-512 and
  * two encryption ones - AES-128-CCM and AES-128-GCM.
- * Windows Server 2022 and Windows 11 introduced two further encryption
- * algorithms - AES-256-CCM and AES-256-GCM.
  */
-#define	MAX_HASHID_NUM	(SMB3_HASH_MAX)
-#define	MAX_CIPHER_NUM	(SMB3_CIPHER_MAX)
+#define	MAX_HASHID_NUM	(1)
+#define	MAX_CIPHER_NUM	(2)
 
 typedef struct smb2_preauth_integrity_caps {
 	uint16_t	picap_hash_count;

--- a/usr/src/uts/common/smbsrv/smbinfo.h
+++ b/usr/src/uts/common/smbsrv/smbinfo.h
@@ -238,14 +238,10 @@ const char *smbnative_lm_str(smb_version_t *);
 #define	SMB_VERS_3_11		0x311	/* "3.11" */
 
 #define	SMB3_HASH_SHA512	1
-#define	SMB3_HASH_MAX		SMB3_HASH_SHA512
 
 #define	SMB3_CIPHER_NONE	0
 #define	SMB3_CIPHER_AES128_CCM	1
 #define	SMB3_CIPHER_AES128_GCM	2
-#define	SMB3_CIPHER_AES256_CCM	3
-#define	SMB3_CIPHER_AES256_GCM	4
-#define	SMB3_CIPHER_MAX		SMB3_CIPHER_AES256_GCM
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/common/sys/sunldi_impl.h
+++ b/usr/src/uts/common/sys/sunldi_impl.h
@@ -72,8 +72,8 @@ void ldi_init(void);
  * LDI streams linking interfaces
  */
 extern int ldi_mlink_lh(vnode_t *, int, intptr_t, cred_t *, int *);
-extern void ldi_mlink_fp(struct stdata *, struct file *, int, int);
-extern void ldi_munlink_fp(struct stdata *, struct file *, int);
+extern int ldi_mlink_fp(struct stdata *, struct file *, int, int);
+extern int ldi_munlink_fp(struct stdata *, struct file *, int);
 
 /*
  * LDI module identifier

--- a/usr/src/uts/i86pc/io/gfx_private/gfxp_bitmap.c
+++ b/usr/src/uts/i86pc/io/gfx_private/gfxp_bitmap.c
@@ -424,12 +424,17 @@ bitmap_cons_display(struct gfxp_fb_softc *softc, struct vis_consdisplay *da)
 
 	/* write all scanlines in rectangle */
 	for (i = 0; i < da->height; i++) {
-		uint8_t *dest = fbp + i * console->fb.pitch;
+		uint8_t *dest = sfbp + i * console->fb.pitch;
 		uint8_t *src = da->data + i * size;
-		if (softc->mode == KD_TEXT)
-			bitmap_cpy(dest, src, size, console->fb.bpp);
-		dest = sfbp + i * console->fb.pitch;
+
+		/* alpha blend bitmap to shadow fb. */
 		bitmap_cpy(dest, src, size, console->fb.bpp);
+		if (softc->mode == KD_TEXT) {
+			/* Copy from shadow to fb. */
+			src = dest;
+			dest = fbp + i * console->fb.pitch;
+			(void) memcpy(dest, src, size);
+		}
 	}
 }
 
@@ -529,11 +534,10 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			fb8 = console->fb.fb + offset + i * pitch;
 			sfb8 = console->fb.shadow_fb + offset + i * pitch;
 			for (j = 0; j < size; j += 1) {
-				if (softc->mode == KD_TEXT) {
-					fb8[j] = (fb8[j] ^ (fg & 0xff)) ^
-					    (bg & 0xff);
-				}
 				sfb8[j] = (sfb8[j] ^ (fg & 0xff)) ^ (bg & 0xff);
+				if (softc->mode == KD_TEXT) {
+					fb8[j] = sfb8[j];
+				}
 			}
 		}
 		break;
@@ -549,12 +553,11 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			sfb16 = (uint16_t *)
 			    (console->fb.shadow_fb + offset + i * pitch);
 			for (j = 0; j < ca->width; j++) {
-				if (softc->mode == KD_TEXT) {
-					fb16[j] = (fb16[j] ^ (fg & 0xffff)) ^
-					    (bg & 0xffff);
-				}
 				sfb16[j] = (sfb16[j] ^ (fg & 0xffff)) ^
 				    (bg & 0xffff);
+				if (softc->mode == KD_TEXT) {
+					fb16[j] = sfb16[j];
+				}
 			}
 		}
 		break;
@@ -569,22 +572,17 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			fb8 = console->fb.fb + offset + i * pitch;
 			sfb8 = console->fb.shadow_fb + offset + i * pitch;
 			for (j = 0; j < size; j += 3) {
-				if (softc->mode == KD_TEXT) {
-					fb8[j] = (fb8[j] ^ ((fg >> 16) & 0xff))
-					    ^ ((bg >> 16) & 0xff);
-					fb8[j+1] =
-					    (fb8[j+1] ^ ((fg >> 8) & 0xff)) ^
-					    ((bg >> 8) & 0xff);
-					fb8[j+2] = (fb8[j+2] ^ (fg & 0xff)) ^
-					    (bg & 0xff);
-				}
-
 				sfb8[j] = (sfb8[j] ^ ((fg >> 16) & 0xff)) ^
 				    ((bg >> 16) & 0xff);
 				sfb8[j+1] = (sfb8[j+1] ^ ((fg >> 8) & 0xff)) ^
 				    ((bg >> 8) & 0xff);
 				sfb8[j+2] = (sfb8[j+2] ^ (fg & 0xff)) ^
 				    (bg & 0xff);
+				if (softc->mode == KD_TEXT) {
+					fb8[j] = sfb8[j];
+					fb8[j+1] = sfb8[j+1];
+					fb8[j+2] = sfb8[j+2];
+				}
 			}
 		}
 		break;
@@ -601,9 +599,9 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			sfb32 = (uint32_t *)
 			    (console->fb.shadow_fb + offset + i * pitch);
 			for (j = 0; j < ca->width; j++) {
-				if (softc->mode == KD_TEXT)
-					fb32[j] = (fb32[j] ^ fg) ^ bg;
 				sfb32[j] = (sfb32[j] ^ fg) ^ bg;
+				if (softc->mode == KD_TEXT)
+					fb32[j] = sfb32[j];
 			}
 		}
 		break;


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Thu Sep 23 08:55:37 UTC 2021 ====
==== Nightly distributed build completed: Thu Sep 23 10:25:52 UTC 2021 ====

==== Total build time ====

real    1:30:15

==== Build environment ====

/usr/bin/uname
SunOS r151038 5.11 omnios-r151038-b3a82a213e i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151038/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151038/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.12+7-omnios-151038"

/usr/bin/openssl
OpenSSL 1.1.1l  24 Aug 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1765 (illumos)

Build project:  default
Build taskid:   90

==== Nightly argument issues ====


==== Build version ====

omnios-r38bp-cad2a7ea1e

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    35:23.4
user  5:31:09.3
sys   1:32:23.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    30:48.8
user  4:41:35.7
sys   1:24:15.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
