### PR TITLE
Upstream merge upstream_merge/2024112701

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8757,7 +8757,9 @@ usr/src/test/bhyve-tests/tests/kdev/wrmsr_tsc
 usr/src/test/bhyve-tests/tests/perf/entry_exit
 usr/src/test/bhyve-tests/tests/perf/payload_entry_exit
 usr/src/test/bhyve-tests/tests/perf/pobj_entry_exit.s
+usr/src/test/bhyve-tests/tests/viona/create_delete
 usr/src/test/bhyve-tests/tests/viona/interface_version
+usr/src/test/bhyve-tests/tests/viona/link_params
 usr/src/test/bhyve-tests/tests/vmm/auto_destruct
 usr/src/test/bhyve-tests/tests/vmm/check_iommu
 usr/src/test/bhyve-tests/tests/vmm/cpuid_ioctl
@@ -9414,6 +9416,7 @@ usr/src/tools/geniconvtbl/lex.yy.c
 usr/src/tools/geniconvtbl/y.tab.c
 usr/src/tools/geniconvtbl/y.tab.h
 usr/src/tools/install.bin/install.bin
+usr/src/tools/lex/lex
 usr/src/tools/lintdump/lintdump
 usr/src/tools/localedef/localedef
 usr/src/tools/localedef/parser.tab.c

--- a/usr/src/cmd/cmd-inet/usr.lib/wpad/Makefile
+++ b/usr/src/cmd/cmd-inet/usr.lib/wpad/Makefile
@@ -33,6 +33,12 @@ include	../../../Makefile.cmd
 
 ROOTMANIFESTDIR = $(ROOTSVCNETWORK)
 
+# The wpa_enc.c file is not ported to the OpenSSL 3.x API yet and so we need to
+# make sure the deprecated 1.x API is fully available for it.  Once the
+# wpa_enc.c file is adapted for OpenSSL 3.x this should be updated or removed.
+# See also https://www.illumos.org/issues/16917
+CPPFLAGS +=	-DOPENSSL_API_COMPAT=10101
+
 LDLIBS +=	-ldladm -ldlpi
 NATIVE_LIBS +=	libcrypto.so
 all install := LDLIBS += -lcrypto

--- a/usr/src/cmd/dtrace/test/tst/common/print/tst.xlate.d
+++ b/usr/src/cmd/dtrace/test/tst/common/print/tst.xlate.d
@@ -15,6 +15,7 @@
 
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright 2024 Ryan Zezeski
  */
 
 #pragma D option quiet
