### PR TITLE
Upstream merge upstream_merge/2024020601

### DIFF
--- a/usr/src/data/zoneinfo/africa
+++ b/usr/src/data/zoneinfo/africa
@@ -30,6 +30,10 @@
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
 # https://www.jstor.org/stable/1774359
 #
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
+#
 # European-style abbreviations are commonly used along the Mediterranean.
 # For sub-Saharan Africa abbreviations were less standardized.
 # Previous editions of this database used WAT, CAT, SAT, and EAT
@@ -113,7 +117,7 @@ Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1912 Jan 01  2:00u # Praia
 
 # Chad
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
+Zone	Africa/Ndjamena	1:00:12 -	LMT	1912 Jan  1 # N'Djamena
 			1:00	-	WAT	1979 Oct 14
 			1:00	1:00	WAST	1980 Mar  8
 			1:00	-	WAT
@@ -139,7 +143,7 @@ Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
 #	Inaccessible, Nightingale: uninhabited
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Abidjan	-0:16:08 -	LMT	1912
+Zone	Africa/Abidjan	-0:16:08 -	LMT	1912 Jan  1
 			 0:00	-	GMT
 
 ###############################################################################

--- a/usr/src/data/zoneinfo/asia
+++ b/usr/src/data/zoneinfo/asia
@@ -2457,18 +2457,33 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # effective December 21st, 2018....
 # http://adilet.zan.kz/rus/docs/P1800000817 (russian language).
 
+# From Zhanbolat Raimbekov (2024-01-19):
+# Kazakhstan (all parts) switching to UTC+5 on March 1, 2024
+# https://www.gov.kz/memleket/entities/mti/press/news/details/688998?lang=ru
+# [in Russian]
+# (2024-01-20): https://primeminister.kz/ru/decisions/19012024-20
+#
+# From Alexander Krivenyshev (2024-01-19):
+# According to a different news and the official web site for the Ministry of
+# Trade and Integration of the Republic of Kazakhstan:
+# https://en.inform.kz/news/kazakhstan-to-switch-to-single-hour-zone-mar-1-54ad0b/
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 #
 # Almaty (formerly Alma-Ata), representing most locations in Kazakhstan
-# This includes KZ-AKM, KZ-ALA, KZ-ALM, KZ-AST, KZ-BAY, KZ-VOS, KZ-ZHA,
-# KZ-KAR, KZ-SEV, KZ-PAV, and KZ-YUZ.
+# This includes Abai/Abay (ISO 3166-2 code KZ-10), Aqmola/Akmola (KZ-11),
+# Almaty (KZ-19), Almaty city (KZ-75), Astana city (KZ-71),
+# East Kazkhstan (KZ-63), Jambyl/Zhambyl (KZ-31), Jetisu/Zhetysu (KZ-33),
+# Karaganda (KZ-35), North Kazakhstan (KZ-59), Pavlodar (KZ-55),
+# Shyumkent city (KZ-79), Turkistan (KZ-61), and Ulytau (KZ-62).
 Zone	Asia/Almaty	5:07:48 -	LMT	1924 May  2 # or Alma-Ata
 			5:00	-	+05	1930 Jun 21
 			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
 			5:00 RussiaAsia	+05/+06	1992 Jan 19  2:00s
 			6:00 RussiaAsia	+06/+07	2004 Oct 31  2:00s
-			6:00	-	+06
-# Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-KZY)
+			6:00	-	+06	2024 Mar  1  0:00
+			5:00	-	+05
+# Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-43)
 Zone	Asia/Qyzylorda	4:21:52 -	LMT	1924 May  2
 			4:00	-	+04	1930 Jun 21
 			5:00	-	+05	1981 Apr  1
@@ -2481,8 +2496,7 @@ Zone	Asia/Qyzylorda	4:21:52 -	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
 			6:00	-	+06	2018 Dec 21  0:00
 			5:00	-	+05
-#
-# Qostanay (aka Kostanay, Kustanay) (KZ-KUS)
+# Qostanay (aka Kostanay, Kustanay) (KZ-39)
 # The 1991/2 rules are unclear partly because of the 1997 Turgai
 # reorganization.
 Zone	Asia/Qostanay	4:14:28 -	LMT	1924 May  2
@@ -2493,9 +2507,9 @@ Zone	Asia/Qostanay	4:14:28 -	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
 			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
 			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			6:00	-	+06
-
-# Aqtöbe (aka Aktobe, formerly Aktyubinsk) (KZ-AKT)
+			6:00	-	+06	2024 Mar  1  0:00
+			5:00	-	+05
+# Aqtöbe (aka Aktobe, formerly Aktyubinsk) (KZ-15)
 Zone	Asia/Aqtobe	3:48:40	-	LMT	1924 May  2
 			4:00	-	+04	1930 Jun 21
 			5:00	-	+05	1981 Apr  1
@@ -2505,7 +2519,7 @@ Zone	Asia/Aqtobe	3:48:40	-	LMT	1924 May  2
 			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
 			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
 			5:00	-	+05
-# Mangghystaū (KZ-MAN)
+# Mangghystaū (KZ-47)
 # Aqtau was not founded until 1963, but it represents an inhabited region,
 # so include timestamps before 1963.
 Zone	Asia/Aqtau	3:21:04	-	LMT	1924 May  2
@@ -2517,7 +2531,7 @@ Zone	Asia/Aqtau	3:21:04	-	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1994 Sep 25  2:00s
 			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
 			5:00	-	+05
-# Atyraū (KZ-ATY) is like Mangghystaū except it switched from
+# Atyraū (KZ-23) is like Mangghystaū except it switched from
 # +04/+05 to +05/+06 in spring 1999, not fall 1994.
 Zone	Asia/Atyrau	3:27:44	-	LMT	1924 May  2
 			3:00	-	+03	1930 Jun 21
@@ -2528,7 +2542,7 @@ Zone	Asia/Atyrau	3:27:44	-	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1999 Mar 28  2:00s
 			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
 			5:00	-	+05
-# West Kazakhstan (KZ-ZAP)
+# West Kazakhstan (KZ-27)
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 Zone	Asia/Oral	3:25:24	-	LMT	1924 May  2 # or Ural'sk
@@ -3430,19 +3444,26 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # ... winter time will begin in Palestine from Saturday 10-28-2023,
 # 02:00 AM by 60 minutes back.
 #
-# From Paul Eggert (2023-03-22):
+# From Heba Hamad (2024-01-25):
+# the summer time for the years 2024,2025 will begin in Palestine
+# from Saturday at 02:00 AM by 60 minutes forward as shown below:
+# year date
+# 2024 2024-04-20
+# 2025 2025-04-12
+#
+# From Paul Eggert (2024-01-25):
 # For now, guess that spring and fall transitions will normally
 # continue to use 2022's rules, that during DST Palestine will switch
 # to standard time at 02:00 the last Saturday before Ramadan and back
-# to DST at 02:00 the first Saturday after Ramadan, and that
+# to DST at 02:00 the second Saturday after Ramadan, and that
 # if the normal spring-forward or fall-back transition occurs during
 # Ramadan the former is delayed and the latter advanced.
 # To implement this, I predicted Ramadan-oriented transition dates for
-# 2023 through 2086 by running the following program under GNU Emacs 28.2,
+# 2026 through 2086 by running the following program under GNU Emacs 29.2,
 # with the results integrated by hand into the table below.
 # Predictions after 2086 are approximated without Ramadan.
 #
-# (let ((islamic-year 1444))
+# (let ((islamic-year 1447))
 #   (require 'cal-islam)
 #   (while (< islamic-year 1510)
 #     (let ((a (calendar-islamic-to-absolute (list 9 1 islamic-year)))
@@ -3451,6 +3472,7 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 #       (while (/= saturday (mod (setq a (1- a)) 7)))
 #       (while (/= saturday (mod b 7))
 #         (setq b (1+ b)))
+#       (setq b (+ 7 b))
 #       (setq a (calendar-gregorian-from-absolute a))
 #       (setq b (calendar-gregorian-from-absolute b))
 #       (insert
@@ -3501,84 +3523,84 @@ Rule Palestine	2021	only	-	Oct	29	1:00	0	-
 Rule Palestine	2022	only	-	Mar	27	0:00	1:00	S
 Rule Palestine	2022	2035	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2023	only	-	Apr	29	2:00	1:00	S
-Rule Palestine	2024	only	-	Apr	13	2:00	1:00	S
-Rule Palestine	2025	only	-	Apr	 5	2:00	1:00	S
+Rule Palestine	2024	only	-	Apr	20	2:00	1:00	S
+Rule Palestine	2025	only	-	Apr	12	2:00	1:00	S
 Rule Palestine	2026	2054	-	Mar	Sat<=30	2:00	1:00	S
 Rule Palestine	2036	only	-	Oct	18	2:00	0	-
 Rule Palestine	2037	only	-	Oct	10	2:00	0	-
 Rule Palestine	2038	only	-	Sep	25	2:00	0	-
 Rule Palestine	2039	only	-	Sep	17	2:00	0	-
-Rule Palestine	2039	only	-	Oct	22	2:00	1:00	S
-Rule Palestine	2039	2067	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2040	only	-	Sep	 1	2:00	0	-
-Rule Palestine	2040	only	-	Oct	13	2:00	1:00	S
+Rule Palestine	2040	only	-	Oct	20	2:00	1:00	S
+Rule Palestine	2040	2067	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2041	only	-	Aug	24	2:00	0	-
-Rule Palestine	2041	only	-	Sep	28	2:00	1:00	S
+Rule Palestine	2041	only	-	Oct	 5	2:00	1:00	S
 Rule Palestine	2042	only	-	Aug	16	2:00	0	-
-Rule Palestine	2042	only	-	Sep	20	2:00	1:00	S
+Rule Palestine	2042	only	-	Sep	27	2:00	1:00	S
 Rule Palestine	2043	only	-	Aug	 1	2:00	0	-
-Rule Palestine	2043	only	-	Sep	12	2:00	1:00	S
+Rule Palestine	2043	only	-	Sep	19	2:00	1:00	S
 Rule Palestine	2044	only	-	Jul	23	2:00	0	-
-Rule Palestine	2044	only	-	Aug	27	2:00	1:00	S
+Rule Palestine	2044	only	-	Sep	 3	2:00	1:00	S
 Rule Palestine	2045	only	-	Jul	15	2:00	0	-
-Rule Palestine	2045	only	-	Aug	19	2:00	1:00	S
+Rule Palestine	2045	only	-	Aug	26	2:00	1:00	S
 Rule Palestine	2046	only	-	Jun	30	2:00	0	-
-Rule Palestine	2046	only	-	Aug	11	2:00	1:00	S
+Rule Palestine	2046	only	-	Aug	18	2:00	1:00	S
 Rule Palestine	2047	only	-	Jun	22	2:00	0	-
-Rule Palestine	2047	only	-	Jul	27	2:00	1:00	S
+Rule Palestine	2047	only	-	Aug	 3	2:00	1:00	S
 Rule Palestine	2048	only	-	Jun	 6	2:00	0	-
-Rule Palestine	2048	only	-	Jul	18	2:00	1:00	S
+Rule Palestine	2048	only	-	Jul	25	2:00	1:00	S
 Rule Palestine	2049	only	-	May	29	2:00	0	-
-Rule Palestine	2049	only	-	Jul	 3	2:00	1:00	S
+Rule Palestine	2049	only	-	Jul	10	2:00	1:00	S
 Rule Palestine	2050	only	-	May	21	2:00	0	-
-Rule Palestine	2050	only	-	Jun	25	2:00	1:00	S
+Rule Palestine	2050	only	-	Jul	 2	2:00	1:00	S
 Rule Palestine	2051	only	-	May	 6	2:00	0	-
-Rule Palestine	2051	only	-	Jun	17	2:00	1:00	S
+Rule Palestine	2051	only	-	Jun	24	2:00	1:00	S
 Rule Palestine	2052	only	-	Apr	27	2:00	0	-
-Rule Palestine	2052	only	-	Jun	 1	2:00	1:00	S
+Rule Palestine	2052	only	-	Jun	 8	2:00	1:00	S
 Rule Palestine	2053	only	-	Apr	12	2:00	0	-
-Rule Palestine	2053	only	-	May	24	2:00	1:00	S
+Rule Palestine	2053	only	-	May	31	2:00	1:00	S
 Rule Palestine	2054	only	-	Apr	 4	2:00	0	-
-Rule Palestine	2054	only	-	May	16	2:00	1:00	S
-Rule Palestine	2055	only	-	May	 1	2:00	1:00	S
-Rule Palestine	2056	only	-	Apr	22	2:00	1:00	S
-Rule Palestine	2057	only	-	Apr	 7	2:00	1:00	S
-Rule Palestine	2058	max	-	Mar	Sat<=30	2:00	1:00	S
+Rule Palestine	2054	only	-	May	23	2:00	1:00	S
+Rule Palestine	2055	only	-	May	 8	2:00	1:00	S
+Rule Palestine	2056	only	-	Apr	29	2:00	1:00	S
+Rule Palestine	2057	only	-	Apr	14	2:00	1:00	S
+Rule Palestine	2058	only	-	Apr	 6	2:00	1:00	S
+Rule Palestine	2059	max	-	Mar	Sat<=30	2:00	1:00	S
 Rule Palestine	2068	only	-	Oct	20	2:00	0	-
 Rule Palestine	2069	only	-	Oct	12	2:00	0	-
 Rule Palestine	2070	only	-	Oct	 4	2:00	0	-
 Rule Palestine	2071	only	-	Sep	19	2:00	0	-
 Rule Palestine	2072	only	-	Sep	10	2:00	0	-
-Rule Palestine	2072	only	-	Oct	15	2:00	1:00	S
+Rule Palestine	2072	only	-	Oct	22	2:00	1:00	S
 Rule Palestine	2072	max	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2073	only	-	Sep	 2	2:00	0	-
-Rule Palestine	2073	only	-	Oct	 7	2:00	1:00	S
+Rule Palestine	2073	only	-	Oct	14	2:00	1:00	S
 Rule Palestine	2074	only	-	Aug	18	2:00	0	-
-Rule Palestine	2074	only	-	Sep	29	2:00	1:00	S
+Rule Palestine	2074	only	-	Oct	 6	2:00	1:00	S
 Rule Palestine	2075	only	-	Aug	10	2:00	0	-
-Rule Palestine	2075	only	-	Sep	14	2:00	1:00	S
+Rule Palestine	2075	only	-	Sep	21	2:00	1:00	S
 Rule Palestine	2076	only	-	Jul	25	2:00	0	-
-Rule Palestine	2076	only	-	Sep	 5	2:00	1:00	S
+Rule Palestine	2076	only	-	Sep	12	2:00	1:00	S
 Rule Palestine	2077	only	-	Jul	17	2:00	0	-
-Rule Palestine	2077	only	-	Aug	28	2:00	1:00	S
+Rule Palestine	2077	only	-	Sep	 4	2:00	1:00	S
 Rule Palestine	2078	only	-	Jul	 9	2:00	0	-
-Rule Palestine	2078	only	-	Aug	13	2:00	1:00	S
+Rule Palestine	2078	only	-	Aug	20	2:00	1:00	S
 Rule Palestine	2079	only	-	Jun	24	2:00	0	-
-Rule Palestine	2079	only	-	Aug	 5	2:00	1:00	S
+Rule Palestine	2079	only	-	Aug	12	2:00	1:00	S
 Rule Palestine	2080	only	-	Jun	15	2:00	0	-
-Rule Palestine	2080	only	-	Jul	20	2:00	1:00	S
+Rule Palestine	2080	only	-	Jul	27	2:00	1:00	S
 Rule Palestine	2081	only	-	Jun	 7	2:00	0	-
-Rule Palestine	2081	only	-	Jul	12	2:00	1:00	S
+Rule Palestine	2081	only	-	Jul	19	2:00	1:00	S
 Rule Palestine	2082	only	-	May	23	2:00	0	-
-Rule Palestine	2082	only	-	Jul	 4	2:00	1:00	S
+Rule Palestine	2082	only	-	Jul	11	2:00	1:00	S
 Rule Palestine	2083	only	-	May	15	2:00	0	-
-Rule Palestine	2083	only	-	Jun	19	2:00	1:00	S
+Rule Palestine	2083	only	-	Jun	26	2:00	1:00	S
 Rule Palestine	2084	only	-	Apr	29	2:00	0	-
-Rule Palestine	2084	only	-	Jun	10	2:00	1:00	S
+Rule Palestine	2084	only	-	Jun	17	2:00	1:00	S
 Rule Palestine	2085	only	-	Apr	21	2:00	0	-
-Rule Palestine	2085	only	-	Jun	 2	2:00	1:00	S
+Rule Palestine	2085	only	-	Jun	 9	2:00	1:00	S
 Rule Palestine	2086	only	-	Apr	13	2:00	0	-
-Rule Palestine	2086	only	-	May	18	2:00	1:00	S
+Rule Palestine	2086	only	-	May	25	2:00	1:00	S
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct
@@ -3606,7 +3628,7 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 
 # Philippines
 
-# From Paul Eggert (2018-11-18):
+# From Paul Eggert (2024-01-21):
 # The Spanish initially used American (west-of-Greenwich) time.
 # It is unknown what time Manila kept when the British occupied it from
 # 1762-10-06 through 1764-04; for now assume it kept American time.
@@ -3614,7 +3636,7 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # Philippines, issued a proclamation announcing that 1844-12-30 was to
 # be immediately followed by 1845-01-01; see R.H. van Gent's
 # History of the International Date Line
-# https://www.staff.science.uu.nl/~gent0113/idl/idl_philippines.htm
+# https://webspace.science.uu.nl/~gent0113/idl/idl_philippines.htm
 # The rest of the data entries are from Shanks & Pottenger.
 
 # From Jesper Nørgaard Welen (2006-04-26):
@@ -4041,7 +4063,8 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # The English-language name of Vietnam's most populous city is "Ho Chi Minh
 # City"; use Ho_Chi_Minh below to avoid a name of more than 14 characters.
 
-# From Paul Eggert (2022-07-27) after a 2014 heads-up from Trần Ngọc Quân:
+# From Paul Eggert (2024-01-14) after a 2014 heads-up from Trần Ngọc Quân
+# and a 2024-01-14 heads-up from Đoàn Trần Công Danh:
 # Trần Tiến Bình's authoritative book "Lịch Việt Nam: thế kỷ XX-XXI (1901-2100)"
 # (Nhà xuất bản Văn Hoá - Thông Tin, Hanoi, 2005), pp 49-50,
 # is quoted verbatim in:
@@ -4071,14 +4094,35 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 #
 # Trần cites the following sources; it's unclear which supplied the info above.
 #
-# Hoàng Xuân Hãn: "Lịch và lịch Việt Nam". Tập san Khoa học Xã hội,
-# No. 9, Paris, February 1982.
+#   Hoàng Xuân Hãn: "Lịch và lịch Việt Nam". Tập san Khoa học Xã hội,
+#   No. 9, Paris, February 1982.
 #
-# Lê Thành Lân: "Lịch và niên biểu lịch sử hai mươi thế kỷ (0001-2010)",
-# NXB Thống kê, Hanoi, 2000.
+#   Lê Thành Lân: "Lịch và niên biểu lịch sử hai mươi thế kỷ (0001-2010)",
+#   NXB Thống kê, Hanoi, 2000.
 #
-# Lê Thành Lân: "Lịch hai thế kỷ (1802-2010) và các lịch vĩnh cửu",
-# NXB Thuận Hoá, Huế, 1995.
+#   Lê Thành Lân: "Lịch hai thế kỷ (1802-2010) và các lịch vĩnh cửu",
+#   NXB Thuận Hoá, Huế, 1995.
+#
+# Here is the decision for the September 1945 transition:
+# Võ Nguyên Giáp, Việt Nam Dân Quốc Công Báo, No. 1 (1945-09-29), page 13
+# http://baochi.nlv.gov.vn/baochi/cgi-bin/baochi?a=d&d=JwvzO19450929.2.5&dliv=none
+# It says that on 1945-09-01 at 24:00, Vietnam moved back two hours, to +07.
+# It also mentions a 1945-03-29 decree (by a Japanese Goveror-General)
+# to set the time zone to +09, but does not say whether that decree
+# merely legalized an earlier change to +09.
+#
+# July 1955 transition:
+# Ngô Đình Diệm, Công Báo Việt Nam, No. 92 (1955-07-02), page 1780-1781
+# Ordinance (Dụ) No. 46 (1955-06-25)
+# http://ddsnext.crl.edu/titles/32341#?c=0&m=29&s=0&cv=4&r=0&xywh=-89%2C342%2C1724%2C1216
+# It says that on 1955-07-01 at 01:00, South Vietnam moved back 1 hour (to +07).
+#
+# December 1959 transition:
+# Ngô Đình Diệm, Công Báo Việt Nam Cộng Hòa, 1960 part 1 (1960-01-02), page 62
+# Decree (Sắc lệnh) No. 362-TTP (1959-12-30)
+# http://ddsnext.crl.edu/titles/32341#?c=0&m=138&s=0&cv=793&r=0&xywh=-54%2C1504%2C1705%2C1202
+# It says that on 1959-12-31 at 23:00, South Vietnam moved forward 1 hour (to +08).
+
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 		#STDOFF	7:06:30.13
@@ -4086,9 +4130,9 @@ Zone Asia/Ho_Chi_Minh	7:06:30 -	LMT	1906 Jul  1
 			7:06:30	-	PLMT	1911 May  1 # Phù Liễn MT
 			7:00	-	+07	1942 Dec 31 23:00
 			8:00	-	+08	1945 Mar 14 23:00
-			9:00	-	+09	1945 Sep  2
+			9:00	-	+09	1945 Sep  1 24:00
 			7:00	-	+07	1947 Apr  1
-			8:00	-	+08	1955 Jul  1
+			8:00	-	+08	1955 Jul  1 01:00
 			7:00	-	+07	1959 Dec 31 23:00
 			8:00	-	+08	1975 Jun 13
 			7:00	-	+07

--- a/usr/src/data/zoneinfo/australasia
+++ b/usr/src/data/zoneinfo/australasia
@@ -420,11 +420,11 @@ Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 
 # French Polynesia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct # Rikitea
+Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct  1 # Rikitea
 			 -9:00	-	-09
-Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct
+Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct  1
 			 -9:30	-	-0930
-Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct # Papeete
+Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct  1 # Papeete
 			-10:00	-	-10
 # Clipperton (near North America) is administered from French Polynesia;
 # it is uninhabited.
@@ -802,7 +802,7 @@ Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 # Solomon Is
 # excludes Bougainville, for which see Papua New Guinea
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct # Honiara
+Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct  1 # Honiara
 			11:00	-	+11
 
 # Tokelau
@@ -962,6 +962,10 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # For data circa 1899, a common source is:
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
 # https://www.jstor.org/stable/1774359
+#
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 #
 # A reliable and entertaining source about time zones is
 # Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
@@ -2039,7 +2043,7 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # ordaining - by a masterpiece of diplomatic flattery - that
 # the Fourth of July should be celebrated twice in that year."
 # This happened in 1892, according to the Evening News (Sydney) of 1892-07-20.
-# https://www.staff.science.uu.nl/~gent0113/idl/idl.htm
+# https://webspace.science.uu.nl/~gent0113/idl/idl_alaska_samoa.htm
 
 # Although Shanks & Pottenger says they both switched to UT -11:30
 # in 1911, and to -11 in 1950. many earlier sources give -11

