### PR TITLE
Backports to r151044

### DIFF
--- a/usr/src/pkg/manifests/system-bhyve-tests.p5m
+++ b/usr/src/pkg/manifests/system-bhyve-tests.p5m
@@ -56,6 +56,7 @@ dir  path=opt/bhyve-tests/tests/vmm
 file path=opt/bhyve-tests/tests/vmm/auto_destruct mode=0555
 file path=opt/bhyve-tests/tests/vmm/check_iommu mode=0555
 file path=opt/bhyve-tests/tests/vmm/cpuid_ioctl mode=0555
+file path=opt/bhyve-tests/tests/vmm/datarw_constraints mode=0555
 file path=opt/bhyve-tests/tests/vmm/drv_hold mode=0555
 file path=opt/bhyve-tests/tests/vmm/fpu_getset mode=0555
 file path=opt/bhyve-tests/tests/vmm/interface_version mode=0555

--- a/usr/src/test/bhyve-tests/runfiles/default.run
+++ b/usr/src/test/bhyve-tests/runfiles/default.run
@@ -24,6 +24,7 @@ user = root
 tests = [
 	'auto_destruct',
 	'cpuid_ioctl',
+	'datarw_constraints',
 	'drv_hold',
 	'fpu_getset',
 	'interface_version',

--- a/usr/src/test/bhyve-tests/tests/vmm/Makefile
+++ b/usr/src/test/bhyve-tests/tests/vmm/Makefile
@@ -25,7 +25,8 @@ PROG =	mem_partial \
 	legacy_destruct \
 	self_destruct \
 	drv_hold \
-	cpuid_ioctl
+	cpuid_ioctl \
+	datarw_constraints
 
 COMMON_OBJS =	common.o
 CLEAN_OBJS =	$(PROG:%=%.o)

--- a/usr/src/test/bhyve-tests/tests/vmm/datarw_constraints.c
+++ b/usr/src/test/bhyve-tests/tests/vmm/datarw_constraints.c
@@ -1,0 +1,111 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <err.h>
+#include <assert.h>
+#include <sys/sysmacros.h>
+#include <stdbool.h>
+
+#include <sys/vmm.h>
+#include <sys/vmm_dev.h>
+#include <sys/vmm_data.h>
+#include <vmmapi.h>
+
+#include "common.h"
+
+static void
+should_eq_u32(const char *field_name, uint32_t a, uint32_t b)
+{
+	if (a != b) {
+		errx(EXIT_FAILURE, "unexpected %s %u != %u",
+		    field_name, a, b);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	const char *suite_name = basename(argv[0]);
+	struct vmctx *ctx;
+
+	ctx = create_test_vm(suite_name);
+	if (ctx == NULL) {
+		errx(EXIT_FAILURE, "could not open test VM");
+	}
+
+	/*
+	 * Check that vmm_data import/export facility is robust in the face of
+	 * potentially invalid inputs
+	 */
+	const int vmfd = vm_get_device_fd(ctx);
+
+	uint8_t buf[sizeof (struct vdi_atpic_v1) + sizeof (int)];
+	struct vm_data_xfer vdx = {
+		.vdx_class = VDC_ATPIC,
+		.vdx_version = 1,
+		.vdx_len = sizeof (struct vdi_atpic_v1),
+		.vdx_data = buf,
+	};
+
+	/* Attempt a valid-sized read first */
+	if (ioctl(vmfd, VM_DATA_READ, &vdx) != 0) {
+		err(EXIT_FAILURE, "valid vmm_dat_read failed");
+	}
+	should_eq_u32("vdx_result_len", vdx.vdx_result_len,
+	    sizeof (struct vdi_atpic_v1));
+
+	/* ... then too-small ... */
+	vdx.vdx_len = sizeof (struct vdi_atpic_v1) - sizeof (int);
+	vdx.vdx_result_len = 0;
+	if (ioctl(vmfd, VM_DATA_READ, &vdx) == 0) {
+		errx(EXIT_FAILURE, "invalid vmm_dat_read should have failed");
+	}
+	int error = errno;
+	if (error != ENOSPC) {
+		errx(EXIT_FAILURE, "expected ENOSPC errno, got %d", error);
+	}
+	/* the "correct" vdx_result_len should still be communicated out */
+	should_eq_u32("vdx_result_len", vdx.vdx_result_len,
+	    sizeof (struct vdi_atpic_v1));
+
+	/*
+	 * ... and too-big to round it out.
+	 *
+	 * This should pass, but still set vdx_result_len to the actual length
+	 */
+	vdx.vdx_len = sizeof (struct vdi_atpic_v1) + sizeof (int);
+	vdx.vdx_result_len = 0;
+	if (ioctl(vmfd, VM_DATA_READ, &vdx) != 0) {
+		err(EXIT_FAILURE, "too-large (but valid) vmm_dat_read failed");
+	}
+	should_eq_u32("vdx_result_len", vdx.vdx_result_len,
+	    sizeof (struct vdi_atpic_v1));
+
+	/*
+	 * The vmm_data_write paths should also be tested, but not until they
+	 * are exposed to the general public without requring mdb -kw settings.
+	 */
+
+	vm_destroy(ctx);
+	(void) printf("%s\tPASS\n", suite_name);
+	return (EXIT_SUCCESS);
+}

--- a/usr/src/tools/find_elf/find_elf.c
+++ b/usr/src/tools/find_elf/find_elf.c
@@ -797,7 +797,7 @@ maybe_obj(const char *name, mode_t mode)
 	size_t len = strlen(name);
 
 	/* If the file name ends in .so, we check */
-	if (len >= 3 && strcmp(&name[len - 4], ".so") == 0) {
+	if (len >= 3 && strcmp(&name[len - 3], ".so") == 0) {
 		return (true);
 	}
 

--- a/usr/src/uts/intel/io/vmm/io/vatpic.c
+++ b/usr/src/uts/intel/io/vmm/io/vatpic.c
@@ -803,7 +803,7 @@ vatpic_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_ATPIC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_atpic_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_atpic_v1));
 
 	struct vatpic *vatpic = datap;
 	struct vdi_atpic_v1 *out = req->vdr_data;
@@ -864,7 +864,7 @@ vatpic_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_ATPIC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_atpic_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_atpic_v1));
 
 	struct vatpic *vatpic = datap;
 	const struct vdi_atpic_v1 *src = req->vdr_data;

