### PR TITLE
Upstream merge/2024053001

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,4 +1,4 @@
 This README is here to keep track of merges from SmartOS
 
-Last illumos-joyent commit: bf1fc769b8016fa7f4091e74f20ffd3431174751
+Last illumos-joyent commit: 3c71165421e1b0fc36533828e5f2369cfff91f53
 

--- a/usr/src/cmd/truss/Makefile
+++ b/usr/src/cmd/truss/Makefile
@@ -38,6 +38,7 @@ OBJS=			\
 	actions.o	\
 	expound.o	\
 	codes.o		\
+	codes_bhyve.o	\
 	print.o		\
 	ramdata.o	\
 	systable.o	\
@@ -68,6 +69,10 @@ LDLIBS	+= -lproc -lrtld_db -lc_db -lnsl -lsocket -ltsol -lnvpair
 CPPFLAGS += -D_REENTRANT
 CPPFLAGS += -I$(SRC)/uts/common/fs/zfs
 CPPFLAGS += -I$(SRC)/uts/common
+
+codes_bhyve.o := CPPFLAGS += -I$(SRC)/compat/bhyve
+codes_bhyve.o := CPPFLAGS += -I$(SRC)/compat/bhyve/amd64
+codes_bhyve.o := CPPFLAGS += -I$(SRC)/uts/intel
 
 ROOTLINK = $(PROG:%=$(ROOTBIN64)/%)
 

--- a/usr/src/cmd/truss/codes.c
+++ b/usr/src/cmd/truss/codes.c
@@ -48,9 +48,9 @@
 #include <sys/sem.h>
 #include <sys/shm.h>
 #include <sys/fstyp.h>
-#if defined(__i386) || defined(__amd64)
+#if defined(__x86)
 #include <sys/sysi86.h>
-#endif /* __i386 */
+#endif /* __x86 */
 #include <sys/unistd.h>
 #include <sys/file.h>
 #include <sys/tiuser.h>
@@ -59,6 +59,7 @@
 #include <sys/stropts.h>
 #include <sys/termios.h>
 #include <sys/termiox.h>
+#include <sys/ioctl.h>
 #include <sys/jioctl.h>
 #include <sys/filio.h>
 #include <fcntl.h>
@@ -106,6 +107,7 @@
 #include <sys/soundcard.h>
 #include <sys/cpuid_drv.h>
 
+#include "codes.h"
 #include "ramdata.h"
 #include "proto.h"
 
@@ -334,387 +336,443 @@ const char *const PATHCONFname[] = {
 	"_PC_XATTR_EXISTS",		/* 101, _PC_LAST */
 };
 
