### PR TITLE
bhyve: NVMe missed mutex initialisation

### DIFF
--- a/usr/src/cmd/bhyve/pci_nvme.c
+++ b/usr/src/cmd/bhyve/pci_nvme.c
@@ -460,8 +460,13 @@ pci_nvme_init_queues(struct pci_nvme_softc *sc, uint32_t nsq, uint32_t ncq)
 	} else {
 		struct nvme_submission_queue *sq = sc->submit_queues;
 
+#ifndef __FreeBSD__
+		for (i = 0; i < sc->num_squeues + 1; i++)
+			pthread_mutex_init(&sq[i].mtx, NULL);
+#else
 		for (i = 0; i < sc->num_squeues; i++)
 			pthread_mutex_init(&sq[i].mtx, NULL);
+#endif
 	}
 
 	/*
@@ -483,8 +488,13 @@ pci_nvme_init_queues(struct pci_nvme_softc *sc, uint32_t nsq, uint32_t ncq)
 	} else {
 		struct nvme_completion_queue *cq = sc->compl_queues;
 
+#ifndef __FreeBSD__
+		for (i = 0; i < sc->num_cqueues + 1; i++)
+			pthread_mutex_init(&cq[i].mtx, NULL);
+#else
 		for (i = 0; i < sc->num_cqueues; i++)
 			pthread_mutex_init(&cq[i].mtx, NULL);
+#endif
 	}
 }
 


### PR DESCRIPTION
```
# mdb /zones/bhyvetest/root/core
Loading modules: [ libumem.so.1 libc.so.1 libnvpair.so.1 libproc.so.1 ld.so.1 ]
> ::status
debugging core file of bhyve (64-bit) from bhyvetest
initial argv: bhyve-bhyvetest -k /etc/bhyve.cfg
threading model: native threads
status: process panicked
upanic message: *** libc mutex system failure: mutex_enter: bad mutex type\x0a
libc panic message: *** libc mutex system failure: mutex_enter: bad mutex type
> $C
fffffc7e9b945800 libc.so.1`syscall+0x30()
fffffc7e9b945820 libc.so.1`upanic+0x22(fffffc7e9b945850, 190)
fffffc7e9b945840 0xfffffc7feef4ae9d()
fffffc7e9b945a10 0xfffffc7feef4af84()
fffffc7e9b945a30 libc.so.1`mutex_panic+0x26(dfbf58, fffffc7feefc2023)
fffffc7e9b945a60 libc.so.1`mutex_enter+0x64(dfbf58)
fffffc7e9b945ae0 pci_nvme_handle_io_cmd+0x53(dd3010, 10)
fffffc7e9b945b40 pci_nvme_handle_doorbell+0x184(dc8990, dd3010, 10, 1, 1)
fffffc7e9b945bd0 pci_nvme_write_bar_0+0x15f(dc8990, dd3010, 1080, 4, 1)
fffffc7e9b945c50 pci_nvme_write+0x11e(dc8990, f, dd1650, 0, 1080, 4)
fffffc7e9b945d00 pci_emul_mem_handler+0x194(dc8990, f, 2, c1001080, 4, fffffc7e9b945d28)
fffffc7e9b945d60 mem_write+0x4a(dc8990, f, c1001080, 1, 4, dc9df0)
fffffc7e9b945da0 emulate_mem_cb+0x41(dc8990, f, c1001080, dc9df0, fffffc7e9b945e70)
fffffc7e9b945e30 access_memory+0x126(dc8990, f, c1001080, 42f320, fffffc7e9b945e70)
fffffc7e9b945e60 emulate_mem+0x25(dc8990, f, fffffc7e9b945e70)
fffffc7e9b945ec0 vmexit_mmio+0x50(dc8990, 492a80, fffffc7e9b945edc)
fffffc7e9b945f60 vm_loop+0xd0(dc8990, f, 0)
fffffc7e9b945fb0 fbsdrun_start_thread+0x5d(492460)
fffffc7e9b945fe0 libc.so.1`_thrp_setup+0x77(fffffc7fedfd2240)
fffffc7e9b945ff0 libc.so.1`_lwp_start()
```