### PR TITLE
lx branded zones should treat IPV6_RECVERR the same IP_ counter part

### DIFF
--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -3351,6 +3351,12 @@ lx_setsockopt_ipv6(sonode_t *so, int optname, void *optval, socklen_t optlen)
 	lx_proto_opts_t sockopts_tbl = PROTO_SOCKOPTS(ltos_ipv6_sockopts);
 
 	switch (optname) {
+	case LX_IPV6_RECVERR:
+		/*
+		 * Ping and glibc's resolver set this.  See lx_setsockopt_ip()'s
+		 * handling of LX_IP_RECVERR for more.
+		 */
+		return (0);
 	case LX_IPV6_MTU:
 		/*
 		 * There isn't a good translation for IPV6_MTU and certain apps


### PR DESCRIPTION
This fixes https://github.com/omniosorg/illumos-omnios/issues/1219

## Summery
When a IPv6 resolver was in /etc/resolv.conf the system was unable to resolve any hostnames, after poking around with dtrace

```
root@saturn:~# ./lxunsup.d
   PID                 NAME CALL
 10698                 curl NOSYS (334): out of bounds\0
 10698                 curl NOSYS (435): out of bounds\0
 10698                 curl setsockopt(41, 25)\0
 10698                 curl setsockopt(41, 25)\0
```

Seems we hut some issues in setsockopt, we can verify it's missing options 25 for proto 41
```
root@saturn:~# ./lxsockops.d
   PID                 NAME PROTO SOCKOPT
 10727                 curl    41 25
 10727                 curl    41 25
```

As @danmcd pointed out https://github.com/omniosorg/illumos-omnios/issues/1219#issuecomment-1723695128 it is IPV6_RECVERR. On IRC he also mentioned FreeBSD is lying about it's support in it's linux syscall emulation layer too.

After some more poking around I found out we are doing it too for IP_RECVERR (IPv4), https://github.com/omniosorg/illumos-omnios/issues/1219#issuecomment-1725307393

This simply does the same for IPV6_RECVERR, which seems to make glibc's resolver and even ping work again.
Resulting in a functional IPv6 connectivity.

## Testing
1. build branch
2. copy over lx_brand kernel module to test host
3. create a be and copy in the new module
4. boot into new be
5. start lx zone

```
root@lxubuntu:~# cat /etc/resolv.conf
# AUTOMATIC ZONE CONFIG
nameserver 2a02:578:470f:10::253
#nameserver 10.23.12.53
nameserver 2a02:578:470f:10::153
#nameserver 10.23.11.53
search acheron.be
root@lxubuntu:~# ping blackdot.be
PING blackdot.be(blackdot.be (2a01:7e01::f03c:93ff:fe79:9d74)) 56 data bytes
64 bytes from blackdot.be (2a01:7e01::f03c:93ff:fe79:9d74): icmp_seq=1 ttl=248 time=9.93 ms
64 bytes from blackdot.be (2a01:7e01::f03c:93ff:fe79:9d74): icmp_seq=2 ttl=248 time=9.26 ms
64 bytes from blackdot.be (2a01:7e01::f03c:93ff:fe79:9d74): icmp_seq=3 ttl=248 time=10.2 ms
^C
--- blackdot.be ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2002ms
rtt min/avg/max/mdev = 9.257/9.788/10.175/0.388 ms
root@lxubuntu:~# ping -4 blackdot.be
PING  (194.233.168.196) 56(84) bytes of data.
64 bytes from blackdot.be (194.233.168.196): icmp_seq=1 ttl=248 time=12.6 ms
64 bytes from blackdot.be (194.233.168.196): icmp_seq=2 ttl=248 time=9.31 ms
64 bytes from blackdot.be (194.233.168.196): icmp_seq=3 ttl=248 time=9.44 ms
^C
---  ping statistics ---
4 packets transmitted, 3 received, 25% packet loss, time 3000ms
rtt min/avg/max/mdev = 9.307/10.441/12.572/1.507 ms
```

As you can see with the IPv4 nameservers commented out ping is still able to resolve the hostnames now, even more interesting is that ping itself is also able to ping the host using IPv6! (and IPv4 also still works)