### PR TITLE
Upstream merge/2024010401

### DIFF
--- a/usr/src/cmd/cmd-inet/usr.bin/nc/socks.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/nc/socks.c
@@ -189,11 +189,11 @@ again:
 		buf[2] = SOCKS_NOAUTH;
 		cnt = atomicio(vwrite, proxyfd, buf, 3);
 		if (cnt != 3)
-			err(1, "write failed (%d/3)", cnt);
+			err(1, "write failed (%zu/3)", cnt);
 
 		cnt = atomicio(read, proxyfd, buf, 2);
 		if (cnt != 2)
-			err(1, "read failed (%d/3)", cnt);
+			err(1, "read failed (%zu/2)", cnt);
 
 		if ((unsigned char)buf[1] == SOCKS_NOMETHOD)
 			errx(1, "authentication method negotiation failed");
@@ -248,7 +248,7 @@ again:
 
 		cnt = atomicio(vwrite, proxyfd, buf, wlen);
 		if (cnt != wlen)
-			err(1, "write failed (%d/%d)", cnt, wlen);
+			err(1, "write failed (%zu/%zu)", cnt, wlen);
 
 		/*
 		 * read proxy reply which is 4 byte "header", BND.ADDR
@@ -257,7 +257,7 @@ again:
 		 */
 		cnt = atomicio(read, proxyfd, buf, 10);
 		if (cnt != 10)
