### PR TITLE
lxinit should handle multiple IPs per VNIC

### DIFF
--- a/usr/src/lib/brand/lx/lx_init/lxinit.c
+++ b/usr/src/lib/brand/lx/lx_init/lxinit.c
@@ -325,17 +325,19 @@ lxi_net_plumb(const char *iface)
 	/* ipadm_create_if stomps on ifbuf, so create a copy: */
 	(void) strncpy(ifbuf, iface, sizeof (ifbuf));
 
-	if ((status = ipadm_create_if(iph, ifbuf, AF_INET, IPADM_OPT_ACTIVE))
-	    != IPADM_SUCCESS) {
+	status = ipadm_create_if(iph, ifbuf, AF_INET, IPADM_OPT_ACTIVE);
+	if (status != IPADM_SUCCESS && status != IPADM_IF_EXISTS) {
 		lxi_err("ipadm_create_if error %d: %s/v4: %s",
 		    status, iface, ipadm_status2str(status));
 	}
 
-	if (ipv6_enable &&
-	    (status = ipadm_create_if(iph, ifbuf, AF_INET6, IPADM_OPT_ACTIVE))
-	    != IPADM_SUCCESS) {
-		lxi_err("ipadm_create_if error %d: %s/v6: %s",
-		    status, iface, ipadm_status2str(status));
+	if (ipv6_enable) {
+		status = ipadm_create_if(iph, ifbuf, AF_INET6,
+		    IPADM_OPT_ACTIVE);
+		if (status != IPADM_SUCCESS && status != IPADM_IF_EXISTS) {
+			lxi_err("ipadm_create_if error %d: %s/v6: %s",
+			    status, iface, ipadm_status2str(status));
+		}
 	}
 }
 


### PR DESCRIPTION
@sjorge hit this when trying to give an lx zone both IPv4 and IPv6, the zone exited with 
```
lx_init err: ipadm_create_if error 10: ubtn0/v4: Interface already exists
```

given a zone configuration with:

```
- allowed-address: 10.23.10.159/20
  defrouter: 10.23.10.1
  global-nic: ixgbe0
  mac-addr: 2:8:20:e5:1:33
  physical: ubtn0
  vlan-id: '100'
- allowed-address: xxxx:xxxx::xxxx/64
  global-nic: ixgbe0
  mac-addr: 2:8:20:e5:1:33
  physical: ubtn0
  vlan-id: '100'
```