--- a/usr/src/data/zoneinfo/etcetera
+++ b/usr/src/data/zoneinfo/etcetera
@@ -5,7 +5,7 @@
 
 # These entries are for uses not otherwise covered by the tz database.
 # Their main practical use is for platforms like Android that lack
-# support for POSIX-style TZ strings.  On such platforms these entries
+# support for POSIX.1-2017-style TZ strings.  On such platforms these entries
 # can be useful if the timezone database is wrong or if a ship or
 # aircraft at sea is not in a timezone.
 

--- a/usr/src/data/zoneinfo/europe
+++ b/usr/src/data/zoneinfo/europe
@@ -990,9 +990,34 @@ Zone	Europe/Sofia	1:33:16 -	LMT	1880
 # Czech Republic (Czechia)
 # Slovakia
 #
-# From Paul Eggert (2018-04-15):
-# The source for Czech data is: Kdy začíná a končí letní čas. 2018-04-15.
+# From Ivan Benovic (2024-01-30):
+# https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1946/54/
+# (This is an official link to the Czechoslovak Summer Time Act of
+# March 8, 1946 that authorizes the Czechoslovak government to set the
+# exact dates of change to summer time and back to Central European Time.
+# The act also implicitly confirms Central European Time as the
+# official time zone of Czechoslovakia and currently remains in force
+# in both the Czech Republic and Slovakia.)
+# https://www.psp.cz/eknih/1945pns/tisky/t0216_00.htm
+# (This is a link to the original legislative proposal dating back to
+# February 22, 1946. The accompanying memorandum to the proposal says
+# that an advisory committee on European railroad transportation that
+# met in Brussels in October 1945 decided that the change of time
+# should be carried out in all participating countries in a strictly
+# coordinated manner....)
+#
+# From Paul Eggert (2024-01-30):
+# The source for Czech data is: Kdy začíná a končí letní čas.
 # https://kalendar.beda.cz/kdy-zacina-a-konci-letni-cas
+# Its main text disagrees with its quoted sources only in 1918,
+# where the main text says spring and autumn transitions
+# occurred at 02:00 and 03:00 respectively (as usual),
+# whereas the 1918 source "Oznámení o zavedení letního času v roce 1918"
+# says transitions were at 01:00 and 02:00 respectively.
+# As the 1918 source appears to be a humorous piece, and it is
+# unlikely that Prague would have disagreed with its neighbors by an hour,
+# go with the main text for now.
+#
 # We know of no English-language name for historical Czech winter time;
 # abbreviate it as "GMT", as it happened to be GMT.
 #

--- a/usr/src/data/zoneinfo/northamerica
+++ b/usr/src/data/zoneinfo/northamerica
@@ -1268,6 +1268,10 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 #	<http://cs.ucla.edu/~eggert/The-Waste-of-Daylight-19th.pdf>
 #	[PDF] (1914-03)
 #
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
+#
 # See the 'europe' file for Greenland.
 
 # Canada
@@ -1354,7 +1358,7 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # From Paul Eggert (2014-10-18):
 # H. David Matthews and Mary Vincent's map
 # "It's about TIME", _Canadian Geographic_ (September-October 1998)
-# http://www.canadiangeographic.ca/Magazine/SO98/alacarte.asp
+# https://web.archive.org/web/19990827055050/https://canadiangeographic.ca/SO98/geomap.htm
 # contains detailed boundaries for regions observing nonstandard
 # time and daylight saving time arrangements in Canada circa 1998.
 #
@@ -1642,6 +1646,15 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 #     Some cities in the United States have pushed the deadline back
 #     three weeks and will change over from daylight saving in October.
 
+# From Chris Walton (2024-01-09):
+# The [Toronto] changes in 1947, 1948, and 1949 took place at 2:00 a.m. local
+# time instead of midnight....  Toronto Daily Star - ...
+# April 2, 1947 - Page 39 ... April 7, 1948 - Page 13 ...
+# April 2, 1949 - Page 1 ... April 7, 1949 - Page 24 ...
+# November 25, 1949 - Page 52 ... April 21, 1950 - Page 14 ...
+# September 19, 1950 - Page 46 ... September 20, 1950 - Page 3 ...
+# November 24, 1950 - Page 21
+
 # From Arthur David Olson (2010-07-17):
 #
 # "Standard Time and Time Zones in Canada" appeared in
@@ -1703,13 +1716,9 @@ Rule	Toronto	1927	1937	-	Sep	Sun>=25	2:00	0	S
 Rule	Toronto	1928	1937	-	Apr	Sun>=25	2:00	1:00	D
 Rule	Toronto	1938	1940	-	Apr	lastSun	2:00	1:00	D
 Rule	Toronto	1938	1939	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1945	1946	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1946	only	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1947	1949	-	Apr	lastSun	0:00	1:00	D
-Rule	Toronto	1947	1948	-	Sep	lastSun	0:00	0	S
-Rule	Toronto	1949	only	-	Nov	lastSun	0:00	0	S
-Rule	Toronto	1950	1973	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1950	only	-	Nov	lastSun	2:00	0	S
+Rule	Toronto	1945	1948	-	Sep	lastSun	2:00	0	S
+Rule	Toronto	1946	1973	-	Apr	lastSun	2:00	1:00	D
+Rule	Toronto	1949	1950	-	Nov	lastSun	2:00	0	S
 Rule	Toronto	1951	1956	-	Sep	lastSun	2:00	0	S
 # Shanks & Pottenger say Toronto ended DST a week early in 1971,
 # namely on 1971-10-24, but Mark Brader wrote (2003-05-31) that this
@@ -3432,7 +3441,7 @@ Zone	America/Jamaica	-5:07:10 -	LMT	1890        # Kingston
 # Martinique
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Martinique	-4:04:20 -      LMT	1890        # Fort-de-France
-			-4:04:20 -	FFMT	1911 May    # Fort-de-France MT
+			-4:04:20 -	FFMT	1911 May  1 # Fort-de-France MT
 			-4:00	-	AST	1980 Apr  6
 			-4:00	1:00	ADT	1980 Sep 28
 			-4:00	-	AST
@@ -3539,7 +3548,7 @@ Zone America/Puerto_Rico -4:24:25 -	LMT	1899 Mar 28 12:00 # San Juan
 # St Pierre and Miquelon
 # There are too many St Pierres elsewhere, so we'll use 'Miquelon'.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
+Zone America/Miquelon	-3:44:40 -	LMT	1911 Jun 15 # St Pierre
 			-4:00	-	AST	1980 May
 			-3:00	-	-03	1987
 			-3:00	Canada	-03/-02

--- a/usr/src/data/zoneinfo/southamerica
+++ b/usr/src/data/zoneinfo/southamerica
@@ -1570,8 +1570,11 @@ Zone Atlantic/Stanley	-3:51:24 -	LMT	1890
 			-3:00	-	-03
 
 # French Guiana
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul
+Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul  1
 			-4:00	-	-04	1967 Oct
 			-3:00	-	-03
 

--- a/usr/src/lib/libbsm/common/adt.c
+++ b/usr/src/lib/libbsm/common/adt.c
@@ -752,24 +752,14 @@ adt_get_hostIP(const char *hostname, au_tid_addr_t *p_term)
 {
 	struct addrinfo	*ai = NULL;
 	int	tries = 3;
-	char	msg[512];
 	int	eai_err;
 
 	while ((tries-- > 0) &&
 	    ((eai_err = getaddrinfo(hostname, NULL, NULL, &ai)) != 0)) {
-		/*
-		 * getaddrinfo returns its own set of errors.
-		 * Log them here, so any subsequent syslogs will
-		 * have a context.  adt_get_hostIP callers can only
-		 * return errno, so subsequent syslogs may be lacking
-		 * that getaddrinfo failed.
-		 */
-		(void) snprintf(msg, sizeof (msg), "getaddrinfo(%s) "
-		    "failed[%s]", hostname, gai_strerror(eai_err));
-		adt_write_syslog(msg, 0);
+		DPRINTF(("getaddrinfo(%s) failed[%s]", hostname,
+		    gai_strerror(eai_err)));
 
 		if (eai_err != EAI_AGAIN) {
-
 			break;
 		}
 		/* see if resolution becomes available */
@@ -804,7 +794,7 @@ adt_get_hostIP(const char *hostname, au_tid_addr_t *p_term)
 			    errno);
 			goto try_interface;
 		}
-		adt_write_syslog("setting Audit IP address to kernel", 0);
+		DPRINTF(("setting Audit IP address to kernel"));
 		*p_term = audit_info.ai_termid;
 		return (0);
 	}
