### PR TITLE
Upstream merge/2022111101

### DIFF
--- a/exception_lists/wscheck
+++ b/exception_lists/wscheck
@@ -108,4 +108,4 @@ usr/src/lib/lib9p/common/*
 # These bits form the mdb test suite are all literal output from mdb and
 # therefore trailing spaces may be part of what mdb does today.
 #
-usr/src/test/util-tests/tests/mdb/*/*.mdb.out
+usr/src/test/util-tests/tests/mdb/*/*.*.out

--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -34,4 +34,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2022.09.04.1
+BOOT_VERSION = $(LOADER_VERSION)-2022.11.02.1

--- a/usr/src/boot/common/module.c
+++ b/usr/src/boot/common/module.c
@@ -458,9 +458,14 @@ build_environment_module(void)
 	vm_offset_t laddr;
 
 	/* We can't load first */
-	if ((file_findfile(NULL, NULL)) == NULL) {
+	if (file_findfile(NULL, NULL) == NULL) {
 		printf("Can not load environment module: %s\n",
 		    "the kernel is not loaded");
+		return;
+	}
+
+	if (file_findfile(name, name) != NULL) {
+		printf("warning: '%s' is already loaded\n", name);
 		return;
 	}
 
@@ -522,9 +527,14 @@ build_font_module(void)
 		return;
 
 	/* We can't load first */
-	if ((file_findfile(NULL, NULL)) == NULL) {
+	if (file_findfile(NULL, NULL) == NULL) {
 		printf("Can not load font module: %s\n",
 		    "the kernel is not loaded");
+		return;
+	}
+
+	if (file_findfile(name, name) != NULL) {
+		printf("warning: '%s' is already loaded\n", name);
 		return;
 	}
 

--- a/usr/src/boot/sys/sys/cdefs.h
+++ b/usr/src/boot/sys/sys/cdefs.h
@@ -587,8 +587,8 @@
 #endif	/* __STDC__ */
 #endif	/* __GNUC__ || __INTEL_COMPILER */
 
-#define	__GLOBL1(sym)	__asm__(".globl " #sym)
-#define	__GLOBL(sym)	__GLOBL1(sym)
+#define	__GLOBL(sym)	__asm__(".globl " __XSTRING(sym))
+#define	__WEAK(sym)	__asm__(".weak " __XSTRING(sym))
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
 #define	__IDSTRING(name,string)	__asm__(".ident\t\"" string "\"")

--- a/usr/src/boot/sys/sys/linker_set.h
+++ b/usr/src/boot/sys/sys/linker_set.h
@@ -55,8 +55,8 @@
  */
 #ifdef __GNUCLIKE___SECTION
 #define __MAKE_SET(set, sym)				\
-	__GLOBL(__CONCAT(__start_set_,set));		\
-	__GLOBL(__CONCAT(__stop_set_,set));		\
+	__WEAK(__CONCAT(__start_set_,set));		\
+	__WEAK(__CONCAT(__stop_set_,set));		\
 	static void const * __MAKE_SET_CONST		\
 	__set_##set##_sym_##sym __section("set_" #set)	\
 	__used = &(sym)

--- a/usr/src/cmd/ctfdump/ctfdump.c
+++ b/usr/src/cmd/ctfdump/ctfdump.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 Oxide Computer Company
  */
 
 /*
@@ -483,8 +484,8 @@ static int
 ctfdump_member_cb(const char *member, ctf_id_t type, ulong_t off, void *arg)
 {
 	int *count = arg;
-	ctfdump_printf(CTFDUMP_TYPES, "\t%s type=%ld off=%lu\n", member, type,
-	    off);
+	ctfdump_printf(CTFDUMP_TYPES, "\t%s type=%ld off=%lu bits (%lu.%lu "
+	    "bytes)\n", member, type, off, off / 8, off % 8);
 	*count = *count + 1;
 	return (0);
 }

--- a/usr/src/cmd/dtrace/test/tst/common/Makefile
+++ b/usr/src/cmd/dtrace/test/tst/common/Makefile
@@ -28,6 +28,7 @@
 # Copyright (c) 2012 by Delphix. All rights reserved.
 # Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2018 Joyent, Inc.
+# Copyright 2022 Oxide Computer Company
 #
 
 #
@@ -90,9 +91,16 @@ json/tst.usdt.exe: json/tst.usdt.o json/usdt.o
 	$(POST_PROCESS) ; $(STRIP_STABS)
 
 #
-# Tests that use the next three programs rely on the binaries having
+# Tests that use the next four programs rely on the binaries having
 # valid CTF data.
 #
+bitfields/tst.bitfields.exe: bitfields/tst.bitfields.c
+	$(COMPILE.c) $(CTF_FLAGS) -o bitfields/tst.bitfields.o bitfields/tst.bitfields.c
+	$(CTFCONVERT) -i -L VERSION bitfields/tst.bitfields.o
+	$(LINK.c) -o bitfields/tst.bitfields.exe bitfields/tst.bitfields.o $(LDLIBS)
+	$(CTFMERGE) -L VERSION -o $@ bitfields/tst.bitfields.o
+	$(POST_PROCESS) ; $(STRIP_STABS)
+
 uctf/tst.aouttype.exe: uctf/tst.aouttype.c
 	$(COMPILE.c) $(CTF_FLAGS) -o uctf/tst.aouttype.o uctf/tst.aouttype.c
 	$(CTFCONVERT) -i -L VERSION uctf/tst.aouttype.o

--- a/usr/src/cmd/dtrace/test/tst/common/bitfields/tst.bitfields.c
+++ b/usr/src/cmd/dtrace/test/tst/common/bitfields/tst.bitfields.c
@@ -1,0 +1,92 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+/*
+ * This is designed to allow us to execute print() and various dereferencing
+ * operations with bitfields. It reads the values from argc and passes them to
+ * functions that we can then take apart. Crtitically this uses bitfields
+ * constructed via CTF and not the D compiler.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+
+typedef struct bit0 {
+	uint32_t a:3;
+	uint32_t b:2;
+	uint32_t c:1;
+	uint32_t d:1;
+	uint32_t e:1;
+	uint32_t f:1;
+	uint32_t g:3;
+	uint32_t h:3;
+	uint32_t i:5;
+	uint32_t j:4;
+	uint32_t k:6;
+	uint32_t l:1;
+	uint32_t m:1;
+} bit0_t;
+
+typedef struct bit1 {
+	uint16_t a:1;
+	uint16_t b:8;
+	uint16_t c:3;
+	uint16_t d:2;
+	uint16_t e:1;
+	uint16_t f:1;
+} bit1_t;
+
+void
+mumble(FILE *f, bit0_t *zero, bit1_t *one)
+{
+	(void) fprintf(f, "%u\n%u\n", zero->k, one->d);
+}
+
+int
+main(int argc, char *argv[])
+{
+	unsigned long l;
+	uint16_t u16;
+	uint32_t u32;
+	FILE *f;
+
+	if (argc != 3) {
+		errx(EXIT_FAILURE, "Need two ints");
+	}
+
+	f = fopen("/dev/null", "rw+");
+	if (f == NULL) {
+		err(EXIT_FAILURE, "failed to open /dev/null");
+	}
+
+	errno = 0;
+	l = strtoul(argv[1], NULL, 0);
+	if (errno != 0 || l == 0 || l > UINT16_MAX) {
+		errx(EXIT_FAILURE, "invalid u16 value: %s", argv[1]);
+	}
+	u16 = (uint16_t)l;
+
+	l = strtoul(argv[2], NULL, 0);
+	if (errno != 0 || l == 0 || l > UINT32_MAX) {
+		errx(EXIT_FAILURE, "invalid u32 value: %s", argv[1]);
+	}
+	u32 = (uint32_t)l;
+	mumble(f, (bit0_t *)&u32, (bit1_t *)&u16);
+
+	return (0);
+}

--- a/usr/src/cmd/dtrace/test/tst/common/bitfields/tst.bitfields.ksh
+++ b/usr/src/cmd/dtrace/test/tst/common/bitfields/tst.bitfields.ksh
@@ -1,0 +1,63 @@
+#!/usr/bin/ksh
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Oxide Computer Company
+#
+
+#
+# This test acts as a series of regression tests in DTrace around
+# printing bitfields that are byte sized at non-byte aligned offsets and
+# around printing fields that are less than a byte in size, but due to their
+# offset, cross a byte boundary (e.g. a 5-bit bitfield that starts at
+# bit 6).
+#
+# The DTrace implementation has two different general paths for this:
+#
+#  o The D compiler compiling a dereference into DIF code to be executed
+#    in probe context to extract a bitfield value.
+#  o The print() action which grabs the larger chunk of memory and then
+#    processes it all in userland.
+#
+
+if [ $# != 1 ]; then
+        echo expected one argument: '<'dtrace-path'>'
+        exit 2
+fi
+
+dtrace=$1
+exe="tst.bitfields.exe"
+
+elfdump "./$exe" | grep -q '.SUNW_ctf'
+if (( $? != 0 )); then
+	echo "CTF does not exist in $exe, that's a bug" >&2
+	exit 1
+fi
+
+$dtrace -qs /dev/stdin -c "./$exe 0xe417 0x9391d7db" <<EOF
+pid\$target::mumble:entry
+{
+	print(*args[1]);
+	printf("\n");
+	print(*args[2]);
+	printf("\n");
+	trace(args[2]->b);
+	printf("\n0x%x 0x%x 0x%x 0x%x 0x%x 0x%x\n", args[2]->a, args[2]->b,
+	    args[2]->c, args[2]->d, args[2]->e, args[2]->f);
+	trace(args[1]->i);
+	printf("\n0x%x 0x%x 0x%x 0x%x\n", args[1]->g, args[1]->h, args[1]->i,
+	    args[1]->j);
+}
+EOF
+
+exit $rc

--- a/usr/src/cmd/dtrace/test/tst/common/bitfields/tst.bitfields.ksh.out
+++ b/usr/src/cmd/dtrace/test/tst/common/bitfields/tst.bitfields.ksh.out
@@ -1,0 +1,28 @@
+bit0_t {
+    unsigned int:3 a :3 = 0x3
+    unsigned int:2 b :2 = 0x3
+    unsigned int:1 c :1 = 0
+    unsigned int:1 d :1 = 0x1
+    unsigned int:1 e :1 = 0x1
+    unsigned int:1 f :1 = 0x1
+    unsigned int:3 g :3 = 0x3
+    unsigned int:3 h :3 = 0x5
+    unsigned int:5 i :5 = 0x3
+    unsigned int:4 j :4 = 0x9
+    unsigned int:6 k :6 = 0x13
+    unsigned int:1 l :1 = 0
+    unsigned int:1 m :1 = 0x1
+}
+bit1_t {
+    unsigned short:1 a :1 = 0x1
+    unsigned short:8 b :8 = 0xb
+    unsigned short:3 c :3 = 0x2
+    unsigned short:2 d :2 = 0x2
+    unsigned short:1 e :1 = 0x1
+    unsigned short:1 f :1 = 0x1
+}
+11
+0x1 0xb 0x2 0x2 0x1 0x1
+3
+0x3 0x5 0x3 0x9
+

--- a/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4localicmp.ksh
+++ b/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4localicmp.ksh
@@ -24,7 +24,6 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #
 # Test ip:::{send,receive} of IPv4 ICMP to a local address.
@@ -45,7 +44,7 @@ fi
 dtrace=$1
 local=127.0.0.1
 
-$dtrace -c "/usr/sbin/ping $local 3" -qs /dev/stdin <<EOF | sort -n
+$dtrace -c "/usr/sbin/ping -D $local 3" -qs /dev/stdin <<EOF | sort -n
 ip:::send
 /args[2]->ip_saddr == "$local" && args[2]->ip_daddr == "$local" &&
     args[4]->ipv4_protocol == IPPROTO_ICMP/

--- a/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4localicmp.ksh.out
+++ b/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4localicmp.ksh.out
@@ -1,6 +1,6 @@
 
-1 ip:::send    (args[2]: 4 64, args[4]: 4 84 0 0 255)
-1 ip:::send    (args[2]: 4 64, args[4]: 4 84 0 0 255)
-2 ip:::receive (args[2]: 4 64, args[4]: 4 84 0 0 255)
-2 ip:::receive (args[2]: 4 64, args[4]: 4 84 0 0 255)
+1 ip:::send    (args[2]: 4 64, args[4]: 4 84 2 0 255)
+1 ip:::send    (args[2]: 4 64, args[4]: 4 84 2 0 255)
+2 ip:::receive (args[2]: 4 64, args[4]: 4 84 2 0 255)
+2 ip:::receive (args[2]: 4 64, args[4]: 4 84 2 0 255)
 127.0.0.1 is alive

--- a/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4remoteicmp.ksh
+++ b/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4remoteicmp.ksh
@@ -24,7 +24,6 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #
 # Test ip:::{send,receive} of IPv4 ICMP to a remote host.
@@ -55,7 +54,7 @@ if (( $? != 0 )); then
 	exit 4
 fi
 
-$dtrace -c "/usr/sbin/ping $dest 3" -qs /dev/stdin <<EOF | \
+$dtrace -c "/usr/sbin/ping -D $dest 3" -qs /dev/stdin <<EOF | \
     grep -v 'is alive' | sort -n
 ip:::send
 /args[2]->ip_saddr == "$source" && args[2]->ip_daddr == "$dest" &&

--- a/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4remoteicmp.ksh.out
+++ b/usr/src/cmd/dtrace/test/tst/common/ip/tst.ipv4remoteicmp.ksh.out
@@ -1,3 +1,3 @@
 
-1 ip:::send    (args[2]: 4 64, args[4]: 4 84 0 0 255)
-2 ip:::receive (args[2]: 4 64, args[4]: 4 84 4 0 255)
+1 ip:::send    (args[2]: 4 64, args[4]: 4 84 2 0 255)
+2 ip:::receive (args[2]: 4 64, args[4]: 4 84 2 0 255)

--- a/usr/src/cmd/dtrace/test/tst/common/pragma/tst.temporal.ksh
+++ b/usr/src/cmd/dtrace/test/tst/common/pragma/tst.temporal.ksh
@@ -1,7 +1,5 @@
 #!/bin/ksh -p
 #
-# CDDL HEADER START
-#
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
@@ -11,11 +9,10 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
-# CDDL HEADER END
-#
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2022 Oxide Computer Company
 #
 
 ############################################################################
@@ -74,7 +71,8 @@ fi
 
 # dtrace outputs a blank line at the end, which will sort to the beginning,
 # so use head to remove the blank line.
-head -n -1 $file > $file.2
+nlines=$(wc -l $file | awk '{ print $1 - 1}')
+head -n $nlines $file > $file.2
 
 sort -n $file.2 | diff $file.2 -
 status=$?

--- a/usr/src/cmd/pcieadm/pcieadm_cfgspace.c
+++ b/usr/src/cmd/pcieadm/pcieadm_cfgspace.c
@@ -5244,7 +5244,11 @@ pcieadm_show_cfgspace_help(const char *fmt, ...)
 	    "\t-n\t\tshow printable short names\n"
 	    "\t-H\t\tomit the column header (for -L and -p)\n"
 	    "\t-p\t\tparsable output (requires -o)\n"
-	    "\t-o field\toutput fields to print (required for -p)\n");
+	    "\t-o field\toutput fields to print (required for -p)\n\n"
+	    "The following fields are supported:\n"
+	    "\thuman\t\ta human-readable description of the specific output\n"
+	    "\tshort\t\tthe short name of the value used for filters\n"
+	    "\tvalue\t\tthe value of a the given capability, register, etc.\n");
 }
 
 int

--- a/usr/src/cmd/pcieadm/pcieadm_devs.c
+++ b/usr/src/cmd/pcieadm/pcieadm_devs.c
@@ -40,6 +40,8 @@ typedef enum pcieadm_show_devs_otype {
 	PCIEADM_SDO_BDF_DEV,
 	PCIEADM_SDO_BDF_FUNC,
 	PCIEADM_SDO_DRIVER,
+	PCIEADM_SDO_INSTANCE,
+	PCIEADM_SDO_INSTNUM,
 	PCIEADM_SDO_TYPE,
 	PCIEADM_SDO_VENDOR,
 	PCIEADM_SDO_DEVICE,
@@ -135,11 +137,26 @@ pcieadm_show_devs_ofmt_cb(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
 			return (B_FALSE);
 		}
 		break;
-	case PCIEADM_SDO_DRIVER:
+	case PCIEADM_SDO_INSTANCE:
 		if (psdo->psdo_driver == NULL || psdo->psdo_instance == -1) {
 			(void) snprintf(buf, buflen, "--");
 		} else if (snprintf(buf, buflen, "%s%d", psdo->psdo_driver,
 		    psdo->psdo_instance) >= buflen) {
+			return (B_FALSE);
+		}
+		break;
+	case PCIEADM_SDO_DRIVER:
+		if (psdo->psdo_driver == NULL) {
+			(void) snprintf(buf, buflen, "--");
+		} else if (strlcpy(buf, psdo->psdo_driver, buflen) >= buflen) {
+			return (B_FALSE);
+		}
+		break;
+	case PCIEADM_SDO_INSTNUM:
+		if (psdo->psdo_instance == -1) {
+			(void) snprintf(buf, buflen, "--");
+		} else if (snprintf(buf, buflen, "%d", psdo->psdo_instance) >=
+		    buflen) {
 			return (B_FALSE);
 		}
 		break;
@@ -248,7 +265,7 @@ pcieadm_show_devs_ofmt_cb(ofmt_arg_t *ofarg, char *buf, uint_t buflen)
 	return (B_TRUE);
 }
 
-static const char *pcieadm_show_dev_fields = "bdf,type,driver,device";
+static const char *pcieadm_show_dev_fields = "bdf,type,instance,device";
 static const char *pcieadm_show_dev_speeds =
 	"bdf,driver,maxspeed,curspeed,maxwidth,curwidth,supspeeds";
 static const ofmt_field_t pcieadm_show_dev_ofmt[] = {
@@ -256,6 +273,8 @@ static const ofmt_field_t pcieadm_show_dev_ofmt[] = {
 	{ "DID", 6, PCIEADM_SDO_DID, pcieadm_show_devs_ofmt_cb },
 	{ "BDF", 8, PCIEADM_SDO_BDF, pcieadm_show_devs_ofmt_cb },
 	{ "DRIVER", 15, PCIEADM_SDO_DRIVER, pcieadm_show_devs_ofmt_cb },
+	{ "INSTANCE", 15, PCIEADM_SDO_INSTANCE, pcieadm_show_devs_ofmt_cb },
+	{ "INSTNUM", 8, PCIEADM_SDO_INSTNUM, pcieadm_show_devs_ofmt_cb },
 	{ "TYPE", 15, PCIEADM_SDO_TYPE, pcieadm_show_devs_ofmt_cb },
 	{ "VENDOR", 30, PCIEADM_SDO_VENDOR, pcieadm_show_devs_ofmt_cb },
 	{ "DEVICE", 30, PCIEADM_SDO_DEVICE, pcieadm_show_devs_ofmt_cb },
@@ -487,8 +506,26 @@ pcieadm_show_devs_help(const char *fmt, ...)
 	    "\t-H\t\tomit the column header\n"
 	    "\t-o field\toutput fields to print\n"
 	    "\t-p\t\tparsable output (requires -o)\n"
-	    "\t-s\t\tlist speeds and widths\n");
-
+	    "\t-s\t\tlist speeds and widths\n\n"
+	    "The following fields are supported:\n"
+	    "\tvid\t\tthe PCI vendor ID in hex\n"
+	    "\tdid\t\tthe PCI device ID in hex\n"
+	    "\tvendor\t\tthe name of the PCI vendor\n"
+	    "\tdevice\t\tthe name of the PCI device\n"
+	    "\tinstance\tthe name of this particular instance, e.g. igb0\n"
+	    "\tdriver\t\tthe name of the driver attached to the device\n"
+	    "\tinstnum\t\tthe instance number of a device, e.g. 2 for nvme2\n"
+	    "\tpath\t\tthe /devices path of the device\n"
+	    "\tbdf\t\tthe PCI bus/device/function, with values in hex\n"
+	    "\tbus\t\tthe PCI bus number of the device in hex\n"
+	    "\tdev\t\tthe PCI device number of the device in hex\n"
+	    "\tfunc\t\tthe PCI function number of the device in hex\n"
+	    "\ttype\t\ta string describing the PCIe generation and width\n"
+	    "\tmaxspeed\tthe maximum supported PCIe speed of the device\n"
+	    "\tcurspeed\tthe current PCIe speed of the device\n"
+	    "\tmaxwidth\tthe maximum supported PCIe lane count of the device\n"
+	    "\tcurwidth\tthe current lane count of the PCIe device\n"
+	    "\tsupspeeds\tthe list of speeds the device supports\n");
 }
 
 int

--- a/usr/src/cmd/smbsrv/smbd/server.xml
+++ b/usr/src/cmd/smbsrv/smbd/server.xml
@@ -25,7 +25,7 @@ Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
 Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
 Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 Copyright 2020 Tintri by DDN, Inc. All rights reserved.
-Copyright 2020 RackTop Systems.
+Copyright 2022 RackTop Systems, Inc.
 
 NOTE:  This service manifest is not editable; its contents will
 be overwritten by package or patch operations, including
@@ -226,6 +226,8 @@ file.
 		<propval name='dfs_stdroot_num' type='integer'
 			value='0' override='true'/>
 		<propval name='print_enable' type='boolean'
+			value='false' override='true'/>
+		<propval name='short_names' type='boolean'
 			value='false' override='true'/>
 		<propval name='traverse_mounts' type='boolean'
 			value='true' override='true'/>

--- a/usr/src/cmd/syseventd/modules/zfs_mod/zfs_mod.c
+++ b/usr/src/cmd/syseventd/modules/zfs_mod/zfs_mod.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2022 Oxide Computer Company
  */
 
 /*
@@ -563,6 +564,13 @@ zfsdle_vdev_online(zpool_handle_t *zhp, void *data)
 	    &avail_spare, &l2cache, NULL)) != NULL) {
 		char *path, fullpath[MAXPATHLEN];
 		uint64_t wholedisk = 0ULL;
+
+		/*
+		 * If the /dev path of the device is invalid because the disk
+		 * has been moved to a new location, we need to try to refresh
+		 * that path before onlining the device.
+		 */
+		zpool_vdev_refresh_path(g_zfshdl, zhp, tgt);
 
 		verify(nvlist_lookup_string(tgt, ZPOOL_CONFIG_PATH,
 		    &path) == 0);

--- a/usr/src/lib/libdtrace/common/dt_ident.c
+++ b/usr/src/lib/libdtrace/common/dt_ident.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright (c) 2013 Joyent, Inc. All rights reserved.
+ * Copyright 2022 Oxide Computer Company
  */
 
 #include <sys/sysmacros.h>
@@ -266,6 +267,7 @@ dt_idcook_func(dt_node_t *dnp, dt_ident_t *idp, int argc, dt_node_t *args)
 			if (strcmp(p1, "@") == 0 || strcmp(p1, "...") == 0) {
 				isp->dis_args[i].dn_ctfp = NULL;
 				isp->dis_args[i].dn_type = CTF_ERR;
+				isp->dis_args[i].dn_bitoff = 0;
 				if (*p1 == '.')
 					isp->dis_varargs = i;
 				continue;

--- a/usr/src/lib/libdtrace/common/dt_impl.h
+++ b/usr/src/lib/libdtrace/common/dt_impl.h
@@ -27,6 +27,7 @@
 /*
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright 2022 Oxide Computer Company
  */
 
 #ifndef	_DT_IMPL_H
@@ -166,7 +167,7 @@ typedef struct dt_ahash {
 } dt_ahash_t;
 
 typedef struct dt_aggregate {
-	dtrace_bufdesc_t dtat_buf; 	/* buf aggregation snapshot */
+	dtrace_bufdesc_t dtat_buf;	/* buf aggregation snapshot */
 	int dtat_flags;			/* aggregate flags */
 	processorid_t dtat_ncpus;	/* number of CPUs in aggregate */
 	processorid_t *dtat_cpus;	/* CPUs in aggregate */
@@ -651,6 +652,8 @@ extern int dt_handle_setopt(dtrace_hdl_t *, dtrace_setoptdata_t *);
 
 extern int dt_lib_depend_add(dtrace_hdl_t *, dt_list_t *, const char *);
 extern dt_lib_depend_t *dt_lib_depend_lookup(dt_list_t *, const char *);
+
+extern boolean_t dt_is_bitfield(const ctf_encoding_t *, ulong_t);
 
 extern dt_pcb_t *yypcb;		/* pointer to current parser control block */
 extern char yyintprefix;	/* int token prefix for macros (+/-) */

--- a/usr/src/lib/libdtrace/common/dt_parser.h
+++ b/usr/src/lib/libdtrace/common/dt_parser.h
@@ -25,6 +25,7 @@
 /*
  * Copyright (c) 2013, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2013 Joyent, Inc. All rights reserved.
+ * Copyright 2022 Oxide Computer Company
  */
 
 #ifndef	_DT_PARSER_H
@@ -50,6 +51,7 @@ extern "C" {
 typedef struct dt_node {
 	ctf_file_t *dn_ctfp;	/* CTF type container for node's type */
 	ctf_id_t dn_type;	/* CTF type reference for node's type */
+	ulong_t dn_bitoff;	/* Offset to the start of the CTF type */
 	uchar_t dn_kind;	/* node kind (DT_NODE_*, defined below) */
 	uchar_t dn_flags;	/* node flags (DT_NF_*, defined below) */
 	ushort_t dn_op;		/* operator (DT_TOK_*, defined by lex) */
@@ -239,6 +241,8 @@ extern void dt_node_link_free(dt_node_t **);
 
 extern void dt_node_attr_assign(dt_node_t *, dtrace_attribute_t);
 extern void dt_node_type_assign(dt_node_t *, ctf_file_t *, ctf_id_t, boolean_t);
+extern void dt_node_type_assign_bitfield(dt_node_t *, ctf_file_t *, ctf_id_t,
+    boolean_t, ulong_t);
 extern void dt_node_type_propagate(const dt_node_t *, dt_node_t *);
 extern const char *dt_node_type_name(const dt_node_t *, char *, size_t);
 extern size_t dt_node_type_size(const dt_node_t *);

--- a/usr/src/lib/libdtrace/common/ip.d.in
+++ b/usr/src/lib/libdtrace/common/ip.d.in
@@ -311,9 +311,9 @@ translator ipv4info_t < ipha_t *I > {
 	ipv4_length = I != NULL ? ntohs(I->ipha_length) : 0;
 	ipv4_ident = I != NULL ? ntohs(I->ipha_ident) : 0;
 	ipv4_flags = I != NULL ? ntohs(I->ipha_fragment_offset_and_flags) >>
-	    12 : 0;
+	    13 : 0;
 	ipv4_offset = I != NULL ? ntohs(I->ipha_fragment_offset_and_flags) &
-	    0x0fff : 0;
+	    0x1fff : 0;
 	ipv4_ttl = I != NULL ? I->ipha_ttl : 0;
 	ipv4_protocol = I != NULL ? I->ipha_protocol : 0;
 	ipv4_protostr = I == NULL ? "<null>" :

--- a/usr/src/lib/libnsl/ipsec/algs.c
+++ b/usr/src/lib/libnsl/ipsec/algs.c
@@ -591,7 +591,7 @@ void
 _build_internal_algs(ipsec_proto_t **alg_context, int *alg_nums)
 {
 	FILE *f;
-	int rc, trash_num;
+	int rc, trash_num = 0;
 	ipsec_proto_t *new_protos = NULL, *trash;
 	time_t filetime;
 	struct stat statbuf;

--- a/usr/src/lib/libnsl/rpc/clnt_generic.c
+++ b/usr/src/lib/libnsl/rpc/clnt_generic.c
@@ -68,11 +68,11 @@ CLIENT *_clnt_tli_create_timed(int, const struct netconfig *, struct netbuf *,
  */
 CLIENT *
 clnt_create_vers(const char *hostname, const rpcprog_t prog,
-	rpcvers_t *vers_out, const rpcvers_t vers_low,
-	const rpcvers_t vers_high, const char *nettype)
+    rpcvers_t *vers_out, const rpcvers_t vers_low,
+    const rpcvers_t vers_high, const char *nettype)
 {
 	return (clnt_create_vers_timed(hostname, prog, vers_out, vers_low,
-				vers_high, nettype, NULL));
+	    vers_high, nettype, NULL));
 }
 
 /*
@@ -102,7 +102,7 @@ clnt_create_vers_timed(const char *hostname, const rpcprog_t prog,
 		to = *tp;
 
 	rpc_stat = clnt_call(clnt, NULLPROC, (xdrproc_t)xdr_void,
-			NULL, (xdrproc_t)xdr_void, NULL, to);
+	    NULL, (xdrproc_t)xdr_void, NULL, to);
 	if (rpc_stat == RPC_SUCCESS) {
 		*vers_out = vers_high;
 		return (clnt);
@@ -126,8 +126,7 @@ clnt_create_vers_timed(const char *hostname, const rpcprog_t prog,
 		}
 		CLNT_CONTROL(clnt, CLSET_VERS, (char *)&v_high);
 		rpc_stat = clnt_call(clnt, NULLPROC, (xdrproc_t)xdr_void,
-				NULL, (xdrproc_t)xdr_void,
-				NULL, to);
+		    NULL, (xdrproc_t)xdr_void, NULL, to);
 		if (rpc_stat == RPC_SUCCESS) {
 			*vers_out = v_high;
 			return (clnt);
@@ -250,7 +249,7 @@ clnt_create_timed(const char *hostname, const rpcprog_t prog,
 			 */
 			if (rpc_createerr.cf_stat == RPC_SYSTEMERROR) {
 				syslog(LOG_ERR, "clnt_create_timed: "
-					"RPC_SYSTEMERROR.");
+				    "RPC_SYSTEMERROR.");
 				break;
 			}
 
@@ -267,8 +266,8 @@ clnt_create_timed(const char *hostname, const rpcprog_t prog,
 	 *	translation failed'' or ``unknown host name''
 	 */
 	if ((rpc_createerr.cf_stat == RPC_N2AXLATEFAILURE ||
-				rpc_createerr.cf_stat == RPC_UNKNOWNHOST) &&
-					(save_cf_stat != RPC_SUCCESS)) {
+	    rpc_createerr.cf_stat == RPC_UNKNOWNHOST) &&
+	    (save_cf_stat != RPC_SUCCESS)) {
 		rpc_createerr.cf_stat = save_cf_stat;
 		rpc_createerr.cf_error = save_cf_error;
 	}
@@ -289,9 +288,9 @@ clnt_create_timed(const char *hostname, const rpcprog_t prog,
 
 CLIENT *
 clnt_create_service_timed(const char *host, const char *service,
-			const rpcprog_t prog, const rpcvers_t vers,
-			const ushort_t port, const char *netclass,
-			const struct timeval *tmout)
+    const rpcprog_t prog, const rpcvers_t vers,
+    const ushort_t port, const char *netclass,
+    const struct timeval *tmout)
 {
 	int fd;
 	void *handle;
@@ -399,7 +398,6 @@ clnt_create_service_timed(const char *host, const char *service,
 
 		__rpc_set_mac_options(fd, nconf, prog);
 
-		/* LINTED pointer cast */
 		if ((tbind = (struct t_bind *)t_alloc(fd, T_BIND, T_ADDR))
 		    == NULL) {
 			(void) t_close(fd);
@@ -423,18 +421,17 @@ clnt_create_service_timed(const char *host, const char *service,
 		netdir_free((void *)raddrs, ND_ADDRLIST);
 
 		if (port) {
-			if (strcmp(nconf->nc_protofmly, NC_INET) == 0)
-				/* LINTED pointer alignment */
+			if (strcmp(nconf->nc_protofmly, NC_INET) == 0) {
 				((struct sockaddr_in *)
-				tbind->addr.buf)->sin_port = htons(port);
-			else if (strcmp(nconf->nc_protofmly, NC_INET6) == 0)
-				/* LINTED pointer alignment */
+				    tbind->addr.buf)->sin_port = htons(port);
+			} else if (strcmp(nconf->nc_protofmly, NC_INET6) == 0) {
 				((struct sockaddr_in6 *)
-				tbind->addr.buf)->sin6_port = htons(port);
+				    tbind->addr.buf)->sin6_port = htons(port);
+			}
 		}
 
 		clnt = _clnt_tli_create_timed(fd, nconf, &tbind->addr,
-					    prog, vers, 0, 0, &to);
+		    prog, vers, 0, 0, &to);
 
 		if (clnt == NULL) {
 			if (tbind)
@@ -453,7 +450,7 @@ clnt_create_service_timed(const char *host, const char *service,
 		 */
 
 		rpc_createerr.cf_stat = clnt_call(clnt, NULLPROC,
-						xdr_void, 0, xdr_void, 0, to);
+		    xdr_void, 0, xdr_void, 0, to);
 
 		rpc_createerr.cf_error.re_errno = rpc_callerr.re_status;
 		rpc_createerr.cf_error.re_terrno = 0;
@@ -464,8 +461,9 @@ clnt_create_service_timed(const char *host, const char *service,
 			if (tbind)
 				(void) t_free((char *)tbind, T_BIND);
 			continue;
-		} else
+		} else {
 			break;
+		}
 	}
 
 	__rpc_endconf(handle);
@@ -520,15 +518,16 @@ clnt_tp_create_timed(const char *hostname, const rpcprog_t prog,
 	/*
 	 * Get the address of the server
 	 */
-	if ((svcaddr = __rpcb_findaddr_timed(prog, vers,
-			(struct netconfig *)nconf, (char *)hostname,
-			&cl, (struct timeval *)tp)) == NULL) {
+	svcaddr = __rpcb_findaddr_timed(prog, vers,
+	    (struct netconfig *)nconf, (char *)hostname,
+	    &cl, (struct timeval *)tp);
+	if (svcaddr == NULL) {
 		/* appropriate error number is set by rpcbind libraries */
 		return (NULL);
 	}
 	if (cl == NULL) {
 		cl = _clnt_tli_create_timed(RPC_ANYFD, nconf, svcaddr,
-					prog, vers, 0, 0, tp);
+		    prog, vers, 0, 0, tp);
 	} else {
 		/* Reuse the CLIENT handle and change the appropriate fields */
 		if (CLNT_CONTROL(cl, CLSET_SVC_ADDR, (void *)svcaddr) == TRUE) {
@@ -538,8 +537,8 @@ clnt_tp_create_timed(const char *hostname, const rpcprog_t prog,
 					netdir_free((char *)svcaddr, ND_ADDR);
 					rpc_createerr.cf_stat = RPC_SYSTEMERROR;
 					syslog(LOG_ERR,
-						"clnt_tp_create_timed: "
-						"strdup failed.");
+					    "clnt_tp_create_timed: "
+					    "strdup failed.");
 					return (NULL);
 				}
 			}
@@ -551,8 +550,8 @@ clnt_tp_create_timed(const char *hostname, const rpcprog_t prog,
 						free(cl->cl_netid);
 					rpc_createerr.cf_stat = RPC_SYSTEMERROR;
 					syslog(LOG_ERR,
-						"clnt_tp_create_timed: "
-						"strdup failed.");
+					    "clnt_tp_create_timed: "
+					    "strdup failed.");
 					return (NULL);
 				}
 			}
@@ -561,7 +560,7 @@ clnt_tp_create_timed(const char *hostname, const rpcprog_t prog,
 		} else {
 			CLNT_DESTROY(cl);
 			cl = _clnt_tli_create_timed(RPC_ANYFD, nconf, svcaddr,
-					prog, vers, 0, 0, tp);
+			    prog, vers, 0, 0, tp);
 		}
 	}
 	netdir_free((char *)svcaddr, ND_ADDR);
@@ -582,7 +581,7 @@ clnt_tli_create(const int fd, const struct netconfig *nconf,
     const uint_t sendsz, const uint_t recvsz)
 {
 	return (_clnt_tli_create_timed(fd, nconf, svcaddr, prog, vers, sendsz,
-		recvsz, NULL));
+	    recvsz, NULL));
 }
 
 /*
@@ -596,12 +595,12 @@ clnt_tli_create(const int fd, const struct netconfig *nconf,
  */
 CLIENT *
 _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
