### PR TITLE
15633 libsocket: getallifaddrs() can die with NULL pointer dereference (r151046)

### DIFF
--- a/usr/src/cmd/fm/modules/common/fabric-xlate/fabric-xlate.c
+++ b/usr/src/cmd/fm/modules/common/fabric-xlate/fabric-xlate.c
@@ -31,6 +31,8 @@
 #include <unistd.h>
 #include <pthread.h>
 
+#include <libxml/tree.h>
+#include <libxml/parser.h>
 #include <libxml/xpathInternals.h>
 
 #include "fabric-xlate.h"

--- a/usr/src/cmd/isns/isnsd/door.c
+++ b/usr/src/cmd/isns/isnsd/door.c
@@ -44,6 +44,7 @@
 #include    <alloca.h>
 #include    <pthread.h>
 #include    <ucred.h>
+#include    <stdlib.h>
 #include    "isns_server.h"
 #include    "admintf.h"
 #include    "isns_mgmt.h"

--- a/usr/src/cmd/isns/isnsd/xml/data.c
+++ b/usr/src/cmd/isns/isnsd/xml/data.c
@@ -843,9 +843,6 @@ xml_init_data(
 	free(cwd);
 	free(p);
 
-	/* do not keep blank spaces */
-	(void) xmlKeepBlanksDefault(0);
-
 	/* remove the tmp file if it exists */
 	if (access(xml_tmp_file, F_OK) == 0) {
 		(void) remove(xml_tmp_file);

--- a/usr/src/cmd/svc/svccfg/svccfg_xml.c
+++ b/usr/src/cmd/svc/svccfg/svccfg_xml.c
@@ -242,16 +242,16 @@ static const char *lxml_prop_types[] = {
 	""				/* SC_XI_INCLUDE */
 };
 
+static int xml_read_options = 0;
+
 int
 lxml_init()
 {
 	if (getenv("SVCCFG_NOVALIDATE") == NULL) {
 		/*
-		 * DTD validation, with line numbers.
+		 * DTD validation.
 		 */
-		(void) xmlLineNumbersDefault(1);
-		xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
-		xmlLoadExtDtdDefaultValue |= XML_COMPLETE_ATTRS;
+		xml_read_options |= XML_PARSE_DTDLOAD | XML_PARSE_DTDATTR;
 	}
 
 	return (0);
@@ -3720,10 +3720,8 @@ lxml_get_bundle_file(bundle_t *bundle, const char *filename, svccfg_op_t op)
 	if (do_validate)
 		dtdpath = getenv("SVCCFG_DTD");
 
-	if (dtdpath != NULL)
-		xmlLoadExtDtdDefaultValue = 0;
-
-	if ((document = xmlReadFile(filename, NULL, 0)) == NULL) {
+	document = xmlReadFile(filename, NULL, xml_read_options);
+	if (document == NULL) {
 		semerr(gettext("couldn't parse document\n"));
 		return (-1);
 	}

--- a/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
+++ b/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
@@ -2004,8 +2004,6 @@ txml_file_parse(topo_mod_t *tmp,
 	 */
 	if (getenv("TOPOXML_VALIDATE") != NULL) {
 		dtdpath = getenv("TOPO_DTD");
-		if (dtdpath != NULL)
-			xmlLoadExtDtdDefaultValue = 0;
 		validate = 1;
 	}
 

--- a/usr/src/lib/libbrand/common/libbrand.c
+++ b/usr/src/lib/libbrand/common/libbrand.c
@@ -139,21 +139,6 @@ libbrand_initialize()
 		return (B_FALSE);
 	}
 
-	/*
-	 * Note that here we're initializing per-process libxml2
-	 * state.  By doing so we're implicitly assuming that
-	 * no other code in this process is also trying to
-	 * use libxml2.  But in most case we know this not to
-	 * be true since we're almost always used in conjunction
-	 * with libzonecfg, which also uses libxml2.  Lucky for
-	 * us, libzonecfg initializes libxml2 to essentially
-	 * the same defaults as we're using below.
-	 */
-	(void) xmlLineNumbersDefault(1);
-	xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
-	xmlDoValidityCheckingDefaultValue = 1;
-	(void) xmlKeepBlanksDefault(0);
-	xmlGetWarningsDefaultValue = 0;
 	xmlSetGenericErrorFunc(NULL, brand_error_func);
 
 	libbrand_initialized = B_TRUE;
@@ -198,7 +183,9 @@ open_xml_file(const char *file)
 	/*
 	 * Parse the file
 	 */
-	if ((doc = xmlParseFile(file)) == NULL)
+	doc = xmlReadFile(file, NULL, XML_PARSE_DTDLOAD |
+	    XML_PARSE_DTDVALID | XML_PARSE_NOBLANKS | XML_PARSE_NOWARNING);
+	if (doc == NULL)
 		return (NULL);
 
 	/*

--- a/usr/src/lib/libpool/common/pool_kernel.c
+++ b/usr/src/lib/libpool/common/pool_kernel.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include <libxml/tree.h>
+#include <libxml/valid.h>
 
 #include <sys/mman.h>
 #include <sys/pool.h>

--- a/usr/src/lib/libpool/common/pool_xml.c
+++ b/usr/src/lib/libpool/common/pool_xml.c
@@ -262,14 +262,6 @@ xml_init()
 	}
 	xmlInitParser();
 
-	/*
-	 * DTD validation, with line numbers.
-	 */
-	(void) xmlLineNumbersDefault(1);
-	xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
-	xmlDoValidityCheckingDefaultValue = 1;
-	/* Try to improve indentation and readability */
-	(void) xmlKeepBlanksDefault(0);
 	/* Send all XML errors to our debug handler */
 	xmlSetGenericErrorFunc(NULL, pool_error_func);
 	/* Load up DTD element a-dtype data to improve performance */
@@ -2703,6 +2695,10 @@ pool_xml_parse_document(pool_conf_t *conf)
 			pool_seterror(POE_INVALID_CONF);
 			return (PO_FAIL);
 		}
+
+		xmlCtxtUseOptions(ctxt,
+		    XML_PARSE_DTDLOAD | XML_PARSE_DTDVALID |
+		    XML_PARSE_NOBLANKS);
 
 		while ((res = fread(chars, 1, size, prov->pxc_file)) > 0) {
 			if (xmlParseChunk(ctxt, chars, res, 0) != 0) {

--- a/usr/src/lib/libzonecfg/common/libzonecfg.c
+++ b/usr/src/lib/libzonecfg/common/libzonecfg.c
@@ -171,6 +171,9 @@
 #define	RCAP_SERVICE	"system/rcap:default"
 #define	POOLD_SERVICE	"system/pools/dynamic:default"
 
+#define	XML_PARSER_OPTIONS	(XML_PARSE_DTDLOAD | XML_PARSE_DTDVALID | \
+				XML_PARSE_NOBLANKS | XML_PARSE_NOWARNING)
+
 /*
  * rctl alias definitions
  *
@@ -339,12 +342,6 @@ zonecfg_init_handle(void)
 		return (NULL);
 	}
 
-	/* generic libxml initialization */
-	(void) xmlLineNumbersDefault(1);
-	xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
-	xmlDoValidityCheckingDefaultValue = 1;
-	(void) xmlKeepBlanksDefault(0);
-	xmlGetWarningsDefaultValue = 0;
 	xmlSetGenericErrorFunc(NULL, zonecfg_error_func);
 
 	return (handle);
@@ -618,7 +615,8 @@ zonecfg_get_handle_impl(const char *zonename, const char *filename,
 	if (zonename == NULL)
 		return (Z_NO_ZONE);
 
-	if ((handle->zone_dh_doc = xmlParseFile(filename)) == NULL) {
+	handle->zone_dh_doc = xmlReadFile(filename, NULL, XML_PARSER_OPTIONS);
+	if (handle->zone_dh_doc == NULL) {
 		/* distinguish file not found vs. found but not parsed */
 		if (stat(filename, &statbuf) == 0)
 			return (Z_INVALID_DOCUMENT);
@@ -736,7 +734,8 @@ zonecfg_attach_manifest(int fd, zone_dochandle_t local_handle,
 	boolean_t valid;
 
 	/* load the manifest into the handle for the remote system */
-	if ((rem_handle->zone_dh_doc = xmlReadFd(fd, NULL, NULL, 0)) == NULL) {
+	rem_handle->zone_dh_doc = xmlReadFd(fd, NULL, NULL, XML_PARSER_OPTIONS);
+	if (rem_handle->zone_dh_doc == NULL) {
 		return (Z_INVALID_DOCUMENT);
 	}
 


### PR DESCRIPTION
This issue has shown up on a system running r151046. Let's get it backported and into next week's release.