### PR TITLE
Upstream merge upstream_merge/2024073001

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4086,14 +4086,18 @@ usr/src/man/man3c/pthread_barrier_init.3c
 usr/src/man/man3c/pthread_barrierattr_init.3c
 usr/src/man/man3c/pthread_barrierattr_setpshared.3c
 usr/src/man/man3c/pthread_cond_broadcast.3c
+usr/src/man/man3c/pthread_cond_clockwait.3c
 usr/src/man/man3c/pthread_cond_destroy.3c
+usr/src/man/man3c/pthread_cond_relclockwait_np.3c
 usr/src/man/man3c/pthread_cond_reltimedwait_np.3c
 usr/src/man/man3c/pthread_cond_timedwait.3c
 usr/src/man/man3c/pthread_condattr_destroy.3c
 usr/src/man/man3c/pthread_condattr_setclock.3c
 usr/src/man/man3c/pthread_condattr_setpshared.3c
 usr/src/man/man3c/pthread_key_create_once_np.3c
+usr/src/man/man3c/pthread_mutex_clocklock.3c
 usr/src/man/man3c/pthread_mutex_destroy.3c
+usr/src/man/man3c/pthread_mutex_relclocklock_np.3c
 usr/src/man/man3c/pthread_mutex_reltimedlock_np.3c
 usr/src/man/man3c/pthread_mutex_setprioceiling.3c
 usr/src/man/man3c/pthread_mutex_trylock.3c
@@ -4104,7 +4108,11 @@ usr/src/man/man3c/pthread_mutexattr_setprotocol.3c
 usr/src/man/man3c/pthread_mutexattr_setpshared.3c
 usr/src/man/man3c/pthread_mutexattr_setrobust.3c
 usr/src/man/man3c/pthread_mutexattr_settype.3c
+usr/src/man/man3c/pthread_rwlock_clockrdlock.3c
+usr/src/man/man3c/pthread_rwlock_clockwrlock.3c
 usr/src/man/man3c/pthread_rwlock_destroy.3c
+usr/src/man/man3c/pthread_rwlock_relclockrdlock_np.3c
+usr/src/man/man3c/pthread_rwlock_relclockwrlock_np.3c
 usr/src/man/man3c/pthread_rwlock_reltimedrdlock_np.3c
 usr/src/man/man3c/pthread_rwlock_reltimedwrlock_np.3c
 usr/src/man/man3c/pthread_rwlock_tryrdlock.3c
@@ -4117,6 +4125,7 @@ usr/src/man/man3c/pthread_setschedparam.3c
 usr/src/man/man3c/pthread_setspecific.3c
 usr/src/man/man3c/pthread_spin_init.3c
 usr/src/man/man3c/pthread_spin_trylock.3c
+usr/src/man/man3c/ptsname_r.3c
 usr/src/man/man3c/putc.3c
 usr/src/man/man3c/putc_unlocked.3c
 usr/src/man/man3c/putchar.3c
@@ -4174,6 +4183,8 @@ usr/src/man/man3c/schedctl_start.3c
 usr/src/man/man3c/schedctl_stop.3c
 usr/src/man/man3c/seconvert.3c
 usr/src/man/man3c/seed48.3c
+usr/src/man/man3c/sem_clockwait.3c
+usr/src/man/man3c/sem_relclockwait_np.3c
 usr/src/man/man3c/sem_reltimedwait_np.3c
 usr/src/man/man3c/sem_trywait.3c
 usr/src/man/man3c/sema_destroy.3c
@@ -8705,6 +8716,8 @@ usr/src/test/libc-tests/tests/c11_tss.64
 usr/src/test/libc-tests/tests/call_once.32
 usr/src/test/libc-tests/tests/call_once.64
 usr/src/test/libc-tests/tests/catopen/catopen
+usr/src/test/libc-tests/tests/clocklock/clock_lock.32
+usr/src/test/libc-tests/tests/clocklock/clock_lock.64
 usr/src/test/libc-tests/tests/closefrom.32
 usr/src/test/libc-tests/tests/closefrom.64
 usr/src/test/libc-tests/tests/endian.32
@@ -8747,6 +8760,8 @@ usr/src/test/libc-tests/tests/printf-9511.64
 usr/src/test/libc-tests/tests/priv_gettext/priv_gettext
 usr/src/test/libc-tests/tests/psignal-5097.32
 usr/src/test/libc-tests/tests/psignal-5097.64
+usr/src/test/libc-tests/tests/ptsname.32
+usr/src/test/libc-tests/tests/ptsname.64
 usr/src/test/libc-tests/tests/qsort/qsort_test
 usr/src/test/libc-tests/tests/qsort/qsort_test.amd64
 usr/src/test/libc-tests/tests/qsort/qsort_test.i386