-const struct ioc {
-	uint_t	code;
-	const char *name;
-	const char *datastruct;
-} ioc[] = {
-	{ (uint_t)TCGETA,	"TCGETA",	NULL },
-	{ (uint_t)TCSETA,	"TCSETA",	NULL },
-	{ (uint_t)TCSETAW,	"TCSETAW",	NULL },
-	{ (uint_t)TCSETAF,	"TCSETAF",	NULL },
-	{ (uint_t)TCFLSH,	"TCFLSH",	NULL },
-	{ (uint_t)TIOCKBON,	"TIOCKBON",	NULL },
-	{ (uint_t)TIOCKBOF,	"TIOCKBOF",	NULL },
-	{ (uint_t)KBENABLED,	"KBENABLED",	NULL },
-	{ (uint_t)TCGETS,	"TCGETS",	NULL },
-	{ (uint_t)TCSETS,	"TCSETS",	NULL },
-	{ (uint_t)TCSETSW,	"TCSETSW",	NULL },
-	{ (uint_t)TCSETSF,	"TCSETSF",	NULL },
-	{ (uint_t)TCXONC,	"TCXONC",	NULL },
-	{ (uint_t)TCSBRK,	"TCSBRK",	NULL },
-	{ (uint_t)TCDSET,	"TCDSET",	NULL },
-	{ (uint_t)RTS_TOG,	"RTS_TOG",	NULL },
-	{ (uint_t)TIOCSWINSZ,	"TIOCSWINSZ",	NULL },
-	{ (uint_t)TIOCGWINSZ,	"TIOCGWINSZ",	NULL },
-	{ (uint_t)TIOCGETD,	"TIOCGETD",	NULL },
-	{ (uint_t)TIOCSETD,	"TIOCSETD",	NULL },
-	{ (uint_t)TIOCHPCL,	"TIOCHPCL",	NULL },
-	{ (uint_t)TIOCGETP,	"TIOCGETP",	NULL },
-	{ (uint_t)TIOCSETP,	"TIOCSETP",	NULL },
-	{ (uint_t)TIOCSETN,	"TIOCSETN",	NULL },
-	{ (uint_t)TIOCEXCL,	"TIOCEXCL",	NULL },
-	{ (uint_t)TIOCNXCL,	"TIOCNXCL",	NULL },
-	{ (uint_t)TIOCFLUSH,	"TIOCFLUSH",	NULL },
-	{ (uint_t)TIOCSETC,	"TIOCSETC",	NULL },
-	{ (uint_t)TIOCGETC,	"TIOCGETC",	NULL },
-	{ (uint_t)TIOCGPGRP,	"TIOCGPGRP",	NULL },
-	{ (uint_t)TIOCSPGRP,	"TIOCSPGRP",	NULL },
-	{ (uint_t)TIOCGSID,	"TIOCGSID",	NULL },
-	{ (uint_t)TIOCSTI,	"TIOCSTI",	NULL },
-	{ (uint_t)TIOCMSET,	"TIOCMSET",	NULL },
-	{ (uint_t)TIOCMBIS,	"TIOCMBIS",	NULL },
-	{ (uint_t)TIOCMBIC,	"TIOCMBIC",	NULL },
-	{ (uint_t)TIOCMGET,	"TIOCMGET",	NULL },
-	{ (uint_t)TIOCREMOTE,	"TIOCREMOTE",	NULL },
-	{ (uint_t)TIOCSIGNAL,	"TIOCSIGNAL",	NULL },
-	{ (uint_t)TIOCSTART,	"TIOCSTART",	NULL },
-	{ (uint_t)TIOCSTOP,	"TIOCSTOP",	NULL },
-	{ (uint_t)TIOCNOTTY,	"TIOCNOTTY",	NULL },
-	{ (uint_t)TIOCSCTTY,	"TIOCSCTTY",	NULL },
-	{ (uint_t)TIOCOUTQ,	"TIOCOUTQ",	NULL },
-	{ (uint_t)TIOCGLTC,	"TIOCGLTC",	NULL },
-	{ (uint_t)TIOCSLTC,	"TIOCSLTC",	NULL },
-	{ (uint_t)TIOCCDTR,	"TIOCCDTR",	NULL },
-	{ (uint_t)TIOCSDTR,	"TIOCSDTR",	NULL },
-	{ (uint_t)TIOCCBRK,	"TIOCCBRK",	NULL },
-	{ (uint_t)TIOCSBRK,	"TIOCSBRK",	NULL },
-	{ (uint_t)TIOCLGET,	"TIOCLGET",	NULL },
-	{ (uint_t)TIOCLSET,	"TIOCLSET",	NULL },
-	{ (uint_t)TIOCLBIC,	"TIOCLBIC",	NULL },
-	{ (uint_t)TIOCLBIS,	"TIOCLBIS",	NULL },
+const struct ioc Tioc[] = { /* ('T'<<8) */
+	{ (uint_t)TCGETA,	"TCGETA",	NULL },	/* 1 */
+	{ (uint_t)TCSETA,	"TCSETA",	NULL },	/* 2 */
+	{ (uint_t)TCSETAW,	"TCSETAW",	NULL },	/* 3 */
+	{ (uint_t)TCSETAF,	"TCSETAF",	NULL },	/* 4 */
+	{ (uint_t)TCSBRK,	"TCSBRK",	NULL },	/* 5 */
+	{ (uint_t)TCXONC,	"TCXONC",	NULL },	/* 6 */
+	{ (uint_t)TCFLSH,	"TCFLSH",	NULL },	/* 7 */
+	{ (uint_t)TIOCKBON,	"TIOCKBON",	NULL },	/* 8 */
+	{ (uint_t)TIOCKBOF,	"TIOCKBOF",	NULL },	/* 9 */
+	{ (uint_t)KBENABLED,	"KBENABLED",	NULL },	/* 10 */
 
-	{ (uint_t)TIOCSILOOP,	"TIOCSILOOP",	NULL },
-	{ (uint_t)TIOCCILOOP,	"TIOCSILOOP",	NULL },
+	{ (uint_t)TCGETS,	"TCGETS",	NULL }, /* 13 */
+	{ (uint_t)TCSETS,	"TCSETS",	NULL }, /* 14 */
+	{ (uint_t)TCSETSW,	"TCSETSW",	NULL }, /* 15 */
+	{ (uint_t)TCSETSF,	"TCSETSF",	NULL }, /* 16 */
 
-	{ (uint_t)TIOCGPPS,	"TIOCGPPS",	NULL },
-	{ (uint_t)TIOCSPPS,	"TIOCSPPS",	NULL },
-	{ (uint_t)TIOCGPPSEV,	"TIOCGPPSEV",	NULL },
+	{ (uint_t)TCDSET,	"TCDSET",	NULL }, /* 32 */
+	{ (uint_t)RTS_TOG,	"RTS_TOG",	NULL }, /* 33 */
 
+	{ (uint_t)TIOCSWINSZ,	"TIOCSWINSZ",	NULL }, /* 103 */
+	{ (uint_t)TIOCGWINSZ,	"TIOCGWINSZ",	NULL }, /* 104 */
+
+	{ (uint_t)TIOCGPPS,	"TIOCGPPS",	NULL }, /* 125 */
+	{ (uint_t)TIOCSPPS,	"TIOCSPPS",	NULL }, /* 126 */
+	{ (uint_t)TIOCGPPSEV,	"TIOCGPPSEV",	NULL }, /* 127 */
+};
+
+const struct ioc tioc[] = { /* ('t'<<8) */
+	{ (uint_t)TIOCGETD,	"TIOCGETD",	NULL }, /* 0 */
+	{ (uint_t)TIOCSETD,	"TIOCSETD",	NULL }, /* 1 */
+	{ (uint_t)TIOCHPCL,	"TIOCHPCL",	NULL }, /* 2 */
+
+	{ (uint_t)TIOCGETP,	"TIOCGETP",	NULL }, /* 8 */
+	{ (uint_t)TIOCSETP,	"TIOCSETP",	NULL }, /* 9 */
+	{ (uint_t)TIOCSETN,	"TIOCSETN",	NULL }, /* 10 */
+
+	{ (uint_t)TIOCEXCL,	"TIOCEXCL",	NULL }, /* 13 */
+	{ (uint_t)TIOCNXCL,	"TIOCNXCL",	NULL }, /* 14 */
+
+	{ (uint_t)TIOCFLUSH,	"TIOCFLUSH",	NULL }, /* 16 */
+	{ (uint_t)TIOCSETC,	"TIOCSETC",	NULL }, /* 17 */
+	{ (uint_t)TIOCGETC,	"TIOCGETC",	NULL }, /* 18 */
+
+	{ (uint_t)TIOCGPGRP,	"TIOCGPGRP",	NULL }, /* 20 */
+	{ (uint_t)TIOCSPGRP,	"TIOCSPGRP",	NULL }, /* 21 */
+	{ (uint_t)TIOCGSID,	"TIOCGSID",	NULL }, /* 22 */
+	{ (uint_t)TIOCSTI,	"TIOCSTI",	NULL }, /* 23 */
+
+	{ (uint_t)TIOCMSET,	"TIOCMSET",	NULL }, /* 26 */
+	{ (uint_t)TIOCMBIS,	"TIOCMBIS",	NULL }, /* 27 */
+	{ (uint_t)TIOCMBIC,	"TIOCMBIC",	NULL }, /* 28 */
+	{ (uint_t)TIOCMGET,	"TIOCMGET",	NULL }, /* 29 */
+
+	{ (uint_t)TIOCREMOTE,	"TIOCREMOTE",	NULL }, /* 30 */
+	{ (uint_t)TIOCSIGNAL,	"TIOCSIGNAL",	NULL }, /* 31 */
+
+	{ (uint_t)TIOCCILOOP,	"TIOCSILOOP",	NULL }, /* 108 */
+	{ (uint_t)TIOCSILOOP,	"TIOCSILOOP",	NULL }, /* 109 */
+	{ (uint_t)TIOCSTART,	"TIOCSTART",	NULL }, /* 110 */
+	{ (uint_t)TIOCSTOP,	"TIOCSTOP",	NULL }, /* 111 */
+
+	{ (uint_t)TIOCNOTTY,	"TIOCNOTTY",	NULL }, /* 113 */
+	{ (uint_t)TIOCOUTQ,	"TIOCOUTQ",	NULL }, /* 115 */
+	{ (uint_t)TIOCGLTC,	"TIOCGLTC",	NULL }, /* 116 */
+	{ (uint_t)TIOCSLTC,	"TIOCSLTC",	NULL }, /* 117 */
+
+	{ (uint_t)TIOCCDTR,	"TIOCCDTR",	NULL }, /* 120 */
+	{ (uint_t)TIOCSDTR,	"TIOCSDTR",	NULL }, /* 121 */
+	{ (uint_t)TIOCCBRK,	"TIOCCBRK",	NULL }, /* 122 */
+	{ (uint_t)TIOCSBRK,	"TIOCSBRK",	NULL }, /* 123 */
+	{ (uint_t)TIOCLGET,	"TIOCLGET",	NULL }, /* 124 */
+	{ (uint_t)TIOCLSET,	"TIOCLSET",	NULL }, /* 125 */
+	{ (uint_t)TIOCLBIC,	"TIOCLBIC",	NULL }, /* 126 */
+	{ (uint_t)TIOCLBIS,	"TIOCLBIS",	NULL }, /* 127 */
+
+	{ (uint_t)TIOCSCTTY,	"TIOCSCTTY",	NULL }, /* 132 */
+};
+
+const struct ioc pty_ioc[] = { /* ('t'<<8) */
 	{ (uint_t)TIOCPKT,	"TIOCPKT",	NULL },	/* ptyvar.h */
 	{ (uint_t)TIOCUCNTL,	"TIOCUCNTL",	NULL },
 	{ (uint_t)TIOCTCNTL,	"TIOCTCNTL",	NULL },
 	{ (uint_t)TIOCISPACE,	"TIOCISPACE",	NULL },
 	{ (uint_t)TIOCISIZE,	"TIOCISIZE",	NULL },
 	{ (uint_t)TIOCSSIZE,	"TIOCSSIZE",	"ttysize" },
-	{ (uint_t)TIOCGSIZE,	"TIOCGSIZE",	"ttysize" },
+	{ (uint_t)TIOCGSIZE,	"TIOCGSIZE",	"ttysize" }
+};
 
+const struct ioc dlpi_ioc[] = { /* ('D'<<8) */
 	/*
 	 * Unfortunately, the DLIOC and LDIOC codes overlap.  Since the LDIOC
 	 * ioctls (for xenix compatibility) are far less likely to be used, we
 	 * give preference to DLIOC.
 	 */
-	{ (uint_t)DLIOCRAW,	"DLIOCRAW",	NULL },
-	{ (uint_t)DLIOCNATIVE,	"DLIOCNATIVE",	NULL },
-	{ (uint_t)DLIOCIPNETINFO, "DLIOCIPNETINFO", NULL},
-	{ (uint_t)DLIOCLOWLINK,	"DLIOCLOWLINK",	NULL },
+	{ (uint_t)DLIOCRAW,	"DLIOCRAW",	NULL }, /* 1 */
+	{ (uint_t)DLIOCNATIVE,	"DLIOCNATIVE",	NULL }, /* 2 */
+	{ (uint_t)DLIOCMARGININFO,	"DLIOCMARGININFO",	NULL }, /* 3 */
+	{ (uint_t)DLIOCIPNETINFO, "DLIOCIPNETINFO", NULL}, /* 4 */
+	{ (uint_t)DLIOCLOWLINK,	"DLIOCLOWLINK",	NULL }, /* 5 */
+	{ (uint_t)DLIOCHDRINFO,	"DLIOCHDRINFO",	NULL }, /* 10 */
+};
 
-	{ (uint_t)LDOPEN,	"LDOPEN",	NULL },
-	{ (uint_t)LDCLOSE,	"LDCLOSE",	NULL },
-	{ (uint_t)LDCHG,	"LDCHG",	NULL },
-	{ (uint_t)LDGETT,	"LDGETT",	NULL },
-	{ (uint_t)LDSETT,	"LDSETT",	NULL },
-	{ (uint_t)LDSMAP,	"LDSMAP",	NULL },
-	{ (uint_t)LDGMAP,	"LDGMAP",	NULL },
-	{ (uint_t)LDNMAP,	"LDNMAP",	NULL },
-	{ (uint_t)TCGETX,	"TCGETX",	NULL },
-	{ (uint_t)TCSETX,	"TCSETX",	NULL },
-	{ (uint_t)TCSETXW,	"TCSETXW",	NULL },
-	{ (uint_t)TCSETXF,	"TCSETXF",	NULL },
-	{ (uint_t)FIORDCHK,	"FIORDCHK",	NULL },
-	{ (uint_t)FIOCLEX,	"FIOCLEX",	NULL },
-	{ (uint_t)FIONCLEX,	"FIONCLEX",	NULL },
-	{ (uint_t)FIONREAD,	"FIONREAD",	NULL },
-	{ (uint_t)FIONBIO,	"FIONBIO",	NULL },
-	{ (uint_t)FIOASYNC,	"FIOASYNC",	NULL },
-	{ (uint_t)FIOSETOWN,	"FIOSETOWN",	NULL },
-	{ (uint_t)FIOGETOWN,	"FIOGETOWN",	NULL },
-#ifdef DIOCGETP
-	{ (uint_t)DIOCGETP,	"DIOCGETP",	NULL },
-	{ (uint_t)DIOCSETP,	"DIOCSETP",	NULL },
-#endif
-#ifdef DIOCGETC
-	{ (uint_t)DIOCGETC,	"DIOCGETC",	NULL },
-	{ (uint_t)DIOCGETB,	"DIOCGETB",	NULL },
-	{ (uint_t)DIOCSETE,	"DIOCSETE",	NULL },
-#endif
-#ifdef IFFORMAT
-	{ (uint_t)IFFORMAT,	"IFFORMAT",	NULL },
-	{ (uint_t)IFBCHECK,	"IFBCHECK",	NULL },
-	{ (uint_t)IFCONFIRM,	"IFCONFIRM",	NULL },
-#endif
-#ifdef LIOCGETP
-	{ (uint_t)LIOCGETP,	"LIOCGETP",	NULL },
-	{ (uint_t)LIOCSETP,	"LIOCSETP",	NULL },
-	{ (uint_t)LIOCGETS,	"LIOCGETS",	NULL },
-	{ (uint_t)LIOCSETS,	"LIOCSETS",	NULL },
-#endif
-#ifdef JBOOT
-	{ (uint_t)JBOOT,	"JBOOT",	NULL },
-	{ (uint_t)JTERM,	"JTERM",	NULL },
-	{ (uint_t)JMPX,		"JMPX",	NULL },
-#ifdef JTIMO
-	{ (uint_t)JTIMO,	"JTIMO",	NULL },
-#endif
-	{ (uint_t)JWINSIZE,	"JWINSIZE",	NULL },
-	{ (uint_t)JTIMOM,	"JTIMOM",	NULL },
-	{ (uint_t)JZOMBOOT,	"JZOMBOOT",	NULL },
-	{ (uint_t)JAGENT,	"JAGENT",	NULL },
-	{ (uint_t)JTRUN,	"JTRUN",	NULL },
-	{ (uint_t)JXTPROTO,	"JXTPROTO",	NULL },
-#endif
+const struct ioc ldioc_ioc[] = { /* ('D'<<8) */
+	{ (uint_t)LDOPEN,	"LDOPEN",	NULL }, /* 0 */
+	{ (uint_t)LDCLOSE,	"LDCLOSE",	NULL }, /* 1 */
+	{ (uint_t)LDCHG,	"LDCHG",	NULL }, /* 2 */
+	{ (uint_t)LDGETT,	"LDGETT",	NULL }, /* 8 */
+	{ (uint_t)LDSETT,	"LDSETT",	NULL }, /* 9 */
+	{ (uint_t)LDSMAP,	"LDSMAP",	NULL }, /* 110 */
+	{ (uint_t)LDGMAP,	"LDGMAP",	NULL }, /* 111 */
+	{ (uint_t)LDNMAP,	"LDNMAP",	NULL }, /* 112 */
+	{ (uint_t)LDEMAP,	"LDEMAP",	NULL }, /* 113 */
+	{ (uint_t)LDDMAP,	"LDDMAP",	NULL }, /* 114 */
+};
+
+const struct ioc xioc_ioc[] = { /* ('X'<<8) */
+	{ (uint_t)TCGETX,	"TCGETX",	NULL }, /* 1 */
+	{ (uint_t)TCSETX,	"TCSETX",	NULL }, /* 2 */
+	{ (uint_t)TCSETXW,	"TCSETXW",	NULL }, /* 3 */
+	{ (uint_t)TCSETXF,	"TCSETXF",	NULL }, /* 4 */
+};
+
+const struct ioc fio_ioc[] = { /* ('f'<<8) */
+	{ (uint_t)FIORDCHK,	"FIORDCHK",	NULL }, /* 3 */
+};
+
+
+const struct ioc fil_ioc[] = {
+	{ (uint_t)FIOCLEX,	"FIOCLEX",	NULL }, /* 1 */
+	{ (uint_t)FIONCLEX,	"FIONCLEX",	NULL }, /* 2 */
+
+	{ (uint_t)FIOGETOWN,	"FIOGETOWN",	NULL }, /* 123 */
+	{ (uint_t)FIOSETOWN,	"FIOSETOWN",	NULL }, /* 124 */
+	{ (uint_t)FIOASYNC,	"FIOASYNC",	NULL }, /* 125 */
+	{ (uint_t)FIONBIO,	"FIONBIO",	NULL }, /* 126 */
+	{ (uint_t)FIONREAD,	"FIONREAD",	NULL }, /* 127 */
+};
+
+const struct ioc dioc_ioc[] = { /* ('d'<<8) */
+	{ (uint_t)DIOCGETC,	"DIOCGETC",	NULL }, /* 1 */
+	{ (uint_t)DIOCGETB,	"DIOCGETB",	NULL }, /* 2 */
+	{ (uint_t)DIOCSETE,	"DIOCSETE",	NULL }, /* 3 */
+	{ (uint_t)DIOCGETP,	"DIOCGETP",	NULL }, /* 8 */
+	{ (uint_t)DIOCSETP,	"DIOCSETP",	NULL }, /* 9 */
+};
+
+const struct ioc lioc_ioc[] = { /* ('l'<<8) */
+	{ (uint_t)LIOCGETP,	"LIOCGETP",	NULL }, /* 1 */
+	{ (uint_t)LIOCSETP,	"LIOCSETP",	NULL }, /* 2 */
+	{ (uint_t)LIOCGETS,	"LIOCGETS",	NULL }, /* 5 */
+	{ (uint_t)LIOCSETS,	"LIOCSETS",	NULL }, /* 6 */
+};
+
+const struct ioc jerq_ioc[] = { /* ('j'<<8) */
+	{ (uint_t)JBOOT,	"JBOOT",	NULL }, /* 1 */
+	{ (uint_t)JTERM,	"JTERM",	NULL }, /* 2 */
+	{ (uint_t)JMPX,		"JMPX",	NULL }, /* 3 */
+	{ (uint_t)JWINSIZE,	"JWINSIZE",	NULL }, /* 5 */
+	{ (uint_t)JTIMOM,	"JTIMOM",	NULL }, /* 6 */
+	{ (uint_t)JZOMBOOT,	"JZOMBOOT",	NULL }, /* 7 */
+	{ (uint_t)JAGENT,	"JAGENT",	NULL }, /* 9 */
+	{ (uint_t)JTRUN,	"JTRUN",	NULL }, /* 10 */
+	{ (uint_t)JXTPROTO,	"JXTPROTO",	NULL }, /* 11 */
+};
+
+const struct ioc kstat_ioc[] = { /* ('K'<<8) */
 	{ (uint_t)KSTAT_IOC_CHAIN_ID,	"KSTAT_IOC_CHAIN_ID",	NULL },
 	{ (uint_t)KSTAT_IOC_READ,	"KSTAT_IOC_READ",	NULL },
 	{ (uint_t)KSTAT_IOC_WRITE,	"KSTAT_IOC_WRITE",	NULL },
-	{ (uint_t)STGET,	"STGET",	NULL },
-	{ (uint_t)STSET,	"STSET",	NULL },
-	{ (uint_t)STTHROW,	"STTHROW",	NULL },
-	{ (uint_t)STWLINE,	"STWLINE",	NULL },
-	{ (uint_t)STTSV,	"STTSV",	NULL },
-	{ (uint_t)I_NREAD,	"I_NREAD",	NULL },
-	{ (uint_t)I_PUSH,	"I_PUSH",	NULL },
-	{ (uint_t)I_POP,	"I_POP",	NULL },
-	{ (uint_t)I_LOOK,	"I_LOOK",	NULL },
-	{ (uint_t)I_FLUSH,	"I_FLUSH",	NULL },
-	{ (uint_t)I_SRDOPT,	"I_SRDOPT",	NULL },
-	{ (uint_t)I_GRDOPT,	"I_GRDOPT",	NULL },
-	{ (uint_t)I_STR,	"I_STR",	NULL },
-	{ (uint_t)I_SETSIG,	"I_SETSIG",	NULL },
-	{ (uint_t)I_GETSIG,	"I_GETSIG",	NULL },
-	{ (uint_t)I_FIND,	"I_FIND",	NULL },
-	{ (uint_t)I_LINK,	"I_LINK",	NULL },
-	{ (uint_t)I_UNLINK,	"I_UNLINK",	NULL },
-	{ (uint_t)I_PEEK,	"I_PEEK",	NULL },
-	{ (uint_t)I_FDINSERT,	"I_FDINSERT",	NULL },
-	{ (uint_t)I_SENDFD,	"I_SENDFD",	NULL },
-	{ (uint_t)I_RECVFD,	"I_RECVFD",	NULL },
-	{ (uint_t)I_SWROPT,	"I_SWROPT",	NULL },
-	{ (uint_t)I_GWROPT,	"I_GWROPT",	NULL },
-	{ (uint_t)I_LIST,	"I_LIST",	NULL },
-	{ (uint_t)I_PLINK,	"I_PLINK",	NULL },
-	{ (uint_t)I_PUNLINK,	"I_PUNLINK",	NULL },
-	{ (uint_t)I_FLUSHBAND,	"I_FLUSHBAND",	NULL },
-	{ (uint_t)I_CKBAND,	"I_CKBAND",	NULL },
-	{ (uint_t)I_GETBAND,	"I_GETBAND",	NULL },
-	{ (uint_t)I_ATMARK,	"I_ATMARK",	NULL },
-	{ (uint_t)I_SETCLTIME,	"I_SETCLTIME",	NULL },
-	{ (uint_t)I_GETCLTIME,	"I_GETCLTIME",	NULL },
-	{ (uint_t)I_CANPUT,	"I_CANPUT",	NULL },
-	{ (uint_t)I_ANCHOR,	"I_ANCHOR",	NULL },
-	{ (uint_t)_I_CMD,	"_I_CMD",	NULL },
-#ifdef TI_GETINFO
-	{ (uint_t)TI_GETINFO,	"TI_GETINFO",	NULL },
-	{ (uint_t)TI_OPTMGMT,	"TI_OPTMGMT",	NULL },
-	{ (uint_t)TI_BIND,	"TI_BIND",	NULL },
-	{ (uint_t)TI_UNBIND,	"TI_UNBIND",	NULL },
-#endif
-#ifdef	TI_CAPABILITY
-	{ (uint_t)TI_CAPABILITY,	"TI_CAPABILITY",	NULL },
-#endif
-#ifdef TI_GETMYNAME
-	{ (uint_t)TI_GETMYNAME,		"TI_GETMYNAME",		NULL },
-	{ (uint_t)TI_GETPEERNAME,	"TI_GETPEERNAME",	NULL },
-	{ (uint_t)TI_SETMYNAME,		"TI_SETMYNAME",		NULL },
-	{ (uint_t)TI_SETPEERNAME,	"TI_SETPEERNAME",	NULL },
-#endif
-#ifdef V_PREAD
-	{ (uint_t)V_PREAD,	"V_PREAD",	NULL },
-	{ (uint_t)V_PWRITE,	"V_PWRITE",	NULL },
-	{ (uint_t)V_PDREAD,	"V_PDREAD",	NULL },
-	{ (uint_t)V_PDWRITE,	"V_PDWRITE",	NULL },
-#if !defined(__i386) && !defined(__amd64)
-	{ (uint_t)V_GETSSZ,	"V_GETSSZ",	NULL },
-#endif /* !__i386 */
-#endif
-	/* audio */
-	{ (uint_t)AUDIO_GETINFO,	"AUDIO_GETINFO",	NULL },
-	{ (uint_t)AUDIO_SETINFO,	"AUDIO_SETINFO",	NULL },
-	{ (uint_t)AUDIO_DRAIN,		"AUDIO_DRAIN",		NULL },
-	{ (uint_t)AUDIO_GETDEV,		"AUDIO_GETDEV",		NULL },
-	{ (uint_t)AUDIO_DIAG_LOOPBACK,	"AUDIO_DIAG_LOOPBACK",	NULL },
-	{ (uint_t)AUDIO_GET_CH_NUMBER,	"AUDIO_GET_CH_NUMBER",	NULL },
-	{ (uint_t)AUDIO_GET_CH_TYPE,	"AUDIO_GET_CH_TYPE",	NULL },
-	{ (uint_t)AUDIO_GET_NUM_CHS,	"AUDIO_GET_NUM_CHS",	NULL },
-	{ (uint_t)AUDIO_GET_AD_DEV,	"AUDIO_GET_AD_DEV",	NULL },
-	{ (uint_t)AUDIO_GET_APM_DEV,	"AUDIO_GET_APM_DEV",	NULL },
-	{ (uint_t)AUDIO_GET_AS_DEV,	"AUDIO_GET_AS_DEV",	NULL },
-	{ (uint_t)AUDIO_MIXER_MULTIPLE_OPEN,	"AUDIO_MIXER_MULTIPLE_OPEN",
-	    NULL },
-	{ (uint_t)AUDIO_MIXER_SINGLE_OPEN,	"AUDIO_MIXER_SINGLE_OPEN",
-	    NULL },
-	{ (uint_t)AUDIO_MIXER_GET_SAMPLE_RATES,	"AUDIO_MIXER_GET_SAMPLE_RATES",
-	    NULL },
-	{ (uint_t)AUDIO_MIXERCTL_GETINFO,	"AUDIO_MIXERCTL_GETINFO",
-	    NULL },
-	{ (uint_t)AUDIO_MIXERCTL_SETINFO,	"AUDIO_MIXERCTL_SETINFO",
-	    NULL },
-	{ (uint_t)AUDIO_MIXERCTL_GET_CHINFO,	"AUDIO_MIXERCTL_GET_CHINFO",
-	    NULL },
-	{ (uint_t)AUDIO_MIXERCTL_SET_CHINFO,	"AUDIO_MIXERCTL_SET_CHINFO",
-	    NULL },
-	{ (uint_t)AUDIO_MIXERCTL_GET_MODE,	"AUDIO_MIXERCTL_GET_MODE",
-	    NULL },
-	{ (uint_t)AUDIO_MIXERCTL_SET_MODE,	"AUDIO_MIXERCTL_SET_MODE",
-	    NULL },
-	/* new style Boomer (OSS) ioctls */
-	{ (uint_t)SNDCTL_SYSINFO,	"SNDCTL_SYSINFO",	NULL },
-	{ (uint_t)SNDCTL_AUDIOINFO,	"SNDCTL_AUDIOINFO",	NULL },
-	{ (uint_t)SNDCTL_AUDIOINFO_EX,	"SNDCTL_AUDIOINFO_EX",	NULL },
-	{ (uint_t)SNDCTL_MIXERINFO,	"SNDCTL_MIXERINFO",	NULL },
-	{ (uint_t)SNDCTL_CARDINFO,	"SNDCTL_CARDINFO",	NULL },
-	{ (uint_t)SNDCTL_ENGINEINFO,	"SNDCTL_ENGINEINFO",	NULL },
-	{ (uint_t)SNDCTL_MIX_NRMIX,	"SNDCTL_MIX_NRMIX",	NULL },
-	{ (uint_t)SNDCTL_MIX_NREXT,	"SNDCTL_MIX_NREXT",	NULL },
-	{ (uint_t)SNDCTL_MIX_EXTINFO,	"SNDCTL_MIX_EXTINFO",	NULL },
-	{ (uint_t)SNDCTL_MIX_READ,	"SNDCTL_MIX_READ",	NULL },
-	{ (uint_t)SNDCTL_MIX_WRITE,	"SNDCTL_MIX_WRITE",	NULL },
-	{ (uint_t)SNDCTL_MIX_ENUMINFO,	"SNDCTL_MIX_ENUMINFO",	NULL },
-	{ (uint_t)SNDCTL_MIX_DESCRIPTION,	"SNDCTL_MIX_DESCRIPTION",
-	    NULL },
-	{ (uint_t)SNDCTL_SETSONG,	"SNDCTL_SETSONG",	NULL },
-	{ (uint_t)SNDCTL_GETSONG,	"SNDCTL_GETSONG",	NULL },
-	{ (uint_t)SNDCTL_SETNAME,	"SNDCTL_SETNAME",	NULL },
-	{ (uint_t)SNDCTL_SETLABEL,	"SNDCTL_SETLABEL",	NULL },
-	{ (uint_t)SNDCTL_GETLABEL,	"SNDCTL_GETLABEL",	NULL },
-	{ (uint_t)SNDCTL_DSP_HALT,	"SNDCTL_DSP_HALT",	NULL },
-	{ (uint_t)SNDCTL_DSP_RESET,	"SNDCTL_DSP_RESET",	NULL },
-	{ (uint_t)SNDCTL_DSP_SYNC,	"SNDCTL_DSP_SYNC",	NULL },
-	{ (uint_t)SNDCTL_DSP_SPEED,	"SNDCTL_DSP_SPEED",	NULL },
-	{ (uint_t)SNDCTL_DSP_STEREO,	"SNDCTL_DSP_STEREO",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETBLKSIZE,	"SNDCTL_DSP_GETBLKSIZE",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SAMPLESIZE,	"SNDCTL_DSP_SAMPLESIZE",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_CHANNELS,	"SNDCTL_DSP_CHANNELS",  NULL },
-	{ (uint_t)SNDCTL_DSP_POST,	"SNDCTL_DSP_POST",	NULL },
-	{ (uint_t)SNDCTL_DSP_SUBDIVIDE,	"SNDCTL_DSP_SUBDIVIDE",	NULL },
-	{ (uint_t)SNDCTL_DSP_SETFRAGMENT,	"SNDCTL_DSP_SETFRAGMENT",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GETFMTS,	"SNDCTL_DSP_GETFMTS",	NULL },
-	{ (uint_t)SNDCTL_DSP_SETFMT,	"SNDCTL_DSP_SETFMT",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETOSPACE,	"SNDCTL_DSP_GETOSPACE",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETISPACE,	"SNDCTL_DSP_GETISPACE",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETCAPS,	"SNDCTL_DSP_CAPS",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETTRIGGER,	"SNDCTL_DSP_GETTRIGGER",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SETTRIGGER,	"SNDCTL_DSP_SETTRIGGER",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GETIPTR,	"SNDCTL_DSP_GETIPTR",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETOPTR,	"SNDCTL_DSP_GETOPTR",	NULL },
-	{ (uint_t)SNDCTL_DSP_SETSYNCRO,	"SNDCTL_DSP_SETSYNCRO",	NULL },
-	{ (uint_t)SNDCTL_DSP_SETDUPLEX,	"SNDCTL_DSP_SETDUPLEX",	NULL },
-	{ (uint_t)SNDCTL_DSP_PROFILE,	"SNDCTL_DSP_PROFILE",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETODELAY,	"SNDCTL_DSP_GETODELAY",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETPLAYVOL,	"SNDCTL_DSP_GETPLAYVOL",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SETPLAYVOL,	"SNDCTL_DSP_SETPLAYVOL",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GETERROR,	"SNDCTL_DSP_GETERROR",	NULL },
-	{ (uint_t)SNDCTL_DSP_READCTL,	"SNDCTL_DSP_READCTL",	NULL },
-	{ (uint_t)SNDCTL_DSP_WRITECTL,	"SNDCTL_DSP_WRITECTL",	NULL },
-	{ (uint_t)SNDCTL_DSP_SYNCGROUP,	"SNDCTL_DSP_SYNCGROUP",	NULL },
-	{ (uint_t)SNDCTL_DSP_SYNCSTART,	"SNDCTL_DSP_SYNCSTART",	NULL },
-	{ (uint_t)SNDCTL_DSP_COOKEDMODE,	"SNDCTL_DSP_COOKEDMODE",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SILENCE,	"SNDCTL_DSP_SILENCE",	NULL },
-	{ (uint_t)SNDCTL_DSP_SKIP,	"SNDCTL_DSP_SKIP",	NULL },
-	{ (uint_t)SNDCTL_DSP_HALT_INPUT,	"SNDCTL_DSP_HALT_INPUT",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_HALT_OUTPUT,	"SNDCTL_DSP_HALT_OUTPUT",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_LOW_WATER,	"SNDCTL_DSP_LOW_WATER",	NULL },
-	{ (uint_t)SNDCTL_DSP_CURRENT_OPTR,	"SNDCTL_DSP_CURRENT_OPTR",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_CURRENT_IPTR,	"SNDCTL_DSP_CURRENT_IPTR",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GET_RECSRC_NAMES,	"SNDCTL_DSP_GET_RECSRC_NAMES",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GET_RECSRC,	"SNDCTL_DSP_GET_RECSRC",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SET_RECSRC,	"SNDCTL_DSP_SET_RECSRC",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GET_PLAYTGT_NAMES,	"SNDCTL_DSP_GET_PLAYTGT_NAMES",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GET_PLAYTGT,	"SNDCTL_DSP_GET_PLAYTGT",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SET_PLAYTGT,	"SNDCTL_DSP_SET_PLAYTGT",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GETRECVOL,		"SNDCTL_DSP_GETRECVOL",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SETRECVOL,		"SNDCTL_DSP_SETRECVOL",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GET_CHNORDER,	"SNDCTL_DSP_GET_CHNORDER",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_SET_CHNORDER,	"SNDCTL_DSP_SET_CHNORDER",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_GETIPEAKS,	"SNDCTL_DSP_GETIPEAKS",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETOPEAKS,	"SNDCTL_DSP_GETOPEAKS",	NULL },
-	{ (uint_t)SNDCTL_DSP_POLICY,	"SNDCTL_DSP_POLICY",	NULL },
-	{ (uint_t)SNDCTL_DSP_GETCHANNELMASK,	"SNDCTL_DSP_GETCHANNELMASK",
-	    NULL },
-	{ (uint_t)SNDCTL_DSP_BIND_CHANNEL,	"SNDCTL_DSP_BIND_CHANNEL",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_VOLUME,	"SOUND_MIXER_READ_VOLUME",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_OGAIN,	"SOUND_MIXER_READ_OGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_PCM,	"SOUND_MIXER_READ_PCM",	NULL },
-	{ (uint_t)SOUND_MIXER_READ_IGAIN,	"SOUND_MIXER_READ_IGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_RECLEV,	"SOUND_MIXER_READ_RECLEV",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_RECSRC,	"SOUND_MIXER_READ_RECSRC",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_DEVMASK,	"SOUND_MIXER_READ_DEVMASK",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_RECMASK,	"SOUND_MIXER_READ_RECMASK",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_CAPS,	"SOUND_MIXER_READ_CAPS",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_STEREODEVS,	"SOUND_MIXER_READ_STEREODEVS",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_RECGAIN,	"SOUND_MIXER_READ_RECGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_READ_MONGAIN,	"SOUND_MIXER_READ_MONGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_VOLUME,	"SOUND_MIXER_WRITE_VOLUME",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_OGAIN,	"SOUND_MIXER_WRITE_OGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_PCM,	"SOUND_MIXER_WRITE_PCM",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_IGAIN,	"SOUND_MIXER_WRITE_IGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_RECLEV,	"SOUND_MIXER_WRITE_RECLEV",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_RECSRC,	"SOUND_MIXER_WRITE_RECSRC",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_RECGAIN,	"SOUND_MIXER_WRITE_RECGAIN",
-	    NULL },
-	{ (uint_t)SOUND_MIXER_WRITE_MONGAIN,	"SOUND_MIXER_WRITE_MONGAIN",
-	    NULL },
+};
 
+const struct ioc stream_ioc[] = { /* ('X'<<8) */
+	{ (uint_t)STGET,	"STGET",	NULL }, /* 0 */
+	{ (uint_t)STSET,	"STSET",	NULL }, /* 1 */
+	{ (uint_t)STTHROW,	"STTHROW",	NULL }, /* 2 */
+	{ (uint_t)STWLINE,	"STWLINE",	NULL }, /* 3 */
+	{ (uint_t)STTSV,	"STTSV",	NULL }, /* 4 */
+};
+
+const struct ioc str_ioc[] = { /* ('S'<<8) */
+	{ (uint_t)I_NREAD,	"I_NREAD",	NULL }, /* 1 */
+	{ (uint_t)I_PUSH,	"I_PUSH",	NULL }, /* 2 */
+	{ (uint_t)I_POP,	"I_POP",	NULL }, /* 3 */
+	{ (uint_t)I_LOOK,	"I_LOOK",	NULL }, /* 4 */
+	{ (uint_t)I_FLUSH,	"I_FLUSH",	NULL }, /* 5 */
+	{ (uint_t)I_SRDOPT,	"I_SRDOPT",	NULL }, /* 6 */
+	{ (uint_t)I_GRDOPT,	"I_GRDOPT",	NULL }, /* 7 */
+	{ (uint_t)I_STR,	"I_STR",	NULL }, /* 10 */
+	{ (uint_t)I_SETSIG,	"I_SETSIG",	NULL }, /* 11 */
+	{ (uint_t)I_GETSIG,	"I_GETSIG",	NULL }, /* 12 */
+	{ (uint_t)I_FIND,	"I_FIND",	NULL }, /* 13 */
+	{ (uint_t)I_LINK,	"I_LINK",	NULL }, /* 14 */
+	{ (uint_t)I_UNLINK,	"I_UNLINK",	NULL }, /* 15 */
+	{ (uint_t)I_PEEK,	"I_PEEK",	NULL }, /* 17 */
+	{ (uint_t)I_FDINSERT,	"I_FDINSERT",	NULL }, /* 20 */
+	{ (uint_t)I_SENDFD,	"I_SENDFD",	NULL }, /* 21 */
+	{ (uint_t)I_RECVFD,	"I_RECVFD",	NULL }, /* 16 */
+	{ (uint_t)I_SWROPT,	"I_SWROPT",	NULL }, /* 23 */
+	{ (uint_t)I_GWROPT,	"I_GWROPT",	NULL }, /* 24 */
+	{ (uint_t)I_LIST,	"I_LIST",	NULL }, /* 25 */
+	{ (uint_t)I_PLINK,	"I_PLINK",	NULL }, /* 26 */
+	{ (uint_t)I_PUNLINK,	"I_PUNLINK",	NULL }, /* 27 */
+	{ (uint_t)I_ANCHOR,	"I_ANCHOR",	NULL }, /* 30 */
+	{ (uint_t)I_FLUSHBAND,	"I_FLUSHBAND",	NULL }, /* 34 */
+	{ (uint_t)I_CKBAND,	"I_CKBAND",	NULL }, /* 35 */
+	{ (uint_t)I_GETBAND,	"I_GETBAND",	NULL }, /* 36 */
+	{ (uint_t)I_ATMARK,	"I_ATMARK",	NULL }, /* 37 */
+	{ (uint_t)I_SETCLTIME,	"I_SETCLTIME",	NULL }, /* 40 */
+	{ (uint_t)I_GETCLTIME,	"I_GETCLTIME",	NULL }, /* 41 */
+	{ (uint_t)I_CANPUT,	"I_CANPUT",	NULL }, /* 42 */
+	{ (uint_t)I_SERROPT,	"I_SERROPT",	NULL }, /* 43 */
+	{ (uint_t)I_GERROPT,	"I_GERROPT",	NULL }, /* 44 */
+	{ (uint_t)I_ESETSIG,	"I_ESETSIG",	NULL }, /* 45 */
+	{ (uint_t)I_EGETSIG,	"I_EGETSIG",	NULL }, /* 46 */
+	{ (uint_t)_I_CMD,	"_I_CMD",	NULL }, /* 63 */
+};
+
+const struct ioc timod_ioc[] = {	/* ('T'<<8) */
+	{ (uint_t)TI_GETINFO,	"TI_GETINFO",	NULL }, /* 140 */
+	{ (uint_t)TI_OPTMGMT,	"TI_OPTMGMT",	NULL }, /* 141 */
+	{ (uint_t)TI_BIND,	"TI_BIND",	NULL }, /* 142 */
+	{ (uint_t)TI_UNBIND,	"TI_UNBIND",	NULL }, /* 143 */
+	{ (uint_t)TI_GETMYNAME, "TI_GETMYNAME",	 NULL }, /* 144 */
+	{ (uint_t)TI_GETPEERNAME, "TI_GETPEERNAME", NULL }, /* 145 */
+	{ (uint_t)TI_SETMYNAME, "TI_SETMYNAME",	 NULL }, /* 146 */
+	{ (uint_t)TI_SETPEERNAME, "TI_SETPEERNAME", NULL }, /* 147 */
+	{ (uint_t)TI_SYNC,	"TI_SYNC",	NULL }, /* 148 */
+	{ (uint_t)TI_GETADDRS,	"TI_GETADDRS",	NULL }, /* 149 */
+	{ (uint_t)TI_CAPABILITY, "TI_CAPABILITY", NULL }, /* 150 */
+};
+
+const struct ioc audio_ioc[] = { /* ('A'<<8) */
+	{ (uint_t)AUDIO_GETINFO,	"AUDIO_GETINFO",	NULL }, /* 1 */
+	{ (uint_t)AUDIO_SETINFO,	"AUDIO_SETINFO",	NULL }, /* 2 */
+	{ (uint_t)AUDIO_DRAIN,		"AUDIO_DRAIN",		NULL }, /* 3 */
+	{ (uint_t)AUDIO_GETDEV,		"AUDIO_GETDEV",		NULL }, /* 4 */
+	{ (uint_t)AUDIO_DIAG_LOOPBACK, "AUDIO_DIAG_LOOPBACK", NULL }, /* 101 */
+	{ (uint_t)AUDIO_GET_CH_NUMBER,	"AUDIO_GET_CH_NUMBER",	NULL }, /* 10 */
+	{ (uint_t)AUDIO_GET_CH_TYPE,	"AUDIO_GET_CH_TYPE",	NULL }, /* 11 */
+	{ (uint_t)AUDIO_GET_NUM_CHS,	"AUDIO_GET_NUM_CHS",	NULL }, /* 12 */
+	{ (uint_t)AUDIO_GET_AD_DEV,	"AUDIO_GET_AD_DEV",	NULL }, /* 13 */
+	{ (uint_t)AUDIO_GET_APM_DEV,	"AUDIO_GET_APM_DEV",	NULL }, /* 14 */
+	{ (uint_t)AUDIO_GET_AS_DEV,	"AUDIO_GET_AS_DEV",	NULL }, /* 15 */
+};
+
+const struct ioc audiom_ioc[] = { /* ('M'<<8) */
+	{ (uint_t)AUDIO_MIXER_MULTIPLE_OPEN,	"AUDIO_MIXER_MULTIPLE_OPEN",
+	    NULL }, /* 10 */
+	{ (uint_t)AUDIO_MIXER_SINGLE_OPEN,	"AUDIO_MIXER_SINGLE_OPEN",
+	    NULL }, /* 11 */
+	{ (uint_t)AUDIO_MIXER_GET_SAMPLE_RATES,	"AUDIO_MIXER_GET_SAMPLE_RATES",
+	    NULL }, /* 12 */
+	{ (uint_t)AUDIO_MIXERCTL_GETINFO,	"AUDIO_MIXERCTL_GETINFO",
+	    NULL }, /* 13 */
+	{ (uint_t)AUDIO_MIXERCTL_SETINFO,	"AUDIO_MIXERCTL_SETINFO",
+	    NULL }, /* 14 */
+	{ (uint_t)AUDIO_MIXERCTL_GET_CHINFO,	"AUDIO_MIXERCTL_GET_CHINFO",
+	    NULL }, /* 15 */
+	{ (uint_t)AUDIO_MIXERCTL_SET_CHINFO,	"AUDIO_MIXERCTL_SET_CHINFO",
+	    NULL }, /* 16 */
+	{ (uint_t)AUDIO_MIXERCTL_GET_MODE,	"AUDIO_MIXERCTL_GET_MODE",
+	    NULL }, /* 17 */
+	{ (uint_t)AUDIO_MIXERCTL_SET_MODE,	"AUDIO_MIXERCTL_SET_MODE",
+	    NULL }, /* 18 */
+};
+
+const struct ioc ossx_ioc[] = { /* ('X'<<8) */
+	/* new style Boomer (OSS) ioctls */
+	{ (uint_t)SNDCTL_SYSINFO,	"SNDCTL_SYSINFO",	NULL }, /* 1 */
+	{ (uint_t)SNDCTL_MIX_NRMIX,	"SNDCTL_MIX_NRMIX",	NULL }, /* 2 */
+	{ (uint_t)SNDCTL_MIX_NREXT,	"SNDCTL_MIX_NREXT",	NULL }, /* 3 */
+	{ (uint_t)SNDCTL_MIX_EXTINFO,	"SNDCTL_MIX_EXTINFO",	NULL }, /* 4 */
+	{ (uint_t)SNDCTL_MIX_READ,	"SNDCTL_MIX_READ",	NULL }, /* 5 */
+	{ (uint_t)SNDCTL_MIX_WRITE,	"SNDCTL_MIX_WRITE",	NULL }, /* 6 */
+	{ (uint_t)SNDCTL_AUDIOINFO,	"SNDCTL_AUDIOINFO",	NULL }, /* 7 */
+	{ (uint_t)SNDCTL_MIX_ENUMINFO,	"SNDCTL_MIX_ENUMINFO",	NULL }, /* 8 */
+	{ (uint_t)SNDCTL_MIDIINFO,	"SNDCTL_MIDIINFO",	NULL }, /* 9 */
+	{ (uint_t)SNDCTL_MIXERINFO,	"SNDCTL_MIXERINFO",	NULL }, /* 10 */
+	{ (uint_t)SNDCTL_CARDINFO,	"SNDCTL_CARDINFO",	NULL }, /* 11 */
+	{ (uint_t)SNDCTL_ENGINEINFO,	"SNDCTL_ENGINEINFO",	NULL }, /* 12 */
+	{ (uint_t)SNDCTL_AUDIOINFO_EX,	"SNDCTL_AUDIOINFO_EX",	NULL }, /* 13 */
+	{ (uint_t)SNDCTL_MIX_DESCRIPTION,	"SNDCTL_MIX_DESCRIPTION",
+	    NULL }, /* 14 */
+};
+
+const struct ioc ossy_ioc[] = { /* ('Y'<<8) */
+	{ (uint_t)SNDCTL_SETSONG,	"SNDCTL_SETSONG",	NULL }, /* 2 */
+	{ (uint_t)SNDCTL_GETSONG,	"SNDCTL_GETSONG",	NULL }, /* 2 */
+	{ (uint_t)SNDCTL_SETNAME,	"SNDCTL_SETNAME",	NULL }, /* 3 */
+	{ (uint_t)SNDCTL_SETLABEL,	"SNDCTL_SETLABEL",	NULL }, /* 4 */
+	{ (uint_t)SNDCTL_GETLABEL,	"SNDCTL_GETLABEL",	NULL }, /* 4 */
+};
+
+const struct ioc ossp_ioc[] = { /* ('P'<<8) */
+	{ (uint_t)SNDCTL_DSP_HALT,	"SNDCTL_DSP_HALT",	NULL }, /* 0 */
+	{ (uint_t)SNDCTL_DSP_SYNC,	"SNDCTL_DSP_SYNC",	NULL }, /* 1 */
+	{ (uint_t)SNDCTL_DSP_SPEED,	"SNDCTL_DSP_SPEED",	NULL }, /* 2 */
+	{ (uint_t)SNDCTL_DSP_STEREO,	"SNDCTL_DSP_STEREO",	NULL }, /* 3 */
+	{ (uint_t)SNDCTL_DSP_GETBLKSIZE,	"SNDCTL_DSP_GETBLKSIZE",
+	    NULL }, /* 4 */
+	{ (uint_t)SNDCTL_DSP_SAMPLESIZE,	"SNDCTL_DSP_SAMPLESIZE",
+	    NULL }, /* 5 */
+	{ (uint_t)SNDCTL_DSP_CHANNELS,	"SNDCTL_DSP_CHANNELS",  NULL }, /* 6 */
+	{ (uint_t)SNDCTL_DSP_POST,	"SNDCTL_DSP_POST",	NULL }, /* 8 */
+	{ (uint_t)SNDCTL_DSP_SUBDIVIDE,	"SNDCTL_DSP_SUBDIVIDE",	NULL }, /* 9 */
+	{ (uint_t)SNDCTL_DSP_SETFRAGMENT,	"SNDCTL_DSP_SETFRAGMENT",
+	    NULL }, /* 10 */
+	{ (uint_t)SNDCTL_DSP_GETFMTS,	"SNDCTL_DSP_GETFMTS",	NULL }, /* 11 */
+	{ (uint_t)SNDCTL_DSP_SETFMT,	"SNDCTL_DSP_SETFMT",	NULL }, /* 5 */
+	{ (uint_t)SNDCTL_DSP_GETOSPACE,	"SNDCTL_DSP_GETOSPACE",	NULL }, /* 12 */
+	{ (uint_t)SNDCTL_DSP_GETISPACE,	"SNDCTL_DSP_GETISPACE",	NULL }, /* 13 */
+	{ (uint_t)SNDCTL_DSP_GETCAPS,	"SNDCTL_DSP_CAPS",	NULL }, /* 15 */
+	{ (uint_t)SNDCTL_DSP_GETTRIGGER,	"SNDCTL_DSP_GETTRIGGER",
+	    NULL }, /* 16 */
+	{ (uint_t)SNDCTL_DSP_SETTRIGGER,	"SNDCTL_DSP_SETTRIGGER",
+	    NULL }, /* 16 */
+	{ (uint_t)SNDCTL_DSP_GETIPTR,	"SNDCTL_DSP_GETIPTR",	NULL }, /* 17 */
+	{ (uint_t)SNDCTL_DSP_GETOPTR,	"SNDCTL_DSP_GETOPTR",	NULL }, /* 18 */
+	{ (uint_t)SNDCTL_DSP_SETSYNCRO,	"SNDCTL_DSP_SETSYNCRO",	NULL }, /* 21 */
+	{ (uint_t)SNDCTL_DSP_SETDUPLEX,	"SNDCTL_DSP_SETDUPLEX",	NULL }, /* 22 */
+	{ (uint_t)SNDCTL_DSP_PROFILE,	"SNDCTL_DSP_PROFILE",	NULL }, /* 23 */
+	{ (uint_t)SNDCTL_DSP_GETODELAY,	"SNDCTL_DSP_GETODELAY",	NULL }, /* 23 */
+	{ (uint_t)SNDCTL_DSP_GETPLAYVOL,	"SNDCTL_DSP_GETPLAYVOL",
+	    NULL }, /* 24 */
+	{ (uint_t)SNDCTL_DSP_SETPLAYVOL,	"SNDCTL_DSP_SETPLAYVOL",
+	    NULL }, /* 24 */
+	{ (uint_t)SNDCTL_DSP_GETERROR,	"SNDCTL_DSP_GETERROR",	NULL }, /* 25 */
+	{ (uint_t)SNDCTL_DSP_READCTL,	"SNDCTL_DSP_READCTL",	NULL }, /* 26 */
+	{ (uint_t)SNDCTL_DSP_WRITECTL,	"SNDCTL_DSP_WRITECTL",	NULL }, /* 27 */
+	{ (uint_t)SNDCTL_DSP_SYNCGROUP,	"SNDCTL_DSP_SYNCGROUP",	NULL }, /* 28 */
+	{ (uint_t)SNDCTL_DSP_SYNCSTART,	"SNDCTL_DSP_SYNCSTART",	NULL }, /* 29 */
+	{ (uint_t)SNDCTL_DSP_COOKEDMODE,	"SNDCTL_DSP_COOKEDMODE",
+	    NULL }, /* 30 */
+	{ (uint_t)SNDCTL_DSP_SILENCE,	"SNDCTL_DSP_SILENCE",	NULL }, /* 31 */
+	{ (uint_t)SNDCTL_DSP_SKIP,	"SNDCTL_DSP_SKIP",	NULL }, /* 32 */
+	{ (uint_t)SNDCTL_DSP_HALT_INPUT,	"SNDCTL_DSP_HALT_INPUT",
+	    NULL }, /* 33 */
+	{ (uint_t)SNDCTL_DSP_HALT_OUTPUT,	"SNDCTL_DSP_HALT_OUTPUT",
+	    NULL }, /* 34 */
+	{ (uint_t)SNDCTL_DSP_LOW_WATER,	"SNDCTL_DSP_LOW_WATER",	NULL }, /* 34 */
+	{ (uint_t)SNDCTL_DSP_CURRENT_IPTR,	"SNDCTL_DSP_CURRENT_IPTR",
+	    NULL }, /* 35 */
+	{ (uint_t)SNDCTL_DSP_CURRENT_OPTR,	"SNDCTL_DSP_CURRENT_OPTR",
+	    NULL }, /* 36 */
+	{ (uint_t)SNDCTL_DSP_GET_RECSRC_NAMES,	"SNDCTL_DSP_GET_RECSRC_NAMES",
+	    NULL }, /* 37 */
+	{ (uint_t)SNDCTL_DSP_GET_RECSRC,	"SNDCTL_DSP_GET_RECSRC",
+	    NULL }, /* 38 */
+	{ (uint_t)SNDCTL_DSP_SET_RECSRC,	"SNDCTL_DSP_SET_RECSRC",
+	    NULL }, /* 38 */
+	{ (uint_t)SNDCTL_DSP_GET_PLAYTGT_NAMES,	"SNDCTL_DSP_GET_PLAYTGT_NAMES",
+	    NULL }, /* 39 */
+	{ (uint_t)SNDCTL_DSP_GET_PLAYTGT,	"SNDCTL_DSP_GET_PLAYTGT",
+	    NULL }, /* 40 */
+	{ (uint_t)SNDCTL_DSP_SET_PLAYTGT,	"SNDCTL_DSP_SET_PLAYTGT",
+	    NULL }, /* 40 */
+	{ (uint_t)SNDCTL_DSP_GETRECVOL,		"SNDCTL_DSP_GETRECVOL",
+	    NULL }, /* 41 */
+	{ (uint_t)SNDCTL_DSP_SETRECVOL,		"SNDCTL_DSP_SETRECVOL",
+	    NULL }, /* 41 */
+	{ (uint_t)SNDCTL_DSP_GET_CHNORDER,	"SNDCTL_DSP_GET_CHNORDER",
+	    NULL }, /* 42 */
+	{ (uint_t)SNDCTL_DSP_SET_CHNORDER,	"SNDCTL_DSP_SET_CHNORDER",
+	    NULL }, /* 42 */
+	{ (uint_t)SNDCTL_DSP_GETIPEAKS,	"SNDCTL_DSP_GETIPEAKS",	NULL }, /* 43 */
+	{ (uint_t)SNDCTL_DSP_GETOPEAKS,	"SNDCTL_DSP_GETOPEAKS",	NULL }, /* 44 */
+	{ (uint_t)SNDCTL_DSP_POLICY,	"SNDCTL_DSP_POLICY",	NULL }, /* 45 */
+	{ (uint_t)SNDCTL_DSP_GETCHANNELMASK,	"SNDCTL_DSP_GETCHANNELMASK",
+	    NULL }, /* 64 */
+	{ (uint_t)SNDCTL_DSP_BIND_CHANNEL,	"SNDCTL_DSP_BIND_CHANNEL",
+	    NULL }, /* 65 */
+};
+
+const struct ioc ossm_ioc[] = { /* ('M'<<8) */
+	{ (uint_t)SOUND_MIXER_READ_VOLUME,	"SOUND_MIXER_READ_VOLUME",
+	    NULL }, /* 0 */
+	{ (uint_t)SOUND_MIXER_READ_OGAIN,	"SOUND_MIXER_READ_OGAIN",
+	    NULL }, /* 13 */
+	{ (uint_t)SOUND_MIXER_READ_PCM,	"SOUND_MIXER_READ_PCM",	NULL }, /* 4 */
+	{ (uint_t)SOUND_MIXER_READ_IGAIN,	"SOUND_MIXER_READ_IGAIN",
+	    NULL }, /* 12 */
+	{ (uint_t)SOUND_MIXER_READ_RECLEV,	"SOUND_MIXER_READ_RECLEV",
+	    NULL }, /* 11 */
+	{ (uint_t)SOUND_MIXER_READ_RECSRC,	"SOUND_MIXER_READ_RECSRC",
+	    NULL }, /* 0xff */
+	{ (uint_t)SOUND_MIXER_READ_DEVMASK,	"SOUND_MIXER_READ_DEVMASK",
+	    NULL }, /* 0xfe */
+	{ (uint_t)SOUND_MIXER_READ_RECMASK,	"SOUND_MIXER_READ_RECMASK",
+	    NULL }, /* 0xfd */
+	{ (uint_t)SOUND_MIXER_READ_CAPS,	"SOUND_MIXER_READ_CAPS",
+	    NULL }, /* 0xfc */
+	{ (uint_t)SOUND_MIXER_READ_STEREODEVS,	"SOUND_MIXER_READ_STEREODEVS",
+	    NULL }, /* 0xfb */
+	{ (uint_t)SOUND_MIXER_READ_RECGAIN,	"SOUND_MIXER_READ_RECGAIN",
+	    NULL }, /* 119 */
+	{ (uint_t)SOUND_MIXER_READ_MONGAIN,	"SOUND_MIXER_READ_MONGAIN",
+	    NULL }, /* 120 */
+	{ (uint_t)SOUND_MIXER_WRITE_VOLUME,	"SOUND_MIXER_WRITE_VOLUME",
+	    NULL }, /* 0 */
+	{ (uint_t)SOUND_MIXER_WRITE_OGAIN,	"SOUND_MIXER_WRITE_OGAIN",
+	    NULL }, /* 13 */
+	{ (uint_t)SOUND_MIXER_WRITE_PCM,	"SOUND_MIXER_WRITE_PCM",
+	    NULL }, /* 4 */
+	{ (uint_t)SOUND_MIXER_WRITE_IGAIN,	"SOUND_MIXER_WRITE_IGAIN",
+	    NULL }, /* 12 */
+	{ (uint_t)SOUND_MIXER_WRITE_RECLEV,	"SOUND_MIXER_WRITE_RECLEV",
+	    NULL }, /* 11 */
+	{ (uint_t)SOUND_MIXER_WRITE_RECSRC,	"SOUND_MIXER_WRITE_RECSRC",
+	    NULL }, /* 0xff */
+	{ (uint_t)SOUND_MIXER_WRITE_RECGAIN,	"SOUND_MIXER_WRITE_RECGAIN",
+	    NULL }, /* 119 */
+	{ (uint_t)SOUND_MIXER_WRITE_MONGAIN,	"SOUND_MIXER_WRITE_MONGAIN",
+	    NULL }, /* 120 */
+};
+
+const struct ioc strredir_ioc[] = { /* STRREDIR_MODID<<16 or 0 */
 	/* STREAMS redirection ioctls */
-	{ (uint_t)SRIOCSREDIR,		"SRIOCSREDIR",	NULL },
-	{ (uint_t)SRIOCISREDIR,		"SRIOCISREDIR",	NULL },
-	{ (uint_t)CPCIO_BIND,		"CPCIO_BIND",		NULL },
-	{ (uint_t)CPCIO_SAMPLE,		"CPCIO_SAMPLE",		NULL },
-	{ (uint_t)CPCIO_RELE,		"CPCIO_RELE",		NULL },
+	{ (uint_t)SRIOCSREDIR,		"SRIOCSREDIR",	NULL }, /* 1 */
+	{ (uint_t)SRIOCISREDIR,		"SRIOCISREDIR",	NULL }, /* 2 */
+};
+
+const struct ioc cpc_ioc[] = { /* (((('c'<<8)|'p')<<8)|'c')<<8 */
+	{ (uint_t)CPCIO_BIND,		"CPCIO_BIND",		NULL }, /* 1 */
+	{ (uint_t)CPCIO_SAMPLE,		"CPCIO_SAMPLE",		NULL }, /* 2 */
+	{ (uint_t)CPCIO_RELE,		"CPCIO_RELE",		NULL }, /* 3 */
+};
+
+const struct ioc dp_ioc[] = { /* 0xD0<<8 */
 	/* /dev/poll ioctl() control codes */
 	{ (uint_t)DP_POLL,	"DP_POLL",	NULL },
 	{ (uint_t)DP_ISPOLLED,	"DP_ISPOLLED",	NULL },
 	{ (uint_t)DP_PPOLL,	"DP_PPOLL",	NULL },
 	{ (uint_t)DP_EPOLLCOMPAT, "DP_EPOLLCOMPAT",	NULL },
+};
+
+const struct ioc p_ioc[] = { /* 'q'<<8 */
 	/* the old /proc ioctl() control codes */
 #define	PIOC	('q'<<8)
 	{ (uint_t)(PIOC|1),	"PIOCSTATUS",	NULL },
@@ -770,381 +828,436 @@ const struct ioc {
 	{ (uint_t)(PIOC|101),	"PIOCGWIN",	NULL },
 	{ (uint_t)(PIOC|103),	"PIOCNLDT",	NULL },
 	{ (uint_t)(PIOC|104),	"PIOCLDT",	NULL },
+};
 
+const struct ioc socket_ioc[] = { /* 's'<<8 */
 	/* ioctl's applicable on sockets */
-	{ (uint_t)SIOCSHIWAT,	"SIOCSHIWAT",	NULL },
-	{ (uint_t)SIOCGHIWAT,	"SIOCGHIWAT",	NULL },
-	{ (uint_t)SIOCSLOWAT,	"SIOCSLOWAT",	NULL },
-	{ (uint_t)SIOCGLOWAT,	"SIOCGLOWAT",	NULL },
-	{ (uint_t)SIOCATMARK,	"SIOCATMARK",	NULL },
-	{ (uint_t)SIOCSPGRP,	"SIOCSPGRP",	NULL },
-	{ (uint_t)SIOCGPGRP,	"SIOCGPGRP",	NULL },
-	{ (uint_t)SIOCADDRT,	"SIOCADDRT",	"rtentry" },
-	{ (uint_t)SIOCDELRT,	"SIOCDELRT",	"rtentry" },
-	{ (uint_t)SIOCGETVIFCNT,	"SIOCGETVIFCNT", "sioc_vif_req" },
-	{ (uint_t)SIOCGETSGCNT,	"SIOCGETSGCNT",	"sioc_sg_req" },
-	{ (uint_t)SIOCGETLSGCNT,	"SIOCGETLSGCNT", "sioc_lsg_req" },
-	{ (uint_t)SIOCSIFADDR,	"SIOCSIFADDR",	"ifreq" },
-	{ (uint_t)SIOCGIFADDR,	"SIOCGIFADDR",	"ifreq" },
-	{ (uint_t)SIOCSIFDSTADDR,	"SIOCSIFDSTADDR", "ifreq" },
-	{ (uint_t)SIOCGIFDSTADDR,	"SIOCGIFDSTADDR", "ifreq" },
-	{ (uint_t)SIOCSIFFLAGS,	"SIOCSIFFLAGS",	"ifreq" },
-	{ (uint_t)SIOCGIFFLAGS,	"SIOCGIFFLAGS",	"ifreq" },
-	{ (uint_t)SIOCSIFMEM,	"SIOCSIFMEM",	"ifreq" },
-	{ (uint_t)SIOCGIFMEM,	"SIOCGIFMEM",	"ifreq" },
-	{ (uint_t)SIOCGIFCONF,	"SIOCGIFCONF",	"ifconf" },
-	{ (uint_t)SIOCSIFMTU,	"SIOCSIFMTU",	"ifreq" },
-	{ (uint_t)SIOCGIFMTU,	"SIOCGIFMTU",	"ifreq" },
-	{ (uint_t)SIOCGIFBRDADDR,	"SIOCGIFBRDADDR",	"ifreq" },
-	{ (uint_t)SIOCSIFBRDADDR,	"SIOCSIFBRDADDR",	"ifreq" },
-	{ (uint_t)SIOCGIFNETMASK,	"SIOCGIFNETMASK",	"ifreq" },
-	{ (uint_t)SIOCSIFNETMASK,	"SIOCSIFNETMASK",	"ifreq" },
-	{ (uint_t)SIOCGIFMETRIC,	"SIOCGIFMETRIC",	"ifreq" },
-	{ (uint_t)SIOCSIFMETRIC,	"SIOCSIFMETRIC",	"ifreq" },
-	{ (uint_t)SIOCSARP,	"SIOCSARP",	"arpreq" },
-	{ (uint_t)SIOCGARP,	"SIOCGARP",	"arpreq" },
-	{ (uint_t)SIOCDARP,	"SIOCDARP",	"arpreq" },
-	{ (uint_t)SIOCUPPER,	"SIOCUPPER",	"ifreq" },
-	{ (uint_t)SIOCLOWER,	"SIOCLOWER",	"ifreq" },
-	{ (uint_t)SIOCSETSYNC,	"SIOCSETSYNC",	"ifreq" },
-	{ (uint_t)SIOCGETSYNC,	"SIOCGETSYNC",	"ifreq" },
-	{ (uint_t)SIOCSSDSTATS,	"SIOCSSDSTATS",	"ifreq" },
-	{ (uint_t)SIOCSSESTATS,	"SIOCSSESTATS",	"ifreq" },
-	{ (uint_t)SIOCSPROMISC,	"SIOCSPROMISC",	NULL },
-	{ (uint_t)SIOCADDMULTI,	"SIOCADDMULTI",	"ifreq" },
-	{ (uint_t)SIOCDELMULTI,	"SIOCDELMULTI",	"ifreq" },
-	{ (uint_t)SIOCGETNAME,	"SIOCGETNAME",	"sockaddr" },
-	{ (uint_t)SIOCGETPEER,	"SIOCGETPEER",	"sockaddr" },
-	{ (uint_t)IF_UNITSEL,	"IF_UNITSEL",	NULL },
-	{ (uint_t)SIOCXPROTO,	"SIOCXPROTO",	NULL },
-	{ (uint_t)SIOCIFDETACH,	"SIOCIFDETACH",	"ifreq" },
-	{ (uint_t)SIOCGENPSTATS,	"SIOCGENPSTATS",	"ifreq" },
-	{ (uint_t)SIOCX25XMT,	"SIOCX25XMT",	"ifreq" },
-	{ (uint_t)SIOCX25RCV,	"SIOCX25RCV",	"ifreq" },
-	{ (uint_t)SIOCX25TBL,	"SIOCX25TBL",	"ifreq" },
-	{ (uint_t)SIOCSLGETREQ,	"SIOCSLGETREQ",	"ifreq" },
-	{ (uint_t)SIOCSLSTAT,	"SIOCSLSTAT",	"ifreq" },
-	{ (uint_t)SIOCSIFNAME,	"SIOCSIFNAME",	"ifreq" },
-	{ (uint_t)SIOCGENADDR,	"SIOCGENADDR",	"ifreq" },
-	{ (uint_t)SIOCGIFNUM,	"SIOCGIFNUM",	NULL },
-	{ (uint_t)SIOCGIFMUXID,	"SIOCGIFMUXID",	"ifreq" },
-	{ (uint_t)SIOCSIFMUXID,	"SIOCSIFMUXID",	"ifreq" },
-	{ (uint_t)SIOCGIFINDEX,	"SIOCGIFINDEX",	"ifreq" },
-	{ (uint_t)SIOCSIFINDEX,	"SIOCSIFINDEX",	"ifreq" },
-	{ (uint_t)SIOCLIFREMOVEIF,	"SIOCLIFREMOVEIF",	"lifreq" },
-	{ (uint_t)SIOCLIFADDIF,		"SIOCLIFADDIF",		"lifreq" },
-	{ (uint_t)SIOCSLIFADDR,		"SIOCSLIFADDR",		"lifreq" },
-	{ (uint_t)SIOCGLIFADDR,		"SIOCGLIFADDR",		"lifreq" },
-	{ (uint_t)SIOCSLIFDSTADDR,	"SIOCSLIFDSTADDR",	"lifreq" },
-	{ (uint_t)SIOCGLIFDSTADDR,	"SIOCGLIFDSTADDR",	"lifreq" },
-	{ (uint_t)SIOCSLIFFLAGS,	"SIOCSLIFFLAGS",	"lifreq" },
-	{ (uint_t)SIOCGLIFFLAGS,	"SIOCGLIFFLAGS",	"lifreq" },
-	{ (uint_t)SIOCGLIFCONF,		"SIOCGLIFCONF",		"lifconf" },
-	{ (uint_t)SIOCSLIFMTU,		"SIOCSLIFMTU",		"lifreq" },
-	{ (uint_t)SIOCGLIFMTU,		"SIOCGLIFMTU",		"lifreq" },
-	{ (uint_t)SIOCGLIFBRDADDR,	"SIOCGLIFBRDADDR",	"lifreq" },
-	{ (uint_t)SIOCSLIFBRDADDR,	"SIOCSLIFBRDADDR",	"lifreq" },
-	{ (uint_t)SIOCGLIFNETMASK,	"SIOCGLIFNETMASK",	"lifreq" },
-	{ (uint_t)SIOCSLIFNETMASK,	"SIOCSLIFNETMASK",	"lifreq" },
-	{ (uint_t)SIOCGLIFMETRIC,	"SIOCGLIFMETRIC",	"lifreq" },
-	{ (uint_t)SIOCSLIFMETRIC,	"SIOCSLIFMETRIC",	"lifreq" },
-	{ (uint_t)SIOCSLIFNAME,		"SIOCSLIFNAME",		"lifreq" },
-	{ (uint_t)SIOCGLIFNUM,		"SIOCGLIFNUM",		"lifnum" },
-	{ (uint_t)SIOCGLIFMUXID,	"SIOCGLIFMUXID",	"lifreq" },
-	{ (uint_t)SIOCSLIFMUXID,	"SIOCSLIFMUXID",	"lifreq" },
-	{ (uint_t)SIOCGLIFINDEX,	"SIOCGLIFINDEX",	"lifreq" },
-	{ (uint_t)SIOCSLIFINDEX,	"SIOCSLIFINDEX",	"lifreq" },
-	{ (uint_t)SIOCSLIFTOKEN,	"SIOCSLIFTOKEN",	"lifreq" },
-	{ (uint_t)SIOCGLIFTOKEN,	"SIOCGLIFTOKEN",	"lifreq" },
-	{ (uint_t)SIOCSLIFSUBNET,	"SIOCSLIFSUBNET",	"lifreq" },
-	{ (uint_t)SIOCGLIFSUBNET,	"SIOCGLIFSUBNET",	"lifreq" },
-	{ (uint_t)SIOCSLIFLNKINFO,	"SIOCSLIFLNKINFO",	"lifreq" },
-	{ (uint_t)SIOCGLIFLNKINFO,	"SIOCGLIFLNKINFO",	"lifreq" },
-	{ (uint_t)SIOCLIFDELND,		"SIOCLIFDELND",		"lifreq" },
-	{ (uint_t)SIOCLIFGETND,		"SIOCLIFGETND",		"lifreq" },
-	{ (uint_t)SIOCLIFSETND,		"SIOCLIFSETND",		"lifreq" },
-	{ (uint_t)SIOCTMYADDR,		"SIOCTMYADDR",	"sioc_addrreq" },
-	{ (uint_t)SIOCTONLINK,		"SIOCTONLINK",	"sioc_addrreq" },
-	{ (uint_t)SIOCTMYSITE,		"SIOCTMYSITE",	"sioc_addrreq" },
-	{ (uint_t)SIOCGLIFBINDING,	"SIOCGLIFBINDING",	"lifreq" },
-	{ (uint_t)SIOCSLIFGROUPNAME,	"SIOCSLIFGROUPNAME",	"lifreq" },
-	{ (uint_t)SIOCGLIFGROUPNAME,	"SIOCGLIFGROUPNAME",	"lifreq" },
-	{ (uint_t)SIOCGLIFGROUPINFO,	"SIOCGLIFGROUPINFO", "lifgroupinfo" },
-	{ (uint_t)SIOCGDSTINFO,		"SIOCGDSTINFO",		NULL },
-	{ (uint_t)SIOCGIP6ADDRPOLICY,	"SIOCGIP6ADDRPOLICY",	NULL },
-	{ (uint_t)SIOCSIP6ADDRPOLICY,	"SIOCSIP6ADDRPOLICY",	NULL },
-	{ (uint_t)SIOCSXARP,		"SIOCSXARP",		"xarpreq" },
-	{ (uint_t)SIOCGXARP,		"SIOCGXARP",		"xarpreq" },
-	{ (uint_t)SIOCDXARP,		"SIOCDXARP",		"xarpreq" },
-	{ (uint_t)SIOCGLIFZONE,		"SIOCGLIFZONE",		"lifreq" },
-	{ (uint_t)SIOCSLIFZONE,		"SIOCSLIFZONE",		"lifreq" },
-	{ (uint_t)SIOCSCTPSOPT,		"SIOCSCTPSOPT",		NULL },
-	{ (uint_t)SIOCSCTPGOPT,		"SIOCSCTPGOPT",		NULL },
-	{ (uint_t)SIOCSCTPPEELOFF,	"SIOPCSCTPPEELOFF",	"int" },
-	{ (uint_t)SIOCGLIFUSESRC,	"SIOCGLIFUSESRC",	"lifreq" },
-	{ (uint_t)SIOCSLIFUSESRC,	"SIOCSLIFUSESRC",	"lifreq" },
-	{ (uint_t)SIOCGLIFSRCOF,	"SIOCGLIFSRCOF",	"lifsrcof" },
-	{ (uint_t)SIOCGMSFILTER,	"SIOCGMSFILTER",    "group_filter" },
-	{ (uint_t)SIOCSMSFILTER,	"SIOCSMSFILTER",    "group_filter" },
-	{ (uint_t)SIOCGIPMSFILTER,	"SIOCGIPMSFILTER",  "ip_msfilter" },
-	{ (uint_t)SIOCSIPMSFILTER,	"SIOCSIPMSFILTER",  "ip_msfilter" },
-	{ (uint_t)SIOCGLIFDADSTATE,	"SIOCGLIFDADSTATE",  "lifreq" },
-	{ (uint_t)SIOCSLIFPREFIX,	"SIOCSLIFPREFIX", "lifreq" },
-	{ (uint_t)SIOCGSTAMP,		"SIOCGSTAMP",		"timeval" },
-	{ (uint_t)SIOCGIFHWADDR,	"SIOCGIFHWADDR",	"ifreq" },
-	{ (uint_t)SIOCGLIFHWADDR,	"SIOCGLIFHWADDR",	"lifreq" },
+	{ (uint_t)SIOCSHIWAT,	"SIOCSHIWAT",	NULL }, /* 0 */
+	{ (uint_t)SIOCGHIWAT,	"SIOCGHIWAT",	NULL }, /* 1 */
+	{ (uint_t)SIOCSLOWAT,	"SIOCSLOWAT",	NULL }, /* 2 */
+	{ (uint_t)SIOCGLOWAT,	"SIOCGLOWAT",	NULL }, /* 3 */
+	{ (uint_t)SIOCATMARK,	"SIOCATMARK",	NULL }, /* 7 */
+	{ (uint_t)SIOCSPGRP,	"SIOCSPGRP",	NULL }, /* 8 */
+	{ (uint_t)SIOCGPGRP,	"SIOCGPGRP",	NULL }, /* 9 */
+	{ (uint_t)SIOCGETNAME,	"SIOCGETNAME",	"sockaddr" }, /* 52 */
+	{ (uint_t)SIOCGETPEER,	"SIOCGETPEER",	"sockaddr" }, /* 53 */
+	{ (uint_t)IF_UNITSEL,	"IF_UNITSEL",	NULL }, /* 54 */
+	{ (uint_t)SIOCXPROTO,	"SIOCXPROTO",	NULL }, /* 55 */
+};
 
+const struct ioc routing_ioc[] = { /* 'r'<<8 */
+	{ (uint_t)SIOCADDRT, "SIOCADDRT",	"rtentry" }, /* 10 */
+	{ (uint_t)SIOCDELRT, "SIOCDELRT",	"rtentry" }, /* 11 */
+	{ (uint_t)SIOCGETVIFCNT, "SIOCGETVIFCNT", "sioc_vif_req" }, /* 20 */
+	{ (uint_t)SIOCGETSGCNT,	"SIOCGETSGCNT",	"sioc_sg_req" }, /* 21 */
+	{ (uint_t)SIOCGETLSGCNT, "SIOCGETLSGCNT", "sioc_lsg_req" }, /* 21 */
+};
+
+const struct ioc sockio_ioc[] = { /* 'i'<<8 */
+	{ (uint_t)SIOCSIFADDR,	"SIOCSIFADDR",	"ifreq" }, /* 12 */
+	{ (uint_t)SIOCGIFADDR,	"SIOCGIFADDR",	"ifreq" }, /* 13 */
+	{ (uint_t)SIOCSIFDSTADDR,	"SIOCSIFDSTADDR", "ifreq" }, /* 14 */
+	{ (uint_t)SIOCGIFDSTADDR,	"SIOCGIFDSTADDR", "ifreq" }, /* 15 */
+	{ (uint_t)SIOCSIFFLAGS,	"SIOCSIFFLAGS",	"ifreq" }, /* 16 */
+	{ (uint_t)SIOCGIFFLAGS,	"SIOCGIFFLAGS",	"ifreq" }, /* 17 */
+	{ (uint_t)SIOCSIFMEM,	"SIOCSIFMEM",	"ifreq" }, /* 18 */
+	{ (uint_t)SIOCGIFMEM,	"SIOCGIFMEM",	"ifreq" }, /* 19 */
+	{ (uint_t)SIOCSIFMTU,	"SIOCSIFMTU",	"ifreq" }, /* 21 */
+	{ (uint_t)SIOCGIFMTU,	"SIOCGIFMTU",	"ifreq" }, /* 22 */
+	{ (uint_t)SIOCGIFBRDADDR, "SIOCGIFBRDADDR", "ifreq" }, /* 23 */
+	{ (uint_t)SIOCSIFBRDADDR, "SIOCSIFBRDADDR", "ifreq" }, /* 24 */
+	{ (uint_t)SIOCGIFNETMASK, "SIOCGIFNETMASK", "ifreq" }, /* 25 */
+	{ (uint_t)SIOCSIFNETMASK, "SIOCSIFNETMASK", "ifreq" }, /* 26 */
+	{ (uint_t)SIOCGIFMETRIC, "SIOCGIFMETRIC", "ifreq" }, /* 27 */
+	{ (uint_t)SIOCSIFMETRIC, "SIOCSIFMETRIC", "ifreq" }, /* 28 */
+	{ (uint_t)SIOCSARP,	"SIOCSARP",	"arpreq" }, /* 30 */
+	{ (uint_t)SIOCGARP,	"SIOCGARP",	"arpreq" }, /* 31 */
+	{ (uint_t)SIOCDARP,	"SIOCDARP",	"arpreq" }, /* 32 */
+	{ (uint_t)SIOCUPPER,	"SIOCUPPER",	"ifreq" },  /* 40 */
+	{ (uint_t)SIOCLOWER,	"SIOCLOWER",	"ifreq" }, /* 41 */
+	{ (uint_t)SIOCSETSYNC,	"SIOCSETSYNC",	"ifreq" }, /* 44 */
+	{ (uint_t)SIOCGETSYNC,	"SIOCGETSYNC",	"ifreq" }, /* 45 */
+	{ (uint_t)SIOCSSDSTATS,	"SIOCSSDSTATS",	"ifreq" }, /* 46 */
+	{ (uint_t)SIOCSSESTATS,	"SIOCSSESTATS",	"ifreq" }, /* 47 */
+	{ (uint_t)SIOCSPROMISC,	"SIOCSPROMISC",	NULL }, /* 48 */
+	{ (uint_t)SIOCADDMULTI,	"SIOCADDMULTI",	"ifreq" }, /* 49 */
+	{ (uint_t)SIOCDELMULTI,	"SIOCDELMULTI",	"ifreq" }, /* 50 */
+	{ (uint_t)SIOCIFDETACH,	"SIOCIFDETACH",	"ifreq" }, /* 56 */
+	{ (uint_t)SIOCGENPSTATS, "SIOCGENPSTATS", "ifreq" }, /* 57 */
+	{ (uint_t)SIOCX25XMT,	"SIOCX25XMT",	"ifreq" }, /* 59 */
+	{ (uint_t)SIOCX25RCV,	"SIOCX25RCV",	"ifreq" }, /* 60 */
+	{ (uint_t)SIOCX25TBL,	"SIOCX25TBL",	"ifreq" }, /* 61 */
+	{ (uint_t)SIOCSLGETREQ,	"SIOCSLGETREQ",	"ifreq" }, /* 71 */
+	{ (uint_t)SIOCSLSTAT,	"SIOCSLSTAT",	"ifreq" }, /* 72 */
+	{ (uint_t)SIOCSIFNAME,	"SIOCSIFNAME",	"ifreq" }, /* 73 */
+	{ (uint_t)SIOCGENADDR,	"SIOCGENADDR",	"ifreq" }, /* 85 */
+	{ (uint_t)SIOCGIFNUM,	"SIOCGIFNUM",	NULL }, /* 87 */
+	{ (uint_t)SIOCGIFMUXID,	"SIOCGIFMUXID",	"ifreq" }, /* 88 */
+	{ (uint_t)SIOCSIFMUXID,	"SIOCSIFMUXID",	"ifreq" }, /* 89 */
+	{ (uint_t)SIOCGIFINDEX,	"SIOCGIFINDEX",	"ifreq" }, /* 90 */
+	{ (uint_t)SIOCSIFINDEX,	"SIOCSIFINDEX",	"ifreq" }, /* 91 */
+	{ (uint_t)SIOCGIFCONF,	"SIOCGIFCONF",	"ifconf" }, /* 92 */
+	{ (uint_t)SIOCLIFREMOVEIF, "SIOCLIFREMOVEIF",	"lifreq" }, /* 110 */
+	{ (uint_t)SIOCLIFADDIF,	"SIOCLIFADDIF",		"lifreq" }, /* 111 */
+	{ (uint_t)SIOCSLIFADDR,	"SIOCSLIFADDR",		"lifreq" }, /* 112 */
+	{ (uint_t)SIOCGLIFADDR,	"SIOCGLIFADDR",		"lifreq" }, /* 113 */
+	{ (uint_t)SIOCSLIFDSTADDR, "SIOCSLIFDSTADDR",	"lifreq" }, /* 114 */
+	{ (uint_t)SIOCGLIFDSTADDR, "SIOCGLIFDSTADDR",	"lifreq" }, /* 115 */
+	{ (uint_t)SIOCSLIFFLAGS, "SIOCSLIFFLAGS",	"lifreq" }, /* 116 */
+	{ (uint_t)SIOCGLIFFLAGS, "SIOCGLIFFLAGS",	"lifreq" }, /* 117 */
+	{ (uint_t)SIOCSLIFMTU, "SIOCSLIFMTU",		"lifreq" }, /* 121 */
+	{ (uint_t)SIOCGLIFMTU,	"SIOCGLIFMTU",		"lifreq" }, /* 122 */
+	{ (uint_t)SIOCGLIFBRDADDR, "SIOCGLIFBRDADDR",	"lifreq" }, /* 123 */
+	{ (uint_t)SIOCSLIFBRDADDR, "SIOCSLIFBRDADDR",	"lifreq" }, /* 124 */
+	{ (uint_t)SIOCGLIFNETMASK, "SIOCGLIFNETMASK",	"lifreq" }, /* 125 */
+	{ (uint_t)SIOCSLIFNETMASK, "SIOCSLIFNETMASK",	"lifreq" }, /* 126 */
+	{ (uint_t)SIOCGLIFMETRIC, "SIOCGLIFMETRIC",	"lifreq" }, /* 127 */
+	{ (uint_t)SIOCSLIFMETRIC, "SIOCSLIFMETRIC",	"lifreq" }, /* 128 */
+	{ (uint_t)SIOCSLIFNAME,	 "SIOCSLIFNAME",	"lifreq" }, /* 129 */
+	{ (uint_t)SIOCGLIFNUM,	 "SIOCGLIFNUM",		"lifnum" }, /* 130 */
+	{ (uint_t)SIOCGLIFMUXID, "SIOCGLIFMUXID",	"lifreq" }, /* 131 */
+	{ (uint_t)SIOCSLIFMUXID, "SIOCSLIFMUXID",	"lifreq" }, /* 132 */
+	{ (uint_t)SIOCGLIFINDEX, "SIOCGLIFINDEX",	"lifreq" }, /* 133 */
+	{ (uint_t)SIOCSLIFINDEX, "SIOCSLIFINDEX",	"lifreq" }, /* 134 */
+	{ (uint_t)SIOCSLIFTOKEN, "SIOCSLIFTOKEN",	"lifreq" }, /* 135 */
+	{ (uint_t)SIOCGLIFTOKEN, "SIOCGLIFTOKEN",	"lifreq" }, /* 136 */
+	{ (uint_t)SIOCSLIFSUBNET, "SIOCSLIFSUBNET",	"lifreq" }, /* 137 */
+	{ (uint_t)SIOCGLIFSUBNET, "SIOCGLIFSUBNET",	"lifreq" }, /* 138 */
+	{ (uint_t)SIOCSLIFLNKINFO, "SIOCSLIFLNKINFO",	"lifreq" }, /* 139 */
+	{ (uint_t)SIOCGLIFLNKINFO, "SIOCGLIFLNKINFO",	"lifreq" }, /* 140 */
+	{ (uint_t)SIOCLIFDELND,	"SIOCLIFDELND",		"lifreq" }, /* 141 */
+	{ (uint_t)SIOCLIFGETND,	"SIOCLIFGETND",		"lifreq" }, /* 142 */
+	{ (uint_t)SIOCLIFSETND,	"SIOCLIFSETND",		"lifreq" }, /* 143 */
+	{ (uint_t)SIOCTMYADDR,	"SIOCTMYADDR",	"sioc_addrreq" }, /* 144 */
+	{ (uint_t)SIOCTONLINK,	"SIOCTONLINK",	"sioc_addrreq" }, /* 145 */
+	{ (uint_t)SIOCTMYSITE,	"SIOCTMYSITE",	"sioc_addrreq" }, /* 146 */
+	{ (uint_t)SIOCGLIFBINDING, "SIOCGLIFBINDING",	"lifreq" }, /* 154 */
+	{ (uint_t)SIOCSLIFGROUPNAME, "SIOCSLIFGROUPNAME", "lifreq" }, /* 155 */
+	{ (uint_t)SIOCGLIFGROUPNAME, "SIOCGLIFGROUPNAME", "lifreq" }, /* 156 */
+	{ (uint_t)SIOCGLIFGROUPINFO, "SIOCGLIFGROUPINFO",
+	    "lifgroupinfo" }, /* 157 */
+	{ (uint_t)SIOCGIP6ADDRPOLICY, "SIOCGIP6ADDRPOLICY", NULL }, /* 162 */
+	{ (uint_t)SIOCSIP6ADDRPOLICY, "SIOCSIP6ADDRPOLICY", NULL }, /* 163 */
+	{ (uint_t)SIOCGDSTINFO,	"SIOCGDSTINFO",	NULL }, /* 164 */
+	{ (uint_t)SIOCGLIFCONF, "SIOCGLIFCONF",		"lifconf" }, /* 165 */
+	{ (uint_t)SIOCSXARP,	"SIOCSXARP",		"xarpreq" }, /* 166 */
+	{ (uint_t)SIOCGXARP,	"SIOCGXARP",		"xarpreq" }, /* 167 */
+	{ (uint_t)SIOCDXARP,	"SIOCDXARP",		"xarpreq" }, /* 168 */
+	{ (uint_t)SIOCGLIFZONE,	"SIOCGLIFZONE",		"lifreq" }, /* 170 */
+	{ (uint_t)SIOCSLIFZONE,	"SIOCSLIFZONE",		"lifreq" }, /* 171 */
+	{ (uint_t)SIOCSCTPSOPT,	"SIOCSCTPSOPT",		NULL }, /* 172 */
+	{ (uint_t)SIOCSCTPGOPT,	"SIOCSCTPGOPT",		NULL }, /* 173 */
+	{ (uint_t)SIOCSCTPPEELOFF, "SIOPCSCTPPEELOFF",	"int" }, /* 174 */
+	{ (uint_t)SIOCGLIFUSESRC, "SIOCGLIFUSESRC",	"lifreq" }, /* 175 */
+	{ (uint_t)SIOCSLIFUSESRC, "SIOCSLIFUSESRC",	"lifreq" }, /* 176 */
+	{ (uint_t)SIOCGLIFSRCOF, "SIOCGLIFSRCOF",	"lifsrcof" }, /* 177 */
+	{ (uint_t)SIOCGMSFILTER, "SIOCGMSFILTER",    "group_filter" }, /* 178 */
+	{ (uint_t)SIOCSMSFILTER, "SIOCSMSFILTER",    "group_filter" }, /* 179 */
+	{ (uint_t)SIOCGIPMSFILTER, "SIOCGIPMSFILTER", "ip_msfilter" }, /* 180 */
+	{ (uint_t)SIOCSIPMSFILTER, "SIOCSIPMSFILTER", "ip_msfilter" }, /* 181 */
+	{ (uint_t)SIOCGIFHWADDR, "SIOCGIFHWADDR",	"ifreq" }, /* 185 */
+	{ (uint_t)SIOCGSTAMP,	"SIOCGSTAMP",		"timeval" }, /* 186 */
+	{ (uint_t)SIOCGLIFDADSTATE, "SIOCGLIFDADSTATE",  "lifreq" }, /* 190 */
+	{ (uint_t)SIOCSLIFPREFIX, "SIOCSLIFPREFIX", "lifreq" }, /* 191 */
+	{ (uint_t)SIOCGLIFHWADDR, "SIOCGLIFHWADDR",	"lifreq" }, /* 192 */
+};
+
+const struct ioc des_ioc[] = { /* 'd'<<8 */
 	/* DES encryption */
-	{ (uint_t)DESIOCBLOCK,	"DESIOCBLOCK",	"desparams" },
-	{ (uint_t)DESIOCQUICK,	"DESIOCQUICK",	"desparams" },
+	{ (uint_t)DESIOCBLOCK,	"DESIOCBLOCK",	"desparams" }, /* 6 */
+	{ (uint_t)DESIOCQUICK,	"DESIOCQUICK",	"desparams" }, /* 7 */
+};
 
+const struct ioc prn_ioc[] = { /* 'p'<<8 */
 	/* Printing system */
-	{ (uint_t)PRNIOC_GET_IFCAP,	"PRNIOC_GET_IFCAP",	NULL },
-	{ (uint_t)PRNIOC_SET_IFCAP,	"PRNIOC_SET_IFCAP",	NULL },
+	{ (uint_t)PRNIOC_GET_IFCAP,	"PRNIOC_GET_IFCAP",	NULL }, /* 90 */
+	{ (uint_t)PRNIOC_SET_IFCAP,	"PRNIOC_SET_IFCAP",	NULL }, /* 91 */
 	{ (uint_t)PRNIOC_GET_IFINFO,	"PRNIOC_GET_IFINFO",
-	    "prn_interface_info" },
-	{ (uint_t)PRNIOC_GET_STATUS,	"PRNIOC_GET_STATUS",	NULL },
+	    "prn_interface_info" }, /* 92 */
+	{ (uint_t)PRNIOC_GET_STATUS,	"PRNIOC_GET_STATUS",	NULL }, /* 93 */
 	{ (uint_t)PRNIOC_GET_1284_DEVID,	"PRNIOC_GET_1284_DEVID",
-	    "prn_1284_device_id" },
+	    "prn_1284_device_id" }, /* 94 */
 	{ (uint_t)PRNIOC_GET_1284_STATUS,
-	    "PRNIOC_GET_IFCANIOC_GET_1284_STATUS", NULL },
+	    "PRNIOC_GET_IFCANIOC_GET_1284_STATUS", NULL }, /* 95 */
 	{ (uint_t)PRNIOC_GET_TIMEOUTS,	"PRNIOC_GET_TIMEOUTS",
-	    "prn_timeouts" },
+	    "prn_timeouts" }, /* 96 */
 	{ (uint_t)PRNIOC_SET_TIMEOUTS,	"PRNIOC_SET_TIMEOUTS",
-	    "prn_timeouts" },
-	{ (uint_t)PRNIOC_RESET,	"PRNIOC_RESET",	NULL },
+	    "prn_timeouts" }, /* 97 */
+	{ (uint_t)PRNIOC_RESET,	"PRNIOC_RESET",	NULL }, /* 98 */
+};
 