-	struct netbuf *svcaddr, rpcprog_t prog, rpcvers_t vers, uint_t sendsz,
-	uint_t recvsz, const struct timeval *tp)
+    struct netbuf *svcaddr, rpcprog_t prog, rpcvers_t vers, uint_t sendsz,
+    uint_t recvsz, const struct timeval *tp)
 {
 	CLIENT *cl;			/* client handle */
 	struct t_info tinfo;		/* transport info */
-	bool_t madefd;			/* whether fd opened here */
+	bool_t madefd = FALSE;		/* whether fd opened here */
 	t_scalar_t servtype;
 	int retval;
 
@@ -647,13 +646,12 @@ _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
 		    (t_getinfo(fd, &tinfo) == -1))
 			goto err;
 		servtype = tinfo.servtype;
-		madefd = FALSE;
 	}
 
 	switch (servtype) {
 	case T_COTS:
 		cl = _clnt_vc_create_timed(fd, svcaddr, prog, vers, sendsz,
-				recvsz, tp);
+		    recvsz, tp);
 		break;
 	case T_COTS_ORD:
 		if (nconf && ((strcmp(nconf->nc_protofmly, NC_INET) == 0) ||
@@ -663,7 +661,7 @@ _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
 				goto err;
 		}
 		cl = _clnt_vc_create_timed(fd, svcaddr, prog, vers, sendsz,
-			recvsz, tp);
+		    recvsz, tp);
 		break;
 	case T_CLTS:
 		cl = clnt_dg_create(fd, svcaddr, prog, vers, sendsz, recvsz);