@@ -8987,6 +9002,9 @@ usr/src/test/os-tests/tests/ksid/ksid.64
 usr/src/test/os-tests/tests/libtopo/digraph-test
 usr/src/test/os-tests/tests/minttl/minttl
 usr/src/test/os-tests/tests/minttl/minttl_err
+usr/src/test/os-tests/tests/oclo/oclo
+usr/src/test/os-tests/tests/oclo/oclo_errors
+usr/src/test/os-tests/tests/oclo/ocloexec_verify
 usr/src/test/os-tests/tests/odirectory.32
 usr/src/test/os-tests/tests/odirectory.64
 usr/src/test/os-tests/tests/pf_key/15146
@@ -9038,6 +9056,7 @@ usr/src/test/os-tests/tests/sockfs/recvmsg.32
 usr/src/test/os-tests/tests/sockfs/recvmsg.64
 usr/src/test/os-tests/tests/sockfs/rights.32
 usr/src/test/os-tests/tests/sockfs/rights.64
+usr/src/test/os-tests/tests/sockfs/so_protocol
 usr/src/test/os-tests/tests/sockfs/sockpair
 usr/src/test/os-tests/tests/spoof-ras/spoof-ras
 usr/src/test/os-tests/tests/stackalign/stackalign.32

--- a/usr/src/test/libc-tests/tests/clocklock/Makefile
+++ b/usr/src/test/libc-tests/tests/clocklock/Makefile
@@ -31,9 +31,11 @@ ROOTOPTPROGS =	$(PROG32:%=$(ROOTOPTDIR)/%) \
 		$(PROG64:%=$(ROOTOPTDIR)/%)
 
 include $(SRC)/cmd/Makefile.cmd
+include $(SRC)/cmd/Makefile.ctf
 
 CSTD = $(GNU_C99)
 CPPFLAGS += -D_REENTRANT
+CTF_MODE = link
 
 .KEEP_STATE:
 

--- a/usr/src/test/libc-tests/tests/clocklock/clock_lock_mutex.c
+++ b/usr/src/test/libc-tests/tests/clocklock/clock_lock_mutex.c
@@ -64,6 +64,7 @@ static void
 clock_mutex_destroy(void *arg)
 {
 	VERIFY0(pthread_mutex_destroy(arg));
+	free(arg);
 }
 
 static void

--- a/usr/src/test/libc-tests/tests/clocklock/clock_lock_rwlock.c
+++ b/usr/src/test/libc-tests/tests/clocklock/clock_lock_rwlock.c
@@ -52,6 +52,7 @@ static void
 clock_rwlock_destroy(void *arg)
 {
 	VERIFY0(pthread_rwlock_destroy(arg));
+	free(arg);
 }
 
 static void

--- a/usr/src/test/libc-tests/tests/clocklock/clock_lock_sem.c
+++ b/usr/src/test/libc-tests/tests/clocklock/clock_lock_sem.c
@@ -53,6 +53,7 @@ static void
 clock_sem_destroy(void *arg)
 {
 	VERIFY0(sem_destroy(arg));
+	free(arg);
 }
 
 static void

--- a/usr/src/uts/common/brand/lx/syscall/lx_fcntl.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_fcntl.c
@@ -12,6 +12,7 @@
 /*
  * Copyright 2018 Joyent, Inc.
  * Copyright 2024 MNX Cloud, Inc.
+ * Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/systm.h>
@@ -34,7 +35,7 @@
 #include <sys/stream.h>
 #include <sys/flock.h>
 
-extern int fcntl(int, int, intptr_t);
+extern int fcntl(int, int, intptr_t, intptr_t);
 extern int flock_check(vnode_t *, flock64_t *, offset_t, offset_t);
 extern int lx_pipe_setsz(stdata_t *, uint_t, boolean_t);
 
@@ -151,7 +152,7 @@ lx_fcntl_getfl(int fd)
 	int retval;
 	int rc;
 
-	retval = fcntl(fd, F_GETFL, 0);
+	retval = fcntl(fd, F_GETFL, 0, 0);
 	if (ttolwp(curthread)->lwp_errno != 0)
 		return (ttolwp(curthread)->lwp_errno);
 
@@ -196,7 +197,7 @@ lx_fcntl_setfl(int fd, ulong_t arg)
 	 * fcntl(F_GETFL) so that the value can be carried
 	 * through.
 	 */
-	flags = fcntl(fd, F_GETFL, 0);
+	flags = fcntl(fd, F_GETFL, 0, 0);
 	if (ttolwp(curthread)->lwp_errno != 0)
 		return (ttolwp(curthread)->lwp_errno);
 
@@ -212,7 +213,7 @@ lx_fcntl_setfl(int fd, ulong_t arg)
 	if (arg & LX_O_ASYNC)
 		flags |= FASYNC;
 
