### PR TITLE
Upstream merge/2021122901

### DIFF
--- a/usr/src/cmd/bhyve/smbiostbl.c
+++ b/usr/src/cmd/bhyve/smbiostbl.c
@@ -200,6 +200,7 @@ struct smbios_table_type3 {
 	uint8_t			psstate;	/* power supply state */
 	uint8_t			tstate;		/* thermal state */
 	uint8_t			security;	/* security status */
+	uint32_t		oemdata;	/* OEM-specific data */
 	uint8_t			uheight;	/* height in 'u's */
 	uint8_t			cords;		/* number of power cords */
 	uint8_t			elems;		/* number of element records */
@@ -418,6 +419,7 @@ struct smbios_table_type3 smbios_type3_template = {
 	SMBIOS_CHST_SAFE,
 	SMBIOS_CHST_SAFE,
 	SMBIOS_CHSC_NONE,
+	0,		/* OEM specific data, we have none */
 	0,		/* height in 'u's (0=enclosure height unspecified) */
 	0,		/* number of power cords (0=number unspecified) */
 	0,		/* number of contained element records */

--- a/usr/src/cmd/smbios/smbios.c
+++ b/usr/src/cmd/smbios/smbios.c
@@ -373,7 +373,10 @@ print_bios(smbios_hdl_t *shp, FILE *fp)
 {
 	smbios_bios_t b;
 
-	(void) smbios_info_bios(shp, &b);
+	if (smbios_info_bios(shp, &b) == -1) {
+		smbios_warn(shp, "failed to read BIOS information");
+		return;
+	}
 
 	str_print(fp, "  Vendor", b.smbb_vendor);
 	str_print(fp, "  Version String", b.smbb_version);
@@ -423,7 +426,10 @@ print_system(smbios_hdl_t *shp, FILE *fp)
 	smbios_system_t s;
 	uint_t i;
 
-	(void) smbios_info_system(shp, &s);
+	if (smbios_info_system(shp, &s) == -1) {
+		smbios_warn(shp, "failed to read system information");
+		return;
+	}
 
 	oprintf(fp, "  UUID: ");
 	for (i = 0; i < s.smbs_uuidlen; i++) {
@@ -446,7 +452,10 @@ print_bboard(smbios_hdl_t *shp, id_t id, FILE *fp)
 	smbios_bboard_t b;
 	int chdl_cnt;
 
-	(void) smbios_info_bboard(shp, id, &b);
+	if (smbios_info_bboard(shp, id, &b) != 0) {
+		smbios_warn(shp, "failed to read baseboard information");
+		return;
+	}
 
 	oprintf(fp, "  Chassis: %u\n", (uint_t)b.smbb_chassis);
 
@@ -483,7 +492,10 @@ print_chassis(smbios_hdl_t *shp, id_t id, FILE *fp)
 	smbios_chassis_entry_t *elts;
 	uint_t nelts, i;
 
-	(void) smbios_info_chassis(shp, id, &c);
+	if (smbios_info_chassis(shp, id, &c) != 0) {
+		smbios_warn(shp, "failed to read chassis information");
+		return;
+	}
 
 	oprintf(fp, "  OEM Data: 0x%x\n", c.smbc_oemdata);
 	str_print(fp, "  SKU Number",
@@ -546,7 +558,10 @@ print_processor(smbios_hdl_t *shp, id_t id, FILE *fp)
 	smbios_processor_t p;
 	uint_t status;
 
-	(void) smbios_info_processor(shp, id, &p);
+	if (smbios_info_processor(shp, id, &p) != 0) {
+		smbios_warn(shp, "failed to read processor information");
+		return;
+	}
 	status = SMB_PRSTATUS_STATUS(p.smbp_status);
 
 	desc_printf(smbios_processor_family_desc(p.smbp_family),
@@ -636,7 +651,10 @@ print_cache(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_cache_t c;
 
-	(void) smbios_info_cache(shp, id, &c);
+	if (smbios_info_cache(shp, id, &c) != 0) {
+		smbios_warn(shp, "failed to read cache information");
+		return;
+	}
 
 	oprintf(fp, "  Level: %u\n", c.smba_level);
 	oprintf(fp, "  Maximum Installed Size: %" PRIu64 " bytes\n",
@@ -685,7 +703,10 @@ print_port(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_port_t p;
 
-	(void) smbios_info_port(shp, id, &p);
+	if (smbios_info_port(shp, id, &p) != 0) {
+		smbios_warn(shp, "failed to read port information");
+		return;
+	}
 
 	str_print(fp, "  Internal Reference Designator", p.smbo_iref);
 	str_print(fp, "  External Reference Designator", p.smbo_eref);
@@ -706,7 +727,10 @@ print_slot(smbios_hdl_t *shp, id_t id, FILE *fp)
 	smbios_slot_t s;
 	smbios_version_t v;
 
-	(void) smbios_info_slot(shp, id, &s);
+	if (smbios_info_slot(shp, id, &s) != 0) {
+		smbios_warn(shp, "failed to read slot information");
+		return;
+	}
 	smbios_info_smbios_version(shp, &v);
 
 	str_print(fp, "  Reference Designator", s.smbl_name);
@@ -808,7 +832,11 @@ print_obdevs_ext(smbios_hdl_t *shp, id_t id, FILE *fp)
 	smbios_obdev_ext_t oe;
 	const char *type;
 
-	(void) smbios_info_obdevs_ext(shp, id, &oe);
+	if (smbios_info_obdevs_ext(shp, id, &oe) != 0) {
+		smbios_warn(shp, "failed to read extended on-board devices "
+		    "information");
+		return;
+	}
 
 	/*
 	 * Bit 7 is always whether or not the device is enabled while bits 0:6
@@ -835,7 +863,11 @@ print_obdevs(smbios_hdl_t *shp, id_t id, FILE *fp)
 
 	if ((argc = smbios_info_obdevs(shp, id, 0, NULL)) > 0) {
 		argv = alloca(sizeof (smbios_obdev_t) * argc);
-		(void) smbios_info_obdevs(shp, id, argc, argv);
+		if (smbios_info_obdevs(shp, id, argc, argv) == -1) {
+			smbios_warn(shp, "failed to read on-board device "
+			    "information");
+			return;
+		}
 		for (i = 0; i < argc; i++)
 			str_print_nolabel(fp, "  ", argv[i].smbd_name);
 	}
@@ -849,7 +881,11 @@ print_strtab(smbios_hdl_t *shp, id_t id, FILE *fp)
 
 	if ((argc = smbios_info_strtab(shp, id, 0, NULL)) > 0) {
 		argv = alloca(sizeof (char *) * argc);
-		(void) smbios_info_strtab(shp, id, argc, argv);
+		if (smbios_info_strtab(shp, id, argc, argv) == -1) {
+			smbios_warn(shp, "failed to read string table "
+			    "information");
+			return;
+		}
 		for (i = 0; i < argc; i++)
 			str_print_nolabel(fp, "  ", argv[i]);
 	}
@@ -860,7 +896,10 @@ print_lang(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_lang_t l;
 
-	(void) smbios_info_lang(shp, &l);
+	if (smbios_info_lang(shp, &l) == -1) {
+		smbios_warn(shp, "failed to read language information");
+		return;
+	}
 
 	str_print(fp, "  Current Language", l.smbla_cur);
 	oprintf(fp, "  Language String Format: %u\n", l.smbla_fmt);
@@ -877,7 +916,10 @@ print_evlog(smbios_hdl_t *shp, id_t id, FILE *fp)
 	smbios_evlog_t ev;
 	uint32_t i;
 
-	(void) smbios_info_eventlog(shp, &ev);
+	if (smbios_info_eventlog(shp, &ev) == -1) {
+		smbios_warn(shp, "failed to read event log information");
+		return;
+	}
 
 	oprintf(fp, "  Log Area Size: %lu bytes\n", (ulong_t)ev.smbev_size);
 	oprintf(fp, "  Header Offset: %lu\n", (ulong_t)ev.smbev_hdr);
@@ -963,7 +1005,10 @@ print_memarray(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_memarray_t ma;
 
-	(void) smbios_info_memarray(shp, id, &ma);
+	if (smbios_info_memarray(shp, id, &ma) != 0) {
+		smbios_warn(shp, "failed to read memarray information");
+		return;
+	}
 
 	desc_printf(smbios_memarray_loc_desc(ma.smbma_location),
 	    fp, "  Location: %u", ma.smbma_location);
@@ -985,7 +1030,10 @@ print_memdevice(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_memdevice_t md;
 
-	(void) smbios_info_memdevice(shp, id, &md);
+	if (smbios_info_memdevice(shp, id, &md) != 0) {
+		smbios_warn(shp, "failed to read memory device information");
+		return;
+	}
 
 	id_printf(fp, "  Physical Memory Array: ", md.smbmd_array);
 	id_printf(fp, "  Memory Error Data: ", md.smbmd_error);
@@ -1140,7 +1188,10 @@ print_memarrmap(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_memarrmap_t ma;
 
-	(void) smbios_info_memarrmap(shp, id, &ma);
+	if (smbios_info_memarrmap(shp, id, &ma) != 0) {
+		smbios_warn(shp, "failed to read memory array map information");
+		return;
+	}
 
 	id_printf(fp, "  Physical Memory Array: ", ma.smbmam_array);
 	oprintf(fp, "  Devices per Row: %u\n", ma.smbmam_width);
@@ -1154,7 +1205,11 @@ print_memdevmap(smbios_hdl_t *shp, id_t id, FILE *fp)
 {
 	smbios_memdevmap_t md;
 
-	(void) smbios_info_memdevmap(shp, id, &md);
+	if (smbios_info_memdevmap(shp, id, &md) != 0) {
+		smbios_warn(shp, "failed to read memory device map "
+		    "information");
+		return;
+	}
 
 	id_printf(fp, "  Memory Device: ", md.smbmdm_device);
 	id_printf(fp, "  Memory Array Mapped Address: ", md.smbmdm_arrmap);
@@ -1172,7 +1227,10 @@ print_hwsec(smbios_hdl_t *shp, FILE *fp)
 {
 	smbios_hwsec_t h;
 
-	(void) smbios_info_hwsec(shp, &h);
+	if (smbios_info_hwsec(shp, &h) == -1) {
+		smbios_warn(shp, "failed to read hwsec information");
+		return;
+	}
 
 	desc_printf(smbios_hwsec_desc(h.smbh_pwr_ps),
 	    fp, "  Power-On Password Status: %u", h.smbh_pwr_ps);
@@ -1410,7 +1468,10 @@ print_boot(smbios_hdl_t *shp, FILE *fp)
 {
 	smbios_boot_t b;
 
-	(void) smbios_info_boot(shp, &b);
+	if (smbios_info_boot(shp, &b) == -1) {
+		smbios_warn(shp, "failed to read boot information");
+		return;
+	}
 
 	desc_printf(smbios_boot_desc(b.smbt_status),
 	    fp, "  Boot Status Code: 0x%x", b.smbt_status);
@@ -1426,7 +1487,10 @@ print_ipmi(smbios_hdl_t *shp, FILE *fp)
 {
 	smbios_ipmi_t i;
 
-	(void) smbios_info_ipmi(shp, &i);
+	if (smbios_info_ipmi(shp, &i) == -1) {
+		smbios_warn(shp, "failed to read ipmi information");
+		return;
+	}
 
 	desc_printf(smbios_ipmi_type_desc(i.smbip_type),
 	    fp, "  Type: %u", i.smbip_type);
@@ -1624,7 +1688,11 @@ print_extprocessor(smbios_hdl_t *shp, id_t id, FILE *fp)
 	if (check_oem(shp) != 0)
 		return;
 
-	(void) smbios_info_extprocessor(shp, id, &ep);
+	if (smbios_info_extprocessor(shp, id, &ep) != 0) {
+		smbios_warn(shp, "failed to read extended processor "
+		    "information");
+		return;
+	}
 
 	oprintf(fp, "  Processor: %u\n", ep.smbpe_processor);
 	oprintf(fp, "  FRU: %u\n", ep.smbpe_fru);
@@ -1644,7 +1712,10 @@ print_extport(smbios_hdl_t *shp, id_t id, FILE *fp)
 	if (check_oem(shp) != 0)
 		return;
 
-	(void) smbios_info_extport(shp, id, &epo);
+	if (smbios_info_extport(shp, id, &epo) != 0) {
+		smbios_warn(shp, "failed to read extended port information");
+		return;
+	}
 
 	oprintf(fp, "  Chassis Handle: %u\n", epo.smbporte_chassis);
 	oprintf(fp, "  Port Connector Handle: %u\n", epo.smbporte_port);
@@ -1661,7 +1732,10 @@ print_pciexrc(smbios_hdl_t *shp, id_t id, FILE *fp)
 	if (check_oem(shp) != 0)
 		return;
 
-	(void) smbios_info_pciexrc(shp, id, &pcie);
+	if (smbios_info_pciexrc(shp, id, &pcie) != 0) {
+		smbios_warn(shp, "failed to read pciexrc information");
+		return;
+	}
 
 	oprintf(fp, "  Component ID: %u\n", pcie.smbpcie_bb);
 	oprintf(fp, "  BDF: 0x%x\n", pcie.smbpcie_bdf);
@@ -1675,7 +1749,10 @@ print_extmemarray(smbios_hdl_t *shp, id_t id, FILE *fp)
 	if (check_oem(shp) != 0)
 		return;
 
-	(void) smbios_info_extmemarray(shp, id, &em);
+	if (smbios_info_extmemarray(shp, id, &em) != 0) {
+		smbios_warn(shp, "failed to read extmemarray information");
+		return;
+	}
 
 	oprintf(fp, "  Physical Memory Array Handle: %u\n", em.smbmae_ma);
 	oprintf(fp, "  Component Parent Handle: %u\n", em.smbmae_comp);
@@ -1691,7 +1768,10 @@ print_extmemdevice(smbios_hdl_t *shp, id_t id, FILE *fp)
 	if (check_oem(shp) != 0)
 		return;
 
-	(void) smbios_info_extmemdevice(shp, id, &emd);
+	if (smbios_info_extmemdevice(shp, id, &emd) != 0) {
+		smbios_warn(shp, "failed to read extmemdevice information");
+		return;
+	}
 
 	oprintf(fp, "  Memory Device Handle: %u\n", emd.smbmdeve_md);
 	oprintf(fp, "  DRAM Channel: %u\n", emd.smbmdeve_drch);


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151041  omnios-upstream_merge-2021122901-276ff928b8     December 2021
illumos development build: 2021-Dec-29 [illumos-omnios]
hadfl@mars:~$ uname -a
SunOS mars 5.11 omnios-upstream_merge-2021122901-276ff928b8 i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Wed Dec 29 12:23:46 CET 2021 ====
==== Nightly distributed build completed: Wed Dec 29 13:51:12 CET 2021 ====

==== Total build time ====

real    1:27:25

==== Build environment ====

/usr/bin/uname
SunOS mars 5.11 omnios-master-5dcfdfc0686 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 10

cw version 6.1
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151041/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-10/bin/gcc
gcc (OmniOS 151041/10.3.0-il-1) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.13+8-omnios-151041"

/usr/bin/openssl
OpenSSL 3.0.0 7 sep 2021 (Library: OpenSSL 3.0.0 7 sep 2021)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1777 (illumos)

Build project:  default
Build taskid:   82

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2021122901-276ff928b8

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    39:31.5
user  3:53:14.5
sys     42:11.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    34:48.1
user  3:23:56.7
sys     38:49.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```