### PR TITLE
14236 signed math leads getelfshdr astray (re-sync)

### DIFF
--- a/usr/src/uts/common/exec/intp/intp.c
+++ b/usr/src/uts/common/exec/intp/intp.c
@@ -26,7 +26,7 @@
  */
 
 /*	Copyright (c) 1988 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 
 /* from S5R4 1.6 */
@@ -134,7 +134,7 @@ getintphead(struct vnode *vp, struct intpdata *idatap)
 	 * to the arguments provided on the command line. Thus, for example,
 	 * you can say
 	 *
-	 * 	#! /usr/bin/awk -f
+	 *	#! /usr/bin/awk -f
 	 *
 	 * However, handling of interpreter arguments varies across operating
 	 * systems and other systems allow more than one argument. In

--- a/usr/src/uts/common/os/brand.c
+++ b/usr/src/uts/common/os/brand.c
@@ -671,9 +671,9 @@ restoreexecenv(struct execenv *ep, stack_t *sp)
 /*ARGSUSED*/
 int
 brand_solaris_elfexec(vnode_t *vp, execa_t *uap, uarg_t *args,
-    intpdata_t *idatap, int level, size_t *execsz, int setid,
-    caddr_t exec_file, cred_t *cred, int *brand_action, struct brand *pbrand,
-    char *bname, char *brandlib, char *brandlib32)
+    intpdata_t *idatap, int level, size_t *execsz, int setid, caddr_t exec_file,
+    cred_t *cred, int *brand_action, struct brand *pbrand, char *bname,
+    char *brandlib, char *brandlib32)
 {
 
 	vnode_t		*nvp;

--- a/usr/src/uts/common/os/core.c
+++ b/usr/src/uts/common/os/core.c
@@ -21,12 +21,12 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2019 Joyent Inc.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2019 Joyent Inc.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
-/*	  All Rights Reserved  	*/
+/*	  All Rights Reserved	*/
 
 #include <sys/param.h>
 #include <sys/types.h>

--- a/usr/src/uts/common/os/exec.c
+++ b/usr/src/uts/common/os/exec.c
@@ -24,7 +24,7 @@
  */
 
 /*	Copyright (c) 1988 AT&T	*/
-/*	All Rights Reserved	*/
+/*	  All Rights Reserved	*/
 /*
  * Copyright 2019 Joyent, Inc.
  */

--- a/usr/src/uts/common/sys/brand.h
+++ b/usr/src/uts/common/sys/brand.h
@@ -173,8 +173,8 @@ struct brand_ops {
 	void	(*b_freelwp)(klwp_t *);
 	void	(*b_lwpexit)(klwp_t *);
 	int	(*b_elfexec)(struct vnode *, struct execa *, struct uarg *,
-	    struct intpdata *, int, size_t *, int, caddr_t, struct cred *,
-	    int *);
+		struct intpdata *, int, size_t *, int, caddr_t, struct cred *,
+		int *);
 	void	(*b_sigset_native_to_brand)(sigset_t *);
 	void	(*b_sigset_brand_to_native)(sigset_t *);
 	void	(*b_sigfd_translate)(k_siginfo_t *);
@@ -210,7 +210,7 @@ struct brand_ops {
  */
 typedef struct brand {
 	int			b_version;
-	char    		*b_name;
+	char			*b_name;
 	struct brand_ops	*b_ops;
 	struct brand_mach_ops	*b_machops;
 	size_t			b_data_size;


### PR DESCRIPTION
This re-syncs OmniOS with the final illumos-gate ELF hardening work in https://code.illumos.org/c/illumos-gate/+/1805
OmniOS already had most of this so the delta is pretty small, but brings in a different approach for dumping DWARF data into core dumps, which is the main diff in `elf.c`.

Before undrafting I will run a full gate build with these bits, check boot an lx and s10-branded zone and run the corefile testsuites.

## mail_msg

```

==== Nightly distributed build started:   Wed Aug 31 15:50:26 UTC 2022 ====
==== Nightly distributed build completed: Wed Aug 31 17:07:04 UTC 2022 ====

==== Total build time ====

real    1:16:38

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-585cb404c03 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 6.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151043/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151043/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.16+8-omnios-151043"

/usr/bin/openssl
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1784 (illumos)

Build project:  default
Build taskid:   418

==== Nightly argument issues ====


==== Build version ====

omnios-elf-1870524a192

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:38.2
user  4:17:50.1
sys   1:17:52.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    25:03.5
user  3:38:30.9
sys   1:09:08.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