-	return (fcntl(fd, F_SETFL, flags));
+	return (fcntl(fd, F_SETFL, flags, 0));
 }
 
 
@@ -286,19 +287,19 @@ lx_fcntl_common(int fd, int cmd, ulong_t arg)
 		return (set_errno(ENOTSUP));
 
 	case LX_F_DUPFD:
-		rc = fcntl(fd, F_DUPFD, arg);
+		rc = fcntl(fd, F_DUPFD, arg, 0);
 		break;
 
 	case LX_F_DUPFD_CLOEXEC:
-		rc = fcntl(fd, F_DUPFD_CLOEXEC, arg);
+		rc = fcntl(fd, F_DUPFD_CLOEXEC, arg, 0);
 		break;
 
 	case LX_F_GETFD:
-		rc = fcntl(fd, F_GETFD, 0);
+		rc = fcntl(fd, F_GETFD, 0, 0);
 		break;
 
 	case LX_F_SETFD:
-		rc = fcntl(fd, F_SETFD, arg);
+		rc = fcntl(fd, F_SETFD, arg, 0);
 		break;
 
 	case LX_F_GETFL:

--- a/usr/src/uts/common/brand/lx/syscall/lx_open.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_open.c
@@ -23,7 +23,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2018 Joyent, Inc.
- * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/systm.h>
@@ -40,7 +40,6 @@
 #include <sys/lx_misc.h>
 #include <sys/brand.h>
 
-extern int fcntl(int, int, intptr_t);
 extern int openat(int, char *, int, int);
 extern int open(char *, int, int);
 extern int close(int);


### PR DESCRIPTION
Weekly upstream for upstream_merge/2024073001

## Backports

None

## onu

```
OmniOS r151051 Version omnios-upstream_merge-2024073001-6a0f1e6a8c9 64-bit
Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
Copyright (c) 2017-2024 OmniOS Community Edition (OmniOSce) Association.
DEBUG enabled
Hostname: bloody

bloody console login: root
Password:
Last login: Fri Jul 26 14:21:10 2024 on console
OmniOS r151051  omnios-upstream_merge-2024073001-6a0f1e6a8c9    July 2024
illumos development build: 2024-Jul-30 [illumos]
root@bloody:~# uname -a
SunOS bloody 5.11 omnios-upstream_merge-2024073001-6a0f1e6a8c9 i86pc i386 i86pc
```

Also tested booting an ubuntu lx zone, which was successful:

```
root@lx:~# systemctl status
● lx
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Tue 2024-07-30 14:19:30 UTC; 28s ago
   CGroup: /
           ├─init.scope
           │ ├─     1 init
           │ └─101610 /lib/systemd/systemd --user
           ├─system.slice
           │ ├─systemd-journald.service
           │ │ └─101534 /lib/systemd/systemd-journald
           │ ├─cron.service
           │ │ └─101546 /usr/sbin/cron -f -P
           │ ├─dbus.service
           │ │ └─101547 @dbus-daemon --system --address=systemd: --nofork --nop>
           │ ├─networkd-dispatcher.service
           │ │ └─101549 /usr/bin/python3 /usr/bin/networkd-dispatcher --run-sta>
           │ ├─rsyslog.service
           │ │ └─101552 /usr/sbin/rsyslogd -n -iNONE
           │ ├─systemd-logind.service
           │ │ └─101553 /lib/systemd/systemd-logind
           │ ├─console-getty.service
           │ │ └─101558 /sbin/agetty -o -p -- \u --noclear --keep-baud console >
           │ └─ssh.service
           │   └─101590 sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups
           └─user.slice
             └─user-0.slice
               ├─user@0.service
               │ └─101611 (sd-
               └─session-c1.scope
                 ├─101599 /bin/login -h zone:global -f
                 ├─101616 -bash
                 ├─101627 systemctl status
                 └─101628 less
```

## mail_msg

```

==== Nightly distributed build started:   Tue Jul 30 12:34:03 UTC 2024 ====
==== Nightly distributed build completed: Tue Jul 30 14:09:22 UTC 2024 ====

==== Total build time ====

real    1:35:18

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-58c788ec764 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 9.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151051/10.5.0-il-1) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151051/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.11+9-omnios-151051"

/usr/bin/openssl
OpenSSL 3.1.6 4 Jun 2024 (Library: OpenSSL 3.1.6 4 Jun 2024)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   80

==== Nightly argument issues ====


==== Build version ====

omnios-upstream_merge-2024073001-6a0f1e6a8c9

==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    50:05.2
user  5:45:02.6
sys   3:35:24.2

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    27:09.8
user  4:01:49.1
sys   1:15:25.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
