### PR TITLE
Upstream idmap fixes (r151038)

### DIFF
--- a/usr/src/cmd/idmap/idmapd/dbutils.c
+++ b/usr/src/cmd/idmap/idmapd/dbutils.c
@@ -224,8 +224,8 @@ static int sql_exec_tran_no_cb(sqlite *db, char *sql, const char *dbname,
 static
 int
 init_db_instance(const char *dbname, int version,
-	const char *detect_version_sql, char * const *sql,
-	init_db_option_t opt, int *created, int *upgraded)
+    const char *detect_version_sql, char * const *sql,
+    init_db_option_t opt, int *created, int *upgraded)
 {
 	int rc, curr_version;
 	int tries = 1;
@@ -331,7 +331,6 @@ done:
  * operation until it is successful.
  */
 int
-/* LINTED E_FUNC_ARG_UNUSED */
 idmap_sqlite_busy_handler(void *arg, const char *table_name, int count)
 {
 	struct idmap_busy	*busy = arg;
@@ -444,7 +443,7 @@ get_cache_handle(sqlite **cache)
  * Initialize cache and db
  */
 int
-init_dbs()
+init_dbs(void)
 {
 	char *sql[4];
 	int created, upgraded;
@@ -477,7 +476,7 @@ init_dbs()
  * Finalize databases
  */
 void
-fini_dbs()
+fini_dbs(void)
 {
 }
 
@@ -519,7 +518,7 @@ idmapd_string2stat(const char *msg)
 static
 int
 sql_exec_tran_no_cb(sqlite *db, char *sql, const char *dbname,
-	const char *while_doing)
+    const char *while_doing)
 {
 	char		*errmsg = NULL;
 	int		rc;
@@ -689,7 +688,7 @@ out:
  */
 idmap_retcode
 process_list_svc_sql(sqlite *db, const char *dbname, char *sql, uint64_t limit,
-		int flag, list_svc_cb cb, void *result)
+    int flag, list_svc_cb cb, void *result)
 {
 	list_cb_data_t	cb_data;
 	char		*errmsg = NULL;
@@ -727,7 +726,7 @@ process_list_svc_sql(sqlite *db, const char *dbname, char *sql, uint64_t limit,
  */
 idmap_retcode
 validate_list_cb_data(list_cb_data_t *cb_data, int argc, char **argv,
-		int ncol, uchar_t **list, size_t valsize)
+    int ncol, uchar_t **list, size_t valsize)
 {
 	size_t	nsize;
 	void	*tmplist;
@@ -759,7 +758,7 @@ validate_list_cb_data(list_cb_data_t *cb_data, int argc, char **argv,
 static
 idmap_retcode
 get_namerule_order(char *winname, char *windomain, char *unixname,
-	int direction, int is_diagonal, int *w2u_order, int *u2w_order)
+    int direction, int is_diagonal, int *w2u_order, int *u2w_order)
 {
 	*w2u_order = 0;
 	*u2w_order = 0;
@@ -1013,7 +1012,7 @@ out:
 static
 idmap_retcode
 sql_compile_n_step_once(sqlite *db, char *sql, sqlite_vm **vm, int *ncol,
-		int reqcol, const char ***values)
+    int reqcol, const char ***values)
 {
 	char		*errmsg = NULL;
 	int		r;
@@ -1157,8 +1156,8 @@ load_cfg_in_state(lookup_state_t *state)
  */
 static void
 idmap_namerule_set(idmap_namerule *rule, const char *windomain,
-		const char *winname, const char *unixname, boolean_t is_user,
-		boolean_t is_wuser, boolean_t is_nt4, int direction)
+    const char *winname, const char *unixname, boolean_t is_user,
+    boolean_t is_wuser, boolean_t is_nt4, int direction)
 {
 	/*
 	 * Only update if they differ because we have to free
@@ -1739,7 +1738,7 @@ xlate_legacy_type(int type)
 static
 idmap_retcode
 lookup_cache_sid2name(sqlite *cache, const char *sidprefix, idmap_rid_t rid,
-		char **canonname, char **canondomain, idmap_id_type *type)
+    char **canonname, char **canondomain, idmap_id_type *type)
 {
 	char		*end;
 	char		*sql = NULL;
@@ -1884,8 +1883,8 @@ lookup_name_cache(sqlite *cache, idmap_mapping *req, idmap_id_res *res)
 
 static int
 ad_lookup_batch_int(lookup_state_t *state, idmap_mapping_batch *batch,
-		idmap_ids_res *result, adutils_ad_t *dir, int how_local,
-		int *num_processed)
+    idmap_ids_res *result, adutils_ad_t *dir, int how_local,
+    int *num_processed)
 {
 	idmap_retcode	retcode;
 	int		i,  num_queued, is_wuser, is_user;
@@ -2378,7 +2377,7 @@ out:
  */
 idmap_retcode
 ad_lookup_batch(lookup_state_t *state, idmap_mapping_batch *batch,
-		idmap_ids_res *result)
+    idmap_ids_res *result)
 {
 	idmap_retcode	retcode;
 	int		i, j;
@@ -2532,7 +2531,7 @@ out:
  */
 idmap_retcode
 sid2pid_first_pass(lookup_state_t *state, idmap_mapping *req,
-		idmap_id_res *res)
+    idmap_id_res *res)
 {
 	idmap_retcode	retcode;
 	int		wksid;
@@ -2756,13 +2755,13 @@ out:
 
 /*
  * Generate SID using the following convention
- * 	<machine-sid-prefix>-<1000 + uid>
- * 	<machine-sid-prefix>-<2^31 + gid>
+ *	<machine-sid-prefix>-<1000 + uid>
+ *	<machine-sid-prefix>-<2^31 + gid>
  */
 static
 idmap_retcode
 generate_localsid(idmap_mapping *req, idmap_id_res *res, int is_user,
-		int fallback)
+    int fallback)
 {
 	free(res->id.idmap_id_u.sid.prefix);
 	res->id.idmap_id_u.sid.prefix = NULL;
@@ -3007,7 +3006,7 @@ ns_lookup_bypid(uid_t pid, int is_user, char **unixname)
 static
 idmap_retcode
 name_based_mapping_sid2pid(lookup_state_t *state,
-		idmap_mapping *req, idmap_id_res *res)
+    idmap_mapping *req, idmap_id_res *res)
 {
 	const char	*unixname, *windomain;
 	char		*sql = NULL, *errmsg = NULL, *lower_winname = NULL;
@@ -3279,7 +3278,7 @@ gethash(const char *str, uint32_t num, uint_t htsize)
 static
 int
 get_from_sid_history(lookup_state_t *state, const char *prefix, uint32_t rid,
-		uid_t *pid)
+    uid_t *pid)
 {
 	uint_t		next, key;
 	uint_t		htsize = state->sid_history_size;
@@ -3335,7 +3334,7 @@ cleanup_lookup_state(lookup_state_t *state)
 static
 idmap_retcode
 dynamic_ephemeral_mapping(lookup_state_t *state,
-		idmap_mapping *req, idmap_id_res *res)
+    idmap_mapping *req, idmap_id_res *res)
 {
 
 	uid_t		next_pid;
@@ -3378,7 +3377,7 @@ dynamic_ephemeral_mapping(lookup_state_t *state,
 
 idmap_retcode
 sid2pid_second_pass(lookup_state_t *state,
-		idmap_mapping *req, idmap_id_res *res)
+    idmap_mapping *req, idmap_id_res *res)
 {
 	idmap_retcode	retcode;
 	idmap_retcode	retcode2;
@@ -3575,7 +3574,7 @@ out:
 
 idmap_retcode
 update_cache_pid2sid(lookup_state_t *state,
-		idmap_mapping *req, idmap_id_res *res)
+    idmap_mapping *req, idmap_id_res *res)
 {
 	char		*sql = NULL;
 	idmap_retcode	retcode;
@@ -3583,7 +3582,7 @@ update_cache_pid2sid(lookup_state_t *state,
 	char		*map_dn = NULL;
 	char		*map_attr = NULL;
 	char		*map_value = NULL;
-	char 		*map_windomain = NULL;
+	char		*map_windomain = NULL;
 	char		*map_winname = NULL;
 	char		*map_unixname = NULL;
 	int		map_is_nt4 = FALSE;
@@ -3725,7 +3724,7 @@ out:
 
 idmap_retcode
 update_cache_sid2pid(lookup_state_t *state,
-		idmap_mapping *req, idmap_id_res *res)
+    idmap_mapping *req, idmap_id_res *res)
 {
 	char		*sql = NULL;
 	idmap_retcode	retcode;
@@ -3733,7 +3732,7 @@ update_cache_sid2pid(lookup_state_t *state,
 	char		*map_dn = NULL;
 	char		*map_attr = NULL;
 	char		*map_value = NULL;
-	char 		*map_windomain = NULL;
+	char		*map_windomain = NULL;
 	char		*map_winname = NULL;
 	char		*map_unixname = NULL;
 	int		map_is_nt4 = FALSE;
@@ -3876,7 +3875,7 @@ out:
 static
 idmap_retcode
 lookup_cache_pid2sid(sqlite *cache, idmap_mapping *req, idmap_id_res *res,
-		int is_user)
+    int is_user)
 {
 	char		*end;
 	char		*sql = NULL;
@@ -4186,10 +4185,10 @@ out:
 static
 idmap_retcode
 ad_lookup_by_winname(lookup_state_t *state,
-		const char *name, const char *domain, int esidtype,
-		char **dn, char **attr, char **value, char **canonname,
-		char **sidprefix, idmap_rid_t *rid, idmap_id_type *wintype,
-		char **unixname)
+    const char *name, const char *domain, int esidtype,
+    char **dn, char **attr, char **value, char **canonname,
+    char **sidprefix, idmap_rid_t *rid, idmap_id_type *wintype,
+    char **unixname)
 {
 	int			retries;
 	idmap_query_state_t	*qs = NULL;
@@ -4406,7 +4405,7 @@ out:
 static
 idmap_retcode
 name_based_mapping_pid2sid(lookup_state_t *state, const char *unixname,
-		int is_user, idmap_mapping *req, idmap_id_res *res)
+    int is_user, idmap_mapping *req, idmap_id_res *res)
 {
 	const char	*winname, *windomain;
 	char		*canonname;
@@ -4648,7 +4647,7 @@ out:
  */
 idmap_retcode
 pid2sid_first_pass(lookup_state_t *state, idmap_mapping *req,
-		idmap_id_res *res, int is_user)
+    idmap_id_res *res, int is_user)
 {
 	idmap_retcode	retcode;
 	idmap_retcode	retcode2;
@@ -4780,7 +4779,7 @@ out:
 
 idmap_retcode
 pid2sid_second_pass(lookup_state_t *state, idmap_mapping *req,
-	idmap_id_res *res, int is_user)
+    idmap_id_res *res, int is_user)
 {
 	bool_t		gen_localsid_on_err = TRUE;
 	idmap_retcode	retcode = IDMAP_SUCCESS;

--- a/usr/src/cmd/idmap/idmapd/idmap.xml
+++ b/usr/src/cmd/idmap/idmapd/idmap.xml
@@ -3,6 +3,7 @@
 <!--
  Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ Copyright 2023 RackTop Systems, Inc.
 
  CDDL HEADER START
 
@@ -101,6 +102,10 @@
 			name='value_authorization'
 			type='astring'
 			value='solaris.smf.value.idmap' />
+		<propval
+			name='discovery_retry_max_delay'
+			type='count'
+			value='30' />
 		<propval
 			name='id_cache_timeout'
 			type='count'

--- a/usr/src/cmd/idmap/idmapd/idmap_config.c
+++ b/usr/src/cmd/idmap/idmapd/idmap_config.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2019 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 
@@ -72,7 +73,7 @@
 #define	REDISCOVERY_INTERVAL_DEFAULT	3600
 
 /*
- * Mininum time between rediscovery runs, in case adutils gives us a
+ * Minimum time between rediscovery runs, in case adutils gives us a
  * really short TTL (which it never should, but be defensive)
  * (not configurable) seconds.
  */
@@ -82,6 +83,22 @@
  * Max number of concurrent door calls
  */
 #define	MAX_THREADS_DEFAULT	40
+
+/*
+ * Number of failed discovery attempts before we mark the service degraded.
+ */
+#define	DISCOVERY_RETRY_DEGRADE_CUTOFF	6
+
+/*
+ * Default maximum time between discovery attempts when we don't have a DC.
+ * config/discovery_retry_max_delay = count: seconds
+ */
+#define	DISCOVERY_RETRY_MAX_DELAY_DEFAULT	30
+
+/*
+ * Initial retry delay when discovery fails. Doubles on every failure.
+ */
+#define	DISCOVERY_RETRY_INITIAL_DELAY	1
 
 enum event_type {
 	EVENT_NOTHING,	/* Woke up for no good reason */
@@ -238,7 +255,7 @@ destruction:
 
 static int
 get_val_bool(idmap_cfg_handles_t *handles, const char *name,
-	boolean_t *val, boolean_t default_val)
+    boolean_t *val, boolean_t default_val)
 {
 	int rc = 0;
 
@@ -285,7 +302,7 @@ destruction:
 
 static int
 get_val_int(idmap_cfg_handles_t *handles, const char *name,
-	void *val, scf_type_t type)
+    void *val, scf_type_t type)
 {
 	int rc = 0;
 
@@ -376,7 +393,7 @@ scf_value2string(const char *name, scf_value_t *value)
 
 static int
 get_val_ds(idmap_cfg_handles_t *handles, const char *name, int defport,
-		ad_disc_ds_t **val)
+    ad_disc_ds_t **val)
 {
 	char port_str[8];
 	struct addrinfo hints;
@@ -965,7 +982,7 @@ update_dirs(ad_disc_ds_t **value, ad_disc_ds_t **new, char *name)
  */
 static int
 update_trusted_domains(ad_disc_trusteddomains_t **value,
-			ad_disc_trusteddomains_t **new, char *name)
+    ad_disc_trusteddomains_t **new, char *name)
 {
 	int i;
 
@@ -1011,7 +1028,7 @@ update_trusted_domains(ad_disc_trusteddomains_t **value,
  */
 static int
 update_domains_in_forest(ad_disc_domainsinforest_t **value,
-			ad_disc_domainsinforest_t **new, char *name)
+    ad_disc_domainsinforest_t **new, char *name)
 {
 	int i;
 
@@ -1068,7 +1085,7 @@ free_trusted_forests(idmap_trustedforest_t **value, int *num_values)
 
 static int
 compare_trusteddomainsinforest(ad_disc_domainsinforest_t *df1,
-			ad_disc_domainsinforest_t *df2)
+    ad_disc_domainsinforest_t *df2)
 {
 	int		i, j;
 	int		num_df1 = 0;
@@ -1112,7 +1129,7 @@ compare_trusteddomainsinforest(ad_disc_domainsinforest_t *df1,
  */
 static int
 update_trusted_forest(idmap_trustedforest_t **value, int *num_value,
-			idmap_trustedforest_t **new, int *num_new, char *name)
+    idmap_trustedforest_t **new, int *num_new, char *name)
 {
 	int i, j;
 	boolean_t match;
@@ -1333,8 +1350,9 @@ idmap_cfg_update_thread(void *arg)
 {
 	NOTE(ARGUNUSED(arg))
 	idmap_pg_config_t *pgcfg = &_idmapdstate.cfg->pgcfg;
-	const ad_disc_t		ad_ctx = _idmapdstate.cfg->handles.ad_ctx;
+	const ad_disc_t	ad_ctx = _idmapdstate.cfg->handles.ad_ctx;
 	int flags = CFG_DISCOVER;
+	uint_t retry_count = 0;
 
 	for (;;) {
 		struct timespec timeout;
@@ -1356,28 +1374,53 @@ idmap_cfg_update_thread(void *arg)
 		}
 
 		/*
+		 * If we don't know our domain name, we're not in a domain;
+		 * don't bother with rediscovery until the next config change.
+		 * Avoids hourly noise in workgroup mode.
+		 *
+		 * If we don't have a DC currently, use a greatly reduced TTL
+		 * until we get one. Degrade if that takes too long.
+		 */
+		if (pgcfg->domain_name == NULL) {
+			ttl = -1;
+			/* We don't need a DC if we're no longer in a domain. */
+			if (retry_count >= DISCOVERY_RETRY_DEGRADE_CUTOFF)
+				restore_svc();
+			retry_count = 0;
+		} else if (pgcfg->domain_controller == NULL) {
+			if (retry_count == 0)
+				ttl = DISCOVERY_RETRY_INITIAL_DELAY;
+			else
+				ttl *= 2;
+
+			if (ttl > pgcfg->discovery_retry_max_delay)
+				ttl = pgcfg->discovery_retry_max_delay;
+
+			if (++retry_count >= DISCOVERY_RETRY_DEGRADE_CUTOFF) {
+				degrade_svc(B_FALSE,
+				    "Too many DC discovery failures");
+			}
+		} else {
+			ttl = ad_disc_get_TTL(ad_ctx);
+			max_ttl = (int)pgcfg->rediscovery_interval;
+			if (ttl > max_ttl)
+				ttl = max_ttl;
+			if (ttl < MIN_REDISCOVERY_INTERVAL)
+				ttl = MIN_REDISCOVERY_INTERVAL;
+			if (retry_count >= DISCOVERY_RETRY_DEGRADE_CUTOFF)
+				restore_svc();
+			retry_count = 0;
+		}
+
+		/*
 		 * Wait for an interesting event.  Note that we might get
 		 * boring events between interesting events.  If so, we loop.
 		 */
 		flags = CFG_DISCOVER;
 		for (;;) {
-			/*
-			 * If we don't know our domain name, don't bother
-			 * with rediscovery until the next config change.
-			 * Avoids hourly noise in workgroup mode.
-			 */
-			if (pgcfg->domain_name == NULL)
-				ttl = -1;
-			else
-				ttl = ad_disc_get_TTL(ad_ctx);
 			if (ttl < 0) {
 				timeoutp = NULL;
 			} else {
-				max_ttl = (int)pgcfg->rediscovery_interval;
-				if (ttl > max_ttl)
-					ttl = max_ttl;
-				if (ttl < MIN_REDISCOVERY_INTERVAL)
-					ttl = MIN_REDISCOVERY_INTERVAL;
 				timeout.tv_sec = ttl;
 				timeout.tv_nsec = 0;
 				timeoutp = &timeout;
@@ -1544,7 +1587,7 @@ check_smf_debug_mode(idmap_cfg_handles_t *handles)
  */
 static int
 idmap_cfg_load_smf(idmap_cfg_handles_t *handles, idmap_pg_config_t *pgcfg,
-	int * const errors)
+    int * const errors)
 {
 	int rc;
 	char *s;
@@ -1616,6 +1659,14 @@ idmap_cfg_load_smf(idmap_cfg_handles_t *handles, idmap_pg_config_t *pgcfg,
 		pgcfg->max_threads = MAX_THREADS_DEFAULT;
 	if (pgcfg->max_threads > UINT_MAX)
 		pgcfg->max_threads = UINT_MAX;
+
+	rc = get_val_int(handles, "discovery_retry_max_delay",
+	    &pgcfg->discovery_retry_max_delay, SCF_TYPE_COUNT);
+	if (rc != 0)
+		(*errors)++;
+	if (pgcfg->discovery_retry_max_delay == 0)
+		pgcfg->discovery_retry_max_delay =
+		    DISCOVERY_RETRY_MAX_DELAY_DEFAULT;
 
 	rc = get_val_int(handles, "id_cache_timeout",
 	    &pgcfg->id_cache_timeout, SCF_TYPE_COUNT);
@@ -2231,6 +2282,9 @@ idmap_cfg_load(idmap_cfg_t *cfg, int flags)
 
 	changed += update_uint64(&live_pgcfg->max_threads,
 	    &new_pgcfg.max_threads, "max_threads");
+
+	changed += update_uint64(&live_pgcfg->discovery_retry_max_delay,
+	    &new_pgcfg.discovery_retry_max_delay, "discovery_retry_max_delay");
 
 	changed += update_uint64(&live_pgcfg->id_cache_timeout,
 	    &new_pgcfg.id_cache_timeout, "id_cache_timeout");

--- a/usr/src/cmd/idmap/idmapd/idmap_config.h
+++ b/usr/src/cmd/idmap/idmapd/idmap_config.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 #ifndef _IDMAP_CONFIG_H
@@ -76,6 +77,7 @@ typedef struct idmap_trustedforest {
 typedef struct idmap_pg_config {
 	uint64_t	list_size_limit;
 	uint64_t	max_threads;
+	uint64_t	discovery_retry_max_delay;
 	uint64_t	id_cache_timeout;
 	uint64_t	name_cache_timeout;
 	uint64_t	rediscovery_interval;

--- a/usr/src/cmd/idmap/idmapd/idmapd.h
+++ b/usr/src/cmd/idmap/idmapd/idmapd.h
@@ -68,7 +68,7 @@ typedef enum idmap_namemap_mode {
  *
  * A typical debugging output sequence would look like
  *
- * 	if (DBG(CONFIG, 2)) {
+ *	if (DBG(CONFIG, 2)) {
  *		idmapdlog(LOG_DEBUG,
  *		    "some message about config at verbosity 2");
  *	}
@@ -305,20 +305,21 @@ typedef int (*list_svc_cb)(void *, int, char **, char **);
 
 extern void	idmap_prog_1(struct svc_req *, register SVCXPRT *);
 extern void	idmapdlog(int, const char *, ...);
-extern int	init_mapping_system();
-extern void	fini_mapping_system();
-extern void	print_idmapdstate();
+extern int	init_mapping_system(void);
+extern void	fini_mapping_system(void);
+extern void	print_idmapdstate(void);
 extern int	create_directory(const char *, uid_t, gid_t);
-extern int	load_config();
-extern void	reload_ad();
+extern int	load_config(void);
+extern void	reload_gcs(void);
+extern void	reload_dcs(void);
 extern void	idmap_init_tsd_key(void);
 extern void	degrade_svc(int, const char *);
 extern void	restore_svc(void);
 extern void	notify_dc_changed(void);
 
 
-extern int		init_dbs();
-extern void		fini_dbs();
+extern int		init_dbs(void);
+extern void		fini_dbs(void);
 extern idmap_retcode	get_db_handle(sqlite **);
 extern idmap_retcode	get_cache_handle(sqlite **);
 extern idmap_retcode	sql_exec_no_cb(sqlite *, const char *, char *);
@@ -326,7 +327,7 @@ extern idmap_retcode	add_namerule(sqlite *, idmap_namerule *);
 extern idmap_retcode	rm_namerule(sqlite *, idmap_namerule *);
 extern idmap_retcode	flush_namerules(sqlite *);
 
-extern char 		*tolower_u8(const char *);
+extern char		*tolower_u8(const char *);
 
 extern idmap_retcode	gen_sql_expr_from_rule(idmap_namerule *, char **);
 extern idmap_retcode	validate_list_cb_data(list_cb_data_t *, int,

--- a/usr/src/cmd/idmap/idmapd/init.c
+++ b/usr/src/cmd/idmap/idmapd/init.c
@@ -40,7 +40,7 @@
 
 
 int
-init_mapping_system()
+init_mapping_system(void)
 {
 	int rc = 0;
 
@@ -60,13 +60,13 @@ init_mapping_system()
 }
 
 void
-fini_mapping_system()
+fini_mapping_system(void)
 {
 	fini_dbs();
 }
 
 int
-load_config()
+load_config(void)
 {
 	int rc;
 	if ((_idmapdstate.cfg = idmap_cfg_init()) == NULL) {
@@ -106,7 +106,7 @@ load_config()
 
 
 void
-reload_gcs()
+reload_gcs(void)
 {
 	int		i, j;
 	adutils_ad_t	**new_gcs;
@@ -240,7 +240,6 @@ out:
  * domains in other forests.  However, we don't yet discover any DCs other
  * than the DCs for the joined domain.
  */
-static
 void
 reload_dcs(void)
 {
@@ -329,14 +328,6 @@ nomem:
 			adutils_ad_free(&new_dcs[0]);
 		free(new_dcs);
 	}
-}
-
-
-void
-reload_ad(void)
-{
-	reload_gcs();
-	reload_dcs();
 }
 
 void

--- a/usr/src/lib/libadutils/common/addisc.c
+++ b/usr/src/lib/libadutils/common/addisc.c
@@ -176,8 +176,11 @@ do_res_ninit(ad_disc_t ctx)
 	int rc;
 
 	rc = res_ninit(&ctx->res_state);
-	if (rc != 0)
+	if (rc != 0) {
+		if (DBG(DNS, 0))
+			logger(LOG_INFO, "res_ninit failed: %d", rc);
 		return (rc);
+	}
 	ctx->res_ninitted = 1;
 	/*
 	 * The SRV records returnd by AD can be larger than 512 bytes,
@@ -244,7 +247,7 @@ is_valid(ad_item_t *item)
 
 static void
 update_item(ad_item_t *item, void *value, enum ad_item_state state,
-		uint32_t ttl)
+    uint32_t ttl)
 {
 	if (item->value != NULL && value != NULL) {
 		if ((item->type == AD_STRING &&
@@ -348,7 +351,7 @@ ds_dup(const ad_disc_ds_t *srv)
 
 int
 ad_disc_compare_trusteddomains(ad_disc_trusteddomains_t *td1,
-			ad_disc_trusteddomains_t *td2)
+    ad_disc_trusteddomains_t *td2)
 {
 	int		i, j;
 	int		num_td1;
@@ -404,7 +407,7 @@ td_dup(const ad_disc_trusteddomains_t *td)
 
 int
 ad_disc_compare_domainsinforest(ad_disc_domainsinforest_t *df1,
-			ad_disc_domainsinforest_t *df2)
+    ad_disc_domainsinforest_t *df2)
 {
 	int		i, j;
 	int		num_df1;
@@ -716,7 +719,7 @@ ldap_lookup_init(ad_disc_ds_t *ds)
  */
 ad_disc_trusteddomains_t *
 ldap_lookup_trusted_domains(LDAP **ld, ad_disc_ds_t *globalCatalog,
-			char *base_dn)
+    char *base_dn)
 {
 	int		scope = LDAP_SCOPE_SUBTREE;
 	char		*attrs[3];
@@ -1696,7 +1699,7 @@ try_global:
 
 ad_disc_ds_t *
 ad_disc_get_GlobalCatalog(ad_disc_t ctx, enum ad_disc_req req,
-			boolean_t *auto_discovered)
+    boolean_t *auto_discovered)
 {
 	ad_disc_ds_t *global_catalog = NULL;
 	ad_item_t *global_catalog_item;
@@ -1928,7 +1931,7 @@ auto_set_DomainGUID(ad_disc_t ctx, uchar_t *u)
 
 int
 ad_disc_set_DomainController(ad_disc_t ctx,
-				const ad_disc_ds_t *domainController)
+    const ad_disc_ds_t *domainController)
 {
 	ad_disc_ds_t *domain_controller = NULL;
 	if (domainController != NULL) {


### PR DESCRIPTION

## mail_msg

```

==== Nightly distributed build started:   Sat Jul  1 07:03:57 UTC 2023 ====
==== Nightly distributed build completed: Sat Jul  1 08:03:01 UTC 2023 ====

==== Total build time ====

real    0:59:03

==== Build environment ====

/usr/bin/uname
SunOS r151038 5.11 omnios-r151038-8ccf9ed9ab i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 4

cw version 5.0
primary: /opt/gcc-7/bin/gcc
gcc (OmniOS 151038/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.19+7-omnios-151038"

/usr/bin/openssl
OpenSSL 1.1.1u  30 May 2023
    API_COMPAT=0x10000000L

/usr/bin/as
as: Sun Compiler Common 12 SunOS_i386 snv_121 08/03/2009

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1765 (illumos)

Build project:  default
Build taskid:   94

==== Nightly argument issues ====


==== Build version ====

omnios-bpr38-128519b536

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    24:56.7
user  2:50:41.0
sys     46:31.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    17:35.7
user  1:47:27.5
sys     33:36.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Validating manifests against proto area ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
