### PR TITLE
15295 SMB services should check IPC caller privileges (r151038)

### DIFF
--- a/usr/src/cmd/idmap/idmapd/idmap_lsa.c
+++ b/usr/src/cmd/idmap/idmapd/idmap_lsa.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 /*
@@ -244,5 +245,10 @@ out:
 void
 notify_dc_changed(void)
 {
-	smb_notify_dc_changed();
+	int rc;
+	rc = smb_notify_dc_changed();
+	if (rc != 0) {
+		idmapdlog(LOG_WARNING,
+		    "Warning: smb_notify_dc_changed, rc=%d", rc);
+	}
 }

--- a/usr/src/lib/smbsrv/libsmb/common/libsmb.h
+++ b/usr/src/lib/smbsrv/libsmb/common/libsmb.h
@@ -259,7 +259,7 @@ int smb_join(smb_joininfo_t *, smb_joinres_t *info);
 bool_t smb_joininfo_xdr(XDR *, smb_joininfo_t *);
 bool_t smb_joinres_xdr(XDR *, smb_joinres_t *);
 boolean_t smb_find_ads_server(char *, char *, int);
-void smb_notify_dc_changed(void);
+int smb_notify_dc_changed(void);
 
 extern void smb_config_getdomaininfo(char *, char *, char *, char *, char *);
 extern void smb_config_setdomaininfo(char *, char *, char *, char *, char *);

--- a/usr/src/lib/smbsrv/libsmb/common/smb_doorclnt.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_doorclnt.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2022 RackTop Systems, Inc.
  */
 
 #include <assert.h>
@@ -293,7 +294,7 @@ smb_find_ads_server(char *fqdn, char *buf, int buflen)
 	return (found);
 }
 
-void
+int
 smb_notify_dc_changed(void)
 {
 	int rc;
@@ -301,8 +302,14 @@ smb_notify_dc_changed(void)
 	rc = smb_door_call(SMB_DR_NOTIFY_DC_CHANGED,
 	    NULL, NULL, NULL, NULL);
 
-	if (rc != 0)
-		syslog(LOG_DEBUG, "smb_notify_dc_changed: %m");
+	if (rc != 0) {
+		rc = errno;
+		if (rc == 0)
+			rc = EPERM;
+		syslog(LOG_DEBUG, "smb_notify_dc_changed: rc=%d", rc);
+		return (rc);
+	}
+	return (0);
 }
 
 


### PR DESCRIPTION

## mail_msg

```

==== Nightly distributed build started:   Fri Dec 30 21:25:24 UTC 2022 ====
==== Nightly distributed build completed: Fri Dec 30 22:30:51 UTC 2022 ====

==== Total build time ====

real    1:05:26

==== Build environment ====

/usr/bin/uname
SunOS r151038 5.11 omnios-r151038-1d6c6e5c34 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151038/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151038/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.17+8-omnios-151038"

/usr/bin/openssl
OpenSSL 1.1.1s  1 Nov 2022
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1765 (illumos)

Build project:  default
Build taskid:   89

==== Nightly argument issues ====


==== Build version ====

omnios-15295r38-7850789f6e

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    25:18.3
user  3:53:34.8
sys   1:03:49.9

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:55.2
user  3:21:00.0
sys     59:19.4

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
