### PR TITLE
16234 BIOS PCI detection failure results in only bus 0 being enumerated (r151046)

### DIFF
--- a/usr/src/uts/i86pc/os/fakebop.c
+++ b/usr/src/uts/i86pc/os/fakebop.c
@@ -27,6 +27,7 @@
  * All rights reserved.
  *
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2024 Oxide Computer Company
  */
 
 /*
@@ -967,12 +968,16 @@ do_bsys_doint(bootops_t *bop, int intnum, struct bop_regs *rp)
 	br.ds = rp->ds;
 	br.es = rp->es;
 
-	DBG_MSG("Doing BIOS call...");
+	DBG_MSG("Doing BIOS call...\n");
 	DBG(br.ax);
 	DBG(br.bx);
 	DBG(br.dx);
 	rp->eflags = bios_func(intnum, &br);
 	DBG_MSG("done\n");
+	DBG(rp->eflags);
+	DBG(br.ax);
+	DBG(br.bx);
+	DBG(br.dx);
 
 	rp->eax.word.ax = br.ax;
 	rp->ebx.word.bx = br.bx;

--- a/usr/src/uts/i86pc/os/pci_cfgspace.c
+++ b/usr/src/uts/i86pc/os/pci_cfgspace.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2024 Oxide Computer Company
  */
 
 /*
@@ -168,8 +169,13 @@ pci_check(void)
 
 	pci_bios_cfg_type = pci_check_bios();
 
-	if (pci_bios_cfg_type == PCI_MECHANISM_NONE)
-		pci_bios_cfg_type = PCI_MECHANISM_1;	/* default to mech 1 */
+	if (pci_bios_cfg_type == PCI_MECHANISM_NONE) {
+		/*
+		 * Default to mechanism 1, and scan all PCI buses
+		 */
+		pci_bios_cfg_type = PCI_MECHANISM_1;
+		pci_bios_maxbus = pci_max_nbus;
+	}
 
 	switch (pci_get_cfg_type()) {
 	case PCI_MECHANISM_1:


### PR DESCRIPTION
16237 Add BIOS INT call results to early debug output
Reviewed by: Bill Sommerfeld <sommerfeld@hamachi.org>
Reviewed by: Gordon Ross <Gordon.W.Ross@gmail.com>
Reviewed by: Keith Wesolowski <wesolows@oxide.computer>
Approved by: Dan McDonald <danmcd@mnx.io>