### PR TITLE
bhyve VNC authentication fails with openssl3

### DIFF
--- a/usr/src/cmd/bhyve/rfb.c
+++ b/usr/src/cmd/bhyve/rfb.c
@@ -379,11 +379,7 @@ rfb_handshake_auth(rfb_client_t *c)
 	memcpy(crypt_expected, challenge, RFBP_SECURITY_VNC_AUTH_LEN);
 
 	/* Encrypt the Challenge with DES. */
-	if (DES_set_key((const_DES_cblock *)keystr, &ks) != 0) {
-		rfb_printf(c, RFB_LOGERR, "DES_set_key() failed");
-		rfb_send_client_status(c, 1, "authentication failed");
-		return (false);
-	}
+	DES_set_key_unchecked((const_DES_cblock *)keystr, &ks);
 	DES_ecb_encrypt((const_DES_cblock *)challenge,
 	    (const_DES_cblock *)crypt_expected, &ks, DES_ENCRYPT);
 	DES_ecb_encrypt(


### PR DESCRIPTION
This is because the DES key is just the supplied password with the bits flipped, and the parity bits are usually all 0 (for a 7-bit ASCII password). OpenSSL 3 reports a parity error, openssl 1.1 and 1.0 do not.

I've tested this new version with all three versions of openssl.