@@ -681,7 +679,7 @@ _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
 			rpc_createerr.cf_error.re_errno = errno;
 			rpc_createerr.cf_error.re_terrno = 0;
 			syslog(LOG_ERR,
-				"clnt_tli_create: strdup failed");
+			    "clnt_tli_create: strdup failed");
 			goto err1;
 		}
 		cl->cl_tp = strdup(nconf->nc_device);
@@ -692,7 +690,7 @@ _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
 			rpc_createerr.cf_error.re_errno = errno;
 			rpc_createerr.cf_error.re_terrno = 0;
 			syslog(LOG_ERR,
-				"clnt_tli_create: strdup failed");
+			    "clnt_tli_create: strdup failed");
 			goto err1;
 		}
 	} else {
@@ -706,8 +704,8 @@ _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
 					rpc_createerr.cf_error.re_errno = errno;
 					rpc_createerr.cf_error.re_terrno = 0;
 					syslog(LOG_ERR,
-						"clnt_tli_create: "
-						"strdup failed");
+					    "clnt_tli_create: "
+					    "strdup failed");
 					goto err1;
 				}
 			}
@@ -720,8 +718,8 @@ _clnt_tli_create_timed(int fd, const struct netconfig *nconf,
 					rpc_createerr.cf_error.re_errno = errno;
 					rpc_createerr.cf_error.re_terrno = 0;
 					syslog(LOG_ERR,
-						"clnt_tli_create: "
-						"strdup failed");
+					    "clnt_tli_create: "
+					    "strdup failed");
 					goto err1;
 				}
 			}
