### PR TITLE
Upstream merge/2022092901

### DIFF
--- a/usr/src/cmd/hal/hald/solaris/sysevent.c
+++ b/usr/src/cmd/hal/hald/solaris/sysevent.c
@@ -184,7 +184,7 @@ sysevent_dev_handler(sysevent_t *ev)
 
 		snprintf(s, sizeof (s), "%s %s %s\n",
 		    class, subclass, phys_path);
-		nwritten = write(sysevent_pipe_fds[1], s, strlen(s) + 1);
+		nwritten = write(sysevent_pipe_fds[1], s, strlen(s));
 
 		HAL_INFO (("sysevent_dev_handler: wrote %d bytes", nwritten));
 		goto out;
@@ -233,7 +233,7 @@ sysevent_dev_handler(sysevent_t *ev)
 
 	snprintf(s, sizeof (s), "%s %s %s %s %s %s %d\n",
 	    class, subclass, phys_path, dev_name, dev_hid, dev_uid, dev_index);
-	nwritten = write(sysevent_pipe_fds[1], s, strlen(s) + 1);
+	nwritten = write(sysevent_pipe_fds[1], s, strlen(s));
 
 	HAL_INFO (("sysevent_dev_handler: wrote %d bytes", nwritten));
 

--- a/usr/src/uts/intel/io/vmm/vmm_sol_dev.c
+++ b/usr/src/uts/intel/io/vmm/vmm_sol_dev.c
@@ -2935,9 +2935,6 @@ vmm_ctl_ioctl(int cmd, intptr_t arg, int md, cred_t *cr, int *rvalp)
 	}
 	case VMM_VM_SUPPORTED:
 		return (vmm_is_supported(arg));
-	case VMM_INTERFACE_VERSION:
-		*rvalp = VMM_CURRENT_INTERFACE_VERSION;
-		return (0);
 	case VMM_CHECK_IOMMU:
 		if (!vmm_check_iommu()) {
 			return (ENXIO);
@@ -2972,6 +2969,15 @@ vmm_ioctl(dev_t dev, int cmd, intptr_t arg, int mode, cred_t *credp,
 	/* The structs in bhyve ioctls assume a 64-bit datamodel */
 	if (ddi_model_convert_from(mode & FMODELS) != DDI_MODEL_NONE) {
 		return (ENOTSUP);
+	}
+
+	/*
+	 * Regardless of minor (vmmctl or instance), we respond to queries of
+	 * the interface version.
+	 */
+	if (cmd == VMM_INTERFACE_VERSION) {
+		*rvalp = VMM_CURRENT_INTERFACE_VERSION;
+		return (0);
 	}
 
 	minor = getminor(dev);


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151043  omnios-upstream_merge-2022092901-7ec4c74df51    September 2022
illumos development build: 2022-Sep-29 [illumos-omnios]
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-upstream_merge-2022092901-7ec4c74df51 i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Thu Sep 29 15:45:29 UTC 2022 ====
==== Nightly distributed build completed: Thu Sep 29 16:26:11 UTC 2022 ====

==== Total build time ====

real    0:40:41

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-58966f25ef4 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 24

cw version 6.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151043/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151043/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.16.1+1-omnios-151043"

/usr/bin/openssl
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1786 (illumos)

Build project:  default
Build taskid:   119

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2022092901-7ec4c74df51

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    15:43.3
user  3:49:05.8
sys   1:17:53.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    12:55.3
user  3:16:33.6
sys   1:08:59.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```