+const struct ioc dtrace_ioc[] = { /* ('d' << 24) | ('t' << 16) | ('r' << 8) */
 	/* DTrace */
-	{ (uint_t)DTRACEIOC_PROVIDER,	"DTRACEIOC_PROVIDER",	NULL },
-	{ (uint_t)DTRACEIOC_PROBES,	"DTRACEIOC_PROBES",	NULL },
-	{ (uint_t)DTRACEIOC_BUFSNAP,	"DTRACEIOC_BUFSNAP",	NULL },
-	{ (uint_t)DTRACEIOC_PROBEMATCH,	"DTRACEIOC_PROBEMATCH",	NULL },
-	{ (uint_t)DTRACEIOC_ENABLE,	"DTRACEIOC_ENABLE",	NULL },
-	{ (uint_t)DTRACEIOC_AGGSNAP,	"DTRACEIOC_AGGSNAP",	NULL },
-	{ (uint_t)DTRACEIOC_EPROBE,	"DTRACEIOC_EPROBE",	NULL },
-	{ (uint_t)DTRACEIOC_PROBEARG,   "DTRACEIOC_PROBEARG",   NULL },
-	{ (uint_t)DTRACEIOC_CONF,	"DTRACEIOC_CONF",	NULL },
-	{ (uint_t)DTRACEIOC_STATUS,	"DTRACEIOC_STATUS",	NULL },
-	{ (uint_t)DTRACEIOC_GO,		"DTRACEIOC_GO",		NULL },
-	{ (uint_t)DTRACEIOC_STOP,	"DTRACEIOC_STOP",	NULL },
-	{ (uint_t)DTRACEIOC_AGGDESC,	"DTRACEIOC_AGGDESC",	NULL },
-	{ (uint_t)DTRACEIOC_FORMAT,	"DTRACEIOC_FORMAT",	NULL },
-	{ (uint_t)DTRACEIOC_DOFGET,	"DTRACEIOC_DOFGET",	NULL },
-	{ (uint_t)DTRACEIOC_REPLICATE,	"DTRACEIOC_REPLICATE",	NULL },
+	{ (uint_t)DTRACEIOC_PROVIDER,	"DTRACEIOC_PROVIDER",	NULL }, /* 1 */
+	{ (uint_t)DTRACEIOC_PROBES,	"DTRACEIOC_PROBES",	NULL }, /* 2 */
+	{ (uint_t)DTRACEIOC_BUFSNAP,	"DTRACEIOC_BUFSNAP",	NULL }, /* 4 */
+	{ (uint_t)DTRACEIOC_PROBEMATCH,	"DTRACEIOC_PROBEMATCH",	NULL }, /* 5 */
+	{ (uint_t)DTRACEIOC_ENABLE,	"DTRACEIOC_ENABLE",	NULL }, /* 6 */
+	{ (uint_t)DTRACEIOC_AGGSNAP,	"DTRACEIOC_AGGSNAP",	NULL }, /* 7 */
+	{ (uint_t)DTRACEIOC_EPROBE,	"DTRACEIOC_EPROBE",	NULL }, /* 8 */
+	{ (uint_t)DTRACEIOC_PROBEARG,   "DTRACEIOC_PROBEARG",   NULL }, /* 9 */
+	{ (uint_t)DTRACEIOC_CONF,	"DTRACEIOC_CONF",	NULL }, /* 10 */
+	{ (uint_t)DTRACEIOC_STATUS,	"DTRACEIOC_STATUS",	NULL }, /* 11 */
+	{ (uint_t)DTRACEIOC_GO,		"DTRACEIOC_GO",		NULL }, /* 12 */
+	{ (uint_t)DTRACEIOC_STOP,	"DTRACEIOC_STOP",	NULL }, /* 13 */
+	{ (uint_t)DTRACEIOC_AGGDESC,	"DTRACEIOC_AGGDESC",	NULL }, /* 14 */
+	{ (uint_t)DTRACEIOC_FORMAT,	"DTRACEIOC_FORMAT",	NULL }, /* 15 */
+	{ (uint_t)DTRACEIOC_DOFGET,	"DTRACEIOC_DOFGET",	NULL }, /* 16 */
+	{ (uint_t)DTRACEIOC_REPLICATE,	"DTRACEIOC_REPLICATE",	NULL }, /* 17 */
+};
 
