### PR TITLE
8662 SMB server ioctls should be appropriately sized (fix mismerge)

### DIFF
--- a/usr/src/uts/common/fs/smbsrv/smb_init.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_init.c
@@ -271,11 +271,6 @@ smb_drv_ioctl(dev_t drv, int cmd, intptr_t argp, int flags, cred_t *cred,
 
 	if (ddi_copyin((void *)argp, &ioc_hdr, sizeof (ioc_hdr), flags))
 		return (EFAULT);
-	/* SMB_IOC_SVCENUM can be quite large.  See libsmb's smb_kmod.c. */
-	alloclen = MAX(ioc_hdr.len, sizeof (*ioc));
-	if (ioc_hdr.version != SMB_IOC_VERSION ||
-	    alloclen > sizeof (smb_ioc_svcenum_t) + SMB_IOC_DATA_SIZE)
-		return (EINVAL);
 
 	/*
 	 * Check version and length.


### PR DESCRIPTION
Reported by @gwr as a dangling difference between gate and omnios.

```
That appears to have come from this:

commit 1fe1b1faaf445ec3a6b487abdf733de481df202a
Author: Dan McDonald <danmcd@joyent.com>
Date:   Wed Aug 30 15:33:47 2017 -0400

    OS-6319 Fix for OS-6297 forgot smb_ioc_svcenum_t
    Reviewed by: Patrick Mooney <patrick.mooney@joyent.com>
    Reviewed by: Mike Zeller <mike.zeller@joyent.com>
    Reviewed by: Jason King <jason.king@joyent.com>
    Approved by: Patrick Mooney <patrick.mooney@joyent.com>

And that was fixed in illumos with:

commit 5f3b52abece3d89262210be84196e7367cd279d2
Author: Gordon Ross <gwr@nexenta.com>
Date:   Mon Aug 28 21:50:05 2017 +0000

    8662 SMB server ioctls should be appropriately sized.
    Reviewed by: Jerry Jelinek <jerry.jelinek@joyent.com>
    Reviewed by: Dan McDonald <danmcd@joyent.com>
    Reviewed by: Patrick Mooney <patrick.mooney@joyent.com>
    Approved by: Albert Lee <trisk@forkgnu.org>

The code that appears in the diff above is redundant with the check
seen right after it.
```