@@ -770,7 +768,7 @@ __rpc_raise_fd(int fd)
 	if (t_close(fd) == -1) {
 		/* this is okay, we will syslog an error, then use the new fd */
 		(void) syslog(LOG_ERR,
-			"could not t_close() fd %d; mem & fd leak", fd);
+		    "could not t_close() fd %d; mem & fd leak", fd);
 	}
 
 	return (nfd);

--- a/usr/src/lib/libshare/smb/libshare_smb.c
+++ b/usr/src/lib/libshare/smb/libshare_smb.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2022 RackTop Systems.
  */
 
 /*
@@ -899,6 +900,8 @@ struct smb_proto_option_defs {
 	{ SMB_CI_BYPASS_TRAVERSE_CHECKING, 0, 0, true_false_validator,
 	    SMB_REFRESH_REFRESH },
 	{ SMB_CI_OPLOCK_ENABLE, 0, 0, true_false_validator,
+	    SMB_REFRESH_REFRESH },
+	{ SMB_CI_SHORT_NAMES, 0, 0, true_false_validator,
 	    SMB_REFRESH_REFRESH },
 };
 

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -316,6 +316,8 @@ extern nvlist_t *zpool_find_vdev_by_physpath(zpool_handle_t *, const char *,
     boolean_t *, boolean_t *, boolean_t *);
 extern int zpool_label_disk(libzfs_handle_t *, zpool_handle_t *, const char *,
     zpool_boot_label_t, uint64_t, int *);
+extern void zpool_vdev_refresh_path(libzfs_handle_t *, zpool_handle_t *,
+    nvlist_t *);
 
 /*
  * Functions to manage pool properties

--- a/usr/src/lib/libzfs/common/mapfile-vers
+++ b/usr/src/lib/libzfs/common/mapfile-vers
@@ -279,6 +279,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	zpool_vdev_name;
 	zpool_vdev_offline;
 	zpool_vdev_online;
+	zpool_vdev_refresh_path;
 	zpool_vdev_remove;
 	zpool_vdev_remove_cancel;
 	zpool_vdev_split;

--- a/usr/src/lib/libzpool/Makefile.com
+++ b/usr/src/lib/libzpool/Makefile.com
@@ -68,7 +68,7 @@ CSTD=	$(CSTD_GNU99)
 
 CFLAGS +=	$(CCGDEBUG) $(CCVERBOSE) $(CNOGLOBAL)
 CFLAGS64 +=	$(CCGDEBUG) $(CCVERBOSE) $(CNOGLOBAL)
-LDLIBS +=	-lcmdutils -lumem -lavl -lnvpair -lz -lc -lsysevent -lmd \
+LDLIBS +=	-lcmdutils -lumem -lavl -lnvpair -lz -lc -lmd \
 		-lfakekernel -lzutil
 NATIVE_LIBS +=	libz.so
 CPPFLAGS.first =	-I$(SRC)/lib/libfakekernel/common

--- a/usr/src/lib/smbsrv/libsmb/common/libsmb.h
+++ b/usr/src/lib/smbsrv/libsmb/common/libsmb.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
- * Copyright 2020 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #ifndef	_LIBSMB_H
@@ -163,6 +163,7 @@ typedef enum {
 	SMB_CI_BYPASS_TRAVERSE_CHECKING,
 	SMB_CI_ENCRYPT_CIPHER,
 	SMB_CI_NETLOGON_FLAGS,
+	SMB_CI_SHORT_NAMES,
 
 	SMB_CI_MAX
 } smb_cfg_id_t;

--- a/usr/src/lib/smbsrv/libsmb/common/smb_cfg.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_cfg.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2022 Tintri by DDN, Inc. All rights reserved.
- * Copyright 2021 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -160,6 +160,7 @@ static smb_cfg_param_t smb_cfg_table[] =
 	    "bypass_traverse_checking", SCF_TYPE_BOOLEAN, 0},
 	{SMB_CI_ENCRYPT_CIPHER, "encrypt_cipher", SCF_TYPE_ASTRING, 0},
 	{SMB_CI_NETLOGON_FLAGS, "netlogon_flags", SCF_TYPE_INTEGER, 0},
+	{SMB_CI_SHORT_NAMES, "short_names", SCF_TYPE_BOOLEAN, 0},
 
 	/* SMB_CI_MAX */
 };

--- a/usr/src/lib/smbsrv/libsmb/common/smb_info.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_info.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
- * Copyright 2020 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #include <sys/types.h>
@@ -157,6 +157,8 @@ smb_load_kconfig(smb_kmod_cfg_t *kcfg)
 	kcfg->skc_oplock_enable = smb_config_getbool(SMB_CI_OPLOCK_ENABLE);
 	kcfg->skc_sync_enable = smb_config_getbool(SMB_CI_SYNC_ENABLE);
 	kcfg->skc_traverse_mounts = smb_config_getbool(SMB_CI_TRAVERSE_MOUNTS);
+	kcfg->skc_short_names = smb_config_getbool(SMB_CI_SHORT_NAMES);
+
 	kcfg->skc_max_protocol = smb_config_get_max_protocol();
 	kcfg->skc_min_protocol = smb_config_get_min_protocol();
 	kcfg->skc_secmode = smb_config_get_secmode();

--- a/usr/src/lib/smbsrv/libsmb/common/smb_kmod.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_kmod.c
@@ -22,7 +22,7 @@
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2017 Joyent, Inc.
- * Copyright 2020 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #include <sys/types.h>
@@ -89,6 +89,8 @@ smb_kmod_setcfg(smb_kmod_cfg_t *cfg)
 	ioc.ipv6_enable = cfg->skc_ipv6_enable;
 	ioc.print_enable = cfg->skc_print_enable;
 	ioc.traverse_mounts = cfg->skc_traverse_mounts;
+	ioc.short_names = cfg->skc_short_names;
+
 	ioc.max_protocol = cfg->skc_max_protocol;
 	ioc.min_protocol = cfg->skc_min_protocol;
 	ioc.exec_flags = cfg->skc_execflags;

--- a/usr/src/man/man1/ctfdump.1
+++ b/usr/src/man/man1/ctfdump.1
@@ -10,6 +10,7 @@
 .\"
 .\"
 .\" Copyright 2018, Joyent, Inc.
+.\" Copyright 2022 Oxide Computer Company
 .\"
 .Dd September 20, 2021
 .Dt CTFDUMP 1
@@ -33,48 +34,30 @@ data contained inside of
 objects and raw
 .Sy CTF
 files.
-.Lp
+.Pp
 .Nm
-can dump information about the
-.Sy CTF header ,
-the
-.Sy labels
-encoded in the
-.Sy CTF
-container,
-the types of
-.Sy data objects ,
-the internal
-.Sy string
-table,
-the types of the return function and the arguments for
-.Sy functions ,
-and of course, it displays information about the
-.Sy types
-defined in the
-.Sy CTF
-container.
-.Lp
+can dump information about the CTF header, the labels encoded in the
+CTF container, the types of data objects, the internal string table,
+the types of the return function and the arguments for functions,
+and of course, it displays information about the types defined in the
+CTF container.
+.Pp
 .Nm
-can also be used to dump out the raw
-.Sy CTF
-data and send it to another file.
-When writing out data, it always ensures that the
-.Sy CTF
-data is decompressed.
-In this form, the
-.Sy CTF
-data can be inspected using
+can also be used to dump out the raw CTF data and send it to another
+file.
+When writing out data, it always ensures that the CTF data is
+decompressed.
+In this form, the CTF data can be inspected using
 .Nm
 and other tools such as
 .Xr mdb 1 .
-.Lp
+.Pp
 .Nm
 in
 .Fl c
 mode will generate C-style output, which can be used for comparison.
 Note that this output is not directly compilable.
-.Lp
+.Pp
 When no options are specified,
 .Nm
 displays all information, except the C-style output.
@@ -84,99 +67,58 @@ option is used, then no information is displayed by default, unless
 requested through the appropriate option.
 .Sh OPTIONS
 The following options are supported:
-.Bl -hang -width Ds
+.Bl -tag -width Ds
 .It Fl c
-.Bd -filled -compact
 Generate C-style output.
-.Ed
 .It Fl d
-.Bd -filled -compact
 Dump the types of symbols that correspond to objects.
-.Ed
 .It Fl f
-.Bd -filled -compact
 Dump the types of the return values and arguments of the functions.
-.Ed
 .It Fl h
-.Bd -filled -compact
-Dump the
-.Sy CTF
-header
-.Ed
+Dump the CTF header
 .It Fl l
-.Bd -filled -compact
-Dump all
-.Sy CTF
-labels associated with the file.
-.Ed
+Dump all CTF labels associated with the file.
 .It Fl p Ar parent
-.Bd -filled -compact
 Use the type information in
-.Em parent
+.Ar parent
 to supplement output.
 This is useful when a
-.Nm CTF
-container has been
-.Sy uniquified
-against
-.Em parent .
+.Nm
+CTF container has been uniquified against
+.Ar parent .
 This allows
 .Nm
 to use the names of types when used with
 .Fl t .
-.Ed
 .It Fl s
-.Bd -filled -compact
-Dump the internal
-.Sy CTF
-string table
-.Ed
+Dump the internal CTF string table
 .It Fl S
-.Bd -filled -compact
-Displays statistics about the
-.Sy CTF
-container.
-.Ed
+Displays statistics about the CTF container.
 .It Fl t