-	{ (uint_t)DTRACEHIOC_ADD,	"DTRACEHIOC_ADD",	NULL },
-	{ (uint_t)DTRACEHIOC_REMOVE,	"DTRACEHIOC_REMOVE",	NULL },
-	{ (uint_t)DTRACEHIOC_ADDDOF,	"DTRACEHIOC_ADDDOF",	NULL },
+const struct ioc dtraceh_ioc[] = { /* ('d' << 24) | ('t' << 16) | ('h' << 8) */
+	{ (uint_t)DTRACEHIOC_ADD,	"DTRACEHIOC_ADD",	NULL }, /* 1 */
+	{ (uint_t)DTRACEHIOC_REMOVE,	"DTRACEHIOC_REMOVE",	NULL }, /* 2 */
+	{ (uint_t)DTRACEHIOC_ADDDOF,	"DTRACEHIOC_ADDDOF",	NULL }, /* 3 */
+};
 
+const struct ioc crypto_ioc[] = { /* 'y'<<8 */
 	/* /dev/cryptoadm ioctl() control codes */
-	{ (uint_t)CRYPTO_GET_VERSION,	"CRYPTO_GET_VERSION",	NULL },
-	{ (uint_t)CRYPTO_GET_DEV_LIST,	"CRYPTO_GET_DEV_LIST",	NULL },
-	{ (uint_t)CRYPTO_GET_SOFT_LIST,	"CRYPTO_GET_SOFT_LIST",	NULL },
-	{ (uint_t)CRYPTO_GET_DEV_INFO,	"CRYPTO_GET_DEV_INFO",	NULL },
-	{ (uint_t)CRYPTO_GET_SOFT_INFO,	"CRYPTO_GET_SOFT_INFO",	NULL },
+	{ (uint_t)CRYPTO_GET_VERSION,	"CRYPTO_GET_VERSION",	NULL }, /* 1 */
+	{ (uint_t)CRYPTO_GET_DEV_LIST,	"CRYPTO_GET_DEV_LIST",	NULL }, /* 2 */
+	{ (uint_t)CRYPTO_GET_SOFT_LIST,	"CRYPTO_GET_SOFT_LIST",	NULL }, /* 3 */
+	{ (uint_t)CRYPTO_GET_DEV_INFO,	"CRYPTO_GET_DEV_INFO",	NULL }, /* 4 */
+	{ (uint_t)CRYPTO_GET_SOFT_INFO,	"CRYPTO_GET_SOFT_INFO",	NULL }, /* 5 */
 	{ (uint_t)CRYPTO_LOAD_DEV_DISABLED,	"CRYPTO_LOAD_DEV_DISABLED",
-	    NULL },
+	    NULL }, /* 8 */
 	{ (uint_t)CRYPTO_LOAD_SOFT_DISABLED,	"CRYPTO_LOAD_SOFT_DISABLED",
-	    NULL },
+	    NULL }, /* 9 */
 	{ (uint_t)CRYPTO_UNLOAD_SOFT_MODULE,	"CRYPTO_UNLOAD_SOFT_MODULE",
-	    NULL },
+	    NULL }, /* 10 */
 	{ (uint_t)CRYPTO_LOAD_SOFT_CONFIG,	"CRYPTO_LOAD_SOFT_CONFIG",
-	    NULL },
-	{ (uint_t)CRYPTO_POOL_CREATE,	"CRYPTO_POOL_CREATE",	NULL },
-	{ (uint_t)CRYPTO_POOL_WAIT,	"CRYPTO_POOL_WAIT",	NULL },
-	{ (uint_t)CRYPTO_POOL_RUN,	"CRYPTO_POOL_RUN",	NULL },
-	{ (uint_t)CRYPTO_LOAD_DOOR,	"CRYPTO_LOAD_DOOR",	NULL },
+	    NULL }, /* 11 */
+	{ (uint_t)CRYPTO_POOL_CREATE,	"CRYPTO_POOL_CREATE",	NULL }, /* 12 */
+	{ (uint_t)CRYPTO_POOL_WAIT,	"CRYPTO_POOL_WAIT",	NULL }, /* 13 */
+	{ (uint_t)CRYPTO_POOL_RUN,	"CRYPTO_POOL_RUN",	NULL }, /* 14 */
+	{ (uint_t)CRYPTO_LOAD_DOOR,	"CRYPTO_LOAD_DOOR",	NULL }, /* 15 */
+	{ (uint_t)CRYPTO_FIPS140_STATUS,
+	    "CRYPTO_FIPS140_STATUS", NULL }, /* 16 */
+	{ (uint_t)CRYPTO_FIPS140_SET, "CRYPTO_FIPS140_SET", NULL }, /* 17 */
 
 	/* /dev/crypto ioctl() control codes */
 	{ (uint_t)CRYPTO_GET_FUNCTION_LIST,	"CRYPTO_GET_FUNCTION_LIST",
-	    NULL },
+	    NULL }, /* 20 */
 	{ (uint_t)CRYPTO_GET_MECHANISM_NUMBER,	"CRYPTO_GET_MECHANISM_NUMBER",
-	    NULL },
-	{ (uint_t)CRYPTO_OPEN_SESSION,	"CRYPTO_OPEN_SESSION",	NULL },
-	{ (uint_t)CRYPTO_CLOSE_SESSION,	"CRYPTO_CLOSE_SESSION",	NULL },
+	    NULL }, /* 21 */
+	{ (uint_t)CRYPTO_OPEN_SESSION,	"CRYPTO_OPEN_SESSION",	NULL }, /* 30 */
+	{ (uint_t)CRYPTO_CLOSE_SESSION,	"CRYPTO_CLOSE_SESSION",	NULL }, /* 31 */
 	{ (uint_t)CRYPTO_CLOSE_ALL_SESSIONS,	"CRYPTO_CLOSE_ALL_SESSIONS",
-	    NULL },
-	{ (uint_t)CRYPTO_LOGIN,		"CRYPTO_LOGIN",		NULL },
-	{ (uint_t)CRYPTO_LOGOUT,	"CRYPTO_LOGOUT",	NULL },
-	{ (uint_t)CRYPTO_ENCRYPT,	"CRYPTO_ENCRYPT",	NULL },
-	{ (uint_t)CRYPTO_ENCRYPT_INIT,	"CRYPTO_ENCRYPT_INIT",	NULL },
+	    NULL }, /* 32 */
+	{ (uint_t)CRYPTO_LOGIN,		"CRYPTO_LOGIN",		NULL }, /* 40 */
+	{ (uint_t)CRYPTO_LOGOUT,	"CRYPTO_LOGOUT",	NULL }, /* 41 */
+	{ (uint_t)CRYPTO_ENCRYPT,	"CRYPTO_ENCRYPT",	NULL }, /* 50 */
+	{ (uint_t)CRYPTO_ENCRYPT_INIT,	"CRYPTO_ENCRYPT_INIT",	NULL }, /* 51 */
 	{ (uint_t)CRYPTO_ENCRYPT_UPDATE,	"CRYPTO_ENCRYPT_UPDATE",
-	    NULL },
-	{ (uint_t)CRYPTO_ENCRYPT_FINAL,	"CRYPTO_ENCRYPT_FINAL",	NULL },
-	{ (uint_t)CRYPTO_DECRYPT,	"CRYPTO_DECRYPT",	NULL },
-	{ (uint_t)CRYPTO_DECRYPT_INIT,	"CRYPTO_DECRYPT_INIT",	NULL },
+	    NULL }, /* 52 */
+	{ (uint_t)CRYPTO_ENCRYPT_FINAL,	"CRYPTO_ENCRYPT_FINAL",	NULL }, /* 53 */
+	{ (uint_t)CRYPTO_DECRYPT,	"CRYPTO_DECRYPT",	NULL }, /* 54 */
+	{ (uint_t)CRYPTO_DECRYPT_INIT,	"CRYPTO_DECRYPT_INIT",	NULL }, /* 55 */
 	{ (uint_t)CRYPTO_DECRYPT_UPDATE,	"CRYPTO_DECRYPT_UPDATE",
-	    NULL },
-	{ (uint_t)CRYPTO_DECRYPT_FINAL,	"CRYPTO_DECRYPT_FINAL",	NULL },
-	{ (uint_t)CRYPTO_DIGEST,	"CRYPTO_DIGEST",	NULL },
-	{ (uint_t)CRYPTO_DIGEST_INIT,	"CRYPTO_DIGEST_INIT",	NULL },
-	{ (uint_t)CRYPTO_DIGEST_UPDATE,	"CRYPTO_DIGEST_UPDATE",	NULL },
-	{ (uint_t)CRYPTO_DIGEST_KEY,	"CRYPTO_DIGEST_KEY",	NULL },
-	{ (uint_t)CRYPTO_DIGEST_FINAL,	"CRYPTO_DIGEST_FINAL",	NULL },
-	{ (uint_t)CRYPTO_MAC,		"CRYPTO_MAC",		NULL },
-	{ (uint_t)CRYPTO_MAC_INIT,	"CRYPTO_MAC_INIT",	NULL },
-	{ (uint_t)CRYPTO_MAC_UPDATE,	"CRYPTO_MAC_UPDATE",	NULL },
-	{ (uint_t)CRYPTO_MAC_FINAL,	"CRYPTO_MAC_FINAL",	NULL },
-	{ (uint_t)CRYPTO_SIGN,		"CRYPTO_SIGN",		NULL },
-	{ (uint_t)CRYPTO_SIGN_INIT,	"CRYPTO_SIGN_INIT",	NULL },
-	{ (uint_t)CRYPTO_SIGN_UPDATE,	"CRYPTO_SIGN_UPDATE",	NULL },
-	{ (uint_t)CRYPTO_SIGN_FINAL,	"CRYPTO_SIGN_FINAL",	NULL },
+	    NULL }, /* 56 */
+	{ (uint_t)CRYPTO_DECRYPT_FINAL,	"CRYPTO_DECRYPT_FINAL",	NULL }, /* 57 */
+	{ (uint_t)CRYPTO_DIGEST,	"CRYPTO_DIGEST",	NULL }, /* 58 */
+	{ (uint_t)CRYPTO_DIGEST_INIT,	"CRYPTO_DIGEST_INIT",	NULL }, /* 59 */
+	{ (uint_t)CRYPTO_DIGEST_UPDATE,	"CRYPTO_DIGEST_UPDATE",	NULL }, /* 60 */
+	{ (uint_t)CRYPTO_DIGEST_KEY,	"CRYPTO_DIGEST_KEY",	NULL }, /* 61 */
+	{ (uint_t)CRYPTO_DIGEST_FINAL,	"CRYPTO_DIGEST_FINAL",	NULL }, /* 62 */
+	{ (uint_t)CRYPTO_MAC,		"CRYPTO_MAC",		NULL }, /* 63 */
+	{ (uint_t)CRYPTO_MAC_INIT,	"CRYPTO_MAC_INIT",	NULL }, /* 64 */
+	{ (uint_t)CRYPTO_MAC_UPDATE,	"CRYPTO_MAC_UPDATE",	NULL }, /* 65 */
+	{ (uint_t)CRYPTO_MAC_FINAL,	"CRYPTO_MAC_FINAL",	NULL }, /* 66 */
+	{ (uint_t)CRYPTO_SIGN,		"CRYPTO_SIGN",		NULL }, /* 67 */
+	{ (uint_t)CRYPTO_SIGN_INIT,	"CRYPTO_SIGN_INIT",	NULL }, /* 68 */
+	{ (uint_t)CRYPTO_SIGN_UPDATE,	"CRYPTO_SIGN_UPDATE",	NULL }, /* 69 */
+	{ (uint_t)CRYPTO_SIGN_FINAL,	"CRYPTO_SIGN_FINAL",	NULL }, /* 70 */
 	{ (uint_t)CRYPTO_SIGN_RECOVER_INIT,	"CRYPTO_SIGN_RECOVER_INIT",
-	    NULL },
-	{ (uint_t)CRYPTO_SIGN_RECOVER,	"CRYPTO_SIGN_RECOVER",	NULL },
-	{ (uint_t)CRYPTO_VERIFY,	"CRYPTO_VERIFY",	NULL },
-	{ (uint_t)CRYPTO_VERIFY_INIT,	"CRYPTO_VERIFY_INIT",	NULL },
-	{ (uint_t)CRYPTO_VERIFY_UPDATE,	"CRYPTO_VERIFY_UPDATE",	NULL },
-	{ (uint_t)CRYPTO_VERIFY_FINAL,	"CRYPTO_VERIFY_FINAL",	NULL },
+	    NULL }, /* 71 */
+	{ (uint_t)CRYPTO_SIGN_RECOVER,	"CRYPTO_SIGN_RECOVER",	NULL }, /* 72 */
+	{ (uint_t)CRYPTO_VERIFY,	"CRYPTO_VERIFY",	NULL }, /* 73 */
+	{ (uint_t)CRYPTO_VERIFY_INIT,	"CRYPTO_VERIFY_INIT",	NULL }, /* 74 */
+	{ (uint_t)CRYPTO_VERIFY_UPDATE,	"CRYPTO_VERIFY_UPDATE",	NULL }, /* 75 */
+	{ (uint_t)CRYPTO_VERIFY_FINAL,	"CRYPTO_VERIFY_FINAL",	NULL }, /* 76 */
 	{ (uint_t)CRYPTO_VERIFY_RECOVER_INIT,	"CRYPTO_VERIFY_RECOVER_INIT",
-	    NULL },
+	    NULL }, /* 77 */
 	{ (uint_t)CRYPTO_VERIFY_RECOVER,	"CRYPTO_VERIFY_RECOVER",
-	    NULL },
+	    NULL }, /* 78 */
 	{ (uint_t)CRYPTO_DIGEST_ENCRYPT_UPDATE,	"CRYPTO_DIGEST_ENCRYPT_UPDATE",
-	    NULL },
+	    NULL }, /* 79 */
 	{ (uint_t)CRYPTO_DECRYPT_DIGEST_UPDATE,	"CRYPTO_DECRYPT_DIGEST_UPDATE",
-	    NULL },
+	    NULL }, /* 80 */
 	{ (uint_t)CRYPTO_SIGN_ENCRYPT_UPDATE,	"CRYPTO_SIGN_ENCRYPT_UPDATE",
-	    NULL },
+	    NULL }, /* 81 */
 	{ (uint_t)CRYPTO_DECRYPT_VERIFY_UPDATE,	"CRYPTO_DECRYPT_VERIFY_UPDATE",
-	    NULL },
-	{ (uint_t)CRYPTO_SEED_RANDOM,	"CRYPTO_SEED_RANDOM",	NULL },
+	    NULL }, /* 82 */
+	{ (uint_t)CRYPTO_SEED_RANDOM,	"CRYPTO_SEED_RANDOM",	NULL }, /* 90 */
 	{ (uint_t)CRYPTO_GENERATE_RANDOM,	"CRYPTO_GENERATE_RANDOM",
-	    NULL },
-	{ (uint_t)CRYPTO_OBJECT_CREATE,	"CRYPTO_OBJECT_CREATE",	NULL },
-	{ (uint_t)CRYPTO_OBJECT_COPY,	"CRYPTO_OBJECT_COPY",	NULL },
+	    NULL }, /* 91 */
+	{ (uint_t)CRYPTO_OBJECT_CREATE,
+	    "CRYPTO_OBJECT_CREATE", NULL }, /* 100 */
+	{ (uint_t)CRYPTO_OBJECT_COPY, "CRYPTO_OBJECT_COPY", NULL }, /* 101 */
 	{ (uint_t)CRYPTO_OBJECT_DESTROY,	"CRYPTO_OBJECT_DESTROY",
-	    NULL },
+	    NULL }, /* 102 */
 	{ (uint_t)CRYPTO_OBJECT_GET_ATTRIBUTE_VALUE,
-	    "CRYPTO_OBJECT_GET_ATTRIBUTE_VALUE",	NULL },
-	{ (uint_t)CRYPTO_OBJECT_GET_SIZE, "CRYPTO_OBJECT_GET_SIZE",	NULL },
+	    "CRYPTO_OBJECT_GET_ATTRIBUTE_VALUE",	NULL }, /* 103 */
+	{ (uint_t)CRYPTO_OBJECT_GET_SIZE, "CRYPTO_OBJECT_GET_SIZE",
+	    NULL }, /* 104 */
 	{ (uint_t)CRYPTO_OBJECT_SET_ATTRIBUTE_VALUE,
-	    "CRYPTO_OBJECT_SET_ATTRIBUTE_VALUE",	NULL },
+	    "CRYPTO_OBJECT_SET_ATTRIBUTE_VALUE",	NULL }, /* 105 */
 	{ (uint_t)CRYPTO_OBJECT_FIND_INIT,	"CRYPTO_OBJECT_FIND_INIT",
-	    NULL },
+	    NULL }, /* 106 */
 	{ (uint_t)CRYPTO_OBJECT_FIND_UPDATE,	"CRYPTO_OBJECT_FIND_UPDATE",
-	    NULL },
+	    NULL }, /* 107 */
 	{ (uint_t)CRYPTO_OBJECT_FIND_FINAL,	"CRYPTO_OBJECT_FIND_FINAL",
-	    NULL },
-	{ (uint_t)CRYPTO_GENERATE_KEY,	"CRYPTO_GENERATE_KEY",	NULL },
-	{ (uint_t)CRYPTO_GENERATE_KEY_PAIR,	"CRYPTO_GENERATE_KEY_PAIR",
-	    NULL },
-	{ (uint_t)CRYPTO_WRAP_KEY,	"CRYPTO_WRAP_KEY",	NULL },
-	{ (uint_t)CRYPTO_UNWRAP_KEY,	"CRYPTO_UNWRAP_KEY",	NULL },
-	{ (uint_t)CRYPTO_DERIVE_KEY,	"CRYPTO_DERIVE_KEY",	NULL },
+	    NULL }, /* 108 */
+	{ (uint_t)CRYPTO_GENERATE_KEY, "CRYPTO_GENERATE_KEY", NULL }, /* 110 */
+	{ (uint_t)CRYPTO_GENERATE_KEY_PAIR, "CRYPTO_GENERATE_KEY_PAIR",
+	    NULL }, /* 111 */
+	{ (uint_t)CRYPTO_WRAP_KEY, "CRYPTO_WRAP_KEY", NULL }, /* 112 */
+	{ (uint_t)CRYPTO_UNWRAP_KEY, "CRYPTO_UNWRAP_KEY", NULL }, /* 113 */
+	{ (uint_t)CRYPTO_DERIVE_KEY, "CRYPTO_DERIVE_KEY", NULL }, /* 114 */
 	{ (uint_t)CRYPTO_GET_PROVIDER_LIST,	"CRYPTO_GET_PROVIDER_LIST",
-	    NULL },
+	    NULL }, /* 120 */
 	{ (uint_t)CRYPTO_GET_PROVIDER_INFO,	"CRYPTO_GET_PROVIDER_INFO",
-	    NULL },
+	    NULL }, /* 121 */
 	{ (uint_t)CRYPTO_GET_PROVIDER_MECHANISMS,
-	    "CRYPTO_GET_PROVIDER_MECHANISMS",	NULL },
+	    "CRYPTO_GET_PROVIDER_MECHANISMS",	NULL }, /* 122 */
 	{ (uint_t)CRYPTO_GET_PROVIDER_MECHANISM_INFO,
-	    "CRYPTO_GET_PROVIDER_MECHANISM_INFO",	NULL },
-	{ (uint_t)CRYPTO_INIT_TOKEN,	"CRYPTO_INIT_TOKEN",	NULL },
-	{ (uint_t)CRYPTO_INIT_PIN,	"CRYPTO_INIT_PIN",	NULL },
-	{ (uint_t)CRYPTO_SET_PIN,	"CRYPTO_SET_PIN",	NULL },
+	    "CRYPTO_GET_PROVIDER_MECHANISM_INFO", NULL }, /* 123 */
+	{ (uint_t)CRYPTO_INIT_TOKEN, "CRYPTO_INIT_TOKEN", NULL }, /* 124 */
+	{ (uint_t)CRYPTO_INIT_PIN, "CRYPTO_INIT_PIN", NULL }, /* 125 */
+	{ (uint_t)CRYPTO_SET_PIN, "CRYPTO_SET_PIN", NULL }, /* 126 */
 	{ (uint_t)CRYPTO_NOSTORE_GENERATE_KEY,
-	    "CRYPTO_NOSTORE_GENERATE_KEY",	NULL },
+	    "CRYPTO_NOSTORE_GENERATE_KEY",	NULL }, /* 127 */
 	{ (uint_t)CRYPTO_NOSTORE_GENERATE_KEY_PAIR,
-	    "CRYPTO_NOSTORE_GENERATE_KEY_PAIR",	NULL },
+	    "CRYPTO_NOSTORE_GENERATE_KEY_PAIR",	NULL }, /* 128 */
 	{ (uint_t)CRYPTO_NOSTORE_DERIVE_KEY,
-	    "CRYPTO_NOSTORE_DERIVE_KEY",	NULL },
-	{ (uint_t)CRYPTO_FIPS140_STATUS,	"CRYPTO_FIPS140_STATUS", NULL },
-	{ (uint_t)CRYPTO_FIPS140_SET,	"CRYPTO_FIPS140_SET",	NULL },
+	    "CRYPTO_NOSTORE_DERIVE_KEY",	NULL }, /* 129 */
+	{ (uint_t)CRYPTO_GET_MECHANISM_LIST,
+	    "CRYPTO_GET_MECHANISM_LIST",	NULL }, /* 140 */
+	{ (uint_t)CRYPTO_GET_ALL_MECHANISM_INFO,
+	    "CRYPTO_GET_ALL_MECHANISM_INFO",	NULL }, /* 141 */
+	{ (uint_t)CRYPTO_GET_PROVIDER_BY_MECH,
+	    "CRYPTO_GET_PROVIDER_BY_MECH",	NULL }, /* 142 */
+};
 
