### PR TITLE
Upstream merge datalink improvements.

### DIFF
--- a/usr/src/cmd/dlmgmtd/dlmgmt_db.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_db.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015, Joyent Inc.
+ * Copyright 2016 Joyent, Inc.
  * Copyright 2023 Oxide Computer Company
  */
 
@@ -45,7 +45,6 @@
 #include <libcontract.h>
 #include <libcontract_priv.h>
 #include <sys/contract/process.h>
-#include <sys/vnic.h>
 #include <zone.h>
 #include "dlmgmt_impl.h"
 
@@ -730,7 +729,6 @@ parse_linkprops(char *buf, dlmgmt_link_t *linkp)
 	char			attr_name[MAXLINKATTRLEN];
 	size_t			attr_buf_len = 0;
 	void			*attr_buf = NULL;
-	boolean_t		rename;
 
 	curr = buf;
 	len = strlen(buf);
@@ -741,7 +739,6 @@ parse_linkprops(char *buf, dlmgmt_link_t *linkp)
 		    (c == ',' && !found_type) || c == ';');
 		boolean_t	rename = B_FALSE;
 
-		rename = B_FALSE;
 		/*
 		 * Move to the next character if there is no match and
 		 * if we have not reached the last character.
@@ -1555,11 +1552,6 @@ done:
 
 /*
  * Remove all links in the given zoneid.
- *
- * We do this work in two different passes. In the first pass, we remove any
- * entry that hasn't been loaned and mark every entry that has been loaned as
- * something that is going to be tombstomed. In the second pass, we drop the
- * table lock for every entry and remove the tombstombed entry for our zone.
  */
 void
 dlmgmt_db_fini(zoneid_t zoneid)
@@ -1569,65 +1561,9 @@ dlmgmt_db_fini(zoneid_t zoneid)
 	while (linkp != NULL) {
 		next_linkp = AVL_NEXT(&dlmgmt_name_avl, linkp);
 		if (linkp->ll_zoneid == zoneid) {
-			boolean_t onloan = linkp->ll_onloan;
-
-			/*
-			 * Cleanup any VNICs that were loaned to the zone
-			 * before the zone goes away and we can no longer
-			 * refer to the VNIC by the name/zoneid.
-			 */
-			if (onloan) {
-				(void) dlmgmt_delete_db_entry(linkp,
-				    DLMGMT_ACTIVE);
-				linkp->ll_tomb = B_TRUE;
-			} else {
-				(void) dlmgmt_destroy_common(linkp,
-				    DLMGMT_ACTIVE | DLMGMT_PERSIST);
-			}
+			(void) dlmgmt_destroy_common(linkp,
+			    DLMGMT_ACTIVE | DLMGMT_PERSIST);
 		}
 		linkp = next_linkp;
 	}
-
-again:
-	linkp = avl_first(&dlmgmt_name_avl);
-	while (linkp != NULL) {
-		vnic_ioc_delete_t ioc;
-
-		next_linkp = AVL_NEXT(&dlmgmt_name_avl, linkp);
-
-		if (linkp->ll_zoneid != zoneid) {
-			linkp = next_linkp;
-			continue;
-		}
-		ioc.vd_vnic_id = linkp->ll_linkid;
-		if (linkp->ll_tomb != B_TRUE)
-			abort();
-
-		/*
-		 * We have to drop the table lock while going up into the
-		 * kernel. If we hold the table lock while deleting a vnic, we
-		 * may get blocked on the mac perimeter and the holder of it may
-		 * want something from dlmgmtd.
-		 */
-		dlmgmt_table_unlock();
-
-		if (ioctl(dladm_dld_fd(dld_handle),
-		    VNIC_IOC_DELETE, &ioc) < 0)
-			dlmgmt_log(LOG_WARNING, "dlmgmt_db_fini "
-			    "delete VNIC ioctl failed %d %d",
-			    ioc.vd_vnic_id, errno);
-
-		/*
-		 * Even though we've dropped the lock, we know that nothing else
-		 * could have removed us. Therefore, it should be safe to go
-		 * through and delete ourselves, but do nothing else. We'll have
-		 * to restart iteration from the beginning. This can be painful.
-		 */
-		dlmgmt_table_lock(B_TRUE);
-
-		(void) dlmgmt_destroy_common(linkp,
-		    DLMGMT_ACTIVE | DLMGMT_PERSIST);
-		goto again;
-	}
-
 }

--- a/usr/src/cmd/dlmgmtd/dlmgmt_impl.h
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_impl.h
@@ -79,7 +79,6 @@ typedef struct dlmgmt_link_s {
 	avl_node_t		ll_loan_node;
 	uint32_t		ll_flags;
 	uint32_t		ll_gen;		/* generation number */
-	boolean_t		ll_tomb;	/* tombstombed */
 	/*
 	 * A transient link is one that is created and destroyed along with the
 	 * lifetime of a zone. It is a non-persistent link that is owned by the
@@ -103,8 +102,6 @@ typedef struct dlmgmt_dlconf_s {
 	uint32_t		ld_gen;
 	avl_node_t		ld_node;
 } dlmgmt_dlconf_t;
-
-#define	ZONE_LOCK	"/etc/dladm/zone.lck"
 
 extern boolean_t	debug;
 extern const char	*progname;

--- a/usr/src/cmd/dlmgmtd/dlmgmt_impl.h
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_impl.h
@@ -21,6 +21,8 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
+ * Copyright 2023 Oxide Computer Company
  */
 
 /*
@@ -60,6 +62,16 @@ typedef struct dlmgmt_link_s {
 	datalink_class_t	ll_class;
 	uint32_t		ll_media;
 	datalink_id_t		ll_linkid;
+	/*
+	 * The zone that owns the link. If this is set to the id of
+	 * an NGZ and ll_onloan is set then the link was created and
+	 * is owned by the GZ but is currently being loaned out to an
+	 * NGZ. E.g., when the GZ admin creates a VNIC for exclusive
+	 * use by an NGZ. If ll_onloan is set then ll_zoneid cannot be 0.
+	 *
+	 * If ll_zoneid is set to the id of an NGZ but ll_onloan is
+	 * not set then the link was created by, and is owned by, the NGZ.
+	 */
 	zoneid_t		ll_zoneid;
 	boolean_t		ll_onloan;
 	avl_node_t		ll_name_node;
@@ -68,6 +80,13 @@ typedef struct dlmgmt_link_s {
 	uint32_t		ll_flags;
 	uint32_t		ll_gen;		/* generation number */
 	boolean_t		ll_tomb;	/* tombstombed */
+	/*
+	 * A transient link is one that is created and destroyed along with the
+	 * lifetime of a zone. It is a non-persistent link that is owned by the
+	 * zone (ll_zoneid is set to the id of the NGZ). It is specifically not
+	 * on-loan from the GZ.
+	 */
+	boolean_t		ll_transient;
 } dlmgmt_link_t;
 
 /*
@@ -141,7 +160,7 @@ void		dlmgmt_handler(void *, char *, size_t, door_desc_t *, uint_t);
 void		dlmgmt_log(int, const char *, ...);
 int		dlmgmt_write_db_entry(const char *, dlmgmt_link_t *, uint32_t);
 int		dlmgmt_delete_db_entry(dlmgmt_link_t *, uint32_t);
-int 		dlmgmt_db_init(zoneid_t, char *);
+int		dlmgmt_db_init(zoneid_t, char *);
 void		dlmgmt_db_fini(zoneid_t);
 
 #ifdef  __cplusplus

--- a/usr/src/cmd/dlmgmtd/dlmgmt_main.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_main.c
@@ -126,7 +126,7 @@ dlmgmt_door_fini(void)
 	dlmgmt_door_fd = -1;
 }
 
-int
+static int
 dlmgmt_door_attach(zoneid_t zoneid, char *rootdir)
 {
 	int	fd;
@@ -232,7 +232,7 @@ dlmgmt_zone_init(zoneid_t zoneid)
 static int
 dlmgmt_allzones_init(void)
 {
-	int		err, i;
+	int		i;
 	zoneid_t	*zids = NULL;
 	uint_t		nzids, nzids_saved;
 
@@ -253,11 +253,39 @@ again:
 	}
 
 	for (i = 0; i < nzids; i++) {
-		if ((err = dlmgmt_zone_init(zids[i])) != 0)
-			break;
+		int res;
+		zone_status_t status;
+
+		/*
+		 * Skip over zones that have gone away or are going down
+		 * since we got the list.  Process all zones in the list,
+		 * logging errors for any that failed.
+		 */
+		if (zone_getattr(zids[i], ZONE_ATTR_STATUS, &status,
+		    sizeof (status)) < 0) {
+			continue;
+		}
+		switch (status) {
+			case ZONE_IS_SHUTTING_DOWN:
+			case ZONE_IS_EMPTY:
+			case ZONE_IS_DOWN:
+			case ZONE_IS_DYING:
+			case ZONE_IS_DEAD:
+			case ZONE_IS_INITIALIZED:
+			case ZONE_IS_UNINITIALIZED:
+				continue;
+			default:
+				break;
+		}
+		if ((res = dlmgmt_zone_init(zids[i])) != 0) {
+			(void) fprintf(stderr, "zone (%ld) init error %s",
+			    zids[i], strerror(res));
+			dlmgmt_log(LOG_ERR, "zone (%d) init error %s",
+			    zids[i], strerror(res));
+		}
 	}
 	free(zids);
