### PR TITLE
Expose more libm.so.0 symbols

### DIFF
--- a/usr/src/contrib/msun/src/e_pow.c
+++ b/usr/src/contrib/msun/src/e_pow.c
@@ -312,3 +312,4 @@ __ieee754_pow(double x, double y)
 #if (LDBL_MANT_DIG == 53)
 __weak_reference(pow, powl);
 #endif
+__weak_reference(pow, __powl);

--- a/usr/src/contrib/msun/src/s_frexp.c
+++ b/usr/src/contrib/msun/src/s_frexp.c
@@ -54,3 +54,4 @@ frexp(double x, int *eptr)
 #if (LDBL_MANT_DIG == 53)
 __weak_reference(frexp, frexpl);
 #endif
+__weak_reference(frexp, __frexpl);

--- a/usr/src/contrib/msun/src/s_scalbnl.c
+++ b/usr/src/contrib/msun/src/s_scalbnl.c
@@ -45,5 +45,6 @@ long double scalbnl(long double x, int n)
 	return x * u.e;
 }
 __strong_reference(scalbnl, ldexpl);
+__weak_reference(scalbnl, __ldexpl);
 #endif
 

--- a/usr/src/lib/libm_aarch64/src/mapfile-vers
+++ b/usr/src/lib/libm_aarch64/src/mapfile-vers
@@ -58,12 +58,15 @@ global:
 	__atan2f;
 	__floorf;
 	__frexpf;
+	__frexpl;
 	__ldexpf;
+	__ldexpl;
 	__log10f;
 	__cosf;
 	__expf;
 	__logf;
 	__powf;
+	__powl;
 	__sinf;
 	__tanf;
 


### PR DESCRIPTION
These three are required to link `gdb`

```
Undefined                       first referenced
 symbol                             in file
__frexpl                            target-float.o
__ldexpl                            target-float.o
__powl                              target-float.o
ld: fatal: symbol referencing errors. No output written to gdb
```

With this change, it links correctly.
