### PR TITLE
Add find_elf symlink in original location

### DIFF
--- a/usr/src/pkg/manifests/developer-build-onbld.p5m
+++ b/usr/src/pkg/manifests/developer-build-onbld.p5m
@@ -92,6 +92,7 @@ file path=opt/onbld/bin/copyrightchk mode=0555 \
     pkg.depend.bypass-generate=.*(?:Checks|onbld|Copyright).*
 file path=opt/onbld/bin/cstyle mode=0555
 file path=opt/onbld/bin/elfcmp mode=0555
+link path=opt/onbld/bin/find_elf target=$(ARCH)/find_elf
 file path=opt/onbld/bin/findcrypto mode=0555
 file path=opt/onbld/bin/flg.flp mode=0555
 file path=opt/onbld/bin/genoffsets mode=0555

--- a/usr/src/tools/find_elf/Makefile
+++ b/usr/src/tools/find_elf/Makefile
@@ -48,7 +48,7 @@ CSTD = $(CSTD_GNU99)
 all:	$(PROG)
 
 install: all .WAIT $(ROOTONBLDMACHPROG) $(ROOTONBLDDATAFILES) \
-	$(ROOTONBLDMAN1ONBLDFILES)
+	$(ROOTONBLDMAN1ONBLDFILES) $(ROOTONBLDPROG)
 
 clean:
 	$(RM) -f $(OBJS)
@@ -56,6 +56,9 @@ clean:
 $(PROG): $(OBJS)
 	$(LINK.c) $(OBJS) -o $@ $(LDLIBS)
 	$(POST_PROCESS)
+
+$(ROOTONBLDPROG): $(ROOTONBLDMACHPROG)
+	-$(RM) $@; $(SYMLINK) $(MACH)/$(@F) $@
 
 %.o: %.c
 	$(COMPILE.c) -o $@ $<


### PR DESCRIPTION
We have some out-of-gate components which use `find_elf` and cannot find it following `14712 Replace find_elf with something faster`. This adds a symlink at the original location.

@jasonbking - do you think we should get this upstreamed too? I know that a few packages use onbld tools (illumos-kvm for example) but I don't know how many use `find_elf` outside of the OmniOS build stuff.