-	return (err);
+	return (0);
 }
 
 static int

--- a/usr/src/cmd/dlmgmtd/dlmgmt_main.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_main.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- * Copyright 2014 Joyent, Inc.  All rights reserved.
+ * Copyright 2016 Joyent, Inc.
  */
 
 /*
@@ -307,8 +307,6 @@ dlmgmt_init(void)
 		    strerror(err));
 		return (err);
 	}
-
-	(void) unlink(ZONE_LOCK);
 
 	/*
 	 * First derive the name of the cache file from the FMRI name. This

--- a/usr/src/cmd/dlmgmtd/dlmgmt_util.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_util.c
@@ -514,7 +514,6 @@ dlmgmt_create_common(const char *name, datalink_class_t class, uint32_t media,
 	linkp->ll_linkid = dlmgmt_nextlinkid;
 	linkp->ll_zoneid = zoneid;
 	linkp->ll_gen = 0;
-	linkp->ll_tomb = B_FALSE;
 
 	/*
 	 * While DLMGMT_TRANSIENT starts off as a flag it is converted

--- a/usr/src/cmd/dlmgmtd/dlmgmt_util.c
+++ b/usr/src/cmd/dlmgmtd/dlmgmt_util.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Joyent, Inc.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  */
 
@@ -360,9 +361,9 @@ link_destroy(dlmgmt_link_t *linkp)
 }
 
 /*
- * Set the DLMGMT_ACTIVE flag on the link to note that it is active.  When a
- * link becomes active and it belongs to a non-global zone, it is also added
- * to that zone.
+ * Set the DLMGMT_ACTIVE flag on the link to note that it is active.
+ * When a link is active and owned by an NGZ then it is added to
+ * that zone's datalink list.
  */
 int
 link_activate(dlmgmt_link_t *linkp)
@@ -370,27 +371,73 @@ link_activate(dlmgmt_link_t *linkp)
 	int		err = 0;
 	zoneid_t	zoneid = ALL_ZONES;
 
+	/*
+	 * If zone_check_datalink() returns 0 it means we found the
+	 * link in one of the NGZ's datalink lists. Otherwise the link
+	 * is under the GZ.
+	 */
 	if (zone_check_datalink(&zoneid, linkp->ll_linkid) == 0) {
 		/*
-		 * This link was already added to a non-global zone.  This can
-		 * happen if dlmgmtd is restarted.
+		 * This is a bit subtle. If the following expression
+		 * is true then the link was found in one of the NGZ's
+		 * datalink lists but the link structure has it under
+		 * the GZ. This means that the link is supposed to be
+		 * loaned out to an NGZ but the dlmgmtd state is out
+		 * of sync -- possibly due to the process restarting.
+		 * In this case we need to sync the dlmgmtd state by
+		 * marking it as on-loan to the NGZ it's currently
+		 * under.
 		 */
 		if (zoneid != linkp->ll_zoneid) {
+			assert(linkp->ll_zoneid == 0);
+			assert(linkp->ll_onloan == B_FALSE);
+			assert(linkp->ll_transient == 0);
+
+			/*
+			 * If dlmgmtd already has a link with this
+			 * name under the NGZ then we have a problem.
+			 */
 			if (link_by_name(linkp->ll_link, zoneid) != NULL) {
 				err = EEXIST;
 				goto done;
 			}
 
+			/*
+			 * Remove the current linkp entry from the
+			 * list because it's under the wrong zoneid.
+			 * We don't have to update the dlmgmt_id_avl
+			 * because it compares entries by ll_linkid
+			 * only.
+			 */
 			if (avl_find(&dlmgmt_name_avl, linkp, NULL) != NULL)
 				avl_remove(&dlmgmt_name_avl, linkp);
 
+			/*
+			 * Update the link to reflect the fact that
+			 * it's on-loan to an NGZ and re-add it to the
+			 * list.
+			 */
 			linkp->ll_zoneid = zoneid;
 			avl_add(&dlmgmt_name_avl, linkp);
+
+			/*
+			 * Since the link was found to be in a zone but
+			 * recorded as a GZ link in the link structure, and
+			 * we've now updated that, also mark it as on-loan to
+			 * the NGZ.
+			 */
 			avl_add(&dlmgmt_loan_avl, linkp);
 			linkp->ll_onloan = B_TRUE;
 		}
 	} else if (linkp->ll_zoneid != GLOBAL_ZONEID) {
+		/*
+		 * In this case the link was not found under any NGZ
+		 * but according to its ll_zoneid member it is owned
+		 * by an NGZ. Add the datalink to the appropriate zone
+		 * datalink list.
+		 */
 		err = zone_add_datalink(linkp->ll_zoneid, linkp->ll_linkid);
+		assert(linkp->ll_onloan == B_FALSE);
 	}
 done:
 	if (err == 0)