@@ -812,7 +802,9 @@ try_interface:
 	{
 		struct ifaddrlist al;
 		int	family;
+#ifdef C2_DEBUG
 		char	ntop[INET6_ADDRSTRLEN];
+#endif
 
 		/*
 		 * getaddrinfo has failed to map the hostname
@@ -845,10 +837,8 @@ try_interface:
 			(void) memcpy(p_term->at_addr, &al.addr.addr6, AU_IPv6);
 		}
 
-		(void) snprintf(msg, sizeof (msg), "mapping %s to %s",
-		    hostname, inet_ntop(family, &(al.addr), ntop,
-		    sizeof (ntop)));
-		adt_write_syslog(msg, 0);
+		DPRINTF(("mapping %s to %s", hostname,
+		    inet_ntop(family, &(al.addr), ntop, sizeof (ntop))));
 		return (0);
 	}
 }

--- a/usr/src/man/man1/ld.1
+++ b/usr/src/man/man1/ld.1
@@ -1,1977 +1,1899 @@
-'\" te
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
 .\" Copyright 1989 AT&T
 .\" Copyright (c) 2009, Sun Microsystems, Inc. All Rights Reserved
 .\" Copyright 2019 Joyent, Inc.
 .\" Copyright 2023 Oxide Computer Company
-.\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
-.\"  See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with
-.\" the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH LD 1 "Jan 28, 2022"
-.SH NAME
-ld \- link-editor for object files
-.SH SYNOPSIS
-.nf
-\fBld\fR [\fB-32\fR | \fB-64\fR] [\fB-a\fR | \fB-r\fR] [\fB-b\fR] [\fB-B\fRdirect | nodirect]
-[\fB-B\fR dynamic | static] [\fB-B\fR eliminate] [\fB-B\fR group] [\fB-B\fR local]
-[\fB-B\fR reduce] [\fB-B\fR symbolic] [\fB-c\fR \fIname\fR] [\fB-C\fR] [\fB-d\fR y | n]
-[\fB-D\fR \fItoken\fR,...] [\fB-e\fR \fIepsym\fR] [\fB-f\fR \fIname\fR | \fB-F\fR \fIname\fR] [\fB-G\fR] [\fB-h\fR \fIname\fR]
-[\fB-i\fR] [\fB-I\fR \fIname\fR] [\fB-l\fR \fIx\fR] [\fB-L\fR \fIpath\fR] [\fB-m\fR] [\fB-M\fR \fImapfile\fR]
-[\fB-N\fR \fIstring\fR] [\fB-o\fR \fIoutfile\fR] [\fB-p\fR \fIauditlib\fR] [\fB-P\fR \fIauditlib\fR]
-[\fB-Q\fR y | n] [\fB-R\fR \fIpath\fR] [\fB-s\fR] [\fB-S\fR \fIsupportlib\fR] [\fB-t\fR]
-[\fB-u\fR \fIsymname\fR] [\fB-V\fR] [\fB-Y P\fR\fI,dirlist\fR] [\fB-z\fR absexec]
-[\fB-z\fR allextract | defaultextract | weakextract ] [\fB-z\fR altexec64]
-[\fB-z\fR aslr[=\fIstate\fR]] [\fB-z\fR assert-deflib] [ \fB-z\fR assert-deflib=\fIlibname\fR]
-[\fB-z\fR combreloc | nocombreloc ] [\fB-z\fR defs | nodefs]
-[\fB-z\fR direct | nodirect] [\fB-z\fR endfiltee]
-[\fB-z\fR fatal-warnings | nofatal-warnings ] [\fB-z\fR finiarray=\fIfunction\fR]
-[\fB-z\fR globalaudit] [\fB-z\fR groupperm | nogroupperm]
-[\fB-z\fR guidance[=\fIid1\fR,\fIid2\fR...] [\fB-z\fR help ]
-[\fB-z\fR ignore | record] [\fB-z\fR initarray=\fIfunction\fR] [\fB-z\fR initfirst]
-[\fB-z\fR interpose] [\fB-z\fR lazyload | nolazyload]
-[\fB-z\fR ld32=\fIarg1\fR,\fIarg2\fR,...] [\fB-z\fR ld64=\fIarg1\fR,\fIarg2\fR,...]
-[\fB-z\fR loadfltr] [\fB-z\fR muldefs] [\fB-z\fR nocompstrtab] [\fB-z\fR nodefaultlib]
-[\fB-z\fR nodelete] [\fB-z\fR nodlopen] [\fB-z\fR nodump] [\fB-z\fR noldynsym]
-[\fB-z\fR nopartial] [\fB-z\fR noversion] [\fB-z\fR now] [\fB-z\fR origin]
-[\fB-z\fR preinitarray=\fIfunction\fR] [\fB-z\fR redlocsym] [\fB-z\fR relaxreloc]
-[\fB-z\fR rescan-now] [\fB-z\fR recan] [\fB-z\fR rescan-start \fI\&...\fR \fB-z\fR rescan-end]]
-[\fB-z\fR symbolcap] [\fB-z\fR target=sparc|x86] [\fB-z\fR text | textwarn | textoff]
-[\fB-z\fR type=\fIexec\fR|\fIkmod\fR|\fIreloc\fR|\fIshared\fR]
-[\fB-z\fR verbose] [\fB-z\fR wrap=\fIsymbol\fR] \fIfilename\fR...
-.fi
-
-.SH DESCRIPTION
-The link-editor, \fBld\fR, combines relocatable object files by resolving
-symbol references to symbol definitions, together with performing relocations.
-\fBld\fR operates in two modes, static or dynamic, as governed by the \fB-d\fR
-option. In all cases, the output of \fBld\fR is left in the file \fBa.out\fR by
-default. See NOTES.
-.sp
-.LP
-In dynamic mode, \fB-dy\fR, the default, relocatable object files that are
-provided as arguments are combined to produce an executable object file. This
-file is linked at execution with any shared object files that are provided as
-arguments. If the \fB-G\fR option is specified, relocatable object files are
-combined to produce a shared object. Without the \fB-G\fR option, a dynamic
-executable is created.
-.sp
-.LP
-In static mode, \fB-dn\fR, relocatable object files that are provided as
-arguments are combined to produce a static executable file. If the \fB-r\fR
+.\" Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+.\"
+.Dd January 15, 2024
+.Dt LD 1
+.Os
+.Sh NAME
+.Nm ld
+.Nd link-editor for object files
+.Sh SYNOPSIS
+.Nm
+.Op Fl 32 | 64
+.Op Fl a | r
+.Op Fl b
+.Op Fl B Cm direct | Fl B Cm nodirect
+.Op Fl B Cm dynamic | Fl B Cm static
+.Op Fl B Cm eliminate
+.Op Fl B Cm group
+.Op Fl B Cm local
+.Op Fl B Cm reduce
+.Op Fl B Cm symbolic
+.Op Fl c Ar name
+.Op Fl C
+.Op Fl d Cm y | Fl d Cm n
+.Op Fl D Ar token Ns No ,...
+.Op Fl e Ar epsym
+.Op Fl f Ar name | Fl F Ar name
+.Op Fl G
+.Op Fl h Ar name
+.Op Fl i
+.Op Fl I Ar name
+.Op Fl l Ar x
+.Op Fl L Ar path
+.Op Fl m
+.Op Fl M Ar mapfile
+.Op Fl N Ar string
+.Op Fl o Ar outfile
+.Op Fl p Ar auditlib
+.Op Fl P Ar auditlib
+.Op Fl Q Cm y | Fl Q Cm n
+.Op Fl R Ar path
+.Op Fl s
+.Op Fl S Ar supportlib
+.Op Fl t
+.Op Fl u Ar symname
+.Op Fl V
+.Op Fl Y Cm P Ns \&, Ns Ar dirlist
+.Op Fl z Cm absexec
+.Op Fl z Cm allextract | Fl z Cm defaultextract | Fl z Cm weakextract
+.Op Fl z Cm altexec64
+.Op Fl z Cm aslr Ns Op Cm \&= Ns Ar state
+.Op Fl z Cm assert-deflib
+.Op Fl z Cm assert-deflib= Ns Ar libname
+.Op Fl z Cm combreloc | Fl z Cm nocombreloc
+.Op Fl z Cm defs | Fl z Cm nodefs
+.Op Fl z Cm direct | Fl z Cm nodirect
+.Op Fl z Cm endfiltee
+.Op Fl z Cm fatal-warnings | Fl z Cm nofatal-warnings
+.Op Fl z Cm finiarray= Ns Ar function
+.Op Fl z Cm globalaudit
+.Op Fl z Cm groupperm | nogroupperm
+.Op Fl z Cm guidance Ns Op Cm \&= Ns Ar id Ns No \&,...
+.Op Fl z Cm help
+.Op Fl z Cm ignore | Fl z Cm record
+.Op Fl z Cm initarray= Ns Ar function
+.Op Fl z Cm initfirst
+.Op Fl z Cm interpose
+.Op Fl z Cm lazyload | Fl z Cm nolazyload
+.Op Fl z Cm ld32= Ns Ar arg Ns No \&,...
+.Op Fl z Cm ld64= Ns Ar arg Ns No \&,...
+.Op Fl z Cm loadfltr
+.Op Fl z Cm muldefs
+.Op Fl z Cm nocompstrtab
+.Op Fl z Cm nodefaultlib
+.Op Fl z Cm nodelete
+.Op Fl z Cm nodlopen
+.Op Fl z Cm nodump
+.Op Fl z Cm noldynsym
+.Op Fl z Cm nopartial
+.Op Fl z Cm noversion
+.Op Fl z Cm now
+.Op Fl z Cm origin
+.Op Fl z Cm preinitarray= Ns Ar function
+.Op Fl z Cm redlocsym
+.Op Fl z Cm relaxreloc
+.Op Fl z Cm rescan
+.Op Fl z Cm rescan-now
+.Op Fl z Cm rescan-start \&... Fl z Cm rescan-end
+.Op Fl z Cm symbolcap
+.Op Fl z Cm target= Ns Cm sparc Ns | Ns Cm x86
+.Op Fl z Cm text | Fl z Cm textwarn | Fl z Cm textoff
+.Sm off
+.Op Fl z\~ Cm type= Cm exec | kmod | reloc | shared
+.Sm on
+.Op Fl z Cm verbose
+.Op Fl z Cm wrap= Ns Ar symbol
+.Ar filename Ns No \&...
+.Sh DESCRIPTION
+The link-editor,
+.Nm ,
+combines relocatable object files by resolving symbol references to symbol
+definitions, together with performing relocations.
+.Nm
+operates in two modes, static or dynamic, as governed by the
+.Fl d
+option.
+In all cases, the output of
+.Nm
+is left in the file
+.Pa a.out
+by default.
+See
+.Sx NOTES .
+.Pp
+In dynamic mode,
+.Fl d Cm y ,
+the default, relocatable object files that are provided as arguments are
+combined to produce an executable object file.
+This file is linked at execution with any shared object files that are provided
+as arguments.
+If the
+.Fl G
+option is specified, relocatable object files are combined to produce a shared
+object.
+Without the
+.Fl G
+option, a dynamic executable is created.
+.Pp
+In static mode,
+.Fl d Cm n ,
+relocatable object files that are provided as arguments are combined to produce
+a static executable file.
+If the
+.Fl r
 option is specified, relocatable object files are combined to produce one
-relocatable object file. See \fBStatic Executables\fR.
-.sp
-.LP
+relocatable object file.
+See
+.Sx Static Executables .
+.Pp
 Dynamic linking is the most common model for combining relocatable objects, and
-the eventual creation of processes within Solaris. This environment tightly
-couples the work of the link-editor and the runtime linker, \fBld.so.1\fR(1).
+the eventual creation of processes within illumos.
+This environment tightly couples the work of the link-editor and the runtime
+linker,
+.Xr ld.so.1 1 .
 Both of these utilities, together with their related technologies and
-utilities, are extensively documented in the \fILinker and Libraries Guide\fR.
-.sp
-.LP
-If any argument is a library, \fBld\fR by default searches the library exactly
-once at the point the library is encountered on the argument list. The library
-can be either a shared object or relocatable archive. See \fBar.h\fR(3HEAD)).
-.sp
-.LP
+utilities, are extensively documented in the
+.%T Linker and Libraries Guide .
+.Pp
+If any argument is a library,
+.Nm
+by default searches the library exactly once at the point the library is
+encountered on the argument list.
+The library can be either a shared object or relocatable archive.
+See
+.Xr ar.h 3HEAD .
+.Pp
 A shared object consists of an indivisible, whole unit that has been generated
-by a previous link-edit of one or more input files. When the link-editor
-processes a shared object, the entire contents of the shared object become a
-logical part of the resulting output file image. The shared object is not
-physically copied during the link-edit as its actual inclusion is deferred
-until process execution. This logical inclusion means that all symbol entries
-defined in the shared object are made available to the link-editing process.
-See Chapter 4, \fIShared Objects,\fR in \fILinker and Libraries Guide\fR
-.sp
-.LP
-For an archive library, \fBld\fR loads only those routines that define an
-unresolved external reference. \fBld\fR searches the symbol table of the
-archive library sequentially to resolve external references that can be
-satisfied by library members. This search is repeated until no external
-references can be resolved by the archive. Thus, the order of members in the
-library is functionally unimportant, unless multiple library members exist that
-define the same external symbol. Archive libraries that have interdependencies
-can require multiple command line definitions, or the use of one of the
-\fB-z\fR \fBrescan\fR options. See \fIArchive Processing\fR in \fILinker and
-Libraries Guide\fR.
-.sp
-.LP
-\fBld\fR is a cross link-editor, able to link 32-bit objects or 64-bit objects,
-for Sparc or x86 targets. \fBld\fR uses the \fBELF\fR class and machine type of
-the first relocatable object on the command line to govern the mode in which to
-operate. The mixing of 32-bit objects and 64-bit objects is not permitted.
-Similarly, only objects of a single machine type are allowed. See the
-\fB-32\fR, \fB-64\fR and \fB-z target\fR options, and the \fBLD_NOEXEC_64\fR
+by a previous link-edit of one or more input files.
+When the link-editor processes a shared object, the entire contents of the
+shared object become a logical part of the resulting output file image.
+The shared object is not physically copied during the link-edit as its actual
+inclusion is deferred until process execution.
+This logical inclusion means that all symbol entries defined in the shared
+object are made available to the link-editing process.
+See Chapter 4,
+.Em Shared Objects ,
+in
+.%T Linker and Libraries Guide .
+.Pp
+For an archive library,
+.Nm
+loads only those routines that define an unresolved external reference.
+.Nm
+searches the symbol table of the archive library sequentially to resolve
+external references that can be satisfied by library members.
+This search is repeated until no external references can be resolved by the
+archive.
+Thus, the order of members in the library is functionally unimportant, unless
+multiple library members exist that define the same external symbol.
+Archive libraries that have interdependencies can require multiple command line
+definitions, or the use of one of the
+.Fl z Cm rescan
+options.
+See
+.Em Archive Processing
+in
+.%T Linker and Libraries Guide .
+.Pp
+.Nm
+is a cross link-editor, able to link 32-bit objects or 64-bit objects, for
+Sparc or x86 targets.
+.Nm
+uses the
+.Sy ELF
+class and machine type of the first relocatable object on the command line to
+govern the mode in which to operate.
+The mixing of 32-bit objects and 64-bit objects is not permitted.
+Similarly, only objects of a single machine type are allowed.
+See the
+.Fl 32 ,
+.Fl 64
+and
+.Fl z Cm target
+options, and the
+.Ev LD_NOEXEC_64
 environment variable.
-.SS "Static Executables"
-The creation of static executables has been discouraged for many releases. In
-fact, 64-bit system archive libraries have never been provided. Because a
-static executable is built against system archive libraries, the executable
-contains system implementation details. This self-containment has a number of
-drawbacks.
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.Ss Static Executables
+The creation of static executables is discouraged.
+Since a static executable is built against system archive libraries, the
+executable contains system implementation details.
+This self-containment has a number of drawbacks.
+.Bl -bullet -offset 4n
+.It
 The executable is immune to the benefits of system updates delivered as shared
-objects. The executable therefore, must be rebuilt to take advantage of many
-system improvements.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+objects.
+The executable therefore, must be rebuilt to take advantage of many system
+improvements.
+.It
 The ability of the executable to run on future releases can be compromised.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.It
 The duplication of system implementation details negatively affects system
 performance.
-.RE
-.sp
-.LP
-With Solaris 10, 32-bit system archive libraries are no longer provided.
-Without these libraries, specifically \fBlibc.a\fR, the creation of static
-executables is no longer achievable without specialized system knowledge.
-However, the capability of \fBld\fR to process static linking options, and the
-processing of archive libraries, remains unchanged.
-.SH OPTIONS
+.El
+.Pp
+On illumos, system archive libraries
+.Po
+such as
+.Pa libc.a
+.Pc
+have never been provided.
+Without these libraries, the creation of static executables is not achievable
+without specialized system knowledge.
+However, the capability of
+.Nm
+to process static linking options, and the processing of archive libraries,
+remains.
+.Sh OPTIONS
 The following options are supported.
-.sp
-.ne 2
-.na
-\fB\fB-32\fR | \fB-64\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Pp
+.Bl -tag -width 4n -compact
+.It Fl 32 | 64
 Creates a 32-bit, or 64-bit object.
-.sp
+.Pp
 By default, the class of the object being generated is determined from the
-first \fBELF\fR object processed from the command line. If no objects are
-specified, the class is determined by the first object encountered within the
-first archive processed from the command line. If there are no objects or
-archives, the link-editor creates a 32-bit object.
-.sp
-The \fB-64\fR option is required to create a 64-bit object solely from a
-mapfile.
-.sp
-This \fB-32\fR or \fB-64\fR options can also be used in the rare case of
-linking entirely from an archive that contains a mixture of 32 and 64-bit
-objects. If the first object in the archive is not the class of the object that
-is required to be created, then the \fB-32\fR or \fB-64\fR option can be used
-to direct the link-editor. See \fIThe 32-bit link-editor and 64-bit
-link-editor\fR in \fILinker and Libraries Guide\fR.
-.sp
-Note that for compability with existing Makefiles and scripts, these options
+first
+.Sy ELF
+object processed from the command line.
+If no objects are specified, the class is determined by the first object
+encountered within the first archive processed from the command line.
+If there are no objects or archives, the link-editor creates a 32-bit object.
+.Pp
+The
+.Fl 64
+option is required to create a 64-bit object solely from a mapfile.
+.Pp
+The
+.Fl 32
+or
+.Fl 64
+options can also be used in the rare case of linking entirely from an archive
+that contains a mixture of 32 and 64-bit objects.
+If the first object in the archive is not the class of the object that is
+required to be created, then the
+.Fl 32
+or
+.Fl 64
+option can be used to direct the link-editor.
+See
+.Em The 32-bit link-editor and 64-bit link-editor
+in
+.%T Linker and Libraries Guide .
+.Pp
+Note that for compatibility with existing Makefiles and scripts, these options
 may be given multiple times and may be mixed in the same invocation: the last
-instance wins, so that, for example, \fBld -64 -32 -64 ...\fR gives 64-bit
-output.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.sp .6
-.RS 4n
-In static mode only, produces an executable object file. Undefined references
-are not permitted. This option is the default behavior for static mode. The
-\fB-a\fR option can not be used with the \fB-r\fR option. See \fBStatic
-Executables\fR under DESCRIPTION.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-b\fR\fR
-.ad
-.sp .6
-.RS 4n
-In dynamic mode only, provides no special processing for dynamic executable
-relocations that reference symbols in shared objects. Without the \fB-b\fR
-option, the link-editor applies techniques within a dynamic executable so that
-the text segment can remain read-only. One technique is the creation of special
-position-independent relocations for references to functions that are defined
-in shared objects. Another technique arranges for data objects that are defined
-in shared objects to be copied into the memory image of an executable at
-runtime.
-.sp
-The \fB-b\fR option is intended for specialized dynamic objects and is not
-recommended for general use. Its use suppresses all specialized processing
-required to ensure an object's shareability, and can even prevent the
-relocation of 64-bit executables.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBdirect\fR | \fBnodirect\fR\fR
-.ad
-.sp .6
-.RS 4n
-These options govern direct binding. \fB-B\fR \fBdirect\fR establishes direct
-binding information by recording the relationship between each symbol reference
-together with the dependency that provides the definition. In addition, direct
-binding information is established between each symbol reference and an
-associated definition within the object being created. The runtime linker uses
-this information to search directly for a symbol in the associated object
-rather than to carry out a default symbol search.
-.sp
-Direct binding information can only be established to dependencies specified
-with the link-edit. Thus, you should use the \fB-z\fR \fBdefs\fR option.
-Objects that wish to interpose on symbols in a direct binding environment
-should identify themselves as interposers with the \fB-z\fR \fBinterpose\fR
-option. The use of \fB-B\fR \fBdirect\fR enables \fB-z\fR \fBlazyload\fR for
-all dependencies.
-.sp
-The \fB-B\fR \fBnodirect\fR option prevents any direct binding to the
-interfaces offered by the object being created. The object being created can
-continue to directly bind to external interfaces by specifying the \fB-z\fR
-\fBdirect\fR option. See Appendix D, \fIDirect Bindings,\fR in \fILinker and
-Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBdynamic\fR | \fBstatic\fR\fR
-.ad
-.sp .6
-.RS 4n
-Options governing library inclusion. \fB-B\fR \fBdynamic\fR is valid in dynamic
-mode only. These options can be specified any number of times on the command
-line as toggles: if the \fB-B\fR \fBstatic\fR option is given, no shared
-objects are accepted until \fB-B\fR \fBdynamic\fR is seen. See the \fB-l\fR
+instance wins, so that, for example,
+.Ql ld -64 -32 -64 \&...
+gives 64-bit output.
+.Pp
+.It Fl a
+In static mode only, produces an executable object file.
+Undefined references are not permitted.
+This option is the default behavior for static mode.
+The
+.Fl a
+option can not be used with the
+.Fl r
 option.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBeliminate\fR\fR
-.ad
-.sp .6
-.RS 4n
+See
+.Sx Static Executables
+.Pp
+.It Fl b
+In dynamic mode only, provides no special processing for dynamic executable
+relocations that reference symbols in shared objects.
+Without the
+.Fl b
+option, the link-editor applies techniques within a dynamic executable so that
+the text segment can remain read-only.
+One technique is the creation of special position-independent relocations for
+references to functions that are defined in shared objects.
+Another technique arranges for data objects that are defined in shared objects
+to be copied into the memory image of an executable at runtime.
+.Pp
+The
+.Fl b
+option is intended for specialized dynamic objects and is not recommended for
+general use.
+Its use suppresses all specialized processing required to ensure an object's
+shareability, and can even prevent the relocation of 64-bit executables.
+.Pp
+.It Fl B Cm direct | Fl B Cm nodirect
+These options govern direct binding.
+.Fl B Cm direct
+establishes direct binding information by recording the relationship between
+each symbol reference together with the dependency that provides the
+definition.
+In addition, direct binding information is established between each symbol
+reference and an associated definition within the object being created.
+The runtime linker uses this information to search directly for a symbol in the
+associated object rather than to carry out a default symbol search.
+.Pp
+Direct binding information can only be established to dependencies specified
+with the link-edit.
+Thus, you should use the
+.Fl z Cm defs
+option.
+Objects that wish to interpose on symbols in a direct binding environment
+should identify themselves as interposers with the
+.Fl z Cm interpose
+option.
+The use of
+.Fl B Cm direct
+enables
+.Fl z Cm lazyload
+for all dependencies.
+.Pp
+The
+.Fl B Cm nodirect
+option prevents any direct binding to the interfaces offered by the object
+being created.
+The object being created can continue to directly bind to external interfaces
+by specifying the
+.Fl z Cm direct
+option.
+See Appendix D,
+.Em Direct Bindings ,
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl B Cm dynamic | Fl B Cm static
+Options governing library inclusion.
+.Fl B Cm dynamic
+is valid in dynamic mode only.
+These options can be specified any number of times on the command line as
+toggles: if the
+.Fl B Cm static
+option is given, no shared objects are accepted until
+.Fl B Cm dynamic
+is seen.
+See the
+.Fl l
+option.
+.Pp
+.It Fl B Cm eliminate
 Causes any global symbols, not assigned to a version definition, to be
-eliminated from the symbol table. Version definitions can be supplied by means
-of a \fBmapfile\fR to indicate the global symbols that should remain visible in
-the generated object. This option achieves the same symbol elimination as the
-\fIauto-elimination\fR directive that is available as part of a \fBmapfile\fR
-version definition. This option can be useful when combining versioned and
-non-versioned relocatable objects. See also the \fB-B\fR \fBlocal\fR option and
-the \fB-B\fR \fBreduce\fR option. See \fIDefining Additional Symbols with a
-mapfile\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBgroup\fR\fR
-.ad
-.sp .6
-.RS 4n
-Establishes a shared object and its dependencies as a group. Objects within the
-group are bound to other members of the group at runtime. This mode is similar
-to adding the object to the process by using \fBdlopen\fR(3C) with the
-\fBRTLD_GROUP\fR mode. An object that has an explicit dependency on a object
-identified as a group, becomes a member of the group.
-.sp
-As the group must be self contained, use of the \fB-B\fR \fBgroup\fR option
-also asserts the \fB-z\fR \fBdefs\fR option.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBlocal\fR\fR
-.ad
-.sp .6
-.RS 4n
+eliminated from the symbol table.
+Version definitions can be supplied by means of a
+.Sy mapfile
+to indicate the global symbols that should remain visible in the generated
+object.
+This option achieves the same symbol elimination as the
+.Em auto-elimination
+directive that is available as part of a mapfile version definition.
+This option can be useful when combining versioned and non-versioned
+relocatable objects.
+See also the
+.Fl B Cm local
+and
+.Fl B Cm reduce
+options.
+See
+.Em Defining Additional Symbols with a mapfile
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl B Cm group
+Establishes a shared object and its dependencies as a group.
+Objects within the group are bound to other members of the group at runtime.
+This mode is similar to adding the object to the process by using
+.Xr dlopen 3C
+with the
+.Dv RTLD_GROUP
+mode.
+An object that has an explicit dependency on a object identified as a group,
+becomes a member of the group.
+.Pp
+As the group must be self contained, use of the
+.Fl B Cm group
+option also asserts the
+.Fl z Cm defs
+option.
+.Pp
+.It Fl B Cm local
 Causes any global symbols, not assigned to a version definition, to be reduced
-to local. Version definitions can be supplied by means of a \fBmapfile\fR to
-indicate the global symbols that should remain visible in the generated object.
-This option achieves the same symbol reduction as the \fIauto-reduction\fR
-directive that is available as part of a \fBmapfile\fR version definition. This
-option can be useful when combining versioned and non-versioned relocatable
-objects. See also the \fB-B\fR \fBeliminate\fR option and the \fB-B\fR
-\fBreduce\fR option. See \fIDefining Additional Symbols with a mapfile\fR in
-\fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBreduce\fR\fR
-.ad
-.sp .6
-.RS 4n
+to local.
+Version definitions can be supplied by means of a
+.Sy mapfile
+to indicate the global symbols that should remain visible in the generated
+object.
+This option achieves the same symbol reduction as the
+.Ar auto-reduction
+directive that is available as part of a mapfile version definition.
+This option can be useful when combining versioned and non-versioned
+relocatable objects.
+See also the
+.Fl B Cm eliminate
+and
+.Fl B Cm reduce
+options.
+See
+.Em Defining Additional Symbols with a mapfile
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl B Cm reduce
 When generating a relocatable object, causes the reduction of symbolic
-information defined by any version definitions. Version definitions can be
-supplied by means of a \fBmapfile\fR to indicate the global symbols that should
-remain visible in the generated object. By default, when a relocatable object
-is generated, version definitions are only recorded in the output image. The
-actual reduction of symbolic information is carried out when the object is used
-in the construction of a dynamic executable or shared object. The \fB-B\fR
-\fBreduce\fR option is applied automatically when a dynamic executable or
-shared object is created.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-B\fR \fBsymbolic\fR\fR
-.ad
-.sp .6
-.RS 4n
-In dynamic mode only. When building a shared object, binds references to global
-symbols to their definitions, if available, within the object. Normally,
-references to global symbols within shared objects are not bound until runtime,
-even if definitions are available. This model allows definitions of the same
-symbol in an executable or other shared object to override the object's own
-definition. \fBld\fR issues warnings for undefined symbols unless \fB-z\fR
-\fBdefs\fR overrides.
-.sp
-The \fB-B\fR \fBsymbolic\fR option is intended for specialized dynamic objects
-and is not recommended for general use. To reduce the runtime relocation
-processing that is required an object, the creation of a version definition is
-recommended.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-c\fR \fIname\fR\fR
-.ad
-.sp .6
-.RS 4n
-Records the configuration file \fIname\fR for use at runtime. Configuration
-files can be employed to alter default search paths, provide a directory cache,
-together with providing alternative object dependencies. See \fBcrle\fR(1).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-C\fR\fR
-.ad
-.sp .6
-.RS 4n
+information defined by any version definitions.
+Version definitions can be supplied by means of a
+.Sy mapfile
+to indicate the global symbols that should remain visible in the generated
+object.
+By default, when a relocatable object is generated, version definitions are
+only recorded in the output image.
+The actual reduction of symbolic information is carried out when the object is
+used in the construction of a dynamic executable or shared object.
+The
+.Fl B Cm reduce
+option is applied automatically when a dynamic executable or shared object is
+created.
+.Pp
+.It Fl B Cm symbolic
+In dynamic mode only.
+When building a shared object, binds references to global symbols to their
+definitions, if available, within the object.
+Normally, references to global symbols within shared objects are not bound
+until runtime, even if definitions are available.
+This model allows definitions of the same symbol in an executable or other
+shared object to override the object's own definition.
+.Nm
+issues warnings for undefined symbols unless
+.Fl z Cm defs
+overrides.
+.Pp
+The
+.Fl B Cm symbolic
+option is intended for specialized dynamic objects and is not recommended for
+general use.
+To reduce the runtime relocation processing that is required an object, the
+creation of a version definition is recommended.
+.Fl c Ar name
+records the configuration file
+.Ar name
+for use at runtime.
+Configuration files can be employed to alter default search paths, provide a
+directory cache, together with providing alternative object dependencies.
+See
+.Xr crle 1 .
+.Pp
+.It Fl C
 Demangles C++ symbol names displayed in diagnostic messages.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-d\fR \fBy\fR | \fBn\fR\fR
-.ad
-.sp .6
-.RS 4n
-When \fB-d\fR \fBy\fR, the default, is specified, \fBld\fR uses dynamic
-linking. When \fB-d\fR \fBn\fR is specified, \fBld\fR uses static linking. See
-\fBStatic Executables\fR under DESCRIPTION, and \fB-B\fR
-\fBdynamic\fR|\fBstatic\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-D\fR \fItoken\fR,...\fR
-.ad
-.sp .6
-.RS 4n
-Prints debugging information as specified by each \fItoken\fR, to the standard
-error. The special token \fBhelp\fR indicates the full list of tokens
-available. See \fIDebugging Aids\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-e\fR \fIepsym\fR\fR
-.ad
-.br
-.na
-\fB\fB--entry\fR \fIepsym\fR\fR
-.ad
-.sp .6
-.RS 4n
-Sets the entry point address for the output file to be the symbol \fIepsym\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-f\fR \fIname\fR\fR
-.ad
-.br
-.na
-\fB\fB--auxiliary\fR \fIname\fR\fR
-.ad
-.sp .6
-.RS 4n
-Useful only when building a shared object. Specifies that the symbol table of
-the shared object is used as an auxiliary filter on the symbol table of the
-shared object specified by \fIname\fR. Multiple instances of this option are
-allowed. This option can not be combined with the \fB-F\fR option. See
-\fIGenerating Auxiliary Filters\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-F\fR \fIname\fR\fR
-.ad
-.br
-.na
-\fB\fB--filter\fR \fIname\fR\fR
-.ad
-.sp .6
-.RS 4n
-Useful only when building a shared object. Specifies that the symbol table of
-the shared object is used as a filter on the symbol table of the shared object
-specified by \fIname\fR. Multiple instances of this option are allowed. This
-option can not be combined with the \fB-f\fR option. See \fIGenerating Standard
-Filters\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-G\fR\fR
-.ad
-.br
-.na
-\fB\fB-shared\fR\fR
-.ad
-.sp .6
-.RS 4n
-In dynamic mode only, produces a shared object. Undefined symbols are allowed.
-See Chapter 4, \fIShared Objects,\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-h\fR \fIname\fR\fR
-.ad
-.br
-.na
-\fB\fB-soname\fR \fIname\fR\fR
-.ad
-.sp .6
-.RS 4n
-In dynamic mode only, when building a shared object, records \fIname\fR in the
-object's dynamic section. \fIname\fR is recorded in any dynamic objects that
-are linked with this object rather than the object's file system name.
-Accordingly, \fIname\fR is used by the runtime linker as the name of the shared
-object to search for at runtime. See \fIRecording a Shared Object Name\fR in
-\fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-i\fR\fR
-.ad
-.sp .6
-.RS 4n
-Ignores \fBLD_LIBRARY_PATH\fR. This option is useful when an
-\fBLD_LIBRARY_PATH\fR setting is in effect to influence the runtime library
-search, which would interfere with the link-editing being performed.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-I\fR \fIname\fR\fR
-.ad
-.br
-.na
-\fB\fB--dynamic-linker\fR \fIname\fR\fR
-.ad
-.sp .6
-.RS 4n
-When building an executable, uses \fIname\fR as the path name of the
-interpreter to be written into the program header. The default in static mode
-is no interpreter. In dynamic mode, the default is the name of the runtime
-linker, \fBld.so.1\fR(1). Either case can be overridden by \fB-I\fR \fIname\fR.
-\fBexec\fR(2) loads this interpreter when the \fBa.out\fR is loaded, and passes
-control to the interpreter rather than to the \fBa.out\fR directly.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-l\fR \fIx\fR\fR
-.ad
-.br
-.na
-\fB\fB--library\fR \fIx\fR\fR
-.ad
-.sp .6
-.RS 4n
-Searches a library \fBlib\fR\fIx\fR\fB\&.so\fR or \fBlib\fR\fIx\fR\fB\&.a\fR,
+.Pp
+.It Fl d Cm y | Fl d Cm n
+When
+.Fl d Cm y ,
+the default, is specified,
+.Nm
+uses dynamic linking.
+When
+.Fl d Cm n
+is specified,
+.Nm
+uses static linking.
+See
+.Sx Static Executables
+and
+.Fl B Cm dynamic | Fl B Cm static .
+.Pp
+.It Fl D Ar token Ns \&,...
+Prints debugging information as specified by each
+.Ar token
+to the standard error.
+The special token
+.Cm help
+indicates the full list of tokens available.
+See
+.Em Debugging Aids
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl e Ar epsym
+.It Fl \&-entry Ar epsym
+Sets the entry point address for the output file to be the symbol
+.Ar epsym .
+.Pp
+.It Fl f Ar name
+.It Fl \&-auxiliary Ar name
+Useful only when building a shared object.
+Specifies that the symbol table of the shared object is used as an auxiliary
+filter on the symbol table of the shared object specified by
+.Ar name .
+Multiple instances of this option are allowed.
+This option can not be combined with the
+.Fl F
+option.
+See
+.Em Generating Auxiliary Filters
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl F Ar name
+.It Fl \&-filter Ar name
+Useful only when building a shared object.
+Specifies that the symbol table of the shared object is used as a filter on the
+symbol table of the shared object specified by
+.Ar name .
+Multiple instances of this option are allowed.
+This option cannot be combined with the
+.Fl f
+option.
+See
+.Em Generating Standard Filters
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl G
+.It Fl shared
+In dynamic mode only, produces a shared object.
+Undefined symbols are allowed.
+See Chapter 4,
+.Em Shared Objects ,
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl h Ar name
+.It Fl soname Ar name
+In dynamic mode only, when building a shared object, records
+.Ar name
+in the object's dynamic section.
+.Ar name
+is recorded in any dynamic objects that are linked with this object rather than
+the object's file system name.
+Accordingly,
+.Ar name
+is used by the runtime linker as the name of the shared object to search for at
+runtime.
+See
+.Em Recording a Shared Object Name
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl i
+Ignores
+.Ev LD_LIBRARY_PATH .
+This option is useful when an
+.Ev LD_LIBRARY_PATH
+setting is in effect to influence the runtime library search, which would
+interfere with the link-editing being performed.
+.Pp
+.It Fl I Ar name
+.It Fl \&-dynamic-linker Ar name
+When building an executable, uses
+.Ar name
+as the path name of the interpreter to be written into the program header.
+The default in static mode is no interpreter.
+In dynamic mode, the default is the name of the runtime linker,
+.Xr ld.so.1 1 .
+Either case can be overridden by
+.Fl I Ar name .
+.Xr exec 2
+loads this interpreter when the
+.Pa a.out
+is loaded, and passes control to the interpreter rather than to the
+.Pa a.out
+directly.
+.Pp
+.It Fl l Ar x
+.It Fl \&-library Ar x
+Searches a library
+.Sy lib Ns Ar x Ns Sy .so
+or
+.Sy lib Ns Ar x Ns Sy .a ,
 the conventional names for shared object and archive libraries, respectively.
-In dynamic mode, unless the \fB-B\fR \fBstatic\fR option is in effect, \fBld\fR
+In dynamic mode, unless the
+.Fl B Cm static
+option is in effect,
+.Nm
 searches each directory specified in the library search path for a
-\fBlib\fR\fIx\fR\fB\&.so\fR or \fBlib\fR\fIx\fR\fB\&.a\fR file. The directory
-search stops at the first directory containing either. \fBld\fR chooses the
-file ending in \fB\&.so\fR if \fB-l\fR\fIx\fR expands to two files with names
-of the form \fBlib\fR\fIx\fR\fB\&.so\fR and \fBlib\fR\fIx\fR\fB\&.a\fR. If no
-\fBlib\fR\fIx\fR\fB\&.so\fR is found, then \fBld\fR accepts
-\fBlib\fR\fIx\fR\fB\&.a\fR. In static mode, or when the \fB-B\fR \fBstatic\fR
-option is in effect, \fBld\fR selects only the file ending in \fB\&.a\fR.
-\fBld\fR searches a library when the library is encountered, so the placement
-of \fB-l\fR is significant. See \fILinking With Additional Libraries\fR in
-\fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-L\fR \fIpath\fR\fR
-.ad
-.br
-.na
-\fB\fB--library-path\fR \fIpath\fR\fR
-.ad
-.sp .6
-.RS 4n
-Adds \fIpath\fR to the library search directories. \fBld\fR searches for
-libraries first in any directories specified by the \fB-L\fR options and then
-in the standard directories. This option is useful only if the option precedes
-the \fB-l\fR options to which the \fB-L\fR option applies. See \fIDirectories
-Searched by the Link-Editor\fR in \fILinker and Libraries Guide\fR.
-.sp
-The environment variable \fBLD_LIBRARY_PATH\fR can be used to supplement the
-library search path, however the \fB-L\fR option is recommended, as the
-environment variable is also interpreted by the runtime environment. See
-\fBLD_LIBRARY_PATH\fR under ENVIRONMENT VARIABLES.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-m\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Sy lib Ns Ar x Ns Sy .so
+or
+.Sy lib Ns Ar x Ns Sy \&.a .
+The directory search stops at the first directory containing either.
+.Nm
+chooses the file ending in
+.Sy .so
+if
+.Fl l Ar x
+expands to two files with names of the form
+.Sy lib Ns Ar x Ns Sy .so
+and
+.Sy lib Ns Ar x Ns Sy .a .
+If no
+.Sy lib Ns Ar x Ns Sy .so
+is found, then
+.Nm
+accepts
+.Sy lib Ns Ar x Ns Sy .a .
+In static mode, or when the
+.Fl B Cm static
+option is in effect,
+.Nm
+selects only the file ending in
+.Sy .a .
+.Nm
+searches a library when the library is encountered, so the placement of
+.Fl l
+is significant.
+See
+.Em Linking With Additional Libraries
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl L Ar path
+.It Fl \&-library-path Ar path
+Adds
+.Ar path
+to the library search directories.
+.Nm
+searches for libraries first in any directories specified by the
+.Fl L
+options and then in the standard directories.
+This option is useful only if the option precedes the
+.Fl l
+options to which the
+.Fl L
+option applies.
+See
+.Em Directories Searched by the Link-Editor
+in
+.%T Linker and Libraries Guide .
+.Pp
+The environment variable
+.Ev LD_LIBRARY_PATH
+can be used to supplement the library search path, however the
+.Fl L
+option is recommended, as the environment variable is also interpreted by the
+runtime environment.
+See
+.Ev LD_LIBRARY_PATH
+under
+.Sx ENVIRONMENT .
+.Pp
+.It Fl m
 Produces a memory map or listing of the input/output sections, together with
 any non-fatal multiply-defined symbols, on the standard output.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-M\fR \fImapfile\fR\fR
-.ad
-.sp .6
-.RS 4n
-Reads \fImapfile\fR as a text file of directives to \fBld\fR. This option can
-be specified multiple times. If \fImapfile\fR is a directory, then all regular
-files, as defined by \fBstat\fR(2), within the directory are processed. See
-Chapter 9, \fIMapfile Option,\fR in \fILinker and Libraries Guide\fR. Example
-mapfiles are provided in \fB/usr/lib/ld\fR. See FILES.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-N\fR \fIstring\fR\fR
-.ad
-.sp .6
-.RS 4n
-This option causes a \fBDT_NEEDED\fR entry to be added to the \fB\&.dynamic\fR
-section of the object being built. The value of the \fBDT_NEEDED\fR string is
-the \fIstring\fR that is specified on the command line. This option is position
-dependent, and the \fBDT_NEEDED\fR \fB\&.dynamic\fR entry is relative to the
-other dynamic dependencies discovered on the link-edit line. This option is
-useful for specifying dependencies within device driver relocatable objects
-when combined with the \fB-dy\fR and \fB-r\fR options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-o\fR \fIoutfile\fR\fR
-.ad
-.br
-.na
-\fB\fB--output\fR \fIoutfile\fR\fR
-.ad
-.sp .6
-.RS 4n
-Produces an output object file that is named \fIoutfile\fR. The name of the
-default object file is \fBa.out\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR \fIauditlib\fR\fR
-.ad
-.sp .6
-.RS 4n
-Identifies an audit library, \fIauditlib\fR. This audit library is used to
-audit the object being created at runtime. A shared object identified as
-requiring auditing with the \fB-p\fR option, has this requirement inherited by
-any object that specifies the shared object as a dependency. See the \fB-P\fR
-option. See \fIRuntime Linker Auditing Interface\fR in \fILinker and Libraries
-Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-P\fR \fIauditlib\fR\fR
-.ad
-.sp .6
-.RS 4n
-Identifies an audit library, \fIauditlib\fR. This audit library is used to
-audit the dependencies of the object being created at runtime. Dependency
-auditing can also be inherited from dependencies that are identified as
-requiring auditing. See the \fB-p\fR option, and the \fB-z\fR \fBglobalaudit\fR
-option. See \fIRuntime Linker Auditing Interface\fR in \fILinker and Libraries
-Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-Q\fR \fBy\fR | \fBn\fR\fR
-.ad
-.sp .6
-.RS 4n
-Under \fB-Q\fR \fBy\fR, an \fBident\fR string is added to the \fB\&.comment\fR
-section of the output file. This string identifies the version of the \fBld\fR
-used to create the file. This results in multiple \fBld\fR \fBidents\fR when
-there have been multiple linking steps, such as when using \fBld\fR \fB-r\fR.
-This identification is identical with the default action of the \fBcc\fR
-command. \fB-Q\fR \fBn\fR suppresses version identification. \fB\&.comment\fR
-sections can be manipulated by the \fBmcs\fR(1) utility.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.br
-.na
-\fB\fB--relocatable\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Pp
+.It Fl M Ar mapfile
+Reads
+.Ar mapfile
+as a text file of directives to
+.Nm .
+This option can be specified multiple times.
+If
+.Ar mapfile
+is a directory, then all regular files, as defined by
+.Xr stat 2 ,
+within the directory are processed.
+See Chapter 9,
+.Em Mapfile Option ,
+in
+.%T Linker and Libraries Guide .
+Example mapfiles are provided in
+.Pa /usr/lib/ld .
+See
+.Sx FILES .
+.Pp
+.It Fl N Ar string
+This option causes a
+.Dv DT_NEEDED
+entry to be added to the
+.Sy .dynamic
+section of the object being built.
+The value of the
+.Dv DT_NEEDED
+string is the
+.Ar string
+that is specified on the command line.
+This option is position dependent, and the
+.Dv DT_NEEDED
+.Sy .dynamic
+entry is relative to the other dynamic dependencies discovered on the link-edit
+line.
+This option is useful for specifying dependencies within device driver
+relocatable objects when combined with the
+.Fl d Cm y
+and
+.Fl r
+options.
+.Pp
+.It Fl o Ar outfile
+.It Fl \&-output Ar outfile
+Produces an output object file that is named
+.Ar outfile .
+The name of the default object file is
+.Pa a.out .
+.Pp
+.It Fl p Ar auditlib
+Identifies an audit library,
+.Ar auditlib .
+This audit library is used to audit the object being created at runtime.
+A shared object identified as requiring auditing with the
+.Fl p
+option, has this requirement inherited by any object that specifies the shared
+object as a dependency.
+See the
+.Fl P
+option.
+See
+.Em Runtime Linker Auditing Interface
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl P Ar auditlib
+Identifies an audit library,
+.Ar auditlib .
+This audit library is used to audit the dependencies of the object being
+created at runtime.
+Dependency auditing can also be inherited from dependencies that are identified
+as requiring auditing.
+See the
+.Fl p
+and
+.Fl z Cm globalaudit
+options.
+See
+.Em Runtime Linker Auditing Interface
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl Q Cm y | Fl Q Cm n
+Under
+.Fl Q Cm y ,
+an
+.Sy ident
+string is added to the
+.Sy .comment
+section of the output file.
+This string identifies the version of the
+.Nm
+used to create the file.
+This results in multiple
+.Nm
+idents when there have been multiple linking steps, such as when using
+.Nm Fl r .
+This identification is identical with the default action of the
+.Xr cc 1
+command.
+.Fl Q Cm n
+suppresses version identification.
+.Sy .comment
+sections can be manipulated by the
+.Xr mcs 1
+utility.
+.Pp
+.It Fl r
+.It Fl \&-relocatable
 Combines relocatable object files to produce one relocatable object file.
-\fBld\fR does not complain about unresolved references. This option cannot be
-used with the \fB-a\fR option.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-R\fR \fIpath\fR\fR
-.ad
-.br
-.na
-\fB\fB-rpath\fR \fIpath\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Nm
+does not complain about unresolved references.
+This option cannot be used with the
+.Fl a
+option.
+.Pp
+.It Fl R Ar path
+.It Fl rpath Ar path
 A colon-separated list of directories used to specify library search
-directories to the runtime linker. If present and not NULL, the path is
-recorded in the output object file and passed to the runtime linker. Multiple
-instances of this option are concatenated together with each \fIpath\fR
-separated by a colon. See \fIDirectories Searched by the Runtime Linker\fR in
-\fILinker and Libraries Guide\fR.
-.sp
+directories to the runtime linker.
+If present and not NULL, the path is recorded in the output object file and
+passed to the runtime linker.
+Multiple instances of this option are concatenated together with each
+.Ar path
+separated by a colon.
+See
+.Em Directories Searched by the Runtime Linker
+in
+.%T Linker and Libraries Guide .
+.Pp
 The use of a runpath within an associated object is preferable to setting
-global search paths such as through the \fBLD_LIBRARY_PATH\fR environment
-variable. Only the runpaths that are necessary to find the objects dependencies
-should be recorded. \fBldd\fR(1) can also be used to discover unused runpaths
-in dynamic objects, when used with the \fB-U\fR option.
-.sp
+global search paths such as through the
+.Ev LD_LIBRARY_PATH
+environment variable.
+Only the runpaths that are necessary to find the objects dependencies should be
+recorded.
+.Xr ldd 1
+can also be used to discover unused runpaths in dynamic objects, when used with
+the
+.Fl U
+option.
+.Pp
 Various tokens can also be supplied with a runpath that provide a flexible
-means of identifying system capabilities or an objects location. See Appendix
-C, \fIEstablishing Dependencies with Dynamic String Tokens,\fR in \fILinker and
-Libraries Guide\fR. The \fB$ORIGIN\fR token is especially useful in allowing
-dynamic objects to be relocated to different locations in the file system.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR\fR
-.ad
-.br
-.na
-\fB\fB--strip-all\fR\fR
-.ad
-.sp .6
-.RS 4n
-Strips symbolic information from the output file. Any debugging information,
-that is, \fB\&.line\fR, \fB\&.debug*\fR, and \fB\&.stab*\fR sections, and their
-associated relocation entries are removed. Except for relocatable files, a
-symbol table \fBSHT_SYMTAB\fR and its associated string table section are not
-created in the output object file. The elimination of a \fBSHT_SYMTAB\fR symbol
-table can reduce the \fB\&.stab*\fR debugging information that is generated
-using the compiler drivers \fB-g\fR option. See the \fB-z\fR \fBredlocsym\fR
-and \fB-z\fR \fBnoldynsym\fR options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-S\fR \fIsupportlib\fR\fR
-.ad
-.sp .6
-.RS 4n
-The shared object \fIsupportlib\fR is loaded with \fBld\fR and given
-information regarding the linking process. Shared objects that are defined by
-using the \fB-S\fR option can also be supplied using the \fBSGS_SUPPORT\fR
-environment variable. See \fILink-Editor Support Interface\fR in \fILinker and
-Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-t\fR\fR
-.ad
-.sp .6
-.RS 4n
+means of identifying system capabilities or an objects location.
+See Appendix C,
+.Em Establishing Dependencies with Dynamic String Tokens ,
+in
+.%T Linker and Libraries Guide .
+The
+.Sy $ORIGIN
+token is especially useful in allowing dynamic objects to be relocated to
+different locations in the file system.
+.Pp
+.It Fl s
+.It Fl \&-strip-all
+Strips symbolic information from the output file.
+Any debugging information,
+that is,
+.Sy .line ,
+.Sy .debug* ,
+and
+.Sy .stab*
+sections, and their associated relocation entries are removed.
+Except for relocatable files, a symbol table
+.Dv SHT_SYMTAB
+and its associated string table section are not created in the output object
+file.
+The elimination of a
+.Dv SHT_SYMTAB
+symbol table can reduce the .stab* debugging information that is generated
+using the compiler driver's
+.Fl g
+option.
+See the
+.Fl z Cm redlocsym
+and
+.Fl z Cm noldynsym
+options.
+.Pp
+.It Fl S Ar supportlib
+The shared object
+.Ar supportlib
+is loaded with
+.Nm
+and given information regarding the linking process.
+Shared objects that are defined by using the
+.Fl S
+option can also be supplied using the
+.Ev SGS_SUPPORT
+environment variable.
+See
+.Em Link-Editor Support Interface
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl t
 Turns off the warning for multiply-defined symbols that have different sizes or
 different alignments.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-u\fR \fIsymname\fR\fR
-.ad
-.br
-.na
-\fB\fB--undefined\fR \fIsymname\fR\fR
-.ad
-.sp .6
-.RS 4n
-Enters \fIsymname\fR as an undefined symbol in the symbol table. This option is
-useful for loading entirely from an archive library. In this instance, an
-unresolved reference is needed to force the loading of the first routine. The
-placement of this option on the command line is significant. This option must
-be placed before the library that defines the symbol. See \fIDefining
-Additional Symbols with the u option\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-V\fR\fR
-.ad
-.br
-.na
-\fB\fB--version\fR\fR
-.ad
-.sp .6
-.RS 4n
-Outputs a message giving information about the version of \fBld\fR being used.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-Y\fR \fBP,\fR\fIdirlist\fR\fR
-.ad
-.sp .6
-.RS 4n
-Changes the default directories used for finding libraries. \fIdirlist\fR is a
-colon-separated path list.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBabsexec\fR\fR
-.ad
-.sp .6
-.RS 4n
-Useful only when building a dynamic executable. Specifies that references to
-external absolute symbols should be resolved immediately instead of being left
-for resolution at runtime. In very specialized circumstances, this option
-removes text relocations that can result in excessive swap space demands by an
-executable.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBallextract\fR | \fBdefaultextract\fR | \fBweakextract\fR\fR
-.ad
-.br
-.na
-\fB\fB--whole-archive\fR | \fB--no-whole-archive\fR\fR
-.ad
-.sp .6
-.RS 4n
-Alters the extraction criteria of objects from any archives that follow. By
-default, archive members are extracted to satisfy undefined references and to
-promote tentative definitions with data definitions. Weak symbol references do
-not trigger extraction. Under the \fB-z\fR \fBallextract\fR or
-\fB--whole-archive\fR options, all archive members are extracted from the
-archive. Under \fB-z\fR \fBweakextract\fR, weak references trigger archive
-extraction. The \fB-z\fR \fBdefaultextract\fR or \fB--no-whole-archive\fR
+.Pp
+.It Fl u Ar symname
+.It Fl \&-undefined Ar symname
+Enters
+.Ar symname
+as an undefined symbol in the symbol table.
+This option is useful for loading entirely from an archive library.
+In this instance, an unresolved reference is needed to force the loading of the
+first routine.
+The placement of this option on the command line is significant.
+This option must be placed before the library that defines the symbol.
+See
+.Em Defining Additional Symbols with the u option
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl V
+.It Fl \&-version
+Outputs a message giving information about the version of
+.Nm
+being used.
+.Pp
+.It Fl Y Cm P\&, Ns Ar dirlist
+Changes the default directories used for finding libraries.
+.Ar dirlist
+is a colon-separated path list.
+.Pp
+.It Fl z Cm absexec
+Useful only when building a dynamic executable.
+Specifies that references to external absolute symbols should be resolved
+immediately instead of being left for resolution at runtime.
+In very specialized circumstances, this option removes text relocations that
+can result in excessive swap space demands by an executable.
+.Pp
+.It Fl z Cm allextract | Fl z Cm defaultextract | Fl z Cm weakextract
+.It Fl \&-whole-archive | \&-no-whole-archive
+Alters the extraction criteria of objects from any archives that follow.
+By default, archive members are extracted to satisfy undefined references and
+to promote tentative definitions with data definitions.
+Weak symbol references do not trigger extraction.
+Under the
+.Fl z Cm allextract
+or
+.Fl \&-whole-archive
+options, all archive members are extracted from the archive.
+Under
+.Fl z Cm weakextract ,
+weak references trigger archive extraction.
+The
+.Fl z Cm defaultextract
+or
+.Fl \&-no-whole-archive
 options provide a means of returning to the default following use of the former
-extract options. See \fIArchive Processing\fR in \fILinker and Libraries
-Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBaltexec64\fR\fR
-.ad
-.sp .6
-.RS 4n
-Execute the 64-bit \fBld\fR. The creation of very large 32-bit objects can
-exhaust the virtual memory that is available to the 32-bit \fBld\fR. The
-\fB-z\fR \fBaltexec64\fR option can be used to force the use of the associated
-64-bit \fBld\fR. The 64-bit \fBld\fR provides a larger virtual address space
-for building 32-bit objects. See \fIThe 32-bit link-editor and 64-bit
-link-editor\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB-z\fR \fBaslr[=\fIstate\fR]\fR
-.ad
-.sp .6
-.RS 4n
+extract options.
+See
+.Em Archive Processing
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm altexec64
+Execute the 64-bit
+.Nm .
+The creation of very large 32-bit objects can exhaust the virtual memory that
+is available to the 32-bit
+.Nm .
+The
+.Fl z Cm altexec64
+option can be used to force the use of the associated 64-bit
+.Nm .
+The 64-bit
+.Nm
+provides a larger virtual address space for building 32-bit objects.
+See
+.Em The 32-bit link-editor and 64-bit link-editor
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm aslr Ns Op Cm \&= Ns Ar state
 Specify whether the executable's address space should be randomized on
-execution.  If \fIstate\fR is "enabled" randomization will always occur when
-this executable is run (regardless of inherited settings).  If \fIstate\fR is
-"disabled" randomization will never occur when this executable is run.  If
-\fIstate\fR is omitted, ASLR is enabled.
-
+execution.
+If
+.Ar state
+is
+.Cm enabled ,
+randomization will always occur when this executable is run
+.Pq regardless of inherited settings .
+If
+.Ar state
+is
+.Cm disabled ,
+randomization will never occur when this executable is run.
+If
+.Ar state
+is omitted, ASLR is enabled.
 An executable that should simply use the settings inherited from its
 environment should not use this flag at all.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBcombreloc\fR | \fBnocombreloc\fR\fR
-.ad
-.sp .6
-.RS 4n
-By default, \fBld\fR combines multiple relocation sections when building
-executables or shared objects. This section combination differs from
-relocatable objects, in which relocation sections are maintained in a
-one-to-one relationship with the sections to which the relocations must be
-applied. The \fB-z\fR \fBnocombreloc\fR option disables this merging of
-relocation sections, and preserves the one-to-one relationship found in the
-original relocatable objects.
-.sp
-\fBld\fR sorts the entries of data relocation sections by their symbol
-reference. This sorting reduces runtime symbol lookup. When multiple relocation
-sections are combined, this sorting produces the least possible relocation
-overhead when objects are loaded into memory, and speeds the runtime loading of
-dynamic objects.
-.sp
+.Pp
+.It Fl z Cm combreloc | Fl z Cm nocombreloc
+By default,
+.Nm
+combines multiple relocation sections when building executables or shared
+objects.
+This section combination differs from relocatable objects, in which relocation
+sections are maintained in a one-to-one relationship with the sections to which
+the relocations must be applied.
+The
+.Fl z Cm nocombreloc
+option disables this merging of relocation sections, and preserves the
+one-to-one relationship found in the original relocatable objects.
+.Pp
+.Nm
+sorts the entries of data relocation sections by their symbol reference.
+This sorting reduces runtime symbol lookup.
+When multiple relocation sections are combined, this sorting produces the least
+possible relocation overhead when objects are loaded into memory, and speeds
+the runtime loading of dynamic objects.
+.Pp
 Historically, the individual relocation sections were carried over to any
-executable or shared object, and the \fB-z\fR \fBcombreloc\fR option was
-required to enable the relocation section merging previously described.
-Relocation section merging is now the default. The \fB-z\fR \fBcombreloc\fR
+executable or shared object, and the
+.Fl z Cm combreloc
+option was required to enable the relocation section merging previously
+described.
+Relocation section merging is now the default.
+The
+.Fl z Cm combreloc
 option is still accepted for the benefit of old build environments, but the
 option is unnecessary, and has no effect.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBassert-deflib\fR\fR
-.ad
-.br
-.na
-\fB\fB-z\fR \fBassert-deflib=\fR\fIlibname\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Pp
+.It Fl z Cm assert-deflib
+.It Fl z Cm assert-deflib= Ns Ar libname
 Enables warnings that check the location of where libraries passed in with
-\fB-l\fR are found. If the link-editor finds a library on its default search
-path it will emit a warning. This warning can be made fatal in conjunction with
-the option \fB-z fatal-warnings\fR. Passing \fIlibname\fR white lists a library
-from this check. The library must be the full name of the library, e.g.
-\fIlibc.so\fR. To white list multiple libraries, the \fB-z
-assert-deflib=\fR\fIlibname\fR option can be repeated multiple times. This
-option is useful when trying to build self-contained objects where a referenced
-library might exist in the default system library path and in alternate paths
-specified by \fB-L\fR, but you only want the alternate paths to be used.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBdefs\fR | \fBnodefs\fR\fR
-.ad
-.br
-.na
-\fB\fB--no-undefined\fR\fR
-.ad
-.sp .6
-.RS 4n
-The \fB-z\fR \fBdefs\fR option and the \fB--no-undefined\fR option force a
-fatal error if any undefined symbols remain at the end of the link. This mode
-is the default when an executable is built. For historic reasons, this mode is
-\fBnot\fR the default when building a shared object. Use of the \fB-z\fR
-\fBdefs\fR option is recommended, as this mode assures the object being built
-is self-contained. A self-contained object has all symbolic references resolved
-internally, or to the object's immediate dependencies.
-.sp
-The \fB-z\fR \fBnodefs\fR option allows undefined symbols. For historic
-reasons, this mode is the default when a shared object is built. When used with
-executables, the behavior of references to such undefined symbols is
-unspecified. Use of the \fB-z\fR \fBnodefs\fR option is not recommended.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBdirect\fR | \fBnodirect\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Fl l
+are found.
+If the link-editor finds a library on its default search path it will emit a
+warning.
+This warning can be made fatal in conjunction with the option
+.Fl z Cm fatal-warnings .
+Passing
+.Ar libname
+white lists a library from this check.
+The library must be the full name of the library, e.g.
+.Pa libc.so .
+To white list multiple libraries, the
+.Fl z Cm assert-deflib= Ns Ar libname
+option can be repeated multiple times.
+This option is useful when trying to build self-contained objects where a
+referenced library might exist in the default system library path and in
+alternate paths specified by
+.Fl L ,
+but you only want the alternate paths to be used.
+.Pp
+.It Fl z Cm defs | Fl z Cm nodefs
+.It Fl \&-no-undefined
+The
+.Fl z Cm defs
+option and the
+.Fl \&-no-undefined
+option force a fatal error if any undefined symbols remain at the end of the
+link.
+This mode is the default when an executable is built.
+For historic reasons, this mode is
+.Em not
+the default when building a shared object.
+Use of the
+.Fl z Cm defs
+option is recommended, as this mode assures the object being built is
+self-contained.
+A self-contained object has all symbolic references resolved internally, or to
+the object's immediate dependencies.
+.Pp
+The
+.Fl z Cm nodefs
+option allows undefined symbols.
+For historic reasons, this mode is the default when a shared object is built.
+When used with executables, the behavior of references to such undefined
+symbols is unspecified.
+Use of the
+.Fl z Cm nodefs
+option is not recommended.
+.Pp
+.It Fl z Cm direct | Fl z Cm nodirect
 Enables or disables direct binding to any dependencies that follow on the
-command line. These options allow finer control over direct binding than the
-global counterpart \fB-B\fR \fBdirect\fR. The \fB-z\fR \fBdirect\fR option also
-differs from the \fB-B\fR \fBdirect\fR option in the following areas. Direct
-binding information is not established between a symbol reference and an
-associated definition within the object being created. Lazy loading is not
-enabled.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBendfiltee\fR\fR
-.ad
-.sp .6
-.RS 4n
+command line.
+These options allow finer control over direct binding than the global
+counterpart
+.Fl B Cm direct .
+The
+.Fl z Cm direct
+option also differs from the
+.Fl B Cm direct
+option in the following areas.
+Direct binding information is not established between a symbol reference and an
+associated definition within the object being created.
+Lazy loading is not enabled.
+.Pp
+.It Fl z Cm endfiltee
 Marks a filtee so that when processed by a filter, the filtee terminates any
-further filtee searches by the filter. See \fIReducing Filtee Searches\fR in
-\fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBfatal-warnings\fR | \fBnofatal-warnings\fR\fR
-.ad
-.br
-.na
-\fB\fB--fatal-warnings\fR | \fB--no-fatal-warnings\fR
-.ad
-.sp .6
-.RS 4n
-Controls the behavior of warnings emitted from the link-editor. Setting \fB-z
-fatal-warnings\fR promotes warnings emitted by the link-editor to fatal errors
-that will cause the link-editor to fail before linking. \fB-z
-nofatal-warnings\fR instead demotes these warnings such that they will not cause
-the link-editor to exit prematurely.
-.RE
-
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBfiniarray=\fR\fIfunction\fR\fR
-.ad
-.sp .6
-.RS 4n
-Appends an entry to the \fB\&.fini_array\fR section of the object being built.
-If no \fB\&.fini_array\fR section is present, a section is created. The new
-entry is initialized to point to \fIfunction\fR. See \fIInitialization and
-Termination Sections\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBglobalaudit\fR\fR
-.ad
-.sp .6
-.RS 4n
+further filtee searches by the filter.
+See
+.Em Reducing Filtee Searches
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm fatal-warnings | Fl z Cm nofatal-warnings
+.It Fl \&-fatal-warnings | \&-no-fatal-warnings
+Controls the behavior of warnings emitted from the link-editor.
+Setting
+.Fl z Cm fatal-warnings
+promotes warnings emitted by the link-editor to fatal errors that will cause
+the link-editor to fail before linking.
+.Fl z Cm nofatal-warnings
+instead demotes these warnings such that they will not cause the link-editor to
+exit prematurely.
+.Pp
+.It Fl z Cm finiarray= Ns Ar function
+Appends an entry to the
+.Sy .fini_array
+section of the object being built.
+If no
+.Sy .fini_array
+section is present, a section is created.
+The new entry is initialized to point to
+.Ar function .
+See
+.Em Initialization and Termination Sections
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm globalaudit
 This option supplements an audit library definition that has been recorded with
-the \fB-P\fR option. This option is only meaningful when building a dynamic
-executable. Audit libraries that are defined within an object with the \fB-P\fR
+the
+.Fl P
+option.
+This option is only meaningful when building a dynamic executable.
+Audit libraries that are defined within an object with the
+.Fl P
 option typically allow for the auditing of the immediate dependencies of the
-object. The \fB-z\fR \fBglobalaudit\fR promotes the auditor to a global
-auditor, thus allowing the auditing of all dependencies. See \fIInvoking the
-Auditing Interface\fR in \fILinker and Libraries Guide\fR.
-.sp
-An auditor established with the \fB-P\fR option and the \fB-z\fR
-\fBglobalaudit\fR option, is equivalent to the auditor being established with
-the \fBLD_AUDIT\fR environment variable. See \fBld.so.1\fR(1).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBgroupperm\fR | \fBnogroupperm\fR\fR
-.ad
-.sp .6
-.RS 4n
-Assigns, or deassigns each dependency that follows to a unique group. The
-assignment of a dependency to a group has the same effect as if the dependency
-had been built using the \fB-B\fR \fBgroup\fR option.
-.RE
-
-.sp
-.ne 2
-.na
-\fB-z\fR \fBguidance\fR[=\fIid1\fR,\fIid2\fR...]
-.ad
-.sp .6
-.RS 4n
+object.
+The
+.Fl z Cm globalaudit
+promotes the auditor to a global auditor, thus allowing the auditing of all
+dependencies.
+See
+.Em Invoking the Auditing Interface
+in
+.%T Linker and Libraries Guide .
+.Pp
+An auditor established with the
+.Fl P
+option and the
+.Fl z Cm globalaudit
+option, is equivalent to the auditor being established with the
+.Ev LD_AUDIT
+environment variable.
+See
+.Xr ld.so.1 1 .
+.Pp
+.It Fl z Cm groupperm | Fl z Cm nogroupperm
+Assigns, or deassigns each dependency that follows to a unique group.
+The assignment of a dependency to a group has the same effect as if the
+dependency had been built using the
+.Fl B Cm group
+option.
+.Pp
+.It Fl z Cm guidance Ns Op Cm \&= Ns Ar id Ns No ,...
 Give messages suggesting link-editor features that could improve the resulting
 dynamic object.
-.LP
 Specific classes of suggestion can be silenced by specifying an optional comma
 separated list of guidance identifiers.
-.LP
 The current classes of suggestion provided are:
-
-.sp
-.ne 2
-.na
-Enable use of direct binding
-.ad
-.sp .6
-.RS 4n
-Suggests that \fB-z direct\fR or \fB-B direct\fR be present prior to any
-specified dependency.  This allows predictable symbol binding at runtime.
-
-Can be disabled with \fB-z guidance=nodirect\fR
-.RE
-
-.sp
-.ne 2
-.na
-Enable lazy dependency loading
-.ad
-.sp .6
-.RS 4n
-Suggests that \fB-z lazyload\fR be present prior to any specified dependency.
+.Bl -tag -width 4n
+.It Enable use of direct binding
+Suggests that
+.Fl z Cm direct
+or
+.Fl B Cm direct
+be present prior to any specified dependency.
+This allows predictable symbol binding at runtime.
+Can be disabled with
+.Fl z Cm guidance=nodirect
+.It Enable lazy dependency loading
+Suggests that
+.Fl z Cm lazyload
+be present prior to any specified dependency.
 This allows the dynamic object to be loaded more quickly.
-
-Can be disabled with \fB-z guidance=nolazyload\fR.
-.RE
-
-.sp
-.ne 2
-.na
-Shared objects should define all their dependencies.
-.ad
-.sp .6
-.RS 4n
-Suggests that \fB-z defs\fR be specified on the link-editor command line.
+Can be disabled with
+.Fl z Cm guidance=nolazyload
+.It Shared objects should define all their dependencies.
+Suggests that
+.Fl z Cm defs
+be specified on the link-editor command line.
 Shared objects that explicitly state all their dependencies behave more
 predictably when used.
-
-Can be be disabled with \fB-z guidance=nodefs\fR
-.RE
-
-.sp
-.ne 2
-.na
-Version 2 mapfile syntax
-.ad
-.sp .6
-.RS 4n
+Can be be disabled with
+.Fl z Cm guidance=nodefs
+.It Version 2 mapfile syntax
 Suggests that any specified mapfiles use the more readable version 2 syntax.
-
-Can be disabled with \fB-z guidance=nomapfile\fR.
-.RE
-
-.sp
-.ne 2
-.na
-Read-only text segment
-.ad
-.sp .6
-.RS 4n
+Can be disabled with
+.Fl z Cm guidance=nomapfile
+.It Read-only text segment
 Should any runtime relocations within the text segment exist, suggests that
-the object be compiled with position independent code (PIC).  Keeping large
-allocatable sections read-only allows them to be shared between processes
-using a given shared object.
-
-Can be disabled with \fB-z guidance=notext\fR
-.RE
-
-.sp
-.ne 2
-.na
-No unused dependencies
-.ad
-.sp .6
-.RS 4n
+the object be compiled with position independent code
+.Pq PIC .
+Keeping large allocatable sections read-only allows them to be shared between
+processes using a given shared object.
+Can be disabled with
+.Fl z Cm guidance=notext
+.It No unused dependencies
 Suggests that any dependency not referenced by the resulting dynamic object be
 removed from the link-editor command line.
-
-Can be disabled with \fB-z guidance=nounused\fR.
-.RE
-
-.sp
-.ne 2
-.na
-Global data in shared libraries built with mapfiles have size assertions
-.ad
-.sp .6
-.RS 4n
+Can be disabled with
+.Fl z Cm guidance=nounused
+.It Global data in shared libraries built with mapfiles have size assertions
 Suggests that any global data in a library built with a mapfile asserts the
 size of that global data for ABI stability purposes.
-
-Can be disabled with \fB-z guidance=noasserts\fR.
-.RE
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBhelp\fR\fR
-.ad
-.br
-.na
-\fB\fB--help\fR\fR
-.ad
-.sp .6
-.RS 4n
+Can be disabled with
+.Fl z Cm guidance=noasserts
+.El
+.Pp
+.It Fl z Cm help
+.It Fl \&-help
 Print a summary of the command line options on the standard output and exit.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBignore\fR | \fBrecord\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Pp
+.It Fl z Cm ignore | Fl z Cm record
 Ignores, or records, dynamic dependencies that are not referenced as part of
-the link-edit. Ignores, or records, unreferenced \fBELF\fR sections from the
-relocatable objects that are read as part of the link-edit. By default,
-\fB-z\fR \fBrecord\fR is in effect.
-.sp
-If an \fBELF\fR section is ignored, the section is eliminated from the output
-file being generated. A section is ignored when three conditions are true. The
-eliminated section must contribute to an allocatable segment. The eliminated
-section must provide no global symbols. No other section from any object that
-contributes to the link-edit, must reference an eliminated section.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBinitarray=\fR\fIfunction\fR\fR
-.ad
-.sp .6
-.RS 4n
-Appends an entry to the \fB\&.init_array\fR section of the object being built.
-If no \fB\&.init_array\fR section is present, a section is created. The new
-entry is initialized to point to \fIfunction\fR. See \fIInitialization and
-Termination Sections\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBinitfirst\fR\fR
-.ad
-.sp .6
-.RS 4n
+the link-edit.
+Ignores, or records, unreferenced
+.Sy ELF
+sections from the relocatable objects
+that are read as part of the link-edit.
+By default,
+.Fl z Cm record
+is in effect.
+.Pp
+If an
+.Sy ELF
+section is ignored, the section is eliminated from the output file being
+generated.
+A section is ignored when three conditions are true.
+The eliminated section must contribute to an allocatable segment.
+The eliminated section must provide no global symbols.
+No other section from any object that contributes to the link-edit, must
+reference an eliminated section.
+.Pp
+.It Fl z Cm initarray= Ns Ar function
+Appends an entry to the
+.Sy .init_array
+section of the object being built.
+If no
+.Sy .init_array
+section is present, a section is created.
+The new entry is initialized to point to
+.Ar function .
+See
+.Em Initialization and Termination Sections
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm initfirst
 Marks the object so that its runtime initialization occurs before the runtime
 initialization of any other objects brought into the process at the same time.
 In addition, the object runtime finalization occurs after the runtime
 finalization of any other objects removed from the process at the same time.
 This option is only meaningful when building a shared object.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBinterpose\fR\fR
-.ad
-.sp .6
-.RS 4n
-Marks the object as an interposer. At runtime, an object is identified as an
-explicit interposer if the object has been tagged using the \fB-z interpose\fR
-option. An explicit interposer is also established when an object is loaded
-using the \fBLD_PRELOAD\fR environment variable. Implicit interposition can
-occur because of the load order of objects, however, this implicit
-interposition is unknown to the runtime linker. Explicit interposition can
-ensure that interposition takes place regardless of the order in which objects
-are loaded. Explicit interposition also ensures that the runtime linker
-searches for symbols in any explicit interposers when direct bindings are in
-effect.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBlazyload\fR | \fBnolazyload\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Pp
+.It Fl z Cm interpose
+Marks the object as an interposer.
+At runtime, an object is identified as an explicit interposer if the object has
+been tagged using the
+.Fl z Cm interpose
+option.
+An explicit interposer is also established when an object is loaded using the
+.Ev LD_PRELOAD
+environment variable.
+Implicit interposition can occur because of the load order of objects, however,
+this implicit interposition is unknown to the runtime linker.
+Explicit interposition can ensure that interposition takes place regardless of
+the order in which objects are loaded.
+Explicit interposition also ensures that the runtime linker searches for
+symbols in any explicit interposers when direct bindings are in effect.
+.Pp
+.It Fl z Cm lazyload | Fl z Cm nolazyload
 Enables or disables the marking of dynamic dependencies to be lazily loaded.
-Dynamic dependencies which are marked \fBlazyload\fR are not loaded at initial
-process start-up. These dependencies are delayed until the first binding to the
-object is made. \fBNote:\fR Lazy loading requires the correct declaration of
-dependencies, together with associated runpaths for each dynamic object used
-within a process. See \fILazy Loading of Dynamic Dependencies\fR in \fILinker
-and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBld32\fR=\fIarg1\fR,\fIarg2\fR,...\fR
-.ad
-.br
-.na
-\fB\fB-z\fR \fBld64\fR=\fIarg1\fR,\fIarg2\fR,...\fR
-.ad
-.sp .6
-.RS 4n
+Dynamic dependencies which are marked
+Cm lazyload
+are not loaded at initial process start-up.
+These dependencies are delayed until the first binding to the object is made.
+Note: Lazy loading requires the correct declaration of dependencies, together
+with associated runpaths for each dynamic object used within a process.
+See
+.Em Lazy Loading of Dynamic Dependencies
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm ld32= Ns Ar arg Ns No ,...
+.It Fl z Cm ld64= Ns Ar arg Ns No ,...
 The class of the link-editor is affected by the class of the output file being
-created and by the capabilities of the underlying operating system. The
-\fB-z\fR \fBld\fR[\fB32\fR|\fB64\fR] options provide a means of defining any
-link-editor argument. The defined argument is only interpreted, respectively,
-by the 32-bit class or 64-bit class of the link-editor.
-.sp
+created and by the capabilities of the underlying operating system.
+The
+.Fl z Cm ld32 | Fl z Cm ld64
+options provide a means of defining any link-editor argument.
+The defined argument is only interpreted, respectively, by the 32-bit class or
+64-bit class of the link-editor.
+.Pp
 For example, support libraries are class specific, so the correct class of
 support library can be ensured using:
-.sp
-.in +2
-.nf
-\fBld ... -z ld32=-Saudit32.so.1 -z ld64=-Saudit64.so.1 ...\fR
-.fi
-.in -2
-.sp
-
-The class of link-editor that is invoked is determined from the \fBELF\fR class
-of the first relocatable file that is seen on the command line. This
-determination is carried out \fBprior\fR to any \fB-z\fR
-\fBld\fR[\fB32\fR|\fB64\fR] processing.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBloadfltr\fR\fR
-.ad
-.sp .6
-.RS 4n
+.Pp
+.Dl ld ... -z ld32=-Saudit32.so.1 -z ld64=-Saudit64.so.1 ...
+.Pp
+The class of link-editor that is invoked is determined from the
+.Sy ELF
+class of the first relocatable file that is seen on the command line.
+This determination is carried out
+.Em prior
+to any
+.Fl z Cm ld32 | Fl z Cm ld64
+processing.
+.Pp
+.It Fl z Cm loadfltr
 Marks a filter to indicate that filtees must be processed immediately at
-runtime. Normally, filter processing is delayed until a symbol reference is
-bound to the filter. The runtime processing of an object that contains this
-flag mimics that which occurs if the \fBLD_LOADFLTR\fR environment variable is
-in effect. See the \fBld.so.1\fR(1).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBmuldefs\fR\fR
-.ad
-.br
-.na
-\fB\fB--allow-multiple-definition\fR\fR
-.ad
-.sp .6
-.RS 4n
-Allows multiple symbol definitions. By default, multiple symbol definitions
-that occur between relocatable objects result in a fatal error condition. This
-option, suppresses the error condition, allowing the first symbol definition to
-be taken.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnocompstrtab\fR\fR
-.ad
-.sp .6
-.RS 4n
-Disables the compression of \fBELF\fR string tables. By default, string
-compression is applied to \fBSHT_STRTAB\fR sections, and to \fBSHT_PROGBITS\fR
-sections that have their \fBSHF_MERGE\fR and \fBSHF_STRINGS\fR section flags
-set.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnodefaultlib\fR\fR
-.ad
-.sp .6
-.RS 4n
+runtime.
+Normally, filter processing is delayed until a symbol reference is bound to the
+filter.
+The runtime processing of an object that contains this flag mimics that which
+occurs if the
+.Ev LD_LOADFLTR
+environment variable is in effect.
+See the
+.Xr ld.so.1 1 .
+.Pp
+.It Fl z Cm muldefs
+.It Fl \&-allow-multiple-definition
+Allows multiple symbol definitions.
+By default, multiple symbol definitions that occur between relocatable objects
+result in a fatal error condition.
+This option, suppresses the error condition, allowing the first symbol
+definition to be taken.
+.Pp
+.It Fl z Cm nocompstrtab
+Disables the compression of
+.Sy ELF
+string tables.
+By default, string compression is applied to
+.Dv SHT_STRTAB
+sections, and to
+.Dv SHT_PROGBITS
+sections that have their
+.Dv SHF_MERGE
+and
+.Dv SHF_STRINGS
+section flags set.
+.Pp
+.It Fl z Cm nodefaultlib
 Marks the object so that the runtime default library search path, used after
-any \fBLD_LIBRARY_PATH\fR or runpaths, is ignored. This option implies that all
-dependencies of the object can be satisfied from its runpath.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnodelete\fR\fR
-.ad
-.sp .6
-.RS 4n
-Marks the object as non-deletable at runtime. This mode is similar to adding
-the object to the process by using \fBdlopen\fR(3C) with the
-\fBRTLD_NODELETE\fR mode.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnodlopen\fR\fR
-.ad
-.sp .6
-.RS 4n
-Marks the object as not available to \fBdlopen\fR(3C), either as the object
-specified by the \fBdlopen()\fR, or as any form of dependency required by the
-object specified by the \fBdlopen()\fR. This option is only meaningful when
-building a shared object.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnodump\fR\fR
-.ad
-.sp .6
-.RS 4n
-Marks the object as not available to \fBdldump\fR(3C).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnoldynsym\fR\fR
-.ad
-.sp .6
-.RS 4n
-Prevents the inclusion of a \fB\&.SUNW_ldynsym\fR section in dynamic
-executables or sharable libraries. The \fB\&.SUNW_ldynsym\fR section augments
-the \fB\&.dynsym\fR section by providing symbols for local functions. Local
-function symbols allow debuggers to display local function names in stack
-traces from stripped programs. Similarly, \fBdladdr\fR(3C) is able to supply
-more accurate results.
-.sp
-The \fB-z\fR \fBnoldynsym\fR option also prevents the inclusion of the two
-symbol sort sections that are related to the \fB\&.SUNW_ldynsym\fR section. The
-\fB\&.SUNW_dynsymsort\fR section provides sorted access to regular function and
-variable symbols. The \fB\&.SUNW_dyntlssort\fR section provides sorted access
-to thread local storage (\fBTLS\fR) variable symbols.
-.sp
-The \fB\&.SUNW_ldynsym\fR, \fB\&.SUNW_dynsymsort\fR, and
-\fB\&.SUNW_dyntlssort\fR sections, which becomes part of the allocable text
-segment of the resulting file, cannot be removed by \fBstrip\fR(1). Therefore,
-the \fB-z\fR \fBnoldynsym\fR option is the only way to prevent their inclusion.
-See the \fB-s\fR and \fB-z\fR \fBredlocsym\fR options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnopartial\fR\fR
-.ad
-.sp .6
-.RS 4n
+any
+.Ev LD_LIBRARY_PATH
+or runpaths, is ignored.
+This option implies that all dependencies of the object can be satisfied from
+its runpath.
+.Pp
+.It Fl z Cm nodelete
+Marks the object as non-deletable at runtime.
+This mode is similar to adding the object to the process by using
+.Xr dlopen 3C
+with the
+.Dv RTLD_NODELETE
+mode.
+.Pp
+.It Fl z Cm nodlopen
+Marks the object as not available to
+.Xr dlopen 3C ,
+either as the object specified by the
+.Xr dlopen 3C ,
+or as any form of dependency required by the object specified by the
+.Xr dlopen 3C .
+This option is only meaningful when building a shared object.
+.Pp
+.It Fl z Cm nodump
+Marks the object as not available to
+.Xr dldump 3C .
+.Pp
+.It Fl z Cm noldynsym
+Prevents the inclusion of a
+.Sy .SUNW_ldynsym
+section in dynamic executables or sharable libraries.
+The
+.Sy .SUNW_ldynsym
+section augments the
+.Sy .dynsym
+section by providing symbols for local functions.
+Local function symbols allow debuggers to display local function names in stack
+traces from stripped programs.
+Similarly,
+.Xr dladdr 3C
+is able to supply more accurate results.
+.Pp
+The
+.Fl z Cm noldynsym
+option also prevents the inclusion of the two symbol sort sections that are
+related to the
+.Sy .SUNW_ldynsym
+section.
+The
+.Sy .SUNW_dynsymsort
+section provides sorted access to regular function and variable symbols.
+The
+.Sy .SUNW_dyntlssort
+section provides sorted access to thread local storage
+.Pq TLS
+variable symbols.
+.Pp
+The
+.Sy .SUNW_ldynsym ,
+.Sy .SUNW_dynsymsort ,
+and
+.Sy .SUNW_dyntlssort
+sections, which becomes part of the allocable text segment of the resulting
+file, cannot be removed by
+.Xr strip 1 .
+Therefore, the
+.Fl z Cm noldynsym
+option is the only way to prevent their inclusion.
+See the
+.Fl s
+and
+.Fl z Cm redlocsym
+options.
+.Pp
+.It Fl z Cm nopartial
 Partially initialized symbols, that are defined within relocatable object
 files, are expanded in the output file being generated.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnoversion\fR\fR
-.ad
-.sp .6
-.RS 4n
-Does not record any versioning sections. Any version sections or associated
-\fB\&.dynamic\fR section entries are not generated in the output image.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBnow\fR\fR
-.ad
-.sp .6
-.RS 4n
-Marks the object as requiring non-lazy runtime binding. This mode is similar to
-adding the object to the process by using \fBdlopen\fR(3C) with the
-\fBRTLD_NOW\fR mode. This mode is also similar to having the \fBLD_BIND_NOW\fR
-environment variable in effect. See \fBld.so.1\fR(1).
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBorigin\fR\fR
-.ad
-.sp .6
-.RS 4n
-Marks the object as requiring immediate \fB$ORIGIN\fR processing at runtime.
+.Pp
+.It Fl z Cm noversion
+Does not record any versioning sections.
+Any version sections or associated
+.Sy .dynamic
+section entries are not generated in the output image.
+.Pp
+.It Fl z Cm now
+Marks the object as requiring non-lazy runtime binding.
+This mode is similar to adding the object to the process by using
+.Xr dlopen 3C
+with the
+.Dv RTLD_NOW
+mode.
+This mode is also similar to having the
+.Ev LD_BIND_NOW
+environment variable in effect.
+See
+.Xr ld.so.1 1 .
+.Pp
+.It Fl z Cm origin
+Marks the object as requiring immediate
+.Sy $ORIGIN
+processing at runtime.
 This option is only maintained for historic compatibility, as the runtime
-analysis of objects to provide for \fB$ORIGIN\fR processing is now default.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBpreinitarray=\fR\fIfunction\fR\fR
-.ad
-.sp .6
-.RS 4n
-Appends an entry to the \fB\&.preinitarray\fR section of the object being
-built. If no \fB\&.preinitarray\fR section is present, a section is created.
-The new entry is initialized to point to \fIfunction\fR. See \fIInitialization
-and Termination Sections\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBredlocsym\fR\fR
-.ad
-.sp .6
-.RS 4n
-Eliminates all local symbols except for the \fISECT\fR symbols from the symbol
-table \fBSHT_SYMTAB\fR. All relocations that refer to local symbols are updated
-to refer to the corresponding \fISECT\fR symbol. This option allows specialized
-objects to greatly reduce their symbol table sizes. Eliminated local symbols
-can reduce the \fB\&.stab*\fR debugging information that is generated using the
-compiler drivers \fB-g\fR option. See the \fB-s\fR and \fB-z\fR \fBnoldynsym\fR
+analysis of objects to provide for
+.Sy $ORIGIN
+processing is now default.
+.Pp
+.It Fl z Cm preinitarray= Ns Ar function
+Appends an entry to the
+.Sy .preinitarray
+section of the object being built.
+If no
+.Sy .preinitarray
+section is present, a section is created.
+The new entry is initialized to point to
+.Ar function .
+See
+.Em Initialization and Termination Sections
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm redlocsym
+Eliminates all local symbols except for the
+.Sy SECT
+symbols from the symbol
+table
+.Dv SHT_SYMTAB .
+All relocations that refer to local symbols are updated to refer to the
+corresponding
+.Sy SECT
+symbol.
+This option allows specialized objects to greatly reduce their symbol table
+sizes.
+Eliminated local symbols can reduce the
+.Sy .stab
+debugging information that is generated using the compiler driver's
+.Fl g
+option.
+See the
+.Fl s
+and
+.Fl z Cm noldynsym
 options.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBrelaxreloc\fR\fR
-.ad
-.sp .6
-.RS 4n
-\fBld\fR normally issues a fatal error upon encountering a relocation using a
-symbol that references an eliminated COMDAT section. If \fB-z\fR
-\fBrelaxreloc\fR is enabled, \fBld\fR instead redirects such relocations to the
-equivalent symbol in the COMDAT section that was kept. \fB-z\fR
-\fBrelaxreloc\fR is a specialized option, mainly of interest to compiler
-authors, and is not intended for general use.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBrescan-now\fR\fR
-.ad
-.br
-.na
-\fB\fB-z\fR \fBrescan\fR\fR
-.ad
-.sp .6
-.RS 4n
-These options rescan the archive files that are provided to the link-edit. By
-default, archives are processed once as the archives appear on the command
-line. Archives are traditionally specified at the end of the command line so
-that their symbol definitions resolve any preceding references. However,
-specifying archives multiple times to satisfy their own interdependencies can
-be necessary.
-.sp
-\fB-z\fR \fBrescan-now\fR is a positional option, and is processed by the
-link-editor immediately when encountered on the command line. All archives seen
-on the command line up to that point are immediately reprocessed in an attempt
-to locate additional archive members that resolve symbol references. This
-archive rescanning is repeated until a pass over the archives occurs in which
-no new members are extracted.
-.sp
-\fB-z\fR \fBrescan\fR is a position independent option. The link-editor defers
-the rescan operation until after it has processed the entire command line, and
-then initiates a final rescan operation over all archives seen on the command
-line. The \fB-z\fR \fBrescan\fR operation can interact incorrectly
-with objects that contain initialization (.init) or finalization (.fini)
-sections, preventing the code in those sections from running. For this reason,
-\fB-z\fR \fBrescan\fR is deprecated, and use of \fB-z\fR \fBrescan-now\fR is
+.Pp
+.It Fl z Cm relaxreloc
+.Nm
+normally issues a fatal error upon encountering a relocation using a
+symbol that references an eliminated COMDAT section.
+If
+.Fl z Cm relaxreloc
+is enabled,
+.Nm
+instead redirects such relocations to the equivalent symbol in the COMDAT
+section that was kept.
+.Fl z Cm relaxreloc
+is a specialized option, mainly of interest to compiler authors, and is not
+intended for general use.
+.Pp
+.It Fl z Cm rescan-now
+.It Fl z Cm rescan
+These options rescan the archive files that are provided to the link-edit.
+By default, archives are processed once as the archives appear on the command
+line.
+Archives are traditionally specified at the end of the command line so that
+their symbol definitions resolve any preceding references.
+However, specifying archives multiple times to satisfy their own
+interdependencies can be necessary.
+.Pp
+.Fl z Cm rescan-now
+is a positional option, and is processed by the link-editor immediately when
+encountered on the command line.
+All archives seen on the command line up to that point are immediately
+reprocessed in an attempt to locate additional archive members that resolve
+symbol references.
+This archive rescanning is repeated until a pass over the archives occurs in
+which no new members are extracted.
+.Pp
+.Fl z Cm rescan
+is a position independent option.
+The link-editor defers the rescan operation until after it has processed the
+entire command line, and then initiates a final rescan operation over all
+archives seen on the command line.
+The
+.Fl z Cm rescan
+operation can interact incorrectly with objects that contain initialization
+.Pq .init
+or finalization
+.Pq .fini
+sections, preventing the code in those sections from running.
+For this reason,
+.Fl z Cm rescan
+is deprecated, and use of
+.Fl z Cm rescan-now
+is
 advised.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBrescan-start\fR ... \fB-z\fR \fBrescan-end\fR\fR
-.ad
-.br
-.na
-\fB\fB--start-group\fR ... \fB--end-group\fR\fR
-.ad
-.br
-.na
-\fB\fB-(\fR ... \fB-)\fR\fR
-.ad
-.sp .6
-.RS 4n
-Defines an archive rescan group. This is a positional construct, and is
-processed by the link-editor immediately upon encountering the closing
-delimiter option.  Archives found within the group delimiter options are
-reprocessed as a group in an attempt to locate additional archive members that
-resolve symbol references. This archive rescanning is repeated until a pass
-over the archives occurs in which no new members are extracted.
+.Pp
+.It Fl z Cm rescan-start No \&... Fl z Cm rescan-end
+.It Fl \&-start-group No \&... Fl \&-end-group
+.It Fl \&( No \&... Fl \&)
+Defines an archive rescan group.
+This is a positional construct, and is processed by the link-editor immediately
+upon encountering the closing delimiter option.
+Archives found within the group delimiter options are reprocessed as a group in
+an attempt to locate additional archive members that resolve symbol references.
+This archive rescanning is repeated until a pass over the archives occurs in
+which no new members are extracted.
 Archive rescan groups cannot be nested.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBsymbolcap\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies that a relocatable object that defines object capabilities
-should have those converted to symbol capabilities. A relocatable object
-that does not have any object capabilities will ignore this option.
-.sp
-Symbol capabilities provide a means for multiple implementations of a
-function to co-exist and have one picked at runtime based upon the
-hardware capabilities of the system. When \fB-z symbolcap\fR is invoked,
-all global functions are converted into local functions that have the
-corresponding capability name appended to them and an undefined symbol
-with the original name left in the resulting relocatable object. At
-runtime, the global symbol will be bound to the corresponding
-implementation that is appropriate based on the capabilities of the
-system.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBtarget=sparc|x86\fR \fI\fR\fR
-.ad
-.sp .6
-.RS 4n
-Specifies the machine type for the output object. Supported targets are Sparc
-and x86. The 32-bit machine type for the specified target is used unless the
-\fB-64\fR option is also present, in which case the corresponding 64-bit
-machine type is used. By default, the machine type of the object being
-generated is determined from the first \fBELF\fR object processed from the
-command line. If no objects are specified, the machine type is determined by
-the first object encountered within the first archive processed from the
-command line. If there are no objects or archives, the link-editor assumes the
-native machine. This option is useful when creating an object directly with
-\fBld\fR whose input is solely from a \fBmapfile\fR. See the \fB-M\fR option.
+.Pp
+.It Fl z Cm symbolcap
+Specifies that a relocatable object that defines object capabilities should
+have those converted to symbol capabilities.
+A relocatable object that does not have any object capabilities will ignore
+this option.
+.Pp
+Symbol capabilities provide a means for multiple implementations of a function
+to co-exist and have one picked at runtime based upon the hardware capabilities
+of the system.
+When
+.Fl z Cm symbolcap
+is invoked, all global functions are converted into local functions that have
+the corresponding capability name appended to them and an undefined symbol with
+the original name left in the resulting relocatable object.
+At runtime, the global symbol will be bound to the corresponding implementation
+that is appropriate based on the capabilities of the system.
+.Pp
+.It Fl z Cm target= Ns Cm sparc Ns | Ns Cm x86
+Specifies the machine type for the output object.
+Supported targets are
+.Cm sparc
+and
+.Cm x86 .
+The 32-bit machine type for the specified target is used unless the
+.Fl 64
+option is also present, in which case the corresponding 64-bit machine type is
+used.
+By default, the machine type of the object being generated is determined from
+the first
+.Sy ELF
+object processed from the command line.
+If no objects are specified, the machine type is determined by the first object
+encountered within the first archive processed from the command line.
+If there are no objects or archives, the link-editor assumes the native
+machine.
+This option is useful when creating an object directly with
+.Nm
+whose input is solely from a
+.Sy mapfile .
+See the
+.Fl M
+option.
 It can also be useful in the rare case of linking entirely from an archive that
 contains objects of different machine types for which the first object is not
-of the desired machine type. See \fIThe 32-bit link-editor and 64-bit
-link-editor\fR in \fILinker and Libraries Guide\fR.
-.sp
-Note that for compability with existing Makefiles and scripts, these options
+of the desired machine type.
+See
+.Em The 32-bit link-editor and 64-bit link-editor
+in
+.%T Linker and Libraries Guide .
+.Pp
+Note that for compatibility with existing Makefiles and scripts, these options
 may be given multiple times and may be mixed in the same invocation: the last
-instance wins, so that, for example, \fBld -z target=sparc -z target=x86 ...\fR
-gives a machine type of \fBx86\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBtext\fR\fR
-.ad
-.sp .6
-.RS 4n
+instance wins, so that, for example,
+.Ql ld -z target=sparc -z target=x86 \&...
+gives a machine type of
+.Sq x86 .
+.Pp
+.It Fl z Cm text
 In dynamic mode only, forces a fatal error if any relocations against
-non-writable, allocatable sections remain. For historic reasons, this mode is
-not the default when building an executable or shared object. However, its use
-is recommended to ensure that the text segment of the dynamic object being
-built is shareable between multiple running processes. A shared text segment
-incurs the least relocation overhead when loaded into memory. See
-\fIPosition-Independent Code\fR in \fILinker and Libraries Guide\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBtextoff\fR\fR
-.ad
-.sp .6
-.RS 4n
+non-writable, allocatable sections remain.
+For historic reasons, this mode is not the default when building an executable
+or shared object.
+However, its use is recommended to ensure that the text segment of the dynamic
+object being built is shareable between multiple running processes.
+A shared text segment incurs the least relocation overhead when loaded into
+memory.
+See
+.Em Position-Independent Code
+in
+.%T Linker and Libraries Guide .
+.Pp
+.It Fl z Cm textoff
 In dynamic mode only, allows relocations against all allocatable sections,
-including non-writable ones. This mode is the default when building a shared
-object.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBtextwarn\fR\fR
-.ad
-.sp .6
-.RS 4n
+including non-writable ones.
+This mode is the default when building a shared object.
+.Pp
+.It Fl z Cm textwarn
 In dynamic mode only, lists a warning if any relocations against non-writable,
-allocatable sections remain. This mode is the default when building an
-executable.
-.RE
-
-.sp
-.ne 2
-.na
-\fB-z\fR \fBtype=exec|kmod|reloc|shared\fR
-.ad
-.sp .6
-.RS 4n
+allocatable sections remain.
+This mode is the default when building an executable.
+.Pp
+.It Xo
+.Sm off
+.Fl z\~ Cm type= Cm exec | kmod | reloc | shared
+.Sm on
+.Xc
 Specifies the type of object to create.
-
-.sp
-.ne 2
-.na
-exec
-.ad
-.sp .6
-.RS 4n
+.Bl -tag -width shared
+.It exec
 Dynamic executable
-.RE
-
-.sp
-.ne 2
-.na
-reloc
-.ad
-.sp .6
-.RS 4n
+.It reloc
 Relocatable object
-.RE
-
-.sp
-.ne 2
-.na
-shared
-.ad
-.sp .6
-.RS 4n
+.It shared
 Dynamic shared object
-.RE
-
-.sp
-.ne 2
-.na
-kmod
-.ad
-.sp .6
-.RS 4n
+.It kmod
 illumos kernel module
-.RE
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR \fBverbose\fR\fR
-.ad
-.sp .6
-.RS 4n
+.El
+.Pp
+.It Fl z Cm verbose
 This option provides additional warning diagnostics during a link-edit.
-Presently, this option conveys suspicious use of displacement relocations. This
-option also conveys the restricted use of static \fBTLS\fR relocations when
-building shared objects. In future, this option might be enhanced to provide
-additional diagnostics that are deemed too noisy to be generated by default.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-z\fR\fBwrap=\fR\fIsymbol\fR\fR
-.ad
-.br
-.na
-\fB\fB-wrap=\fR \fIsymbol\fR\fR
-.ad
-.br
-.na
-\fB\fB--wrap=\fR \fIsymbol\fR\fR
-.ad
-.sp .6
-.RS 4n
-Rename undefined references to \fIsymbol\fR in order to allow wrapper code to
-be linked into the output object without having to modify source code. When
-\fB-z wrap\fR is specified, all undefined references to \fIsymbol\fR are
-modified to reference \fB__wrap_\fR\fIsymbol\fR, and all references to
-\fB__real_\fR\fIsymbol\fR are modified to reference \fIsymbol\fR. The user is
-expected to provide an object containing the \fB__wrap_\fR\fIsymbol\fR
-function. This wrapper function can call \fB__real_\fR\fIsymbol\fR in order to
-reference the actual function being wrapped.
-.sp
-The following is an example of a wrapper for the \fBmalloc\fR(3C) function:
-.sp
-.in +2
-.nf
+Presently, this option conveys suspicious use of displacement relocations.
+This option also conveys the restricted use of static TLS relocations when
+building shared objects.
+In future, this option might be enhanced to provide additional diagnostics that
+are deemed too noisy to be generated by default.
+.Pp
+.It Fl z Cm wrap= Ns Ar symbol
+.It Fl wrap Ns Cm \&= Ns Ar symbol
+.It Fl \&-wrap Ns Cm \&= Ns Ar symbol
+Rename undefined references to
+.Ar symbol
+in order to allow wrapper code to be linked into the output object without
+having to modify source code.
+When
+.Fl z Cm wrap
+is specified, all undefined references to
+.Ar symbol
+are modified to reference
+.Sy __wrap_ Ns Ar symbol ,
+and all references to
+.Sy __real_ Ns Ar symbol
+are modified to reference
+.Ar symbol .
+The user is expected to provide an object containing the
+.Sy __wrap_ Ns Ar symbol
+function.
+This wrapper function can call
+.Sy __real_ Ns Ar symbol
+in order to reference the actual function being wrapped.
+.Pp
+The following is an example of a wrapper for the
+.Xr malloc 3C
+function:
+.Bd -literal -offset 4n
 void *
 __wrap_malloc(size_t c)
 {
-        (void) printf("malloc called with %zu\en", c);
-        return (__real_malloc(c));
+    (void) printf("malloc called with %zu\en", c);
+    return (__real_malloc(c));
 }
-.fi
-.in -2
-
-If you link other code with this file using \fB-z\fR \fBwrap=malloc\fR to
-compile all the objects, then all calls to \fBmalloc\fR will call the function
-\fB__wrap_malloc\fR instead. The call to \fB__real_malloc\fR will call the real
-\fBmalloc\fR function.
-.sp
+.Ed
+.Pp
+If you link other code with this file using
+.Fl z Cm wrap= Ns Ar malloc
+to compile all the objects, then all calls to
+.Sy malloc
+will call the function
+.Sy __wrap_malloc
+instead.
+The call to
+.Sy __real_malloc
+will call the real
+.Sy malloc
+function.
+.Pp
 The real and wrapped functions should be maintained in separate source files.
 Otherwise, the compiler or assembler may resolve the call instead of leaving
 that operation for the link-editor to carry out, and prevent the wrap from
 occurring.
-.RE
-
-.SH ENVIRONMENT VARIABLES
-.ne 2
-.na
-\fB\fBLD_ALTEXEC\fR\fR
-.ad
-.sp .6
-.RS 4n
-An alternative link-editor path name. \fBld\fR executes, and passes control to
-this alternative link-editor. This environment variable provides a generic
-means of overriding the default link-editor that is called from the various
-compiler drivers. See the \fB-z altexec64\fR option.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBLD_LIBRARY_PATH\fR\fR
-.ad
-.sp .6
-.RS 4n
+.El
+.Sh ENVIRONMENT
+.Bl -tag -width 4n
+.It Ev LD_ALTEXEC
+An alternative link-editor path name.
+.Nm
+executes, and passes control to this alternative link-editor.
+This environment variable provides a generic means of overriding the default
+link-editor that is called from the various compiler drivers.
+See the
+.Fl z Cm altexec64
+option.
+.It Ev LD_LIBRARY_PATH
 A list of directories in which to search for the libraries specified using the
-\fB-l\fR option. Multiple directories are separated by a colon. In the most
-general case, this environment variable contains two directory lists separated
-by a semicolon:
-.sp
-.in +2
-.nf
-\fIdirlist1\fR\fB;\fR\fIdirlist2\fR
-.fi
-.in -2
-.sp
-
-If \fBld\fR is called with any number of occurrences of \fB-L\fR, as in:
-.sp
-.in +2
-.nf
-\fBld ... -L\fIpath1\fR ... -L\fIpathn\fR ...\fR
-.fi
-.in -2
-.sp
-
+.Fl l
+option.
+Multiple directories are separated by a colon.
+In the most general case, this environment variable contains two directory
+lists separated by a semicolon:
+.Pp
+.D1 Ar dirlist1 Ns Cm \&; Ns Ar dirlist2
+.Pp
+If
+.Nm
+is called with any number of occurrences of
+.Fl L ,
+as in:
+.Pp
+.D1 Nm No ... Fl L Ns Ar path1 No ... Fl L Ns Ar pathn No ...
+.Pp
 then the search path ordering is:
-.sp
-.in +2
-.nf
-\fB\fIdirlist1 path1\fR ... \fIpathn dirlist2\fR LIBPATH\fR
-.fi
-.in -2
-.sp
-
+.Pp
+.D1 Ar dirlist1 Ar path1 No ... Ar pathn Ar dirlist2 Ev LIBPATH
+.Pp
 When the list of directories does not contain a semicolon, the list is
-interpreted as \fIdirlist2\fR.
-.sp
-The \fBLD_LIBRARY_PATH\fR environment variable also affects the runtime linkers
-search for dynamic dependencies.
-.sp
-This environment variable can be specified with a _32 or _64 suffix. This makes
-the environment variable specific, respectively, to 32-bit or 64-bit processes
+interpreted as
+.Ar dirlist2 .
+.Pp
+The
+.Ev LD_LIBRARY_PATH
+environment variable also affects the runtime linkers search for dynamic
+dependencies.
+.Pp
+This environment variable can be specified with a _32 or _64 suffix.
+This makes the environment variable specific, respectively, to 32-bit or 64-bit
+processes and overrides any non-suffixed version of the environment variable
+that is in effect.
+.It Ev LD_NOEXEC_64
+Suppresses the automatic execution of the 64-bit link-editor.
+By default, the link-editor executes the 64-bit version when the
+.Sy ELF
+class of the first relocatable file identifies a 64-bit object.
+The 64-bit image that a 32-bit link-editor can create, has some limitations.
+However, some link-edits might find the use of the 32-bit link-editor faster.
+.It Ev LD_OPTIONS
+A default set of options to
+.Nm .
+.Ev LD_OPTIONS
+is interpreted by
+.Nm
+just as though its value had been placed on the command line, immediately
+following the name used to invoke
+.Nm ,
+as in:
+.Pp
+.D1 Nm Ev $LD_OPTIONS No ... Ar other-arguments No ...
+.It Ev LD_RUN_PATH
+An alternative mechanism for specifying a runpath to the link-editor.
+See the
+.Fl R
+option.
+If both
+.Ev LD_RUN_PATH
+and the
+.Fl R
+option are specified,
+.Fl R
+supersedes.
+.It Ev SGS_SUPPORT
+Provides a colon-separated list of shared objects that are loaded with the
+link-editor and given information regarding the linking process.
+This environment variable can be specified with a _32 or _64 suffix.
+This makes the environment variable specific, respectively, to the 32-bit or
+64-bit class of
+.Nm
 and overrides any non-suffixed version of the environment variable that is in
 effect.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBLD_NOEXEC_64\fR\fR
-.ad
-.sp .6
-.RS 4n
-Suppresses the automatic execution of the 64-bit link-editor. By default, the
-link-editor executes the 64-bit version when the \fBELF\fR class of the first
-relocatable file identifies a 64-bit object. The 64-bit image that a 32-bit
-link-editor can create, has some limitations. However, some link-edits might
-find the use of the 32-bit link-editor faster.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBLD_OPTIONS\fR\fR
-.ad
-.sp .6
-.RS 4n
-A default set of options to \fBld\fR. \fBLD_OPTIONS\fR is interpreted by
-\fBld\fR just as though its value had been placed on the command line,
-immediately following the name used to invoke \fBld\fR, as in:
-.sp
-.in +2
-.nf
-\fBld $LD_OPTIONS ... \fIother-arguments\fR ...\fR
-.fi
-.in -2
-.sp
-
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBLD_RUN_PATH\fR\fR
-.ad
-.sp .6
-.RS 4n
-An alternative mechanism for specifying a runpath to the link-editor. See the
-\fB-R\fR option. If both \fBLD_RUN_PATH\fR and the \fB-R\fR option are
-specified, \fB-R\fR supersedes.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBSGS_SUPPORT\fR\fR
-.ad
-.sp .6
-.RS 4n
-Provides a colon-separated list of shared objects that are loaded with the
-link-editor and given information regarding the linking process. This
-environment variable can be specified with a _32 or _64 suffix. This makes the
-environment variable specific, respectively, to the 32-bit or 64-bit class of
-\fBld\fR and overrides any non-suffixed version of the environment variable
-that is in effect. See the \fB-S\fR option.
-.RE
-
-.sp
-.LP
-Notice that environment variable-names that begin with the
-characters '\fBLD_\fR' are reserved for possible future enhancements to
-\fBld\fR and \fBld.so.1\fR(1).
-.SH FILES
-.ne 2
-.na
-\fB\fBlib\fIx\fR.so\fR\fR
-.ad
-.RS 15n
+See the
+.Fl S
+option.
+.El
+.Pp
+Notice that environment variable-names that begin with the characters
+.Sq LD_
+are reserved for possible future enhancements to
+.Nm
+and
+.Xr ld.so.1 1 .
+.Sh FILES
+.Bl -tag -width 4n
+.It lib Ns Ar x Ns No .so
 shared object libraries.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBlib\fIx\fR.a\fR\fR
-.ad
-.RS 15n
+.It lib Ns Ar x Ns No .a
 archive libraries.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fBa.out\fR\fR
-.ad
-.RS 15n
+.It Pa a.out
 default output file.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fILIBPATH\fR\fR
-.ad
-.RS 15n
-For 32-bit libraries, the default search path is \fB/usr/ccs/lib\fR, followed
-by \fB/lib\fR, and finally \fB/usr/lib\fR. For 64-bit libraries, the default
-search path is \fB/lib/64\fR, followed by \fB/usr/lib/64\fR.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB/usr/lib/ld\fR\fR
-.ad
-.RS 15n
-A directory containing several \fBmapfiles\fR that can be used during
-link-editing. These \fBmapfiles\fR provide various capabilities, such as
-defining memory layouts, aligning bss, and defining non-executable stacks.
-.RE
-
-.SH ATTRIBUTES
-See \fBattributes\fR(7) for descriptions of the following attributes:
-.sp
-
-.sp
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-Interface Stability	Committed
-.TE
-
-.SH SEE ALSO
-.BR as (1),
-.BR crle (1),
-.BR gprof (1),
-.BR ld.so.1 (1),
-.BR ldd (1),
-.BR mcs (1),
-.BR pvs (1),
-.BR exec (2),
-.BR stat (2),
-.BR dldump (3C),
-.BR dlopen (3C),
-.BR elf (3ELF),
-.BR ar.h (3HEAD),
-.BR a.out (5),
-.BR attributes (7)
-.sp
-.LP
-\fILinker and Libraries Guide\fR
-.SH NOTES
-Default options applied by \fBld\fR are maintained for historic reasons. In
-today's programming environment, where dynamic objects dominate, alternative
-defaults would often make more sense. However, historic defaults must be
-maintained to ensure compatibility with existing program development
-environments. Historic defaults are called out wherever possible in this
-manual. For a description of the current recommended options, see Appendix A,
-\fILink-Editor Quick Reference,\fR in \fILinker and Libraries Guide\fR.
-.sp
-.LP
-If the file being created by \fBld\fR already exists, the file is unlinked
-after all input files have been processed. A new file with the specified name
-is then created. This allows \fBld\fR to create a new version of the file,
-while simultaneously allowing existing processes that are accessing the old
-file contents to continue running. If the old file has no other links, the disk
-space of the removed file is freed when the last process referencing the file
-terminates.
-.sp
-.LP
-The behavior of \fBld\fR when the file being created already exists was changed
-with \fBSXCE\fR build \fB43\fR. In older versions, the existing file was
-rewritten in place, an approach with the potential to corrupt any running
-processes that is using the file. This change has an implication for output
-files that have multiple hard links in the file system. Previously, all links
-would remain intact, with all links accessing the new file contents. The new
-\fBld\fR behavior \fBbreaks\fR such links, with the result that only the
-specified output file name references the new file. All the other links
-continue to reference the old file. To ensure consistent behavior, applications
-that rely on multiple hard links to linker output files should explicitly
-remove and relink the other file names.
+.It Ev LIBPATH
+For 32-bit libraries, the default search path is
+.Pa /usr/ccs/lib ,
+followed by
+.Pa /lib ,
+and finally
+.Pa /usr/lib .
+For 64-bit libraries, the default search path is
+.Pa /lib/64 ,
+followed by
+.Pa /usr/lib/64 .
+.It Pa /usr/lib/ld
+A directory containing several mapfiles that can be used during link-editing.
+These mapfiles provide various capabilities, such as defining memory layouts,
+aligning bss, and defining non-executable stacks.
+.El
+.Sh ATTRIBUTES
+The command line interface of
+.Nm
+is
+.Sy Committed .
+The output of
+.Nm
+is
+.Sy Committed .
+.Sh SEE ALSO
+.Xr as 1 ,
+.Xr crle 1 ,
+.Xr gprof 1 ,
+.Xr ld.so.1 1 ,
+.Xr ldd 1 ,
+.Xr mcs 1 ,
+.Xr pvs 1 ,
+.Xr strip 1 ,
+.Xr exec 2 ,
+.Xr stat 2 ,
+.Xr dladdr 3C ,
+.Xr dldump 3C ,
+.Xr dlopen 3C ,
+.Xr malloc 3C ,
+.Xr elf 3ELF ,
+.Xr ar.h 3HEAD ,
+.Xr a.out 5 ,
+.Xr attributes 7
+.Rs
+.%B Linker and Libraries Guide
+.Re
+.Sh NOTES
+Default options applied by
+.Nm
+are maintained for historic reasons.
+In today's programming environment, where dynamic objects dominate, alternative
+defaults would often make more sense.
+However, historic defaults must be maintained to ensure compatibility with
+existing program development environments.
+Historic defaults are called out wherever possible in this manual.
+For a description of the current recommended options, see Appendix A,
+.Em Link-Editor Quick Reference ,
+in
+.%T Linker and Libraries Guide .
+.Pp
+If the file being created by
+.Nm
+already exists, the file is unlinked after all input files have been processed.
+A new file with the specified name is then created.
+This allows
+.Nm
+to create a new version of the file, while simultaneously allowing existing
+processes that are accessing the old file contents to continue running.
+If the old file has no other links, the disk space of the removed file is freed
+when the last process referencing the file terminates.
+.Pp
+The behavior of
+.Nm
+when the file being created already exists was changed
+with SXCE build 43.
+In older versions, the existing file was rewritten in place, an approach with
+the potential to corrupt any running processes that is using the file.
+This change has an implication for output files that have multiple hard links
+in the file system.
+Previously, all links would remain intact, with all links accessing the new
+file contents.
+The new
+.Nm
+behavior
+.Em breaks
+such links, with the result that only the specified output file name references
+the new file.
+All the other links continue to reference the old file.
+To ensure consistent behavior, applications that rely on multiple hard links to
+linker output files should explicitly remove and relink the other file names.

--- a/usr/src/pkg/manifests/driver-crypto-viorand.p5m
+++ b/usr/src/pkg/manifests/driver-crypto-viorand.p5m
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Toomas Soome <tsoome@me.com>
+#
+
+<include global_zone_only_component>
+set name=pkg.fmri value=pkg:/driver/crypto/viorand@$(PKGVERS)
+set name=pkg.summary value="VirtIO Random number Driver"
+set name=pkg.description value="VirtIO Random number Driver"
+set name=info.classification \
+    value="org.opensolaris.category.2008:Drivers/Other Peripherals"
+set name=variant.arch value=$(ARCH)
+dir  path=kernel group=sys
+dir  path=kernel/drv group=sys
+dir  path=kernel/drv/$(ARCH64) group=sys
+file path=kernel/drv/$(ARCH64)/viorand group=sys
+driver name=viorand alias=pci1af4,1005
+license lic_CDDL license=lic_CDDL

--- a/usr/src/pkg/manifests/system-data-zoneinfo.p5m
+++ b/usr/src/pkg/manifests/system-data-zoneinfo.p5m
@@ -14,11 +14,11 @@
 # Copyright (c) 2014 Joyent, Inc. All rights reserved.
 # Copyright 2017 OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
-# Copyright 2023 Oxide Computer Company
+# Copyright 2024 Oxide Computer Company
 #
 
 set name=pkg.fmri \
-    value=pkg:/system/data/zoneinfo@2023.4,$(PKGVERS_BUILTON)-$(PKGVERS_BRANCH)
+    value=pkg:/system/data/zoneinfo@2024.1,$(PKGVERS_BUILTON)-$(PKGVERS_BRANCH)
 set name=pkg.summary value="Timezone Information"
 set name=pkg.description value="timezone information"
 set name=info.classification value=org.opensolaris.category.2008:System/Core

--- a/usr/src/tools/scripts/git-pbchk.1onbld
+++ b/usr/src/tools/scripts/git-pbchk.1onbld
@@ -1,4 +1,3 @@
-'\" t
 .\"
 .\" This file and its contents are supplied under the terms of the
 .\" Common Development and Distribution License ("CDDL"), version 1.0.
@@ -13,71 +12,108 @@
 .\" Copyright 2011 Richard Lowe.
 .\" Copyright 2015 Elysium Digital, L.L.C.
 .\" Copyright 2018 Joyent, Inc.
+.\" Copyright 2024 Bill Sommerfeld <sommerfeld@hamachi.org>
 .\"
-
-.TH "GIT\-PBCHK" "1ONBLD" "February 10, 2022" "" ""
-
-.SH "NAME"
-\fBgit\-pbchk\fR \- nits and pre\-putback checks for git
-
-.SH "SYNOPSIS"
-git\-pbchk [\-c \fIcheck\fR] [\-p \fIbranch\fR] [file...]
-
-.P
-git\-nits [\-c \fIcheck\fR] [\-p \fIbranch\fR] [file...]
-
-.SH "OPTIONS"
-
-.TP
-\fB\-c check\fR:
-.IP
-Run the specific \fIcheck\fR, as named below.
+.Dd February 1, 2024
+.Dt GIT-PBCHK 1ONBLD
+.Os
+.Sh NAME
+.Nm git-pbchk ,
+.Nm git-nits
+.Nd nits and pre-putback checks for git
+.Sh SYNOPSIS
+.Nm git-pbchk
+.Op Fl c Ar check
+.Op Fl p Ar branch
+.Nm git-nits
+.Op Fl c Ar check
+.Op Fl p Ar branch
+.Op Ar file Ns ...
+.Sh DESCRIPTION
+Check your workspace for common nits and putback-ending mistakes.
+A simple set of checks are run over various parts of your workspace
+and errors encountered are reported, all of which should, generally,
+be fixed.
+.Pp
+As these command names start with
+.Sq git-
+they can also be run by
+.Xr git 1
+as subcommands:
+.Pp
+.Dl $ git pbchk
+.Sh OPTIONS
+.Bl -tag -width 6n
+.It Fl c Ar check
+Run the specific
+.Ar check ,
+as named below.
 In this mode, individual files can be provided to check.
-.TP
-\fB\-p branch\fR:
-.IP
-Compare the current workspace to the parent \fIbranch\fR for the purposes of generating file and comment lists\.
-.IP
-If this option is not specified an attempt is made to determine this automatically, if the git branch configuration contains this information\.
-.IP
-If no branch is specified and none can be determined automatically \fBorigin/master\fR is used\.
-.SH "DESCRIPTION"
-Check your workspace for common nits and putback\-ending mistakes, a simple set of checks are run over various parts of your workspace and errors encountered are reported, all of which should, generally, be fixed\.
-.TP
-Comment format [comchk]
-Check that putback comments follow the prescribed format (only run for pbchk)
-.TP
-Copyrights [copyright]
+.It Fl p Ar branch
+Compare the current workspace to the parent
+.Ar branch
+for the purposes of generating file and comment lists.
+.Pp
+If this option is not specified an attempt is made to determine this
+automatically, if the git branch configuration contains this information.
+.Pp
+If no branch is specified and none can be determined automatically
+.Pa origin/master
+is used.
+.El
+.Sh CHECKS
+.Bl -tag -width 6n
+.It Comment format: Cm comchk
+Check that putback comments follow the prescribed format
+.Pq only run for pbchk .
+.It Copyrights: Cm copyright
 Check that each source file contains a copyright notice for the current
-year\. You don't need to fix this if you, the potential new copyright holder, chooses not to
-.TP
-C style [cstyle]
+year\. You don't need to fix this if you, the potential new copyright holder,
+chooses not to
+.It C style: Cm cstyle
 Check that C source files conform to the illumos C style rules
-.TP
-Header check [hdrchk]
-Check that C header files conform to the illumos header style rules (in addition to the general C rules)
-.TP
-Java style [jstyle]
-Check that Java source files conform to the illumos Java style rules (which differ from the traditionally recommended Java style)
-.TP
-SCCS Keywords [keywords]
-Check that no source files contain unexpanded SCCS keywords\. It is possible that this check may false positive on certain inputs\. It is generally obvious when this is the case\.
-.IP
-This check does not check for expanded SCCS keywords, though the common \'ident\'\-style lines should be removed regardless of whether they are expanded\.
-.TP
-Man page check [manlint]
+.It Header check: Cm hdrchk
+Check that C header files conform to the illumos header style rules
+.Pq in addition to the general C rules .
+.It Java style: Cm jstyle
+Check that Java source files conform to the illumos Java style rules
+.Pq which differ from the traditionally recommended Java style .
+.It SCCS Keywords: Cm keywords
+Check that no source files contain unexpanded SCCS keywords.
+It is possible that this check may false positive on certain inputs.
+It is generally obvious when this is the case.
+.Pp
+This check does not check for expanded SCCS keywords, though the common
+.Sq ident Ns
+-style lines should be removed regardless of whether they are
+expanded.
+.It Man page check: Cm manlint
 Check for problems with man pages.
-.TP
-Mapfile check [mapfilechk]
-Check that linker mapfiles contain a comment directing anyone editing to read the directions in \fBusr/lib/README\.mapfiles\fR\.
-.TP
-Whitespace check [wscheck]
+.It Mapfile check: Cm mapfilechk
+Check that linker mapfiles contain a comment directing anyone editing to
+read the directions in
+.Pa usr/lib/README.mapfiles .
+.It Shell script check: Cm shelllint
+Check for problems with shell scripts.
+.It Package manifest formatting: Cm pkgfmt
+Check package manifests for common errors.
+.It Windows special filename check Cm winnames
+Check for filenames which would prevent you from checking out
+illumos-gate on a Windows system.
+.It Whitespace check: Cm wscheck
 Check for whitespace issues such as mixed tabs/spaces in source files.
-.SH "FILES"
-Exception lists can be used to exclude certain files from checking, named after
+.It Committed symlinks check: Cm symlinks
+Report if there are any symlinks checked into your change; they are
+not allowed by illumos policy.
+.El
+.Sh FILES
+Exception lists can be used to exclude certain files from checks, named after
 the specific check.
-They can be found in \fB$CODEMGR_WS/exception_lists/\fR, or optionally under
-\fB$CODEMGR_WS/\.git/info/\fR, where they must be suffixed \fB.NOT\fR.
-
-.IP "" 0
-
+They can be found in
+.Pa $CODEMGR_WS/exception_lists ,
+or optionally under
+.Pa $CODEMGR_WS/.git/info/ ,
+where they must be suffixed
+.Pa .NOT .
+.Sh SEE ALSO
+.Xr git 1

--- a/usr/src/uts/common/Makefile.files
+++ b/usr/src/uts/common/Makefile.files
@@ -1652,6 +1652,8 @@ RSAPROV_OBJS += rsa.o rsa_impl.o pkcs1.o
 
 SWRANDPROV_OBJS += swrand.o
 
+VIORANDPROV_OBJS += viorand.o
+
 #
 #			misc. modules
 #

--- a/usr/src/uts/common/crypto/core/kcf_cryptoadm.c
+++ b/usr/src/uts/common/crypto/core/kcf_cryptoadm.c
@@ -118,6 +118,7 @@ kcf_soft_config_init(void)
 	 * CKM_SHA1_RSA_PKCS,CKM_SHA256_RSA_PKCS,CKM_SHA384_RSA_PKCS,\
 	 * CKM_SHA512_RSA_PKCS
 	 * swrand:supportedlist=random
+	 * viorand:supportedlist=random
 	 *
 	 * WARNING: If you add a new kernel crypto provider or mechanism,
 	 * you must update these structures.
@@ -162,6 +163,8 @@ kcf_soft_config_init(void)
 		"CKM_SHA512_RSA_PKCS", ""};
 	static crypto_mech_name_t	swrand_mechs[] = {
 		"random", ""};
+	static crypto_mech_name_t	viorand_mechs[] = {
+		"random", ""};
 	static initial_soft_config_entry_t
 		initial_soft_config_entry[] = {
 			"des", des_mechs,
@@ -174,7 +177,8 @@ kcf_soft_config_init(void)
 			"md4", md4_mechs,
 			"md5", md5_mechs,
 			"rsa", rsa_mechs,
-			"swrand", swrand_mechs
+			"swrand", swrand_mechs,
+			"viorand", viorand_mechs
 		};
 	const int initial_soft_config_entries =
 	    sizeof (initial_soft_config_entry)

--- a/usr/src/uts/common/crypto/io/viorand.c
+++ b/usr/src/uts/common/crypto/io/viorand.c
@@ -1,0 +1,530 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Toomas Soome <tsoome@me.com>
+ */
+
+/*
+ * Virtio random data device.
+ */
+
+#include <sys/types.h>
+#include <sys/modctl.h>
+#include <sys/conf.h>
+#include <sys/sunddi.h>
+#include <sys/sysmacros.h>
+#include <sys/crypto/spi.h>
+#include <sys/time.h>
+#include <virtio.h>
+
+#define	VIORAND_FEATURES	0
+#define	VIORAND_RQ		0
+
+typedef struct viorand_state viorand_state_t;
+
+typedef struct viorand_rdbuf {
+	viorand_state_t		*rb_viornd;
+	virtio_dma_t		*rb_dma;
+	virtio_chain_t		*rb_chain;
+	size_t			rb_recv_len;
+	uchar_t			*rb_req_buf;
+	size_t			rb_req_len;
+	crypto_req_handle_t	rb_req_handle;
+	list_node_t		rb_link;
+} viorand_rdbuf_t;
+
+struct viorand_state {
+	dev_info_t	*vio_dip;
+	kmutex_t	vio_mutex;
+	kcondvar_t	vio_cv;
+	crypto_kcf_provider_handle_t vio_handle;
+	taskq_t		*vio_taskq;
+	virtio_t	*vio_virtio;
+	virtio_queue_t	*vio_rq;
+	uint64_t	vio_features;
+
+	uint_t		vio_rdbufs_capacity;
+	uint_t		vio_rdbufs_alloc;
+	list_t		vio_rdbufs_free;	/* Free list */
+	viorand_rdbuf_t	*vio_rdbuf_mem;
+};
+
+static const ddi_dma_attr_t viorand_dma_attr = {
+	.dma_attr_version =	DMA_ATTR_V0,
+	.dma_attr_addr_lo =	0x0000000000000000,
+	.dma_attr_addr_hi =	0xFFFFFFFFFFFFFFFF,
+	.dma_attr_count_max =	0x00000000FFFFFFFF,
+	.dma_attr_align =	1,
+	.dma_attr_burstsizes =	1,
+	.dma_attr_minxfer =	1,
+	.dma_attr_maxxfer =	0x00000000FFFFFFFF,
+	.dma_attr_seg =		0x00000000FFFFFFFF,
+	.dma_attr_sgllen =	64,
+	.dma_attr_granular =	1,
+	.dma_attr_flags =	0
+};
+
+/* If set, we do not allow to detach ourselves. */
+boolean_t virtio_registered = B_TRUE;
+static void *viorand_statep;
+
+static int viorand_attach(dev_info_t *, ddi_attach_cmd_t);
+static int viorand_detach(dev_info_t *, ddi_detach_cmd_t);
+static int viorand_quiesce(dev_info_t *);
+
+static void viorand_provider_status(crypto_provider_handle_t, uint_t *);
+static int viorand_generate_random(crypto_provider_handle_t,
+    crypto_session_id_t, uchar_t *, size_t, crypto_req_handle_t);
+
+static uint_t viorand_interrupt(caddr_t, caddr_t);
+
+/*
+ * Module linkage information for the kernel.
+ */
+
+static struct dev_ops devops = {
+	.devo_rev = DEVO_REV,
+	.devo_refcnt = 0,
+	.devo_getinfo = ddi_no_info,
+	.devo_identify = nulldev,
+	.devo_probe = nulldev,
+	.devo_attach = viorand_attach,
+	.devo_detach = viorand_detach,
+	.devo_reset = nodev,
+	.devo_cb_ops = NULL,
+	.devo_bus_ops = NULL,
+	.devo_power = NULL,
+	.devo_quiesce = viorand_quiesce
+};
+
+static struct modldrv modldrv = {
+	.drv_modops = &mod_driverops,
+	.drv_linkinfo = "VirtIO Random Number Driver",
+	.drv_dev_ops = &devops
+};
+
+static struct modlcrypto modlcrypto = {
+	.crypto_modops = &mod_cryptoops,
+	.crypto_linkinfo = "VirtIO Random Number Provider"
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev = MODREV_1,
+	.ml_linkage = { &modldrv, &modlcrypto, NULL }
+};
+
+/*
+ * CSPI information (entry points, provider info, etc.)
+ */
+static void viorand_provider_status(crypto_provider_handle_t, uint_t *);
+
+static crypto_control_ops_t viorand_control_ops = {
+	.provider_status = viorand_provider_status
+};
+
+static int viorand_generate_random(crypto_provider_handle_t,
+    crypto_session_id_t, uchar_t *, size_t, crypto_req_handle_t);
+
+static crypto_random_number_ops_t viorand_random_number_ops = {
+	.generate_random = viorand_generate_random
+};
+
+static crypto_ops_t viorand_crypto_ops = {
+	.co_control_ops = &viorand_control_ops,
+	.co_random_ops = &viorand_random_number_ops
+};
+
+static crypto_provider_info_t viorand_prov_info = {
+	.pi_interface_version = CRYPTO_SPI_VERSION_1,
+	.pi_provider_description = "VirtIO Random Number Provider",
+	.pi_provider_type = CRYPTO_HW_PROVIDER,
+	.pi_ops_vector = &viorand_crypto_ops,
+};
+
+/*
+ * DDI entry points.
+ */
+int
+_init(void)
+{
+	int error;
+
+	error = ddi_soft_state_init(&viorand_statep,
+	    sizeof (viorand_state_t), 0);
+	if (error != 0)
+		return (error);
+
+	return (mod_install(&modlinkage));
+}
+
+int
+_fini(void)
+{
+	int error;
+
+	error = mod_remove(&modlinkage);
+	if (error == 0)
+		ddi_soft_state_fini(&viorand_statep);
+
+	return (error);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}
+
+/*
+ * return buffer from free list.
+ */
+static viorand_rdbuf_t *
+viorand_rbuf_alloc(viorand_state_t *state)
+{
+	viorand_rdbuf_t *rb;
+
+	VERIFY(MUTEX_HELD(&state->vio_mutex));
+
+	while ((rb = list_remove_head(&state->vio_rdbufs_free)) == NULL)
+		cv_wait(&state->vio_cv, &state->vio_mutex);
+
+	state->vio_rdbufs_alloc++;
+	return (rb);
+}
+
+/*
+ * return buffer to free list
+ */
+static void
+viorand_rbuf_free(viorand_state_t *state, viorand_rdbuf_t *rb)
+{
+	VERIFY(MUTEX_HELD(&state->vio_mutex));
+	VERIFY3U(state->vio_rdbufs_alloc, >, 0);
+
+	state->vio_rdbufs_alloc--;
+	virtio_chain_clear(rb->rb_chain);
+	if (rb->rb_dma != NULL) {
+		virtio_dma_free(rb->rb_dma);
+		rb->rb_dma = NULL;
+	}
+	list_insert_head(&state->vio_rdbufs_free, rb);
+}
+
+/*
+ * Free all allocated buffers. This is called to clean everything up,
+ * so we do not want to leave anything around.
+ */
+static void
+viorand_free_bufs(viorand_state_t *state)
+{
+	VERIFY(MUTEX_HELD(&state->vio_mutex));
+
+	for (uint_t i = 0; i < state->vio_rdbufs_capacity; i++) {
+		viorand_rdbuf_t *rb = &state->vio_rdbuf_mem[i];
+
+		if (rb->rb_dma != NULL) {
+			virtio_dma_free(rb->rb_dma);
+			rb->rb_dma = NULL;
+		}
+
+		if (rb->rb_chain != NULL) {
+			virtio_chain_free(rb->rb_chain);
+			rb->rb_chain = NULL;
+		}
+	}
+
+	if (state->vio_rdbuf_mem != NULL) {
+		kmem_free(state->vio_rdbuf_mem,
+		    sizeof (viorand_rdbuf_t) * state->vio_rdbufs_capacity);
+		state->vio_rdbuf_mem = NULL;
+		state->vio_rdbufs_capacity = 0;
+		state->vio_rdbufs_alloc = 0;
+	}
+}
+
+static int
+viorand_alloc_bufs(viorand_state_t *state)
+{
+	VERIFY(MUTEX_HELD(&state->vio_mutex));
+
+	state->vio_rdbufs_capacity = virtio_queue_size(state->vio_rq);
+	state->vio_rdbuf_mem = kmem_zalloc(sizeof (viorand_rdbuf_t) *
+	    state->vio_rdbufs_capacity, KM_SLEEP);
+	list_create(&state->vio_rdbufs_free, sizeof (viorand_rdbuf_t),
+	    offsetof(viorand_rdbuf_t, rb_link));
+
+	/* Put everything in free list. */
+	for (uint_t i = 0; i < state->vio_rdbufs_capacity; i++)
+		list_insert_tail(&state->vio_rdbufs_free,
+		    &state->vio_rdbuf_mem[i]);
+
+	for (viorand_rdbuf_t *rb = list_head(&state->vio_rdbufs_free);
+	    rb != NULL; rb = list_next(&state->vio_rdbufs_free, rb)) {
+		rb->rb_viornd = state;
+		rb->rb_chain = virtio_chain_alloc(state->vio_rq, KM_SLEEP);
+		if (rb->rb_chain == NULL)
+			goto fail;
+
+		virtio_chain_data_set(rb->rb_chain, rb);
+	}
+	return (0);
+
+fail:
+	viorand_free_bufs(state);
+	return (ENOMEM);
+}
+
+static int
+viorand_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	int instance = ddi_get_instance(dip);
+	int rv = 0;
+	viorand_state_t *state;
+	virtio_t *vio;
+
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+
+	case DDI_RESUME:
+	default:
+		return (DDI_FAILURE);
+	}
+
+	if (ddi_soft_state_zalloc(viorand_statep, instance) != DDI_SUCCESS)
+		return (DDI_FAILURE);
+
+	vio = virtio_init(dip, VIORAND_FEATURES, B_TRUE);
+	if (vio == NULL) {
+		ddi_soft_state_free(viorand_statep, instance);
+		return (DDI_FAILURE);
+	}
+
+	state = ddi_get_soft_state(viorand_statep, instance);
+	state->vio_dip = dip;
+	state->vio_virtio = vio;
+	state->vio_rq = virtio_queue_alloc(vio, VIORAND_RQ, "requestq",
+	    viorand_interrupt, state, B_FALSE, 1);
+	if (state->vio_rq == NULL) {
+		virtio_fini(state->vio_virtio, B_TRUE);
+		ddi_soft_state_free(viorand_statep, instance);
+		return (DDI_FAILURE);
+	}
+
+	if (virtio_init_complete(state->vio_virtio, VIRTIO_ANY_INTR_TYPE) !=
+	    DDI_SUCCESS) {
+		virtio_fini(state->vio_virtio, B_TRUE);
+		ddi_soft_state_free(viorand_statep, instance);
+		return (DDI_FAILURE);
+	}
+
+	cv_init(&state->vio_cv, NULL, CV_DRIVER, NULL);
+	mutex_init(&state->vio_mutex, NULL, MUTEX_DRIVER, virtio_intr_pri(vio));
+	mutex_enter(&state->vio_mutex);
+
+	if (viorand_alloc_bufs(state) != 0) {
+		mutex_exit(&state->vio_mutex);
+		dev_err(dip, CE_WARN, "failed to allocate memory");
+		goto fail;
+	}
+	mutex_exit(&state->vio_mutex);
+
+	viorand_prov_info.pi_provider_dev.pd_hw = dip;
+	viorand_prov_info.pi_provider_handle = state;
+
+	if (virtio_interrupts_enable(state->vio_virtio) != DDI_SUCCESS)
+		goto fail;
+
+	rv = crypto_register_provider(&viorand_prov_info, &state->vio_handle);
+	if (rv == CRYPTO_SUCCESS) {
+		return (DDI_SUCCESS);
+	}
+
+fail:
+	virtio_interrupts_disable(state->vio_virtio);
+	mutex_enter(&state->vio_mutex);
+	viorand_free_bufs(state);
+	mutex_exit(&state->vio_mutex);
+	cv_destroy(&state->vio_cv);
+	mutex_destroy(&state->vio_mutex);
+	virtio_fini(state->vio_virtio, B_TRUE);
+	ddi_soft_state_free(viorand_statep, instance);
+	return (DDI_FAILURE);
+}
+
+static int
+viorand_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	int instance = ddi_get_instance(dip);
+	viorand_state_t *state = ddi_get_soft_state(viorand_statep, instance);
+
+	switch (cmd) {
+	case DDI_DETACH:
+		if (!virtio_registered)
+			break;
+
+		/* FALLTHROUGH */
+	case DDI_SUSPEND:
+	default:
+		return (DDI_FAILURE);
+	}
+
+	if (crypto_unregister_provider(state->vio_handle) != CRYPTO_SUCCESS)
+		return (DDI_FAILURE);
+
+	virtio_interrupts_disable(state->vio_virtio);
+	virtio_shutdown(state->vio_virtio);
+
+	mutex_enter(&state->vio_mutex);
+	for (;;) {
+		virtio_chain_t *vic;
+
+		vic = virtio_queue_evacuate(state->vio_rq);
+		if (vic == NULL)
+			break;
+
+		viorand_rbuf_free(state, virtio_chain_data(vic));
+	}
+
+	viorand_free_bufs(state);
+	mutex_exit(&state->vio_mutex);
+	cv_destroy(&state->vio_cv);
+	mutex_destroy(&state->vio_mutex);
+	(void) virtio_fini(state->vio_virtio, B_FALSE);
+	ddi_soft_state_free(viorand_statep, instance);
+	return (DDI_SUCCESS);
+}
+
+static int
+viorand_quiesce(dev_info_t *dip)
+{
+	int instance = ddi_get_instance(dip);
+	viorand_state_t *state = ddi_get_soft_state(viorand_statep, instance);
+
+	if (state == NULL)
+		return (DDI_FAILURE);
+
+	return (virtio_quiesce(state->vio_virtio));
+}
+
+/*
+ * Control entry points.
+ */
+static void
+viorand_provider_status(crypto_provider_handle_t provider __unused,
+    uint_t *status)
+{
+	*status = CRYPTO_PROVIDER_READY;
+}
+
+static boolean_t
+viorand_submit_request(viorand_rdbuf_t *rb)
+{
+	if (virtio_chain_append(rb->rb_chain,
+	    virtio_dma_cookie_pa(rb->rb_dma, 0),
+	    rb->rb_req_len,
+	    VIRTIO_DIR_DEVICE_WRITES) != DDI_SUCCESS) {
+		return (B_FALSE);
+	}
+
+	virtio_dma_sync(rb->rb_dma, DDI_DMA_SYNC_FORDEV);
+	virtio_chain_submit(rb->rb_chain, B_TRUE);
+	return (B_TRUE);
+}
+
+/* We got portion of data, process it */
+static void
+viorand_process_data(viorand_rdbuf_t *rb)
+{
+	size_t len;
+	int error = CRYPTO_SUCCESS;
+
+	len = MIN(rb->rb_req_len, rb->rb_recv_len);
+	bcopy(virtio_dma_va(rb->rb_dma, 0), rb->rb_req_buf, len);
+	bzero(virtio_dma_va(rb->rb_dma, 0), len);
+	if (len < rb->rb_req_len) {
+		rb->rb_req_len -= len;
+		rb->rb_req_buf += len;
+		/* Try to get reminder */
+		if (viorand_submit_request(rb))
+			return;
+
+		/* Release our buffer and return error */
+		viorand_rbuf_free(rb->rb_viornd, rb);
+		error = CRYPTO_HOST_MEMORY;
+	} else {
+		/* Got all the data, free our buffer */
+		viorand_rbuf_free(rb->rb_viornd, rb);
+	}
+	crypto_op_notification(rb->rb_req_handle, error);
+}
+
+static uint_t
+viorand_interrupt(caddr_t a, caddr_t b __unused)
+{
+	viorand_state_t *state = (viorand_state_t *)a;
+	virtio_chain_t *vic;
+	boolean_t notify = B_FALSE;
+
+	mutex_enter(&state->vio_mutex);
+	while ((vic = virtio_queue_poll(state->vio_rq)) != NULL) {
+		/* Actual received len and our read buffer */
+		size_t len = virtio_chain_received_length(vic);
+		viorand_rdbuf_t *rb = virtio_chain_data(vic);
+
+		virtio_dma_sync(rb->rb_dma, DDI_DMA_SYNC_FORCPU);
+		rb->rb_recv_len = len;
+		viorand_process_data(rb);
+		notify = B_TRUE;
+	}
+	if (notify)
+		cv_broadcast(&state->vio_cv);
+	mutex_exit(&state->vio_mutex);
+	if (notify)
+		return (DDI_INTR_CLAIMED);
+	return (DDI_INTR_UNCLAIMED);
+}
+
+/*
+ * Random number entry point.
+ */
+static int
+viorand_generate_random(crypto_provider_handle_t provider,
+    crypto_session_id_t sid __unused, uchar_t *buf, size_t len,
+    crypto_req_handle_t req)
+{
+	viorand_state_t *state = provider;
+	viorand_rdbuf_t *rb;
+
+	mutex_enter(&state->vio_mutex);
+	rb = viorand_rbuf_alloc(state);
+	mutex_exit(&state->vio_mutex);
+
+	rb->rb_req_buf = buf;
+	rb->rb_req_len = len;
+	rb->rb_req_handle = req;
+
+	rb->rb_dma = virtio_dma_alloc(state->vio_virtio, len,
+	    &viorand_dma_attr, DDI_DMA_READ | DDI_DMA_STREAMING, KM_SLEEP);
+	if (rb->rb_dma == NULL) {
+		goto error;
+	}
+
+	if (viorand_submit_request(rb))
+		return (CRYPTO_QUEUED);
+
+error:
+	mutex_enter(&state->vio_mutex);
+	viorand_rbuf_free(state, rb);
+	mutex_exit(&state->vio_mutex);
+	return (CRYPTO_HOST_MEMORY);
+}

