### PR TITLE
Backports to r151044

### DIFF
--- a/usr/src/common/zfs/zprop_common.c
+++ b/usr/src/common/zfs/zprop_common.c
@@ -410,6 +410,12 @@ zprop_width(int prop, boolean_t *fixed, zfs_type_t type)
 		 */
 		if (prop == ZFS_PROP_CREATION)
 			*fixed = B_FALSE;
+		/*
+		 * 'health' is handled specially because it's a number
+		 * internally, but displayed as a fixed 8 character string.
+		 */
+		if (prop == ZPOOL_PROP_HEALTH)
+			ret = 8;
 		break;
 	case PROP_TYPE_INDEX:
 		idx = prop_tbl[prop].pd_table;

--- a/usr/src/pkg/manifests/system-test-ostest.p5m
+++ b/usr/src/pkg/manifests/system-test-ostest.p5m
@@ -99,6 +99,8 @@ file path=opt/os-tests/tests/poll_test mode=0555
 dir  path=opt/os-tests/tests/portfs
 file path=opt/os-tests/tests/portfs/file_assoc.32 mode=0555
 file path=opt/os-tests/tests/portfs/file_assoc.64 mode=0555
+dir  path=opt/os-tests/tests/regression
+file path=opt/os-tests/tests/regression/illumos-15031 mode=0555
 dir  path=opt/os-tests/tests/sdevfs
 file path=opt/os-tests/tests/sdevfs/sdevfs_eisdir mode=0555
 dir  path=opt/os-tests/tests/secflags

--- a/usr/src/test/os-tests/runfiles/default.run
+++ b/usr/src/test/os-tests/runfiles/default.run
@@ -142,3 +142,6 @@ tests = ['coretests']
 
 [/opt/os-tests/tests/portfs]
 tests = ['file_assoc.32', 'file_assoc.64']
+
+[/opt/os-tests/tests/regression]
+tests = ['illumos-15031']

--- a/usr/src/test/os-tests/tests/Makefile
+++ b/usr/src/test/os-tests/tests/Makefile
@@ -29,6 +29,7 @@ SUBDIRS =       \
 		pf_key \
 		poll \
 		portfs \
+		regression \
 		sdevfs \
 		secflags \
 		sigqueue \

--- a/usr/src/test/os-tests/tests/regression/Makefile
+++ b/usr/src/test/os-tests/tests/regression/Makefile
@@ -1,0 +1,53 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Oxide Computer Company
+#
+
+PROGS = \
+	illumos-15031
+
+ROOTOPTDIR = $(ROOT)/opt/os-tests/tests
+ROOTOPTREGRESSION = $(ROOTOPTDIR)/regression
+ROOTOPTPROGS = $(PROGS:%=$(ROOTOPTREGRESSION)/%)
+
+include $(SRC)/cmd/Makefile.cmd
+
+CSTD=$(GNU_C99)
+
+.KEEP_STATE:
+
+all: $(PROGS)
+
+install: $(ROOTOPTPROGS)
+
+clean:
+
+$(ROOTOPTPROGS): $(PROGS) $(ROOTOPTREGRESSION)
+
+$(ROOTOPTDIR):
+	$(INS.dir)
+
+$(ROOTOPTREGRESSION): $(ROOTOPTDIR)
+	$(INS.dir)
+
+$(ROOTOPTREGRESSION)/%: %
+	$(INS.file)
+
+%: %.c
+	$(LINK.c) -o $@ $< $(LDLIBS)
+	$(POST_PROCESS)
+
+clobber:
+	$(RM) $(PROGS)
+
+FRC:

--- a/usr/src/test/os-tests/tests/regression/illumos-15031.c
+++ b/usr/src/test/os-tests/tests/regression/illumos-15031.c
@@ -1,0 +1,85 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <port.h>
+#include <err.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/param.h>
+#include <sys/poll.h>
+#include <stdbool.h>
+
+static bool
+has_event(int pfd)
+{
+	port_event_t ev = { 0 };
+	timespec_t ts = { 0 };
+
+	/* Because of illumos 14912, more care needs to be taken here */
+	int res = port_get(pfd, &ev, &ts);
+	if (res != 0 || ev.portev_source == 0) {
+		return (false);
+	} else {
+		return (true);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	int res;
+	int pipes[2];
+
+	res = pipe2(pipes, 0);
+	assert(res == 0);
+
+	int pfd = port_create();
+	assert(pfd >= 0);
+
+	res = port_associate(pfd, PORT_SOURCE_FD, (uintptr_t)pipes[1], POLLIN,
+	    NULL);
+	assert(res == 0);
+
+	if (has_event(pfd)) {
+		errx(EXIT_FAILURE, "FAIL - unexpected early event");
+	}
+
+	char port_path[MAXPATHLEN];
+	(void) sprintf(port_path, "/proc/%d/fd/%d", getpid(), pfd);
+
+	/* incur the procfs FDINFO access */
+	struct stat sbuf;
+	res = lstat(port_path, &sbuf);
+	assert(res == 0);
+
+	/* write a byte to wake up the pipe */
+	(void) write(pipes[0], port_path, 1);
+
+	/*
+	 * Check to see that the FDINFO access did not detach our registration
+	 * for the event port.
+	 */
+	if (!has_event(pfd)) {
+		errx(EXIT_FAILURE, "FAIL - no event found");
+	}
+
+	(void) printf("PASS\n");
+	return (EXIT_SUCCESS);
+}

--- a/usr/src/uts/common/fs/proc/prdata.h
+++ b/usr/src/uts/common/fs/proc/prdata.h
@@ -354,6 +354,7 @@ extern	int	pr_set(proc_t *, long);
 extern	int	pr_unset(proc_t *, long);
 extern	void	pr_sethold(prnode_t *, sigset_t *);
 extern	file_t	*pr_getf(proc_t *, uint_t, short *);
+extern	void	pr_releasef(file_t *);
 extern	void	pr_setfault(proc_t *, fltset_t *);
 extern	int	prusrio(proc_t *, enum uio_rw, struct uio *, int);
 extern	int	prreadargv(proc_t *, char *, size_t, size_t *);

--- a/usr/src/uts/common/fs/proc/prsubr.c
+++ b/usr/src/uts/common/fs/proc/prsubr.c
@@ -24,6 +24,7 @@
  * Copyright 2019 Joyent, Inc.
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2022 MNX Cloud, Inc.
+ * Copyright 2022 Oxide Computer Company
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1620,6 +1621,54 @@ retry:
 	}
 
 	return (fp);
+}
+
+
+/*
+ * Just as pr_getf() is a little unusual in how it goes about making the file_t
+ * safe for procfs consumers to access it, so too is pr_releasef() for safely
+ * releasing that "hold".  The "hold" is unlike normal file descriptor activity
+ * -- procfs is just an interloper here, wanting access to the vnode_t without
+ * risk of a racing close() disrupting the state.  Just as pr_getf() avoids some
+ * of the typical file_t behavior (such as auditing) when establishing its hold,
+ * so too should pr_releasef().  It should not go through the motions of
+ * closef() (since it is not a true close()) unless racing activity causes it to
+ * be the last actor holding the refcount above zero.
+ *
+ * Under normal circumstances, we expect to find file_t`f_count > 1 after
+ * the successful pr_getf() call.  We are, after all, accessing a resource
+ * already held by the process in question.  We would also expect to rarely race
+ * with a close() of the underlying fd, meaning that file_t`f_count > 1 would
+ * still holds at pr_releasef() time.  That would mean we only need to decrement
+ * f_count, leaving it to the process to later close the fd (thus triggering
+ * VOP_CLOSE(), etc).
+ *
+ * It is only when that process manages to close() the fd while we have it
+ * "held" in procfs that we must make a trip through the traditional closef()
+ * logic to ensure proper tear-down of the file_t.
+ */
+void
+pr_releasef(file_t *fp)
+{
+	mutex_enter(&fp->f_tlock);
+	if (fp->f_count > 1) {
+		/*
+		 * This is the most common case: The file is still held open by
+		 * the process, and we simply need to release our hold by
+		 * decrementing f_count
+		 */
+		fp->f_count--;
+		mutex_exit(&fp->f_tlock);
+	} else {
+		/*
+		 * A rare occasion: The process snuck a close() of this file
+		 * while we were doing our business in procfs.  Given that
+		 * f_count == 1, we are the only one with a reference to the
+		 * file_t and need to take a trip through closef() to free it.
+		 */
+		mutex_exit(&fp->f_tlock);
+		(void) closef(fp);
+	}
 }
 
 void