+const struct ioc kbd_ioc[] = { /* 'k'<<8 */
 	/* kbio ioctls */
-	{ (uint_t)KIOCTRANS,		"KIOCTRANS",	NULL },
-	{ (uint_t)KIOCGTRANS,		"KIOCGTRANS",	NULL },
-	{ (uint_t)KIOCTRANSABLE,	"KIOCTRANSABLE",	NULL },
-	{ (uint_t)KIOCGTRANSABLE,	"KIOCGTRANSABLE",	NULL },
-	{ (uint_t)KIOCSETKEY,		"KIOCSETKEY",	NULL },
-	{ (uint_t)KIOCGETKEY,		"KIOCGETKEY",	NULL },
-	{ (uint_t)KIOCCMD,		"KIOCCMD",	NULL },
-	{ (uint_t)KIOCTYPE,		"KIOCTYPE",	NULL },
-	{ (uint_t)KIOCSDIRECT,		"KIOCSDIRECT",	NULL },
-	{ (uint_t)KIOCGDIRECT,		"KIOCGDIRECT",	NULL },
-	{ (uint_t)KIOCSKEY,		"KIOCSKEY",	NULL },
-	{ (uint_t)KIOCGKEY,		"KIOCGKEY",	NULL },
-	{ (uint_t)KIOCSLED,		"KIOCSLED",	NULL },
-	{ (uint_t)KIOCGLED,		"KIOCGLED",	NULL },
-	{ (uint_t)KIOCSCOMPAT,		"KIOCSCOMPAT",	NULL },
-	{ (uint_t)KIOCGCOMPAT,		"KIOCGCOMPAT",	NULL },
-	{ (uint_t)KIOCSLAYOUT,		"KIOCSLAYOUT",	NULL },
-	{ (uint_t)KIOCLAYOUT,		"KIOCLAYOUT",	NULL },
-	{ (uint_t)KIOCSKABORTEN,	"KIOCSKABORTEN",	NULL },
-	{ (uint_t)KIOCGRPTCOUNT,	"KIOCGRPTCOUNT",	NULL },
-	{ (uint_t)KIOCSRPTCOUNT,	"KIOCSRPTCOUNT",	NULL },
-	{ (uint_t)KIOCGRPTDELAY,	"KIOCGRPTDELAY",	NULL },
-	{ (uint_t)KIOCSRPTDELAY,	"KIOCSRPTDELAY",	NULL },
-	{ (uint_t)KIOCGRPTRATE,		"KIOCGRPTRATE",	NULL },
-	{ (uint_t)KIOCSRPTRATE,		"KIOCSRPTRATE",	NULL },
-	{ (uint_t)KIOCSETFREQ,		"KIOCSETFREQ",	NULL },
-	{ (uint_t)KIOCMKTONE,		"KIOCMKTONE",	NULL },
+	{ (uint_t)KIOCTRANS,		"KIOCTRANS",	NULL }, /* 30 */
+	{ (uint_t)KIOCSETKEY,		"KIOCSETKEY",	NULL }, /* 31 */
+	{ (uint_t)KIOCGETKEY,		"KIOCGETKEY",	NULL }, /* 32 */
+	{ (uint_t)KIOCGTRANS,		"KIOCGTRANS",	NULL }, /* 35 */
+	{ (uint_t)KIOCTRANSABLE,	"KIOCTRANSABLE",	NULL }, /* 36 */
+	{ (uint_t)KIOCGTRANSABLE,	"KIOCGTRANSABLE",	NULL }, /* 37 */
+	{ (uint_t)KIOCCMD,		"KIOCCMD",	NULL }, /* 8 */
+	{ (uint_t)KIOCTYPE,		"KIOCTYPE",	NULL }, /* 9 */
+	{ (uint_t)KIOCSDIRECT,		"KIOCSDIRECT",	NULL }, /* 10 */
+	{ (uint_t)KIOCGDIRECT,		"KIOCGDIRECT",	NULL }, /* 41 */
+	{ (uint_t)KIOCSKEY,		"KIOCSKEY",	NULL }, /* 42 */
+	{ (uint_t)KIOCGKEY,		"KIOCGKEY",	NULL }, /* 13 */
+	{ (uint_t)KIOCSLED,		"KIOCSLED",	NULL }, /* 14 */
+	{ (uint_t)KIOCGLED,		"KIOCGLED",	NULL }, /* 15 */
+	{ (uint_t)KIOCSCOMPAT,		"KIOCSCOMPAT",	NULL }, /* 16 */
+	{ (uint_t)KIOCGCOMPAT,		"KIOCGCOMPAT",	NULL }, /* 17 */
+	{ (uint_t)KIOCSLAYOUT,		"KIOCSLAYOUT",	NULL }, /* 19 */
+	{ (uint_t)KIOCLAYOUT,		"KIOCLAYOUT",	NULL }, /* 20 */
+	{ (uint_t)KIOCSKABORTEN,	"KIOCSKABORTEN",	NULL }, /* 21 */
+	{ (uint_t)KIOCGRPTDELAY,	"KIOCGRPTDELAY",	NULL }, /* 22 */
+	{ (uint_t)KIOCSRPTDELAY,	"KIOCSRPTDELAY",	NULL }, /* 23 */
+	{ (uint_t)KIOCGRPTRATE,		"KIOCGRPTRATE",	NULL }, /* 24 */
+	{ (uint_t)KIOCSRPTRATE,		"KIOCSRPTRATE",	NULL }, /* 25 */
+	{ (uint_t)KIOCSETFREQ,		"KIOCSETFREQ",	NULL }, /* 26 */
+	{ (uint_t)KIOCMKTONE,		"KIOCMKTONE",	NULL }, /* 27 */
+	{ (uint_t)KIOCGRPTCOUNT,	"KIOCGRPTCOUNT",	NULL }, /* 28 */
+	{ (uint_t)KIOCSRPTCOUNT,	"KIOCSRPTCOUNT",	NULL }, /* 29 */
+};
 
+const struct ioc ptm_ioc[] = { /* 'P'<<8 */
 	/* ptm/pts driver I_STR ioctls */
-	{ (uint_t)ISPTM,		"ISPTM",		NULL},
-	{ (uint_t)UNLKPT,		"UNLKPT",		NULL},
-	{ (uint_t)PTSSTTY,		"PTSSTTY",		NULL},
-	{ (uint_t)ZONEPT,		"ZONEPT",		NULL},
-	{ (uint_t)OWNERPT,		"OWNERPT",		NULL},
+	{ (uint_t)ISPTM,		"ISPTM",	NULL }, /* 1 */
+	{ (uint_t)UNLKPT,		"UNLKPT",	NULL }, /* 2 */
+	{ (uint_t)PTSSTTY,		"PTSSTTY",	NULL }, /* 3 */
+	{ (uint_t)ZONEPT,		"ZONEPT",	NULL }, /* 4 */
+	{ (uint_t)OWNERPT,		"OWNERPT",	NULL }, /* 5 */
+};
 
+const struct ioc aggr_ioc[] = { /* 0x0A66 << 16 */
 	/* aggr link aggregation pseudo driver ioctls */
-	{ (uint_t)LAIOC_CREATE,		"LAIOC_CREATE",		"laioc_create"},
-	{ (uint_t)LAIOC_DELETE,		"LAIOC_DELETE",		"laioc_delete"},
-	{ (uint_t)LAIOC_INFO,		"LAIOC_INFO",		"laioc_info"},
-	{ (uint_t)LAIOC_ADD,		"LAIOC_ADD",
-	    "laioc_add_rem"},
-	{ (uint_t)LAIOC_REMOVE,		"LAIOC_REMOVE",
-	    "laioc_add_rem"},
-	{ (uint_t)LAIOC_MODIFY,		"LAIOC_MODIFY",		"laioc_modify"},
+	{ (uint_t)LAIOC_CREATE,	"LAIOC_CREATE",	"laioc_create"}, /* 1 */
+	{ (uint_t)LAIOC_DELETE,	"LAIOC_DELETE",	"laioc_delete"}, /* 2 */
+	{ (uint_t)LAIOC_INFO,	"LAIOC_INFO",	"laioc_info"}, /* 3 */
+	{ (uint_t)LAIOC_ADD,	"LAIOC_ADD", "laioc_add_rem"}, /* 4 */
+	{ (uint_t)LAIOC_REMOVE,	"LAIOC_REMOVE", "laioc_add_rem"}, /* 5 */
+	{ (uint_t)LAIOC_MODIFY,	"LAIOC_MODIFY",	"laioc_modify"}, /* 6 */
+};
 