--- a/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_dispatch.c
@@ -979,10 +979,13 @@ cmd_done:
 	 * If there's a next command, figure out where it starts,
 	 * and fill in the next header offset for the reply.
 	 * Note: We sanity checked smb2_next_command above.
+	 * Once we've gone async, replies are not compounded.
 	 */
 	if (sr->smb2_next_command != 0) {
 		sr->command.chain_offset =
 		    sr->smb2_cmd_hdr + sr->smb2_next_command;
+	}
+	if (sr->smb2_next_command != 0 && !sr->smb2_async) {
 		sr->smb2_next_reply =
 		    sr->reply.chain_offset - sr->smb2_reply_hdr;
 	} else {

--- a/usr/src/uts/common/fs/smbsrv/smb2_flush.c
+++ b/usr/src/uts/common/fs/smbsrv/smb2_flush.c
@@ -12,6 +12,7 @@
 /*
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 Syneto S.R.L. All rights reserved.
+ * Copyright 2023 RackTop Systems, Inc.
  */
 
 /*
@@ -65,7 +66,7 @@ smb2_flush(smb_request_t *sr)
 	 * SMB2 Flush reply
 	 */
 	(void) smb_mbc_encodef(
-	    &sr->reply, "wwl",
+	    &sr->reply, "ww",
 	    4,	/* StructSize */	/* w */
 	    0); /* reserved */		/* w */
 

--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -27,6 +27,7 @@
  * Copyright (c) 2011, 2019, Delphix. All rights reserved.
  * Copyright (c) 2020, George Amanakis. All rights reserved.
  * Copyright (c) 2020, The FreeBSD Foundation [1]
+ * Copyright 2024 Bill Sommerfeld <sommerfeld@hamachi.org>
  *
  * [1] Portions of this software were developed by Allan Jude
  *     under sponsorship from the FreeBSD Foundation.
@@ -6772,6 +6773,20 @@ arc_memory_throttle(spa_t *spa, uint64_t reserve, uint64_t txg)
 	spa->spa_lowmem_page_load = 0;
 #endif /* _KERNEL */
 	return (0);
+}
+
+/*
+ * In more extreme cases, return B_TRUE if system memory is tight enough
+ * that ZFS should defer work requiring new allocations.
+ */
+boolean_t
+arc_memory_is_low(void)
+{
+#ifdef _KERNEL
+	if (freemem < minfree + needfree)
+		return (B_TRUE);
+#endif /* _KERNEL */
+	return (B_FALSE);
 }
 
 void