--- a/usr/src/uts/intel/io/vmm/io/vatpit.c
+++ b/usr/src/uts/intel/io/vmm/io/vatpit.c
@@ -502,7 +502,7 @@ vatpit_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_ATPIT);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_atpit_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_atpit_v1));
 
 	struct vatpit *vatpit = datap;
 	struct vdi_atpit_v1 *out = req->vdr_data;
@@ -556,7 +556,7 @@ vatpit_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_ATPIT);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_atpit_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_atpit_v1));
 
 	struct vatpit *vatpit = datap;
 	const struct vdi_atpit_v1 *src = req->vdr_data;

--- a/usr/src/uts/intel/io/vmm/io/vhpet.c
+++ b/usr/src/uts/intel/io/vmm/io/vhpet.c
@@ -744,7 +744,7 @@ vhpet_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_HPET);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_hpet_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_hpet_v1));
 
 	struct vhpet *vhpet = datap;
 	struct vdi_hpet_v1 *out = req->vdr_data;
@@ -789,7 +789,7 @@ static enum vhpet_validation_error
 vhpet_data_validate(const vmm_data_req_t *req, struct vm *vm)
 {
 	ASSERT(req->vdr_version == 1 &&
-	    req->vdr_len == sizeof (struct vdi_hpet_v1));
+	    req->vdr_len >= sizeof (struct vdi_hpet_v1));
 	const struct vdi_hpet_v1 *src = req->vdr_data;
 
 	/* LegacyReplacement Routing is not supported */
@@ -859,7 +859,7 @@ vhpet_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_HPET);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_hpet_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_hpet_v1));
 
 	struct vhpet *vhpet = datap;
 