+const struct ioc dld_ioc[] = { /* 0x0D1D << 16 */
 	/* dld data-link ioctls */
-	{ (uint_t)DLDIOC_ATTR,		"DLDIOC_ATTR",		"dld_ioc_attr"},
-	{ (uint_t)DLDIOC_PHYS_ATTR,	"DLDIOC_PHYS_ATTR",
-		"dld_ioc_phys_attr"},
-	{ (uint_t)DLDIOC_DOORSERVER,	"DLDIOC_DOORSERVER", "dld_ioc_door"},
-	{ (uint_t)DLDIOC_RENAME,	"DLDIOC_RENAME", "dld_ioc_rename"},
-	{ (uint_t)DLDIOC_SECOBJ_GET,		"DLDIOC_SECOBJ_GET",
-		"dld_ioc_secobj_get"},
-	{ (uint_t)DLDIOC_SECOBJ_SET,		"DLDIOC_SECOBJ_SET",
-		"dld_ioc_secobj_set"},
-	{ (uint_t)DLDIOC_SECOBJ_UNSET,		"DLDIOC_SECOBJ_UNSET",
-		"dld_ioc_secobj_unset"},
-	{ (uint_t)DLDIOC_MACADDRGET,		"DLDIOC_MACADDRGET",
+	{ (uint_t)DLDIOC_ATTR, "DLDIOC_ATTR", "dld_ioc_attr"}, /* 3 */
+	{ (uint_t)DLDIOC_VLAN_ATTR, "DLDIOC_VLAN_ATTR",
+	    "dld_ioc_vlan_attr"}, /* 4 */
+	{ (uint_t)DLDIOC_PHYS_ATTR, "DLDIOC_PHYS_ATTR",
+	    "dld_ioc_phys_attr"}, /* 5 */
+	{ (uint_t)DLDIOC_SECOBJ_SET, "DLDIOC_SECOBJ_SET",
+		"dld_ioc_secobj_set"}, /* 6 */
+	{ (uint_t)DLDIOC_SECOBJ_GET, "DLDIOC_SECOBJ_GET",
+		"dld_ioc_secobj_get"}, /* 7 */
+	{ (uint_t)DLDIOC_SECOBJ_UNSET, "DLDIOC_SECOBJ_UNSET",
+		"dld_ioc_secobj_unset"}, /* 10 */
+	{ (uint_t)DLDIOC_CREATE_VLAN, "DLDIOC_CREATE_VLAN",
+		"dld_ioc_create_vlan"}, /* 11 */
+	{ (uint_t)DLDIOC_DELETE_VLAN, "DLDIOC_DELETE_VLAN",
+		"dld_ioc_delete_vlan"}, /* 12 */
+	{ (uint_t)DLDIOC_DOORSERVER, "DLDIOC_DOORSERVER",
+		"dld_ioc_door"}, /* 16 */
+	{ (uint_t)DLDIOC_RENAME, "DLDIOC_RENAME", "dld_ioc_rename"}, /* 17 */
+	{ (uint_t)DLDIOC_MACADDRGET, "DLDIOC_MACADDRGET", /* 21 */
 		"dld_ioc_macaddrget"},
-	{ (uint_t)DLDIOC_SETMACPROP,		"DLDIOC_SETMACPROP",
-		"dld_ioc_macprop_s"},
-	{ (uint_t)DLDIOC_GETMACPROP,		"DLDIOC_GETMACPROP",
-		"dld_ioc_macprop_s"},
-	{ (uint_t)DLDIOC_ADDFLOW,		"DLDIOC_ADDFLOW",
-		"dld_ioc_addflow"},
-	{ (uint_t)DLDIOC_REMOVEFLOW,		"DLDIOC_REMOVEFLOW",
-		"dld_ioc_removeflow"},
-	{ (uint_t)DLDIOC_MODIFYFLOW,		"DLDIOC_MODIFYFLOW",
-		"dld_ioc_modifyflow"},
-	{ (uint_t)DLDIOC_WALKFLOW,		"DLDIOC_WALKFLOW",
-		"dld_ioc_walkflow"},
-	{ (uint_t)DLDIOC_USAGELOG,		"DLDIOC_USAGELOG",
-		"dld_ioc_usagelog"},
+	{ (uint_t)DLDIOC_ADDFLOW, "DLDIOC_ADDFLOW",
+		"dld_ioc_addflow"}, /* 22 */
+	{ (uint_t)DLDIOC_REMOVEFLOW, "DLDIOC_REMOVEFLOW",
+		"dld_ioc_removeflow"}, /* 23 */
+	{ (uint_t)DLDIOC_MODIFYFLOW, "DLDIOC_MODIFYFLOW",
+		"dld_ioc_modifyflow"}, /* 24 */
+	{ (uint_t)DLDIOC_WALKFLOW, "DLDIOC_WALKFLOW",
+		"dld_ioc_walkflow"}, /* 25 */
+	{ (uint_t)DLDIOC_USAGELOG, "DLDIOC_USAGELOG",
+		"dld_ioc_usagelog"}, /* 26 */
+	{ (uint_t)DLDIOC_SETMACPROP, "DLDIOC_SETMACPROP",
+		"dld_ioc_macprop_s"}, /* 27 */
+	{ (uint_t)DLDIOC_GETMACPROP, "DLDIOC_GETMACPROP",
+		"dld_ioc_macprop_s"}, /* 28 */
+	{ (uint_t)DLDIOC_GETHWGRP, "DLDIOC_GETHWGRP",
+		"dld_ioc_hwgrpget"}, /* 29 */
+	{ (uint_t)DLDIOC_GETTRAN, "DLDIOC_GETTRAN",
+		"dld_ioc_gettran"}, /* 30 */
+	{ (uint_t)DLDIOC_READTRAN, "DLDIOC_READTRAN",
+		"dld_ioc_tranio"}, /* 31 */
+};
 
+const struct ioc simnet_ioc[] = { /* 0x5132 << 16 */
 	/* simnet ioctls */
 	{ (uint_t)SIMNET_IOC_CREATE,		"SIMNET_IOC_CREATE",
-		"simnet_ioc_create"},
+		"simnet_ioc_create"}, /* 1 */
 	{ (uint_t)SIMNET_IOC_DELETE,		"SIMNET_IOC_DELETE",
-		"simnet_ioc_delete"},
+		"simnet_ioc_delete"}, /* 2 */
 	{ (uint_t)SIMNET_IOC_INFO,		"SIMNET_IOC_INFO",
-		"simnet_ioc_info"},
+		"simnet_ioc_info"}, /* 3 */
 	{ (uint_t)SIMNET_IOC_MODIFY,		"SIMNET_IOC_MODIFY",
-		"simnet_ioc_info"},
+		"simnet_ioc_info"}, /* 4 */
+};
 
+const struct ioc vnic_ioc[] = { /* 0x0171 << 16 */
 	/* vnic ioctls */
 	{ (uint_t)VNIC_IOC_CREATE,		"VNIC_IOC_CREATE",
-		"vnic_ioc_create"},
+		"vnic_ioc_create"}, /* 1 */
 	{ (uint_t)VNIC_IOC_DELETE,		"VNIC_IOC_DELETE",
-		"vnic_ioc_delete"},
+		"vnic_ioc_delete"}, /* 2 */
 	{ (uint_t)VNIC_IOC_INFO,		"VNIC_IOC_INFO",
-		"vnic_ioc_info"},
+		"vnic_ioc_info"}, /* 3 */
+	{ (uint_t)VNIC_IOC_MODIFY,		"VNIC_IOC_MODIFY",
+		"vnic_ioc_modify"}, /* 4 */
+};
 
+const struct ioc zfs_ioc[] = { /* 'Z' << 8 */
 	/* ZFS ioctls */
 	{ (uint_t)ZFS_IOC_POOL_CREATE,		"ZFS_IOC_POOL_CREATE",
 		"zfs_cmd_t" },
@@ -1168,10 +1281,6 @@ const struct ioc {
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_POOL_GET_HISTORY,	"ZFS_IOC_POOL_GET_HISTORY",
 		"zfs_cmd_t" },
-	{ (uint_t)ZFS_IOC_POOL_CHECKPOINT,	"ZFS_IOC_POOL_CHECKPOINT",
-		"zfs_cmd_t" },
-	{ (uint_t)ZFS_IOC_POOL_DISCARD_CHECKPOINT,
-		"ZFS_IOC_POOL_DISCARD_CHECKPOINT", "zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_VDEV_ADD,		"ZFS_IOC_VDEV_ADD",
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_VDEV_REMOVE,		"ZFS_IOC_VDEV_REMOVE",
@@ -1266,6 +1375,8 @@ const struct ioc {
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_SPACE_WRITTEN,	"ZFS_IOC_SPACE_WRITTEN",
 		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_SPACE_SNAPS,		"ZFS_IOC_SPACE_SNAPS",
+		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_DESTROY_SNAPS,	"ZFS_IOC_DESTROY_SNAPS",
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_POOL_REGUID,		"ZFS_IOC_POOL_REGUID",
@@ -1290,11 +1401,9 @@ const struct ioc {
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_DESTROY_BOOKMARKS,	"ZFS_IOC_DESTROY_BOOKMARKS",
 		"zfs_cmd_t" },
-	{ (uint_t)ZFS_IOC_CHANNEL_PROGRAM,	"ZFS_IOC_CHANNEL_PROGRAM",
-		"zfs_cmd_t" },
-	{ (uint_t)ZFS_IOC_POOL_INITIALIZE,	"ZFS_IOC_POOL_INITIALIZE",
-		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_POOL_SYNC,		"ZFS_IOC_POOL_SYNC",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_CHANNEL_PROGRAM,	"ZFS_IOC_CHANNEL_PROGRAM",
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_LOAD_KEY,		"ZFS_IOC_LOAD_KEY",
 		"zfs_cmd_t" },
@@ -1302,208 +1411,262 @@ const struct ioc {
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_CHANGE_KEY,		"ZFS_IOC_CHANGE_KEY",
 		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_REMAP,		"ZFS_IOC_REMAP",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_POOL_CHECKPOINT,	"ZFS_IOC_POOL_CHECKPOINT",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_POOL_DISCARD_CHECKPOINT,
+		"ZFS_IOC_POOL_DISCARD_CHECKPOINT", "zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_POOL_INITIALIZE,	"ZFS_IOC_POOL_INITIALIZE",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_POOL_TRIM,		"ZFS_IOC_POOL_TRIM",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_REDACT,		"ZFS_IOC_REDACT",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_GET_BOOKMARK_PROPS,	"ZFS_IOC_GET_BOOKMARK_PROPS",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_EVENTS_NEXT,		"ZFS_IOC_EVENTS_NEXT",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_EVENTS_CLEAR,		"ZFS_IOC_EVENTS_CLEAR",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_EVENTS_SEEK,		"ZFS_IOC_EVENTS_SEEK",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_NEXTBOOT,		"ZFS_IOC_NEXTBOOT",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_JAIL,			"ZFS_IOC_JAIL",
+		"zfs_cmd_t" },
+	{ (uint_t)ZFS_IOC_UNJAIL,		"ZFS_IOC_UNJAIL",
+		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_SET_BOOTENV,		"ZFS_IOC_SET_BOOTENV",
 		"zfs_cmd_t" },
 	{ (uint_t)ZFS_IOC_GET_BOOTENV,		"ZFS_IOC_GET_BOOTENV",
 		"zfs_cmd_t" },
+};
 
+const struct ioc dkio_ioc[] = { /* 0x4 << 8 */
 	/* disk ioctls - (0x04 << 8) - dkio.h */
 	{ (uint_t)DKIOCGGEOM,		"DKIOCGGEOM",
-		"struct dk_geom"},
-	{ (uint_t)DKIOCINFO,		"DKIOCINFO",
-		"struct dk_info"},
-	{ (uint_t)DKIOCEJECT,		"DKIOCEJECT",
-		NULL},
-	{ (uint_t)DKIOCGVTOC,		"DKIOCGVTOC",
-		"struct vtoc"},
-	{ (uint_t)DKIOCSVTOC,		"DKIOCSVTOC",
-		"struct vtoc"},
-	{ (uint_t)DKIOCGEXTVTOC,	"DKIOCGEXTVTOC",
-		"struct extvtoc"},
-	{ (uint_t)DKIOCSEXTVTOC,	"DKIOCSEXTVTOC",
-		"struct extvtoc"},
-	{ (uint_t)DKIOCFLUSHWRITECACHE,	"DKIOCFLUSHWRITECACHE",
-		NULL},
-	{ (uint_t)DKIOCGETWCE,		"DKIOCGETWCE",
-		NULL},
-	{ (uint_t)DKIOCSETWCE,		"DKIOCSETWCE",
-		NULL},
+		"dk_geom"}, /* 1 */
 	{ (uint_t)DKIOCSGEOM,		"DKIOCSGEOM",
-		"struct dk_geom"},
+		"dk_geom"}, /* 2 */
+	{ (uint_t)DKIOCINFO,		"DKIOCINFO",
+		"dk_info"}, /* 3 */
 	{ (uint_t)DKIOCSAPART,		"DKIOCSAPART",
-		"struct dk_allmap"},
+		"dk_allmap"}, /* 4 */
 	{ (uint_t)DKIOCGAPART,		"DKIOCGAPART",
-		"struct dk_allmap"},
-	{ (uint_t)DKIOCG_PHYGEOM,	"DKIOCG_PHYGEOM",
-		"struct dk_geom"},
-	{ (uint_t)DKIOCG_VIRTGEOM,	"DKIOCG_VIRTGEOM",
-		"struct dk_geom"},
+		"dk_allmap"}, /* 5 */
+	{ (uint_t)DKIOCEJECT,		"DKIOCEJECT",
+		NULL}, /* 6 */
 	{ (uint_t)DKIOCLOCK,		"DKIOCLOCK",
-		NULL},
+		NULL}, /* 7 */
 	{ (uint_t)DKIOCUNLOCK,		"DKIOCUNLOCK",
-		NULL},
-	{ (uint_t)DKIOCSTATE,		"DKIOCSTATE",
-		NULL},
-	{ (uint_t)DKIOCREMOVABLE,	"DKIOCREMOVABLE",
-		NULL},
-	{ (uint_t)DKIOCHOTPLUGGABLE,	"DKIOCHOTPLUGGABLE",
-		NULL},
-	{ (uint_t)DKIOCADDBAD,		"DKIOCADDBAD",
-		NULL},
-	{ (uint_t)DKIOCGETDEF,		"DKIOCGETDEF",
-		NULL},
-	{ (uint_t)DKIOCPARTINFO,	"DKIOCPARTINFO",
-		"struct part_info"},
-	{ (uint_t)DKIOCEXTPARTINFO,	"DKIOCEXTPARTINFO",
-		"struct extpart_info"},
-	{ (uint_t)DKIOCGMEDIAINFO,	"DKIOCGMEDIAINFO",
-		"struct dk_minfo"},
-	{ (uint_t)DKIOCGMBOOT,		"DKIOCGMBOOT",
-		NULL},
-	{ (uint_t)DKIOCSMBOOT,		"DKIOCSMBOOT",
-		NULL},
-	{ (uint_t)DKIOCSETEFI,		"DKIOCSETEFI",
-		"struct dk_efi"},
-	{ (uint_t)DKIOCGETEFI,		"DKIOCGETEFI",
-		"struct dk_efi"},
+		NULL}, /* 8 */
 	{ (uint_t)DKIOCPARTITION,	"DKIOCPARTITION",
-		"struct partition64"},
+		"partition64"}, /* 9 */
+	{ (uint_t)DKIOCGVTOC,		"DKIOCGVTOC",
+		"vtoc"}, /* 11 */
+	{ (uint_t)DKIOCSVTOC,		"DKIOCSVTOC",
+		"vtoc"}, /* 12 */
+	{ (uint_t)DKIOCSTATE,		"DKIOCSTATE",
+		NULL}, /* 13 */
+	{ (uint_t)DKIOCREMOVABLE,	"DKIOCREMOVABLE",
+		NULL}, /* 16 */
+	{ (uint_t)DKIOCSETEFI,		"DKIOCSETEFI",
+		"dk_efi"}, /* 17 */
+	{ (uint_t)DKIOCGETEFI,		"DKIOCGETEFI",
+		"dk_efi"}, /* 18 */
+	{ (uint_t)DKIOCEXTPARTINFO,	"DKIOCEXTPARTINFO",
+		"extpart_info"}, /* 19 */
+	{ (uint_t)DKIOCADDBAD,		"DKIOCADDBAD",
+		NULL}, /* 20 */
+	{ (uint_t)DKIOCGETDEF,		"DKIOCGETDEF",
+		NULL}, /* 21 */
+	{ (uint_t)DKIOCPARTINFO,	"DKIOCPARTINFO",
+		"part_info"}, /* 22 */
+	{ (uint_t)DKIOCGEXTVTOC,	"DKIOCGEXTVTOC",
+		"extvtoc"}, /* 23 */
+	{ (uint_t)DKIOCSEXTVTOC,	"DKIOCSEXTVTOC",
+		"extvtoc"}, /* 24 */
 	{ (uint_t)DKIOCGETVOLCAP,	"DKIOCGETVOLCAP",
-		"struct volcap_t"},
+		"volcap_t"}, /* 25 */
 	{ (uint_t)DKIOCSETVOLCAP,	"DKIOCSETVOLCAP",
-		"struct volcap_t"},
+		"volcap_t"}, /* 26 */
 	{ (uint_t)DKIOCDMR,		"DKIOCDMR",
-		"struct vol_directed_rd"},
+		"vol_directed_rd"}, /* 27 */
 	{ (uint_t)DKIOCDUMPINIT,	"DKIOCDUMPINIT",
-		NULL},
+		NULL}, /* 28 */
 	{ (uint_t)DKIOCDUMPFINI,	"DKIOCDUMPFINI",
-		NULL},
+		NULL}, /* 29 */
+	{ (uint_t)DKIOCG_PHYGEOM,	"DKIOCG_PHYGEOM",
+		"dk_geom"}, /* 32 */
+	{ (uint_t)DKIOCG_VIRTGEOM,	"DKIOCG_VIRTGEOM",
+		"dk_geom"}, /* 33 */
+	{ (uint_t)DKIOCFLUSHWRITECACHE,	"DKIOCFLUSHWRITECACHE",
+		NULL}, /* 34 */
+	{ (uint_t)DKIOCHOTPLUGGABLE,	"DKIOCHOTPLUGGABLE",
+		NULL}, /* 35 */
+	{ (uint_t)DKIOCGETWCE,		"DKIOCGETWCE",
+		NULL}, /* 36 */
+	{ (uint_t)DKIOCSETWCE,		"DKIOCSETWCE",
+		NULL}, /* 37 */
+	{ (uint_t)DKIOCSOLIDSTATE,	"DKIOCSOLIDSTATE",
+		NULL}, /* 38 */
+	{ (uint_t)DKIOCGMEDIAINFO,	"DKIOCGMEDIAINFO",
+		"dk_minfo"}, /* 42 */
+	{ (uint_t)DKIOCGMBOOT,		"DKIOCGMBOOT",
+		NULL}, /* 43 */
+	{ (uint_t)DKIOCSMBOOT,		"DKIOCSMBOOT",
+		NULL}, /* 44 */
+	{ (uint_t)DKIOCGTEMPERATURE,	"DKIOCGTEMPERATURE",
+		"dk_temperature"}, /* 45 */
+	{ (uint_t)DKIOCSETEXTPART,	"DKIOCSETEXTPART",
+		NULL}, /* 46 */
+	{ (uint_t)DKIOC_GETDISKID,	"DKIOC_GETDISKID",
+		"dk_disk_id"}, /* 46 - bug? */
+	{ (uint_t)DKIOC_UPDATEFW,	"DKIOC_UPDATEFW",
+		"dk_updatefw"}, /* 47 */
+	{ (uint_t)DKIOCGMEDIAINFOEXT,	"DKIOCGMEDIAINFOEXT",
+		"dk_minfo_ext"}, /* 48 */
 	{ (uint_t)DKIOCREADONLY,	"DKIOCREADONLY",
-		NULL},
+		NULL}, /* 49 */
 	{ (uint_t)DKIOCFREE,		"DKIOCFREE",
-		NULL},
+		"dkioc_free_list_s"}, /* 50 */
 	{ (uint_t)DKIOC_CANFREE,	"DKIOC_CANFREE",
-		NULL},
+		NULL}, /* 60 */
 
 	/* disk ioctls - (0x04 << 8) - fdio.h */
 	{ (uint_t)FDIOGCHAR,		"FDIOGCHAR",
-		"struct fd_char"},
+		"fd_char"}, /* 51 */
 	{ (uint_t)FDIOSCHAR,		"FDIOSCHAR",
-		"struct fd_char"},
+		"fd_char"}, /* 52 */
 	{ (uint_t)FDEJECT,		"FDEJECT",
-		NULL},
+		NULL}, /* 53 */
 	{ (uint_t)FDGETCHANGE,		"FDGETCHANGE",
-		NULL},
+		NULL}, /* 54 */
 	{ (uint_t)FDGETDRIVECHAR,	"FDGETDRIVECHAR",
-		"struct fd_drive"},
+		"fd_drive"}, /* 55 */
 	{ (uint_t)FDSETDRIVECHAR,	"FDSETDRIVECHAR",
-		"struct fd_drive"},
+		"fd_drive"}, /* 56 */
 	{ (uint_t)FDGETSEARCH,		"FDGETSEARCH",
-		NULL},
+		NULL}, /* 57 */
 	{ (uint_t)FDSETSEARCH,		"FDSETSEARCH",
-		NULL},
+		NULL}, /* 58 */
 	{ (uint_t)FDIOCMD,		"FDIOCMD",
-		"struct fd_cmd"},
+		"fd_cmd"}, /* 59 */
 	{ (uint_t)FDRAW,		"FDRAW",
-		"struct fd_raw"},
+		"fd_raw"}, /* 70 */
 	{ (uint_t)FDDEFGEOCHAR,		"FDDEFGEOCHAR",
-		NULL},
+		NULL}, /* 86 */
 
 	/* disk ioctls - (0x04 << 8) - cdio.h */
 	{ (uint_t)CDROMPAUSE,		"CDROMPAUSE",
-		NULL},
+		NULL}, /* 151 */
 	{ (uint_t)CDROMRESUME,		"CDROMRESUME",
-		NULL},
+		NULL}, /* 152 */
 	{ (uint_t)CDROMPLAYMSF,		"CDROMPLAYMSF",
-		"struct cdrom_msf"},
+		"cdrom_msf"}, /* 153 */
 	{ (uint_t)CDROMPLAYTRKIND,	"CDROMPLAYTRKIND",
-		"struct cdrom_ti"},
+		"cdrom_ti"}, /* 154 */
 	{ (uint_t)CDROMREADTOCHDR,	"CDROMREADTOCHDR",
-		"struct cdrom_tochdr"},
+		"cdrom_tochdr"}, /* 155 */
 	{ (uint_t)CDROMREADTOCENTRY,	"CDROMREADTOCENTRY",
-		"struct cdrom_tocentry"},
+		"cdrom_tocentry"}, /* 156 */
 	{ (uint_t)CDROMSTOP,		"CDROMSTOP",
-		NULL},
+		NULL}, /* 157 */
 	{ (uint_t)CDROMSTART,		"CDROMSTART",
-		NULL},
+		NULL}, /* 158 */
 	{ (uint_t)CDROMEJECT,		"CDROMEJECT",
-		NULL},
+		NULL}, /* 159 */
 	{ (uint_t)CDROMVOLCTRL,		"CDROMVOLCTRL",
-		"struct cdrom_volctrl"},
+		"cdrom_volctrl"}, /* 160 */
 	{ (uint_t)CDROMSUBCHNL,		"CDROMSUBCHNL",
-		"struct cdrom_subchnl"},
+		"cdrom_subchnl"}, /* 161 */
 	{ (uint_t)CDROMREADMODE2,	"CDROMREADMODE2",
-		"struct cdrom_read"},
+		"cdrom_read"}, /* 162 */
 	{ (uint_t)CDROMREADMODE1,	"CDROMREADMODE1",
-		"struct cdrom_read"},
+		"cdrom_read"}, /* 163 */
 	{ (uint_t)CDROMREADOFFSET,	"CDROMREADOFFSET",
-		NULL},
+		NULL}, /* 164 */
 	{ (uint_t)CDROMGBLKMODE,	"CDROMGBLKMODE",
-		NULL},
+		NULL}, /* 165 */
 	{ (uint_t)CDROMSBLKMODE,	"CDROMSBLKMODE",
-		NULL},
+		NULL}, /* 166 */
 	{ (uint_t)CDROMCDDA,		"CDROMCDDA",
-		"struct cdrom_cdda"},
+		"cdrom_cdda"}, /* 167 */
 	{ (uint_t)CDROMCDXA,		"CDROMCDXA",
-		"struct cdrom_cdxa"},
+		"cdrom_cdxa"}, /* 168 */
 	{ (uint_t)CDROMSUBCODE,		"CDROMSUBCODE",
-		"struct cdrom_subcode"},
+		"cdrom_subcode"}, /* 169 */
 	{ (uint_t)CDROMGDRVSPEED,	"CDROMGDRVSPEED",
-		NULL},
+		NULL}, /* 170 */
 	{ (uint_t)CDROMSDRVSPEED,	"CDROMSDRVSPEED",
-		NULL},
+		NULL}, /* 171 */
 	{ (uint_t)CDROMCLOSETRAY,	"CDROMCLOSETRAY",
-		NULL},
+		NULL}, /* 172 */
 
 	/* disk ioctls - (0x04 << 8) - uscsi.h */
 	{ (uint_t)USCSICMD,		"USCSICMD",
-		"struct uscsi_cmd"},
+		"uscsi_cmd"}, /* 201 */
+	{ (uint_t)USCSIMAXXFER,		"USCSIMAXXFER",
+		NULL}, /* 202 */
+};
 