-.Bd -filled -compact
-Dump the type information contained in the
-.Sy CTF
-container.
-.Ed
+Dump the type information contained in the CTF container.
 .It Fl u Ar outfile
-.Bd -filled -compact
-Copies the uncompressed
-.Sy CTF
-data to the file specified by
-.Em outfile .
-This can be used to make it easier to inspect the raw
-.Sy CTF
-data.
-.Ed
+Copies the uncompressed CTF data to the file specified by
+.Ar outfile .
+This can be used to make it easier to inspect the raw CTF data.
 .El
 .Sh OUTPUT
 When the
 .Nm
 utility is executed with its default options, it prints out a textual
-representation of the
-.Sy CTF
-information.
+representation of the CTF information.
 Note, the output format of
 .Nm
 is subject to change at any time and should not be relied upon as a
 stable format to be used for parsing.
 .Ss CTF Header
-This section describes the values in the
-.Sy CTF
-header.
+This section describes the values in the CTF header.
 Each line in the section describes the value of one of the
 members of the header.
 For more information on the meaning and interpretation of these members,
 see
 .Xr ctf 5 .
 .Ss Label Table
-This section describes information about the labels present in the
-.Sy CTF
+This section describes information about the labels present in the CTF
 information.
 Each entry in this section, if present, starts with a
 number and is followed by a string.
@@ -196,8 +138,7 @@ is the name of the label.
 In this case, if there were no other labels,
 it would indicate that the label applied to all types up to, and
 including, the type number 2270.
-For more information on how labels are used with
-.Sy CTF
+For more information on how labels are used with CTF
 information, see the section
 .Em The Label Section
 in
@@ -260,8 +201,7 @@ symbol table.
 The following portions of this entry describe the return
 type and then all of the arguments, in positional order.
 .Ss Types
-The types section gives information about each type in the
-.Sy CTF
+The types section gives information about each type in the CTF
 container.
 Each entry begins with its type identifier.
 The type identifier may either be in square brackets or in angle
@@ -303,40 +243,43 @@ Structures and unions will be preceded with the corresponding C keyword,
 or
 .Sy union .
 After that, the size in bytes of the structure will be indicated.
-ON each subsequent line, a single member will be listed.
+On each subsequent line, a single member will be listed.
 That line will contain the member's name, it's type identifier, and the
-offset into the structure that it can be found in, in bits.
+offset into the structure that the member starts at.
+The first values is in bits, which is what CTF encodes.
+It is then followed by bytes and the bit offset into the byte.
+That is the value
+.Sq 2.5
+indicates that it starts at the 5th bit in the 2nd byte
+.Pq i.e. bit 21 .
 .Pp
 The following show examples of type information for all of these
 different types:
 .Bd -literal
 \&...
-  [5] char [12] contents: 1, index: 2
-  [6] short encoding=SIGNED offset=0 bits=16
-  <7> struct exit_status (4 bytes)
-        e_termination type=6 off=0
-        e_exit type=6 off=16
+  [155] struct ctf_merge_handle (80 bytes)
+        cmh_inputs type=165 off=0 bits (0.0 bytes)
+        cmh_ninputs type=6 off=256 bits (32.0 bytes)
+        cmh_nthreads type=6 off=288 bits (36.0 bytes)
+        cmh_unique type=65 off=320 bits (40.0 bytes)
+        cmh_msyms type=115 off=384 bits (48.0 bytes)
+        cmh_ofd type=34 off=416 bits (52.0 bytes)
+        cmh_flags type=34 off=448 bits (56.0 bytes)
+        cmh_label type=94 off=512 bits (64.0 bytes)
+        cmh_pname type=94 off=576 bits (72.0 bytes)
 
-  <8> typedef time_t refers to 2
-  <9> struct utmp (36 bytes)
-        ut_user type=3 off=0
-        ut_id type=4 off=64
-        ut_line type=5 off=96
-        ut_pid type=6 off=192
-        ut_type type=6 off=208
-        ut_exit type=7 off=224
-        ut_time type=8 off=256
+  <156> typedef ctf_merge_t refers to 155
+  [157] struct __va_list_tag (24 bytes)
+        gp_offset type=5 off=0 bits (0.0 bytes)
+        fp_offset type=5 off=32 bits (4.0 bytes)
+        overflow_arg_area type=41 off=64 bits (8.0 bytes)
+        reg_save_area type=41 off=128 bits (16.0 bytes)
 
-  <10> struct utmp * refers to 9
-  [11] const struct utmp refers to 9
-  [12] const struct utmp * refers to 11
-  <13> int encoding=SIGNED offset=0 bits=32
-  <14> typedef int32_t refers to 13
+  [158] struct __va_list_tag [1] contents: 157, index: 9
 \&...
 .Ed
 .Ss String Table
-This section describes all of the strings that are present in the
-.Sy CTF
+This section describes all of the strings that are present in the CTF
 container.
 Each line represents an entry in the string table.
 First the byte offset into the string table is shown in brackets and
@@ -351,25 +294,24 @@ Note the following examples:
   [35] short
 .Ed
 .Ss Statistics
-This section contains miscellaneous statistics about the
-.Sy CTF
-data present.
+This section contains miscellaneous statistics about the CTF data
+present.
 Each line contains a single statistic.
 A brief explanation of the statistic is placed first, followed by an
 equals sign, and then finally the value.
 .Sh EXIT STATUS
-.Bl -inset
+.Bl -tag -width Ds
 .It Sy 0
-.Dl Execution completed successfully.
+Execution completed successfully.
 .It Sy 1
-.Dl A fatal error occurred.
+A fatal error occurred.
 .It Sy 2
-.Dl Invalid command line options were specified.
+Invalid command line options were specified.
 .El
 .Sh EXAMPLES
 .Sy Example 1
 Displaying the Type Section of a Single File
-.Lp
+.Pp
 The following example dumps the type section of the file
 .Sy /usr/lib/libc.so.1 .
 .Bd -literal -offset 6n
@@ -385,10 +327,10 @@ $ ctfdump -t /usr/lib/libc.so.1
   <7> typedef uintptr_t refers to 4
 \&...
 .Ed
-.Lp
+.Pp
 .Sy Example 2
 Dumping the CTF data to Another File
-.Lp
+.Pp
 The following example dumps the entire CTF data from the file
 .Sy /usr/lib/libc.so.1
 and places it into the file
@@ -417,7 +359,7 @@ $ mdb ./ctf.out
     cth_strlen = 0x7c9c
 }
 .Ed
-.Lp
+.Pp
 .Sy Example 3
 Dumping C-style output
 .Bd -literal -offset 6n

--- a/usr/src/man/man5/smb.5
+++ b/usr/src/man/man5/smb.5
@@ -1,7 +1,7 @@
 '\" te
 .\" Copyright (c) 2009, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 2017, Nexenta Systems, Inc. All Rights Reserved.
-.\" Copyright 2021, RackTop Systems, Inc. All Rights Reserved.
+.\" Copyright 2022, RackTop Systems, Inc. All Rights Reserved.
 .\" The contents of this file are subject to the terms of the
 .\" Common Development and Distribution License (the "License").
 .\" You may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 .\" fields enclosed by brackets "[]" replaced with your own identifying
 .\" information: Portions Copyright [yyyy] [name of copyright owner]
 .\"
-.TH SMB 5 "December 28, 2020"
+.TH SMB 5 "January 17, 2022"
 .SH NAME
 smb \- configuration properties for Solaris CIFS server
 .SH DESCRIPTION
@@ -496,6 +496,19 @@ Disables anonymous access to IPC$, which requires that the client be
 authenticated to get access to MSRPC services through IPC$. A value of
 \fBtrue\fR disables anonymous access to IPC$, while a value of \fBfalse\fR
 enables anonymous access.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBshort_names\fR\fR
+.ad
+.sp .6
+.RS 4n
+Enables use of "short names" by SMB clients.  The default value is
+\fBfalse\fR because modern SMB clients do not need short names, and
+using short names has some performance cost while listing directories
+and opening or renaming files.
 .RE
 
 .sp

--- a/usr/src/pkg/manifests/system-bhyve-tests.p5m
+++ b/usr/src/pkg/manifests/system-bhyve-tests.p5m
@@ -33,6 +33,8 @@ dir  path=opt/bhyve-tests/tests
 dir  path=opt/bhyve-tests/tests/inst_emul
 file path=opt/bhyve-tests/tests/inst_emul/cpuid mode=0555
 file path=opt/bhyve-tests/tests/inst_emul/exit_paging mode=0555
+file path=opt/bhyve-tests/tests/inst_emul/imul mode=0555
+file path=opt/bhyve-tests/tests/inst_emul/page_dirty mode=0555
 file path=opt/bhyve-tests/tests/inst_emul/rdmsr mode=0555
 file path=opt/bhyve-tests/tests/inst_emul/triple_fault mode=0555
 file path=opt/bhyve-tests/tests/inst_emul/wrmsr mode=0555

--- a/usr/src/pkg/manifests/system-dtrace-tests.p5m
+++ b/usr/src/pkg/manifests/system-dtrace-tests.p5m
@@ -352,6 +352,9 @@ file \
     mode=0444
 file path=opt/SUNWdtrt/tst/common/bitfields/tst.BitFieldPromotion.d mode=0444
 file path=opt/SUNWdtrt/tst/common/bitfields/tst.SizeofBitField.d mode=0444
+file path=opt/SUNWdtrt/tst/common/bitfields/tst.bitfields.exe mode=0555
+file path=opt/SUNWdtrt/tst/common/bitfields/tst.bitfields.ksh mode=0444
+file path=opt/SUNWdtrt/tst/common/bitfields/tst.bitfields.ksh.out mode=0444
 dir  path=opt/SUNWdtrt/tst/common/buffering
 file path=opt/SUNWdtrt/tst/common/buffering/err.end.d mode=0444
 file path=opt/SUNWdtrt/tst/common/buffering/err.resize1.d mode=0444

