### PR TITLE
Upstream merge upstream_merge/2023071301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5368,7 +5368,6 @@ usr/src/man/man3ext/rd_reset.3ext
 usr/src/man/man3ext/run_crypt.3ext
 usr/src/man/man3ext/run_setkey.3ext
 usr/src/man/man3ext/setkey.3ext
-usr/src/man/man3ext/tsalarm_set.3ext
 usr/src/man/man3ext/write_vtoc.3ext
 usr/src/man/man3fstyp/fstyp_fini.3fstyp
 usr/src/man/man3fstyp/fstyp_mod_dump.3fstyp
@@ -8572,10 +8571,12 @@ usr/src/pkg/license-list
 usr/src/pkg/packages.i386/
 usr/src/pkg/proto_list_i386
 usr/src/test/bhyve-tests/tests/inst_emul/cpuid
+usr/src/test/bhyve-tests/tests/inst_emul/exit_consistent
 usr/src/test/bhyve-tests/tests/inst_emul/exit_paging
 usr/src/test/bhyve-tests/tests/inst_emul/imul
 usr/src/test/bhyve-tests/tests/inst_emul/page_dirty
 usr/src/test/bhyve-tests/tests/inst_emul/payload_cpuid
+usr/src/test/bhyve-tests/tests/inst_emul/payload_exit_consistent
 usr/src/test/bhyve-tests/tests/inst_emul/payload_exit_paging
 usr/src/test/bhyve-tests/tests/inst_emul/payload_imul
 usr/src/test/bhyve-tests/tests/inst_emul/payload_page_dirty
@@ -8583,6 +8584,7 @@ usr/src/test/bhyve-tests/tests/inst_emul/payload_rdmsr
 usr/src/test/bhyve-tests/tests/inst_emul/payload_triple_fault
 usr/src/test/bhyve-tests/tests/inst_emul/payload_wrmsr
 usr/src/test/bhyve-tests/tests/inst_emul/pobj_cpuid.s
+usr/src/test/bhyve-tests/tests/inst_emul/pobj_exit_consistent.s
 usr/src/test/bhyve-tests/tests/inst_emul/pobj_exit_paging.s
 usr/src/test/bhyve-tests/tests/inst_emul/pobj_imul.s
 usr/src/test/bhyve-tests/tests/inst_emul/pobj_page_dirty.s
@@ -8633,6 +8635,7 @@ usr/src/test/bhyve-tests/tests/vmm/auto_destruct
 usr/src/test/bhyve-tests/tests/vmm/check_iommu
 usr/src/test/bhyve-tests/tests/vmm/cpuid_ioctl
 usr/src/test/bhyve-tests/tests/vmm/datarw_constraints
+usr/src/test/bhyve-tests/tests/vmm/datarw_msrs
 usr/src/test/bhyve-tests/tests/vmm/datarw_vcpu
 usr/src/test/bhyve-tests/tests/vmm/default_capabs
 usr/src/test/bhyve-tests/tests/vmm/drv_hold

--- a/usr/src/boot/Makefile.inc
+++ b/usr/src/boot/Makefile.inc
@@ -50,7 +50,7 @@ CFLAGS +=	-_gcc=-ffunction-sections -_gcc=-fdata-sections
 CFLAGS +=	-_gcc=-mno-mmx -_gcc=-mno-3dnow -_gcc=-mno-sse -_gcc=-mno-sse2
 CFLAGS +=	-_gcc=-mno-sse3 -_gcc=-msoft-float
 CFLAGS +=	-_gcc=-mno-avx -_gcc=-mno-aes
-CFLAGS +=	-_gcc=-Wall
+CFLAGS +=	-_gcc=-Wall -_gcc=-Werror
 CFLAGS +=	$(CCNOAUTOINLINE) $(CCNOREORDER) $(CSTD_GNU99)
 CFLAGS +=	$(CSOURCEDEBUGFLAGS)
 CCASFLAGS=	-Wa,--divide