@@ -450,6 +497,11 @@ dlmgmt_create_common(const char *name, datalink_class_t class, uint32_t media,
 		return (EINVAL);
 	if (dlmgmt_nextlinkid == DATALINK_INVALID_LINKID)
 		return (ENOSPC);
+	if (flags & ~(DLMGMT_ACTIVE | DLMGMT_PERSIST | DLMGMT_TRANSIENT) ||
+	    ((flags & DLMGMT_PERSIST) && (flags & DLMGMT_TRANSIENT)) ||
+	    flags == 0) {
+		return (EINVAL);
+	}
 
 	if ((linkp = calloc(1, sizeof (dlmgmt_link_t))) == NULL) {
 		err = ENOMEM;
@@ -463,6 +515,15 @@ dlmgmt_create_common(const char *name, datalink_class_t class, uint32_t media,
 	linkp->ll_zoneid = zoneid;
 	linkp->ll_gen = 0;
 	linkp->ll_tomb = B_FALSE;
+
+	/*
+	 * While DLMGMT_TRANSIENT starts off as a flag it is converted
+	 * into a link field since it is really a substate of
+	 * DLMGMT_ACTIVE -- it should not survive as a flag beyond
+	 * this point.
+	 */
+	linkp->ll_transient = (flags & DLMGMT_TRANSIENT) ? B_TRUE : B_FALSE;
+	flags &= ~DLMGMT_TRANSIENT;
 
 	if (link_by_name(name, zoneid) != NULL ||
 	    avl_find(&dlmgmt_name_avl, linkp, &name_where) != NULL ||
@@ -493,6 +554,12 @@ done:
 int
 dlmgmt_destroy_common(dlmgmt_link_t *linkp, uint32_t flags)
 {
+	/*
+	 * After dlmgmt_create_common() the link flags should only
+	 * ever include ACTIVE or PERSIST.
+	 */
+	assert((linkp->ll_flags & ~(DLMGMT_ACTIVE | DLMGMT_PERSIST)) == 0);
+
 	if ((linkp->ll_flags & flags) == 0) {
 		/*
 		 * The link does not exist in the specified space.

--- a/usr/src/cmd/zoneadmd/vplat.c
+++ b/usr/src/cmd/zoneadmd/vplat.c
@@ -21,10 +21,11 @@
 
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2016, Joyent Inc.
+ * Copyright 2018, Joyent Inc.
  * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
  * Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2020 RackTop Systems Inc.
+ * Copyright 2023 Oxide Computer Company
  */
 
 /*
@@ -80,10 +81,13 @@
 #include <sys/conf.h>
 #include <sys/systeminfo.h>
 #include <sys/secflags.h>
+#include <sys/vnic.h>
 
 #include <libdlpi.h>
 #include <libdllink.h>
 #include <libdlvlan.h>
+#include <libdlvnic.h>
+#include <libdlaggr.h>
 
 #include <inet/tcp.h>
 #include <arpa/inet.h>
@@ -2994,13 +2998,75 @@ configure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 	return (0);
 }
 
+/*
+ * Retrieve the list of datalink IDs assigned to a zone.
+ *
+ * On return, *count will be updated with the total number of links and, if it
+ * is not NULL, **linksp will be updated to point to allocated memory
+ * containing the link IDs. This should be passed to free() when the caller is
+ * finished with it.
+ */
+static int
+fetch_zone_datalinks(zlog_t *zlogp, zoneid_t zoneid, int *countp,
+    datalink_id_t **linksp)
+{
+	datalink_id_t *links = NULL;
+	int links_size = 0;
+	int num_links;
+
+	if (linksp != NULL)
+		*linksp = NULL;
+	*countp = 0;
+
+	num_links = 0;
+	if (zone_list_datalink(zoneid, &num_links, NULL) != 0) {
+		zerror(zlogp, B_TRUE,
+		    "unable to determine number of network interfaces");
+		return (-1);
+	}
+
+	if (num_links == 0)
+		return (0);
+
+	/* If linkp is NULL, the caller only wants the count. */
+	if (linksp == NULL) {
+		*countp = num_links;
+		return (0);
+	}
+
+	do {
+		datalink_id_t *p;
+
+		links_size = num_links;
+		p = reallocarray(links, links_size, sizeof (datalink_id_t));
+
+		if (p == NULL) {
+			zerror(zlogp, B_TRUE,
+			    "failed to allocate memory for zone links");
+			free(links);
+			return (-1);
+		}
+		links = p;
+
+		if (zone_list_datalink(zoneid, &num_links, links) != 0) {
+			zerror(zlogp, B_TRUE, "failed to list zone links");
+			free(links);
+			return (-1);
+		}
+	} while (links_size < num_links);
+
+	*countp = num_links;
+	*linksp = links;
+
+	return (0);
+}
+
 static int
 remove_datalink_pool(zlog_t *zlogp, zoneid_t zoneid)
 {
 	ushort_t flags;
 	zone_iptype_t iptype;
-	int i, dlnum = 0;
-	datalink_id_t *dllink, *dllinks = NULL;
+	int i;
 	dladm_status_t err;
 
 	if (strlen(pool_name) == 0)
@@ -3020,34 +3086,15 @@ remove_datalink_pool(zlog_t *zlogp, zoneid_t zoneid)
 	}
 
 	if (iptype == ZS_EXCLUSIVE) {
-		/*
-		 * Get the datalink count and for each datalink,
-		 * attempt to clear the pool property and clear
-		 * the pool_name.
-		 */
-		if (zone_list_datalink(zoneid, &dlnum, NULL) != 0) {
-			zerror(zlogp, B_TRUE, "unable to count network "
-			    "interfaces");
-			return (-1);
-		}
+		datalink_id_t *dllinks = NULL;
+		int dlnum = 0;
 
-		if (dlnum == 0)
-			return (0);
-
-		if ((dllinks = malloc(dlnum * sizeof (datalink_id_t)))
-		    == NULL) {
-			zerror(zlogp, B_TRUE, "memory allocation failed");
+		if (fetch_zone_datalinks(zlogp, zoneid, &dlnum, &dllinks) != 0)
 			return (-1);
-		}
-		if (zone_list_datalink(zoneid, &dlnum, dllinks) != 0) {
-			zerror(zlogp, B_TRUE, "unable to list network "
-			    "interfaces");
-			return (-1);
-		}
 
 		bzero(pool_name, sizeof (pool_name));
-		for (i = 0, dllink = dllinks; i < dlnum; i++, dllink++) {
-			err = dladm_set_linkprop(dld_handle, *dllink, "pool",
+		for (i = 0; i < dlnum; i++) {
+			err = dladm_set_linkprop(dld_handle, dllinks[i], "pool",
 			    NULL, 0, DLADM_OPT_ACTIVE);
 			if (err != DLADM_STATUS_OK) {
 				zerror(zlogp, B_TRUE,
@@ -3066,7 +3113,7 @@ remove_datalink_protect(zlog_t *zlogp, zoneid_t zoneid)
 	zone_iptype_t iptype;
 	int i, dlnum = 0;
 	dladm_status_t dlstatus;
-	datalink_id_t *dllink, *dllinks = NULL;
+	datalink_id_t *dllinks = NULL;
 
 	if (zone_getattr(zoneid, ZONE_ATTR_FLAGS, &flags,
 	    sizeof (flags)) < 0) {
@@ -3085,32 +3132,17 @@ remove_datalink_protect(zlog_t *zlogp, zoneid_t zoneid)
 		return (0);
 
 	/*
-	 * Get the datalink count and for each datalink,
-	 * attempt to clear the pool property and clear
-	 * the pool_name.
+	 * Get the datalink count and for each datalink, attempt to clear the
+	 * protection and allowed_ips properties.
 	 */
-	if (zone_list_datalink(zoneid, &dlnum, NULL) != 0) {
-		zerror(zlogp, B_TRUE, "unable to count network interfaces");
-		return (-1);
-	}
 
-	if (dlnum == 0)
-		return (0);
-
-	if ((dllinks = malloc(dlnum * sizeof (datalink_id_t))) == NULL) {
-		zerror(zlogp, B_TRUE, "memory allocation failed");
+	if (fetch_zone_datalinks(zlogp, zoneid, &dlnum, &dllinks) != 0)
 		return (-1);
-	}
-	if (zone_list_datalink(zoneid, &dlnum, dllinks) != 0) {
-		zerror(zlogp, B_TRUE, "unable to list network interfaces");
-		free(dllinks);
-		return (-1);
-	}
 
-	for (i = 0, dllink = dllinks; i < dlnum; i++, dllink++) {
+	for (i = 0; i < dlnum; i++) {
 		char dlerr[DLADM_STRSIZE];
 
-		dlstatus = dladm_set_linkprop(dld_handle, *dllink,
+		dlstatus = dladm_set_linkprop(dld_handle, dllinks[i],
 		    "protection", NULL, 0, DLADM_OPT_ACTIVE);
 		if (dlstatus == DLADM_STATUS_NOTFOUND) {
 			/* datalink does not belong to the GZ */
@@ -3118,17 +3150,16 @@ remove_datalink_protect(zlog_t *zlogp, zoneid_t zoneid)
 		}
 		if (dlstatus != DLADM_STATUS_OK) {
 			zerror(zlogp, B_FALSE,
-			    dladm_status2str(dlstatus, dlerr));
-			free(dllinks);
-			return (-1);
+			    "clear link %d 'protection' link property: %s",
+			    dllinks[i], dladm_status2str(dlstatus, dlerr));
 		}
-		dlstatus = dladm_set_linkprop(dld_handle, *dllink,
+
+		dlstatus = dladm_set_linkprop(dld_handle, dllinks[i],
 		    "allowed-ips", NULL, 0, DLADM_OPT_ACTIVE);
 		if (dlstatus != DLADM_STATUS_OK) {
 			zerror(zlogp, B_FALSE,
-			    dladm_status2str(dlstatus, dlerr));
-			free(dllinks);
-			return (-1);
+			    "clear link %d 'allowed-ips' link property: %s",
+			    dllinks[i], dladm_status2str(dlstatus, dlerr));
 		}
 	}
 	free(dllinks);
@@ -3138,23 +3169,74 @@ remove_datalink_protect(zlog_t *zlogp, zoneid_t zoneid)
 static int
 unconfigure_exclusive_network_interfaces(zlog_t *zlogp, zoneid_t zoneid)
 {
+	datalink_id_t *dllinks;
 	int dlnum = 0;
+	uint_t i;
 
 	/*
 	 * The kernel shutdown callback for the dls module should have removed
 	 * all datalinks from this zone.  If any remain, then there's a
 	 * problem.
 	 */
-	if (zone_list_datalink(zoneid, &dlnum, NULL) != 0) {
-		zerror(zlogp, B_TRUE, "unable to list network interfaces");
+
+	if (fetch_zone_datalinks(zlogp, zoneid, &dlnum, &dllinks) != 0)
 		return (-1);
+
+	if (dlnum == 0)
+		return (0);
+
+	/*
+	 * There are some datalinks left in the zone. The most likely cause of
+	 * this is that the datalink-management daemon (dlmgmtd) was not
+	 * running when the zone was shut down. That prevented the kernel from
+	 * doing the required upcall to move the links back to the GZ. To
+	 * attempt recovery, do that now.
+	 */
+
+	for (i = 0; i < dlnum; i++) {
+		char dlerr[DLADM_STRSIZE];
+		dladm_status_t status;
+		uint32_t link_flags;
+		datalink_id_t link = dllinks[i];
+		char *prop_vals[] = { GLOBAL_ZONENAME };
+
+		status = dladm_datalink_id2info(dld_handle, link,
+		    &link_flags, NULL, NULL, NULL, 0);
+
+		if (status != DLADM_STATUS_OK) {
+			zerror(zlogp, B_FALSE,
+			    "failed to get link info for %u: %s",
+			    link, dladm_status2str(status, dlerr));
+			continue;
+		}
+
+		if (link_flags & DLADM_OPT_TRANSIENT)
+			continue;
+
+		status = dladm_set_linkprop(dld_handle, link, "zone",
+		    prop_vals, 1, DLADM_OPT_ACTIVE);
+
+		if (status != DLADM_STATUS_OK) {
+			zerror(zlogp, B_FALSE,
+			    "failed to move link %u to GZ: %s",
+			    link, dladm_status2str(status, dlerr));
+		}
 	}
-	if (dlnum != 0) {
-		zerror(zlogp, B_FALSE,
-		    "datalinks remain in zone after shutdown");
+
+	free(dllinks);
+
+	/* Check again and log a message if links remain */
+
+	if (fetch_zone_datalinks(zlogp, zoneid, &dlnum, NULL) != 0)
 		return (-1);
-	}
-	return (0);
+
+	if (dlnum == 0)
+		return (0);
+
+	zerror(zlogp, B_FALSE, "%d datalink(s) remain in zone after shutdown",
+	    dlnum);
+
+	return (-1);
 }
 
 static int
@@ -5201,6 +5283,79 @@ unmounted:
 	}
 }
 
+/*
+ * Delete all transient links belonging to this zone. A transient link
+ * is one that is created and destroyed along with the lifetime of the
+ * zone. Non-transient links, ones that are assigned from the GZ to a
+ * NGZ, are reassigned to the GZ in zone_shutdown() via the
+ * zone-specific data (zsd) callbacks.
+ */
+static int
+delete_transient_links(zlog_t *zlogp, zoneid_t zoneid)
+{
+	datalink_id_t *dllinks = NULL;
+	int dlnum = 0;
+	uint_t i;
+
+	if (fetch_zone_datalinks(zlogp, zoneid, &dlnum, &dllinks) != 0)
+		return (-1);
+
+	if (dlnum == 0)
+		return (0);
+
+	for (i = 0; i < dlnum; i++) {
+		char link_name[MAXLINKNAMELEN];
+		char dlerr[DLADM_STRSIZE];
+		datalink_id_t link = dllinks[i];
+		datalink_class_t link_class;
+		dladm_status_t status;
+		uint32_t link_flags;
+
+		status = dladm_datalink_id2info(dld_handle, link, &link_flags,
+		    &link_class, NULL, link_name, sizeof (link_name));
+
+		if (status != DLADM_STATUS_OK) {
+			zerror(zlogp, B_FALSE,
+			    "failed to get link info for %u: %s",
+			    link, dladm_status2str(status, dlerr));
+			continue;
+		}
+
+		if (!(link_flags & DLADM_OPT_TRANSIENT))
+			continue;
+
+		switch (link_class) {
+		case DATALINK_CLASS_VNIC:
+		case DATALINK_CLASS_ETHERSTUB:
+			status = dladm_vnic_delete(dld_handle, link,
+			    DLADM_OPT_ACTIVE);
+			break;
+		case DATALINK_CLASS_VLAN:
+			status = dladm_vlan_delete(dld_handle, link,
+			    DLADM_OPT_ACTIVE);
+			break;
+		case DATALINK_CLASS_AGGR:
+			status = dladm_aggr_delete(dld_handle, link,
+			    DLADM_OPT_ACTIVE);
+			break;
+		default:
+			zerror(zlogp, B_FALSE,
+			    "unhandled class for transient link %s (%u)",
+			    link_name, link);
+			continue;
+		}
+
+		if (status != DLADM_STATUS_OK) {
+			zerror(zlogp, B_TRUE,
+			    "failed to delete transient link %s (%u): %s",
+			    link_name, link, dladm_status2str(status, dlerr));
+		}
+	}
+
+	free(dllinks);
+	return (0);
+}
+
 int
 vplat_teardown(zlog_t *zlogp, boolean_t unmount_cmd, boolean_t rebooting)
 {
@@ -5241,14 +5396,13 @@ vplat_teardown(zlog_t *zlogp, boolean_t unmount_cmd, boolean_t rebooting)
 	}
 
 	if (remove_datalink_pool(zlogp, zoneid) != 0) {
-		zerror(zlogp, B_FALSE, "unable clear datalink pool property");
-		goto error;
+		zerror(zlogp, B_FALSE,
+		    "unable to clear datalink pool property");
 	}
 
 	if (remove_datalink_protect(zlogp, zoneid) != 0) {
 		zerror(zlogp, B_FALSE,
-		    "unable clear datalink protect property");
-		goto error;
+		    "unable to clear datalink protect property");
 	}
 
 	/*
@@ -5315,6 +5469,11 @@ vplat_teardown(zlog_t *zlogp, boolean_t unmount_cmd, boolean_t rebooting)
 			}
 			break;
 		case ZS_EXCLUSIVE:
+			if (delete_transient_links(zlogp, zoneid) != 0) {
+				zerror(zlogp, B_FALSE, "unable to delete "
+				    "transient links in zone");
+				goto error;
+			}
 			if (unconfigure_exclusive_network_interfaces(zlogp,
 			    zoneid) != 0) {
 				zerror(zlogp, B_FALSE, "unable to unconfigure "

--- a/usr/src/lib/libdladm/common/libdladm.h
+++ b/usr/src/lib/libdladm/common/libdladm.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, Joyent, Inc. All rights reserved.
  */
 
 /*
@@ -77,6 +78,10 @@ extern "C" {
  *  - DLADM_OPT_BOOT:
  *    Bypass check functions during boot (used by pool property since pools
  *    can come up after link properties are set)
+ *
+ *  - DLADM_OPT_TRANSIENT:
+ *    Indicates that the link assigned to a zone is transient and will be
+ *    removed when the zone shuts down.
  */
 #define	DLADM_OPT_ACTIVE	0x00000001
 #define	DLADM_OPT_PERSIST	0x00000002
@@ -87,6 +92,7 @@ extern "C" {
 #define	DLADM_OPT_VLAN		0x00000040
 #define	DLADM_OPT_NOREFRESH	0x00000080
 #define	DLADM_OPT_BOOT		0x00000100
+#define	DLADM_OPT_TRANSIENT	0x00000200
 
 #define	DLADM_WALK_TERMINATE	0
 #define	DLADM_WALK_CONTINUE	-1

--- a/usr/src/uts/common/io/dls/dls_mgmt.c
+++ b/usr/src/uts/common/io/dls/dls_mgmt.c
@@ -86,6 +86,14 @@ static door_handle_t	dls_mgmt_dh = NULL;
 /* dls_devnet_t dd_flags */
 #define	DD_CONDEMNED		0x1
 #define	DD_IMPLICIT_IPTUN	0x2 /* Implicitly-created ip*.*tun* tunnel */
+#define	DD_INITIALIZING		0x4
+
+/*
+ * If the link is marked as initializing or condemned then it should
+ * not be visible outside of the DLS framework.
+ */
+#define	DD_NOT_VISIBLE(flags)	(					\
+	(flags & (DD_CONDEMNED | DD_INITIALIZING)) != 0)
 
 /*
  * This structure is used to keep the <linkid, macname> mapping.
@@ -109,13 +117,14 @@ typedef struct dls_devnet_s {
 	zoneid_t	dd_zid;		/* current zone */
 	boolean_t	dd_prop_loaded;
 	taskqid_t	dd_prop_taskid;
+	boolean_t	dd_transient;	/* link goes away when zone does */
 } dls_devnet_t;
 
 static int i_dls_devnet_create_iptun(const char *, const char *,
     datalink_id_t *);
 static int i_dls_devnet_destroy_iptun(datalink_id_t);
-static int i_dls_devnet_setzid(dls_devnet_t *, zoneid_t, boolean_t);
-static int dls_devnet_unset(const char *, datalink_id_t *, boolean_t);
+static int i_dls_devnet_setzid(dls_devnet_t *, zoneid_t, boolean_t, boolean_t);
+static int dls_devnet_unset(mac_handle_t, datalink_id_t *, boolean_t);
 
 /*ARGSUSED*/
 static int
@@ -135,9 +144,9 @@ i_dls_devnet_destructor(void *buf, void *arg)
 {
 	dls_devnet_t	*ddp = buf;
 
-	ASSERT(ddp->dd_ksp == NULL);
-	ASSERT(ddp->dd_ref == 0);
-	ASSERT(ddp->dd_tref == 0);
+	VERIFY(ddp->dd_ksp == NULL);
+	VERIFY(ddp->dd_ref == 0);
+	VERIFY(ddp->dd_tref == 0);
 	mutex_destroy(&ddp->dd_mutex);
 	cv_destroy(&ddp->dd_cv);
 }
@@ -149,7 +158,12 @@ dls_zone_remove(datalink_id_t linkid, void *arg)
 	dls_devnet_t *ddp;
 
 	if (dls_devnet_hold_tmp(linkid, &ddp) == 0) {
-		(void) dls_devnet_setzid(ddp, GLOBAL_ZONEID);
+		/*
+		 * Don't bother moving transient links back to the global zone
+		 * since we will simply delete them in dls_devnet_unset.
+		 */
+		if (!ddp->dd_transient)
+			(void) dls_devnet_setzid(ddp, GLOBAL_ZONEID);
 		dls_devnet_rele_tmp(ddp);
 	}
 	return (0);
@@ -791,12 +805,16 @@ dls_devnet_stat_rename(dls_devnet_t *ddp)
 }
 
 /*
- * Associate a linkid with a given link (identified by macname)
+ * Associate the linkid with the link identified by macname. If this
+ * is called on behalf of a physical link then linkid may be
+ * DATALINK_INVALID_LINKID. Otherwise, if called on behalf of a
+ * virtual link, linkid must have a value.
  */
 static int
-dls_devnet_set(const char *macname, datalink_id_t linkid, zoneid_t zoneid,
+dls_devnet_set(mac_handle_t mh, datalink_id_t linkid, zoneid_t zoneid,
     dls_devnet_t **ddpp)
 {
+	const char		*macname = mac_name(mh);
 	dls_devnet_t		*ddp = NULL;
 	datalink_class_t	class;
 	int			err;
@@ -829,20 +847,52 @@ dls_devnet_set(const char *macname, datalink_id_t linkid, zoneid_t zoneid,
 		}
 
 		/*
-		 * This might be a physical link that has already
-		 * been created, but which does not have a linkid
-		 * because dlmgmtd was not running when it was created.
+		 * If we arrive here we know we are attempting to set
+		 * the linkid on a physical link. A virtual link
+		 * should never arrive here because it should never
+		 * call this function without a linkid. Virtual links
+		 * are created through dlgmtmd and thus we know
+		 * dlmgmtd is alive to assign it a linkid (search for
+		 * uses of dladm_create_datalink_id() to prove this to
+		 * yourself); we don't have the same guarantee for a
+		 * physical link which may perform an upcall for a
+		 * linkid while dlmgmtd is down but will continue
+		 * creating a devnet without the linkid (see
+		 * softmac_create_datalink() to see how physical link
+		 * creation works). That is why there is no entry in
+		 * the id hash but there is one in the macname hash --
+		 * softmac couldn't acquire a linkid the first time it
+		 * called this function.
+		 *
+		 * Because of the check above, we also know that
+		 * ddp->dd_linkid is not set. Following this, the link
+		 * must still be in the DD_INITIALIZING state because
+		 * that flag is removed IFF dd_linkid is set. This is
+		 * why we can ASSERT the DD_INITIALIZING flag below if
+		 * the call to i_dls_devnet_setzid() fails.
 		 */
 		if (linkid == DATALINK_INVALID_LINKID ||
 		    class != DATALINK_CLASS_PHYS) {
 			err = EINVAL;
 			goto done;
 		}
+
+		ASSERT(ddp->dd_flags & DD_INITIALIZING);
+
 	} else {
 		ddp = kmem_cache_alloc(i_dls_devnet_cachep, KM_SLEEP);
+		ddp->dd_flags = DD_INITIALIZING;
 		ddp->dd_tref = 0;
 		ddp->dd_ref++;
 		ddp->dd_owner_zid = zoneid;
+		/*
+		 * If we are creating a new devnet which will be owned by a NGZ
+		 * then mark it as transient. This link has never been in the
+		 * GZ, the GZ will not have a hold on its reference, and we do
+		 * not want to return it to the GZ when the zone halts.
+		 */
+		if (zoneid != GLOBAL_ZONEID)
+			ddp->dd_transient = B_TRUE;
 		(void) strlcpy(ddp->dd_mac, macname, sizeof (ddp->dd_mac));
 		VERIFY(mod_hash_insert(i_dls_devnet_hash,
 		    (mod_hash_key_t)ddp->dd_mac, (mod_hash_val_t)ddp) == 0);
@@ -857,12 +907,6 @@ dls_devnet_set(const char *macname, datalink_id_t linkid, zoneid_t zoneid,
 		    (mod_hash_val_t)ddp) == 0);
 		devnet_need_rebuild = B_TRUE;
 		stat_create = B_TRUE;
-		mutex_enter(&ddp->dd_mutex);
-		if (!ddp->dd_prop_loaded && (ddp->dd_prop_taskid == 0)) {
-			ddp->dd_prop_taskid = taskq_dispatch(system_taskq,
-			    dls_devnet_prop_task, ddp, TQ_SLEEP);
-		}
-		mutex_exit(&ddp->dd_mutex);
 	}
 	err = 0;
 done:
@@ -874,10 +918,28 @@ done:
 	 * and ensure that *ddp is valid.
 	 */
 	rw_exit(&i_dls_devnet_lock);
+
+	if (err == 0 && zoneid != GLOBAL_ZONEID) {
+		/*
+		 * If this link is being created directly within a non-global
+		 * zone, then flag it as transient so that it will be cleaned
+		 * up when the zone is shut down.
+		 */
+		err = i_dls_devnet_setzid(ddp, zoneid, B_FALSE, B_TRUE);
+		if (err != 0) {
+			/*
+			 * At this point the link is marked as
+			 * DD_INITIALIZING -- there can be no
+			 * outstanding temp refs and therefore no need
+			 * to wait for them.
+			 */
+			ASSERT(ddp->dd_flags & DD_INITIALIZING);
+			(void) dls_devnet_unset(mh, &linkid, B_FALSE);
+			return (err);
+		}
+	}
+
 	if (err == 0) {
-		if (zoneid != GLOBAL_ZONEID &&
-		    (err = i_dls_devnet_setzid(ddp, zoneid, B_FALSE)) != 0)
-			(void) dls_devnet_unset(macname, &linkid, B_TRUE);
 		/*
 		 * The kstat subsystem holds its own locks (rather perimeter)
 		 * before calling the ks_update (dls_devnet_stat_update) entry
@@ -888,17 +950,32 @@ done:
 			dls_devnet_stat_create(ddp, zoneid);
 		if (ddpp != NULL)
 			*ddpp = ddp;
+
+		mutex_enter(&ddp->dd_mutex);
+		if (linkid != DATALINK_INVALID_LINKID &&
+		    !ddp->dd_prop_loaded && ddp->dd_prop_taskid == 0) {
+			ddp->dd_prop_taskid = taskq_dispatch(system_taskq,
+			    dls_devnet_prop_task, ddp, TQ_SLEEP);
+		}
+		mutex_exit(&ddp->dd_mutex);
+
 	}
 	return (err);
 }
 
 /*
- * Disassociate a linkid with a given link (identified by macname)
- * This waits until temporary references to the dls_devnet_t are gone.
+ * Disassociate the linkid from the link identified by macname. If
+ * wait is B_TRUE, wait until all temporary refs are released and the
+ * prop task is finished.
+ *
+ * If waiting then you SHOULD NOT call this from inside the MAC perim
+ * as deadlock will ensue. Otherwise, this function is safe to call
+ * from inside or outside the MAC perim.
  */
 static int
-dls_devnet_unset(const char *macname, datalink_id_t *id, boolean_t wait)
+dls_devnet_unset(mac_handle_t mh, datalink_id_t *id, boolean_t wait)
 {
+	const char	*macname = mac_name(mh);
 	dls_devnet_t	*ddp;
 	int		err;
 	mod_hash_val_t	val;
@@ -919,20 +996,62 @@ dls_devnet_unset(const char *macname, datalink_id_t *id, boolean_t wait)
 	 * deadlock. Return EBUSY if the asynchronous thread started for
 	 * property loading as part of the post attach hasn't yet completed.
 	 */
-	ASSERT(ddp->dd_ref != 0);
+	VERIFY(ddp->dd_ref != 0);
 	if ((ddp->dd_ref != 1) || (!wait &&
 	    (ddp->dd_tref != 0 || ddp->dd_prop_taskid != 0))) {
-		mutex_exit(&ddp->dd_mutex);
-		rw_exit(&i_dls_devnet_lock);
-		return (EBUSY);
+		int zstatus = 0;
+
+		/*
+		 * There are a couple of alternatives that might be going on
+		 * here; a) the zone is shutting down and it has a transient
+		 * link assigned, in which case we want to clean it up instead
+		 * of moving it back to the global zone, or b) its possible
+		 * that we're trying to clean up an orphaned vnic that was
+		 * delegated to a zone and which wasn't cleaned up properly
+		 * when the zone went away.  Check for either of these cases
+		 * before we simply return EBUSY.
+		 *
+		 * zstatus indicates which situation we are dealing with:
+		 *	 0 - means return EBUSY
+		 *	 1 - means case (a), cleanup transient link
+		 *	-1 - means case (b), orphaned VNIC
+		 */
+		if (ddp->dd_ref > 1 && ddp->dd_zid != GLOBAL_ZONEID) {
+			zone_t	*zp;
+
+			if ((zp = zone_find_by_id(ddp->dd_zid)) == NULL) {
+				zstatus = -1;
+			} else {
+				if (ddp->dd_transient) {
+					zone_status_t s = zone_status_get(zp);
+
+					if (s >= ZONE_IS_SHUTTING_DOWN)
+						zstatus = 1;
+				}
+				zone_rele(zp);
+			}
+		}
+
+		if (zstatus == 0) {
+			mutex_exit(&ddp->dd_mutex);
+			rw_exit(&i_dls_devnet_lock);
+			return (EBUSY);
+		}
+
+		/*
+		 * We want to delete the link, reset ref to 1;
+		 */
+		if (zstatus == -1) {
+			/* Log a warning, but continue in this case */
+			cmn_err(CE_WARN, "clear orphaned datalink: %s\n",
+			    ddp->dd_linkname);
+		}
+		ddp->dd_ref = 1;
 	}
 
 	ddp->dd_flags |= DD_CONDEMNED;
 	ddp->dd_ref--;
 	*id = ddp->dd_linkid;
-
-	if (ddp->dd_zid != GLOBAL_ZONEID)
-		(void) i_dls_devnet_setzid(ddp, GLOBAL_ZONEID, B_FALSE);
 
 	/*
 	 * Remove this dls_devnet_t from the hash table.
@@ -948,15 +1067,49 @@ dls_devnet_unset(const char *macname, datalink_id_t *id, boolean_t wait)
 	}
 	rw_exit(&i_dls_devnet_lock);
 
+	/*
+	 * It is important to call i_dls_devnet_setzid() WITHOUT the
+	 * i_dls_devnet_lock held. The setzid call grabs the MAC
+	 * perim; thus causing DLS -> MAC lock ordering if performed
+	 * with the i_dls_devnet_lock held. This forces consumers to
+	 * grab the MAC perim before calling dls_devnet_unset() (the
+	 * locking rules state MAC -> DLS order). By performing the
+	 * setzid outside of the i_dls_devnet_lock consumers can
+	 * safely call dls_devnet_unset() outside the MAC perim.
+	 */
+	if (ddp->dd_zid != GLOBAL_ZONEID) {
+		/*
+		 * We need to release the dd_mutex before we try and destroy the
+		 * stat. When we destroy it, we'll need to grab the lock for the
+		 * kstat but if there's a concurrent reader of the kstat, we'll
+		 * be blocked on it. This will lead to deadlock because these
+		 * kstats employ a ks_update function (dls_devnet_stat_update)
+		 * which needs the dd_mutex that we currently hold.
+		 *
+		 * Because we've already flagged the dls_devnet_t as
+		 * DD_CONDEMNED and we still have a write lock on
+		 * i_dls_devnet_lock, we should be able to release the dd_mutex.
+		 */
+		mutex_exit(&ddp->dd_mutex);
+		dls_devnet_stat_destroy(ddp, ddp->dd_zid);
+		mutex_enter(&ddp->dd_mutex);
+		(void) i_dls_devnet_setzid(ddp, GLOBAL_ZONEID, B_FALSE,
+		    B_FALSE);
+	}
+
 	if (wait) {
 		/*
 		 * Wait until all temporary references are released.
+		 * The holders of the tref need the MAC perim to
+		 * perform their work and release the tref. To avoid
+		 * deadlock, assert that the perim is never held here.
 		 */
+		ASSERT0(MAC_PERIM_HELD(mh));
 		while ((ddp->dd_tref != 0) || (ddp->dd_prop_taskid != 0))
 			cv_wait(&ddp->dd_cv, &ddp->dd_mutex);
 	} else {
-		ASSERT(ddp->dd_tref == 0 &&
-		    ddp->dd_prop_taskid == (taskqid_t)NULL);
+		VERIFY(ddp->dd_tref == 0);
+		VERIFY(ddp->dd_prop_taskid == 0);
 	}
 
 	if (ddp->dd_linkid != DATALINK_INVALID_LINKID)
@@ -990,8 +1143,8 @@ dls_devnet_hold_tmp_by_link(dls_link_t *dlp, dls_dl_handle_t *ddhp)
 	}
 
 	mutex_enter(&ddp->dd_mutex);
-	ASSERT(ddp->dd_ref > 0);
-	if (ddp->dd_flags & DD_CONDEMNED) {
+	VERIFY(ddp->dd_ref > 0);
+	if (DD_NOT_VISIBLE(ddp->dd_flags)) {
 		mutex_exit(&ddp->dd_mutex);
 		rw_exit(&i_dls_devnet_lock);
 		return (ENOENT);
@@ -1020,8 +1173,8 @@ dls_devnet_hold_common(datalink_id_t linkid, dls_devnet_t **ddpp,
 	}
 
 	mutex_enter(&ddp->dd_mutex);
-	ASSERT(ddp->dd_ref > 0);
-	if (ddp->dd_flags & DD_CONDEMNED) {
+	VERIFY(ddp->dd_ref > 0);
+	if (DD_NOT_VISIBLE(ddp->dd_flags)) {
 		mutex_exit(&ddp->dd_mutex);
 		rw_exit(&i_dls_devnet_lock);
 		return (ENOENT);
@@ -1088,8 +1241,8 @@ dls_devnet_hold_by_dev(dev_t dev, dls_dl_handle_t *ddhp)
 		return (ENOENT);
 	}
 	mutex_enter(&ddp->dd_mutex);
-	ASSERT(ddp->dd_ref > 0);
-	if (ddp->dd_flags & DD_CONDEMNED) {
+	VERIFY(ddp->dd_ref > 0);
+	if (DD_NOT_VISIBLE(ddp->dd_flags)) {
 		mutex_exit(&ddp->dd_mutex);
 		rw_exit(&i_dls_devnet_lock);
 		return (ENOENT);
@@ -1106,7 +1259,7 @@ void
 dls_devnet_rele(dls_devnet_t *ddp)
 {
 	mutex_enter(&ddp->dd_mutex);
-	ASSERT(ddp->dd_ref > 1);
+	VERIFY(ddp->dd_ref > 1);
 	ddp->dd_ref--;
 	if ((ddp->dd_flags & DD_IMPLICIT_IPTUN) && ddp->dd_ref == 1) {
 		mutex_exit(&ddp->dd_mutex);
@@ -1408,7 +1561,8 @@ done:
 }
 
 static int
-i_dls_devnet_setzid(dls_devnet_t *ddp, zoneid_t new_zoneid, boolean_t setprop)
+i_dls_devnet_setzid(dls_devnet_t *ddp, zoneid_t new_zoneid, boolean_t setprop,
+    boolean_t transient)
 {
 	int			err;
 	mac_perim_handle_t	mph;
@@ -1448,6 +1602,7 @@ i_dls_devnet_setzid(dls_devnet_t *ddp, zoneid_t new_zoneid, boolean_t setprop)
 	}
 	if ((err = dls_link_setzid(ddp->dd_mac, new_zoneid)) == 0) {
 		ddp->dd_zid = new_zoneid;
+		ddp->dd_transient = transient;
 		devnet_need_rebuild = B_TRUE;
 	}
 
@@ -1484,7 +1639,7 @@ dls_devnet_setzid(dls_dl_handle_t ddh, zoneid_t new_zid)
 		refheld = B_TRUE;
 	}
 
-	if ((err = i_dls_devnet_setzid(ddh, new_zid, B_TRUE)) != 0) {
+	if ((err = i_dls_devnet_setzid(ddh, new_zid, B_TRUE, B_FALSE)) != 0) {
 		if (refheld)
 			dls_devnet_rele(ddp);
 		return (err);
@@ -1636,13 +1791,32 @@ dls_devnet_create(mac_handle_t mh, datalink_id_t linkid, zoneid_t zoneid)
 	 * we need to use the linkid to get the user name for the link
 	 * when we create the MAC client.
 	 */
-	if ((err = dls_devnet_set(mac_name(mh), linkid, zoneid, &ddp)) == 0) {
+	if ((err = dls_devnet_set(mh, linkid, zoneid, &ddp)) == 0) {
 		if ((err = dls_link_hold_create(mac_name(mh), &dlp)) != 0) {
 			mac_perim_exit(mph);
-			(void) dls_devnet_unset(mac_name(mh), &linkid, B_TRUE);
+			(void) dls_devnet_unset(mh, &linkid, B_FALSE);
 			return (err);
 		}
+
+		/*
+		 * If dd_linkid is set then the link was successfully
+		 * initialized. In this case we can remove the
+		 * initializing flag and make the link visible to the
+		 * rest of the system.
+		 *
+		 * If not set then we were called by softmac and it
+		 * was unable to obtain a linkid for the physical link
+		 * because dlmgmtd is down. In that case softmac will
+		 * eventually obtain a linkid and call
+		 * dls_devnet_recreate() to complete initialization.
+		 */
+		mutex_enter(&ddp->dd_mutex);
+		if (ddp->dd_linkid != DATALINK_INVALID_LINKID)
+			ddp->dd_flags &= ~DD_INITIALIZING;
+		mutex_exit(&ddp->dd_mutex);
+
 	}
+
 	mac_perim_exit(mph);
 	return (err);
 }
@@ -1656,8 +1830,19 @@ dls_devnet_create(mac_handle_t mh, datalink_id_t linkid, zoneid_t zoneid)
 int
 dls_devnet_recreate(mac_handle_t mh, datalink_id_t linkid)
 {
-	ASSERT(linkid != DATALINK_INVALID_LINKID);
-	return (dls_devnet_set(mac_name(mh), linkid, GLOBAL_ZONEID, NULL));
+	dls_devnet_t	*ddp;
+	int		err;
+
+	VERIFY(linkid != DATALINK_INVALID_LINKID);
+	if ((err = dls_devnet_set(mh, linkid, GLOBAL_ZONEID, &ddp)) == 0) {
+		mutex_enter(&ddp->dd_mutex);
+		if (ddp->dd_linkid != DATALINK_INVALID_LINKID)
+			ddp->dd_flags &= ~DD_INITIALIZING;
+		mutex_exit(&ddp->dd_mutex);
+	}
+
+	return (err);
+
 }
 
 int
@@ -1667,7 +1852,43 @@ dls_devnet_destroy(mac_handle_t mh, datalink_id_t *idp, boolean_t wait)
 	mac_perim_handle_t	mph;
 
 	*idp = DATALINK_INVALID_LINKID;
-	err = dls_devnet_unset(mac_name(mh), idp, wait);
+	err = dls_devnet_unset(mh, idp, wait);
+
+	/*
+	 * We continue on in the face of ENOENT because the devnet
+	 * unset and DLS link release are not atomic and we may have a
+	 * scenario where there is no entry in i_dls_devnet_hash for
+	 * the MAC name but there is an entry in i_dls_link_hash. For
+	 * example, if the following occurred:
+	 *
+	 * 1. dls_devnet_unset() returns success, and
+	 *
+	 * 2. dls_link_rele_by_name() fails with ENOTEMPTY because
+	 *    flows still exist, and
+	 *
+	 * 3. dls_devnet_set() fails to set the zone id and calls
+	 *    dls_devnet_unset() -- leaving an entry in
+	 *    i_dls_link_hash but no corresponding entry in
+	 *    i_dls_devnet_hash.
+	 *
+	 * Even if #3 wasn't true the dls_devnet_set() may fail for
+	 * different reasons in the future; the point is that it _can_
+	 * fail as part of its contract. We can't rely on it working
+	 * so we must assume that these two pieces of state (devnet
+	 * and link hashes), which should always be in sync, can get
+	 * out of sync and thus even if we get ENOENT from the devnet
+	 * hash we should still try to delete from the link hash just
+	 * in case.
+	 *
+	 * We could prevent the ENOTEMPTY from dls_link_rele_by_name()
+	 * by calling mac_disable() before calling
+	 * dls_devnet_destroy() but that's not currently possible due
+	 * to a long-standing bug. OpenSolaris 6791335: The semantics
+	 * of mac_disable() were modified by Crossbow such that
+	 * dls_devnet_destroy() needs to be called before
+	 * mac_disable() can succeed. This is because of the implicit
+	 * reference that dls has on the mac_impl_t.
+	 */
 	if (err != 0 && err != ENOENT)
 		return (err);
 
@@ -1676,6 +1897,8 @@ dls_devnet_destroy(mac_handle_t mh, datalink_id_t *idp, boolean_t wait)
 	mac_perim_exit(mph);
 
 	if (err != 0) {
+		dls_devnet_t	*ddp;
+
 		/*
 		 * XXX It is a general GLDv3 bug that dls_devnet_set() has to
 		 * be called to re-set the link when destroy fails.  The
@@ -1683,8 +1906,19 @@ dls_devnet_destroy(mac_handle_t mh, datalink_id_t *idp, boolean_t wait)
 		 * called from kernel context or from a zone other than that
 		 * which initially created the link.
 		 */
-		(void) dls_devnet_set(mac_name(mh), *idp, crgetzoneid(CRED()),
-		    NULL);
+		(void) dls_devnet_set(mh, *idp, crgetzoneid(CRED()), &ddp);
+
+		/*
+		 * You might think dd_linkid should always be set
+		 * here, but in the case where dls_devnet_unset()
+		 * returns ENOENT it will be DATALINK_INVALID_LINKID.
+		 * Stay consistent with the rest of DLS and only
+		 * remove the initializing flag if linkid is set.
+		 */
+		mutex_enter(&ddp->dd_mutex);
+		if (ddp->dd_linkid != DATALINK_INVALID_LINKID)
+			ddp->dd_flags &= ~DD_INITIALIZING;
+		mutex_exit(&ddp->dd_mutex);
 	}
 	return (err);
 }

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -7711,6 +7711,13 @@ zone_list_datalink(zoneid_t zoneid, int *nump, datalink_id_t *idarray)
 	mutex_exit(&zone->zone_lock);
 	zone_rele(zone);
 
+	/*
+	 * Prevent returning negative nump values -- we should never
+	 * have this many links anyways.
+	 */
+	if (num > INT_MAX)
+		return (set_errno(EOVERFLOW));
+
 	/* Increased or decreased, caller should be notified. */
 	if (num != dlcount) {
 		if (copyout(&num, nump, sizeof (num)) != 0)

--- a/usr/src/uts/common/sys/dls_mgmt.h
+++ b/usr/src/uts/common/sys/dls_mgmt.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2015, Joyent, Inc.
+ * Copyright 2016 Joyent, Inc.
  * Copyright 2023 Oxide Computer Company
  */
 
@@ -116,10 +116,14 @@ typedef uint64_t	datalink_media_t;
 #define	DLMGMT_CMD_BASE			128
 
 /*
- * Indicate the link mapping is active or persistent
+ * Indicate if the link mapping is active, persistent, or transient. A
+ * transient link is an active link with a twist -- it is an active
+ * link which is destroyed along with the zone rather than reassigned
+ * to the GZ.
  */
 #define	DLMGMT_ACTIVE		0x01
 #define	DLMGMT_PERSIST		0x02
+#define	DLMGMT_TRANSIENT	0x04
 
 /* upcall argument */
 typedef struct dlmgmt_door_arg {


### PR DESCRIPTION

## mail_msg

```

==== Nightly distributed build started:   Mon Mar 27 12:35:05 UTC 2023 ====
==== Nightly distributed build completed: Mon Mar 27 13:52:43 UTC 2023 ====

==== Total build time ====

real    1:17:38

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-69de2a5279f i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 8.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151045/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151045/7.5.0-il-1) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.18+10-omnios-151045"

/usr/bin/openssl
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1788 (illumos)

Build project:  default
Build taskid:   79

==== Nightly argument issues ====


==== Build version ====

omnios-dlink-0762dbd47a9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:57.3
user  4:16:38.0
sys   1:10:23.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:38.7
user  3:40:52.7
sys   1:05:07.5

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