@@ -31,9 +32,53 @@ translator pancakes_t < void *V > {
 	t = *(timespec_t *)`dtrace_zero;
 };
 
+typedef struct stb {
+	uint8_t v;
+	uint8_t z;
+} stb_t;
+
+translator stb_t < void *V > {
+	v = 0x8877665544332211;
+};
+
+typedef struct sth {
+	uint16_t v;
+	uint8_t z;
+} sth_t;
+
+translator sth_t < void *V > {
+	v = 0x8877665544332211;
+};
+
+typedef struct stw {
+	uint32_t v;
+	uint8_t z;
+} stw_t;
+
+translator stw_t < void *V > {
+	v = 0x8877665544332211;
+};
+
+typedef struct stx {
+	uint64_t v;
+	uint8_t z;
+} stx_t;
+
+translator stx_t < void *V > {
+	v = 0x8877665544332211;
+};
+
 BEGIN
 {
 	print(*(xlate < pancakes_t * > ((void *)NULL)));
+	printf("\n");
+	print(*(xlate < stb_t * > ((void *)NULL)));
+	printf("\n");
+	print(*(xlate < sth_t * > ((void *)NULL)));
+	printf("\n");
+	print(*(xlate < stw_t * > ((void *)NULL)));
+	printf("\n");
+	print(*(xlate < stx_t * > ((void *)NULL)));
 }
 
 BEGIN

--- a/usr/src/cmd/dtrace/test/tst/common/print/tst.xlate.d.out
+++ b/usr/src/cmd/dtrace/test/tst/common/print/tst.xlate.d.out
@@ -6,3 +6,19 @@ pancakes_t {
         long tv_nsec = 0
     }
 }
+stb_t {
+    uint8_t v = 0x11
+    uint8_t z = 0
+}
+sth_t {
+    uint16_t v = 0x2211
+    uint8_t z = 0
+}
+stw_t {
+    uint32_t v = 0x44332211
+    uint8_t z = 0
+}
+stx_t {
+    uint64_t v = 0x8877665544332211
+    uint8_t z = 0
+}

--- a/usr/src/cmd/sendmail/src/Makefile
+++ b/usr/src/cmd/sendmail/src/Makefile
@@ -58,6 +58,12 @@ SUNENVDEF=	-DSUN_EXTENSIONS -DVENDOR_DEFAULT=VENDOR_SUN \
 
 CPPFLAGS =	$(INCPATH) $(ENVDEF) $(SUNENVDEF) $(DBMDEF) $(CPPFLAGS.sm)
 
+# The tls.c file is not ported to the OpenSSL 3.x API yet and so we need to
+# make sure the deprecated 1.x API is fully available for it.  Once the tls.c
+# file is adapted for OpenSSL 3.x this should be updated or removed.
+# See also https://www.illumos.org/issues/16918
+CPPFLAGS +=	-DOPENSSL_API_COMPAT=10101
+
 FILEMODE=	2555
 
 ROOTSYMLINKS=	$(ROOTLIBSMTPSM)/newaliases

--- a/usr/src/lib/krb5/plugins/preauth/pkinit/Makefile.com
+++ b/usr/src/lib/krb5/plugins/preauth/pkinit/Makefile.com
@@ -65,6 +65,13 @@ CPPFLAGS +=	-I$(SRC)/lib/krb5 \
 		-I$(SRC)/uts/common/gssapi/mechs/krb5/include \
 		-I$(SRC)
 
+# The pkinit_crypto_openssl.c file is not ported to the OpenSSL 3.x API yet and
+# so we need to make sure the deprecated 1.x API is fully available for it.
+# Once the pkinit_crypto_openssl.c file is adapted for OpenSSL 3.x this should
+# be updated or removed.
+# See also https://www.illumos.org/issues/16915
+CPPFLAGS +=	-DOPENSSL_API_COMPAT=10101
+
 CERRWARN	+= $(CNOWARN_UNINIT)
 CERRWARN	+= -_gcc=-Wno-unused-function
 

--- a/usr/src/lib/libdtrace/common/dt_cg.c
+++ b/usr/src/lib/libdtrace/common/dt_cg.c
@@ -29,6 +29,7 @@
  * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright 2017 Joyent, Inc.
  * Copyright 2022 Oxide Computer Company
+ * Copyright 2024 Ryan Zezeski
  */
 
 #include <sys/types.h>
@@ -1423,8 +1424,9 @@ dt_cg_xlate_member(const char *name, ctf_id_t type, ulong_t off, void *arg)
 	instr = DIF_INSTR_FMT(DIF_OP_ADD, dx->dtxl_dreg, reg, reg);
 	dt_irlist_append(dlp, dt_cg_node_alloc(DT_LBL_NONE, instr));
 
-	size = ctf_type_size(mnp->dn_membexpr->dn_ctfp,
-	    mnp->dn_membexpr->dn_type);
+	/* Determine the size of the destination member's type. */
+	size = ctf_type_size(dxp->dx_dst_ctfp, type);
+
 	if (dt_node_is_scalar(mnp->dn_membexpr)) {
 		/*
 		 * Copying scalars is simple.

--- a/usr/src/lib/libkmf/plugins/kmf_openssl/Makefile.com
+++ b/usr/src/lib/libkmf/plugins/kmf_openssl/Makefile.com
@@ -48,6 +48,13 @@ CFLAGS		+=	$(CCVERBOSE)
 CPPFLAGS	+=	-D_REENTRANT $(KMFINC) \
 			-I$(INCDIR) -I$(ADJUNCT_PROTO)/usr/include/libxml2
 
+# The openssl_spi.c file is not ported to the OpenSSL 3.x API yet and so we
+# need to make sure the deprecated 1.x API is fully available for it.  Once the
+# openssl_spi.c file is adapted for OpenSSL 3.x this should be updated or
+# removed.
+# See also https://www.illumos.org/issues/16916
+CPPFLAGS	+=	-DOPENSSL_API_COMPAT=10101
+
 CERRWARN	+=	-_gcc=-Wno-unused-label
 CERRWARN	+=	-_gcc=-Wno-unused-value
 CERRWARN	+=	$(CNOWARN_UNINIT)

--- a/usr/src/pkg/manifests/driver-network-vioif.p5m
+++ b/usr/src/pkg/manifests/driver-network-vioif.p5m
@@ -40,6 +40,6 @@ file path=usr/share/man/man4d/vioif.4d
 driver name=vioif perms="* 0666 root sys" \
     alias=pci1af4,1 \
     alias=pci1af4,1000,p
-legacy pkg=SUNWvioif desc="VirtIO network driver" name="VirtIO network driver"
-license cr_Sun license=cr_Sun
 license lic_CDDL license=lic_CDDL
+license usr/src/uts/common/io/vioif/THIRDPARTYLICENSE \
+    license=usr/src/uts/common/io/vioif/THIRDPARTYLICENSE

--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -27,6 +27,7 @@
 # Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
 # Copyright (c) 2017 Datto Inc.
 # Copyright 2020 Joyent, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 . ${STF_TOOLS}/contrib/include/logapi.shlib
@@ -2394,6 +2395,9 @@ function get_fstype
 function labelvtoc
 {
 	typeset disk=$1
+	typeset -i iter=120
+	typeset -i ret_val=1
+
 	if [[ -z $disk ]]; then
 		log_fail "The disk name is unspecified."
 	fi
@@ -2401,15 +2405,13 @@ function labelvtoc
 	typeset arch=$(uname -p)
 
 	if [[ $arch == "i386" ]]; then
+		log_must fdisk -B ${disk}p0
+
 		echo "label" > $label_file
 		echo "0" >> $label_file
 		echo "" >> $label_file
 		echo "q" >> $label_file
 		echo "q" >> $label_file
-
-		fdisk -B $disk >/dev/null 2>&1
-		# wait a while for fdisk finishes
-		sleep 60
 	elif [[ $arch == "sparc" ]]; then
 		echo "label" > $label_file
 		echo "0" >> $label_file
@@ -2421,13 +2423,17 @@ function labelvtoc
 		log_fail "unknown arch type"
 	fi
 
-	format -e -s -d $disk -f $label_file
-	typeset -i ret_val=$?
+	# Disk update from fdisk -B may be delayed
+	while ((iter > 0)); do
+		if format -e -s -d $disk -f $label_file ; then
+			iter=0
+			ret_val=0
+		else
+			sleep 1
+			((iter -= 1))
+		fi
+	done
 	rm -f $label_file
-	#
-	# wait the format to finish
-	#
-	sleep 60
 	if ((ret_val != 0)); then
 		log_fail "unable to label $disk as VTOC."
 	fi

--- a/usr/src/uts/common/io/1394/t1394.c
+++ b/usr/src/uts/common/io/1394/t1394.c
@@ -144,7 +144,7 @@ t1394_attach(dev_info_t *dip, int version, uint_t flags,
 	attachinfo->dma_attr	= target->on_hal->halinfo.dma_attr;
 
 	unit_dir = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-		DDI_PROP_DONTPASS, "unit-dir-offset", 0);
+	    DDI_PROP_DONTPASS, "unit-dir-offset", 0);
 	target->unit_dir = unit_dir;
 
 	/* By default, disable all physical AR requests */
@@ -909,7 +909,7 @@ t1394_alloc_addr(t1394_handle_t t1394_hdl, t1394_alloc_addr_t *addr_allocp,
 	/* If not T1394_ADDR_FIXED, then allocate a block */
 	if (addr_allocp->aa_type != T1394_ADDR_FIXED) {
 		err = s1394_request_addr_blk((s1394_hal_t *)target->on_hal,
-					addr_allocp);
+		    addr_allocp);
 		if (err != DDI_SUCCESS) {
 			*result = T1394_EALLOC_ADDR;
 			/* kstats - addr alloc failures */
@@ -920,7 +920,7 @@ t1394_alloc_addr(t1394_handle_t t1394_hdl, t1394_alloc_addr_t *addr_allocp,
 		return (err);
 	} else {
 		err = s1394_claim_addr_blk((s1394_hal_t *)target->on_hal,
-					addr_allocp);
+		    addr_allocp);
 		if (err != DDI_SUCCESS) {
 			*result = T1394_EALLOC_ADDR;
 			/* kstats - addr alloc failures */
@@ -1342,7 +1342,7 @@ t1394_cmp_cas(t1394_handle_t t1394_hdl, t1394_cmp_reg_t reg, uint32_t arg_val,
 	ASSERT(t1394_hdl != NULL);
 
 	result = s1394_cmp_cas((s1394_target_t *)t1394_hdl, reg, arg_val,
-				new_val, old_valp);
+	    new_val, old_valp);
 
 	return (result);
 }
@@ -1432,7 +1432,7 @@ t1394_alloc_isoch_single(t1394_handle_t t1394_hdl,
 	cec_new->filter_channel_mask	= sii->si_channel_mask;
 	cec_new->bandwidth		= sii->si_bandwidth;
 	cec_new->state_transitions	= ISOCH_CEC_FREE | ISOCH_CEC_JOIN |
-					    ISOCH_CEC_SETUP;
+	    ISOCH_CEC_SETUP;
 
 	mutex_enter(&hal->isoch_cec_list_mutex);
 
@@ -1658,7 +1658,7 @@ t1394_alloc_isoch_cec(t1394_handle_t t1394_hdl, t1394_isoch_cec_props_t *props,
 	cec_new->bandwidth		= props->cec_bandwidth;
 	cec_new->cec_options		= props->cec_options;
 	cec_new->state_transitions	= ISOCH_CEC_FREE | ISOCH_CEC_JOIN |
-					    ISOCH_CEC_SETUP;
+	    ISOCH_CEC_SETUP;
 
 	mutex_enter(&hal->isoch_cec_list_mutex);
 
@@ -1844,6 +1844,7 @@ t1394_join_isoch_cec(t1394_handle_t t1394_hdl,
 	    (join_isoch_info->isoch_cec_evts.stop_target	== NULL) ||
 	    (join_isoch_info->isoch_cec_evts.rsrc_fail_target	== NULL) ||
 	    (join_isoch_info->isoch_cec_evts.teardown_target	== NULL))) {
+		kmem_free(member_new, sizeof (s1394_isoch_cec_member_t));
 		/* Unlock the Isoch CEC member list */
 		mutex_exit(&cec_curr->isoch_cec_mutex);
 		return (DDI_FAILURE);
@@ -2034,7 +2035,7 @@ t1394_setup_isoch_cec(t1394_handle_t t1394_hdl,
 	int				ret;
 	int				j;
 	int	(*setup_callback)(t1394_isoch_cec_handle_t, opaque_t,
-			    t1394_setup_target_args_t *);
+	    t1394_setup_target_args_t *);
 
 	ASSERT(t1394_hdl != NULL);
 	ASSERT(t1394_isoch_cec_hdl != NULL);
@@ -3039,7 +3040,7 @@ t1394_add_cfgrom_entry(t1394_handle_t t1394_hdl,
 		mutex_exit(&hal->local_config_rom_mutex);
 		hal->config_rom_timer =
 		    timeout(s1394_update_config_rom_callback, hal,
-			drv_usectohz(CONFIG_ROM_UPDATE_DELAY * 1000));
+		    drv_usectohz(CONFIG_ROM_UPDATE_DELAY * 1000));
 	} else {
 		mutex_exit(&hal->local_config_rom_mutex);
 	}
@@ -3099,7 +3100,7 @@ t1394_rem_cfgrom_entry(t1394_handle_t t1394_hdl, uint_t flags,
 		mutex_exit(&hal->local_config_rom_mutex);
 		hal->config_rom_timer =
 		    timeout(s1394_update_config_rom_callback, hal,
-			drv_usectohz(CONFIG_ROM_UPDATE_DELAY * 1000));
+		    drv_usectohz(CONFIG_ROM_UPDATE_DELAY * 1000));
 	} else {
 		mutex_exit(&hal->local_config_rom_mutex);
 	}

--- a/usr/src/uts/common/io/cardbus/cardbus.c
+++ b/usr/src/uts/common/io/cardbus/cardbus.c
@@ -1623,6 +1623,7 @@ cardbus_parse_devprop(cbus_t *cbp, char *cp)
 				cmn_err(CE_CONT, "cardbus_parse_devprop: "
 				    "escape not allowed outside "
 				    "of quotes at [%s]\n", token);
+				cardbus_devprops_free(cdsp);
 				return (DDI_FAILURE);
 
 			} /* if (!qm) */
@@ -1660,6 +1661,7 @@ cardbus_parse_devprop(cbus_t *cbp, char *cp)
 					    "cardbus_parse_devprop: "
 					    "unexpected string [%s] after "
 					    "[%s]\n", quote, token);
+					cardbus_devprops_free(cdsp);
 					return (DDI_FAILURE);
 				} else {
 					if (strcmp(token, cb_bnamestr) == 0) {

--- a/usr/src/uts/common/io/ib/clients/of/sol_ofs/sol_kverbs.c
+++ b/usr/src/uts/common/io/ib/clients/of/sol_ofs/sol_kverbs.c
@@ -141,9 +141,9 @@ static void
 ofs_async_handler(void *clntp, ibt_hca_hdl_t hdl, ibt_async_code_t code,
     ibt_async_event_t *event)
 {
-	ofs_client_t 	*ofs_client = (ofs_client_t *)clntp;
+	ofs_client_t	*ofs_client = (ofs_client_t *)clntp;
 	struct ib_event ib_event;
-	struct ib_qp 	*qpp;
+	struct ib_qp	*qpp;
 	struct ib_cq	*cqp;
 
 
@@ -823,6 +823,7 @@ ib_alloc_pd(struct ib_device *device)
 		SOL_OFS_DPRINTF_L2(sol_kverbs_dbg_str,
 		    "ib_alloc_pd: device: 0x%p => invalid device state (%d)",
 		    device, device->reg_state);
+		kmem_free(pd, sizeof (struct ib_pd));
 		return ((struct ib_pd *)-ENXIO);
 	}
 
@@ -839,11 +840,11 @@ ib_alloc_pd(struct ib_device *device)
 		    "rtn: 0x%x", device, pd, pd->ibt_pd, rtn);
 		return (pd);
 	}
-	kmem_free(pd, sizeof (struct ib_pd));
 
 	SOL_OFS_DPRINTF_L2(sol_kverbs_dbg_str,
 	    "ib_alloc_pd: device: 0x%p, pd: 0x%p, ibt_pd: 0x%p => "
 	    "ibt_alloc_pd failed w/ 0x%x", device, pd, pd->ibt_pd, rtn);
+	kmem_free(pd, sizeof (struct ib_pd));
 
 	switch (rtn) {
 	case IBT_INSUFF_RESOURCE:
@@ -963,6 +964,7 @@ ib_create_cq(struct ib_device *device, ib_comp_handler comp_handler,
 		    "comp_vector: %p => invalid device state (%d)", device,
 		    comp_handler, event_handler, cq_context, cqe, comp_vector,
 		    device->reg_state);
+		kmem_free(cq, sizeof (struct ib_cq));
 		return ((struct ib_cq *)-ENXIO);
 	}
 
@@ -992,11 +994,11 @@ ib_create_cq(struct ib_device *device, ib_comp_handler comp_handler,
 		    "rtn: 0x%x", device, cqe, cq->ibt_cq, rtn);
 		return (cq);
 	}
-	kmem_free(cq, sizeof (struct ib_cq));
 
 	SOL_OFS_DPRINTF_L2(sol_kverbs_dbg_str,
 	    "ib_create_cq: device: 0x%p, cqe: 0x%x, ibt_cq: 0x%p => "
 	    "ibt_alloc_cq failed w/ 0x%x", device, cqe, cq->ibt_cq, rtn);
+	kmem_free(cq, sizeof (struct ib_cq));
 
 	switch (rtn) {
 	case IBT_HCA_CQ_EXCEEDED:

--- a/usr/src/uts/common/io/vioif/THIRDPARTYLICENSE
+++ b/usr/src/uts/common/io/vioif/THIRDPARTYLICENSE
@@ -1,0 +1,25 @@
+/* Based on the NetBSD virtio driver by Minoura Makoto. */
+/*
+ * Copyright (c) 2010 Minoura Makoto.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/usr/src/uts/common/io/vioif/THIRDPARTYLICENSE.descrip
+++ b/usr/src/uts/common/io/vioif/THIRDPARTYLICENSE.descrip
@@ -1,0 +1,1 @@
+portions of virtio network interface driver

--- a/usr/src/uts/common/os/ipc.c
+++ b/usr/src/uts/common/os/ipc.c
@@ -1283,7 +1283,7 @@ ipc_ids(ipc_service_t *service, int *buf, uint_t nids, uint_t *pnids)
 	size_t	idsize = 0;
 	int	error = 0;
 	int	idcount;
-	int	*ids;
+	int	*ids = NULL;
 	int	numids = 0;
 	zoneid_t zoneid = getzoneid();
 	int	global = INGLOBALZONE(curproc);
@@ -1319,6 +1319,7 @@ ipc_ids(ipc_service_t *service, int *buf, uint_t nids, uint_t *pnids)
 
 		if (idsize != 0) {
 			kmem_free(ids, idsize);
+			ids = NULL;
 			idsize = 0;
 		}
 	}
@@ -1342,7 +1343,7 @@ out:
 	if (suword32(pnids, (uint32_t)numids) ||
 	    (nids != 0 && copyout(ids, buf, numids * sizeof (int))))
 		error = EFAULT;
-	if (idsize != 0)
+	if (ids != NULL)
 		kmem_free(ids, idsize);
 	return (error);
 }


### PR DESCRIPTION
Weekly upstream for upstream_merge/2024112701

## Backports

None

## onu

```
OmniOS r151053 Version omnios-upstream_merge-2024112701-5cdacf2c8bf 64-bit
Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
Copyright (c) 2017-2024 OmniOS Community Edition (OmniOSce) Association.
DEBUG enabled
Hostname: bloody

bloody console login: root
Password:
OmniOS r151053  omnios-upstream_merge-2024112701-5cdacf2c8bf    November 2024
illumos development build: 2024-Nov-27 [illumos]
root@bloody:~# uname -a
SunOS bloody 5.11 omnios-upstream_merge-2024112701-5cdacf2c8bf i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Wed Nov 27 15:26:31 UTC 2024 ====
==== Nightly distributed build completed: Wed Nov 27 16:39:49 UTC 2024 ====

==== Total build time ====

real    1:13:17

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-eb7f449c9c8 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 9.1
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151053/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-7/bin/gcc
gcc (OmniOS 151053/7.5.0-il-2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.13+11-omnios-151053"

/usr/bin/openssl
OpenSSL 3.4.0 22 Oct 2024 (Library: OpenSSL 3.4.0 22 Oct 2024)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   104

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-upstream_merge-2024112701-5cdacf2c8bf

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:12.7
user  4:08:02.3
sys   1:20:30.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:13.0
user  3:51:27.8
sys   1:17:51.1

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
