### PR TITLE
Restore early ZONE_ATTR_ values

### DIFF
--- a/usr/src/cmd/truss/print.c
+++ b/usr/src/cmd/truss/print.c
@@ -2551,8 +2551,21 @@ prt_zga(private_t *pri, int raw, long val)
 		case ZONE_ATTR_INITNAME:	s = "ZONE_ATTR_INITNAME"; break;
 		case ZONE_ATTR_BOOTARGS:	s = "ZONE_ATTR_BOOTARGS"; break;
 		case ZONE_ATTR_BRAND:	s = "ZONE_ATTR_BRAND"; break;
+		case ZONE_ATTR_SCHED_CLASS: s = "ZONE_ATTR_SCHED_CLASS"; break;
 		case ZONE_ATTR_FLAGS:	s = "ZONE_ATTR_FLAGS"; break;
-		case ZONE_ATTR_DID:	s = "ZONE_ATTR_DID"; break;
+		case ZONE_ATTR_HOSTID:	s = "ZONE_ATTR_HOSTID"; break;
+		case ZONE_ATTR_FS_ALLOWED: s = "ZONE_ATTR_FS_ALLOWED"; break;
+		case ZONE_ATTR_NETWORK:	s = "ZONE_ATTR_NETWORK"; break;
+		case ZONE_ATTR_INITNORESTART: s = "ZONE_ATTR_INITNORESTART";
+			break;
+		case ZONE_ATTR_SECFLAGS: s = "ZONE_ATTR_SECFLAGS"; break;
+		case ZONE_ATTR_INITRESTART0: s = "ZONE_ATTR_INITRESTART0";
+			break;
+		case ZONE_ATTR_INITREBOOT: s = "ZONE_ATTR_INITREBOOT"; break;
+		case ZONE_ATTR_DID: s = "ZONE_ATTR_DID"; break;
+		case ZONE_ATTR_APP_SVC_CT: s = "ZONE_ATTR_APP_SVC_CT"; break;
+		case ZONE_ATTR_SCHED_FIXEDHI: s = "ZONE_ATTR_SCHED_FIXEDHI";
+			break;
 		}
 	}
 

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -109,7 +109,13 @@ extern "C" {
 #define	ZONE_CHECK_DATALINK	12
 #define	ZONE_LIST_DATALINK	13
 
-/* zone attributes */
+/*
+ * zone attributes
+ *
+ * Note that values up to ZONE_ATTR_HOSTID are baked into things like Solaris
+ * 10 which can be run under the s10 brand; don't renumber or change them. Ones
+ * which are no longer used are commented out.
+ */
 #define	ZONE_ATTR_ROOT		1
 #define	ZONE_ATTR_NAME		2
 #define	ZONE_ATTR_STATUS	3
@@ -121,18 +127,23 @@ extern "C" {
 #define	ZONE_ATTR_INITNAME	9
 #define	ZONE_ATTR_BOOTARGS	10
 #define	ZONE_ATTR_BRAND		11
-#define	ZONE_ATTR_SCHED_CLASS	12
-#define	ZONE_ATTR_FLAGS		13
-#define	ZONE_ATTR_HOSTID	14
-#define	ZONE_ATTR_FS_ALLOWED	15
-#define	ZONE_ATTR_NETWORK	16
-#define	ZONE_ATTR_DID		17
-#define	ZONE_ATTR_INITNORESTART	18
-#define	ZONE_ATTR_APP_SVC_CT	19
-#define	ZONE_ATTR_SCHED_FIXEDHI	20
+/*#define	ZONE_ATTR_PHYS_MCAP	12*/
+#define	ZONE_ATTR_SCHED_CLASS	13
+#define	ZONE_ATTR_FLAGS		14
+#define	ZONE_ATTR_HOSTID	15
+#define	ZONE_ATTR_FS_ALLOWED	16
+#define	ZONE_ATTR_NETWORK	17
+
+/* illumos extensions */
+#define	ZONE_ATTR_INITNORESTART	20
 #define	ZONE_ATTR_SECFLAGS	21
 #define	ZONE_ATTR_INITRESTART0	22
 #define	ZONE_ATTR_INITREBOOT	23
+
+/* OmniOS/SmartOS extensions */
+#define	ZONE_ATTR_DID		30
+#define	ZONE_ATTR_APP_SVC_CT	31
+#define	ZONE_ATTR_SCHED_FIXEDHI	32
 
 /* Start of the brand-specific attribute namespace */
 #define	ZONE_ATTR_BRAND_ATTRS	32768


### PR DESCRIPTION
While testing the `s10` brand under the upcoming r151042 release, a service failed to come online:

```
# /usr/sbin/ipsecalgs -s
ipsecalgs: Unable to determine zone IP type: Invalid argument

zone_getattr(10, ZONE_ATTR_FLAGS, 0x08047DE8, 2) Err#22 EINVAL
```

Some dtrace showed that the branded zone was requesting attribute number `14`:

```
r151042# dtrace -n 'zone_getattr:entry/arg0==11/{self->t++; trace(arg1)}' -n 'zone_getattr:return/self->t/{self->t--; trace(arg1)}' -n 'zone_status_get:return/self->t/{trace(arg1)}' -n 'zone_list_access:return/self->t/{trace(arg1)}' -n 's10_getattr:entry/self->t/{trace(arg1)}' -n 's10_getattr:return/self->t/{trace(arg1)}'

CPU     ID                    FUNCTION:NAME
  2  28085               zone_getattr:entry             32768
  2  37731           zone_status_get:return                 4
  2  28078          zone_list_access:return                 1
  2   9380                s10_getattr:entry             32768
  2   9381               s10_getattr:return                 0
  2  28086              zone_getattr:return                 1
  2  28085               zone_getattr:entry                14
  2  37731           zone_status_get:return                 4
  2  28078          zone_list_access:return                 1
  2  28086              zone_getattr:return                22
```

and, unfortunately, our attribute 14 is not what it once was:

```
s10# grep ZONE_ATTR_FLAGS /usr/include/sys/zone.h
#define ZONE_ATTR_FLAGS         14
r151042# grep ZONE_ATTR_FLAGS /usr/include/sys/zone.h
#define   ZONE_ATTR_FLAGS            13
```

it was renumbered as part of 4ece2794ae1d270557481c8e35eeab134206c831

This restores the numbering of the early flags, so that they are what branded zones expect. It also re-synchronises the ones in the 20-29 range with the values in gate and moves the OmniOS/SmartOS-only ones to 30+