### PR TITLE
HYPERV: Hyper-V SCSI HBA Refactoring

### DIFF
--- a/usr/src/uts/intel/io/hyperv/storvsc/hv_vstorage.h
+++ b/usr/src/uts/intel/io/hyperv/storvsc/hv_vstorage.h
@@ -39,6 +39,7 @@
 
 /*
  * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #ifndef __HV_VSTORAGE_H__
@@ -59,21 +60,6 @@
 #define	VMSTOR_PROTOCOL_VERSION_WIN8		VMSTOR_PROTOCOL_VERSION(5, 1)
 #define	VMSTOR_PROTOCOL_VERSION_WIN8_1		VMSTOR_PROTOCOL_VERSION(6, 0)
 #define	VMSTOR_PROTOCOL_VERSION_WIN10		VMSTOR_PROTOCOL_VERSION(6, 2)
-/*
- * Invalid version.
- */
-#define	VMSTOR_INVALID_PROTOCOL_VERSION  -1
-
-/*
- * Version history:
- * V1 Beta                    0.1
- * V1 RC < 2008/1/31          1.0
- * V1 RC > 2008/1/31          2.0
- * Win7: 4.2
- * Win8: 5.1
- */
-
-#define	VMSTOR_PROTOCOL_VERSION_CURRENT	VMSTOR_PROTOCOL_VERSION(5, 1)
 
 /*
  *  Packet structure ops describing virtual storage requests.
@@ -103,24 +89,7 @@ enum vstor_packet_ops {
  */
 
 #define	CDB16GENERIC_LENGTH			0x10
-#define	SENSE_BUFFER_SIZE			0x14
 #define	MAX_DATA_BUFFER_LENGTH_WITH_PADDING	0x14
-
-#define	POST_WIN7_STORVSC_SENSE_BUFFER_SIZE	0x14
-#define	PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE	0x12
-
-
-struct vmscsi_win8_extension {
-	/*
-	 * The following were added in Windows 8
-	 */
-	uint16_t reserve;
-	uint8_t  queue_tag;
-	uint8_t  queue_action;
-	uint32_t srb_flags;
-	uint32_t time_out_value;
-	uint32_t queue_sort_ey;
-} __packed;
 
 struct vmscsi_req {
 	uint16_t length;
@@ -145,15 +114,20 @@ struct vmscsi_req {
 	union {
 		uint8_t cdb[CDB16GENERIC_LENGTH];
 
-		uint8_t sense_data[SENSE_BUFFER_SIZE];
+		uint8_t sense_data[SENSE_LENGTH];
 
 		uint8_t reserved_array[MAX_DATA_BUFFER_LENGTH_WITH_PADDING];
 	} u;
 
 	/*
-	 * The following was added in win8.
+	 * The following were added in win8.
 	 */
-	struct vmscsi_win8_extension win8_extension;
+	uint16_t reserve;
+	uint8_t  queue_tag;
+	uint8_t  queue_action;
+	uint32_t srb_flags;
+	uint32_t time_out_value;
+	uint32_t queue_sort_ey;
 
 } __packed;
 
@@ -256,7 +230,7 @@ struct vstor_packet {
 #define	SRB_STATUS_SUCCESS		0x01
 #define	SRB_STATUS_ABORTED		0x02
 #define	SRB_STATUS_ERROR		0x04
-#define	SRB_STATUS_INVALID_LUN		0X20
+#define	SRB_STATUS_INVALID_LUN		0x20
 
 /*
  * SRB Status Masks (can be combined with above status codes)


### PR DESCRIPTION
This is a rather large refactoring of the SCSI HBA driver for Hyper-V.

It has been reviewed by Jerry Jelinek at RackTop, but has received only light testing thus far.

(Note that it dropped an OmniOS copyright, because I started from the version prior to the OmniOS commit, but with this factor that change -- cc60b39673999c129e584bbcb78746ff7be6b7af -- is no longer needed at all.)

The code is rewritten to use iport(9) and the common tran_setup_pkt(9e) infrastructure.  It also removes support for HyperV versions before Windows 10.  (Rationale: Windows 8.1 is on Extended Support, which will end in January, and Azure -- the main target for this -- uses newer versions anyway.  We don't think anyone is actively using this with HyperV versions before that, and the workarounds for the older HyperV versions were annoying -- not having to frob the inquiry responses means we can avoid the bp_mapin() mess and this driver remains purely DDI compliant, modulo understandable use of the HyperV specific APIs.

The driver also supports hot plug so disks can be added and removed and the reasonable thing happens.  There is some ugliness around what happens if Lun 0 is not present but some other Lun is -- which is not typical, but it works (although there will be complaint about non-standards compliant page 83 data for Lun 0... that's fine.)

There were a number of bugs in the old driver... use-after-free for example,  and the driver claiming to be scsi_clean() when it very clearly was *not*.  (The cache had an inlined copy of the scsi_pkt_t.)  My instinct is that the first version of the driver was written by someone with only passing familiarity with the SCSA DDI, perhaps copy-paste coding from a poor example (mptsas is a poor example).

The entire code changes should improve the functionality of this driver (modulo not supporting Windows 7, 8, or 8.1 hypervisors), and trims something like a thousand lines of code that was clearly not terrifically understandable.

I believe that folks reviewing this driver may find it *much* easier to just review it as if it were new work, as I have been fairly free about fixing lots of things like inconsistent symbol naming, as well as the major refactoring of large portions of the code, so that a diff-based view may be less useful than typical for a modification.

I would welcome more thorough public review, as well as test reports of this driver.

Future directions here likely involve adding support for some additional capabilities Microsoft seems to be adding -- such as an emulated Fibre Channel HBA with richer target/lun support.