### PR TITLE
HYPERV: Update VMBus version 4.0 and 5.0 support.

### DIFF
--- a/usr/src/uts/intel/io/hyperv/README.sync
+++ b/usr/src/uts/intel/io/hyperv/README.sync
@@ -3,8 +3,8 @@
 The hyperv drivers and their associated userland consumers have been updated
 to the latest upstream FreeBSD sources as of:
 
-	commit 792d8e91e0bc2592e738ab21a4f15286d49ac056
-	Author: sephe <sephe@FreeBSD.org>
+	commit 1e851378414a6bf953a931df74ca2c7bc52dddd1
+	Author: Sepherosa Ziehau <sephe@FreeBSD.org>
 	Date:   Fri Apr 14 05:29:27 2017 +0000
 
 	    hyperv/kvp: Remove always false condition.

--- a/usr/src/uts/intel/io/hyperv/netvsc/hn_nvs.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/hn_nvs.c
@@ -357,7 +357,8 @@ hn_nvs_disconn_rxbuf(struct hn_softc *sc)
 		delay(MSEC_TO_TICK(200));
 	}
 
-	if (sc->hn_rxbuf_gpadl != 0) {
+	if (vmbus_current_version < VMBUS_VERSION_WIN10 &&
+	    sc->hn_rxbuf_gpadl != 0) {
 		/*
 		 * Disconnect RXBUF from primary channel.
 		 */
@@ -418,7 +419,8 @@ hn_nvs_disconn_chim(struct hn_softc *sc)
 		delay(MSEC_TO_TICK(200));
 	}
 
-	if (sc->hn_chim_gpadl != 0) {
+	if (vmbus_current_version < VMBUS_VERSION_WIN10 &&
+	    sc->hn_chim_gpadl != 0) {
 		/*
 		 * Disconnect chimney sending buffer from primary channel.
 		 */

--- a/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
+++ b/usr/src/uts/intel/io/hyperv/netvsc/if_hn.c
@@ -2472,6 +2472,41 @@ hn_synth_detach(struct hn_softc *sc)
 	/* Detach all of the channels. */
 	hn_detach_allchans(sc);
 
+	if (vmbus_current_version >= VMBUS_VERSION_WIN10 &&
+	    sc->hn_rxbuf_gpadl != 0) {
+		/*
+		 * Host is post-Win2016, disconnect RXBUF from primary channel
+		 * here.
+		 */
+		int error;
+
+		error = vmbus_chan_gpadl_disconnect(sc->hn_prichan,
+		    sc->hn_rxbuf_gpadl);
+		if (error) {
+			HN_WARN(sc, "rxbuf gpadl disconn failed: %d",
+			    error);
+			sc->hn_flags |= HN_FLAG_RXBUF_REF;
+		}
+		sc->hn_rxbuf_gpadl = 0;
+	}
+
+	if (vmbus_current_version >= VMBUS_VERSION_WIN10 &&
+	    sc->hn_chim_gpadl != 0) {
+		/*
+		 * Host is post-Win2016, disconnect chimney sending buffer from
+		 * primary channel here.
+		 */
+		int error;
+
+		error = vmbus_chan_gpadl_disconnect(sc->hn_prichan,
+		    sc->hn_chim_gpadl);
+		if (error) {
+			HN_WARN(sc, "chim gpadl disconn failed: %d", error);
+			sc->hn_flags |= HN_FLAG_CHIM_REF;
+		}
+		sc->hn_chim_gpadl = 0;
+	}
+
 	sc->hn_flags &= ~HN_FLAG_SYNTH_ATTACHED;
 }
 

--- a/usr/src/uts/intel/io/hyperv/sys/hyperv.h
+++ b/usr/src/uts/intel/io/hyperv/sys/hyperv.h
@@ -74,4 +74,9 @@ int		hyperv_guid2str(const struct hyperv_guid *, char *, size_t);
 extern uint_t	hyperv_features;	/* CPUID_HV_MSR_ */
 extern uint_t	hyperv_ver_major;
 
+/*
+ * Vmbus version after negotiation with host.
+ */
+extern uint32_t vmbus_current_version;
+
 #endif /* _SYS_HYPERV_H */

--- a/usr/src/uts/intel/io/hyperv/sys/vmbus.h
+++ b/usr/src/uts/intel/io/hyperv/sys/vmbus.h
@@ -57,11 +57,15 @@
  * 1.1   --  Windows 7
  * 2.4   --  Windows 8
  * 3.0   --  Windows 8.1
+ * 4.0   --  Windows 10
+ * 5.0   --  Newer Windows 10
  */
 #define	VMBUS_VERSION_WS2008		((0 << 16) | (13))
 #define	VMBUS_VERSION_WIN7		((1 << 16) | (1))
 #define	VMBUS_VERSION_WIN8		((2 << 16) | (4))
 #define	VMBUS_VERSION_WIN8_1		((3 << 16) | (0))
+#define	VMBUS_VERSION_WIN10		((4 << 16) | (0))
+#define	VMBUS_VERSION_WIN10_V5		((5 << 16) | (0))
 
 #define	VMBUS_VERSION_MAJOR(ver)	(((uint32_t)(ver)) >> 16)
 #define	VMBUS_VERSION_MINOR(ver)	(((uint32_t)(ver)) & 0xffff)

--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
@@ -42,7 +42,7 @@
  */
 
 /*
- * Implements low-level interactions with Hypver-V/Azure
+ * Implements low-level interactions with Hyper-V/Azure
  */
 
 #include <sys/param.h>

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -101,7 +101,10 @@ static void			vmbus_xcall(vmbus_xcall_func_t, void *);
 static void			*vmbus_state = NULL;
 static struct vmbus_softc	*vmbus_sc;
 
+uint32_t			vmbus_current_version;
+
 static const uint32_t		vmbus_version[] = {
+	VMBUS_VERSION_WIN10,
 	VMBUS_VERSION_WIN8_1,
 	VMBUS_VERSION_WIN8,
 	VMBUS_VERSION_WIN7,
@@ -337,6 +340,7 @@ vmbus_init(struct vmbus_softc *sc)
 		if (!error) {
 			char version[16];
 
+			vmbus_current_version = vmbus_version[i];
 			sc->vmbus_version = vmbus_version[i];
 			(void) snprintf(version, sizeof (version),
 			    "%u.%u", VMBUS_VERSION_MAJOR(sc->vmbus_version),


### PR DESCRIPTION
Add VMBus protocol version 4.0. and 5.0 to support Windows 10 and newer HyperV
hosts.

For VMBus 4.0 and newer HyperV, the netvsc gpadl teardown must be done after
vmbus close.

@jasonbking