-			err(1, "read failed (%d/10)", cnt);
+			err(1, "read failed (%zu/10)", cnt);
 		if (buf[1] != 0)
 			errx(1, "connection failed, SOCKS error %d", buf[1]);
 	} else if (socksv == 4) {
@@ -275,7 +275,7 @@ again:
 
 		cnt = atomicio(vwrite, proxyfd, buf, wlen);
 		if (cnt != wlen)
-			err(1, "write failed (%d/%d)", cnt, wlen);
+			err(1, "write failed (%zu/%zu)", cnt, wlen);
 
 		/*
 		 * SOCKSv4 proxy replies consists of 2 byte "header",
@@ -283,7 +283,7 @@ again:
 		 */
 		cnt = atomicio(read, proxyfd, buf, 8);
 		if (cnt != 8)
-			err(1, "read failed (%d/8)", cnt);
+			err(1, "read failed (%zu/8)", cnt);
 		if (buf[1] != 90)
 			errx(1, "connection failed, SOCKS error %d", buf[1]);
 	} else if (socksv == -1) {
@@ -309,7 +309,7 @@ again:
 
 		cnt = atomicio(vwrite, proxyfd, buf, r);
 		if (cnt != r)
-			err(1, "write failed (%d/%d)", cnt, r);
+			err(1, "write failed (%zu/%d)", cnt, r);
 
 		if (authretry > 1) {
 			char resp[1024];
@@ -328,7 +328,7 @@ again:
 				errx(1, "Proxy auth response too long");
 			r = strlen(buf);
 			if ((cnt = atomicio(vwrite, proxyfd, buf, r)) != r)
-				err(1, "write failed (%d/%d)", cnt, r);
+				err(1, "write failed (%zu/%d)", cnt, r);
 		}
 
 		/* Terminate headers */

--- a/usr/src/lib/libc/port/regex/regex2.h
+++ b/usr/src/lib/libc/port/regex/regex2.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2023 Bill Sommerfeld <sommerfeld@hamachi.org>
  * Copyright (c) 1992, 1993, 1994 Henry Spencer.
  * Copyright (c) 1992, 1993, 1994
  *	The Regents of the University of California.  All rights reserved.
@@ -119,13 +120,13 @@ typedef struct {
 	int		icase;
 } cset;
 
-static int
-CHIN1(cset *cs, wint_t ch)
+static inline int
+CHIN1(int nc, cset *cs, wint_t ch)
 {
 	unsigned int i;
 
 	assert(ch >= 0);
-	if (ch < NC)
+	if (ch < nc)
 		return (((cs->bmp[ch >> 3] & (1 << (ch & 7))) != 0) ^
 		    cs->invert);
 	for (i = 0; i < cs->nwides; i++) {
@@ -145,19 +146,19 @@ CHIN1(cset *cs, wint_t ch)
 	return (cs->invert);
 }
 
-static int
-CHIN(cset *cs, wint_t ch)
+static inline int
+CHIN(int nc, cset *cs, wint_t ch)
 {
 
 	assert(ch >= 0);
-	if (ch < NC)
+	if (ch < nc)
 		return (((cs->bmp[ch >> 3] & (1 << (ch & 7))) != 0) ^
 		    cs->invert);
 	else if (cs->icase)
-		return (CHIN1(cs, ch) || CHIN1(cs, towlower(ch)) ||
-		    CHIN1(cs, towupper(ch)));
+		return (CHIN1(nc, cs, ch) || CHIN1(nc, cs, towlower(ch)) ||
+		    CHIN1(nc, cs, towupper(ch)));
 	else
-		return (CHIN1(cs, ch));
+		return (CHIN1(nc, cs, ch));
 }
 
 /*
@@ -187,6 +188,7 @@ struct re_guts {
 	size_t nsub;		/* copy of re_nsub */
 	int backrefs;		/* does it use back references? */
 	sopno nplus;		/* how deep does it nest +s? */
+	unsigned int mb_cur_max;
 };
 
 /* misc utilities */

--- a/usr/src/lib/libc/port/regex/regexec.c
+++ b/usr/src/lib/libc/port/regex/regexec.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2023 Bill Sommerfeld <sommerfeld@hamachi.org>
  * Copyright 2010 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 1992, 1993, 1994 Henry Spencer.
  * Copyright (c) 1992, 1993, 1994
@@ -109,6 +110,7 @@ xmbrtowc_dummy(wint_t *wi, const char *s, size_t n __unused,
 /* no multibyte support */
 #define	XMBRTOWC	xmbrtowc_dummy
 #define	ZAPSTATE(mbs)	((void)(mbs))
+#define	NC_ENGINE NC_MAX
 /* function names */
 #define	SNAMES			/* engine.c looks after details */
 
@@ -136,6 +138,7 @@ xmbrtowc_dummy(wint_t *wi, const char *s, size_t n __unused,
 #undef	SNAMES
 #undef	XMBRTOWC
 #undef	ZAPSTATE
+#undef	NC_ENGINE
 
 /* macros for manipulating states, large version */
 #define	states	char *
@@ -164,6 +167,7 @@ xmbrtowc_dummy(wint_t *wi, const char *s, size_t n __unused,
 /* no multibyte support */
 #define	XMBRTOWC	xmbrtowc_dummy
 #define	ZAPSTATE(mbs)	((void)(mbs))
+#define	NC_ENGINE NC_MAX
 /* function names */
 #define	LNAMES			/* flag */
 
@@ -173,7 +177,9 @@ xmbrtowc_dummy(wint_t *wi, const char *s, size_t n __unused,
 #undef	LNAMES
 #undef	XMBRTOWC
 #undef	ZAPSTATE
+#undef	NC_ENGINE
 #define	XMBRTOWC	xmbrtowc
+#define	NC_ENGINE NC_WIDE
 #define	ZAPSTATE(mbs)	(void) memset((mbs), 0, sizeof (*(mbs)))
 #define	MNAMES
 
@@ -208,7 +214,7 @@ regexec(const regex_t *_RESTRICT_KYWD preg, const char *_RESTRICT_KYWD string,
 		return (REG_BADPAT);
 	eflags = GOODFLAGS(eflags);
 
-	if (MB_CUR_MAX > 1)
+	if (g->mb_cur_max > 1)
 		return (mmatcher(g, string, nmatch, pmatch, eflags));
 	else if (g->nstates <= CHAR_BIT*sizeof (states1) && !(eflags&REG_LARGE))
 		return (smatcher(g, string, nmatch, pmatch, eflags));

--- a/usr/src/lib/libc/port/regex/regfree.c
+++ b/usr/src/lib/libc/port/regex/regfree.c
@@ -54,11 +54,6 @@ regfree(regex_t *preg)
 	struct re_guts *g;
 	int i;
 
-#ifdef	__lint
-	/* shut up lint! */
-	CHIN(NULL, 0);
-#endif
-
 	if (preg->re_magic != MAGIC1)	/* oops */
 		return;			/* nice to complain, but hard */
 

--- a/usr/src/lib/libc/port/regex/utils.h
+++ b/usr/src/lib/libc/port/regex/utils.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2023 Bill Sommerfeld <sommerfeld@hamachi.org>
  * Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
  * Copyright (c) 1992, 1993, 1994 Henry Spencer.
  * Copyright (c) 1992, 1993, 1994
@@ -37,7 +38,7 @@
 #define	INFINITY	(DUPMAX + 1)
 
 #define	NC_MAX		(CHAR_MAX - CHAR_MIN + 1)
-#define	NC		((MB_CUR_MAX) == 1 ? (NC_MAX) : (128))
+#define	NC_WIDE		(128)
 typedef unsigned char uch;
 
 /* switch off assertions (if not already off) if no REDEBUG */

--- a/usr/src/lib/libfru/Makefile.flag
+++ b/usr/src/lib/libfru/Makefile.flag
@@ -42,6 +42,9 @@ CCERRWARN +=	-_gcc=-Wno-switch
 CCERRWARN +=	-_gcc=-Wno-reorder
 CCERRWARN +=	-_gcc=-Wno-type-limits
 
+pics/nameSyntaxYacc.o := CPPFLAGS += -D__EXTERN_C__
+pics/nameSyntaxLex.o := CPPFLAGS += -D__EXTERN_C__
+
 CLEANFILES +=	pics/lex.fru.cc pics/y.tab.cc pics/y.tab.h
 CLOBBERFILES +=	$(DYNLIBCCC) libfru.so
 

--- a/usr/src/lib/libfru/libfru/Parser.cc
+++ b/usr/src/lib/libfru/libfru/Parser.cc
@@ -31,8 +31,14 @@
 #include "Parser.h"
 
 // yacc symbols
+#ifdef	__cplusplus
+extern "C" {
+#endif
 int fruparse(void);
 extern int frudebug;
+#ifdef	__cplusplus
+}
+#endif
 
 // global data to/from the lexer
 pthread_mutex_t gParserLock;

--- a/usr/src/lib/libfru/libfru/nameSyntaxYacc.y
+++ b/usr/src/lib/libfru/libfru/nameSyntaxYacc.y
@@ -39,8 +39,15 @@ extern Ancestor *gParserAnts;
 extern PathDef *gParserHead;
 extern int *gParserAbs;
 
-extern void yyerror (const char *msg);
-extern int  yylex   (void);
+#ifdef	__cplusplus
+extern "C" {
+#endif
+extern void yyerror(const char *msg);
+extern int yylex(void);
+extern int yywrap (void);
+#ifdef	__cplusplus
+}
+#endif
 
 %}
 

--- a/usr/src/man/man3c/regcomp.3c
+++ b/usr/src/man/man3c/regcomp.3c
@@ -74,7 +74,7 @@
 .\" Portions Copyright (c) 2003, Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\"
-.Dd June 14, 2017
+.Dd December 26, 2023
 .Dt REGCOMP 3C
 .Os
 .Sh NAME
@@ -119,6 +119,14 @@ and
 .Fn regfree
 frees any dynamically-allocated storage used by the internal form
 of an RE.
+.Pp
+The translation of an RE into the internal form contained in a
+.Ft regex_t
+is inherently locale-specific; changes to the locale in effect between
+.Fn regcomp
+and subsequent calls to
+.Fn regexec
+may result in unexpected or undefined behavior.
 .Pp
 The header
 .In regex.h
@@ -244,6 +252,10 @@ The RE must have been compiled by a previous invocation of
 The compiled form is not altered during execution of
 .Fn regexec ,
 so a single compiled RE can be used simultaneously by multiple threads.
+The locale in effect at the time of
+.Fn regexec
+must be the same as the one in effect when the RE was compiled by
+.Fn regcomp .
 .Pp
 By default, the NUL-terminated string pointed to by
 .Fa string
@@ -748,9 +760,12 @@ The
 .Fn regcomp
 function can be used safely in a multithreaded application as long as
 .Xr setlocale 3C
-is not being called to change the locale.
+or
+.Xr uselocale 3C
+are not being called to change the locale.
 .Sh SEE ALSO
 .Xr attributes 7 ,
+.Xr locale 7 ,
 .Xr regex 7 ,
 .Xr standards 7
 .Pp

--- a/usr/src/test/util-tests/tests/ctf/check-common.c
+++ b/usr/src/test/util-tests/tests/ctf/check-common.c
@@ -227,8 +227,8 @@ ctftest_check_symbol_cb(const char *obj, ctf_id_t type, ulong_t idx, void *arg)
 		}
 
 		if (id != type) {
-			warnx("type mismatch for symbol %s, has type id %"
-			    _PRIuID ", but specified type %s has id %" _PRIuID,
+			warnx("type mismatch for symbol %s, has type id %ld"
+			    ", but specified type %s has id %ld",
 			    tests[i].cs_symbol, type, tests[i].cs_type, id);
 			cb->csc_ret = B_FALSE;
 			return (0);
@@ -294,9 +294,9 @@ ctftest_check_descent(const char *symbol, ctf_file_t *fp,
 
 		if (tid != base) {
 			if (!quiet) {
-				warnx("type mismatch at layer %u: found id %"
-				    _PRIuID ", but expecting type id %" _PRIuID
-				    " for type %s, symbol %s", layer, base, tid,
+				warnx("type mismatch at layer %u: found "
+				    "id %ld, but expecting type id %ld for "
+				    "type %s, symbol %s", layer, base, tid,
 				    tests->cd_tname, symbol);
 			}
 			return (B_FALSE);
@@ -318,7 +318,7 @@ ctftest_check_descent(const char *symbol, ctf_file_t *fp,
 			if (ctf_array_info(fp, base, &ari) == CTF_ERR) {
 				if (!quiet) {
 					warnx("failed to lookup array info at "
-					    "layer %" _PRIuID " for type %s, "
+					    "layer %ld for type %s, "
 					    "symbol %s: %s", base,
 					    tests->cd_tname, symbol,
 					    ctf_errmsg(ctf_errno(fp)));
@@ -350,8 +350,8 @@ ctftest_check_descent(const char *symbol, ctf_file_t *fp,
 				if (!quiet) {
 					warnx("array contents mismatch at "
 					    "layer %u for type %s, symbol %s: "
-					    "found %" _PRIuID ", expected %s/%"
-					    _PRIuID, layer, tests->cd_tname,
+					    "found %ld, expected %s/%ld",
+					    layer, tests->cd_tname,
 					    symbol, ari.ctr_contents,
 					    tests->cd_contents, tid);
 				}
@@ -370,7 +370,7 @@ ctftest_check_descent(const char *symbol, ctf_file_t *fp,
 
 	if (base != CTF_ERR) {
 		if (!quiet) {
-			warnx("found additional type %" _PRIuID " in chain, "
+			warnx("found additional type %ld in chain, "
 			    "but expected no more", base);
 		}
 		return (B_FALSE);


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151049  omnios-upstream_merge-2024010401-be0b3eb938c    January 2024
illumos development build: 2024-Jan-04 [illumos-omnios]
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-upstream_merge-2024010401-be0b3eb938c i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Thu Jan  4 16:48:21 UTC 2024 ====
==== Nightly distributed build completed: Thu Jan  4 17:24:46 UTC 2024 ====

==== Total build time ====

real    0:36:25

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-973ed9565af i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 24

cw version 9.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151049/10.5.0-il-1) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151049/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.21+9-omnios-151049"

/usr/bin/openssl
OpenSSL 3.1.4 24 Oct 2023 (Library: OpenSSL 3.1.4 24 Oct 2023)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   131

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2024010401-be0b3eb938c

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    14:38.0
user  3:36:30.9
sys   1:16:54.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:02.6
user  3:22:08.0
sys   1:13:09.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```