### PR TITLE
Backports to r151038

### DIFF
--- a/usr/src/lib/libmlrpc/common/libmlrpc.h
+++ b/usr/src/lib/libmlrpc/common/libmlrpc.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 #ifndef	_LIBMLRPC_H
@@ -468,6 +469,8 @@ typedef struct ndr_auth_ops {
 	int (*nao_recv)(void *, ndr_xa_t *);
 	int (*nao_sign)(void *, ndr_xa_t *);
 	int (*nao_verify)(void *, ndr_xa_t *, boolean_t);
+	int (*nao_encrypt)(void *, ndr_xa_t *);
+	int (*nao_decrypt)(void *, ndr_xa_t *, boolean_t);
 } ndr_auth_ops_t;
 
 /*

--- a/usr/src/lib/smbsrv/libmlsvc/common/netr_logon.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/netr_logon.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2021 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 /*
@@ -815,6 +816,8 @@ netr_invalidate_chain(netr_info_t *netr_info)
 	netr_info->flags &= ~NETR_FLG_VALID;
 	explicit_bzero(&netr_info->session_key,
 	    sizeof (netr_info->session_key));
+	explicit_bzero(&netr_info->rpc_seal_key,
+	    sizeof (netr_info->rpc_seal_key));
 	explicit_bzero(&netr_info->client_credential,
 	    sizeof (netr_info->client_credential));
 	explicit_bzero(&netr_info->server_credential,

--- a/usr/src/lib/smbsrv/libmlsvc/common/netr_ssp.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/netr_ssp.c
@@ -11,9 +11,11 @@
 
 /*
  * Copyright 2020 Tintri by DDN, Inc. All Rights Reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 #include <sys/md5.h>
+#include <sys/debug.h>
 #include <strings.h>
 #include <stdio.h>
 #include <smbsrv/netrauth.h>
@@ -91,10 +93,10 @@ typedef struct nl_auth_message {
 /*
  * The size of this structure is used for space accounting.
  * The confounder is not present on the wire unless confidentiality
- * has been negotiated. If we ever support confidentiality,
- * we'll need to adjust space accounting based on whether
- * the confounder is needed.
+ * has been negotiated. When generating a token, we'll adjust space accounting
+ * based on whether the confounder is present.
  */
+#define	NL_AUTH_CONFOUNDER_SIZE	8
 typedef struct nl_auth_sig {
 	uint16_t nas_sig_alg;
 	uint16_t nas_seal_alg;
@@ -102,8 +104,11 @@ typedef struct nl_auth_sig {
 	uint16_t nas_flags;
 	uchar_t nas_seqnum[8];
 	uchar_t nas_sig[8];
-	/* uchar_t nas_confounder[8]; */ /* only for encryption */
+	uchar_t nas_confounder[NL_AUTH_CONFOUNDER_SIZE]; /* Sealing only */
 } nl_auth_sig_t;
+
+#define	NL_AUTH_SIG_SIGN_SIZE	24
+#define	NL_AUTH_SIG_SEAL_SIZE	32
 
 void
 netr_show_msg(nl_auth_message_t *nam, ndr_stream_t *nds)
@@ -115,15 +120,16 @@ void
 netr_show_sig(nl_auth_sig_t *nas, ndr_stream_t *nds)
 {
 	ndo_printf(nds, NULL, "nl_auth_sig: SignatureAlg=0x%x SealAlg=0x%x "
-	    "pad=0x%x flags=0x%x SequenceNumber=%llu Signature=0x%x",
+	    "pad=0x%x flags=0x%x SequenceNumber=%llu Signature=0x%x "
+	    "Confounder=0x%x",
 	    nas->nas_sig_alg, nas->nas_seal_alg, nas->nas_pad,
 	    nas->nas_flags, *(uint64_t *)nas->nas_seqnum,
-	    *(uint64_t *)nas->nas_sig);
+	    *(uint64_t *)nas->nas_sig, *(uint64_t *)nas->nas_confounder);
 }
 
 /*
  * NETLOGON SSP gss_init_sec_context equivalent
- * [MS-RPCE] 3.3.4.1.1 "Generating an Initial NL_AUTH_MESSAGE"
+ * [MS-NRPC] 3.3.4.1.1 "Generating an Initial NL_AUTH_MESSAGE"
  *
  * We need to encode at least one Computer name and at least one
  * Domain name. The server uses this to find the Session Key
@@ -216,7 +222,7 @@ netr_ssp_init(void *arg, ndr_xa_t *mxa)
 
 /*
  * NETLOGON SSP response-side gss_init_sec_context equivalent
- * [MS-RPCE] 3.3.4.1.4 "Receiving a Return NL_AUTH_MESSAGE"
+ * [MS-NRPC] 3.3.4.1.4 "Receiving a Return NL_AUTH_MESSAGE"
  */
 int
 netr_ssp_recv(void *arg, ndr_xa_t *mxa)
