### PR TITLE
Upstream merge upstream_merge/2022031001

### DIFF
--- a/usr/src/lib/libdladm/common/libdladm.c
+++ b/usr/src/lib/libdladm/common/libdladm.c
@@ -438,9 +438,6 @@ dladm_status2str(dladm_status_t status, char *buf)
 	case DLADM_STATUS_INVALID_MTU:
 		s = "MTU check failed, MTU outside of device's supported range";
 		break;
-	case DLADM_STATUS_ADDRNOTAVAIL:
-		s = "can't assign requested address";
-		break;
 	case DLADM_STATUS_PERSIST_ON_TEMP:
 		s = "can't create persistent object on top of temporary object";
 		break;

--- a/usr/src/lib/libdladm/common/libdladm.c
+++ b/usr/src/lib/libdladm/common/libdladm.c
@@ -20,15 +20,12 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+
+/*
  * Copyright (c) 2015, Joyent, Inc.
- */
-
-/*
- * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
- */
-
-/*
  * Copyright 2020 Peter Tribble.
+ * Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <unistd.h>
@@ -449,6 +446,9 @@ dladm_status2str(dladm_status_t status, char *buf)
 		break;
 	case DLADM_STATUS_BAD_ENCAP:
 		s = "invalid encapsulation protocol";
+		break;
+	case DLADM_STATUS_ADDRNOTAVAIL:
+		s = "can't assign requested address";
 		break;
 	default:
 		s = "<unknown error>";

--- a/usr/src/lib/libdladm/common/libdladm.h
+++ b/usr/src/lib/libdladm/common/libdladm.h
@@ -24,7 +24,7 @@
 
 /*
  * Copyright 2015, Joyent, Inc.
- * Copyright 2020 OmniOS Community Edition (OmniOSce) Association
+ * Copyright 2022 OmniOS Community Edition (OmniOSce) Association
  */
 
 #ifndef _LIBDLADM_H