--- a/usr/src/uts/intel/io/vmm/io/vioapic.c
+++ b/usr/src/uts/intel/io/vmm/io/vioapic.c
@@ -458,7 +458,7 @@ vioapic_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_IOAPIC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_ioapic_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_ioapic_v1));
 
 	struct vioapic *vioapic = datap;
 	struct vdi_ioapic_v1 *out = req->vdr_data;
@@ -480,7 +480,7 @@ vioapic_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_IOAPIC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_ioapic_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_ioapic_v1));
 
 	struct vioapic *vioapic = datap;
 	const struct vdi_ioapic_v1 *src = req->vdr_data;

--- a/usr/src/uts/intel/io/vmm/io/vlapic.c
+++ b/usr/src/uts/intel/io/vmm/io/vlapic.c
@@ -1713,7 +1713,7 @@ vlapic_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_LAPIC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_lapic_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_lapic_v1));
 
 	struct vlapic *vlapic = datap;
 	struct vdi_lapic_v1 *out = req->vdr_data;
@@ -1807,7 +1807,7 @@ static enum vlapic_validation_error
 vlapic_data_validate(const struct vlapic *vlapic, const vmm_data_req_t *req)
 {
 	ASSERT(req->vdr_version == 1 &&
-	    req->vdr_len == sizeof (struct vdi_lapic_v1));
+	    req->vdr_len >= sizeof (struct vdi_lapic_v1));
 	const struct vdi_lapic_v1 *src = req->vdr_data;
 
 	if ((src->vl_esr_pending & ~APIC_VALID_MASK_ESR) != 0 ||
@@ -1865,7 +1865,7 @@ vlapic_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_LAPIC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_lapic_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_lapic_v1));
 
 	struct vlapic *vlapic = datap;
 	if (vlapic_data_validate(vlapic, req) != VVE_OK) {

--- a/usr/src/uts/intel/io/vmm/io/vpmtmr.c
+++ b/usr/src/uts/intel/io/vmm/io/vpmtmr.c
@@ -161,7 +161,7 @@ vpmtmr_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_PM_TIMER);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_pm_timer_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_pm_timer_v1));
 
 	struct vpmtmr *vpmtmr = datap;
 	struct vdi_pm_timer_v1 *out = req->vdr_data;
@@ -177,7 +177,7 @@ vpmtmr_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_PM_TIMER);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_pm_timer_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_pm_timer_v1));
 
 	struct vpmtmr *vpmtmr = datap;
 	const struct vdi_pm_timer_v1 *src = req->vdr_data;

--- a/usr/src/uts/intel/io/vmm/io/vrtc.c
+++ b/usr/src/uts/intel/io/vmm/io/vrtc.c
@@ -975,7 +975,7 @@ vrtc_data_read(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_RTC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_rtc_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_rtc_v1));
 
 	struct vrtc *vrtc = datap;
 	struct vdi_rtc_v1 *out = req->vdr_data;
@@ -999,7 +999,7 @@ vrtc_data_write(void *datap, const vmm_data_req_t *req)
 {
 	VERIFY3U(req->vdr_class, ==, VDC_RTC);
 	VERIFY3U(req->vdr_version, ==, 1);
-	VERIFY3U(req->vdr_len, ==, sizeof (struct vdi_rtc_v1));
+	VERIFY3U(req->vdr_len, >=, sizeof (struct vdi_rtc_v1));
 
 	struct vrtc *vrtc = datap;
 	const struct vdi_rtc_v1 *src = req->vdr_data;


### PR DESCRIPTION

## mail_msg

```

==== Nightly distributed build started:   Thu Oct 27 11:15:14 UTC 2022 ====
==== Nightly distributed build completed: Thu Oct 27 12:29:07 UTC 2022 ====

==== Total build time ====

real    1:13:52

==== Build environment ====

/usr/bin/uname
SunOS r151044 5.11 omnios-r151044-caa7cadcf6 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 6.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151044/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151044/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151044/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.17+8-omnios-151044"

/usr/bin/openssl
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1786 (illumos)

Build project:  default
Build taskid:   97

==== Nightly argument issues ====


==== Build version ====

omnios-bpr44-2a007d8f65

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:42.6
user  4:16:17.4
sys   1:09:59.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    24:35.2
user  3:38:08.4
sys   1:02:58.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