@@ -251,29 +257,48 @@ errout:
 #define	CLS_BYTE(n, seqnum) ((seqnum >> (8 * (n))) & 0xff)
 
 /*
- * NETLOGON SSP gss_MICEx equivalent
- * [MS-RPCE] 3.3.4.2.1 "Generating a Client Netlogon Signature Token"
- *
- * Set up the metadata, encrypt and increment the SequenceNumber,
- * and sign the PDU body.
+ * Perform key derivation using HMAC-MD5, as specified in MS-NRPC.
+ * This generates an intermediate key using HMAC-MD5 over zeroes using
+ * the input key, then generates the final key using HMAC-MD5 over some
+ * caller-specified data using the intermediate key.
+ * See callers for spec references (there are multiple!).
  */
 int
-netr_ssp_sign(void *arg, ndr_xa_t *mxa)
+netr_ssp_derive_key(uchar_t *input_key, uint_t key_len,
+    uchar_t *data, uint_t data_len, uchar_t *out_key)
+{
+	int rc;
+	uint32_t zeroes = 0;
+
+	rc = smb_auth_hmac_md5((uchar_t *)&zeroes, 4,
+	    input_key, key_len,
+	    out_key);
+
+	if (rc == 0)
+		rc = smb_auth_hmac_md5(data, data_len,
+		    out_key, MD_DIGEST_LEN,
+		    out_key);
+
+	return (rc);
+}
+/*
+ * [MS-NRPC] 3.3.4.2.1 "Generating a Client Netlogon Signature Token"
+ *
+ * Set up the metadata, encrypt and increment the SequenceNumber,
+ * and sign the PDU body. If a confounder is provided, encrypt it and
+ * the PDU body.
+ * Encryption happens here because the RC4 key is derived from data
+ * generated locally for signing/verification.
+ */
+int
+netr_ssp_make_token(netr_info_t *auth, ndr_stream_t *nds, nl_auth_sig_t *nas,
+    uchar_t *confounder)
 {
 	uint32_t zeroes = 0;
-	netr_info_t *auth = arg;
-	ndr_common_header_t *hdr = &mxa->send_hdr.common_hdr;
-	ndr_stream_t *nds = &mxa->send_nds;
-	nl_auth_sig_t *nas;
 	MD5_CTX md5h;
 	BYTE local_sig[MD_DIGEST_LEN];
 	BYTE enc_key[MD_DIGEST_LEN];
-
-	hdr->auth_length = sizeof (nl_auth_sig_t);
-
-	nas = NDR_MALLOC(mxa, hdr->auth_length);
-	if (nas == NULL)
-		return (NDR_DRC_FAULT_SEC_OUT_OF_MEMORY);
+	uchar_t *pdu_body = nds->pdu_base_addr + nds->pdu_body_offset;
 
 	/*
 	 * SignatureAlgorithm is first byte 0x77, second byte 00 for HMAC-MD5
@@ -289,7 +314,10 @@ netr_ssp_sign(void *arg, ndr_xa_t *mxa)
 	 * Each of these is always encoded in little-endian order.
 	 */
 	nas->nas_sig_alg = 0x0077;
-	nas->nas_seal_alg = 0xffff;
+	if (confounder != NULL)
+		nas->nas_seal_alg = 0x007A;
+	else
+		nas->nas_seal_alg = 0xffff;
 	nas->nas_pad = 0xffff;
 	nas->nas_flags = 0;
 
@@ -313,15 +341,16 @@ netr_ssp_sign(void *arg, ndr_xa_t *mxa)
 	 * The HMAC-MD5 signature is computed as follows:
 	 * First 8 bytes of
 	 * HMAC_MD5(
-	 *	MD5(0x00000000 | sig_alg | seal_alg | pad | flags | PDU body),
+	 *	MD5(0x00000000 | sig_alg | seal_alg | pad | flags |
+	 *		<confounder if present> | PDU body),
 	 *	session_key)
 	 */
 	MD5Init(&md5h);
 	MD5Update(&md5h, (uchar_t *)&zeroes, 4);
 	MD5Update(&md5h, (uchar_t *)nas, 8);
-	MD5Update(&md5h,
-	    (uchar_t *)nds->pdu_base_addr + nds->pdu_body_offset,
-	    nds->pdu_body_size);
+	if (confounder != NULL)
+		MD5Update(&md5h, confounder, NL_AUTH_CONFOUNDER_SIZE);
+	MD5Update(&md5h, pdu_body, nds->pdu_body_size);
 
 	MD5Final(local_sig, &md5h);
 	if (smb_auth_hmac_md5(local_sig, sizeof (local_sig),
@@ -332,78 +361,103 @@ netr_ssp_sign(void *arg, ndr_xa_t *mxa)
 	bcopy(local_sig, nas->nas_sig, 8);
 
 	/*
+	 * [MS-NRPC] 3.3.4.2.1 "Generating a Client Netlogon Signature Token"
+	 * Encrypt the Confounder and PDU Body.
+	 * For RC4 Encryption, the EncryptionKey is computed as follows:
+	 * XorKey = (XOR each byte of session_key with 0xf0)
+	 * HMAC_MD5(local_seqnum, HMAC_MD5(0x00000000, xor_key))
+	 *
+	 * Step 8 says "the Confounder field and the data MUST be encrypted,
+	 * in that order, using the same encryption algorithm". It also says
+	 * "The server MUST initialize RC4 only once, before encrypting the
+	 * Confounder field".
+	 * However, that's a lie! They're encrypted independently for RC4.
+	 */
+	if (confounder != NULL) {
+		int rc;
+
+		rc = netr_ssp_derive_key(
+		    auth->rpc_seal_key.key, auth->rpc_seal_key.len,
+		    (uchar_t *)nas->nas_seqnum, sizeof (nas->nas_seqnum),
+		    enc_key);
+
+		if (rc != 0)
+			goto errout;
+
+		if (smb_auth_RC4(nas->nas_confounder,
+		    sizeof (nas->nas_confounder),
+		    enc_key, sizeof (enc_key),
+		    confounder, NL_AUTH_CONFOUNDER_SIZE) != 0)
+			goto errout;
+
+		if (smb_auth_RC4(pdu_body, nds->pdu_body_size,
+		    enc_key, sizeof (enc_key),
+		    pdu_body, nds->pdu_body_size) != 0)
+			goto errout;
+	}
+
+	/*
 	 * Encrypt the SequenceNumber.
 	 * For RC4 Encryption, the EncryptionKey is computed as follows:
 	 * HMAC_MD5(signature, HMAC_MD5(0x00000000, session_key))
 	 */
-	if (smb_auth_hmac_md5((uchar_t *)&zeroes, 4,
-	    auth->session_key.key, auth->session_key.len,
-	    enc_key) != 0)
-		return (NDR_DRC_FAULT_SEC_SSP_FAILED);
-	if (smb_auth_hmac_md5((uchar_t *)nas->nas_sig, sizeof (nas->nas_sig),
-	    enc_key, sizeof (enc_key),
-	    enc_key) != 0)
-		return (NDR_DRC_FAULT_SEC_SSP_FAILED);
+	if (netr_ssp_derive_key(auth->session_key.key, auth->session_key.len,
+	    (uchar_t *)nas->nas_sig, sizeof (nas->nas_sig), enc_key) != 0)
+		goto errout;
 
 	if (smb_auth_RC4(nas->nas_seqnum, sizeof (nas->nas_seqnum),
 	    enc_key, sizeof (enc_key),
 	    nas->nas_seqnum, sizeof (nas->nas_seqnum)) != 0)
-		return (NDR_DRC_FAULT_SEC_SSP_FAILED);
+		goto errout;
 
-	mxa->send_auth.auth_value = (void *)nas;
-
+	explicit_bzero(enc_key, sizeof (enc_key));
 	return (NDR_DRC_OK);
+
+errout:
+	explicit_bzero(enc_key, sizeof (enc_key));
+	return (NDR_DRC_FAULT_SEC_SSP_FAILED);
 }
 
 /*
- * NETLOGON SSP gss_VerifyMICEx equivalent
- * [MS-RPCE] 3.3.4.2.4 "Receiving a Server Netlogon Signature Token"
+ * [MS-NRPC] 3.3.4.2.4 "Receiving a Server Netlogon Signature Token"
  *
- * Verify the metadata, decrypt, verify, and increment the SequenceNumber,
+ * Verify the metadata; decrypt, verify, and increment the SequenceNumber;
  * and validate the PDU body against the provided signature.
+ * If the confounder is present, decrypt it and the PDU body. This is done here
+ * because the key relies on local_seqnum ("CopySeqNumber"), which can only be
+ * retrieved here.
  */
 int
-netr_ssp_verify(void *arg, ndr_xa_t *mxa, boolean_t verify_resp)
+netr_ssp_check_token(netr_info_t *auth, ndr_stream_t *nds, nl_auth_sig_t *nas,
+    boolean_t verify_resp, boolean_t has_confounder)
 {
 	uint32_t zeroes = 0;
-	netr_info_t *auth = arg;
-	ndr_sec_t *secp = &mxa->recv_auth;
-	ndr_stream_t *nds = &mxa->recv_nds;
-	nl_auth_sig_t *nas;
 	MD5_CTX md5h;
 	BYTE local_sig[MD_DIGEST_LEN];
 	BYTE dec_key[MD_DIGEST_LEN];
 	BYTE local_seqnum[8];
+	uchar_t confounder[NL_AUTH_CONFOUNDER_SIZE];
+	uchar_t *pdu_body = nds->pdu_base_addr + nds->pdu_body_offset;
 	int rc;
 	boolean_t seqnum_bumped = B_FALSE;
-
-	nas = (nl_auth_sig_t *)secp->auth_value;
 
 	/*
 	 * Verify SignatureAlgorithm, SealAlgorithm, and Pad are as expected.
 	 * These follow the same values as in the Client Signature.
 	 */
 	if (nas->nas_sig_alg != 0x0077 ||
-	    nas->nas_seal_alg != 0xffff ||
+	    nas->nas_seal_alg != (has_confounder ? 0x007A : 0xffff) ||
 	    nas->nas_pad != 0xffff) {
 		rc = NDR_DRC_FAULT_SEC_META_INVALID;
 		goto errout;
 	}
 
 	/* Decrypt the SequenceNumber. This is done the same as the Client. */
-	if (smb_auth_hmac_md5((uchar_t *)&zeroes, 4,
-	    auth->session_key.key, auth->session_key.len,
-	    dec_key) != 0) {
+	if (netr_ssp_derive_key(auth->session_key.key, auth->session_key.len,
+	    (uchar_t *)nas->nas_sig, sizeof (nas->nas_sig), dec_key) != 0) {
 		rc = NDR_DRC_FAULT_SEC_SSP_FAILED;
 		goto errout;
 	}
-	if (smb_auth_hmac_md5((uchar_t *)nas->nas_sig, sizeof (nas->nas_sig),
-	    dec_key, sizeof (dec_key),
-	    dec_key) != 0) {
-		rc = NDR_DRC_FAULT_SEC_SSP_FAILED;
-		goto errout;
-	}
-
 	if (smb_auth_RC4(nas->nas_seqnum, sizeof (nas->nas_seqnum),
 	    dec_key, sizeof (dec_key),
 	    nas->nas_seqnum, sizeof (nas->nas_seqnum)) != 0) {
@@ -437,15 +491,44 @@ netr_ssp_verify(void *arg, ndr_xa_t *mxa, boolean_t verify_resp)
 	seqnum_bumped = B_TRUE;
 
 	/*
+	 * Decrypt the Confounder and PDU Body.
+	 * For RC4 Encryption, the EncryptionKey is computed as follows:
+	 * XorKey = (XOR each byte of session_key with 0xf0)
+	 * HMAC_MD5(local_seqnum, HMAC_MD5(0x00000000, xor_key))
+	 */
+	if (has_confounder) {
+		if (netr_ssp_derive_key(
+		    auth->rpc_seal_key.key, auth->rpc_seal_key.len,
+		    (uchar_t *)local_seqnum, sizeof (local_seqnum),
+		    dec_key) != 0) {
+			rc = NDR_DRC_FAULT_SEC_SSP_FAILED;
+			goto errout;
+		}
+
+		if (smb_auth_RC4(confounder, NL_AUTH_CONFOUNDER_SIZE,
+		    dec_key, sizeof (dec_key),
+		    nas->nas_confounder, sizeof (nas->nas_confounder)) != 0) {
+			rc = NDR_DRC_FAULT_SEC_SSP_FAILED;
+			goto errout;
+		}
+		if (smb_auth_RC4(pdu_body, nds->pdu_body_size,
+		    dec_key, sizeof (dec_key),
+		    pdu_body, nds->pdu_body_size) != 0) {
+			rc = NDR_DRC_FAULT_SEC_SSP_FAILED;
+			goto errout;
+		}
+	}
+
+	/*
 	 * Calculate the signature.
 	 * This is done the same as the Client.
 	 */
 	MD5Init(&md5h);
 	MD5Update(&md5h, (uchar_t *)&zeroes, 4);
 	MD5Update(&md5h, (uchar_t *)nas, 8);
-	MD5Update(&md5h,
-	    (uchar_t *)nds->pdu_base_addr + nds->pdu_body_offset,
-	    nds->pdu_body_size);
+	if (has_confounder)
+		MD5Update(&md5h, confounder, NL_AUTH_CONFOUNDER_SIZE);
+	MD5Update(&md5h, pdu_body, nds->pdu_body_size);
 	MD5Final(local_sig, &md5h);
 	if (smb_auth_hmac_md5(local_sig, sizeof (local_sig),
 	    auth->session_key.key, auth->session_key.len,
@@ -463,11 +546,13 @@ netr_ssp_verify(void *arg, ndr_xa_t *mxa, boolean_t verify_resp)
 		goto errout;
 	}
 
+	explicit_bzero(dec_key, sizeof (dec_key));
 	return (NDR_DRC_OK);
 
 errout:
-	netr_show_sig(nas, &mxa->recv_nds);
+	netr_show_sig(nas, nds);
 
+	explicit_bzero(dec_key, sizeof (dec_key));
 	if (!verify_resp) {
 		if (!seqnum_bumped)
 			auth->clh_seqnum++;
@@ -477,6 +562,87 @@ errout:
 	return (rc);
 }
 
+/*
+ * NETLOGON SSP gss_MICEx equivalent.
+ * Note that auth_length does NOT include the length of the confounder.
+ */
+int
+netr_ssp_sign(void *arg, ndr_xa_t *mxa)
+{
+	ndr_common_header_t *hdr = &mxa->send_hdr.common_hdr;
+	nl_auth_sig_t *nas;
+
+	hdr->auth_length = NL_AUTH_SIG_SIGN_SIZE;
+	CTASSERT(NL_AUTH_SIG_SIGN_SIZE ==
+	    (offsetof(nl_auth_sig_t, nas_sig) + sizeof (nas->nas_sig)));
+	nas = NDR_MALLOC(mxa, sizeof (*nas));
+	if (nas == NULL)
+		return (NDR_DRC_FAULT_SEC_OUT_OF_MEMORY);
+
+	mxa->send_auth.auth_value = (void *)nas;
+
+	return (netr_ssp_make_token(arg, &mxa->send_nds, nas, NULL));
+}
+
+/*
+ * NETLOGON SSP gss_VerifyMICEx equivalent.
+ */
+int
+netr_ssp_verify(void *arg, ndr_xa_t *mxa, boolean_t verify_resp)
+{
+	ndr_common_header_t *hdr = &mxa->recv_hdr.common_hdr;
+	ndr_sec_t *secp = &mxa->recv_auth;
+	nl_auth_sig_t *nas = (nl_auth_sig_t *)secp->auth_value;
+
+	if (hdr->auth_length < NL_AUTH_SIG_SIGN_SIZE)
+		return (NDR_DRC_FAULT_SEC_AUTH_LENGTH_INVALID);
+
+	return (netr_ssp_check_token(arg, &mxa->recv_nds, nas, verify_resp,
+	    B_FALSE));
+}
+
+/*
+ * NETLOGON SSP gss_WrapEx equivalent.
+ * Generate a cryptographically random confounder before signing/sealing.
+ * It is included in auth_length here.
+ */
+int
+netr_ssp_encrypt(void *arg, ndr_xa_t *mxa)
+{
+	uchar_t confounder[NL_AUTH_CONFOUNDER_SIZE];
+	ndr_common_header_t *hdr = &mxa->send_hdr.common_hdr;
+	nl_auth_sig_t *nas;
+
+	hdr->auth_length = NL_AUTH_SIG_SEAL_SIZE;
+	CTASSERT(NL_AUTH_SIG_SEAL_SIZE == sizeof (*nas));
+	nas = NDR_MALLOC(mxa, sizeof (*nas));
+	if (nas == NULL)
+		return (NDR_DRC_FAULT_SEC_OUT_OF_MEMORY);
+
+	mxa->send_auth.auth_value = (void *)nas;
+
+	arc4random_buf(confounder, NL_AUTH_CONFOUNDER_SIZE);
+	return (netr_ssp_make_token(arg, &mxa->send_nds, nas, confounder));
+}
+
+/*
+ * NETLOGON SSP gss_UnwrapEx equivalent.
+ * Note that the Confounder is only used for calculating the signature.
+ */
+int
+netr_ssp_decrypt(void *arg, ndr_xa_t *mxa, boolean_t verify_resp)
+{
+	ndr_common_header_t *hdr = &mxa->recv_hdr.common_hdr;
+	ndr_sec_t *secp = &mxa->recv_auth;
+	nl_auth_sig_t *nas = (nl_auth_sig_t *)secp->auth_value;
+
+	if (hdr->auth_length < NL_AUTH_SIG_SEAL_SIZE)
+		return (NDR_DRC_FAULT_SEC_AUTH_LENGTH_INVALID);
+
+	return (netr_ssp_check_token(arg, &mxa->recv_nds, nas, verify_resp,
+	    B_TRUE));
+}
+
 extern struct netr_info netr_global_info;
 
 ndr_auth_ctx_t netr_ssp_ctx = {
@@ -484,11 +650,13 @@ ndr_auth_ctx_t netr_ssp_ctx = {
 		.nao_init = netr_ssp_init,
 		.nao_recv = netr_ssp_recv,
 		.nao_sign = netr_ssp_sign,
-		.nao_verify = netr_ssp_verify
+		.nao_verify = netr_ssp_verify,
+		.nao_encrypt = netr_ssp_encrypt,
+		.nao_decrypt = netr_ssp_decrypt
 	},
 	.auth_ctx = &netr_global_info,
 	.auth_context_id = 0,
 	.auth_type = NDR_C_AUTHN_GSS_NETLOGON,
-	.auth_level = NDR_C_AUTHN_LEVEL_PKT_INTEGRITY,
+	.auth_level = NDR_C_AUTHN_LEVEL_PKT_PRIVACY,
 	.auth_verify_resp = B_TRUE
 };

--- a/usr/src/lib/smbsrv/libmlsvc/common/smb_logon.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/smb_logon.c
@@ -726,12 +726,21 @@ smb_token_setup_guest(smb_logon_t *user_info, smb_token_t *token)
 	(void) rw_unlock(&smb_logoninit_rwl);
 	token->tkn_flags = SMB_ATF_GUEST;
 
+	/*
+	 * [MS-NLMP] 3.2.5.1.2 "Server Receives an AUTHENTICATE_MESSAGE from the
+	 * Client":
+	 * The 'SessionBaseKey' for Guests is 16-bytes of 0s.
+	 */
+	token->tkn_ssnkey.val = calloc(1, SMBAUTH_SESSION_KEY_SZ);
+
 	if (token->tkn_account_name == NULL ||
 	    token->tkn_domain_name == NULL ||
 	    token->tkn_user.i_sid == NULL ||
-	    token->tkn_primary_grp.i_sid == NULL)
+	    token->tkn_primary_grp.i_sid == NULL ||
+	    token->tkn_ssnkey.val == NULL)
 		return (NT_STATUS_NO_MEMORY);
 
+	token->tkn_ssnkey.len = SMBAUTH_SESSION_KEY_SZ;
 	return (smb_token_setup_wingrps(token));
 }
 
@@ -750,12 +759,21 @@ smb_token_setup_anon(smb_token_t *token)
 	token->tkn_primary_grp.i_sid = smb_sid_dup(user_sid);
 	token->tkn_flags = SMB_ATF_ANON;
 
+	/*
+	 * [MS-NLMP] 3.2.5.1.2 "Server Receives an AUTHENTICATE_MESSAGE from the
+	 * Client":
+	 * The 'SessionBaseKey' for Anonymous users is 16-bytes of 0s.
+	 */
+	token->tkn_ssnkey.val = calloc(1, SMBAUTH_SESSION_KEY_SZ);
+
 	if (token->tkn_account_name == NULL ||
 	    token->tkn_domain_name == NULL ||
 	    token->tkn_user.i_sid == NULL ||
-	    token->tkn_primary_grp.i_sid == NULL)
+	    token->tkn_primary_grp.i_sid == NULL ||
+	    token->tkn_ssnkey.val == NULL)
 		return (NT_STATUS_NO_MEMORY);
 
+	token->tkn_ssnkey.len = SMBAUTH_SESSION_KEY_SZ;
 	return (smb_token_setup_wingrps(token));
 }
 

--- a/usr/src/uts/common/fs/smbsrv/smb_authenticate.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_authenticate.c
@@ -20,8 +20,8 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
- * Copyright 2020 RackTop Systems, Inc.
+ * Copyright 2015-2021 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2022-2023 RackTop Systems, Inc.
  */
 
 /*
@@ -486,17 +486,10 @@ smb_auth_get_token(smb_request_t *sr)
 	crfree(cr);
 
 	/*
-	 * Some basic processing for encryption needs to be done,
-	 * even for anonymous/guest sessions. In particular,
-	 * we need to set Session.EncryptData.
-	 *
-	 * Windows handling of anon/guest and encryption is strange.
-	 * It allows these accounts to get through session setup,
-	 * even when they provide no key material.
-	 * Additionally, Windows somehow manages to have key material
-	 * for anonymous accounts under unknown circumstances.
-	 * As such, We set EncryptData on anon/guest to behave like Windows,
-	 * at least through Session Setup.
+	 * Set Session.EncryptData so encryption can be enforced,
+	 * and set up encryption keys if we have a session key.
+	 * This happens even for anonymous/guest users, as Windows
+	 * currently will send encrypted requests from them.
 	 */
 	if (sr->session->dialect >= SMB_VERS_3_0)
 		smb3_encrypt_begin(sr, token);

--- a/usr/src/uts/common/smbsrv/netrauth.h
+++ b/usr/src/uts/common/smbsrv/netrauth.h
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 #ifndef _SMBSRV_NETRAUTH_H
@@ -183,6 +184,7 @@ typedef struct netr_info {
 	netr_cred_t client_credential;
 	netr_cred_t server_credential;
 	netr_session_key_t session_key;
+	netr_session_key_t rpc_seal_key;
 	BYTE password[NETR_MACHINE_ACCT_PASSWD_MAX];
 	time_t timestamp;
 	uint64_t clh_seqnum; /* Client SequenceNumber for Netlogon SSP */


### PR DESCRIPTION
## mail_msg

```

==== Nightly distributed build started:   Tue Jun 13 09:23:35 UTC 2023 ====
==== Nightly distributed build completed: Tue Jun 13 10:46:10 UTC 2023 ====

==== Total build time ====

real    1:22:34

==== Build environment ====

/usr/bin/uname
SunOS r151038 5.11 omnios-r151038-b230ab3fe8 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151038/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-4.4.4/bin/gcc
gcc (GCC) 4.4.4
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151038/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-5

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.19+7-omnios-151038"

/usr/bin/openssl
OpenSSL 1.1.1u  30 May 2023
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1765 (illumos)

Build project:  default
Build taskid:   216

==== Nightly argument issues ====


==== Build version ====

omnios-r38bp-8f15cdda76

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    33:58.4
user  5:30:03.2
sys   1:32:53.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    29:46.4
user  4:43:31.5
sys   1:24:50.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Linting packages ====
```