--- a/usr/src/uts/common/fs/zfs/dsl_scan.c
+++ b/usr/src/uts/common/fs/zfs/dsl_scan.c
@@ -25,6 +25,7 @@
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  * Copyright 2019 Joyent, Inc.
  * Copyright (c) 2017, 2019, Datto Inc. All rights reserved.
+ * Copyright 2024 Bill Sommerfeld <sommerfeld@hamachi.org>
  */
 
 #include <sys/dsl_scan.h>
@@ -1214,6 +1215,14 @@ dsl_scan_should_clear(dsl_scan_t *scn)
 	spa_t *spa = scn->scn_dp->dp_spa;
 	vdev_t *rvd = scn->scn_dp->dp_spa->spa_root_vdev;
 	uint64_t alloc, mlim_hard, mlim_soft, mused;
+
+	if (arc_memory_is_low()) {
+		/*
+		 * System memory is tight, and scanning requires allocation.
+		 * Throttle the scan until we have more headroom.
+		 */
+		return (B_TRUE);
+	}
 
 	alloc = metaslab_class_get_alloc(spa_normal_class(spa));
 	alloc += metaslab_class_get_alloc(spa_special_class(spa));

--- a/usr/src/uts/common/fs/zfs/sys/arc.h
+++ b/usr/src/uts/common/fs/zfs/sys/arc.h
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright 2024 Bill Sommerfeld <sommerfeld@hamachi.org>
  */
 
 #ifndef	_SYS_ARC_H