--- a/usr/src/uts/common/fs/proc/prvnops.c
+++ b/usr/src/uts/common/fs/proc/prvnops.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2017 by Delphix. All rights reserved.
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2022 MNX Cloud, Inc.
+ * Copyright 2022 Oxide Computer Company
  */
 
 /*	Copyright (c) 1984,	 1986, 1987, 1988, 1989 AT&T	*/
@@ -963,7 +964,7 @@ pr_read_fdinfo(prnode_t *pnp, uio_t *uiop, cred_t *cr)
 
 	error = prgetfdinfo(p, fp->f_vnode, fdinfo, cr, fp->f_cred, &data);
 
-	(void) closef(fp);
+	pr_releasef(fp);
 
 out:
 	if (error == 0)
@@ -3386,7 +3387,7 @@ prgetattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *cr,
 		prunlock(pnp);
 		vap->va_size = prgetfdinfosize(p, fp->f_vnode, cr);
 		vap->va_nblocks = (fsblkcnt64_t)btod(vap->va_size);
-		(void) closef(fp);
+		pr_releasef(fp);
 		return (0);
 	}
 	case PR_LWPDIR:
@@ -4497,8 +4498,9 @@ pr_lookup_fddir(vnode_t *dp, char *comp)
 	}
 
 	prunlock(dpnp);
-	if (fp != NULL)
-		(void) closef(fp);
+	if (fp != NULL) {
+		pr_releasef(fp);
+	}
 
 	if (vp == NULL) {
 		prfreenode(pnp);

--- a/usr/src/uts/common/fs/zfs/sys/zfs_vfsops.h
+++ b/usr/src/uts/common/fs/zfs/sys/zfs_vfsops.h
@@ -68,6 +68,7 @@ struct zfsvfs {
 	krwlock_t	z_teardown_inactive_lock;
 	list_t		z_all_znodes;	/* all vnodes in the fs */
 	kmutex_t	z_znodes_lock;	/* lock for z_all_znodes */
+	vnode_t		*z_rootdir;	/* mount root directory pointer */
 	vnode_t		*z_ctldir;	/* .zfs directory pointer */
 	boolean_t	z_show_ctldir;	/* expose .zfs in the root dir */
 	boolean_t	z_issnap;	/* true if this is a snapshot */

--- a/usr/src/uts/common/fs/zfs/zfs_vfsops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vfsops.c
@@ -26,6 +26,7 @@
  * Copyright 2020 Joyent, Inc.
  * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2022 Oxide Computer Company
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -1435,6 +1436,13 @@ zfs_domount(vfs_t *vfsp, char *osname)
 		error = zfsvfs_setup(zfsvfs, B_TRUE);
 	}
 
+	/* cache the root vnode for this mount */
+	znode_t *rootzp;
+	if (error = zfs_zget(zfsvfs, zfsvfs->z_root, &rootzp)) {
+		goto out;
+	}
+	zfsvfs->z_rootdir = ZTOV(rootzp);
+
 	if (!zfsvfs->z_issnap)
 		zfsctl_create(zfsvfs);
 out:
@@ -1837,22 +1845,21 @@ zfs_mountroot(vfs_t *vfsp, enum whymountroot why)
 			goto out;
 		}
 
+		/* zfs_domount has already cached the root vnode for us */
 		zfsvfs = (zfsvfs_t *)vfsp->vfs_data;
 		ASSERT(zfsvfs);
-		if (error = zfs_zget(zfsvfs, zfsvfs->z_root, &zp)) {
-			cmn_err(CE_NOTE, "zfs_zget: error %d", error);
-			goto out;
-		}
+		ASSERT(zfsvfs->z_rootdir);
 
-		vp = ZTOV(zp);
+		vp = zfsvfs->z_rootdir;
 		mutex_enter(&vp->v_lock);
 		vp->v_flag |= VROOT;
 		mutex_exit(&vp->v_lock);
-		rootvp = vp;
 
 		/*
 		 * Leave rootvp held.  The root file system is never unmounted.
 		 */