--- a/usr/src/cmd/cmd-inet/usr.bin/telnet/ring.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/telnet/ring.c
@@ -99,10 +99,7 @@ ulong_t ring_clock = 0;
 /* Buffer state transition routines */
 
 int
-    ring_init(ring, buffer, count)
-Ring *ring;
-    unsigned char *buffer;
-    int count;
+ring_init(Ring *ring, unsigned char *buffer, int count)
 {
 	(void) memset(ring, 0, sizeof (*ring));
 
@@ -124,8 +121,7 @@ Ring *ring;
  */
 
 void
-ring_mark(ring)
-	Ring *ring;
+ring_mark(Ring *ring)
 {
 	ring->mark = ring_decrement(ring, ring->supply, 1);
 }
@@ -135,8 +131,7 @@ ring_mark(ring)
  */
 
 int
-ring_at_mark(ring)
-	Ring *ring;
+ring_at_mark(Ring *ring)
 {
 	if (ring->mark == ring->consume) {
 		return (1);
@@ -150,8 +145,7 @@ ring_at_mark(ring)
  */
 
 void
-ring_clear_mark(ring)
-	Ring *ring;
+ring_clear_mark(Ring *ring)
 {
 	ring->mark = 0;
 }
@@ -160,21 +154,17 @@ ring_clear_mark(ring)
  * Add characters from current segment to ring buffer.
  */
     void
-ring_supplied(ring, count)
-    Ring *ring;
-    int count;
+ring_supplied(Ring *ring, int count)
 {
-    ring->supply = ring_increment(ring, ring->supply, count);
-    ring->supplytime = ++ring_clock;
+	ring->supply = ring_increment(ring, ring->supply, count);
+	ring->supplytime = ++ring_clock;
 }
 
 /*
  * We have just consumed "c" bytes.
  */
 void
-ring_consumed(ring, count)
-	Ring *ring;
-	int count;
+ring_consumed(Ring *ring, int count)
 {
 	if (count == 0)	/* don't update anything */
 		return;
@@ -188,8 +178,7 @@ ring_consumed(ring, count)
 	    ring->clearto <= ring->consume + count)
 		ring->clearto = 0;
 	else if (ring->consume + count > ring->top &&
-	    ring->bottom <= ring->clearto &&
-	    ring->bottom + ((ring->consume + count) - ring->top))
+	    ring->bottom <= ring->clearto)
 		ring->clearto = 0;
 
 	ring->consume = ring_increment(ring, ring->consume, count);
@@ -209,8 +198,7 @@ ring_consumed(ring, count)
 
 /* Number of bytes that may be supplied */
 int
-ring_empty_count(ring)
-	Ring *ring;
+ring_empty_count(Ring *ring)
 {
 	if (ring_empty(ring)) {	/* if empty */
 		return (ring->size);
@@ -221,8 +209,7 @@ ring_empty_count(ring)
 
 /* number of CONSECUTIVE bytes that may be supplied */
 int
-ring_empty_consecutive(ring)
-	Ring *ring;
+ring_empty_consecutive(Ring *ring)
 {
 	if ((ring->consume < ring->supply) || ring_empty(ring)) {
 		/*
@@ -244,8 +231,7 @@ ring_empty_consecutive(ring)
  */
 
 int
-ring_full_count(ring)
-	Ring *ring;
+ring_full_count(Ring *ring)
 {
 	if ((ring->mark == 0) || (ring->mark == ring->consume)) {
 		if (ring_full(ring)) {
@@ -264,8 +250,7 @@ ring_full_count(ring)
  * However, don't return more than enough to cross over set mark.
  */
 int
-ring_full_consecutive(ring)
-	Ring *ring;
+ring_full_consecutive(Ring *ring)
 {
 	if ((ring->mark == 0) || (ring->mark == ring->consume)) {
 		if ((ring->supply < ring->consume) || ring_full(ring)) {
@@ -287,10 +272,7 @@ ring_full_consecutive(ring)
  * Move data into the "supply" portion of of the ring buffer.
  */
 void
-ring_supply_data(ring, buffer, count)
-	Ring *ring;
-	unsigned char *buffer;
-	int count;
+ring_supply_data(Ring *ring, unsigned char *buffer, int count)
 {
 	int i;
 
@@ -309,10 +291,7 @@ ring_supply_data(ring, buffer, count)
  * Move data from the "consume" portion of the ring buffer
  */
 void
-ring_consume_data(ring, buffer, count)
-	Ring *ring;
-	unsigned char *buffer;
-	int count;
+ring_consume_data(Ring *ring, unsigned char *buffer, int count)
 {
 	int i;
 
@@ -327,9 +306,7 @@ ring_consume_data(ring, buffer, count)
 #endif
 
 void
-ring_encrypt(ring, encryptor)
-	Ring *ring;
-	void (*encryptor)();
+ring_encrypt(Ring *ring, void (*encryptor)())
 {
 	unsigned char *s, *c;
 
@@ -351,11 +328,10 @@ ring_encrypt(ring, encryptor)
 }
 
     void
-ring_clearto(ring)
-    Ring *ring;
+ring_clearto(Ring *ring)
 {
-    if (!ring_empty(ring))
-	ring->clearto = ring->supply;
-    else
-	ring->clearto = 0;
+	if (!ring_empty(ring))
+		ring->clearto = ring->supply;
+	else
+		ring->clearto = 0;
 }

--- a/usr/src/cmd/ipf/tools/ipfcomp.c
+++ b/usr/src/cmd/ipf/tools/ipfcomp.c
@@ -216,25 +216,22 @@ static u_long ipf%s_rule_data_%s_%u[] = {\n",
 
 	g->fg_ref++;
 
-	if (f->fr_grhead != 0) {
-		for (g = groups; g != NULL; g = g->fg_next)
-			if ((strncmp(g->fg_name, f->fr_grhead,
-				     FR_GROUPLEN) == 0) &&
-			    g->fg_flags == (f->fr_flags & FR_INOUT))
-				break;
+	for (g = groups; g != NULL; g = g->fg_next)
+		if ((strncmp(g->fg_name, f->fr_grhead, FR_GROUPLEN) == 0) &&
+		    g->fg_flags == (f->fr_flags & FR_INOUT))
+			break;
+	if (g == NULL) {
+		g = (frgroup_t *)calloc(1, sizeof(*g));
 		if (g == NULL) {
-			g = (frgroup_t *)calloc(1, sizeof(*g));
-			if (g == NULL) {
-				fprintf(stderr, "out of memory\n");
-				exit(1);
-			}
-			g->fg_next = groups;
-			groups = g;
-			g->fg_head = f;
-			bcopy(f->fr_grhead, g->fg_name, FR_GROUPLEN);
-			g->fg_ref = 0;
-			g->fg_flags = f->fr_flags & FR_INOUT;
+			fprintf(stderr, "out of memory\n");
+			exit(1);
 		}
+		g->fg_next = groups;
+		groups = g;
+		g->fg_head = f;
+		bcopy(f->fr_grhead, g->fg_name, FR_GROUPLEN);
+		g->fg_ref = 0;
+		g->fg_flags = f->fr_flags & FR_INOUT;
 	}
 }
 
@@ -945,7 +942,7 @@ u_int incount, outcount;
 			fr->fr_flags & FR_INQUE ? "in" : "out",
 			fr->fr_group, num);
 	}
-	if (n == NULL) { 
+	if (n == NULL) {
 		n = (mc_t *)malloc(sizeof(*n) * FRC_MAX);
 		if (n == NULL) {
 			fprintf(stderr, "out of memory\n");
@@ -963,13 +960,13 @@ int dir;
 	static mc_t *m = NULL;
 	frgroup_t *g;
 
-	if (m == NULL) { 
+	if (m == NULL) {
 		m = (mc_t *)calloc(1, sizeof(*m) * FRC_MAX);
-		if (m == NULL) { 
-			fprintf(stderr, "out of memory\n"); 
-			exit(1); 
-		} 
-	} 
+		if (m == NULL) {
+			fprintf(stderr, "out of memory\n");
+			exit(1);
+		}
+	}
 
 	for (g = groups; g != NULL; g = g->fg_next) {
 		if ((dir == 0) && ((g->fg_flags & FR_INQUE) != 0))

--- a/usr/src/lib/smbsrv/libsmb/common/smb_idmap.c
+++ b/usr/src/lib/smbsrv/libsmb/common/smb_idmap.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 /*
@@ -84,7 +85,8 @@ smb_idmap_getsid(uid_t id, int idtype, smb_sid_t **sid)
 		return (stat);
 	}
 
-	stat = smb_idmap_batch_getmappings(&sib);
+	/* Leave error reporting to the caller. */
+	stat = smb_idmap_batch_getmappings(&sib, NULL);
 
 	if (stat != IDMAP_SUCCESS) {
 		smb_idmap_batch_destroy(&sib);
@@ -122,7 +124,8 @@ smb_idmap_getid(smb_sid_t *sid, uid_t *id, int *id_type)
 		return (stat);
 	}
 
-	stat = smb_idmap_batch_getmappings(&sib);
+	/* Leave error reporting to the caller. */
+	stat = smb_idmap_batch_getmappings(&sib, NULL);
 
 	if (stat != IDMAP_SUCCESS) {
 		smb_idmap_batch_destroy(&sib);
@@ -336,28 +339,6 @@ smb_idmap_batch_getsid(idmap_get_handle_t *idmaph, smb_idmap_t *sim,
 	return (stat);
 }
 
-static void
-smb_idmap_bgm_report(smb_idmap_batch_t *sib, smb_idmap_t *sim)
-{
-
-	if ((sib->sib_flags & SMB_IDMAP_ID2SID) != 0) {
-		/*
-		 * Note: The ID and type we asked idmap to map
-		 * were saved in *sim_id and sim_idtype.
-		 */
-		uint_t id = (sim->sim_id == NULL) ?
-		    0 : (uint_t)*sim->sim_id;
-		syslog(LOG_ERR, "Can't get SID for "
-		    "ID=%u type=%d, status=%d",
-		    id, sim->sim_idtype, sim->sim_stat);
-	}
-
-	if ((sib->sib_flags & SMB_IDMAP_SID2ID) != 0) {
-		syslog(LOG_ERR, "Can't get ID for SID %s-%u, status=%d",
-		    sim->sim_domsid, sim->sim_rid, sim->sim_stat);
-	}
-}
-
 /*
  * smb_idmap_batch_getmappings
  *
@@ -367,7 +348,8 @@ smb_idmap_bgm_report(smb_idmap_batch_t *sib, smb_idmap_t *sim)
  * Checks the result of all the queued requests.
  */
 idmap_stat
-smb_idmap_batch_getmappings(smb_idmap_batch_t *sib)
+smb_idmap_batch_getmappings(smb_idmap_batch_t *sib,
+    smb_idmap_batch_errcb_t errcb)
 {
 	idmap_stat stat = IDMAP_SUCCESS;
 	smb_idmap_t *sim;
@@ -383,7 +365,9 @@ smb_idmap_batch_getmappings(smb_idmap_batch_t *sib)
 	 */
 	for (i = 0, sim = sib->sib_maps; i < sib->sib_nmap; i++, sim++) {
 		if (sim->sim_stat != IDMAP_SUCCESS) {
-			smb_idmap_bgm_report(sib, sim);
+			sib->sib_nerr++;
+			if (errcb != NULL)
+				errcb(sib, sim);
 			if ((sib->sib_flags & SMB_IDMAP_SKIP_ERRS) == 0) {
 				return (sim->sim_stat);
 			}

--- a/usr/src/man/man9e/mac.9e
+++ b/usr/src/man/man9e/mac.9e
@@ -12,8 +12,9 @@
 .\" Copyright 2019 Joyent, Inc.
 .\" Copyright 2020 RackTop Systems, Inc.
 .\" Copyright 2023 Oxide Computer Company
+.\" Copyright 2023 Jason King
 .\"
-.Dd March 4, 2023
+.Dd June 22, 2023
 .Dt MAC 9E
 .Os
 .Sh NAME
@@ -727,7 +728,7 @@ The pseudo-header checksum will be available for the mblk_t when calling
 Note this does not imply that the hardware is capable of calculating
 the partial checksum for other L4 protocols or the IPv4 header checksum.
 That should be indicated with the
-.Dv HCKSUM_IPHDRCKSUM flag.
+.Dv HCKSUM_IPHDRCKSUM flag .
 .It Dv HCKSUM_INET_FULL_V4
 This indicates that the hardware will fully calculate the L4 checksum for
 outgoing IPv4 UDP or TCP packets only, and does not require a pseudo-header
@@ -1926,11 +1927,11 @@ Permissions:
 .Ed
 .Pp
 The
-.Sy MAC_PROP_ADV_100T4_CAP
+.Dv MAC_PROP_EN_100T4_CAP
 property describes whether or not 100 Mbit/s Ethernet using the
 100BASE-T4 standard is
 enabled.
-.It Sy MAC_PROP_ADV_1000HDX_CAP
+.It Dv MAC_PROP_ADV_1000HDX_CAP
 .Bd -filled -compact
 Type:
 .Vt uint8_t |

--- a/usr/src/uts/common/exec/elf/elf_notes.c
+++ b/usr/src/uts/common/exec/elf/elf_notes.c
@@ -118,7 +118,7 @@ setup_note_header(Phdr *v, proc_t *p)
 	}
 
 	size = sizeof (prcred_t) + sizeof (gid_t) * (ngroups_max - 1);
-	pcrp = kmem_alloc(size, KM_SLEEP);
+	pcrp = kmem_zalloc(size, KM_SLEEP);
 	prgetcred(p, pcrp);
 	if (pcrp->pr_ngroups != 0) {
 		v[0].p_filesz += sizeof (Note) + roundup(sizeof (prcred_t) +
@@ -306,6 +306,7 @@ write_elfnotes(proc_t *p, int sig, vnode_t *vp, offset_t offset,
 	if (error)
 		goto done;
 
+	bzero(bigwad, crsize);
 	prgetcred(p, &bigwad->pcred);
 
 	if (bigwad->pcred.pr_ngroups != 0) {

--- a/usr/src/uts/common/fs/proc/prsubr.c
+++ b/usr/src/uts/common/fs/proc/prsubr.c
@@ -4950,6 +4950,7 @@ prgetsecflags(proc_t *p, prsecflags_t *psfp)
 {
 	ASSERT(psfp != NULL);
 
+	bzero(psfp, sizeof (*psfp));
 	psfp->pr_version = PRSECFLAGS_VERSION_CURRENT;
 	psfp->pr_lower = p->p_secflags.psf_lower;
 	psfp->pr_upper = p->p_secflags.psf_upper;

--- a/usr/src/uts/common/fs/proc/prvnops.c
+++ b/usr/src/uts/common/fs/proc/prvnops.c
@@ -1125,7 +1125,7 @@ pr_read_cred(prnode_t *pnp, uio_t *uiop, cred_t *cr)
 	 * the number of supplementary groups is variable.
 	 */
 	pcrp =
-	    kmem_alloc(sizeof (prcred_t) + sizeof (gid_t) * (ngroups_max - 1),
+	    kmem_zalloc(sizeof (prcred_t) + sizeof (gid_t) * (ngroups_max - 1),
 	    KM_SLEEP);
 
 	if ((error = prlock(pnp, ZNO)) != 0)
@@ -1150,7 +1150,7 @@ pr_read_priv(prnode_t *pnp, uio_t *uiop, cred_t *cr)
 {
 	proc_t *p;
 	size_t psize = prgetprivsize();
-	prpriv_t *ppriv = kmem_alloc(psize, KM_SLEEP);
+	prpriv_t *ppriv = kmem_zalloc(psize, KM_SLEEP);
 	int error;
 
 	ASSERT(pnp->pr_type == PR_PRIV);

--- a/usr/src/uts/common/fs/smbsrv/smb_user.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_user.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2020 Tintri by DDN, Inc. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright 2022-2023 RackTop Systems, Inc.
  */
 
 /*
@@ -695,12 +696,12 @@ smb_user_wait_trees(smb_user_t *user)
 			break;
 	}
 	mutex_exit(&user->u_mutex);
-#ifdef	DEBUG
 	if (user->u_owned_tree_cnt != 0) {
-		cmn_err(CE_NOTE, "smb_user_wait_trees failed");
-		debug_enter("smb_user_wait_trees debug");
-	}
+#ifdef	DEBUG
+		cmn_err(CE_NOTE, "!smb_user_wait_trees failed");
 #endif
+		DTRACE_PROBE1(max__wait, smb_user_t *, user);
+	}
 }
 
 /* *************************** Static Functions ***************************** */

--- a/usr/src/uts/common/inet/ipf/fil.c
+++ b/usr/src/uts/common/inet/ipf/fil.c
@@ -193,7 +193,7 @@ int	fr_features = 0
 #endif
 	;
 
-#define	IPF_BUMP(x)	(x)++	
+#define	IPF_BUMP(x)	(x)++
 
 static	INLINE int	fr_ipfcheck __P((fr_info_t *, frentry_t *, int));
 static	INLINE int	fr_ipfcheck __P((fr_info_t *, frentry_t *, int));
@@ -796,7 +796,7 @@ fr_info_t *fin;
 	for (i = 0; ip6exthdr[i].ol_bit != 0; i++)
 		if (ip6exthdr[i].ol_val == IPPROTO_ESP) {
 			fin->fin_optmsk |= ip6exthdr[i].ol_bit;
-			break;			
+			break;
 		}
 }
 
@@ -825,7 +825,7 @@ fr_info_t *fin;
 	for (i = 0; ip6exthdr[i].ol_bit != 0; i++)
 		if (ip6exthdr[i].ol_val == IPPROTO_AH) {
 			fin->fin_optmsk |= ip6exthdr[i].ol_bit;
-			break;			
+			break;
 		}
 
 	ah = (authhdr_t *)fin->fin_dp;
@@ -1367,12 +1367,12 @@ fr_info_t *fin;
 		if (off != 0) {
 			fin->fin_flx |= FI_FRAGBODY;
 			off <<= 3;
-			if ((off + fin->fin_dlen > 65535) || 
+			if ((off + fin->fin_dlen > 65535) ||
 			    (fin->fin_dlen == 0) ||
 			    ((morefrag != 0) && ((fin->fin_dlen & 7) != 0))) {
-				/* 
+				/*
 				 * The length of the packet, starting at its
-				 * offset cannot exceed 65535 (0xffff) as the 
+				 * offset cannot exceed 65535 (0xffff) as the
 				 * length of an IP packet is only 16 bits.
 				 *
 				 * Any fragment that isn't the last fragment
@@ -2648,7 +2648,7 @@ ipf_stack_t *ifs;
 						IPF_BUMP(
 						ifs->ifs_frstats[out].fr_ret);
 					}
-					/* 
+					/*
 					 * we drop packet silently in case we
 					 * failed assemble fake response for it
 					 */
@@ -2660,7 +2660,7 @@ ipf_stack_t *ifs;
 					IPF_BUMP(
 					    ifs->ifs_frstats[out].fr_block);
 					RWLOCK_EXIT(&ifs->ifs_ipf_mutex);
-					
+
 					return (0);
 				}
 #endif	/* _KERNEL && SOLARIS2 >= 10 */
@@ -2686,7 +2686,7 @@ ipf_stack_t *ifs;
 						ifs->ifs_frstats[out].fr_ret);
 					}
 					else if (mp != NULL) {
-					/* 
+					/*
 					 * we drop packet silently in case we
 					 * failed assemble fake response for it
 					 */
@@ -2697,7 +2697,7 @@ ipf_stack_t *ifs;
 					IPF_BUMP(
 					    ifs->ifs_frstats[out].fr_block);
 					RWLOCK_EXIT(&ifs->ifs_ipf_mutex);
-					
+
 					return (0);
 				 }
 #endif /* _KERNEL && _SOLARIS2 >= 10 */
@@ -3536,10 +3536,8 @@ ipf_stack_t *ifs;
 			(void) frflushlist(set, unit, nfreedp, fp->fr_grp, ifs);
 		}
 
-		if (fp->fr_grhead != NULL) {
-			fr_delgroup(fp->fr_grhead, unit, set, ifs);
-			*fp->fr_grhead = '\0';
-		}
+		fr_delgroup(fp->fr_grhead, unit, set, ifs);
+		*fp->fr_grhead = '\0';
 
 		ASSERT(fp->fr_ref > 0);
 		fp->fr_next = NULL;
@@ -3806,7 +3804,7 @@ ipf_stack_t *ifs;
 			rval = newifp;
 		break;
 	case IPFSYNC_OLDIFP :
-		/* 
+		/*
 		 * If interface gets unplumbed it must be invalidated, which
 		 * means set all existing references to the interface to -1.
 		 * We don't want to invalidate references for wildcard
@@ -4040,7 +4038,7 @@ ipf_stack_t *ifs;
 
 	for (i = 0; i < rules; i++) {
 		fr_syncindex(rule_lists[i], ifp, newifp);
-	} 
+	}
 
 	/*
 	 * Update rule groups.
@@ -7356,7 +7354,7 @@ ipf_stack_t *ifs;
 		 * Now that we have ref, it's save to give up lock.
 		 */
 		RWLOCK_EXIT(&ifs->ifs_ipf_mutex);
- 
+
 		/*
 		 * Copy out data and clean up references and token as needed.
 		 */
@@ -7383,7 +7381,7 @@ ipf_stack_t *ifs;
 				break;
 			}
 		}
- 
+
 		if ((count == 1) || (error != 0))
 			break;
 

--- a/usr/src/uts/common/inet/ipf/ip_htable.c
+++ b/usr/src/uts/common/inet/ipf/ip_htable.c
@@ -197,7 +197,7 @@ ipf_stack_t *ifs;
 	if (iph->iph_unit != op->iplo_unit) {
 		return EINVAL;
 	}
-	
+
 	if (iph->iph_ref != 1) {
 		return EBUSY;
 	}
@@ -310,7 +310,7 @@ ipf_stack_t *ifs;
 #ifdef USE_INET6
 	if (ipe->ipe_family == AF_INET6) {
 		bits = count6bits((u_32_t *)ipe->ipe_mask.in6_addr8);
-		hv = IPE_HASH_FN(sum4((uint32_t *)ipe->ipe_addr.in6_addr8), 
+		hv = IPE_HASH_FN(sum4((uint32_t *)ipe->ipe_addr.in6_addr8),
 				 sum4((uint32_t *)ipe->ipe_mask.in6_addr8),
 				 iph->iph_size);
 	} else
@@ -399,9 +399,8 @@ ipf_stack_t *ifs;
 	switch (iph->iph_type & ~IPHASH_ANON)
 	{
 	case IPHASH_GROUPMAP :
-		if (ipe->ipe_group != NULL)
-			fr_delgroup(ipe->ipe_group, IPL_LOGIPF,
-				    ifs->ifs_fr_active, ifs);
+		fr_delgroup(ipe->ipe_group, IPL_LOGIPF,
+		    ifs->ifs_fr_active, ifs);
 		break;
 
 	default :
@@ -413,7 +412,7 @@ ipf_stack_t *ifs;
 	KFREE(ipe);
 
 	ifs->ifs_ipf_nhtnodes[iph->iph_unit]--;
-	
+
 	return 0;
 }
 
@@ -592,14 +591,14 @@ maskloop:
 			      (hmsk[1] != 0) ||
 			      (hmsk[2] != 0) ||
 			      (hmsk[3] != 0) )) {
-		while ((hmsk[0] != 0) && (hmsk[1] != 0) && 
+		while ((hmsk[0] != 0) && (hmsk[1] != 0) &&
 		       (hmsk[2] != 0) && (hmsk[3] != 0)) {
 			left_shift_ipv6((char *)msk);
 			if (hmsk[0] & 0x80000000)
 				break;
 			left_shift_ipv6((char *)hmsk);
 		}
-		if ((hmsk[0] != 0) && (hmsk[1] != 0) && 
+		if ((hmsk[0] != 0) && (hmsk[1] != 0) &&
 		    (hmsk[2] != 0) && (hmsk[3] != 0)) {
 			left_shift_ipv6((char *)hmsk);
 			goto maskloop;

--- a/usr/src/uts/common/smbsrv/smb_idmap.h
+++ b/usr/src/uts/common/smbsrv/smb_idmap.h
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2018 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 #ifndef _SMB_IDMAP_H
@@ -78,18 +79,22 @@ typedef struct smb_idmap {
 
 typedef struct smb_idmap_batch {
 	uint16_t		sib_nmap;
+	uint16_t		sib_nerr;
 	uint32_t		sib_flags;
 	uint32_t		sib_size;
 	smb_idmap_t		*sib_maps;
 	idmap_get_handle_t	*sib_idmaph;
 } smb_idmap_batch_t;
 
+typedef void (*smb_idmap_batch_errcb_t)(smb_idmap_batch_t *, smb_idmap_t *);
+
 idmap_stat smb_idmap_getsid(uid_t, int, smb_sid_t **);
 idmap_stat smb_idmap_getid(smb_sid_t *, uid_t *, int *);
 
 void smb_idmap_batch_destroy(smb_idmap_batch_t *);
 idmap_stat smb_idmap_batch_create(smb_idmap_batch_t *, uint16_t, int);
-idmap_stat smb_idmap_batch_getmappings(smb_idmap_batch_t *);
+idmap_stat smb_idmap_batch_getmappings(smb_idmap_batch_t *,
+    smb_idmap_batch_errcb_t);
 idmap_stat smb_idmap_batch_getid(idmap_get_handle_t *, smb_idmap_t *,
     smb_sid_t *, int);
 idmap_stat smb_idmap_batch_getsid(idmap_get_handle_t *, smb_idmap_t *,


### PR DESCRIPTION
Weekly upstream for upstream_merge/2023071301

## Backports

To all releases:
- 15779 libuuid can produce invalid V4 UUIDs
- 15788 kernel stack leak through prgetsecflags()
- 14306 Can't get SID for ID=0 type=0, status=-9977

## onu

```
OmniOS r151047 Version omnios-upstream_merge-2023071301-467ec3a905f 64-bit
Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
Copyright (c) 2017-2023 OmniOS Community Edition (OmniOSce) Association.
DEBUG enabled
Hostname: bloody

bloody console login: root
Password:
Last login: Tue Jul 11 20:52:40 2023 on console
OmniOS r151047  omnios-upstream_merge-2023071301-467ec3a905f    July 2023
illumos development build: 2023-Jul-13 [illumos]
You have new mail.
root@bloody:~#
root@bloody:~# uname -a
SunOS bloody 5.11 omnios-upstream_merge-2023071301-467ec3a905f i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Thu Jul 13 13:07:28 UTC 2023 ====
==== Nightly distributed build completed: Thu Jul 13 14:18:39 UTC 2023 ====

==== Total build time ====

real    1:11:10

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-765ef75fcd i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 9.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151047/10.4.0-il-1) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151047/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.19+7-omnios-151047"

/usr/bin/openssl
OpenSSL 3.1.1 30 May 2023 (Library: OpenSSL 3.1.1 30 May 2023)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   81

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2023071301-467ec3a905f

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:35.1
user  4:12:39.0
sys   1:12:30.5

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    25:25.9
user  3:46:06.1
sys   1:08:14.0

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