+const struct ioc dumpadm_ioc[] = { /* 0xdd << 8 */
 	/* dumpadm ioctls - (0xdd << 8) */
-	{ (uint_t)DIOCGETDEV,	"DIOCGETDEV",
-		NULL},
+	{ (uint_t)DIOCGETDUMPSIZE, "DIOCGETDEV", NULL}, /* 0x10 */
+	{ (uint_t)DIOCGETCONF, "DIOCGETCONF", NULL}, /* 0x11 */
+	{ (uint_t)DIOCSETCONF, "DIOCSETCONF", NULL}, /* 0x12 */
+	{ (uint_t)DIOCGETDEV, "DIOCGETDEV", NULL}, /* 0x13 */
+	{ (uint_t)DIOCSETDEV, "DIOCSETDEV", NULL}, /* 0x14 */
+	{ (uint_t)DIOCTRYDEV, "DIOCTRYDEV", NULL}, /* 0x15 */
+	{ (uint_t)DIOCDUMP, "DIOCDUMP", NULL}, /* 0x16 */
+	{ (uint_t)DIOCSETUUID, "DIOCSETUUID", NULL}, /* 0x17 */
+	{ (uint_t)DIOCGETUUID, "DIOCGETUUID", NULL}, /* 0x18 */
+	{ (uint_t)DIOCRMDEV, "DIOCRMDEV", NULL}, /* 0x19 */
+};
 
+const struct ioc mnt_ioc[] = { /* 'm' << 8 */
 	/* mntio ioctls - ('m' << 8) */
-	{ (uint_t)MNTIOC_NMNTS,		"MNTIOC_NMNTS",
-		NULL},
-	{ (uint_t)MNTIOC_GETDEVLIST,	"MNTIOC_GETDEVLIST",
-		NULL},
-	{ (uint_t)MNTIOC_SETTAG,	"MNTIOC_SETTAG",
-		"struct mnttagdesc"},
-	{ (uint_t)MNTIOC_CLRTAG,	"MNTIOC_CLRTAG",
-		"struct mnttagdesc"},
-	{ (uint_t)MNTIOC_SHOWHIDDEN,	"MNTIOC_SHOWHIDDEN",
-		NULL},
-	{ (uint_t)MNTIOC_GETMNTENT,	"MNTIOC_GETMNTENT",
-		"struct mnttab"},
-	{ (uint_t)MNTIOC_GETEXTMNTENT,	"MNTIOC_GETEXTMNTENT",
-		"struct extmnttab"},
-	{ (uint_t)MNTIOC_GETMNTANY,	"MNTIOC_GETMNTANY",
-		"struct mnttab"},
+	{ (uint_t)MNTIOC_NMNTS, "MNTIOC_NMNTS", NULL }, /* 1 */
+	{ (uint_t)MNTIOC_GETDEVLIST, "MNTIOC_GETDEVLIST", NULL }, /* 2 */
+	{ (uint_t)MNTIOC_SETTAG, "MNTIOC_SETTAG", "mnttagdesc" }, /* 3 */
+	{ (uint_t)MNTIOC_CLRTAG, "MNTIOC_CLRTAG", "mnttagdesc" }, /* 4 */
+	{ (uint_t)MNTIOC_SHOWHIDDEN, "MNTIOC_SHOWHIDDEN", NULL }, /* 6 */
+	{ (uint_t)MNTIOC_GETMNTENT, "MNTIOC_GETMNTENT", "mnttab" }, /* 7 */
+	{ (uint_t)MNTIOC_GETEXTMNTENT, "MNTIOC_GETEXTMNTENT",
+	    "extmnttab" }, /* 8 */
+	{ (uint_t)MNTIOC_GETMNTANY, "MNTIOC_GETMNTANY", "mnttab" }, /* 9 */
+};
 
+const struct ioc devinfo_ioc[] = { /* 0xdf << 8 */
 	/* devinfo ioctls - ('df' << 8) - devinfo_impl.h */
-	{ (uint_t)DINFOUSRLD,		"DINFOUSRLD",
-		NULL},
-	{ (uint_t)DINFOLODRV,		"DINFOLODRV",
-		NULL},
-	{ (uint_t)DINFOIDENT,		"DINFOIDENT",
-		NULL},
+	{ (uint_t)DINFOUSRLD, "DINFOUSRLD", NULL}, /* 80 */
+	{ (uint_t)DINFOLODRV, "DINFOLODRV", NULL}, /* 81 */
+	{ (uint_t)DINFOIDENT, "DINFOIDENT", NULL}, /* 82 */
+};
 
-	{ (uint_t)IPTUN_CREATE,	"IPTUN_CREATE",	"iptun_kparams_t"},
-	{ (uint_t)IPTUN_DELETE,	"IPTUN_DELETE", "datalink_id_t"},
-	{ (uint_t)IPTUN_MODIFY, "IPTUN_MODIFY", "iptun_kparams_t"},
-	{ (uint_t)IPTUN_INFO,	"IPTUN_INFO",	NULL},
-	{ (uint_t)IPTUN_SET_6TO4RELAY, "IPTUN_SET_6TO4RELAY",	NULL},
-	{ (uint_t)IPTUN_GET_6TO4RELAY, "IPTUN_GET_6TO4RELAY",	NULL},
+const struct ioc iptun_ioc[] = { /* 0x454A << 16 */
+	{ (uint_t)IPTUN_CREATE,	"IPTUN_CREATE",	"iptun_kparams_t"}, /* 1 */
+	{ (uint_t)IPTUN_DELETE,	"IPTUN_DELETE", "datalink_id_t"}, /* 2 */
+	{ (uint_t)IPTUN_MODIFY, "IPTUN_MODIFY", "iptun_kparams_t"}, /* 3 */
+	{ (uint_t)IPTUN_INFO,	"IPTUN_INFO",	NULL}, /* 4 */
+	{ (uint_t)IPTUN_SET_6TO4RELAY, "IPTUN_SET_6TO4RELAY",	NULL}, /* 9 */
+	{ (uint_t)IPTUN_GET_6TO4RELAY, "IPTUN_GET_6TO4RELAY",	NULL}, /* 10 */
+};
 
+const struct ioc zcons_ioc[] = { /* (('Z' << 24) | ('o' << 16) | ('n' << 8)) */
 	/* zcons ioctls */
-	{ (uint_t)ZC_HOLDSUBSID,	"ZC_HOLDSUBSID",	NULL },
-	{ (uint_t)ZC_RELEASESUBSID,	"ZC_RELEASESUBSID",	NULL },
+	{ (uint_t)ZC_HOLDSUBSID,	"ZC_HOLDSUBSID",	NULL }, /* 0 */
+	{ (uint_t)ZC_RELEASESUBSID,	"ZC_RELEASESUBSID",	NULL }, /* 1 */
+};
 
+const struct ioc hid_ioc[] = { /* 'h' << 8 */
 	/* hid ioctls - ('h' << 8) - hid.h */
-	{ (uint_t)HIDIOCKMGDIRECT,	"HIDIOCKMGDIRECT",	NULL },
-	{ (uint_t)HIDIOCKMSDIRECT,	"HIDIOCKMSDIRECT",	NULL },
+	{ (uint_t)HIDIOCKMGDIRECT,	"HIDIOCKMGDIRECT",	NULL }, /* 0 */
+	{ (uint_t)HIDIOCKMSDIRECT,	"HIDIOCKMSDIRECT",	NULL }, /* 1 */
+};
 
+const struct ioc pm_ioc[] = { /* 0 */
 	/* pm ioctls */
 	{ (uint_t)PM_SCHEDULE,		"PM_SCHEDULE",		NULL },
 	{ (uint_t)PM_GET_IDLE_TIME,	"PM_GET_IDLE_TIME",	NULL },
@@ -1669,14 +1832,71 @@ const struct ioc {
 	{ (uint_t)PM_SEARCH_LIST,	"PM_SEARCH_LIST",
 		"pm_searchargs_t" },
 #endif /* _SYSCALL */
+};
 
+const struct ioc cpuid_ioc[] = { /* (('c'<<24)|('i'<<16)|('d'<<8)) */
 	/* cpuid ioctls */
-	{ (uint_t)CPUID_GET_HWCAP,		"CPUID_GET_HWCAP", NULL },
-#if defined(__i386) || defined(__amd64)
-	{ (uint_t)CPUID_RDMSR,			"CPUID_RDMSR", NULL },
-#endif
+	{ (uint_t)CPUID_GET_HWCAP, "CPUID_GET_HWCAP", NULL }, /* 0 */
+	{ (uint_t)CPUID_RDMSR, "CPUID_RDMSR", NULL }, /* 1 */
+};
 
-	{ (uint_t)0, NULL, NULL	}
+/*
+ * Because some IOC codes do overlap, and we are performing linear
+ * lookup with first match returned, care must be taken about the order
+ * of the array elements.
+ */
+const struct iocs iocs[] = {
+	/* GLDv3 module ioc lists */
+	{ .nitems = ARRAY_SIZE(aggr_ioc), .data = aggr_ioc},
+	{ .nitems = ARRAY_SIZE(dld_ioc), .data = dld_ioc},
+	{ .nitems = ARRAY_SIZE(simnet_ioc), .data = simnet_ioc},
+	{ .nitems = ARRAY_SIZE(vnic_ioc), .data = vnic_ioc},
+	{ .nitems = ARRAY_SIZE(iptun_ioc), .data = iptun_ioc},
+
+	{ .nitems = ARRAY_SIZE(Tioc), .data = Tioc},
+	{ .nitems = ARRAY_SIZE(tioc), .data = tioc},
+	{ .nitems = ARRAY_SIZE(pty_ioc), .data = pty_ioc},
+	{ .nitems = ARRAY_SIZE(dlpi_ioc), .data = dlpi_ioc},
+	{ .nitems = ARRAY_SIZE(ldioc_ioc), .data = ldioc_ioc},
+	{ .nitems = ARRAY_SIZE(xioc_ioc), .data = xioc_ioc},
+	{ .nitems = ARRAY_SIZE(fio_ioc), .data = fio_ioc},
+	{ .nitems = ARRAY_SIZE(fil_ioc), .data = fil_ioc},
+	{ .nitems = ARRAY_SIZE(dioc_ioc), .data = dioc_ioc},
+	{ .nitems = ARRAY_SIZE(lioc_ioc), .data = lioc_ioc},
+	{ .nitems = ARRAY_SIZE(jerq_ioc), .data = jerq_ioc},
+	{ .nitems = ARRAY_SIZE(kstat_ioc), .data = kstat_ioc},
+	{ .nitems = ARRAY_SIZE(stream_ioc), .data = stream_ioc},
+	{ .nitems = ARRAY_SIZE(str_ioc), .data = str_ioc},
+	{ .nitems = ARRAY_SIZE(audio_ioc), .data = audio_ioc},
+	{ .nitems = ARRAY_SIZE(audiom_ioc), .data = audiom_ioc},
+	{ .nitems = ARRAY_SIZE(ossx_ioc), .data = ossx_ioc},
+	{ .nitems = ARRAY_SIZE(ossy_ioc), .data = ossy_ioc},
+	{ .nitems = ARRAY_SIZE(ossp_ioc), .data = ossp_ioc},
+	{ .nitems = ARRAY_SIZE(ossm_ioc), .data = ossm_ioc},
+	{ .nitems = ARRAY_SIZE(strredir_ioc), .data = strredir_ioc},
+	{ .nitems = ARRAY_SIZE(cpc_ioc), .data = cpc_ioc},
+	{ .nitems = ARRAY_SIZE(dp_ioc), .data = dp_ioc},
+	{ .nitems = ARRAY_SIZE(p_ioc), .data = p_ioc},
+	{ .nitems = ARRAY_SIZE(socket_ioc), .data = socket_ioc},
+	{ .nitems = ARRAY_SIZE(routing_ioc), .data = routing_ioc},
+	{ .nitems = ARRAY_SIZE(sockio_ioc), .data = sockio_ioc},
+	{ .nitems = ARRAY_SIZE(des_ioc), .data = des_ioc},
+	{ .nitems = ARRAY_SIZE(prn_ioc), .data = prn_ioc},
+	{ .nitems = ARRAY_SIZE(dtrace_ioc), .data = dtrace_ioc},
+	{ .nitems = ARRAY_SIZE(dtraceh_ioc), .data = dtraceh_ioc},
+	{ .nitems = ARRAY_SIZE(crypto_ioc), .data = crypto_ioc},
+	{ .nitems = ARRAY_SIZE(kbd_ioc), .data = kbd_ioc},
+	{ .nitems = ARRAY_SIZE(ptm_ioc), .data = ptm_ioc},
+	{ .nitems = ARRAY_SIZE(zfs_ioc), .data = zfs_ioc},
+	{ .nitems = ARRAY_SIZE(dkio_ioc), .data = dkio_ioc},
+	{ .nitems = ARRAY_SIZE(dumpadm_ioc), .data = dumpadm_ioc},
+	{ .nitems = ARRAY_SIZE(mnt_ioc), .data = mnt_ioc},
+	{ .nitems = ARRAY_SIZE(devinfo_ioc), .data = devinfo_ioc},
+	{ .nitems = ARRAY_SIZE(zcons_ioc), .data = zcons_ioc},
+	{ .nitems = ARRAY_SIZE(hid_ioc), .data = hid_ioc},
+	{ .nitems = ARRAY_SIZE(cpuid_ioc), .data = cpuid_ioc},
+	{ .nitems = ARRAY_SIZE(pm_ioc), .data = pm_ioc},
+	{ .nitems = 0, .data = NULL }
 };
 
 void
@@ -1699,6 +1919,30 @@ ioctl_ioccom(char *buf, size_t size, uint_t code, int nbytes, int x, int y)
 		    x, y, nbytes);
 }
 
+static const struct ioc *
+find_ioc(const struct iocs *iocs, uint_t code)
+{
+	const struct iocs *ptr;
+	const struct ioc *ip;
+
+	for (ptr = &iocs[0]; ptr->nitems > 0; ptr++) {
+		/* search for "close enough" table */
+		if ((ptr->data->code & 0xffff0000) != (code & 0xffff0000) &&
+		    (ptr->data->code & 0xffff00) != (code & 0xffff00) &&
+		    (ptr->data->code & IOCTYPE) != (code & IOCTYPE)) {
+			continue;
+		}
+
+		ip = ptr->data;
+		for (uint_t i = 0; i < ptr->nitems; i++) {
+			/* Do exact match there */
+			if (code == ip[i].code)
+				return (&ip[i]);
+		}
+	}
+
+	return (NULL);
+}
 
 const char *
 ioctlname(private_t *pri, uint_t code)
@@ -1706,13 +1950,12 @@ ioctlname(private_t *pri, uint_t code)
 	const struct ioc *ip;
 	const char *str = NULL;
 
-	for (ip = &ioc[0]; ip->name; ip++) {
-		if (code == ip->code) {
-			str = ip->name;
-			break;
-		}
-	}
+	ip = find_ioc(vmm_iocs, code);
+	if (ip == NULL)
+		ip = find_ioc(iocs, code);
 
+	if (ip != NULL)
+		str = ip->name;
 	/*
 	 * Developers hide ascii ioctl names in the ioctl subcode; for example
 	 * 0x445210 should be printed 'D'<<16|'R'<<8|10.  We allow for all
@@ -1758,12 +2001,12 @@ ioctldatastruct(uint_t code)
 	const struct ioc *ip;
 	const char *str = NULL;
 
-	for (ip = &ioc[0]; ip->name != NULL; ip++) {
-		if (code == ip->code) {
-			str = ip->datastruct;
-			break;
-		}
-	}
+	ip = find_ioc(vmm_iocs, code);
+	if (ip == NULL)
+		ip = find_ioc(iocs, code);
+
+	if (ip != NULL)
+		str = ip->datastruct;
 	return (str);
 }
 
@@ -1794,7 +2037,7 @@ si86name(int code)
 {
 	const char *str = NULL;
 
-#if defined(__i386) || defined(__amd64)
+#if defined(__x86)
 	switch (code) {
 	case SI86SWPI:		str = "SI86SWPI";	break;
 	case SI86SYM:		str = "SI86SYM";	break;
@@ -1847,7 +2090,7 @@ si86name(int code)
 	case GGMTL:		str = "GGMTL";		break;
 	case RTCSYNC:		str = "RTCSYNC";	break;
 	}
-#endif /* __i386 */
+#endif /* __x86 */
 
 	return (str);
 }

--- a/usr/src/cmd/truss/codes.h
+++ b/usr/src/cmd/truss/codes.h
@@ -1,0 +1,40 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Toomas Soome <tsoome@me.com>
+ */
+
+#ifndef _CODES_H
+#define	_CODES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ioc {
+	uint_t	code;
+	const char *name;
+	const char *datastruct;
+};
+
+struct iocs {
+	uint_t nitems;
+	const struct ioc *data;
+};
+
+extern const struct iocs vmm_iocs[];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CODES_H */

--- a/usr/src/cmd/truss/codes_bhyve.c
+++ b/usr/src/cmd/truss/codes_bhyve.c
@@ -1,0 +1,160 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Toomas Soome <tsoome@me.com>
+ */
+
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include "codes.h"
+
+#if defined(__x86)
+
+/* vmm_dev.h is expecting to have the types below. */
+typedef uint64_t vm_paddr_t;
+typedef int64_t vm_ooffset_t;
+#include <sys/vmm_dev.h>
+
+/* VMM ioctls */
+const struct ioc vmmctl_ioc[] = {
+	{ (uint_t)VMM_CREATE_VM,		"VMM_CREATE_VM", NULL },
+	{ (uint_t)VMM_DESTROY_VM,		"VMM_DESTROY_VM", NULL },
+	{ (uint_t)VMM_VM_SUPPORTED,		"VMM_VM_SUPPORTED", NULL },
+
+	{ (uint_t)VMM_RESV_QUERY,		"VMM_RESV_QUERY", NULL },
+	{ (uint_t)VMM_RESV_SET_TARGET,		"VMM_RESV_SET_TARGET", NULL }
+};
+
+const struct ioc vmm_cpu_ioc[] = {
+	{ (uint_t)VM_RUN,			"VM_RUN", NULL },
+	{ (uint_t)VM_SET_REGISTER,		"VM_SET_REGISTER", NULL },
+	{ (uint_t)VM_GET_REGISTER,		"VM_GET_REGISTER", NULL },
+	{ (uint_t)VM_SET_SEGMENT_DESCRIPTOR,	"VM_SET_SEGMENT_DESCRIPTOR",
+		NULL },
+	{ (uint_t)VM_GET_SEGMENT_DESCRIPTOR,	"VM_GET_SEGMENT_DESCRIPTOR",
+		NULL },
+	{ (uint_t)VM_SET_REGISTER_SET,		"VM_SET_REGISTER_SET", NULL },
+	{ (uint_t)VM_GET_REGISTER_SET,		"VM_GET_REGISTER_SET", NULL },
+	{ (uint_t)VM_INJECT_EXCEPTION,		"VM_INJECT_EXCEPTION", NULL },
+	{ (uint_t)VM_SET_CAPABILITY,		"VM_SET_CAPABILITY", NULL },
+	{ (uint_t)VM_GET_CAPABILITY,		"VM_GET_CAPABILITY", NULL },
+	{ (uint_t)VM_PPTDEV_MSI,		"VM_PPTDEV_MSI", NULL },
+	{ (uint_t)VM_PPTDEV_MSIX,		"VM_PPTDEV_MSIX", NULL },
+	{ (uint_t)VM_SET_X2APIC_STATE,		"VM_SET_X2APIC_STATE", NULL },
+	{ (uint_t)VM_GLA2GPA,			"VM_GLA2GPA", NULL },
+	{ (uint_t)VM_GLA2GPA_NOFAULT,		"VM_GLA2GPA_NOFAULT", NULL },
+	{ (uint_t)VM_ACTIVATE_CPU,		"VM_ACTIVATE_CPU", NULL },
+	{ (uint_t)VM_SET_INTINFO,		"VM_SET_INTINFO", NULL },
+	{ (uint_t)VM_GET_INTINFO,		"VM_GET_INTINFO", NULL },
+	{ (uint_t)VM_RESTART_INSTRUCTION,	"VM_RESTART_INSTRUCTION",
+		NULL },
+	{ (uint_t)VM_SET_KERNEMU_DEV,		"VM_SET_KERNEMU_DEV", NULL },
+	{ (uint_t)VM_GET_KERNEMU_DEV,		"VM_GET_KERNEMU_DEV", NULL },
+	{ (uint_t)VM_RESET_CPU,			"VM_RESET_CPU", NULL },
+	{ (uint_t)VM_GET_RUN_STATE,		"VM_GET_RUN_STATE", NULL },
+	{ (uint_t)VM_SET_RUN_STATE,		"VM_SET_RUN_STATE", NULL },
+	{ (uint_t)VM_GET_FPU,			"VM_GET_FPU", NULL },
+	{ (uint_t)VM_SET_FPU,			"VM_SET_FPU", NULL },
+	{ (uint_t)VM_GET_CPUID,			"VM_GET_CPUID", NULL },
+	{ (uint_t)VM_SET_CPUID,			"VM_SET_CPUID", NULL },
+	{ (uint_t)VM_LEGACY_CPUID,		"VM_LEGACY_CPUID", NULL }
+};
+
+const struct ioc vmm_lock_ioc[] = {
+	{ (uint_t)VM_REINIT,			"VM_REINIT", NULL },
+	{ (uint_t)VM_BIND_PPTDEV,		"VM_BIND_PPTDEV", NULL },
+	{ (uint_t)VM_UNBIND_PPTDEV,		"VM_UNBIND_PPTDEV", NULL },
+	{ (uint_t)VM_MAP_PPTDEV_MMIO,		"VM_MAP_PPTDEV_MMIO", NULL },
+	{ (uint_t)VM_ALLOC_MEMSEG,		"VM_ALLOC_MEMSEG", NULL },
+	{ (uint_t)VM_MMAP_MEMSEG,		"VM_MMAP_MEMSEG", NULL },
+	{ (uint_t)VM_PMTMR_LOCATE,		"VM_PMTMR_LOCATE", NULL },
+	{ (uint_t)VM_MUNMAP_MEMSEG,		"VM_MUNMAP_MEMSEG", NULL },
+	{ (uint_t)VM_UNMAP_PPTDEV_MMIO,		"VM_UNMAP_PPTDEV_MMIO", NULL },
+	{ (uint_t)VM_PAUSE,			"VM_PAUSE", NULL },
+	{ (uint_t)VM_RESUME,			"VM_RESUME", NULL },
+
+	{ (uint_t)VM_WRLOCK_CYCLE,		"VM_WRLOCK_CYCLE", NULL }
+};
+
+const struct ioc vmm_ioc[] = {
+	{ (uint_t)VM_GET_GPA_PMAP,		"VM_GET_GPA_PMAP", NULL },
+	{ (uint_t)VM_GET_MEMSEG,		"VM_GET_MEMSEG", NULL },
+	{ (uint_t)VM_MMAP_GETNEXT,		"VM_MMAP_GETNEXT", NULL },
+
+	{ (uint_t)VM_LAPIC_IRQ,			"VM_LAPIC_IRQ", NULL },
+	{ (uint_t)VM_LAPIC_LOCAL_IRQ,		"VM_LAPIC_LOCAL_IRQ", NULL },
+	{ (uint_t)VM_LAPIC_MSI,			"VM_LAPIC_MSI", NULL },
+
+	{ (uint_t)VM_IOAPIC_ASSERT_IRQ,		"VM_IOAPIC_ASSERT_IRQ", NULL },
+	{ (uint_t)VM_IOAPIC_DEASSERT_IRQ,	"VM_IOAPIC_DEASSERT_IRQ",
+		NULL },
+	{ (uint_t)VM_IOAPIC_PULSE_IRQ,		"VM_IOAPIC_PULSE_IRQ", NULL },
+
+	{ (uint_t)VM_ISA_ASSERT_IRQ,		"VM_ISA_ASSERT_IRQ", NULL },
+	{ (uint_t)VM_ISA_DEASSERT_IRQ,		"VM_ISA_DEASSERT_IRQ", NULL },
+	{ (uint_t)VM_ISA_PULSE_IRQ,		"VM_ISA_PULSE_IRQ", NULL },
+	{ (uint_t)VM_ISA_SET_IRQ_TRIGGER,	"VM_ISA_SET_IRQ_TRIGGER",
+		NULL },
+
+	{ (uint_t)VM_RTC_WRITE,			"VM_RTC_WRITE", NULL },
+	{ (uint_t)VM_RTC_READ,			"VM_RTC_READ", NULL },
+	{ (uint_t)VM_RTC_SETTIME,		"VM_RTC_SETTIME", NULL },
+	{ (uint_t)VM_RTC_GETTIME,		"VM_RTC_GETTIME", NULL },
+
+	{ (uint_t)VM_SUSPEND,			"VM_SUSPEND", NULL },
+
+	{ (uint_t)VM_IOAPIC_PINCOUNT,		"VM_IOAPIC_PINCOUNT", NULL },
+	{ (uint_t)VM_GET_PPTDEV_LIMITS,		"VM_GET_PPTDEV_LIMITS", NULL },
+	{ (uint_t)VM_GET_HPET_CAPABILITIES,	"VM_GET_HPET_CAPABILITIES",
+		NULL },
+
+	{ (uint_t)VM_STATS_IOC,			"VM_STATS_IOC", NULL },
+	{ (uint_t)VM_STAT_DESC,			"VM_STAT_DESC", NULL },
+
+	{ (uint_t)VM_INJECT_NMI,		"VM_INJECT_NMI", NULL },
+	{ (uint_t)VM_GET_X2APIC_STATE,		"VM_GET_X2APIC_STATE", NULL },
+	{ (uint_t)VM_SET_TOPOLOGY,		"VM_SET_TOPOLOGY", NULL },
+	{ (uint_t)VM_GET_TOPOLOGY,		"VM_GET_TOPOLOGY", NULL },
+	{ (uint_t)VM_GET_CPUS,			"VM_GET_CPUS", NULL },
+	{ (uint_t)VM_SUSPEND_CPU,		"VM_SUSPEND_CPU", NULL },
+	{ (uint_t)VM_RESUME_CPU,		"VM_RESUME_CPU", NULL },
+
+	{ (uint_t)VM_PPTDEV_DISABLE_MSIX,	"VM_PPTDEV_DISABLE_MSIX",
+		NULL },
+
+	{ (uint_t)VM_TRACK_DIRTY_PAGES,		"VM_TRACK_DIRTY_PAGES", NULL },
+	{ (uint_t)VM_DESC_FPU_AREA,		"VM_DESC_FPU_AREA", NULL },
+
+	{ (uint_t)VM_DATA_READ,			"VM_DATA_READ", NULL },
+	{ (uint_t)VM_DATA_WRITE,		"VM_DATA_WRITE", NULL },
+
+	{ (uint_t)VM_SET_AUTODESTRUCT,		"VM_SET_AUTODESTRUCT", NULL },
+	{ (uint_t)VM_DESTROY_SELF,		"VM_DESTROY_SELF", NULL },
+	{ (uint_t)VM_DESTROY_PENDING,		"VM_DESTROY_PENDING", NULL },
+
+	{ (uint_t)VM_VCPU_BARRIER,		"VM_VCPU_BARRIER", NULL },
+
+	{ (uint_t)VM_DEVMEM_GETOFFSET,		"VM_DEVMEM_GETOFFSET", NULL }
+};
+
+const struct iocs vmm_iocs[] = {
+	{ .nitems = ARRAY_SIZE(vmmctl_ioc), .data = vmmctl_ioc },
+	{ .nitems = ARRAY_SIZE(vmm_cpu_ioc), .data = vmm_cpu_ioc },
+	{ .nitems = ARRAY_SIZE(vmm_lock_ioc), .data = vmm_lock_ioc },
+	{ .nitems = ARRAY_SIZE(vmm_ioc), .data = vmm_ioc },
+	{ .nitems = 0, .data = NULL }
+};
+#else
+const struct iocs vmm_iocs[] = {
+	{ .nitems = 0, .data = NULL }
+};
+#endif /* __x86 */

