### PR TITLE
Errors from lx zone boot

### DIFF
--- a/usr/src/lib/brand/lx/zone/lx_boot_zone_debian.ksh
+++ b/usr/src/lib/brand/lx/zone/lx_boot_zone_debian.ksh
@@ -87,7 +87,7 @@ fi
 # Don't bother changing the file if it looks like we already did.
 #
 fnm=$ZONEROOT/etc/inittab
-if ! egrep -s "Modified by lx brand" $fnm; then
+if [ -f $fnm ] && ! egrep -s "Modified by lx brand" $fnm; then
 	sed 's/^[1-6]:/# Disabled by lx brand: &/' \
 	    $fnm > $tmpfile
 	echo "1:2345:respawn:/sbin/getty 38400 console" >> $tmpfile
@@ -153,7 +153,7 @@ RMSVCS="
 "
 for f in $RMSVCS
 do
-	disable_svc $f
+	disable_svc $f 2>/dev/null
 done
 
 #


### PR DESCRIPTION
After fixing zoneadmd so that it passes stderr back to zoneadm clients, booting some lx images is noisy, for example, devuan (which uses the debian boot script but does not have systemd):

```
bloody% pfexec zadm boot lx
zone 'lx': /usr/lib/brand/lx/lx_boot[151]: .[138]: /zones/lx/root/etc/init/network-interface-security.override: cannot create [No such file or directory]
zone 'lx': /usr/lib/brand/lx/lx_boot[151]: .[138]: /zones/lx/root/etc/init/udev.override: cannot create [No such file or directory]
zone 'lx': /usr/lib/brand/lx/lx_boot[151]: .[138]: /zones/lx/root/etc/init/udevmonitor.override: cannot create [No such file or directory]
zone 'lx': /usr/lib/brand/lx/lx_boot[151]: .[138]: /zones/lx/root/etc/init/udevtrigger.override: cannot create [No such file or directory]
zone 'lx': /usr/lib/brand/lx/lx_boot[151]: .[138]: /zones/lx/root/etc/init/udev-fallback-graphics.override: cannot create [No such file or directory]
zone 'lx': /usr/lib/brand/lx/lx_boot[151]: .[138]: /zones/lx/root/etc/init/udev-finish.override: cannot create [No such file or directory]
```