### PR TITLE
AARCH64: add support to libctf

### DIFF
--- a/usr/src/lib/libctf/common/ctf_dwarf.c
+++ b/usr/src/lib/libctf/common/ctf_dwarf.c
@@ -919,6 +919,12 @@ static const ctf_dwarf_fpmap_t ctf_dwarf_fpmaps[] = {
 		{ 16, { CTF_FP_LDOUBLE, CTF_FP_LDCPLX, CTF_FP_LDIMAGRY } },
 		{ 0, { 0 } }
 	} },
+	{ EM_AARCH64, {
+		{ 4, { CTF_FP_SINGLE, CTF_FP_CPLX, CTF_FP_IMAGRY } },
+		{ 8, { CTF_FP_DOUBLE, CTF_FP_DCPLX, CTF_FP_DIMAGRY } },
+		{ 16, { CTF_FP_LDOUBLE, CTF_FP_LDCPLX, CTF_FP_LDIMAGRY } },
+		{ 0, { 0 } },
+	} },
 	{ EM_X86_64, {
 		{ 4, { CTF_FP_SINGLE, CTF_FP_CPLX, CTF_FP_IMAGRY } },
 		{ 8, { CTF_FP_DOUBLE, CTF_FP_DCPLX, CTF_FP_DIMAGRY } },

--- a/usr/src/lib/libctf/common/ctf_lib.c
+++ b/usr/src/lib/libctf/common/ctf_lib.c
@@ -22,8 +22,8 @@
 /*
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- */
-/*
+ *
+ * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 2019, Joyent, Inc.
  */
 
@@ -39,7 +39,7 @@
 #include <zlib.h>
 #include <sys/debug.h>
 
-#ifdef _LP64
+#if defined(_LP64) && defined(_MULTI_DATAMODEL)
 static const char *_libctf_zlib = "/usr/lib/64/libz.so.1";
 #else
 static const char *_libctf_zlib = "/usr/lib/libz.so.1";


### PR DESCRIPTION
This is cherry picked from arm64-gate and it extends libctf.so so that we can do more CTF conversions for aarch64 artefacts.