### PR TITLE
HYPERV: vmbus ndi_devi_online should not destroy node if fails

### DIFF
--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -39,6 +39,7 @@
 
 /*
  * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -986,8 +987,6 @@ vmbus_add_child(struct vmbus_channel *chan)
 	ddi_set_parent_data(chan->ch_dev, chan);
 	int err = ndi_devi_online(chan->ch_dev, 0);
 	if (err != NDI_SUCCESS) {
-		(void) ndi_devi_free(chan->ch_dev);
-		chan->ch_dev = NULL;
 		mutex_exit(&vmbus_lock);
 		dev_err(parent, CE_CONT, "?failed to online: classid %s, "
 		    "devname %s for chan%u, err %d\n", classid, devname,


### PR DESCRIPTION
This small change was something I noticed while debugging HyperV.  I'm going to be submitting another PR that basically "rewrites" hv_storvsc (fixing numerous bugs along the way).

After this change, various extra nodes will show in the device tree (all the other nodes that vmbus creates but we don't have drivers for), and if you don't have a functional driver (because say you've moved it out of the way or it is buggy and doesn't attach), you can still attach a new one without needing to reboot.

It's unlikely that this will matter much to end users, but its a signficant quality of life improvement for anyone working on these drivers.  We also would like to follow good practices in case anyone decides to "copy" this code in the future.