+		VN_HOLD(vp);
+		rootvp = vp;
 
 		vfs_add((struct vnode *)0, vfsp,
 		    (vfsp->vfs_flag & VFS_RDONLY) ? MS_RDONLY : 0);
@@ -2085,17 +2092,24 @@ static int
 zfs_root(vfs_t *vfsp, vnode_t **vpp)
 {
 	zfsvfs_t *zfsvfs = vfsp->vfs_data;
-	znode_t *rootzp;
+	struct vnode *vp;
 	int error;
 
 	ZFS_ENTER(zfsvfs);
 
-	error = zfs_zget(zfsvfs, zfsvfs->z_root, &rootzp);
-	if (error == 0)
-		*vpp = ZTOV(rootzp);
+	vp = zfsvfs->z_rootdir;
+	if (vp != NULL) {
+		VN_HOLD(vp);
+		error = 0;
+	} else {
+		/* forced unmount */
+		error = EIO;
+	}
+	*vpp = vp;
 
 	ZFS_EXIT(zfsvfs);
 	return (error);
+
 }
 
 /*
@@ -2167,9 +2181,20 @@ zfsvfs_teardown(zfsvfs_t *zfsvfs, boolean_t unmounting)
 	 * other vops will fail with EIO.
 	 */
 	if (unmounting) {
+		/*
+		 * Clear the cached root vnode now that we are unmounted.
+		 * Its release must be performed outside the teardown locks to
+		 * avoid recursive lock entry via zfs_inactive().
+		 */
+		vnode_t *vp = zfsvfs->z_rootdir;
+		zfsvfs->z_rootdir = NULL;
+
 		zfsvfs->z_unmounted = B_TRUE;
 		rw_exit(&zfsvfs->z_teardown_inactive_lock);
 		rrm_exit(&zfsvfs->z_teardown_lock, FTAG);
+
+		/* Drop the cached root vp now that it is safe */
+		VN_RELE(vp);
 	}
 
 	/*
@@ -2237,14 +2262,24 @@ zfs_umount(vfs_t *vfsp, int fflag, cred_t *cr)
 		 */
 		boolean_t draining;
 		uint_t thresh = 1;
+		vnode_t *ctlvp, *rvp;
+
+		/*
+		 * The cached vnode for the root directory of the mount also
+		 * maintains a hold on the vfs structure.
+		 */
+		rvp = zfsvfs->z_rootdir;
+		thresh++;
 
 		/*
 		 * The '.zfs' directory maintains a reference of its own, and
 		 * any active references underneath are reflected in the vnode
 		 * count. Allow one additional reference for it.
 		 */
-		if (zfsvfs->z_ctldir != NULL)
+		ctlvp = zfsvfs->z_ctldir;
+		if (ctlvp != NULL) {
 			thresh++;
+		}
 
 		/*
 		 * If it's running, the asynchronous unlinked drain task needs
@@ -2255,8 +2290,8 @@ zfs_umount(vfs_t *vfsp, int fflag, cred_t *cr)
 		if (draining)
 			zfs_unlinked_drain_stop_wait(zfsvfs);
 
-		if (vfsp->vfs_count > thresh || (zfsvfs->z_ctldir != NULL &&
-		    zfsvfs->z_ctldir->v_count > 1)) {
+		if (vfsp->vfs_count > thresh || rvp->v_count > 1 ||
+		    (ctlvp != NULL && ctlvp->v_count > 1)) {
 			if (draining) {
 				/* If it was draining, restart the task */
 				zfs_unlinked_drain(zfsvfs);


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Tue Oct  4 15:20:32 UTC 2022 ====
==== Nightly distributed build completed: Tue Oct  4 16:40:59 UTC 2022 ====

==== Total build time ====

real    1:20:27

==== Build environment ====

/usr/bin/uname
SunOS r151044 5.11 omnios-r151044-8d2a88fb9d i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 6.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151044/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151044/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151044/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.16.1+1-omnios-151044"

/usr/bin/openssl
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1786 (illumos)

Build project:  default
Build taskid:   180

==== Nightly argument issues ====


==== Build version ====

omnios-bpr44-cd6d6a70d9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    31:19.1
user  4:25:05.7
sys   1:26:15.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:29.6
user  3:44:53.1
sys   1:16:37.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