--- a/usr/src/test/bhyve-tests/runfiles/default.run
+++ b/usr/src/test/bhyve-tests/runfiles/default.run
@@ -53,6 +53,7 @@ tests = [
 user = root
 tests = [
 	'cpuid',
+	'imul',
 	'rdmsr',
 	'wrmsr',
 	'triple_fault',

--- a/usr/src/test/bhyve-tests/tests/inst_emul/Makefile
+++ b/usr/src/test/bhyve-tests/tests/inst_emul/Makefile
@@ -17,12 +17,14 @@ include $(SRC)/test/Makefile.com
 
 PROG =	rdmsr \
 	wrmsr \
+	imul \
 	cpuid
 
 # These should probably go in the `vmm` tests, but since they depend on
 # in-guest payloads, it is easier to build them here.
 PROG +=	triple_fault \
-	exit_paging
+	exit_paging \
+	page_dirty
 
 # C-based payloads need additional utils object
 CPAYLOADS =	cpuid

--- a/usr/src/test/bhyve-tests/tests/inst_emul/imul.c
+++ b/usr/src/test/bhyve-tests/tests/inst_emul/imul.c
@@ -1,0 +1,115 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <libgen.h>
+#include <assert.h>
+
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/debug.h>
+#include <sys/vmm.h>
+#include <sys/vmm_dev.h>
+#include <vmmapi.h>
+
+#include "in_guest.h"
+
+#define	MMIO_TEST_BASE	0x10001000
+#define	MMIO_TEST_END	0x10002000
+
+static bool
+handle_test_mmio(const struct vm_exit *vexit, struct vm_entry *ventry)
+{
+	/* expecting only reads */
+	if (vexit->u.mmio.read == 0) {
+		return (false);
+	}
+
+	/* expecting only in the [0x10001000 - 0x10002000) range */
+	if (vexit->u.mmio.gpa < MMIO_TEST_BASE ||
+	    vexit->u.mmio.gpa >= MMIO_TEST_END) {
+		return (false);
+	}
+
+	/*
+	 * Emit a pattern of the lowest 16 bits of the address, ascending by the
+	 * 2-byte stride for every 2 additional bytes, as the result.
+	 *
+	 * For example, an 8-byte read of 0x00001234 would result in:
+	 * 0x123a123812361234 being returned
+	 */
+	const uint16_t addr = vexit->u.mmio.gpa;
+	uint64_t val = 0;
+	switch (vexit->u.mmio.bytes) {
+	case 8:
+		val |= (uint64_t)(addr + 6) << 48;
+		val |= (uint64_t)(addr + 4) << 32;
+		/* FALLTHROUGH */
+	case 4:
+		val |= (uint32_t)(addr + 2) << 16;
+		/* FALLTHROUGH */
+	case 2:
+		val |= addr;
+		break;
+	default:
+		/* expect only 2/4/8-byte reads */
+		return (false);
+	}
+
+	ventry_fulfill_mmio(vexit, ventry, val);
+	return (true);
+}
+
+int
+main(int argc, char *argv[])
+{
+	const char *test_suite_name = basename(argv[0]);
+	struct vmctx *ctx = NULL;
+	int err;
+
+	ctx = test_initialize(test_suite_name);
+
+	err = test_setup_vcpu(ctx, 0, MEM_LOC_PAYLOAD, MEM_LOC_STACK);
+	if (err != 0) {
+		test_fail_errno(err, "Could not initialize vcpu0");
+	}
+
+	struct vm_entry ventry = { 0 };
+	struct vm_exit vexit = { 0 };
+
+	do {
+		const enum vm_exit_kind kind =
+		    test_run_vcpu(ctx, 0, &ventry, &vexit);
+		switch (kind) {
+		case VEK_REENTR:
+			break;
+		case VEK_UNHANDLED:
+			if (!handle_test_mmio(&vexit, &ventry)) {
+				test_fail_vmexit(&vexit);
+			}
+			break;
+		case VEK_TEST_PASS:
+			test_pass();
+			break;
+		case VEK_TEST_FAIL:
+		default:
+			test_fail_vmexit(&vexit);
+			break;
+		}
+	} while (true);
+}

--- a/usr/src/test/bhyve-tests/tests/inst_emul/page_dirty.c
+++ b/usr/src/test/bhyve-tests/tests/inst_emul/page_dirty.c
@@ -1,0 +1,162 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <libgen.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/debug.h>
+#include <sys/mman.h>
+#include <sys/vmm.h>
+#include <sys/vmm_dev.h>
+#include <vmmapi.h>
+
+#include "in_guest.h"
+
+#define	PAGE_SZ	4096
+
+#define	DIRTY_BITMAP_SZ	(MEM_TOTAL_SZ / (PAGE_SZ * 8))
+
+static void
+read_dirty_bitmap(struct vmctx *ctx, uint8_t *bitmap)
+{
+	struct vmm_dirty_tracker track = {
+		.vdt_start_gpa = 0,
+		.vdt_len = MEM_TOTAL_SZ,
+		.vdt_pfns = (void *)bitmap,
+	};
+	int err = ioctl(vm_get_device_fd(ctx), VM_TRACK_DIRTY_PAGES, &track);
+	if (err != 0) {
+		test_fail_errno(errno, "Could not get dirty page bitmap");
+	}
+}
+
+static uint8_t
+popc8(uint8_t val)
+{
+	uint8_t cnt;
+
+	for (cnt = 0; val != 0; val &= (val - 1)) {
+		cnt++;
+	}
+	return (cnt);
+}
+
+static uint_t
+count_dirty_pages(const uint8_t *bitmap)
+{
+	uint_t count = 0;
+	for (uint_t i = 0; i < DIRTY_BITMAP_SZ; i++) {
+		count += popc8(bitmap[i]);
+	}
+	return (count);
+}
+
+int
+main(int argc, char *argv[])
+{
+	const char *test_suite_name = basename(argv[0]);
+	struct vmctx *ctx = NULL;
+	int err;
+
+	ctx = test_initialize(test_suite_name);
+
+	/* Until #14251 is fixed, warn the user of the test requirement */
+	(void) fprintf(stderr,
+	    "Ensure that 'gpt_track_dirty' is set to 1 via mdb -kw\n"
+	    "The reasoning is described in illumos #14251\n");
+
+	err = test_setup_vcpu(ctx, 0, MEM_LOC_PAYLOAD, MEM_LOC_STACK);
+	if (err != 0) {
+		test_fail_errno(err, "Could not initialize vcpu0");
+	}
+
+	uint8_t dirty_bitmap[DIRTY_BITMAP_SZ] = { 0 };
+
+	/* Clear pages which were dirtied as part of initialization */
+	read_dirty_bitmap(ctx, dirty_bitmap);
+	if (count_dirty_pages(dirty_bitmap) == 0) {
+		test_fail_msg("no pages dirtied during setup\n");
+	}
+
+	/*
+	 * With nothing running, and the old dirty bits cleared, the NPT should
+	 * now be devoid of pages marked dirty.
+	 */
+	read_dirty_bitmap(ctx, dirty_bitmap);
+	if (count_dirty_pages(dirty_bitmap) != 0) {
+		test_fail_msg("pages still dirty after clear\n");
+	}
+
+	/* Dirty a page through the segvmm mapping. */
+	uint8_t *dptr = vm_map_gpa(ctx, MEM_LOC_STACK, 1);
+	*dptr = 1;
+
+	/* Check that it was marked as such */
+	read_dirty_bitmap(ctx, dirty_bitmap);
+	if (count_dirty_pages(dirty_bitmap) != 1) {
+		test_fail_msg("direct access did not dirty page\n");
+	}
+	if (dirty_bitmap[MEM_LOC_STACK / (PAGE_SZ * 8)] == 0) {
+		test_fail_msg("unexpected page dirtied\n");
+	}
+
+
+	/* Dirty it again to check shootdown logic */
+	*dptr = 2;
+	if (count_dirty_pages(dirty_bitmap) != 1) {
+		test_fail_msg("subsequent direct access did not dirty page\n");
+	}
+
+	struct vm_entry ventry = { 0 };
+	struct vm_exit vexit = { 0 };
+	do {
+		const enum vm_exit_kind kind =
+		    test_run_vcpu(ctx, 0, &ventry, &vexit);
+		switch (kind) {
+		case VEK_REENTR:
+			break;
+		case VEK_TEST_PASS:
+			/*
+			 * By now, the guest should have dirtied that page
+			 * directly via hardware-accelerated path.
+			 */
+			read_dirty_bitmap(ctx, dirty_bitmap);
+			/*
+			 * The guest will dirty more than the page it is
+			 * explicitly writing to: it must mark its own page
+			 * tables with accessed/dirty bits too.
+			 */
+			if (count_dirty_pages(dirty_bitmap) <= 1) {
+				test_fail_msg(
+				    "in-guest access did not dirty page\n");
+			}
+			if (dirty_bitmap[MEM_LOC_STACK / (PAGE_SZ * 8)] == 0) {
+				test_fail_msg("expected page not dirtied\n");
+			}
+			test_pass();
+			break;
+		default:
+			test_fail_vmexit(&vexit);
+			break;
+		}
+	} while (true);
+}

--- a/usr/src/test/bhyve-tests/tests/inst_emul/payload_imul.s
+++ b/usr/src/test/bhyve-tests/tests/inst_emul/payload_imul.s
@@ -1,0 +1,59 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+#include <sys/asm_linkage.h>
+#include "payload_common.h"
+
+ENTRY(start)
+	/* check that the mmio values we expect are emitted */
+	movw	0x10001234, %ax
+	cmpw	$0x1234, %ax
+	jne		fail
+	movl	0x10001232, %eax
+	cmpl	$0x12341232, %eax
+	jne		fail
+	movq	0x10001230, %rax
+	movq	$0x1236123412321230, %rdx
+	cmpq	%rdx, %rax
+	jne		fail
+
+	/* attempt the imul at 2/4/8 byte widths */
+	movl	$0x2, %eax
+	imulw	0x10001234, %ax
+	cmpw	$0x2468, %ax
+	jne		fail
+
+	movl	$0x2, %eax
+	imull	0x10001232, %eax
+	cmpl	$0x24682464, %eax
+	jne		fail
+
+	movl	$0x10, %eax
+	imulq	0x10001230, %rax
+	movq	$0x2361234123212300, %rcx
+	cmpq	%rcx, %rax
+	jne		fail
+
+	movw    $IOP_TEST_RESULT, %dx
+	movb    $TEST_RESULT_PASS, %al
+	outb    (%dx)
+	hlt
+
+fail:
+	movw    $IOP_TEST_RESULT, %dx
+	movb    $TEST_RESULT_FAIL, %al
+	outb    (%dx)
+	hlt
+SET_SIZE(start)

--- a/usr/src/test/bhyve-tests/tests/inst_emul/payload_page_dirty.s
+++ b/usr/src/test/bhyve-tests/tests/inst_emul/payload_page_dirty.s
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2022 Oxide Computer Company
+ */
+
+#include <sys/asm_linkage.h>
+#include "payload_common.h"
+
+
+ENTRY(start)
+	/* Dirty the stack page once again */
+	xorl	%eax, %eax
+	movq	%rax, MEM_LOC_STACK
+
+	movw    $IOP_TEST_RESULT, %dx
+	movb    $TEST_RESULT_PASS, %al
+	outb    (%dx)
+	hlt
+SET_SIZE(start)

--- a/usr/src/test/elf-tests/tests/linker-sets/simple-src.c
+++ b/usr/src/test/elf-tests/tests/linker-sets/simple-src.c
@@ -31,41 +31,7 @@
  */
 
 #include <stdio.h>
-
-#define	MAKE_SET(set, sym)					\
-	__asm__(".globl __start_set_" #set);			\
-	__asm__(".globl __stop_set_" #set);			\
-	static __attribute__((section("set_" #set), used))	\
-	void const *__set_##set##_sym_##sym = &(sym)
-
-/*
- * Initialize before referring to a given linker set.
- */
-#define	SET_DECLARE(set, ptype)						\
-	extern  __attribute__((weak)) ptype *__start_set_ ## set;	\
-	extern __attribute__((weak)) ptype *__stop_set_ ## set
-
-#define	SET_BEGIN(set)	(&__start_set_ ## set)
-#define	SET_LIMIT(set)	(&__stop_set_ ## set)
-
-/*
- * Iterate over all the elements of a set.
- *
- * Sets always contain addresses of things, and "pvar" points to words
- * containing those addresses.  Thus is must be declared as "type **pvar",
- * and the address of each set item is obtained inside the loop by "*pvar".
- */
-#define	SET_FOREACH(pvar, set)						\
-	for (pvar = SET_BEGIN(set); pvar < SET_LIMIT(set); pvar++)
-
-#define	SET_ITEM(set, i)						\
-	((SET_BEGIN(set))[i])
-
-/*
- * Provide a count of the items in a set.
- */
-#define	SET_COUNT(set)							\
-	(SET_LIMIT(set) - SET_BEGIN(set))
+#include <sys/linker_set.h>
 
 struct foo {
 	char buf[128];
@@ -77,9 +43,9 @@ struct foo a = { "foo" };
 struct foo b = { "bar" };
 struct foo c = { "baz" };
 
-MAKE_SET(foo, a);
-MAKE_SET(foo, b);
-MAKE_SET(foo, c);
+SET_ENTRY(foo, a);
+SET_ENTRY(foo, b);
+SET_ENTRY(foo, c);
 
 int
 main(int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
@@ -87,7 +53,7 @@ main(int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
 	struct foo **c;
 	int i = 0;
 
-	printf("Set count: %d\n", SET_COUNT(foo));
+	printf("Set count: %d\n", (int)SET_COUNT(foo));
 
 
 	printf("a: %s\n", ((struct foo *)__set_foo_sym_a)->buf);

--- a/usr/src/test/util-tests/tests/mdb/numbers/tst.bitfields.ksh
+++ b/usr/src/test/util-tests/tests/mdb/numbers/tst.bitfields.ksh
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright 2021 Oxide Computer Company
+# Copyright 2022 Oxide Computer Company
 #
 
 #
@@ -26,5 +26,81 @@ tst_prog="$tst_root/progs/bitfields"
 tst_outfile="/tmp/mdb.bitfield.out.$$"
 tst_exp="$0.out"
 
+#
+# Top level ::print
+#
 $MDB -e "first::print -t broken_t" $tst_prog > $ODIR/stdout
 $MDB -e "second::print -t broken6491_t" $tst_prog >> $ODIR/stdout
+
+#
+# ::print of specific members
+#
+$MDB -e "first::print broken_t brk_a" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_b" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_c" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_d" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_e" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_f" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_g" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_h" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_i" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_j" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_k" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_l" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_m" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t a" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t b" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t c" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t d" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t e" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t f" $tst_prog >> $ODIR/stdout
+
+#
+# ::printf of members. Note, if ::printf said '%x\n' below then we would
+# include the string "\n" (not a newline) in the output. Instead we rely
+# upon the implicit newline from mdb -e.
+#
+$MDB -e "first::printf '%x' broken_t brk_a" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_b" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_c" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_d" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_e" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_f" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_g" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_h" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_i" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_j" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_k" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_l" $tst_prog >> $ODIR/stdout
+$MDB -e "first::printf '%x' broken_t brk_m" $tst_prog >> $ODIR/stdout
+$MDB -e "second::printf '%x' broken6491_t a" $tst_prog >> $ODIR/stdout
+$MDB -e "second::printf '%x' broken6491_t b" $tst_prog >> $ODIR/stdout
+$MDB -e "second::printf '%x' broken6491_t c" $tst_prog >> $ODIR/stdout
+$MDB -e "second::printf '%x' broken6491_t d" $tst_prog >> $ODIR/stdout
+$MDB -e "second::printf '%x' broken6491_t e" $tst_prog >> $ODIR/stdout
+$MDB -e "second::printf '%x' broken6491_t f" $tst_prog >> $ODIR/stdout
+
+#
+# If we pipe the output of ::print that is a different bitfield logic
+# path. So we take that all to a `::eval '.=K'` as a basic way to get it
+# out.
+#
+$MDB -e "first::print broken_t brk_a | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_b | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_c | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_d | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_e | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_f | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_g | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_h | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_i | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_j | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_k | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_l | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "first::print broken_t brk_m | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t a | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t b | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t c | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t d | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t e | ::eval '.=K'" $tst_prog >> $ODIR/stdout
+$MDB -e "second::print broken6491_t f | ::eval '.=K'" $tst_prog >> $ODIR/stdout

--- a/usr/src/test/util-tests/tests/mdb/numbers/tst.bitfields.ksh.out
+++ b/usr/src/test/util-tests/tests/mdb/numbers/tst.bitfields.ksh.out
@@ -21,3 +21,60 @@ broken6491_t {
     unsigned short:1 e :1 = 0x1
     unsigned short:1 f :1 = 0
 }
+brk_a = 0x3
+brk_b = 0x3
+brk_c = 0
+brk_d = 0x1
+brk_e = 0x1
+brk_f = 0x1
+brk_g = 0x3
+brk_h = 0x5
+brk_i = 0x3
+brk_j = 0x9
+brk_k = 0x13
+brk_l = 0
+brk_m = 0x1
+a = 0x1
+b = 0x2
+c = 0
+d = 0
+e = 0x1
+f = 0
+3
+3
+0
+1
+1
+1
+3
+5
+3
+9
+13
+0
+1
+1
+2
+0
+0
+1
+0
+                3               
+                3               
+                0               
+                1               
+                1               
+                1               
+                3               
+                5               
+                3               
+                9               
+                13              
+                0               
+                1               
+                1               
+                2               
+                0               
+                0               
+                1               
+                0               

--- a/usr/src/test/util-tests/tests/pcieadm/pcieadm-priv.ksh
+++ b/usr/src/test/util-tests/tests/pcieadm/pcieadm-priv.ksh
@@ -102,9 +102,9 @@ else
 fi
 
 #
-# Do the same based on the device name
+# Do the same based on the device instance.
 #
-pcieadm_dev=$($pcieadm_prog show-devs -p -o driver | \
+pcieadm_dev=$($pcieadm_prog show-devs -p -o instance | \
     awk '{ if ($1 != "--") { print $1; exit 0 } }')
 if [[ -z "$pcieadm_dev" ]]; then
 	warn "failed to obtain driver based filter"

--- a/usr/src/uts/common/fs/smbsrv/smb2_query_dir.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_query_dir.c
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -441,7 +442,7 @@ smb2_find_mbc_encode(smb_request_t *sr, smb2_find_args_t *args)
 	int		shortlen = 0;
 	int		rc, starting_offset;
 	uint32_t	next_entry_offset;
-	uint32_t	mb_flags = SMB_MSGBUF_UNICODE;
+	uint32_t	mb_flags = SMB_MSGBUF_UNICODE | SMB_MSGBUF_NOTERM;
 	uint32_t	resume_key;
 
 	namelen = smb_wcequiv_strlen(fileinfo->fi_name);
@@ -527,8 +528,11 @@ smb2_find_mbc_encode(smb_request_t *sr, smb2_find_args_t *args)
 	case FileBothDirectoryInformation:	/* 3 */
 		bzero(buf83, sizeof (buf83));
 		smb_msgbuf_init(&mb, buf83, sizeof (buf83), mb_flags);
-		if (!smb_msgbuf_encode(&mb, "U", fileinfo->fi_shortname))
-			shortlen = smb_wcequiv_strlen(fileinfo->fi_shortname);
+		shortlen = smb_msgbuf_encode(&mb, "U", fileinfo->fi_shortname);
+		if (shortlen < 0) {
+			shortlen = 0;
+			bzero(buf83, sizeof (buf83));
+		}
 
 		rc = smb_mbc_encodef(
 		    &sr->raw_data, "llTTTTqqlllb.24c",
@@ -553,8 +557,11 @@ smb2_find_mbc_encode(smb_request_t *sr, smb2_find_args_t *args)
 	case FileIdBothDirectoryInformation:	/* 37 */
 		bzero(buf83, sizeof (buf83));
 		smb_msgbuf_init(&mb, buf83, sizeof (buf83), mb_flags);
-		if (!smb_msgbuf_encode(&mb, "U", fileinfo->fi_shortname))
-			shortlen = smb_wcequiv_strlen(fileinfo->fi_shortname);
+		shortlen = smb_msgbuf_encode(&mb, "U", fileinfo->fi_shortname);
+		if (shortlen < 0) {
+			shortlen = 0;
+			bzero(buf83, sizeof (buf83));
+		}
 
 		rc = smb_mbc_encodef(
 		    &sr->raw_data, "llTTTTqqlllb.24c..q",

--- a/usr/src/uts/common/fs/smbsrv/smb2_tree_connect.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_tree_connect.c
@@ -127,6 +127,7 @@ errout:
 
 	/*
 	 * XXX These need work..
+	 * See SMB1 flags in tcon->optional_support
 	 */
 	if (tree->t_encrypt != SMB_CONFIG_DISABLED)
 		ShareFlags = SMB2_SHAREFLAG_ENCRYPT_DATA;

--- a/usr/src/uts/common/fs/smbsrv/smb2_write.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_write.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -150,6 +151,17 @@ smb2_write(smb_request_t *sr)
 			break;
 		/* This revokes read cache delegations. */
 		(void) smb_oplock_break_WRITE(of->f_node, of);
+		/*
+		 * Don't want the performance cost of generating
+		 * change notify events on every write.  Instead:
+		 * Keep track of the fact that we have written
+		 * data via this handle, and do change notify
+		 * work on the first write, and during close.
+		 */
+		if (of->f_written == B_FALSE) {
+			of->f_written = B_TRUE;
+			smb_node_notify_modified(of->f_node);
+		}
 		break;
 
 	case STYPE_IPC:

--- a/usr/src/uts/common/fs/smbsrv/smb_fem.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_fem.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Tintri by DDN, Inc.  All rights reserved.
  * Copyright 2015 Joyent, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #include <smbsrv/smb_kproto.h>
@@ -206,6 +207,16 @@ smb_fem_oplock_uninstall(smb_node_t *node)
  *
  * The FCN monitors intercept the respective VOP_* call regardless
  * of whether the call originates from CIFS, NFS, or a local process.
+ *
+ * Here we're only interested in operations that change the list of
+ * names contained in the directory.  SMB clients can also ask to be
+ * notified about events where a file in this directory has had its
+ * meta-data changed (size, times, etc) but that's outside of the
+ * design intent for these FEM hooks.  Those meta-data events DO
+ * happen when caused by SMB clients (via smb_node_notify_modified)
+ * but not by other FS activity because we don't have a good way to
+ * place all the FEM hooks that would be required for that, and if
+ * we did, the performance cost could be severe.
  */
 
 /*

--- a/usr/src/uts/common/fs/smbsrv/smb_init.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_init.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #include <sys/types.h>
@@ -67,7 +68,6 @@ int	smb_maxbufsize = SMB_NT_MAXBUF;
 int	smb_flush_required = 1;
 int	smb_dirsymlink_enable = 1;
 int	smb_sign_debug = 0;
-int	smb_shortnames = 1;
 uint_t	smb_audit_flags =
 #ifdef	DEBUG
     SMB_AUDIT_NODE;

--- a/usr/src/uts/common/fs/smbsrv/smb_kshare.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_kshare.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2017 Joyent, Inc.
+ * Copyright 2022 RackTop Systems.
  */
 
 #include <smbsrv/smb_door.h>
@@ -508,8 +509,14 @@ out:
 int
 smb_kshare_info(smb_ioc_shareinfo_t *ioc)
 {
-	ioc->shortnames = smb_shortnames;
-	return (0);
+	smb_server_t	*sv;
+	int		rc;
+
+	if ((rc = smb_server_lookup(&sv)) == 0) {
+		ioc->shortnames = sv->sv_cfg.skc_short_names;
+		smb_server_release(sv);
+	}
+	return (rc);
 }
 
 /*

--- a/usr/src/uts/common/fs/smbsrv/smb_ofile.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_ofile.c
@@ -23,7 +23,7 @@
  * Copyright 2011-2020 Tintri by DDN, Inc. All rights reserved.
  * Copyright 2016 Syneto S.R.L. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
- * Copyright 2021 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -580,6 +580,16 @@ smb_ofile_close(smb_ofile_t *of, int32_t mtime_sec)
 			 */
 			(void) smb_node_setattr(NULL, of->f_node,
 			    of->f_cr, NULL, pa);
+		}
+		/*
+		 * Don't want the performance cost of generating
+		 * change notify events on every write.  Instead:
+		 * Keep track of the fact that we have written
+		 * data via this handle, and do change notify
+		 * work on the first write, and during close.
+		 */
+		if (of->f_written) {
+			smb_node_notify_modified(of->f_node);
 		}
 
 		smb_server_dec_files(of->f_server);

--- a/usr/src/uts/common/fs/smbsrv/smb_server.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_server.c
@@ -2123,6 +2123,7 @@ smb_server_store_cfg(smb_server_t *sv, smb_ioc_cfg_t *ioc)
 	sv->sv_cfg.skc_ipv6_enable = ioc->ipv6_enable;
 	sv->sv_cfg.skc_print_enable = ioc->print_enable;
 	sv->sv_cfg.skc_traverse_mounts = ioc->traverse_mounts;
+	sv->sv_cfg.skc_short_names = ioc->short_names;
 	sv->sv_cfg.skc_max_protocol = ioc->max_protocol;
 	sv->sv_cfg.skc_min_protocol = ioc->min_protocol;
 	sv->sv_cfg.skc_encrypt = ioc->encrypt;

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -32,6 +32,7 @@
  * Copyright (c) 2017, Intel Corporation.
  * Copyright 2020 Joshua M. Clulow <josh@sysmgr.org>
  * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2022 Oxide Computer Company
  */
 
 /*
@@ -5478,6 +5479,21 @@ spa_import_rootpool(char *devpath, char *devid, uint64_t pool_guid,
 	char *pname;
 	int error;
 	const char *altdevpath = NULL;
+	const char *rdpath = NULL;
+
+	if ((rdpath = vdev_disk_preroot_force_path()) != NULL) {
+		/*
+		 * We expect to import a single-vdev pool from a specific
+		 * device such as a ramdisk device.  We don't care what the
+		 * pool label says.
+		 */
+		config = spa_generate_rootconf(rdpath, NULL, &guid, 0);
+		if (config != NULL) {
+			goto configok;
+		}
+		cmn_err(CE_NOTE, "Cannot use root disk device '%s'", rdpath);
+		return (SET_ERROR(EIO));
+	}
 
 	/*
 	 * Read the label from the boot device and generate a configuration.
@@ -5520,6 +5536,7 @@ spa_import_rootpool(char *devpath, char *devid, uint64_t pool_guid,
 		return (SET_ERROR(EIO));
 	}
 
+configok:
 	VERIFY(nvlist_lookup_string(config, ZPOOL_CONFIG_POOL_NAME,
 	    &pname) == 0);
 	VERIFY(nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_TXG, &txg) == 0);
@@ -5592,6 +5609,12 @@ spa_import_rootpool(char *devpath, char *devid, uint64_t pool_guid,
 		error = SET_ERROR(EINVAL);
 		goto out;
 	}
+
+	/*
+	 * The root disk may have been expanded while the system was offline.
+	 * Kick off an async task to check for and handle expansion.
+	 */
+	spa_async_request(spa, SPA_ASYNC_AUTOEXPAND);
 
 	error = 0;
 out:
@@ -7517,8 +7540,6 @@ spa_async_probe(spa_t *spa, vdev_t *vd)
 static void
 spa_async_autoexpand(spa_t *spa, vdev_t *vd)
 {
-	sysevent_id_t eid;
-	nvlist_t *attr;
 	char *physpath;
 
 	if (!spa->spa_autoexpand)
@@ -7535,13 +7556,8 @@ spa_async_autoexpand(spa_t *spa, vdev_t *vd)
 	physpath = kmem_zalloc(MAXPATHLEN, KM_SLEEP);
 	(void) snprintf(physpath, MAXPATHLEN, "/devices%s", vd->vdev_physpath);
 
-	VERIFY(nvlist_alloc(&attr, NV_UNIQUE_NAME, KM_SLEEP) == 0);
-	VERIFY(nvlist_add_string(attr, DEV_PHYS_PATH, physpath) == 0);
+	zfs_post_dle_sysevent(physpath);
 
-	(void) ddi_log_sysevent(zfs_dip, SUNW_VENDOR, EC_DEV_STATUS,
-	    ESC_DEV_DLE, attr, &eid, DDI_SLEEP);
-
-	nvlist_free(attr);
 	kmem_free(physpath, MAXPATHLEN);
 }
 

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -1104,6 +1104,7 @@ extern sysevent_t *spa_event_create(spa_t *spa, vdev_t *vd, nvlist_t *hist_nvl,
     const char *name);
 extern void spa_event_post(sysevent_t *ev);
 extern void spa_event_discard(sysevent_t *ev);
+extern void zfs_post_dle_sysevent(const char *);
 
 #ifdef ZFS_DEBUG
 #define	dprintf_bp(bp, fmt, ...) do {				\

--- a/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
@@ -589,9 +589,10 @@ typedef struct vdev_buf {
  * Support routines used during boot from a ZFS pool
  */
 extern int vdev_disk_read_rootlabel(const char *, const char *, nvlist_t **);
-extern void vdev_disk_preroot_init(void);
+extern void vdev_disk_preroot_init(const char *);
 extern void vdev_disk_preroot_fini(void);
 extern const char *vdev_disk_preroot_lookup(uint64_t, uint64_t);
+extern const char *vdev_disk_preroot_force_path(void);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -302,6 +302,7 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	int otyp;
 	boolean_t validate_devid = B_FALSE;
 	uint64_t capacity = 0, blksz = 0, pbsize;
+	const char *rdpath = vdev_disk_preroot_force_path();
 
 	/*
 	 * We must have a pathname, and it must be absolute.
@@ -329,7 +330,8 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	/*
 	 * Allow bypassing the devid.
 	 */
-	if (vd->vdev_devid != NULL && vdev_disk_bypass_devid) {
+	if (vd->vdev_devid != NULL &&
+	    (vdev_disk_bypass_devid || rdpath != NULL)) {
 		vdev_dbgmsg(vd, "vdev_disk_open, devid %s bypassed",
 		    vd->vdev_devid);
 		spa_strfree(vd->vdev_devid);
@@ -364,6 +366,17 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	}
 
 	error = EINVAL;		/* presume failure */
+
+	if (rdpath != NULL) {
+		/*
+		 * We have been asked to open only a specific root device, and
+		 * to fail otherwise.
+		 */
+		error = ldi_open_by_name((char *)rdpath, spa_mode(spa), kcred,
+		    &dvd->vd_lh, zfs_li);
+		validate_devid = B_TRUE;
+		goto rootdisk_only;
+	}
 
 	if (vd->vdev_path != NULL) {
 		if (vd->vdev_wholedisk == -1ULL) {
@@ -502,6 +515,7 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		}
 	}
 
+rootdisk_only:
 	if (error != 0) {
 		vd->vdev_stat.vs_aux = VDEV_AUX_OPEN_FAILED;
 		vdev_dbgmsg(vd, "vdev_disk_open: failed to open [error=%d]",
@@ -1159,6 +1173,7 @@ vdev_disk_read_rootlabel(const char *devpath, const char *devid,
 struct veb {
 	list_t veb_ents;
 	boolean_t veb_scanned;
+	char *veb_force_path;
 };
 
 struct veb_ent {
@@ -1270,8 +1285,22 @@ vdev_disk_preroot_lookup(uint64_t pool_guid, uint64_t vdev_guid)
 	return (path);
 }
 
+const char *
+vdev_disk_preroot_force_path(void)
+{
+	const char *force_path = NULL;
+
+	mutex_enter(&veb_lock);
+	if (veb != NULL) {
+		force_path = veb->veb_force_path;
+	}
+	mutex_exit(&veb_lock);
+
+	return (force_path);
+}
+
 void
-vdev_disk_preroot_init(void)
+vdev_disk_preroot_init(const char *force_path)
 {
 	mutex_init(&veb_lock, NULL, MUTEX_DEFAULT, NULL);
 
@@ -1280,6 +1309,9 @@ vdev_disk_preroot_init(void)
 	list_create(&veb->veb_ents, sizeof (struct veb_ent),
 	    offsetof(struct veb_ent, vebe_link));
 	veb->veb_scanned = B_FALSE;
+	if (force_path != NULL) {
+		veb->veb_force_path = spa_strdup(force_path);
+	}
 }
 
 void
@@ -1294,6 +1326,10 @@ vdev_disk_preroot_fini(void)
 			spa_strfree(vebe->vebe_devpath);
 
 			kmem_free(vebe, sizeof (*vebe));
+		}
+
+		if (veb->veb_force_path != NULL) {
+			spa_strfree(veb->veb_force_path);
 		}
 
 		kmem_free(veb, sizeof (*veb));

--- a/usr/src/uts/common/fs/zfs/zvol.c
+++ b/usr/src/uts/common/fs/zfs/zvol.c
@@ -813,20 +813,12 @@ zvol_update_live_volsize(zvol_state_t *zv, uint64_t volsize)
 	 * Generate a LUN expansion event.
 	 */
 	if (error == 0) {
-		sysevent_id_t eid;
-		nvlist_t *attr;
 		char *physpath = kmem_zalloc(MAXPATHLEN, KM_SLEEP);
 
 		(void) snprintf(physpath, MAXPATHLEN, "%s%u", ZVOL_PSEUDO_DEV,
 		    zv->zv_minor);
 
-		VERIFY(nvlist_alloc(&attr, NV_UNIQUE_NAME, KM_SLEEP) == 0);
-		VERIFY(nvlist_add_string(attr, DEV_PHYS_PATH, physpath) == 0);
-
-		(void) ddi_log_sysevent(zfs_dip, SUNW_VENDOR, EC_DEV_STATUS,
-		    ESC_DEV_DLE, attr, &eid, DDI_SLEEP);
-
-		nvlist_free(attr);
+		zfs_post_dle_sysevent(physpath);
 		kmem_free(physpath, MAXPATHLEN);
 	}
 	return (error);

--- a/usr/src/uts/common/smbsrv/smb_ioctl.h
+++ b/usr/src/uts/common/smbsrv/smb_ioctl.h
@@ -22,7 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2017 Joyent, Inc.
- * Copyright 2020 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #ifndef _SMB_IOCTL_H_
@@ -172,6 +172,7 @@ typedef struct smb_ioc_cfg {
 	int32_t		ipv6_enable;
 	int32_t		print_enable;
 	int32_t		traverse_mounts;
+	int32_t		short_names;
 	uint32_t	max_protocol;
 	uint32_t	min_protocol;
 	uint32_t	encrypt;

--- a/usr/src/uts/common/smbsrv/smb_kproto.h
+++ b/usr/src/uts/common/smbsrv/smb_kproto.h
@@ -23,6 +23,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Syneto S.R.L.  All rights reserved.
  * Copyright 2011-2022 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -537,6 +538,7 @@ boolean_t smb_node_share_check(smb_node_t *);
 void smb_node_fcn_subscribe(smb_node_t *);
 void smb_node_fcn_unsubscribe(smb_node_t *);
 void smb_node_notify_change(smb_node_t *, uint_t, const char *);
+void smb_node_notify_modified(smb_node_t *);
 
 int smb_node_getattr(smb_request_t *, smb_node_t *, cred_t *,
     smb_ofile_t *, smb_attr_t *);

--- a/usr/src/uts/common/smbsrv/smb_ktypes.h
+++ b/usr/src/uts/common/smbsrv/smb_ktypes.h
@@ -1417,6 +1417,7 @@ typedef struct smb_ofile {
 	cred_t			*f_cr;
 	pid_t			f_pid;
 	smb_attr_t		f_pending_attr;
+	boolean_t		f_written;
 	smb_oplock_grant_t	f_oplock;
 	boolean_t		f_oplock_closing;
 	uint8_t			TargetOplockKey[SMB_LEASE_KEY_SZ];

--- a/usr/src/uts/common/smbsrv/smbinfo.h
+++ b/usr/src/uts/common/smbsrv/smbinfo.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
- * Copyright 2021 RackTop Systems, Inc.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #ifndef	_SMBSRV_SMBINFO_H
@@ -158,6 +158,7 @@ typedef struct smb_kmod_cfg {
 	int32_t skc_ipv6_enable;
 	int32_t skc_print_enable;
 	int32_t skc_traverse_mounts;
+	int32_t skc_short_names;
 	uint32_t skc_max_protocol;	/* SMB_VERS_... */
 	uint32_t skc_min_protocol;	/* SMB_VERS_... */
 	smb_cfg_val_t skc_encrypt; /* EncryptData and RejectUnencryptedAccess */

--- a/usr/src/uts/common/sys/linker_set.h
+++ b/usr/src/uts/common/sys/linker_set.h
@@ -41,14 +41,17 @@
 #define	__CONCAT1(x, y)	x ## y
 #define	__CONCAT(x, y)	__CONCAT1(x, y)
 
-#define	__GLOBL1(sym)	__asm__(".globl " #sym)
-#define	__GLOBL(sym)	__GLOBL1(sym)
+#define	__STRING(x)	#x		/* stringify without expanding x */
+#define	__XSTRING(x)	__STRING(x)	/* expand x, then stringify */
+
+#define	__GLOBL(sym)	__asm__(".globl " __XSTRING(sym))
+#define	__WEAK(sym)	__asm__(".weak " __XSTRING(sym))
 /*
  * Private macros, not to be used outside this header file.
  */
 #define	__MAKE_SET(set, sym)				\
-	__GLOBL(__CONCAT(__start_set_, set));		\
-	__GLOBL(__CONCAT(__stop_set_, set));		\
+	__WEAK(__CONCAT(__start_set_, set));		\
+	__WEAK(__CONCAT(__stop_set_, set));		\
 	static void const * __MAKE_SET_CONST		\
 	__set_##set##_sym_##sym __section("set_" #set)	\
 	__used = &(sym)


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151045  omnios-upstream_merge-2022111101-11470e46815    November 2022
illumos development build: 2022-Nov-11 [illumos-omnios]
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-upstream_merge-2022111101-11470e46815 i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Fri Nov 11 16:31:12 UTC 2022 ====
==== Nightly distributed build completed: Fri Nov 11 17:09:13 UTC 2022 ====

==== Total build time ====

real    0:38:00

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-b153bc52e0 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 24

cw version 7.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151045/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151045/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.17+8-omnios-151045"

/usr/bin/openssl
OpenSSL 3.0.7 1 Nov 2022 (Library: OpenSSL 3.0.7 1 Nov 2022)

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1786 (illumos)

Build project:  default
Build taskid:   72

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2022111101-11470e46815

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    14:47.3
user  3:45:55.4
sys   1:10:28.6

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    12:11.6
user  3:15:43.6
sys   1:02:20.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```