### PR TITLE
HYPERV: feature descriptions printed out twice

### DIFF
--- a/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/hyperv.c
@@ -649,7 +649,6 @@ hyperv_show_features(uint64_t val, const char *desc, const hvbit_t *fields,
 
 	ilstr_init_prealloc(&ils, buf, sizeof (buf));
 
-	ilstr_append_str(&ils, desc);
 	ilstr_aprintf(&ils, "%s: 0x%08x\n", desc, val);
 
 	for (i = 0; i < nfields; i++) {


### PR DESCRIPTION
We currently see the `desc` field twice during a verbose boot:

    Hyper-V featuresHyper-V features: 0x00000000
    Hyper-V guest recommendationsHyper-V guest recommendations: 0x00000000