@@ -246,6 +247,7 @@ void arc_flush(spa_t *spa, boolean_t retry);
 void arc_tempreserve_clear(uint64_t reserve);
 int arc_tempreserve_space(spa_t *spa, uint64_t reserve, uint64_t txg);
 
+boolean_t arc_memory_is_low(void);
 uint64_t arc_all_memory(void);
 uint64_t arc_max_bytes(void);
 void arc_init(void);

--- a/usr/src/uts/common/io/ena/ena.h
+++ b/usr/src/uts/common/io/ena/ena.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2021 Oxide Computer Company
+ * Copyright 2024 Oxide Computer Company
  */
 
 #ifndef	_ENA_H
@@ -438,8 +438,9 @@ typedef enum ena_rxq_state {
 	ENA_RXQ_STATE_HOST_ALLOC	= 1 << 0,
 	ENA_RXQ_STATE_CQ_CREATED	= 1 << 1,
 	ENA_RXQ_STATE_SQ_CREATED	= 1 << 2,
-	ENA_RXQ_STATE_READY		= 1 << 3, /* RxQ ready and waiting */
-	ENA_RXQ_STATE_RUNNING		= 1 << 4, /* intrs enabled */
+	ENA_RXQ_STATE_SQ_FILLED		= 1 << 3,
+	ENA_RXQ_STATE_READY		= 1 << 4, /* RxQ ready and waiting */
+	ENA_RXQ_STATE_RUNNING		= 1 << 5, /* intrs enabled */
 } ena_rxq_state_t;
 
 typedef struct ena_rx_ctrl_block {
@@ -696,6 +697,7 @@ typedef struct ena {
 	 * Hardware info
 	 */
 	uint32_t		ena_supported_features;
+	uint32_t		ena_capabilities;
 	uint8_t			ena_dma_width;
 	boolean_t		ena_link_up;
 	boolean_t		ena_link_autoneg;

--- a/usr/src/uts/common/os/modconf.c
+++ b/usr/src/uts/common/os/modconf.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2021 Oxide Computer Company
  */
 
 #include <sys/types.h>
@@ -565,10 +566,8 @@ mod_installdrv(struct modldrv *modl, struct modlinkage *modlp)
 
 	/* Sanity check modname */
 	if ((major = ddi_name_to_major(modname)) == DDI_MAJOR_T_NONE) {
-#ifdef DEBUG
 		cmn_err(CE_WARN,
 		    "mod_installdrv: no major number for %s", modname);
-#endif
 		err = ENXIO;
 		goto done;
 	}

--- a/usr/src/uts/intel/Makefile.intel
+++ b/usr/src/uts/intel/Makefile.intel
@@ -425,6 +425,7 @@ DRV_KMODS	+= vr
 DRV_KMODS	+= virtio
 DRV_KMODS	+= vioblk
 DRV_KMODS	+= vioif
+DRV_KMODS	+= viorand
 DRV_KMODS	+= vioscsi
 
 # Virtio 9P transport driver

--- a/usr/src/uts/intel/os/cpuid.c
+++ b/usr/src/uts/intel/os/cpuid.c
@@ -2190,8 +2190,14 @@ determine_platform(void)
 			platform_type = HW_BHYVE;
 			return;
 		}
-		if (strcmp(hvstr, HVSIG_MICROSOFT) == 0)
+		if (strcmp(hvstr, HVSIG_MICROSOFT) == 0) {
 			platform_type = HW_MICROSOFT;
+			return;
+		}
+		if (strcmp(hvstr, HVSIG_QEMU_TCG) == 0) {
+			platform_type = HW_QEMU_TCG;
+			return;
+		}
 	} else {
 		/*
 		 * Check older VMware hardware versions. VMware hypervisor is

--- a/usr/src/uts/intel/sys/x86_archext.h
+++ b/usr/src/uts/intel/sys/x86_archext.h
@@ -1785,6 +1785,7 @@ extern int enable_platform_detection;
 #define	HVSIG_KVM	"KVMKVMKVM"
 #define	HVSIG_MICROSOFT	"Microsoft Hv"
 #define	HVSIG_BHYVE	"bhyve bhyve "
+#define	HVSIG_QEMU_TCG	"TCGTCGTCGTCG"
 
 /*
  * Defined hardware environments
@@ -1797,9 +1798,10 @@ extern int enable_platform_detection;
 #define	HW_KVM		(1 << 4)	/* Running on KVM hypervisor */
 #define	HW_MICROSOFT	(1 << 5)	/* Running on Microsoft hypervisor */
 #define	HW_BHYVE	(1 << 6)	/* Running on bhyve hypervisor */
+#define	HW_QEMU_TCG	(1 << 7)	/* Running on QEMU TCG hypervisor */
 
 #define	HW_VIRTUAL	(HW_XEN_HVM | HW_VMWARE | HW_KVM | HW_MICROSOFT | \
-	    HW_BHYVE)
+	    HW_BHYVE | HW_QEMU_TCG)
 
 #endif	/* _KERNEL */
 

