### PR TITLE
Various fixes for zoneadmd

### DIFF
--- a/usr/src/cmd/zoneadm/Makefile
+++ b/usr/src/cmd/zoneadm/Makefile
@@ -28,6 +28,7 @@ MANIFEST=	zones.xml resource-mgmt.xml
 SVCMETHOD=	svc-zones svc-resource-mgmt
 
 include ../Makefile.cmd
+include ../Makefile.ctf
 
 ROOTMANIFESTDIR=        $(ROOTSVCSYSTEM)
 

--- a/usr/src/cmd/zoneadmd/Makefile
+++ b/usr/src/cmd/zoneadmd/Makefile
@@ -30,6 +30,7 @@
 PROG= zoneadmd
 
 include ../Makefile.cmd
+include ../Makefile.ctf
 
 ROOTCMDDIR=	$(ROOTLIB)/zones
 

--- a/usr/src/cmd/zoneadmd/vplat.c
+++ b/usr/src/cmd/zoneadmd/vplat.c
@@ -2420,6 +2420,7 @@ configure_shared_network_interfaces(zlog_t *zlogp)
 		for (;;) {
 			if (zonecfg_getnwifent(snap_hndl, &nwiftab) != Z_OK)
 				break;
+			nwifent_free_attrs(&nwiftab);
 			if (configure_one_interface(zlogp, zoneid, &nwiftab) !=
 			    Z_OK) {
 				(void) zonecfg_endnwifent(snap_hndl);
@@ -2915,6 +2916,7 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 		if (zonecfg_getnwifent(snap_hndl, &nwiftab) != Z_OK)
 			break;
 
+		nwifent_free_attrs(&nwiftab);
 		if (prof == NULL) {
 			if (zone_get_devroot(zone_name, rootpath,
 			    sizeof (rootpath)) != Z_OK) {
@@ -4982,6 +4984,8 @@ error:
 	}
 	if (rctlbuf != NULL)
 		free(rctlbuf);
+	if (zfsbuf != NULL)
+		free(zfsbuf);
 	priv_freeset(privs);
 	if (fp != NULL)
 		zonecfg_close_scratch(fp);

--- a/usr/src/cmd/zoneadmd/zoneadmd.c
+++ b/usr/src/cmd/zoneadmd/zoneadmd.c
@@ -793,6 +793,8 @@ do_subproc(zlog_t *zlogp, char *cmdbuf, char **retstr)
 	FILE *file;
 	int status;
 	int rd_cnt;
+	int fds[2];
+	pid_t child;
 
 	if (retstr != NULL) {
 		if ((*retstr = malloc(1024)) == NULL) {
@@ -805,31 +807,100 @@ do_subproc(zlog_t *zlogp, char *cmdbuf, char **retstr)
 		inbuf = buf;
 	}
 
-	file = popen(cmdbuf, "r");
-	if (file == NULL) {
-		zerror(zlogp, B_TRUE, "could not launch: %s", cmdbuf);
+	if (pipe(fds) != 0) {
+		zerror(zlogp, B_TRUE, "failed to create pipe for subprocess");
 		return (-1);
 	}
 
+	if ((child = fork()) == 0) {
+		int in;
+
+		/*
+		 * SIGINT is currently ignored.  It probably shouldn't be so
+		 * hard to kill errant children, so we revert to SIG_DFL.
+		 * SIGHUP and SIGUSR1 are used to perform log rotation.  We
+		 * leave those as-is because we don't want a 'pkill -HUP
+		 * zoneadmd' to kill this child process before exec().  On
+		 * exec(), SIGHUP and SIGUSR1 will become SIG_DFL.
+		 */
+		(void) sigset(SIGINT, SIG_DFL);
+
+		/*
+		 * Do not call zerror() in child process zerror() is not
+		 * designed to handle multiple processes logging. Rather,
+		 * write all errors to the pipe.
+		 */
+		if (dup2(fds[1], STDERR_FILENO) == -1) {
+			(void) snprintf(buf, sizeof (buf),
+			    "subprocess failed to dup2(STDERR_FILENO): %s\n",
+			    strerror(errno));
+			(void) write(fds[1], buf, strlen(buf));
+			_exit(127);
+		}
+		if (dup2(fds[1], STDOUT_FILENO) == -1) {
+			perror("subprocess failed to dup2(STDOUT_FILENO)");
+			_exit(127);
+		}
+		/*
+		 * Some children may try to read from stdin. Be sure that the
+		 * first file that a child opens doesn't get stdin's file
+		 * descriptor.
+		 */
+		if ((in = open("/dev/null", O_RDONLY)) == -1 ||
+		    dup2(in, STDIN_FILENO) == -1) {
+			perror("subprocess failed to set up STDIN_FILENO");
+			_exit(127);
+		}
+		closefrom(STDERR_FILENO + 1);
+
+		(void) execl("/bin/sh", "sh", "-c", cmdbuf, NULL);
+
+		perror("subprocess execl failed");
+		_exit(127);
+	} else if (child == -1) {
+		zerror(zlogp, B_TRUE, "failed to create subprocess for '%s'",
+		    cmdbuf);
+		(void) close(fds[0]);
+		(void) close(fds[1]);
+		return (-1);
+	}
+
+	(void) close(fds[1]);
+
+	file = fdopen(fds[0], "r");
 	while (fgets(inbuf, 1024, file) != NULL) {
 		if (retstr == NULL) {
-			if (zlogp != &logsys)
+			if (zlogp != &logsys) {
+				int last = strlen(inbuf) - 1;
+
+				if (inbuf[last] == '\n')
+					inbuf[last] = '\0';
 				zerror(zlogp, B_FALSE, "%s", inbuf);
+			}
 		} else {
 			char *p;
 
 			rd_cnt += 1024 - 1;
 			if ((p = realloc(*retstr, rd_cnt + 1024)) == NULL) {
 				zerror(zlogp, B_FALSE, "out of memory");
-				(void) pclose(file);
-				return (-1);
+				break;
 			}
 
 			*retstr = p;
 			inbuf = *retstr + rd_cnt;
 		}
 	}
-	status = pclose(file);
+
+	while (fclose(file) != 0) {
+		assert(errno == EINTR);
+	}
+	while (waitpid(child, &status, 0) == -1) {
+		if (errno != EINTR) {
+			zerror(zlogp, B_TRUE,
+			    "failed to get exit status of '%s'", cmdbuf);
+			return (-1);
+		}
+	}
 
 	if (WIFSIGNALED(status)) {
 		zerror(zlogp, B_FALSE, "%s unexpectedly terminated due to "

--- a/usr/src/cmd/zoneadmd/zoneadmd.c
+++ b/usr/src/cmd/zoneadmd/zoneadmd.c
@@ -780,6 +780,19 @@ mount_early_fs(void *data, const char *spec, const char *dir,
 	return (0);
 }
 
+void
+nwifent_free_attrs(struct zone_nwiftab *np)
+{
+	struct zone_res_attrtab *rap;
+
+	for (rap = np->zone_nwif_attrp; rap != NULL; ) {
+		struct zone_res_attrtab *tp = rap;
+
+		rap = rap->zone_res_attr_next;
+		free(tp);
+	}
+}
+
 /*
  * If retstr is not NULL, the output of the subproc is returned in the str,
  * otherwise it is output using zerror().  Any memory allocated for retstr

--- a/usr/src/cmd/zoneadmd/zoneadmd.h
+++ b/usr/src/cmd/zoneadmd/zoneadmd.h
@@ -104,6 +104,7 @@ extern dladm_handle_t dld_handle;
 
 extern void zerror(zlog_t *, boolean_t, const char *, ...);
 extern char *localize_msg(char *locale, const char *msg);
+extern void nwifent_free_attrs(struct zone_nwiftab *);
 
 /*
  * Eventstream interfaces.

--- a/usr/src/cmd/zonecfg/Makefile
+++ b/usr/src/cmd/zonecfg/Makefile
@@ -40,6 +40,7 @@ MAPOPTS =	$(MAPFILES:%=-Wl,-M%)
 LFLAGS =	-t
 YFLAGS =	-d -b zonecfg_grammar
 LDLIBS +=	-lzonecfg -ll -lnsl -ltecla -lzfs -lbrand -ldladm -linetutil
+CFLAGS +=	-DYYLMAX=2048
 CPPFLAGS +=	-I.
 LDFLAGS +=	$(MAPOPTS)
 CLEANFILES +=	zonecfg_lex.c zonecfg_grammar.tab.c zonecfg_grammar.tab.h

--- a/usr/src/cmd/zonecfg/Makefile
+++ b/usr/src/cmd/zonecfg/Makefile
@@ -29,6 +29,7 @@ PROG=	zonecfg
 OBJS=	zonecfg.o zonecfg_lex.o zonecfg_grammar.tab.o
 
 include ../Makefile.cmd
+include ../Makefile.ctf
 
 # zonecfg has a name clash with main() and libl.so.1.  However, zonecfg must
 # still export a number of "yy*" (libl) interfaces.  Reduce all other symbols

--- a/usr/src/cmd/zonecfg/zonecfg.c
+++ b/usr/src/cmd/zonecfg/zonecfg.c
@@ -2512,8 +2512,13 @@ do_res_attr(struct zone_res_attrtab **headp, complex_property_ptr_t cpp)
 				    pt_to_str(PT_NAME));
 				goto bad;
 			}
-			(void) strlcpy(np->zone_res_attr_name, cp->cp_value,
-			    sizeof (np->zone_res_attr_name));
+			if (strlcpy(np->zone_res_attr_name, cp->cp_value,
+			    sizeof (np->zone_res_attr_name)) >=
+			    sizeof (np->zone_res_attr_name)) {
+				zerr(gettext("Input for %s is too long"),
+				    pt_to_str(PT_NAME));
+				goto bad;
+			}
 			seen_name = B_TRUE;
 			break;
 		case PT_VALUE:
@@ -2522,8 +2527,14 @@ do_res_attr(struct zone_res_attrtab **headp, complex_property_ptr_t cpp)
 				    pt_to_str(PT_VALUE));
 				goto bad;
 			}
-			(void) strlcpy(np->zone_res_attr_value, cp->cp_value,
-			    sizeof (np->zone_res_attr_value));
+			if (strlcpy(np->zone_res_attr_value, cp->cp_value,
+			    sizeof (np->zone_res_attr_value)) >=
+			    sizeof (np->zone_res_attr_value)) {
+				zerr(gettext("Input for %s is too long"),
+				    pt_to_str(PT_VALUE));
+				goto bad;
+			}
+
 			seen_value = B_TRUE;
 			break;
 		default:

--- a/usr/src/cmd/zonename/Makefile
+++ b/usr/src/cmd/zonename/Makefile
@@ -28,8 +28,10 @@
 #
 
 PROG=	zonename
+OBJS=	zonename.o
 
 include	../Makefile.cmd
+include ../Makefile.ctf
 
 LDLIBS +=	-lzonecfg
 
@@ -37,12 +39,20 @@ LDLIBS +=	-lzonecfg
 
 all: $(PROG)
 
+$(PROG): $(OBJS)
+	$(LINK.c) -o $@ $(OBJS) $(LDLIBS)
+	$(POST_PROCESS)
+
 install: all $(ROOTSBINPROG)
 	$(RM) $(ROOTPROG)
 	$(SYMLINK) ../../sbin/$(PROG) $(ROOTPROG)
 
 check:	$(PROG).c
 	$(CSTYLE) -pP $(PROG).c
+
+%.o: %.c
+	$(COMPILE.c) $<
+	$(POST_PROCESS_O)
 
 clean:
 

--- a/usr/src/head/libzonecfg.h
+++ b/usr/src/head/libzonecfg.h
@@ -120,6 +120,8 @@ extern "C" {
 
 #define	ZONE_STATE_MAXSTRLEN	14
 
+#define	ZONE_PROP_MAXSTRLEN	1024
+
 #define	LIBZONECFG_PATH		"libzonecfg.so.1"
 
 #define	ZONE_CONFIG_ROOT	"/etc/zones"
@@ -203,7 +205,7 @@ struct zone_fstab {
  */
 struct zone_res_attrtab {
 	char	zone_res_attr_name[MAXNAMELEN];
-	char	zone_res_attr_value[MAXNAMELEN];
+	char	zone_res_attr_value[ZONE_PROP_MAXSTRLEN];
 	struct zone_res_attrtab *zone_res_attr_next;
 };
 

--- a/usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot_zone_ubuntu.ksh
@@ -12,7 +12,7 @@
 
 #
 # Copyright 2016 Joyent, Inc.
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -71,15 +71,16 @@ if [[ -f $fnm || -h $fnm ]]; then
 	mv -f $tmpfile $fnm
 fi
 
-src_fnm=$ZONEROOT/etc/init/console.conf
-tgt_fnm=$ZONEROOT/etc/init/console.override
-if [[ -f $src_fnm && ! -f $tgt_fnm && ! -h $tgt_fnm ]] then
-	sed -e 's/lxc/smartos/' $src_fnm > /tmp/console.conf.$$
-	mv /tmp/console.conf.$$ $tgt_fnm
-fi
+if [ -d $ZONEROOT/etc/init ]; then
+	src_fnm=$ZONEROOT/etc/init/console.conf
+	tgt_fnm=$ZONEROOT/etc/init/console.override
+	if [[ -f $src_fnm && ! -f $tgt_fnm && ! -h $tgt_fnm ]] then
+		sed -e 's/lxc/smartos/' $src_fnm > /tmp/console.conf.$$
+		mv /tmp/console.conf.$$ $tgt_fnm
+	fi
 
-fnm=$ZONEROOT/etc/init/container-detect.override
-if [[ ! -f $fnm && ! -h $fnm ]] then
+	fnm=$ZONEROOT/etc/init/container-detect.override
+	if [[ ! -f $fnm && ! -h $fnm ]] then
 	cat <<'DONE' > $fnm
 description "Track if upstart is running in a container"
 
@@ -97,13 +98,13 @@ pre-start script
     exit 0
 end script
 DONE
-fi
+	fi
 
-# XXX need to add real mounting into this svc definition
+	# XXX need to add real mounting into this svc definition
 
-fnm=$ZONEROOT/etc/init/mountall.override
-if [[ ! -h $fnm ]] then
-	cat <<DONE > $fnm
+	fnm=$ZONEROOT/etc/init/mountall.override
+	if [[ ! -h $fnm ]] then
+		cat <<DONE > $fnm
 description	"Mount filesystems on boot"
 
 start on startup
@@ -132,6 +133,7 @@ script
     /sbin/initctl emit --no-wait filesystem
 end script
 DONE
+	fi
 fi
 
 #

--- a/usr/src/lib/libdladm/common/libdladm.h
+++ b/usr/src/lib/libdladm/common/libdladm.h
@@ -47,7 +47,7 @@ extern "C" {
 #endif
 
 #define	LINKID_STR_WIDTH	10
-#define	DLADM_STRSIZE		256
+#define	DLADM_STRSIZE		2048
 
 /*
  * option flags taken by the libdladm functions

--- a/usr/src/lib/libzonecfg/common/libzonecfg.c
+++ b/usr/src/lib/libzonecfg/common/libzonecfg.c
@@ -7921,6 +7921,10 @@ start_zoneadmd(const char *zone_name, boolean_t lock)
 
 	if (child_pid == 0) {
 		const char *argv[6], **ap;
+		const char *envp[] = {
+			"PATH=" ZONEADMD_PATH,
+			NULL
+		};
 
 		/* child process */
 		prepare_audit_context(zone_name);
@@ -7935,7 +7939,8 @@ start_zoneadmd(const char *zone_name, boolean_t lock)
 		}
 		*ap = NULL;
 
-		(void) execv("/usr/lib/zones/zoneadmd", (char * const *)argv);
+		(void) execve("/usr/lib/zones/zoneadmd",
+		    (char * const *)argv, (char * const *)envp);
 		/*
 		 * TRANSLATION_NOTE
 		 * zoneadmd is a literal that should not be translated.

--- a/usr/src/lib/libzonecfg/common/libzonecfg.c
+++ b/usr/src/lib/libzonecfg/common/libzonecfg.c
@@ -4934,7 +4934,7 @@ get_pool_sched_class(char *poolname, char *class, int clsize)
 	pool_conf_t *poolconf;
 	pool_t *pool;
 	pool_elem_t *pe;
-	pool_value_t *pv = pool_value_alloc();
+	pool_value_t *pv;
 	const char *sched_str;
 
 	if (pool_get_status(&status) != PO_SUCCESS || status != POOL_ENABLED)
@@ -4955,15 +4955,23 @@ get_pool_sched_class(char *poolname, char *class, int clsize)
 		return (Z_NO_POOL);
 	}
 
+	if ((pv = pool_value_alloc()) == NULL) {
+		(void) pool_conf_close(poolconf);
+		pool_conf_free(poolconf);
+		return (Z_NO_POOL);
+	}
+
 	pe = pool_to_elem(poolconf, pool);
 	if (pool_get_property(poolconf, pe, "pool.scheduler", pv) !=
 	    POC_STRING) {
 		(void) pool_conf_close(poolconf);
+		pool_value_free(pv);
 		pool_conf_free(poolconf);
 		return (Z_NO_ENTRY);
 	}
 	(void) pool_value_get_string(pv, &sched_str);
 	(void) pool_conf_close(poolconf);
+	pool_value_free(pv);
 	pool_conf_free(poolconf);
 	if (strlcpy(class, sched_str, clsize) >= clsize)
 		return (Z_TOO_BIG);

--- a/usr/src/lib/libzonecfg/common/zonecfg_impl.h
+++ b/usr/src/lib/libzonecfg/common/zonecfg_impl.h
@@ -39,6 +39,8 @@ extern "C" {
 #define	TEXT_DOMAIN	"SYS_TEST"	/* Use this only if it wasn't */
 #endif
 
+#define	ZONEADMD_PATH	"/usr/sbin:/usr/bin"
+
 typedef enum {
 	PZE_MODIFY = -1,
 	PZE_REMOVE = 0,


### PR DESCRIPTION
Initially to address problems with `zoneadmd`'s stderr being lost, but also pulled in some other (old) fixes from SmartOS including support for longer attribute values, which will help with cloud-init and the `sshkey` option, and a fix to stop `zoneadmd` ending up with the environment of the shell that called `zoneadm` in the case of manually booting a zone.