### PR TITLE
Bhyve backports (r151042)

### DIFF
--- a/usr/src/cmd/bhyve/pci_e82545.c
+++ b/usr/src/cmd/bhyve/pci_e82545.c
@@ -232,7 +232,7 @@ struct ck_info {
  * Debug printf
  */
 static int e82545_debug = 0;
-#define WPRINTF(msg,params...) PRINTLN("e82545: " msg, params)
+#define WPRINTF(msg,params...) PRINTLN("e82545: " msg, ##params)
 #define DPRINTF(msg,params...) if (e82545_debug) WPRINTF(msg, params)
 
 #define	MIN(a,b) (((a)<(b))?(a):(b))
@@ -1089,15 +1089,18 @@ e82545_transmit(struct e82545_softc *sc, uint16_t head, uint16_t tail,
 	union  e1000_tx_udesc *dsc;
 	int desc, dtype, len, ntype, iovcnt, tcp, tso;
 	int mss, paylen, seg, tiovcnt, left, now, nleft, nnow, pv, pvoff;
-	unsigned hdrlen, vlen;
+	unsigned hdrlen, vlen, pktlen;
 	uint32_t tcpsum, tcpseq;
 	uint16_t ipcs, tcpcs, ipid, ohead;
+	bool invalid;
 
 	ckinfo[0].ck_valid = ckinfo[1].ck_valid = 0;
 	iovcnt = 0;
 	ntype = 0;
 	tso = 0;
+	pktlen = 0;
 	ohead = head;
+	invalid = false;
 
 	/* iovb[0/1] may be used for writable copy of headers. */
 	iov = &iovb[2];
@@ -1147,17 +1150,23 @@ e82545_transmit(struct e82545_softc *sc, uint16_t head, uint16_t tail,
 		len = (dtype == E1000_TXD_TYP_L) ? dsc->td.lower.flags.length :
 		    dsc->dd.lower.data & 0xFFFFF;
 
-		if (len > 0) {
-			/* Strip checksum supplied by guest. */
-			if ((dsc->td.lower.data & E1000_TXD_CMD_EOP) != 0 &&
-			    (dsc->td.lower.data & E1000_TXD_CMD_IFCS) == 0)
+		/* Strip checksum supplied by guest. */
+		if ((dsc->td.lower.data & E1000_TXD_CMD_EOP) != 0 &&
+		    (dsc->td.lower.data & E1000_TXD_CMD_IFCS) == 0) {
+			if (len <= 2) {
+				WPRINTF("final descriptor too short (%d) -- dropped",
+				    len);
+				invalid = true;
+			} else
 				len -= 2;
-			if (iovcnt < I82545_MAX_TXSEGS) {
-				iov[iovcnt].iov_base = paddr_guest2host(
-				    sc->esc_ctx, dsc->td.buffer_addr, len);
-				iov[iovcnt].iov_len = len;
-			}
+		}
+
+		if (len > 0 && iovcnt < I82545_MAX_TXSEGS) {
+			iov[iovcnt].iov_base = paddr_guest2host(sc->esc_ctx,
+			    dsc->td.buffer_addr, len);
+			iov[iovcnt].iov_len = len;
 			iovcnt++;
+			pktlen += len;
 		}
 
 		/*
@@ -1204,6 +1213,9 @@ e82545_transmit(struct e82545_softc *sc, uint16_t head, uint16_t tail,
 			break;
 		}
 	}
+
+	if (invalid)
+		goto done;
 
 	if (iovcnt > I82545_MAX_TXSEGS) {
 		WPRINTF("tx too many descriptors (%d > %d) -- dropped",
@@ -1298,8 +1310,13 @@ e82545_transmit(struct e82545_softc *sc, uint16_t head, uint16_t tail,
 		}
 	}
 
+	if (pktlen < hdrlen + vlen) {
+		WPRINTF("packet too small for writable header");
+		goto done;
+	}
+
 	/* Allocate, fill and prepend writable header vector. */
-	if (hdrlen != 0) {
+	if (hdrlen + vlen != 0) {
 		hdr = __builtin_alloca(hdrlen + vlen);
 		hdr += vlen;
 		for (left = hdrlen, hdrp = hdr; left > 0;

--- a/usr/src/cmd/bhyve/pci_e82545.c
+++ b/usr/src/cmd/bhyve/pci_e82545.c
@@ -1308,6 +1308,11 @@ e82545_transmit(struct e82545_softc *sc, uint16_t head, uint16_t tail,
 			    "(%d) -- dropped", hdrlen);
 			goto done;
 		}
+		if (ckinfo[1].ck_valid && hdrlen < ckinfo[1].ck_off + 2) {
+			WPRINTF("TSO hdrlen too small for TCP/UDP fields "
+			    "(%d) -- dropped", hdrlen);
+			goto done;
+		}
 	}
 
 	if (pktlen < hdrlen + vlen) {

--- a/usr/src/cmd/bhyve/pci_emul.c
+++ b/usr/src/cmd/bhyve/pci_emul.c
@@ -178,6 +178,18 @@ CFGREAD(struct pci_devinst *pi, int coff, int bytes)
 		return (pci_get_cfgdata32(pi, coff));
 }
 
+static int
+is_pcir_bar(int coff)
+{
+	return (coff >= PCIR_BAR(0) && coff < PCIR_BAR(PCI_BARMAX + 1));
+}
+
+static int
+is_pcir_bios(int coff)
+{
+	return (coff >= PCIR_BIOS && coff < PCIR_BIOS + 4);
+}
+
 /*
  * I/O access
  */
@@ -2132,27 +2144,23 @@ pci_cfgrw(struct vmctx *ctx, int vcpu, int in, int bus, int slot, int func,
 		/*
 		 * Special handling for write to BAR and ROM registers
 		 */
-		if ((coff >= PCIR_BAR(0) && coff < PCIR_BAR(PCI_BARMAX + 1)) ||
-		    (coff >= PCIR_BIOS && coff < PCIR_BIOS + 4)) {
+		if (is_pcir_bar(coff) || is_pcir_bios(coff)) {
 			/*
 			 * Ignore writes to BAR registers that are not
 			 * 4-byte aligned.
 			 */
 			if (bytes != 4 || (coff & 0x3) != 0)
 				return;
-#ifndef __FreeBSD__
-			if (coff < PCIR_BIOS) {
+
+			if (is_pcir_bar(coff)) {
 				idx = (coff - PCIR_BAR(0)) / 4;
-			} else {
+			} else if (is_pcir_bios(coff)) {
 				idx = PCI_ROM_IDX;
-			}
-#else
-			if (coff != PCIR_BIOS) {
-				idx = (coff - PCIR_BAR(0)) / 4;
 			} else {
-				idx = PCI_ROM_IDX;
+				errx(4, "%s: invalid BAR offset %d", __func__,
+				    coff);
 			}
-#endif
+
 			mask = ~(pi->pi_bar[idx].size - 1);
 			switch (pi->pi_bar[idx].type) {
 			case PCIBAR_NONE:

--- a/usr/src/cmd/bhyve/pci_xhci.c
+++ b/usr/src/cmd/bhyve/pci_xhci.c
@@ -167,6 +167,13 @@ struct pci_xhci_dev_ep {
 #define	ep_tr		_ep_trbsctx._epu_tr
 #define	ep_sctx		_ep_trbsctx._epu_sctx
 
+	/*
+	 * Caches the value of MaxPStreams from the endpoint context
+	 * when an endpoint is initialized and is used to validate the
+	 * use of ep_ringaddr vs ep_sctx_trbs[] as well as the length
+	 * of ep_sctx_trbs[].
+	 */
+	uint32_t ep_MaxPStreams;
 	union {
 		struct pci_xhci_trb_ring _epu_trb;
 		struct pci_xhci_trb_ring *_epu_sctx_trbs;
@@ -674,6 +681,7 @@ pci_xhci_init_ep(struct pci_xhci_dev_emu *dev, int epid)
 		devep->ep_tr = XHCI_GADDR(dev->xsc, devep->ep_ringaddr);
 		DPRINTF(("init_ep tr DCS %x", devep->ep_ccs));
 	}
+	devep->ep_MaxPStreams = pstreams;
 
 	if (devep->ep_xfer == NULL) {
 		devep->ep_xfer = malloc(sizeof(struct usb_data_xfer));
@@ -695,9 +703,8 @@ pci_xhci_disable_ep(struct pci_xhci_dev_emu *dev, int epid)
 	ep_ctx->dwEpCtx0 = (ep_ctx->dwEpCtx0 & ~0x7) | XHCI_ST_EPCTX_DISABLED;
 
 	devep = &dev->eps[epid];
-	if (XHCI_EPCTX_0_MAXP_STREAMS_GET(ep_ctx->dwEpCtx0) > 0 &&
-	    devep->ep_sctx_trbs != NULL)
-			free(devep->ep_sctx_trbs);
+	if (devep->ep_MaxPStreams > 0)
+		free(devep->ep_sctx_trbs);
 
 	if (devep->ep_xfer != NULL) {
 		free(devep->ep_xfer);
@@ -1157,7 +1164,7 @@ pci_xhci_cmd_reset_ep(struct pci_xhci_softc *sc, uint32_t slot,
 
 	ep_ctx->dwEpCtx0 = (ep_ctx->dwEpCtx0 & ~0x7) | XHCI_ST_EPCTX_STOPPED;
 
-	if (XHCI_EPCTX_0_MAXP_STREAMS_GET(ep_ctx->dwEpCtx0) == 0)
+	if (devep->ep_MaxPStreams == 0)
 		ep_ctx->qwEpCtx2 = devep->ep_ringaddr | devep->ep_ccs;
 
 	DPRINTF(("pci_xhci: reset ep[%u] %08x %08x %016lx %08x",
@@ -1178,16 +1185,15 @@ done:
 
 static uint32_t
 pci_xhci_find_stream(struct pci_xhci_softc *sc, struct xhci_endp_ctx *ep,
-    uint32_t streamid, struct xhci_stream_ctx **osctx)
+    struct pci_xhci_dev_ep *devep, uint32_t streamid,
+    struct xhci_stream_ctx **osctx)
 {
 	struct xhci_stream_ctx *sctx;
-	uint32_t	maxpstreams;
 
-	maxpstreams = XHCI_EPCTX_0_MAXP_STREAMS_GET(ep->dwEpCtx0);
-	if (maxpstreams == 0)
+	if (devep->ep_MaxPStreams == 0)
 		return (XHCI_TRB_ERROR_TRB);
 
-	if (maxpstreams > XHCI_STREAMS_MAX)
+	if (devep->ep_MaxPStreams > XHCI_STREAMS_MAX)
 		return (XHCI_TRB_ERROR_INVALID_SID);
 
 	if (XHCI_EPCTX_0_LSA_GET(ep->dwEpCtx0) == 0) {
@@ -1196,7 +1202,7 @@ pci_xhci_find_stream(struct pci_xhci_softc *sc, struct xhci_endp_ctx *ep,
 	}
 
 	/* only support primary stream */
-	if (streamid > maxpstreams)
+	if (streamid > devep->ep_MaxPStreams)
 		return (XHCI_TRB_ERROR_STREAM_TYPE);
 
 	sctx = XHCI_GADDR(sc, ep->qwEpCtx2 & ~0xFUL) + streamid;
@@ -1258,11 +1264,12 @@ pci_xhci_cmd_set_tr(struct pci_xhci_softc *sc, uint32_t slot,
 	}
 
 	streamid = XHCI_TRB_2_STREAM_GET(trb->dwTrb2);
-	if (XHCI_EPCTX_0_MAXP_STREAMS_GET(ep_ctx->dwEpCtx0) > 0) {
+	if (devep->ep_MaxPStreams > 0) {
 		struct xhci_stream_ctx *sctx;
 
 		sctx = NULL;
-		cmderr = pci_xhci_find_stream(sc, ep_ctx, streamid, &sctx);
+		cmderr = pci_xhci_find_stream(sc, ep_ctx, devep, streamid,
+		    &sctx);
 		if (sctx != NULL) {
 			assert(devep->ep_sctx != NULL);
 
@@ -1632,7 +1639,7 @@ pci_xhci_update_ep_ring(struct pci_xhci_softc *sc, struct pci_xhci_dev_emu *dev,
     uint32_t streamid, uint64_t ringaddr, int ccs)
 {
 
-	if (XHCI_EPCTX_0_MAXP_STREAMS_GET(ep_ctx->dwEpCtx0) != 0) {
+	if (devep->ep_MaxPStreams != 0) {
 		devep->ep_sctx[streamid].qwSctx0 = (ringaddr & ~0xFUL) |
 		                                   (ccs & 0x1);
 
@@ -1959,7 +1966,7 @@ pci_xhci_device_doorbell(struct pci_xhci_softc *sc, uint32_t slot,
 	}
 
 	/* get next trb work item */
-	if (XHCI_EPCTX_0_MAXP_STREAMS_GET(ep_ctx->dwEpCtx0) != 0) {
+	if (devep->ep_MaxPStreams != 0) {
 		struct xhci_stream_ctx *sctx;
 
 		/*
@@ -1972,7 +1979,7 @@ pci_xhci_device_doorbell(struct pci_xhci_softc *sc, uint32_t slot,
 		}
 
 		sctx = NULL;
-		pci_xhci_find_stream(sc, ep_ctx, streamid, &sctx);
+		pci_xhci_find_stream(sc, ep_ctx, devep, streamid, &sctx);
 		if (sctx == NULL) {
 			DPRINTF(("pci_xhci: invalid stream %u", streamid));
 			return;


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Sun Sep 18 16:27:20 UTC 2022 ====
==== Nightly distributed build completed: Sun Sep 18 18:22:58 UTC 2022 ====

==== Total build time ====

real    1:55:37

==== Build environment ====

/usr/bin/uname
SunOS r151042 5.11 omnios-r151042-73702cd512 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 6.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151042/10.3.0-il-1) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151042/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151042/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.16+8-omnios-151042"

/usr/bin/openssl
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1781 (illumos)

Build project:  default
Build taskid:   166

==== Nightly argument issues ====


==== Build version ====

omnios-bhyver42-1a7cf211eb

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    56:24.6
user  7:25:24.7
sys   4:02:41.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    34:40.9
user  5:22:07.3
sys   1:45:04.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
