### PR TITLE
Backports to r151030

### DIFF
--- a/usr/src/uts/common/sys/sunldi_impl.h
+++ b/usr/src/uts/common/sys/sunldi_impl.h
@@ -72,8 +72,8 @@ void ldi_init(void);
  * LDI streams linking interfaces
  */
 extern int ldi_mlink_lh(vnode_t *, int, intptr_t, cred_t *, int *);
-extern void ldi_mlink_fp(struct stdata *, struct file *, int, int);
-extern void ldi_munlink_fp(struct stdata *, struct file *, int);
+extern int ldi_mlink_fp(struct stdata *, struct file *, int, int);
+extern int ldi_munlink_fp(struct stdata *, struct file *, int);
 
 /*
  * LDI module identifier

--- a/usr/src/uts/i86pc/io/gfx_private/gfxp_bitmap.c
+++ b/usr/src/uts/i86pc/io/gfx_private/gfxp_bitmap.c
@@ -419,12 +419,17 @@ bitmap_cons_display(struct gfxp_fb_softc *softc, struct vis_consdisplay *da)
 
 	/* write all scanlines in rectangle */
 	for (i = 0; i < da->height; i++) {
-		uint8_t *dest = fbp + i * console->fb.pitch;
+		uint8_t *dest = sfbp + i * console->fb.pitch;
 		uint8_t *src = da->data + i * size;
-		if (softc->mode == KD_TEXT)
-			bitmap_cpy(dest, src, size, console->fb.bpp);
-		dest = sfbp + i * console->fb.pitch;
+
+		/* alpha blend bitmap to shadow fb. */
 		bitmap_cpy(dest, src, size, console->fb.bpp);
+		if (softc->mode == KD_TEXT) {
+			/* Copy from shadow to fb. */
+			src = dest;
+			dest = fbp + i * console->fb.pitch;
+			(void) memcpy(dest, src, size);
+		}
 	}
 }
 
@@ -524,11 +529,10 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			fb8 = console->fb.fb + offset + i * pitch;
 			sfb8 = console->fb.shadow_fb + offset + i * pitch;
 			for (j = 0; j < size; j += 1) {
-				if (softc->mode == KD_TEXT) {
-					fb8[j] = (fb8[j] ^ (fg & 0xff)) ^
-					    (bg & 0xff);
-				}
 				sfb8[j] = (sfb8[j] ^ (fg & 0xff)) ^ (bg & 0xff);
+				if (softc->mode == KD_TEXT) {
+					fb8[j] = sfb8[j];
+				}
 			}
 		}
 		break;
@@ -544,12 +548,11 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			sfb16 = (uint16_t *)
 			    (console->fb.shadow_fb + offset + i * pitch);
 			for (j = 0; j < ca->width; j++) {
-				if (softc->mode == KD_TEXT) {
-					fb16[j] = (fb16[j] ^ (fg & 0xffff)) ^
-					    (bg & 0xffff);
-				}
 				sfb16[j] = (sfb16[j] ^ (fg & 0xffff)) ^
 				    (bg & 0xffff);
+				if (softc->mode == KD_TEXT) {
+					fb16[j] = sfb16[j];
+				}
 			}
 		}
 		break;
@@ -564,22 +567,17 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			fb8 = console->fb.fb + offset + i * pitch;
 			sfb8 = console->fb.shadow_fb + offset + i * pitch;
 			for (j = 0; j < size; j += 3) {
-				if (softc->mode == KD_TEXT) {
-					fb8[j] = (fb8[j] ^ ((fg >> 16) & 0xff))
-					    ^ ((bg >> 16) & 0xff);
-					fb8[j+1] =
-					    (fb8[j+1] ^ ((fg >> 8) & 0xff)) ^
-					    ((bg >> 8) & 0xff);
-					fb8[j+2] = (fb8[j+2] ^ (fg & 0xff)) ^
-					    (bg & 0xff);
-				}
-
 				sfb8[j] = (sfb8[j] ^ ((fg >> 16) & 0xff)) ^
 				    ((bg >> 16) & 0xff);
 				sfb8[j+1] = (sfb8[j+1] ^ ((fg >> 8) & 0xff)) ^
 				    ((bg >> 8) & 0xff);
 				sfb8[j+2] = (sfb8[j+2] ^ (fg & 0xff)) ^
 				    (bg & 0xff);
+				if (softc->mode == KD_TEXT) {
+					fb8[j] = sfb8[j];
+					fb8[j+1] = sfb8[j+1];
+					fb8[j+2] = sfb8[j+2];
+				}
 			}
 		}
 		break;
@@ -596,9 +594,9 @@ bitmap_display_cursor(struct gfxp_fb_softc *softc, struct vis_conscursor *ca)
 			sfb32 = (uint32_t *)
 			    (console->fb.shadow_fb + offset + i * pitch);
 			for (j = 0; j < ca->width; j++) {
-				if (softc->mode == KD_TEXT)
-					fb32[j] = (fb32[j] ^ fg) ^ bg;
 				sfb32[j] = (sfb32[j] ^ fg) ^ bg;
+				if (softc->mode == KD_TEXT)
+					fb32[j] = sfb32[j];
 			}
 		}
 		break;


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Thu Sep 23 09:41:51 UTC 2021 ====
==== Nightly distributed build completed: Thu Sep 23 10:32:40 UTC 2021 ====

==== Total build time ====

real    0:50:49

==== Build environment ====

/usr/bin/uname
SunOS r151030 5.11 omnios-r151030-5bd7739fe4 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 4.0
primary: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151030/7.4.0-il-1) 7.4.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk1.8.0/bin/javac
openjdk full version "1.8.0_302-omnios-151030-b08"

/usr/bin/openssl
OpenSSL 1.1.1l  24 Aug 2021
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1758 (illumos)

Build project:  default
Build taskid:   88

==== Nightly argument issues ====


==== Build version ====

omnios-r30bp-8a3e07e635

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    19:33.9
user  2:50:30.6
sys     45:29.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:23.4
user  2:29:08.2
sys     43:47.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