--- a/usr/src/uts/intel/viorand/Makefile
+++ b/usr/src/uts/intel/viorand/Makefile
@@ -1,0 +1,65 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Toomas Soome <tsoome@me.com>
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+COM_DIR = $(COMMONBASE)/crypto
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= viorand
+OBJECTS		= $(VIORANDPROV_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/intel/Makefile.intel
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+CFLAGS		+= -I$(COM_DIR) -I$(UTSBASE)/common/io/virtio
+
+#
+# Linkage dependencies
+#
+LDFLAGS += -N misc/kcf -N misc/virtio
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/intel/Makefile.targ


### PR DESCRIPTION
Weekly upstream for upstream_merge/2024020601

## Backports

To r46, r48:

- 14845 ena panic during first AMI boot
- 16139 unix: we should recognize qemu
- 16230 Update tzdata to 2024a

## onu

```
OmniOS r151049 Version omnios-upstream_merge-2024020601-ae5925fe32b 64-bit
Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
Copyright (c) 2017-2024 OmniOS Community Edition (OmniOSce) Association.
DEBUG enabled
Hostname: bloody

bloody console login: root
Password:
Last login: Fri Jan 26 17:42:58 2024 on console
OmniOS r151049  omnios-upstream_merge-2024020601-ae5925fe32b    February 2024
illumos development build: 2024-Feb-06 [illumos]
You have mail.
root@bloody:~# uname -a
SunOS bloody 5.11 omnios-upstream_merge-2024020601-ae5925fe32b i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Tue Feb  6 18:32:45 UTC 2024 ====
==== Nightly distributed build completed: Tue Feb  6 19:45:11 UTC 2024 ====

==== Total build time ====

real    1:12:25

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-71f55ca7377 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 9.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151049/10.5.0-il-1) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151049/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk11.0/bin/javac
openjdk full version "11.0.22+7-omnios-151049"

/usr/bin/openssl
OpenSSL 3.1.5 30 Jan 2024 (Library: OpenSSL 3.1.5 30 Jan 2024)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   120

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2024020601-ae5925fe32b

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:01.9
user  4:04:08.7
sys   1:20:11.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:33.9
user  3:48:31.0
sys   1:16:40.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