--- a/usr/src/lib/libtermcap/Makefile
+++ b/usr/src/lib/libtermcap/Makefile
@@ -11,8 +11,8 @@
 
 #
 # Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 #
-
 
 include		../Makefile.lib
 
@@ -20,6 +20,12 @@ HDRS =		termcap.h
 HDRDIR=		common
 SUBDIRS=	$(MACH)
 $(BUILD64)SUBDIRS += $(MACH64)
+
+# Install XPG4v2 header variants so that libtermcap can be used to
+# filter over libcurses(3xcurses).
+XHDRS =		termcap.h
+XROOTHDRDIR=	$(ROOT)/usr/xpg4/include
+XROOTHDRS=	$(XHDRS:%=$(XROOTHDRDIR)/%)
 
 all :=		TARGET= all
 clean :=	TARGET= clean
@@ -30,13 +36,15 @@ install :=	TARGET= install
 
 all clean clobber install: $(SUBDIRS)
 
-
-install_h: $(ROOTHDRS)
+install_h: $(ROOTHDRS) $(XROOTHDRS)
 
 check: $(CHECKHDRS)
 
 $(SUBDIRS): FRC
 	@cd $@; pwd; $(MAKE) $(TARGET)
+
+$(XROOTHDRDIR)/%: $(HDRDIR)/x%
+	$(INS.rename)
 
 FRC:
 

--- a/usr/src/lib/libtermcap/common/xtermcap.h
+++ b/usr/src/lib/libtermcap/common/xtermcap.h
@@ -1,0 +1,55 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+ */
+
+#ifndef	_TERMCAP_H_
+#define	_TERMCAP_H_
+
+/*
+ * This declares the public functions exported by the
+ * "filter" library: libtermcap.  That exports only
+ * the traditional BSD-style functions and data.
+ *
+ * Note that the libtermcap filter library uses NODIRECT
+ * linker bindings when filtering what libcurses exports
+ * so that an application can link with an alternative
+ * curses library providing the symbols below, and those
+ * will be used instead of the ones in libcurses.
+ */
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+extern char PC, *UP, *BC;
+extern short ospeed;
+
+/*
+ * These are intentionally the same as the XPG4v2 term.h
+ * declares so the compiler won't bark if that is included
+ * too.
+ */
+extern int tgetent(char *, const char *);
+extern int tgetflag(char *);
+extern int tgetnum(char *);
+extern char *tgetstr(char *, char **);
+extern char *tgoto(char *, int, int);
+extern int tputs(const char *, int, int (*)(int));
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _TERMCAP_H_ */

--- a/usr/src/lib/libumem/common/umem.c
+++ b/usr/src/lib/libumem/common/umem.c
@@ -3563,5 +3563,8 @@ fail:
 void
 umem_setmtbf(uint32_t mtbf)
 {
+	extern uint32_t vmem_mtbf;
+
 	umem_mtbf = mtbf;
+	vmem_mtbf = mtbf;
 }

--- a/usr/src/man/man3c/aligned_alloc.3c
+++ b/usr/src/man/man3c/aligned_alloc.3c
@@ -11,7 +11,7 @@
 .\"
 .\" Copyright 2016 Joyent, Inc.
 .\"
-.Dd "Mar 26, 2016"
+.Dd May 11, 2024
 .Dt ALIGNED_ALLOC 3C
 .Os
 .Sh NAME
@@ -33,8 +33,7 @@ bytes aligned on the specified alignment boundary
 .Fa alignment .
 The value of
 .Fa alignment
-is constrained, it must be a power of two and it must be greater than or
-equal to the size of a word on the platform.
+is constrained: it must be a power of two.
 .Sh RETURN VALUES
 Upon successful completion, the
 .Fn aligned_alloc
@@ -63,10 +62,10 @@ bytes of memory; but the application could try again later.
 An invalid value for
 .Fa alignment
 was passed in.
-It is not a power of two multiple of the word size.
+It is not a power of two.
 .El
 .Sh INTERFACE STABILITY
-.Sy STANDARD
+.Sy Comitted
 .Sh MT-LEVEL
 .Sy MT-Safe
 .Sh SEE ALSO

--- a/usr/src/pkg/manifests/system-header.p5m
+++ b/usr/src/pkg/manifests/system-header.p5m
@@ -28,7 +28,7 @@
 # Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 # Copyright 2020 Joyent, Inc.
 # Copyright 2019 Peter Tribble.
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 # Copyright 2023 Oxide Computer company
 #
 
@@ -1944,6 +1944,7 @@ dir  path=usr/xpg4
 dir  path=usr/xpg4/include
 file path=usr/xpg4/include/curses.h
 file path=usr/xpg4/include/term.h
+file path=usr/xpg4/include/termcap.h
 file path=usr/xpg4/include/unctrl.h
 legacy pkg=SUNWhea \
     desc="SunOS C/C++ header files for general development of software" \

--- a/usr/src/pkg/manifests/system-test-libctest.p5m
+++ b/usr/src/pkg/manifests/system-test-libctest.p5m
@@ -64,6 +64,7 @@ file path=opt/libc-tests/cfg/symbols/wctype_h.cfg mode=0444
 dir  path=opt/libc-tests/runfiles
 file path=opt/libc-tests/runfiles/default.run mode=0444
 dir  path=opt/libc-tests/tests
+file path=opt/libc-tests/tests/aligned_alloc mode=0555
 file path=opt/libc-tests/tests/aligned_alloc.32 mode=0555
 file path=opt/libc-tests/tests/aligned_alloc.64 mode=0555
 file path=opt/libc-tests/tests/ascftime.32 mode=0555

--- a/usr/src/test/libc-tests/runfiles/default.run
+++ b/usr/src/test/libc-tests/runfiles/default.run
@@ -96,8 +96,7 @@ timeout = 600
 [/opt/libc-tests/tests/stdio/test_mbrtowc.32]
 [/opt/libc-tests/tests/stdio/test_mbrtowc.64]
 
-[/opt/libc-tests/tests/aligned_alloc.32]
-[/opt/libc-tests/tests/aligned_alloc.64]
+[/opt/libc-tests/tests/aligned_alloc]
 [/opt/libc-tests/tests/ascftime.32]
 [/opt/libc-tests/tests/ascftime.64]
 [/opt/libc-tests/tests/asprintf-14933.32]

--- a/usr/src/test/libc-tests/tests/Makefile
+++ b/usr/src/test/libc-tests/tests/Makefile
@@ -70,6 +70,7 @@ PROGS = \
 	utimes
 
 SCRIPTS = \
+	aligned_alloc \
 	quick_exit \
 	psignal
 
@@ -80,6 +81,8 @@ PROGS64 = \
 	$(PROGS:%=%.64) \
 	printf-6961.64
 
+aligned_alloc.32 :=	CSTD=$(GNU_C99)
+aligned_alloc.64 :=	CSTD=$(GNU_C99)
 aligned_alloc.32 :=	LDLIBS += -lproc
 aligned_alloc.64 :=	LDLIBS64 += -lproc
 posix_memalign.32 :=	LDLIBS += -lproc

--- a/usr/src/test/libc-tests/tests/aligned_alloc.c
+++ b/usr/src/test/libc-tests/tests/aligned_alloc.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2016 Joyent, Inc.
+ * Copyright 2024 Oxide Computer Company
  */
 
 /*
@@ -24,36 +25,119 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <libproc.h>
+#include <stdio.h>
+#include <stdalign.h>
+#include <err.h>
 #include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <sys/debug.h>
+#include <stdbool.h>
+#include <string.h>
 
-int
-main(void)
+typedef struct {
+	size_t at_size;
+	size_t at_align;
+	int at_errno;
+	const char *at_desc;
+} alloc_test_t;
+
+static const alloc_test_t alloc_tests[] = {
+	{ 0, sizeof (long), EINVAL, "zero alignment fails with EINVAL" },
+	{ sizeof (long), 0, EINVAL, "zero size fails with EINVAL" },
+	{ 128, 3, EINVAL, "3-byte alignment fails with EINVAL" },
+	{ 128, 7777, EINVAL, "7777-byte alignment fails with EINVAL" },
+	{ 128, 23, EINVAL, "23-byte alignment fails with EINVAL" },
+	{ sizeof (char), alignof (char), 0, "alignof (char), 1 byte" },
+	{ 5, alignof (char), 0, "alignof (char), multiple bytes" },
+	{ 1, alignof (short), 0, "alignof (short), 1 byte" },
+	{ 16, alignof (short), 0, "alignof (short), 16 byte" },
+	{ 1, alignof (int), 0, "alignof (int), 1 byte" },
+	{ 4, alignof (int), 0, "alignof (int), 4 bytes" },
+	{ 22, alignof (int), 0, "alignof (int), 22 bytes" },
+	/* We skip long here because it varies between ILP32/LP64 */
+	{ 7, alignof (long long), 0, "alignof (long long), 7 bytes" },
+	{ 128, alignof (long long), 0, "alignof (long long), 128 bytes" },
+	{ 511, alignof (long long), 0, "alignof (long long), 511 bytes" },
+	{ 16, 16, 0, "16-byte alignment), 16 bytes" },
+	{ 256, 16, 0, "16-byte alignment), 256 bytes" },
+	{ 256, 4096, 0, "4096-byte alignment), 256 bytes" },
+	{ 4096, 4096, 0, "4096-byte alignment), 4096 bytes" },
+};
+
+/*
+ * Disable the per-thread caches and enable debugging if launched with umem.
+ */
+const char *
+_umem_debug_init(void)
+{
+	return ("default,verbose");
+}
+
+const char *
+_umem_options_init(void)
+{
+	return ("perthreadcache=0");
+}
+
+static bool
+alloc_test_one(const alloc_test_t *test)
+{
+	bool ret = false;
+	void *buf = aligned_alloc(test->at_align, test->at_size);
+
+	if (buf == NULL) {
+		if (test->at_errno == 0) {
+			warnx("TEST FAILED: %s: allocation failed with %s, but "
+			    "expected success", test->at_desc,
+			    strerrorname_np(errno));
+		} else if (errno != test->at_errno) {
+			warnx("TEST FAILED: %s: allocation failed with %s, but "
+			    "expected errno %s", test->at_desc,
+			    strerrorname_np(errno),
+			    strerrorname_np(test->at_errno));
+		} else {
+			(void) printf("TEST PASSED: %s\n", test->at_desc);
+			ret = true;
+		}
+	} else if (test->at_errno != 0) {
+		warnx("TEST FAILED: %s: allocation succeeded, but expected "
+		    "errno %s", test->at_desc, strerrorname_np(test->at_errno));
+	} else {
+		(void) printf("TEST PASSED: %s\n", test->at_desc);
+		ret = true;
+	}
+
+	free(buf);
+	return (ret);
+}
+
+static bool
+alloc_test_enomem(const alloc_test_t *test)
+{
+	bool ret = false;
+	void *buf = aligned_alloc(test->at_align, test->at_size);
+
+	if (buf != NULL) {
+		warnx("TEST FAILED: %s (forced ENOMEM/EAGAIN): succeeded, but "
+		    "expected ENOMEM", test->at_desc);
+	} else if (errno != ENOMEM && errno != EAGAIN) {
+		warnx("TEST FAILED: %s (forced ENOMEM/EAGAIN): failed with %s, "
+		    "but expected ENOMEM", test->at_desc,
+		    strerrordesc_np(errno));
+	} else {
+		(void) printf("TEST PASSED: %s: ENOMEM/EAGAIN forced\n",
+		    test->at_desc);
+		ret = true;
+	}
+
+	return (ret);
+}
+
+static void
+libc_enomem(void)
 {
 	pstatus_t status;
-	void *buf;
 
-	/*
-	 * Alignment must be sizeof (void *) (word) aligned.
-	 */
-	VERIFY3P(aligned_alloc(sizeof (void *) - 1, 16), ==, NULL);
-	VERIFY3S(errno, ==, EINVAL);
-
-	VERIFY3P(aligned_alloc(sizeof (void *) + 1, 16), ==, NULL);
-	VERIFY3S(errno, ==, EINVAL);
-
-
-	VERIFY3P(aligned_alloc(23, 16), ==, NULL);
-	VERIFY3S(errno, ==, EINVAL);
-
-	buf = aligned_alloc(sizeof (void *), 16);
-	VERIFY3P(buf, !=, NULL);
-	free(buf);
-
-	/*
-	 * Cause ENOMEM
-	 */
 	VERIFY0(proc_get_status(getpid(), &status));
 	VERIFY3P(mmap((caddr_t)P2ROUNDUP(status.pr_brkbase +
 	    status.pr_brksize, 0x1000), 0x1000,
@@ -69,9 +153,67 @@ main(void)
 		if (aligned_alloc(sizeof (void *), 16) == NULL)
 			break;
 	}
+}
 
-	VERIFY3P(aligned_alloc(sizeof (void *), 16), ==, NULL);
-	VERIFY3S(errno, ==, ENOMEM);
+/*
+ * Because this test is leveraging LD_PRELOAD in the test runner to test
+ * different malloc libraries, we can't call umem_setmtbf() directly. Instead we
+ * ask rtld to find it for us, which is a bit gross, but works.
+ */
+static void
+libumem_enomem(void)
+{
+	void (*mtbf)(uint32_t) = dlsym(RTLD_DEFAULT, "umem_setmtbf");
+	if (mtbf == NULL) {
+		errx(EXIT_FAILURE, "failed to find umem_setmtbf: %s",
+		    dlerror());
+	}
 
-	return (0);
+	mtbf(1);
+}
+
+int
+main(void)
+{
+	const char *preload;
+	int ret = EXIT_SUCCESS;
+
+	for (size_t i = 0; i < ARRAY_SIZE(alloc_tests); i++) {
+		if (!alloc_test_one(&alloc_tests[i])) {
+			ret = EXIT_FAILURE;
+		}
+	}
+
+	/*
+	 * To catch failure tests, we need to know what memory allocator we're
+	 * using which we expect to be indicated via an LD_PRELOAD environment
+	 * variable. If it's not set, assume libc.
+	 */
+	preload = getenv("LD_PRELOAD");
+	if (preload != NULL) {
+		if (strstr(preload, "umem") != NULL) {
+			libumem_enomem();
+		} else {
+			warnx("malloc(3C) library %s not supported, skipping "
+			    "ENOMEM tests", preload);
+			goto skip;
+		}
+	} else {
+		libc_enomem();
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(alloc_tests); i++) {
+		if (alloc_tests[i].at_errno != 0)
+			continue;
+		if (!alloc_test_enomem(&alloc_tests[i])) {
+			ret = EXIT_FAILURE;
+		}
+	}
+
+skip:
+	if (ret == EXIT_SUCCESS) {
+		(void) printf("All tests passed successfully\n");
+	}
+
+	return (ret);
 }

--- a/usr/src/test/libc-tests/tests/aligned_alloc.ksh
+++ b/usr/src/test/libc-tests/tests/aligned_alloc.ksh
@@ -1,0 +1,74 @@
+#! /usr/bin/ksh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Oxide Computer Company
+#
+
+#
+# Wrap up the aligned_alloc() tests with the different malloc libraries
+# that make sense to test as this calls into their implementation of
+# memalign. Currently we test libc, libumem, and libmtmalloc. mapmalloc
+# is skipped because it doesn't implement memalign. libmtmalloc
+# currently doesn't have an ENOMEM/EAGAIN test strategy.
+#
+
+unalias -a
+set -o pipefail
+export LANG=C.UTF-8
+
+alloc_arg0="$(basename $0)"
+alloc_dir="$(dirname $0)"
+alloc_exit=0
+alloc_file="aligned_alloc"
+alloc_libraries="none
+libumem.so
+libmtmalloc.so"
+alloc_archs="32
+64"
+
+function warn
+{
+	typeset msg="$*"
+	echo "TEST FAILED: $msg" >&2
+	alloc_exit=1
+}
+
+function run_one
+{
+	typeset preload="$1"
+	typeset suffix="$2"
+
+	if [[ "$1" != none ]]; then
+		export LD_PRELOAD=$preload
+	fi
+
+	printf "Running %u-bit tests with library %s\n" $suffix "$preload"
+
+	if ! $alloc_dir/$alloc_file.$suffix; then
+		alloc_exit=1
+	fi
+
+	unset LD_PRELOAD
+}
+
+for lib in ${alloc_libraries[@]}; do
+	for arch in ${alloc_archs[@]}; do
+		run_one "$lib" "$arch"
+	done
+done
+
+if ((alloc_exit != 0)); then
+	printf "Some library/architecture variants failed!\n" >&2
+fi
+
+exit $alloc_exit

--- a/usr/src/test/os-tests/tests/fifo-tvnsec.c
+++ b/usr/src/test/os-tests/tests/fifo-tvnsec.c
@@ -125,12 +125,12 @@ check_fifos(int wfd, int rfd)
 	struct timespec update[2];
 
 	VERIFY0(fstat(wfd, &st));
-	if (check_times(&st, CHK_ALL_GT, "write", "creation")) {
+	if (!check_times(&st, CHK_ALL_GT, "write", "creation")) {
 		ret = false;
 	}
 
 	VERIFY0(fstat(rfd, &st));
-	if (check_times(&st, CHK_ALL_GT, "read", "creation")) {
+	if (!check_times(&st, CHK_ALL_GT, "read", "creation")) {
 		ret = false;
 	}
 
@@ -146,13 +146,13 @@ check_fifos(int wfd, int rfd)
 	}
 
 	VERIFY0(fstat(wfd, &st));
-	if (check_times(&st, CHK_CTIME_GT | CHK_MTIME_GT | CHK_ATIME_LT,
+	if (!check_times(&st, CHK_CTIME_GT | CHK_MTIME_GT | CHK_ATIME_LT,
 	    "write", "post-write")) {
 		ret = false;
 	}
 
 	VERIFY0(fstat(rfd, &st));
-	if (check_times(&st, CHK_CTIME_GT | CHK_MTIME_GT | CHK_ATIME_LT,
+	if (!check_times(&st, CHK_CTIME_GT | CHK_MTIME_GT | CHK_ATIME_LT,
 	    "read", "post-write")) {
 		ret = false;
 	}
@@ -164,13 +164,13 @@ check_fifos(int wfd, int rfd)
 	}
 
 	VERIFY0(fstat(rfd, &st));
-	if (check_times(&st, CHK_CTIME_LT | CHK_MTIME_LT | CHK_ATIME_GT,
+	if (!check_times(&st, CHK_CTIME_LT | CHK_MTIME_LT | CHK_ATIME_GT,
 	    "read", "post-read")) {
 		ret = false;
 	}
 
 	VERIFY0(fstat(wfd, &st));
-	if (check_times(&st, CHK_CTIME_LT | CHK_MTIME_LT | CHK_ATIME_GT,
+	if (!check_times(&st, CHK_CTIME_LT | CHK_MTIME_LT | CHK_ATIME_GT,
 	    "write", "post-read")) {
 		ret = false;
 	}
@@ -182,12 +182,12 @@ check_fifos(int wfd, int rfd)
 
 	update_time();
 	VERIFY0(fstat(wfd, &st));
-	if (check_times(&st, CHK_ALL_LT, "write", "post-futimens")) {
+	if (!check_times(&st, CHK_ALL_LT, "write", "post-futimens")) {
 		ret = false;
 	}
 
 	VERIFY0(fstat(rfd, &st));
-	if (check_times(&st, CHK_ALL_LT, "read", "post-futimens")) {
+	if (!check_times(&st, CHK_ALL_LT, "read", "post-futimens")) {
 		ret = false;
 	}
 
@@ -240,6 +240,10 @@ main(void)
 		ret = EXIT_FAILURE;
 	}
 	(void) unlink(path);
+
+	if (ret == EXIT_SUCCESS) {
+		(void) printf("All tests completed successfully\n");
+	}
 
 	return (ret);
 }

--- a/usr/src/uts/common/brand/lx/sys/lx_fcntl.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_fcntl.h
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2015 Joyent, Inc.
+ * Copyright 2024 MNX Cloud, Inc.
  */
 
 #ifndef _SYS_LX_FCNTL_H
@@ -73,6 +74,10 @@ extern "C" {
 #define	LX_F_GETLK64		12
 #define	LX_F_SETLK64		13
 #define	LX_F_SETLKW64		14
+
+#define	LX_F_OFD_GETLK		36
+#define	LX_F_OFD_SETLK		37
+#define	LX_F_OFD_SETLKW		38
 
 #define	LX_F_SETLEASE		1024
 #define	LX_F_GETLEASE		1025

--- a/usr/src/uts/common/inet/udp/udp.c
+++ b/usr/src/uts/common/inet/udp/udp.c
@@ -24,6 +24,7 @@
  * Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
  * Copyright 2018, Joyent, Inc.
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2024 Oxide Computer Company
  */
 /* Copyright (c) 1990 Mentat Inc. */
 
@@ -3864,6 +3865,16 @@ udp_output_newdst(conn_t *connp, mblk_t *data_mp, sin_t *sin, sin6_t *sin6,
 		error = EISCONN;
 		goto ud_error;
 	}
+
+	/*
+	 * Before we modify the ixa at all, invalidate our most recent address
+	 * to assure that any subsequent call to conn_same_as_last_v6() will
+	 * not indicate a match: any thread that picks up conn_lock after we
+	 * drop it (but before we pick it up again and properly set the most
+	 * recent address) must not associate the ixa with the (now old) last
+	 * address.
+	 */
+	connp->conn_v6lastdst = ipv6_all_zeros;
 
 	/* In case previous destination was multicast or multirt */
 	ip_attr_newdst(ixa);

--- a/usr/src/uts/common/io/blkdev/blkdev.c
+++ b/usr/src/uts/common/io/blkdev/blkdev.c
@@ -166,7 +166,6 @@ struct bd {
 	uint64_t	d_io_counter;
 
 	uint32_t	d_qcount;
-	uint32_t	d_qactive;
 	uint32_t	d_maxxfer;
 	uint32_t	d_blkshift;
 	uint32_t	d_pblkshift;

--- a/usr/src/uts/common/io/nvme/nvme_var.h
+++ b/usr/src/uts/common/io/nvme/nvme_var.h
@@ -236,6 +236,12 @@ struct nvme_qpair {
 	ksema_t nq_sema; /* semaphore to ensure q always has >= 1 empty slot */
 };
 
+typedef struct nvme_mgmt_lock {
+	kmutex_t nml_lock;
+	kcondvar_t nml_cv;
+	uintptr_t nml_bd_own;
+} nvme_mgmt_lock_t;
+
 struct nvme {
 	dev_info_t *n_dip;
 	nvme_progress_t n_progress;
@@ -333,7 +339,7 @@ struct nvme {
 	ksema_t n_abort_sema;
 
 	/* protects namespace management operations */
-	kmutex_t n_mgmt_mutex;
+	nvme_mgmt_lock_t n_mgmt;
 
 	/*
 	 * This lock protects the minor node locking state across the controller

--- a/usr/src/uts/common/sys/blkdev.h
+++ b/usr/src/uts/common/sys/blkdev.h
@@ -234,14 +234,19 @@ struct bd_errstats {
  */
 bd_handle_t	bd_alloc_handle(void *, bd_ops_t *, ddi_dma_attr_t *, int);
 void		bd_free_handle(bd_handle_t);
-int		bd_attach_handle(dev_info_t *, bd_handle_t);
-int		bd_detach_handle(bd_handle_t);
-void		bd_state_change(bd_handle_t);
 const char	*bd_address(bd_handle_t);
 void		bd_xfer_done(bd_xfer_t *, int);
 void		bd_error(bd_xfer_t *, int);
 void		bd_mod_init(struct dev_ops *);
 void		bd_mod_fini(struct dev_ops *);
+
+/*
+ * The following functions will cause the various bd_ops entries that were
+ * registered to be called. Locks should not be held across any calls to these.
+ */
+int		bd_attach_handle(dev_info_t *, bd_handle_t);
+int		bd_detach_handle(bd_handle_t);
+void		bd_state_change(bd_handle_t);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* 16579 bhyve: xhci tablet device probe fails under recent Linux kernels
* OS-8543 Want support for OFD locks in lx-brand

## onu

```
OmniOS r151051  omnios-upstream_merge-2024053001-fec05c08d27    May 2024
illumos development build: 2024-May-30 [illumos-omnios]
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-upstream_merge-2024053001-fec05c08d27 i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Thu May 30 15:29:45 UTC 2024 ====
==== Nightly distributed build completed: Thu May 30 16:06:07 UTC 2024 ====

==== Total build time ====

real    0:36:22

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-615aba20106 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 24

cw version 9.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151051/10.5.0-il-1) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151051/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.10+7-omnios-151051"

/usr/bin/openssl
OpenSSL 3.1.5 30 Jan 2024 (Library: OpenSSL 3.1.5 30 Jan 2024)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   120

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2024053001-fec05c08d27

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    14:22.6
user  3:37:45.0
sys   1:17:17.0

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:01.7
user  3:23:01.4
sys   1:14:25.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```