@@ -180,9 +180,9 @@ typedef enum {
 	DLADM_STATUS_INVALID_PKEY_TBL_SIZE,
 	DLADM_STATUS_PORT_NOPROTO,
 	DLADM_STATUS_INVALID_MTU,
+	DLADM_STATUS_PERSIST_ON_TEMP,
 	DLADM_STATUS_BAD_ENCAP,
-	DLADM_STATUS_ADDRNOTAVAIL,
-	DLADM_STATUS_PERSIST_ON_TEMP
+	DLADM_STATUS_ADDRNOTAVAIL
 } dladm_status_t;
 
 typedef enum {

--- a/usr/src/lib/libdladm/common/libdlvnic.c
+++ b/usr/src/lib/libdladm/common/libdlvnic.c
@@ -405,7 +405,7 @@ dladm_vnic_create(dladm_handle_t handle, const char *vnic, datalink_id_t linkid,
 {
 	dladm_vnic_attr_t attr;
 	datalink_id_t vnic_id;
-	datalink_class_t class;
+	datalink_class_t class, pclass;
 	uint32_t media = DL_ETHER;
 	uint32_t link_flags;
 	char name[MAXLINKNAMELEN];
@@ -443,7 +443,7 @@ dladm_vnic_create(dladm_handle_t handle, const char *vnic, datalink_id_t linkid,
 
 	if (!is_etherstub) {
 		if ((status = dladm_datalink_id2info(handle, linkid,
-		    &link_flags, &class, &media, NULL, 0)) != DLADM_STATUS_OK)
+		    &link_flags, &pclass, &media, NULL, 0)) != DLADM_STATUS_OK)
 			return (status);
 
 		/* Disallow persistent objects on top of temporary ones */
@@ -452,8 +452,8 @@ dladm_vnic_create(dladm_handle_t handle, const char *vnic, datalink_id_t linkid,
 			return (DLADM_STATUS_PERSIST_ON_TEMP);
 
 		/* Links cannot be created on top of these object types */
-		if (class == DATALINK_CLASS_VNIC ||
-		    class == DATALINK_CLASS_VLAN)
+		if (pclass == DATALINK_CLASS_VNIC ||
+		    pclass == DATALINK_CLASS_VLAN)
 			return (DLADM_STATUS_BADARG);
 	}
 
@@ -548,8 +548,17 @@ dladm_vnic_create(dladm_handle_t handle, const char *vnic, datalink_id_t linkid,
 	attr.va_force = (flags & DLADM_OPT_FORCE) != 0;
 
 	status = i_dladm_vnic_create_sys(handle, &attr);
-	if (status != DLADM_STATUS_OK)
+	if (status != DLADM_STATUS_OK) {
+		if (!is_etherstub && pclass == DATALINK_CLASS_OVERLAY &&
+		    status == DLADM_STATUS_ADDRNOTAVAIL) {
+			char errmsg[DLADM_STRSIZE];
+			(void) dladm_errlist_append(errs,
+			    "failed to start overlay device; "
+			    "could not open underlay socket: %s",
+			    dladm_status2str(status, errmsg));
+		}
 		goto done;
+	}
 	vnic_created = B_TRUE;
 
 	/* Save vnic configuration and its properties */

--- a/usr/src/uts/common/fs/vnode.c
+++ b/usr/src/uts/common/fs/vnode.c
@@ -857,8 +857,6 @@ vn_rele(vnode_t *vp)
 void
 vn_phantom_rele(vnode_t *vp)
 {
-	VERIFY(vp->v_count > 0);
-
 	mutex_enter(&vp->v_lock);
 	VERIFY3U(vp->v_count, >=, vp->v_phantom_count);
 	vp->v_phantom_count--;
@@ -869,6 +867,7 @@ vn_phantom_rele(vnode_t *vp)
 		VOP_INACTIVE(vp, CRED(), NULL);
 		return;
 	}
+	VERIFY(vp->v_count > 0);
 	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }

--- a/usr/src/uts/common/fs/vnode.c
+++ b/usr/src/uts/common/fs/vnode.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 Spencer Evans-Cole.
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
@@ -842,13 +843,13 @@ done:
 void
 vn_rele(vnode_t *vp)
 {
-	VERIFY(vp->v_count > 0);
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count == 1) {
 		mutex_exit(&vp->v_lock);
 		VOP_INACTIVE(vp, CRED(), NULL);
 		return;
 	}
+	VERIFY(vp->v_count > 0);
 	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }
@@ -893,8 +894,8 @@ vn_count(vnode_t *vp)
 void
 vn_rele_dnlc(vnode_t *vp)
 {
-	VERIFY((vp->v_count > 0) && (vp->v_count_dnlc > 0));
 	mutex_enter(&vp->v_lock);
+	VERIFY((vp->v_count > 0) && (vp->v_count_dnlc > 0));
 	if (--vp->v_count_dnlc == 0) {
 		if (vp->v_count == 1) {
 			mutex_exit(&vp->v_lock);
@@ -916,7 +917,6 @@ vn_rele_dnlc(vnode_t *vp)
 void
 vn_rele_stream(vnode_t *vp)
 {
-	VERIFY(vp->v_count > 0);
 	mutex_enter(&vp->v_lock);
 	vp->v_stream = NULL;
 	if (vp->v_count == 1) {
@@ -924,6 +924,7 @@ vn_rele_stream(vnode_t *vp)
 		VOP_INACTIVE(vp, CRED(), NULL);
 		return;
 	}
+	VERIFY(vp->v_count > 0);
 	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }
@@ -947,7 +948,6 @@ vn_rele_inactive(vnode_t *vp)
 void
 vn_rele_async(vnode_t *vp, taskq_t *taskq)
 {
-	VERIFY(vp->v_count > 0);
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count == 1) {
 		mutex_exit(&vp->v_lock);
@@ -955,6 +955,7 @@ vn_rele_async(vnode_t *vp, taskq_t *taskq)
 		    vp, TQ_SLEEP) != TASKQID_INVALID);
 		return;
 	}
+	VERIFY(vp->v_count > 0);
 	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }

--- a/usr/src/uts/common/io/cxgbe/firmware/t4fw_interface.h
+++ b/usr/src/uts/common/io/cxgbe/firmware/t4fw_interface.h
@@ -7259,7 +7259,7 @@ enum fw_port_mdi32 {
     (((x) >> S_FW_PORT_CAP32_MDI) & M_FW_PORT_CAP32_MDI)
 
 #define S_FW_PORT_CAP32_FEC	23
-#define M_FW_PORT_CAP32_FEC	0x5f
+#define M_FW_PORT_CAP32_FEC	0x1f
 #define V_FW_PORT_CAP32_FEC(x)	((x) << S_FW_PORT_CAP32_FEC)
 #define G_FW_PORT_CAP32_FEC(x) \
     (((x) >> S_FW_PORT_CAP32_FEC) & M_FW_PORT_CAP32_FEC)

--- a/usr/src/uts/i86pc/os/tscc_hpet.c
+++ b/usr/src/uts/i86pc/os/tscc_hpet.c
@@ -98,9 +98,16 @@ tsc_calibrate_hpet(uint64_t *freqp)
 	return (B_TRUE);
 }
 
+/*
+ * Reports from the field suggest that HPET calibration is currently producing
+ * a substantially greater error than PIT calibration on a wide variety of
+ * systems.  We are placing it last in the preference order until that can be
+ * resolved.  HPET calibration cannot be disabled completely, as some systems
+ * no longer emulate the PIT at all.
+ */
 static tsc_calibrate_t tsc_calibration_hpet = {
 	.tscc_source = "HPET",
-	.tscc_preference = 50,
+	.tscc_preference = 1,
 	.tscc_calibrate = tsc_calibrate_hpet,
 };
 TSC_CALIBRATION_SOURCE(tsc_calibration_hpet);

--- a/usr/src/uts/i86pc/os/tscc_pit.c
+++ b/usr/src/uts/i86pc/os/tscc_pit.c
@@ -157,8 +157,9 @@ tsc_calibrate_pit(uint64_t *freqp)
 }
 
 /*
- * Typically any source besides the PIT is going to provide better
- * results, so a low preference is assigned to the PIT so it is tried last.
+ * Typically a calibration source that allows the hardware or the hypervisor to
+ * simply declare a specific frequency, rather than requiring calibration at
+ * runtime, is going to provide better results than the using PIT.
  */
 static tsc_calibrate_t tsc_calibration_pit = {
 	.tscc_source = "PIT",


### PR DESCRIPTION
Weekly upstream for upstream_merge/2022031001

## onu

```
OmniOS r151041  omnios-upstream_merge-2022031001-51f61ef898     March 2022
illumos development build: 2022-Mar-10 [illumos]
bloody% uname -a
SunOS bloody 5.11 omnios-upstream_merge-2022031001-51f61ef898 i86pc i386 i86pc
```

## mail_msg

```

==== Nightly distributed build started:   Thu Mar 10 23:15:16 UTC 2022 ====
==== Nightly distributed build completed: Fri Mar 11 00:58:54 UTC 2022 ====

==== Total build time ====

real    1:43:38

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-b3f6954b58 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 6.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151041/10.3.0-il-1) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151041/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.14+9-omnios-151041"

/usr/bin/openssl
OpenSSL 3.0.1 14 Dec 2021 (Library: OpenSSL 3.0.1 14 Dec 2021)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1781 (illumos)

Build project:  default
Build taskid:   337

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2022031001-51f61ef898

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    30:36.4
user  4:17:51.0
sys   1:22:56.1

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    46:01.4
user  5:27:05.6
sys   2:57:56.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
