### PR TITLE
Add TSC calibration support using Hyper-V MSRs

### DIFF
--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -27,6 +27,7 @@
 # Copyright 2020 Joyent, Inc.
 # Copyright 2021 Oxide Computer Company
 # Copyright 2021 Jason King
+# Copyright 2021 Racktop Systems, Inc.
 #
 #	This Makefile defines file modules in the directory uts/i86pc
 #	and its children. These are the source files which are i86pc
@@ -124,6 +125,7 @@ CORE_OBJS +=			\
 	timestamp.o		\
 	todpc_subr.o		\
 	tscc_hpet.o		\
+	tscc_hyperv.o		\
 	tscc_pit.o		\
 	tscc_vmware.o		\
 	trap.o			\

--- a/usr/src/uts/i86pc/os/tscc_hyperv.c
+++ b/usr/src/uts/i86pc/os/tscc_hyperv.c
@@ -1,0 +1,85 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2021 Racktop Systems, Inc.
+ */
+
+#include <sys/tsc.h>
+#include <sys/types.h>
+#include <sys/x86_archext.h>
+#include <sys/hyperv.h>
+#include <hyperv_reg.h>
+
+static boolean_t
+tsc_calibrate_hyperv(uint64_t *freqp)
+{
+	struct cpuid_regs regs;
+	uint64_t freq;
+
+	/*
+	 * While hyperv_features should (on Hyper-V systems) contain the
+	 * bitfield we need to verify TSC frequency support, we are early
+	 * enough in the boot process that it's not yet available, so we
+	 * must issue the CPUID instructions ourself.
+	 */
+	if (get_hwenv() != HW_MICROSOFT) {
+		return (B_FALSE);
+	}
+
+	/*
+	 * Not having a max HV leaf if we're Hyper-V (per the above test)
+	 * should not happen. Warn and fallback to other methods if this
+	 * happens.
+	 */
+	bzero(&regs, sizeof (regs));
+	regs.cp_eax = CPUID_LEAF_HV_MAXLEAF;
+	__cpuid_insn(&regs);
+	if (regs.cp_eax < CPUID_LEAF_HV_FEATURES) {
+		cmn_err(CE_WARN, "%s: hv max leaf returned 0x%x\n", __func__,
+		    regs.cp_eax);
+		return (B_FALSE);
+	}
+
+	/*
+	 * The earliest (pre-2008) versions of Hyper-V do not support
+	 * the TSC FREQ MSR. HV_FEATURES will tell us if the MSR is supported
+	 * on this Hyper-V host or not.
+	 */
+	bzero(&regs, sizeof (regs));
+	regs.cp_eax = CPUID_LEAF_HV_FEATURES;
+	__cpuid_insn(&regs);
+	if ((regs.cp_eax & CPUID_HV_MSR_TSC_FREQ) == 0) {
+		return (B_FALSE);
+	}
+
+	freq = rdmsr(MSR_HV_TSC_FREQUENCY);
+
+	/*
+	 * We could panic here since a value of 0 is wrong per Microsoft's own
+	 * documentation. But there's little harm in attempting the other
+	 * TSC sources -- on Gen1 VMs either the emulated HPET or PIT may
+	 * succeed and the worst case is that we panic if those fail.
+	 */
+	if (freq == 0) {
+		cmn_err(CE_WARN, "%s: tsc freq was 0\n", __func__);
+		return (B_FALSE);
+	}
+	*freqp = freq;
+	return (B_TRUE);
+}
+
+static tsc_calibrate_t tsc_calibration_hyperv = {
+	.tscc_source = "Hyper-V",
+	.tscc_preference = 100,
+	.tscc_calibrate = tsc_calibrate_hyperv,
+};
+TSC_CALIBRATION_SOURCE(tsc_calibration_hyperv);

--- a/usr/src/uts/i86pc/unix/Makefile
+++ b/usr/src/uts/i86pc/unix/Makefile
@@ -23,6 +23,7 @@
 #
 # Copyright 2019 Joyent, Inc.
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 Racktop Systems, Inc.
 
 #
 #	Path to the base of the uts directory tree (usually /usr/src/uts).
@@ -117,6 +118,10 @@ $(OBJS_DIR)/instr_size.o :=	EXTRA_OPTIONS	= -I$(SRC)/common/dis/i386
 # output from gcc can end up confusing studio.
 #
 $(OBJS_DIR)/comm_page_ctf.o :=	CERRWARN += -_cc=-erroff=E_TKNS_IGNORED_AT_END_OF_DIR
+
+# tscc_hyperv.o needs a few hyperv headers in $(UTSBASE)/intel
+$(OBJS_DIR)/tscc_hyperv.o := INC_PATH += -I$(UTSBASE)/intel/io/hyperv
+$(OBJS_DIR)/tscc_hyperv.o := INC_PATH += -I$(UTSBASE)/intel/io/hyperv/vmbus
 
 CFLAGS += -DDIS_MEM
 

--- a/usr/src/uts/intel/io/hyperv/sys/hyperv.h
+++ b/usr/src/uts/intel/io/hyperv/sys/hyperv.h
@@ -39,6 +39,7 @@
 
 /*
  * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright 2021 Racktop Systems, Inc.
  */
 
 #ifndef _SYS_HYPERV_H
@@ -47,6 +48,7 @@
 #include <sys/hyperv_illumos.h>
 
 #define	MSR_HV_TIME_REF_COUNT		0x40000020
+#define	MSR_HV_TSC_FREQUENCY		0x40000022
 
 #define	CPUID_HV_MSR_TIME_REFCNT	0x0002	/* MSR_HV_TIME_REF_COUNT */
 #define	CPUID_HV_MSR_SYNIC		0x0004	/* MSRs for SynIC */
@@ -56,6 +58,7 @@
 #define	CPUID_HV_MSR_HYPERCALL		0x0020
 #define	CPUID_HV_MSR_VP_INDEX		0x0040	/* MSR_HV_VP_INDEX */
 #define	CPUID_HV_MSR_GUEST_IDLE		0x0400	/* MSR_HV_GUEST_IDLE */
+#define	CPUID_HV_MSR_TSC_FREQ		0x0800
 
 #define	HYPERV_TIMER_NS_FACTOR		100ULL
 #define	HYPERV_TIMER_FREQ		(NANOSEC / HYPERV_TIMER_NS_FACTOR)


### PR DESCRIPTION
This is a prerequisite for enabling Gen2 VM support (though there is still more work). It also works fine with Gen1 VMs (both Hyper-V and Azure) and will fallback to the existing methods if the MSRs are unsupported.