### PR TITLE
pgrep -n/-o uses wrong process argv

### DIFF
--- a/usr/src/cmd/pgrep/pgrep.c
+++ b/usr/src/cmd/pgrep/pgrep.c
@@ -372,6 +372,7 @@ scan_proc_dir(const char *dirpath, DIR *dirp, psexp_t *psexp,
 	}
 
 	if ((g_flags & (F_NEWEST | F_OLDEST)) && ovalid) {
+		get_argv(g_flags, &ops, argv, sizeof (argv));
 		(*funcp)(&ops, argv, sizeof (argv));
 
 		nmatches++;


### PR DESCRIPTION
Fixes #1385