### PR TITLE
Backports to r151054

### DIFF
--- a/usr/src/boot/efi/include/Uefi/UefiMultiPhase.h
+++ b/usr/src/boot/efi/include/Uefi/UefiMultiPhase.h
@@ -103,6 +103,15 @@ typedef enum {
   /// however it happens to also support byte-addressable non-volatility.
   ///
   EfiPersistentMemory,
+  ///
+  /// A memory region that represents unaccepted memory, that must be
+  /// accepted by the boot target before it can be used. Unless otherwise noted, all
+  /// other EFI memory types are accepted. For platforms that support unaccepted
+  /// memory, all unaccepted valid memory will be reported as unaccepted in the
+  /// memory map. Unreported physical address ranges must be treated as not-
+  /// present memory.
+  ///
+  EfiUnacceptedMemoryType,
   EfiMaxMemoryType
 } EFI_MEMORY_TYPE;
 

--- a/usr/src/boot/efi/include/Uefi/UefiSpec.h
+++ b/usr/src/boot/efi/include/Uefi/UefiSpec.h
@@ -177,7 +177,7 @@ typedef struct {
                                 2) MemoryType is in the range
                                 EfiMaxMemoryType..0x6FFFFFFF.
                                 3) Memory is NULL.
-                                4) MemoryType is EfiPersistentMemory.
+                                4) MemoryType is EfiPersistentMemory or EfiUnacceptedMemoryType.
   @retval EFI_OUT_OF_RESOURCES  The pages could not be allocated.
   @retval EFI_NOT_FOUND         The requested pages could not be found.
 

--- a/usr/src/boot/efi/loader/memmap.c
+++ b/usr/src/boot/efi/loader/memmap.c
@@ -38,7 +38,8 @@ static struct bios_smap *smapbase;
 static int smaplen;
 
 /*
- * See ACPI 6.1 Table 15-330 UEFI Memory Types and mapping to ACPI address
+ * See "ACPI Specification Release 6.5 Errata A"
+ * Table 15-6 (page 785), UEFI Memory Types and mapping to ACPI address
  * range types.
  */
 static int

--- a/usr/src/cmd/mdb/Makefile.kmdb.files
+++ b/usr/src/cmd/mdb/Makefile.kmdb.files
@@ -26,6 +26,7 @@
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
 # Copyright 2021 Joyent, Inc.
+# Copyright 2025 Oxide Computer Company
 #
 
 KMDBSRCS += \
@@ -77,6 +78,7 @@ KMDBSRCS += \
 	mdb_set.c \
 	kmdb_shell.c \
 	mdb_signal.c \
+	mdb_stack.c \
 	mdb_string.c \
 	mdb_strio.c \
 	kmdb_stubs.c \

--- a/usr/src/cmd/mdb/Makefile.mdb
+++ b/usr/src/cmd/mdb/Makefile.mdb
@@ -28,6 +28,7 @@
 # Copyright (c) 2012 by Delphix. All rights reserved.
 # Copyright 2021 Joyent, Inc.
 # Copyright 2018 Jason King
+# Copyright 2025 Oxide Computer Company
 #
 
 .KEEP_STATE:
@@ -80,6 +81,7 @@ SRCS += \
 	mdb_set.c \
 	mdb_shell.c \
 	mdb_signal.c \
+	mdb_stack.c \
 	mdb_stdlib.c \
 	mdb_string.c \
 	mdb_strio.c \

--- a/usr/src/cmd/mdb/common/kmdb/kmdb_kvm.c
+++ b/usr/src/cmd/mdb/common/kmdb/kmdb_kvm.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2013 by Delphix. All rights reserved.
  *
  * Copyright 2019 Joyent, Inc.
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 #include <kmdb/kmdb_kvm.h>
@@ -610,9 +610,26 @@ kmt_switch(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	return (DCMD_OK);
 }
 
+static void
+kmt_stack_help(void)
+{
+	mdb_printf(
+	    "Options:\n"
+	    "  -s   show the size of each stack frame to the left\n"
+	    "  -t   where CTF is present, show types for functions and "
+	    "arguments\n"
+	    "  -v   include frame pointer information (this is the default "
+	    "for %<b>$C%</b>)\n"
+	    "\n"
+	    "If the optional %<u>cnt%</u> is given, no more than %<u>cnt%</u> "
+	    "arguments are shown\nfor each stack frame.\n");
+}
+
 static const mdb_dcmd_t kmt_dcmds[] = {
-	{ "$c", "?[cnt]", "print stack backtrace", kmt_stack },
-	{ "$C", "?[cnt]", "print stack backtrace", kmt_stackv },
+	{ "$c", "?[-stv] [cnt]", "print stack backtrace", kmt_stack,
+	    kmt_stack_help },
+	{ "$C", "?[-stv] [cnt]", "print stack backtrace", kmt_stackv,
+	    kmt_stack_help },
 	{ "$r", NULL, "print general-purpose registers", kmt_regs },
 	{ "$?", NULL, "print status and registers", kmt_regs },
 	{ ":x", ":", "change the active CPU", kmt_switch },
@@ -628,14 +645,16 @@ static const mdb_dcmd_t kmt_dcmds[] = {
 	{ "rdmsr", ":", "read an MSR", kmt_rdmsr },
 	{ "wrmsr", ": val", "write an MSR", kmt_wrmsr },
 	{ "rdpcicfg", ": bus dev func", "read a register in PCI config space",
-	kmt_rdpcicfg },
-	{ "wrpcicfg", ": bus dev func val", "write a register in PCI config "
-	"space", kmt_wrpcicfg },
+	    kmt_rdpcicfg },
+	{ "wrpcicfg", ": bus dev func val",
+	    "write a register in PCI config space", kmt_wrpcicfg },
 #endif
 	{ "noducttape", NULL, NULL, kmt_noducttape },
 	{ "regs", NULL, "print general-purpose registers", kmt_regs },
-	{ "stack", "?[cnt]", "print stack backtrace", kmt_stack },
-	{ "stackregs", "?", "print stack backtrace and registers", kmt_stackr },
+	{ "stack", "?[-stv] [cnt]", "print stack backtrace", kmt_stack,
+	    kmt_stack_help },
+	{ "stackregs", "?[-stv] [cnt]", "print stack backtrace and registers",
+	    kmt_stackr, kmt_stack_help },
 	{ "status", NULL, "print summary of current target", kmt_status_dcmd },
 	{ "switch", ":", "change the active CPU", kmt_switch },
 	{ NULL }

--- a/usr/src/cmd/mdb/common/kmdb/kmdb_kvm.c
+++ b/usr/src/cmd/mdb/common/kmdb/kmdb_kvm.c
@@ -615,6 +615,7 @@ kmt_stack_help(void)
 {
 	mdb_printf(
 	    "Options:\n"
+	    "  -n   do not resolve addresses to names\n"
 	    "  -s   show the size of each stack frame to the left\n"
 	    "  -t   where CTF is present, show types for functions and "
 	    "arguments\n"
@@ -626,9 +627,9 @@ kmt_stack_help(void)
 }
 
 static const mdb_dcmd_t kmt_dcmds[] = {
-	{ "$c", "?[-stv] [cnt]", "print stack backtrace", kmt_stack,
+	{ "$c", "?[-nstv] [cnt]", "print stack backtrace", kmt_stack,
 	    kmt_stack_help },
-	{ "$C", "?[-stv] [cnt]", "print stack backtrace", kmt_stackv,
+	{ "$C", "?[-nstv] [cnt]", "print stack backtrace", kmt_stackv,
 	    kmt_stack_help },
 	{ "$r", NULL, "print general-purpose registers", kmt_regs },
 	{ "$?", NULL, "print status and registers", kmt_regs },
@@ -651,9 +652,9 @@ static const mdb_dcmd_t kmt_dcmds[] = {
 #endif
 	{ "noducttape", NULL, NULL, kmt_noducttape },
 	{ "regs", NULL, "print general-purpose registers", kmt_regs },
-	{ "stack", "?[-stv] [cnt]", "print stack backtrace", kmt_stack,
+	{ "stack", "?[-nstv] [cnt]", "print stack backtrace", kmt_stack,
 	    kmt_stack_help },
-	{ "stackregs", "?[-stv] [cnt]", "print stack backtrace and registers",
+	{ "stackregs", "?[-nstv] [cnt]", "print stack backtrace and registers",
 	    kmt_stackr, kmt_stack_help },
 	{ "status", NULL, "print summary of current target", kmt_status_dcmd },
 	{ "switch", ":", "change the active CPU", kmt_switch },

--- a/usr/src/cmd/mdb/common/kmdb/kvm.h
+++ b/usr/src/cmd/mdb/common/kmdb/kvm.h
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef _KVM_H
@@ -145,7 +146,7 @@ extern int kmt_next(mdb_tgt_t *, uintptr_t *);
 extern int kmt_stack(uintptr_t, uint_t, int, const mdb_arg_t *);
 extern int kmt_stackv(uintptr_t, uint_t, int, const mdb_arg_t *);
 extern int kmt_stackr(uintptr_t, uint_t, int, const mdb_arg_t *);
-extern int kmt_cpustack(uintptr_t, uint_t, int, const mdb_arg_t *, int, int);
+extern int kmt_cpustack(uintptr_t, uint_t, int, const mdb_arg_t *, int, uint_t);
 
 extern const char *kmt_trapname(int);
 

--- a/usr/src/cmd/mdb/common/mdb/mdb_ctf.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_ctf.c
@@ -573,6 +573,18 @@ mdb_ctf_type_name(mdb_ctf_id_t id, char *buf, size_t len)
 }
 
 ssize_t
+mdb_ctf_type_lname(mdb_ctf_id_t id, char *buf, size_t len)
+{
+	mdb_ctf_impl_t *idp = (mdb_ctf_impl_t *)&id;
+	char *ret;
+
+	if (!mdb_ctf_type_valid(id))
+		return (set_errno(EINVAL));
+
+	return (ctf_type_lname(idp->mci_fp, idp->mci_id, buf, len));
+}
+
+ssize_t
 mdb_ctf_type_size(mdb_ctf_id_t id)
 {
 	mdb_ctf_impl_t *idp = (mdb_ctf_impl_t *)&id;

--- a/usr/src/cmd/mdb/common/mdb/mdb_ctf.h
+++ b/usr/src/cmd/mdb/common/mdb/mdb_ctf.h
@@ -25,6 +25,7 @@
 /*
  * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef	_MDB_CTF_H
@@ -91,6 +92,7 @@ extern int mdb_ctf_type_cmp(mdb_ctf_id_t, mdb_ctf_id_t);
 
 extern int mdb_ctf_type_resolve(mdb_ctf_id_t, mdb_ctf_id_t *);
 extern char *mdb_ctf_type_name(mdb_ctf_id_t, char *, size_t);
+extern ssize_t mdb_ctf_type_lname(mdb_ctf_id_t, char *, size_t);
 extern ssize_t mdb_ctf_type_size(mdb_ctf_id_t);
 extern int mdb_ctf_type_kind(mdb_ctf_id_t);
 extern int mdb_ctf_type_reference(const mdb_ctf_id_t, mdb_ctf_id_t *);

--- a/usr/src/cmd/mdb/common/mdb/mdb_kvm.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_kvm.c
@@ -24,6 +24,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2025 Oxide Computer Company
  */
 
 /*
@@ -514,14 +515,33 @@ kt_status_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	return (DCMD_OK);
 }
 
+static void
+kt_stack_help(void)
+{
+	mdb_printf(
+	    "Options:\n"
+	    "  -s   show the size of each stack frame to the left\n"
+	    "  -t   where CTF is present, show types for functions and "
+	    "arguments\n"
+	    "  -v   include frame pointer information (this is the default "
+	    "with %<b>$C%</b>)\n"
+	    "\n"
+	    "If the optional %<u>cnt%</u> is given, no more than %<u>cnt%</u> "
+	    "arguments are shown\nfor each stack frame.\n");
+}
+
 static const mdb_dcmd_t kt_dcmds[] = {
-	{ "$c", "?[cnt]", "print stack backtrace", kt_stack },
-	{ "$C", "?[cnt]", "print stack backtrace", kt_stackv },
+	{ "$c", "?[-stv] [cnt]", "print stack backtrace", kt_stack,
+	    kt_stack_help },
+	{ "$C", "?[-stv] [cnt]", "print stack backtrace", kt_stackv,
+	    kt_stack_help },
 	{ "$r", NULL, "print general-purpose registers", kt_regs },
 	{ "$?", NULL, "print status and registers", kt_regs },
 	{ "regs", NULL, "print general-purpose registers", kt_regs },
-	{ "stack", "?[cnt]", "print stack backtrace", kt_stack },
-	{ "stackregs", "?", "print stack backtrace and registers", kt_stackr },
+	{ "stack", "?[-stv] [cnt]", "print stack backtrace", kt_stack,
+	    kt_stack_help },
+	{ "stackregs", "?[-stv] [cnt]", "print stack backtrace and registers",
+	    kt_stackr, kt_stack_help },
 #ifdef __x86
 	{ "cpustack", "?[-v] [-c cpuid] [cnt]", "print stack backtrace for a "
 	    "specific CPU", kt_cpustack },

--- a/usr/src/cmd/mdb/common/mdb/mdb_kvm.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_kvm.c
@@ -520,6 +520,7 @@ kt_stack_help(void)
 {
 	mdb_printf(
 	    "Options:\n"
+	    "  -n   do not resolve addresses to names\n"
 	    "  -s   show the size of each stack frame to the left\n"
 	    "  -t   where CTF is present, show types for functions and "
 	    "arguments\n"
@@ -531,16 +532,16 @@ kt_stack_help(void)
 }
 
 static const mdb_dcmd_t kt_dcmds[] = {
-	{ "$c", "?[-stv] [cnt]", "print stack backtrace", kt_stack,
+	{ "$c", "?[-nstv] [cnt]", "print stack backtrace", kt_stack,
 	    kt_stack_help },
-	{ "$C", "?[-stv] [cnt]", "print stack backtrace", kt_stackv,
+	{ "$C", "?[-nstv] [cnt]", "print stack backtrace", kt_stackv,
 	    kt_stack_help },
 	{ "$r", NULL, "print general-purpose registers", kt_regs },
 	{ "$?", NULL, "print status and registers", kt_regs },
 	{ "regs", NULL, "print general-purpose registers", kt_regs },
-	{ "stack", "?[-stv] [cnt]", "print stack backtrace", kt_stack,
+	{ "stack", "?[-nstv] [cnt]", "print stack backtrace", kt_stack,
 	    kt_stack_help },
-	{ "stackregs", "?[-stv] [cnt]", "print stack backtrace and registers",
+	{ "stackregs", "?[-nstv] [cnt]", "print stack backtrace and registers",
 	    kt_stackr, kt_stack_help },
 #ifdef __x86
 	{ "cpustack", "?[-v] [-c cpuid] [cnt]", "print stack backtrace for a "

--- a/usr/src/cmd/mdb/common/mdb/mdb_proc.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_proc.c
@@ -88,6 +88,7 @@
 #include <mdb/mdb_proc.h>
 #include <mdb/mdb_disasm.h>
 #include <mdb/mdb_signal.h>
+#include <mdb/mdb_stack.h>
 #include <mdb/mdb_string.h>
 #include <mdb/mdb_module.h>
 #include <mdb/mdb_debug.h>
@@ -997,76 +998,78 @@ pt_setflags(mdb_tgt_t *t, int flags)
 	return (0);
 }
 
-/*ARGSUSED*/
 static int
-pt_frame(void *arglim, uintptr_t pc, uint_t argc, const long *argv,
+pt_frame(void *argp, uintptr_t pc, uint_t argc, const long *argv,
     const mdb_tgt_gregset_t *gregs)
 {
-	argc = MIN(argc, (uint_t)(uintptr_t)arglim);
-	mdb_printf("%a(", pc);
+	mdb_stack_frame_hdl_t *hdl = argp;
+	uint64_t bp;
 
-	if (argc != 0) {
-		mdb_printf("%lr", *argv++);
-		for (argc--; argc != 0; argc--)
-			mdb_printf(", %lr", *argv++);
-	}
-
-	mdb_printf(")\n");
-	return (0);
-}
-
-static int
-pt_framev(void *arglim, uintptr_t pc, uint_t argc, const long *argv,
-    const mdb_tgt_gregset_t *gregs)
-{
-	argc = MIN(argc, (uint_t)(uintptr_t)arglim);
 #if defined(__i386) || defined(__amd64)
-	mdb_printf("%0?lr %a(", gregs->gregs[R_FP], pc);
+	bp = gregs->gregs[R_FP];
 #else
-	mdb_printf("%0?lr %a(", gregs->gregs[R_SP], pc);
+	bp = gregs->gregs[R_SP];
 #endif
-	if (argc != 0) {
-		mdb_printf("%lr", *argv++);
-		for (argc--; argc != 0; argc--)
-			mdb_printf(", %lr", *argv++);
-	}
 
-	mdb_printf(")\n");
+	mdb_stack_frame(hdl, pc, bp, argc, argv);
+
 	return (0);
 }
 
 static int
-pt_framer(void *arglim, uintptr_t pc, uint_t argc, const long *argv,
+pt_framer(void *argp, uintptr_t pc, uint_t argc, const long *argv,
     const mdb_tgt_gregset_t *gregs)
 {
-	if (pt_frameregs(arglim, pc, argc, argv, gregs, pc == PC_FAKE) == -1) {
+	mdb_stack_frame_hdl_t *hdl = argp;
+
+	uint_t arglim = mdb_stack_frame_arglim(hdl);
+
+	if (pt_frameregs((void *)(uintptr_t)arglim, pc,
+	    argc, argv, gregs, pc == PC_FAKE) == -1) {
 		/*
 		 * Use verbose format if register format is not supported.
 		 */
-		return (pt_framev(arglim, pc, argc, argv, gregs));
+		mdb_stack_frame_flags_set(hdl, MSF_VERBOSE);
+		return (pt_frame((void *)hdl, pc, argc, argv, gregs));
 	}
 
 	return (0);
 }
 
-/*ARGSUSED*/
 static int
 pt_stack_common(uintptr_t addr, uint_t flags, int argc,
-    const mdb_arg_t *argv, mdb_tgt_stack_f *func, prgreg_t saved_pc)
+    const mdb_arg_t *argv, mdb_stack_frame_flags_t sflags,
+    mdb_tgt_stack_f *func, prgreg_t saved_pc)
 {
-	void *arg = (void *)(uintptr_t)mdb.m_nargs;
 	mdb_tgt_t *t = mdb.m_target;
 	mdb_tgt_gregset_t gregs;
+	mdb_stack_frame_hdl_t *hdl;
+	uint_t arglim = mdb.m_nargs;
+	int i;
+
+	i = mdb_getopts(argc, argv,
+	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
+	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
+	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,
+	    NULL);
+
+	argc -= i;
+	argv += i;
 
 	if (argc != 0) {
 		if (argv->a_type == MDB_TYPE_CHAR || argc > 1)
 			return (DCMD_USAGE);
 
-		arg = (void *)(uintptr_t)mdb_argtoull(argv);
+		arglim = mdb_argtoull(argv);
 	}
 
 	if (t->t_pshandle == NULL || Pstate(t->t_pshandle) == PS_IDLE) {
 		mdb_warn("no process active\n");
+		return (DCMD_ERR);
+	}
+
+	if ((hdl = mdb_stack_frame_init(t, arglim, sflags)) == NULL) {
+		mdb_warn("failed to init stack frame\n");
 		return (DCMD_ERR);
 	}
 
@@ -1087,20 +1090,21 @@ pt_stack_common(uintptr_t addr, uint_t flags, int argc,
 		return (DCMD_ERR);
 	}
 
-	(void) mdb_tgt_stack_iter(t, &gregs, func, arg);
+	(void) mdb_tgt_stack_iter(t, &gregs, func, (void *)hdl);
 	return (DCMD_OK);
 }
 
 static int
 pt_stack(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	return (pt_stack_common(addr, flags, argc, argv, pt_frame, 0));
+	return (pt_stack_common(addr, flags, argc, argv, 0, pt_frame, 0));
 }
 
 static int
 pt_stackv(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	return (pt_stack_common(addr, flags, argc, argv, pt_framev, 0));
+	return (pt_stack_common(addr, flags, argc, argv, MSF_VERBOSE,
+	    pt_frame, 0));
 }
 
 static int
@@ -1110,7 +1114,8 @@ pt_stackr(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 	 * Force printing of first register window, by setting  the
 	 * saved pc (%i7) to PC_FAKE.
 	 */
-	return (pt_stack_common(addr, flags, argc, argv, pt_framer, PC_FAKE));
+	return (pt_stack_common(addr, flags, argc, argv, 0,
+	    pt_framer, PC_FAKE));
 }
 
 /*ARGSUSED*/
@@ -1331,15 +1336,20 @@ pt_findstack(uintptr_t tid, uint_t flags, int argc, const mdb_arg_t *argv)
 {
 	mdb_tgt_t *t = mdb.m_target;
 	mdb_tgt_gregset_t gregs;
-	int showargs = 0;
+	boolean_t showargs = B_FALSE;
+	boolean_t types = B_FALSE;
+	boolean_t sizes = B_FALSE;
 	int count;
 	uintptr_t pc, sp;
-	char name[128];
+	char buf[128];
 
 	if (!(flags & DCMD_ADDRSPEC))
 		return (DCMD_USAGE);
 
-	count = mdb_getopts(argc, argv, 'v', MDB_OPT_SETBITS, TRUE, &showargs,
+	count = mdb_getopts(argc, argv,
+	    's', MDB_OPT_SETBITS, TRUE, &sizes,
+	    't', MDB_OPT_SETBITS, TRUE, &types,
+	    'v', MDB_OPT_SETBITS, TRUE, &showargs,
 	    NULL);
 	argc -= count;
 	argv += count;
@@ -1359,21 +1369,25 @@ pt_findstack(uintptr_t tid, uint_t flags, int argc, const mdb_arg_t *argv)
 	sp = gregs.gregs[R_SP];
 #endif
 
-	(void) pt_thread_name(t, tid, name, sizeof (name));
+	(void) pt_thread_name(t, tid, buf, sizeof (buf));
 
-	mdb_printf("stack pointer for thread %s: %p\n", name, sp);
+	mdb_printf("stack pointer for thread %s: %p\n", buf, sp);
 	if (pc != 0)
 		mdb_printf("[ %0?lr %a() ]\n", sp, pc);
 
 	(void) mdb_inc_indent(2);
 	mdb_set_dot(sp);
 
-	if (argc == 1)
+	if (argc == 1) {
 		(void) mdb_eval(argv->a_un.a_str);
-	else if (showargs)
-		(void) mdb_eval("<.$C");
-	else
-		(void) mdb_eval("<.$C0");
+	} else {
+		(void) mdb_snprintf(buf, sizeof (buf),
+		    "<.$C%s%s%s",
+		    sizes ? " -s" : "",
+		    types ? " -t" : "",
+		    showargs ? "" : " 0");
+		(void) mdb_eval(buf);
+	}
 
 	(void) mdb_dec_indent(2);
 	return (DCMD_OK);
@@ -2171,9 +2185,40 @@ getenv_help(void)
 	    " instead of initial environment.\n");
 }
 
+static void
+pt_stack_help(void)
+{
+	mdb_printf(
+	    "Options:\n"
+	    "  -s   show the size of each stack frame to the left\n"
+	    "  -t   where CTF is present, show types for functions and "
+	    "arguments\n"
+	    "  -v   include frame pointer information (this is the default "
+	    "for %<b>$C%</b>)\n"
+	    "\n"
+	    "If the optional %<u>cnt%</u> is given, no more than %<u>cnt%</u> "
+	    "arguments are shown\nfor each stack frame.\n");
+}
+
+static void
+pt_findstack_help(void)
+{
+	mdb_printf(
+	    "Options:\n"
+	    "  -s   show the size of each stack frame to the left\n"
+	    "  -t   where CTF is present, show types for functions and "
+	    "arguments\n"
+	    "  -v   show function arguments\n"
+	    "\n"
+	    "If the optional %<u>cnt%</u> is given, no more than %<u>cnt%</u> "
+	    "arguments are shown\nfor each stack frame.\n");
+}
+
 static const mdb_dcmd_t pt_dcmds[] = {
-	{ "$c", "?[cnt]", "print stack backtrace", pt_stack },
-	{ "$C", "?[cnt]", "print stack backtrace", pt_stackv },
+	{ "$c", "?[-stv] [cnt]", "print stack backtrace", pt_stack,
+	    pt_stack_help },
+	{ "$C", "?[-stv] [cnt]", "print stack backtrace", pt_stackv,
+	    pt_stack_help },
 	{ "$i", NULL, "print signals that are ignored", pt_ignored },
 	{ "$l", NULL, "print the representative thread's lwp id", pt_lwpid },
 	{ "$L", NULL, "print list of the active lwp ids", pt_lwpids },
@@ -2189,7 +2234,8 @@ static const mdb_dcmd_t pt_dcmds[] = {
 	{ ":R", "[-a]", "release the previously attached process", pt_detach },
 	{ "attach", "?[core|pid]",
 	    "attach to process or core file", pt_attach },
-	{ "findstack", ":[-v]", "find user thread stack", pt_findstack },
+	{ "findstack", ":[-stv]", "find user thread stack", pt_findstack,
+	    pt_findstack_help },
 	{ "gcore", "[-o prefix] [-c content]",
 	    "produce a core file for the attached process", pt_gcore },
 	{ "getenv", "[-t] [name]", "display an environment variable",
@@ -2200,8 +2246,10 @@ static const mdb_dcmd_t pt_dcmds[] = {
 	{ "regs", "?[-u]", "print general-purpose registers", pt_regs },
 	{ "fpregs", "?[-dqs]", "print floating point registers", pt_fpregs },
 	{ "setenv", "name=value", "set an environment variable", pt_setenv },
-	{ "stack", "?[cnt]", "print stack backtrace", pt_stack },
-	{ "stackregs", "?", "print stack backtrace and registers", pt_stackr },
+	{ "stack", "?[-stv] [cnt]", "print stack backtrace", pt_stack,
+	    pt_stack_help },
+	{ "stackregs", "?[-stv]", "print stack backtrace and registers",
+	    pt_stackr, pt_stack_help },
 	{ "status", NULL, "print summary of current target", pt_status_dcmd },
 	{ "tls", ":symbol",
 	    "lookup TLS data in the context of a given thread", pt_tls },

--- a/usr/src/cmd/mdb/common/mdb/mdb_stack.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_stack.c
@@ -1,0 +1,188 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Oxide Computer Company
+ */
+
+/*
+ * Common code to help printing stack frames in a consistent way, and with
+ * options to include frame size and type data where it can be retrieved from
+ * CTF data.
+ */
+
+#include <sys/types.h>
+
+#include <mdb/mdb_string.h>
+#include <mdb/mdb_modapi.h>
+#include <mdb/mdb_debug.h>
+#include <mdb/mdb_ctf.h>
+#include <mdb/mdb_stack.h>
+#include <mdb/mdb.h>
+
+typedef struct {
+	mdb_tgt_t		*msfd_tgt;
+	uint_t			msfd_arglim;
+	mdb_stack_frame_flags_t	msfd_flags;
+	uintptr_t		msfd_lastbp;
+	char			*msfd_buf;
+	size_t			msfd_buflen;
+} mdb_stack_frame_data_t;
+
+mdb_stack_frame_hdl_t *
+mdb_stack_frame_init(mdb_tgt_t *tgt, uint_t arglim,
+    mdb_stack_frame_flags_t flags)
+{
+	mdb_stack_frame_data_t *data;
+
+	data = mdb_alloc(sizeof (*data), UM_SLEEP | UM_GC);
+	if (data == NULL)
+		return (NULL);
+	data->msfd_tgt = tgt;
+	data->msfd_arglim = arglim;
+	data->msfd_flags = flags;
+	data->msfd_lastbp = 0;
+	data->msfd_buf = NULL;
+	data->msfd_buflen = 0;
+
+	return (data);
+}
+
+uint_t
+mdb_stack_frame_arglim(mdb_stack_frame_hdl_t *datap)
+{
+	mdb_stack_frame_data_t *data = datap;
+
+	return (data->msfd_arglim);
+}
+
+void
+mdb_stack_frame_flags_set(mdb_stack_frame_hdl_t *datap,
+    mdb_stack_frame_flags_t flags)
+{
+	mdb_stack_frame_data_t *data = datap;
+
+	ASSERT((flags & ~MSF_ALL) == 0);
+	data->msfd_flags |= flags;
+}
+
+static char *
+mdb_stack_typename(mdb_ctf_id_t id, char **bufp, size_t *lenp)
+{
+	char *buf = *bufp;
+	size_t len = *lenp;
+	ssize_t newlen;
+
+	if (mdb_ctf_type_name(id, buf, len) != NULL)
+		return (buf);
+
+	/*
+	 * Retrieve the buffer size required to store this type.
+	 */
+	newlen = mdb_ctf_type_lname(id, NULL, 0) + 1;
+	/*
+	 * To avoid reallocations in most cases, we always allocate at least
+	 * space for 32 characters and the NUL terminator. This will
+	 * accommodate most types.
+	 */
+	newlen = MAX(newlen, 33);
+	if (newlen > len) {
+		char *newbuf = mdb_alloc(newlen, UM_SLEEP | UM_GC);
+		if (newbuf == NULL)
+			return (NULL);
+		mdb_free(buf, len);
+		*bufp = newbuf;
+		*lenp = newlen;
+		return (mdb_ctf_type_name(id, newbuf, newlen));
+	}
+
+	return (NULL);
+}
+
+void
+mdb_stack_frame(mdb_stack_frame_hdl_t *datap, uintptr_t pc, uintptr_t bp,
+    uint_t argc, const long *argv)
+{
+	mdb_stack_frame_data_t *data = datap;
+	uint_t nargc = MIN(argc, data->msfd_arglim);
+	mdb_ctf_id_t argtypes[nargc];
+	mdb_ctf_funcinfo_t mcfi;
+	boolean_t ctf;
+	mdb_syminfo_t msi;
+	GElf_Sym sym;
+	uint_t i;
+
+	ctf = B_FALSE;
+
+	if ((data->msfd_flags & MSF_TYPES) &&
+	    mdb_tgt_lookup_by_addr(data->msfd_tgt, pc, MDB_TGT_SYM_FUZZY,
+	    NULL, 0, &sym, &msi) == 0 &&
+	    mdb_ctf_func_info(&sym, &msi, &mcfi) == 0) {
+		ctf = B_TRUE;
+	}
+
+	if (data->msfd_flags & MSF_SIZES) {
+		if (data->msfd_lastbp != 0)
+			mdb_printf("[%4lr] ", bp - data->msfd_lastbp);
+		else
+			mdb_printf("%7s", "");
+		data->msfd_lastbp = bp;
+	}
+
+	if (data->msfd_flags & MSF_VERBOSE)
+		mdb_printf("%0?lr ", bp);
+
+	if (ctf) {
+		if (mdb_stack_typename(mcfi.mtf_return,
+		    &data->msfd_buf, &data->msfd_buflen) != NULL) {
+			mdb_printf("%s ", data->msfd_buf);
+		}
+	}
+
+	mdb_printf("%a(", pc);
+
+	if (ctf && mdb_ctf_func_args(&mcfi, nargc, argtypes) != 0)
+		ctf = B_FALSE;
+
+	for (i = 0; i < nargc; i++) {
+		if (i > 0)
+			mdb_printf(", ");
+		if (ctf && mdb_stack_typename(argtypes[i],
+		    &data->msfd_buf, &data->msfd_buflen) != NULL) {
+			const char *type = data->msfd_buf;
+
+			switch (mdb_ctf_type_kind(argtypes[i])) {
+			case CTF_K_POINTER:
+				if (argv[i] == 0)
+					mdb_printf("(%s)NULL", type);
+				else
+					mdb_printf("(%s)%lr", type, argv[i]);
+				break;
+			case CTF_K_ENUM: {
+				const char *cp;
+
+				cp = mdb_ctf_enum_name(argtypes[i], argv[i]);
+				if (cp != NULL)
+					mdb_printf("(%s)%s", type, cp);
+				else
+					mdb_printf("(%s)%lr", type, argv[i]);
+				break;
+			}
+			default:
+				mdb_printf("(%s)%lr", type, argv[i]);
+			}
+		} else {
+			mdb_printf("%lr", argv[i]);
+		}
+	}
+
+	mdb_printf(")\n");
+}

--- a/usr/src/cmd/mdb/common/mdb/mdb_stack.h
+++ b/usr/src/cmd/mdb/common/mdb/mdb_stack.h
@@ -28,10 +28,11 @@ typedef void mdb_stack_frame_hdl_t;
 typedef enum {
 	MSF_VERBOSE		= 1 << 0,
 	MSF_TYPES		= 1 << 1,
-	MSF_SIZES		= 1 << 2
+	MSF_SIZES		= 1 << 2,
+	MSF_ADDR		= 1 << 3
 } mdb_stack_frame_flags_t;
 
-#define	MSF_ALL	(MSF_VERBOSE|MSF_TYPES|MSF_SIZES)
+#define	MSF_ALL	(MSF_VERBOSE|MSF_TYPES|MSF_SIZES|MSF_ADDR)
 
 extern mdb_stack_frame_hdl_t *mdb_stack_frame_init(mdb_tgt_t *, uint_t,
     mdb_stack_frame_flags_t);

--- a/usr/src/cmd/mdb/common/mdb/mdb_stack.h
+++ b/usr/src/cmd/mdb/common/mdb/mdb_stack.h
@@ -1,0 +1,48 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Oxide Computer Company
+ */
+
+#ifndef	_MDB_STACK_H
+#define	_MDB_STACK_H
+
+#include <sys/types.h>
+#include <mdb/mdb_target.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef void mdb_stack_frame_hdl_t;
+
+typedef enum {
+	MSF_VERBOSE		= 1 << 0,
+	MSF_TYPES		= 1 << 1,
+	MSF_SIZES		= 1 << 2
+} mdb_stack_frame_flags_t;
+
+#define	MSF_ALL	(MSF_VERBOSE|MSF_TYPES|MSF_SIZES)
+
+extern mdb_stack_frame_hdl_t *mdb_stack_frame_init(mdb_tgt_t *, uint_t,
+    mdb_stack_frame_flags_t);
+extern void mdb_stack_frame(mdb_stack_frame_hdl_t *, uintptr_t, uintptr_t,
+    uint_t, const long *);
+extern uint_t mdb_stack_frame_arglim(mdb_stack_frame_hdl_t *);
+extern void mdb_stack_frame_flags_set(mdb_stack_frame_hdl_t *,
+    mdb_stack_frame_flags_t);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _MDB_STACK_H */

--- a/usr/src/cmd/mdb/common/modules/conf/mapfile-extern
+++ b/usr/src/cmd/mdb/common/modules/conf/mapfile-extern
@@ -161,6 +161,10 @@ SYMBOL_SCOPE {
 		mdb_set_pipe			{ FLAGS = EXTERN };
 		mdb_snprintf			{ FLAGS = EXTERN };
 		mdb_strtoull			{ FLAGS = EXTERN };
+		mdb_stack_frame			{ FLAGS = EXTERN };
+		mdb_stack_frame_arglim		{ FLAGS = EXTERN };
+		mdb_stack_frame_flags_set	{ FLAGS = EXTERN };
+		mdb_stack_frame_init		{ FLAGS = EXTERN };
 		mdb_symbol_iter			{ FLAGS = EXTERN };
 		mdb_tgt_notsup			{ FLAGS = EXTERN };
 		mdb_thread_name			{ FLAGS = EXTERN };

--- a/usr/src/cmd/mdb/common/modules/genunix/findstack.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/findstack.c
@@ -58,10 +58,12 @@ print_stack(uintptr_t sp, uintptr_t pc, uintptr_t addr,
 	boolean_t showargs = B_FALSE;
 	boolean_t types = B_FALSE;
 	boolean_t sizes = B_FALSE;
+	boolean_t addrs = B_FALSE;
 	int count, err;
 	char tdesc[128] = "";
 
 	count = mdb_getopts(argc, argv,
+	    'n', MDB_OPT_SETBITS, TRUE, &addrs,
 	    's', MDB_OPT_SETBITS, TRUE, &sizes,
 	    't', MDB_OPT_SETBITS, TRUE, &types,
 	    'v', MDB_OPT_SETBITS, TRUE, &showargs,
@@ -86,7 +88,8 @@ print_stack(uintptr_t sp, uintptr_t pc, uintptr_t addr,
 		err = mdb_eval(argv->a_un.a_str);
 	} else {
 		(void) mdb_snprintf(tdesc, sizeof (tdesc),
-		    "<.$C%s%s%s",
+		    "<.$C%s%s%s%s",
+		    addrs ? " -n" : "",
 		    sizes ? " -s" : "",
 		    types ? " -t" : "",
 		    showargs ? "" : " 0");

--- a/usr/src/cmd/mdb/common/modules/genunix/findstack.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/findstack.c
@@ -23,6 +23,7 @@
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #include <mdb/mdb_modapi.h>
@@ -54,11 +55,17 @@ static int
 print_stack(uintptr_t sp, uintptr_t pc, uintptr_t addr,
     int argc, const mdb_arg_t *argv, int free_state)
 {
-	int showargs = 0, count, err;
+	boolean_t showargs = B_FALSE;
+	boolean_t types = B_FALSE;
+	boolean_t sizes = B_FALSE;
+	int count, err;
 	char tdesc[128] = "";
 
 	count = mdb_getopts(argc, argv,
-	    'v', MDB_OPT_SETBITS, TRUE, &showargs, NULL);
+	    's', MDB_OPT_SETBITS, TRUE, &sizes,
+	    't', MDB_OPT_SETBITS, TRUE, &types,
+	    'v', MDB_OPT_SETBITS, TRUE, &showargs,
+	    NULL);
 	argc -= count;
 	argv += count;
 
@@ -75,12 +82,16 @@ print_stack(uintptr_t sp, uintptr_t pc, uintptr_t addr,
 	mdb_inc_indent(2);
 	mdb_set_dot(sp);
 
-	if (argc == 1)
+	if (argc == 1) {
 		err = mdb_eval(argv->a_un.a_str);
-	else if (showargs)
-		err = mdb_eval("<.$C");
-	else
-		err = mdb_eval("<.$C0");
+	} else {
+		(void) mdb_snprintf(tdesc, sizeof (tdesc),
+		    "<.$C%s%s%s",
+		    sizes ? " -s" : "",
+		    types ? " -t" : "",
+		    showargs ? "" : " 0");
+		err = mdb_eval(tdesc);
+	}
 
 	mdb_dec_indent(2);
 

--- a/usr/src/cmd/mdb/common/modules/genunix/genunix.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/genunix.c
@@ -4109,6 +4109,7 @@ findstack_help(void)
 {
 	mdb_printf(
 	    "Options:\n"
+	    "  -n   do not resolve addresses to names\n"
 	    "  -s   show the size of each stack frame to the left\n"
 	    "  -t   where CTF is present, show types for functions and "
 	    "arguments\n"
@@ -4238,7 +4239,7 @@ static const mdb_dcmd_t dcmds[] = {
 	    devinfo_fmce},
 
 	/* from findstack.c */
-	{ "findstack", ":[-stv]", "find kernel thread stack", findstack,
+	{ "findstack", ":[-nstv]", "find kernel thread stack", findstack,
 		findstack_help },
 	{ "findstack_debug", NULL, "toggle findstack debugging",
 		findstack_debug },

--- a/usr/src/cmd/mdb/common/modules/genunix/genunix.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/genunix.c
@@ -4098,10 +4098,24 @@ time_help(void)
 	    "if called from, kmdb(1); the core dump's high resolution \n"
 	    "time if inspecting one; or the running hires time if we're \n"
 	    "looking at a live system.\n\n"
-	    "Switches:\n"
+	    "Options:\n"
 	    "  -d   report times in decimal\n"
 	    "  -l   prints the number of clock ticks since system boot\n"
 	    "  -x   report times in hexadecimal\n");
+}
+
+static void
+findstack_help(void)
+{
+	mdb_printf(
+	    "Options:\n"
+	    "  -s   show the size of each stack frame to the left\n"
+	    "  -t   where CTF is present, show types for functions and "
+	    "arguments\n"
+	    "  -v   show function arguments\n"
+	    "\n"
+	    "If the optional %<u>cnt%</u> is given, no more than %<u>cnt%</u> "
+	    "arguments are shown\nfor each stack frame.\n");
 }
 
 extern int cmd_refstr(uintptr_t, uint_t, int, const mdb_arg_t *);
@@ -4224,7 +4238,8 @@ static const mdb_dcmd_t dcmds[] = {
 	    devinfo_fmce},
 
 	/* from findstack.c */
-	{ "findstack", ":[-v]", "find kernel thread stack", findstack },
+	{ "findstack", ":[-stv]", "find kernel thread stack", findstack,
+		findstack_help },
 	{ "findstack_debug", NULL, "toggle findstack debugging",
 		findstack_debug },
 	{ "stacks", "?[-afiv] [-c func] [-C func] [-m module] [-M module] "

--- a/usr/src/cmd/mdb/intel/kmdb/kvm_isadep.c
+++ b/usr/src/cmd/mdb/intel/kmdb/kvm_isadep.c
@@ -34,6 +34,7 @@
 #include <kmdb/kmdb_kdi.h>
 #include <kmdb/kmdb_asmutil.h>
 #include <mdb/mdb_debug.h>
+#include <mdb/mdb_stack.h>
 #include <mdb/mdb_err.h>
 #include <mdb/mdb_list.h>
 #include <mdb/mdb_target_impl.h>
@@ -120,66 +121,83 @@ kmt_next(mdb_tgt_t *t, uintptr_t *p)
 	return (mdb_isa_next(t, p, pc, instr));
 }
 
-/*ARGSUSED*/
 static int
 kmt_stack_common(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv,
-    int cpuid, mdb_tgt_stack_f *func)
+    int cpuid, mdb_stack_frame_flags_t sflags, mdb_tgt_stack_f *func)
 {
+	mdb_tgt_t *t = mdb.m_target;
 	const mdb_tgt_gregset_t *grp = NULL;
 	mdb_tgt_gregset_t gregs;
-	void *arg = (void *)(uintptr_t)mdb.m_nargs;
+	mdb_stack_frame_hdl_t *hdl;
+	uint_t arglim = mdb.m_nargs;
+	int i;
 
 	if (flags & DCMD_ADDRSPEC) {
 		bzero(&gregs, sizeof (gregs));
 		gregs.kregs[KREG_FP] = addr;
 		grp = &gregs;
-	} else
+	} else {
 		grp = kmdb_dpi_get_gregs(cpuid);
+	}
 
 	if (grp == NULL) {
 		warn("failed to retrieve registers for cpu %d", cpuid);
 		return (DCMD_ERR);
 	}
 
+	i = mdb_getopts(argc, argv,
+	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
+	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
+	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,
+	    NULL);
+
+	argc -= i;
+	argv += i;
+
 	if (argc != 0) {
 		if (argv->a_type == MDB_TYPE_CHAR || argc > 1)
 			return (DCMD_USAGE);
 
-		arg = (void *)(uintptr_t)mdb_argtoull(argv);
+		arglim = mdb_argtoull(argv);
 	}
 
-	(void) mdb_isa_kvm_stack_iter(mdb.m_target, grp, func, arg);
+	if ((hdl = mdb_stack_frame_init(t, arglim, sflags)) == NULL) {
+		mdb_warn("failed to init stack frame\n");
+		return (DCMD_ERR);
+	}
+
+	(void) mdb_isa_kvm_stack_iter(t, grp, func, (void *)hdl);
 
 	return (DCMD_OK);
 }
 
 int
 kmt_cpustack(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv,
-    int cpuid, int verbose)
+    int cpuid, uint_t verbose)
 {
 	return (kmt_stack_common(addr, flags, argc, argv, cpuid,
-	    (verbose ? mdb_isa_kvm_framev : mdb_isa_kvm_frame)));
+	    verbose != 0 ? MSF_VERBOSE : 0, mdb_isa_kvm_frame));
 }
 
 int
 kmt_stack(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
 	return (kmt_stack_common(addr, flags, argc, argv, DPI_MASTER_CPUID,
-	    mdb_isa_kvm_frame));
+	    0, mdb_isa_kvm_frame));
 }
 
 int
 kmt_stackv(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
 	return (kmt_stack_common(addr, flags, argc, argv, DPI_MASTER_CPUID,
-	    mdb_isa_kvm_framev));
+	    MSF_VERBOSE, mdb_isa_kvm_frame));
 }
 
 int
 kmt_stackr(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
 	return (kmt_stack_common(addr, flags, argc, argv, DPI_MASTER_CPUID,
-	    mdb_isa_kvm_framev));
+	    MSF_VERBOSE, mdb_isa_kvm_frame));
 }
 
 /*ARGSUSED*/

--- a/usr/src/cmd/mdb/intel/kmdb/kvm_isadep.c
+++ b/usr/src/cmd/mdb/intel/kmdb/kvm_isadep.c
@@ -146,6 +146,7 @@ kmt_stack_common(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv,
 	}
 
 	i = mdb_getopts(argc, argv,
+	    'n', MDB_OPT_SETBITS, MSF_ADDR, &sflags,
 	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
 	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
 	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,

--- a/usr/src/cmd/mdb/intel/mdb/kvm_amd64dep.c
+++ b/usr/src/cmd/mdb/intel/mdb/kvm_amd64dep.c
@@ -85,6 +85,7 @@ kt_stack_common(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv,
 	}
 
 	i = mdb_getopts(argc, argv,
+	    'n', MDB_OPT_SETBITS, MSF_ADDR, &sflags,
 	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
 	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
 	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,

--- a/usr/src/cmd/mdb/intel/mdb/kvm_ia32dep.c
+++ b/usr/src/cmd/mdb/intel/mdb/kvm_ia32dep.c
@@ -83,6 +83,7 @@ kt_stack_common(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv,
 		grp = kt->k_regs;
 
 	i = mdb_getopts(argc, argv,
+	    'n', MDB_OPT_SETBITS, MSF_ADDR, &sflags,
 	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
 	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
 	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,

--- a/usr/src/cmd/mdb/intel/mdb/kvm_ia32dep.c
+++ b/usr/src/cmd/mdb/intel/mdb/kvm_ia32dep.c
@@ -45,6 +45,7 @@
 #include <mdb/mdb_disasm.h>
 #include <mdb/mdb_modapi.h>
 #include <mdb/mdb_conf.h>
+#include <mdb/mdb_stack.h>
 #include <mdb/mdb_kreg_impl.h>
 #include <mdb/mdb_isautil.h>
 #include <mdb/mdb_ia32util.h>
@@ -64,12 +65,15 @@ kt_regs(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 }
 
 static int
-kt_stack_common(uintptr_t addr, uint_t flags, int argc,
-    const mdb_arg_t *argv, mdb_tgt_stack_f *func)
+kt_stack_common(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv,
+    mdb_stack_frame_flags_t sflags, mdb_tgt_stack_f *func)
 {
-	kt_data_t *kt = mdb.m_target->t_data;
-	void *arg = (void *)mdb.m_nargs;
+	mdb_tgt_t *t = mdb.m_target;
+	kt_data_t *kt = t->t_data;
 	mdb_tgt_gregset_t gregs, *grp;
+	mdb_stack_frame_hdl_t *hdl;
+	uint_t arglim = mdb.m_nargs;
+	int i;
 
 	if (flags & DCMD_ADDRSPEC) {
 		bzero(&gregs, sizeof (gregs));
@@ -78,27 +82,43 @@ kt_stack_common(uintptr_t addr, uint_t flags, int argc,
 	} else
 		grp = kt->k_regs;
 
+	i = mdb_getopts(argc, argv,
+	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
+	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
+	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,
+	    NULL);
+
+	argc -= i;
+	argv += i;
+
 	if (argc != 0) {
 		if (argv->a_type == MDB_TYPE_CHAR || argc > 1)
 			return (DCMD_USAGE);
 
-		arg = (void *)(uint_t)mdb_argtoull(argv);
+		arglim = mdb_argtoull(argv);
 	}
 
-	(void) mdb_ia32_kvm_stack_iter(mdb.m_target, grp, func, arg);
+	if ((hdl = mdb_stack_frame_init(t, arglim, sflags)) == NULL) {
+		mdb_warn("failed to init stack frame\n");
+		return (DCMD_ERR);
+	}
+
+	(void) mdb_ia32_kvm_stack_iter(mdb.m_target, grp, func, (void *)hdl);
 	return (DCMD_OK);
 }
 
 int
 kt_stack(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	return (kt_stack_common(addr, flags, argc, argv, mdb_ia32_kvm_frame));
+	return (kt_stack_common(addr, flags, argc, argv, 0,
+	    mdb_ia32_kvm_frame));
 }
 
 int
 kt_stackv(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	return (kt_stack_common(addr, flags, argc, argv, mdb_ia32_kvm_framev));
+	return (kt_stack_common(addr, flags, argc, argv, MSF_VERBOSE,
+	    mdb_ia32_kvm_frame));
 }
 
 const mdb_tgt_ops_t kt_ia32_ops = {

--- a/usr/src/cmd/mdb/intel/mdb/mdb_amd64util.c
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_amd64util.c
@@ -513,3 +513,78 @@ mdb_amd64_kvm_frame(void *argp, uintptr_t pc, uint_t argc, const long *argv,
 	mdb_stack_frame(hdl, pc, bp, argc, argv);
 	return (0);
 }
+
+/*
+ * Check if the instruction immediately before the given program counter (pcp)
+ * is a CALL instruction on AMD64. Since x86-64 instructions are
+ * variable-length, we read the 8 bytes preceding the PC and look for specific
+ * call encodings at known offsets that would align with common call
+ * instruction lengths. Although x86 instructions can be up to 15 bytes long,
+ * for a CALL to reach that length would require a long sequence of prefixes.
+ * Of those, only the address-size prefix would affect where we need to look
+ * for the instruction, and such prefixes are extremely rare in real-world
+ * code.
+ */
+boolean_t
+mdb_amd64_prev_callcheck(uintptr_t pcp)
+{
+	uint8_t buf[8];
+
+	/*
+	 * Ensure we can read 8 bytes before the PC. This accommodates the
+	 * largest call encoding we care about (far calls).
+	 */
+	if (pcp < 8 || mdb_vread(buf, sizeof (buf), pcp - 8) != sizeof (buf))
+		return (B_FALSE);
+
+	/*
+	 * Direct near call: CALL rel32
+	 * Opcode: E8, followed by 4-byte PC-relative offset.
+	 * Instruction is 5 bytes long; opcode is at buf[3].
+	 */
+	if (buf[3] == 0xe8)
+		return (B_TRUE);
+
+	/*
+	 * Indirect near call: CALL r/m64
+	 * Opcode: FF /2 (i.e., reg field of ModR/M is 010).
+	 *
+	 * We're expecting the instruction to be exactly 2 bytes: FF 14,
+	 * with opcode at buf[5] and ModR/M at buf[6].
+	 *
+	 * buf[6] == 0x14 means:
+	 *  - mod = 00 (no displacement)
+	 *  - reg = 010 (CALL)
+	 *  - r/m = 100 (SIB follows — typically [rsp])
+	 *
+	 * This form is common in PLT stubs like: CALL QWORD PTR [RSP]
+	 *
+	 * Other encodings of FF /2 are less plausible here:
+	 *  - mod = 01 - 8-bit displacement - unlikely for noreturn functions
+	 *  - mod = 10 - 32-bit displacement - would overlap with PC; invalid
+	 *  - mod = 00 with r/m != 100 - e.g., CALL RAX - would return to
+	 *    buf[7], not pcp
+	 */
+	if (buf[5] == 0xff && buf[6] == 0x14)
+		return (B_TRUE);
+
+	/*
+	 * Indirect RIP-relative call: CALL QWORD PTR [RIP + disp32]
+	 * Encoding: FF 15 xx xx xx xx
+	 * Instruction is 6 bytes long; opcode at buf[2], ModR/M at buf[3].
+	 * Common in PLT thunks and PIC code.
+	 */
+	if (buf[2] == 0xff && buf[3] == 0x15)
+		return (B_TRUE);
+
+	/*
+	 * Far call (segment-based): CALL FAR ptr16:32
+	 * Opcode: 9A, followed by 6-byte far pointer.
+	 * Rare in modern 64-bit code but still valid.
+	 * Instruction is 7 bytes; opcode at buf[0].
+	 */
+	if (buf[0] == 0x9a)
+		return (B_TRUE);
+
+	return (B_FALSE);
+}

--- a/usr/src/cmd/mdb/intel/mdb/mdb_amd64util.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_amd64util.h
@@ -49,6 +49,7 @@ extern int mdb_amd64_kvm_stack_iter(mdb_tgt_t *, const mdb_tgt_gregset_t *,
 
 extern int mdb_amd64_kvm_frame(void *, uintptr_t, uint_t, const long *,
     const mdb_tgt_gregset_t *);
+extern boolean_t mdb_amd64_prev_callcheck(uintptr_t);
 
 #ifdef __cplusplus
 }

--- a/usr/src/cmd/mdb/intel/mdb/mdb_amd64util.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_amd64util.h
@@ -24,6 +24,7 @@
  */
 /*
  * Copyright (c) 2018, Joyent, Inc.  All rights reserved.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef _MDB_AMD64UTIL_H
@@ -47,8 +48,6 @@ extern int mdb_amd64_kvm_stack_iter(mdb_tgt_t *, const mdb_tgt_gregset_t *,
     mdb_tgt_stack_f *, void *);
 
 extern int mdb_amd64_kvm_frame(void *, uintptr_t, uint_t, const long *,
-    const mdb_tgt_gregset_t *);
-extern int mdb_amd64_kvm_framev(void *, uintptr_t, uint_t, const long *,
     const mdb_tgt_gregset_t *);
 
 #ifdef __cplusplus

--- a/usr/src/cmd/mdb/intel/mdb/mdb_bhyve.c
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_bhyve.c
@@ -372,6 +372,7 @@ bhyve_stack_common(uintptr_t addr, uint_t flags, int argc,
 		return (DCMD_ERR);
 
 	i = mdb_getopts(argc, argv,
+	    'n', MDB_OPT_SETBITS, MSF_ADDR, &sflags,
 	    's', MDB_OPT_SETBITS, MSF_SIZES, &sflags,
 	    't', MDB_OPT_SETBITS, MSF_TYPES, &sflags,
 	    'v', MDB_OPT_SETBITS, MSF_VERBOSE, &sflags,
@@ -875,6 +876,7 @@ bhyve_stack_help(void)
 {
 	mdb_printf(
 	    "Options:\n"
+	    "  -n   do not resolve addresses to names\n"
 	    "  -s   show the size of each stack frame to the left\n"
 	    "  -t   where CTF is present, show types for functions and "
 	    "arguments\n"
@@ -886,9 +888,9 @@ bhyve_stack_help(void)
 }
 
 static const mdb_dcmd_t bhyve_dcmds[] = {
-	{ "$c", "[-stv]", "print stack backtrace", bhyve_stack_dcmd,
+	{ "$c", "[-nstv]", "print stack backtrace", bhyve_stack_dcmd,
 	    bhyve_stack_help },
-	{ "$C", "[-stv]", "print stack backtrace", bhyve_stackv_dcmd,
+	{ "$C", "[-nstv]", "print stack backtrace", bhyve_stackv_dcmd,
 	    bhyve_stack_help },
 	{ "$r", NULL, "print general-purpose registers", bhyve_regs_dcmd },
 	{ "$?", NULL, "print status and registers", bhyve_regs_dcmd },
@@ -902,9 +904,9 @@ static const mdb_dcmd_t bhyve_dcmds[] = {
 	{ "defseg", "?[-s segment]", "change the default segment used to "
 	    "translate addresses", bhyve_defseg_dcmd },
 	{ "regs", NULL, "print general-purpose registers", bhyve_regs_dcmd },
-	{ "stack", "[-stv]", "print stack backtrace", bhyve_stack_dcmd,
+	{ "stack", "[-nstv]", "print stack backtrace", bhyve_stack_dcmd,
 	    bhyve_stack_help },
-	{ "stackregs", "[-stv]", "print stack backtrace and registers",
+	{ "stackregs", "[-nstv]", "print stack backtrace and registers",
 	    bhyve_stackr_dcmd, bhyve_stack_help },
 	{ "status", NULL, "print summary of current target",
 	    bhyve_status_dcmd },

--- a/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.c
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.c
@@ -437,3 +437,76 @@ mdb_ia32_kvm_frame(void *argp, uintptr_t pc, uint_t argc, const long *argv,
 	mdb_stack_frame(hdl, pc, bp, argc, argv);
 	return (0);
 }
+
+/*
+ * Check if the instruction immediately before the given program counter (pcp)
+ * is a CALL instruction in IA-32 (x86 32-bit) mode. Since x86 instructions are
+ * variable-length, we read the 8 bytes preceding the PC and look for specific
+ * call encodings at known offsets that would align with common call
+ * instruction lengths. Although x86 instructions can be up to 15 bytes long,
+ * for a CALL to reach that length would require a long sequence of prefixes.
+ * Of those, only the address-size prefix would affect where we need to look
+ * for the instruction, and such prefixes are extremely rare in real-world
+ * code.
+ */
+boolean_t
+mdb_ia32_prev_callcheck(uintptr_t pcp)
+{
+	uint8_t buf[8];
+
+	/*
+	 * Ensure we can read 8 bytes before the PC. This accommodates the
+	 * largest call encoding we care about (far calls).
+	 */
+	if (pcp < 8 || mdb_vread(buf, sizeof (buf), pcp - 8) != sizeof (buf))
+		return (B_FALSE);
+
+	/*
+	 * Direct near call: CALL rel32
+	 * Opcode: E8, followed by 4-byte PC-relative offset.
+	 */
+	if (buf[3] == 0xe8)
+		return (B_TRUE);
+
+	/*
+	 * Indirect near call: CALL r/m32
+	 * Opcode: FF /2 (i.e., reg field of ModR/M is 010).
+	 *
+	 * We're expecting the instruction to be exactly 2 bytes: FF 14,
+	 * with opcode at buf[5] and ModR/M at buf[6].
+	 *
+	 * buf[6] == 0x14 means:
+	 *  - mod = 00 (no displacement)
+	 *  - reg = 010 (CALL)
+	 *  - r/m = 100 (SIB follows — typically [esp])
+	 *
+	 * This form is common in PLT stubs like: CALL DWORD PTR [ESP]
+	 *
+	 * Other encodings of FF /2 are less plausible here:
+	 *  - mod = 01 - 8-bit displacement - unlikely for noreturn functions
+	 *  - mod = 10 - 32-bit displacement - would overlap with PC; invalid
+	 *  - mod = 00 with r/m != 100 - e.g., CALL EAX - would return to
+	 *    buf[7], not pcp
+	 */
+	if (buf[5] == 0xff && buf[6] == 0x14)
+		return (B_TRUE);
+
+	/*
+	 * Indirect absolute call: CALL DWORD PTR [disp32]
+	 * Encoding: FF 15 xx xx xx xx
+	 * Instruction is 6 bytes long; opcode at buf[2], ModR/M at buf[3].
+	 * Used to call through global function pointers.
+	 */
+	if (buf[2] == 0xff && buf[3] == 0x15)
+		return (B_TRUE);
+
+	/*
+	 * Far call (segment-based): CALL FAR ptr16:32
+	 * Opcode: 9A, followed by 6-byte far pointer.
+	 * Instruction is 7 bytes; opcode at buf[0].
+	 */
+	if (buf[0] == 0x9a)
+		return (B_TRUE);
+
+	return (B_FALSE);
+}

--- a/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.c
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.c
@@ -25,6 +25,7 @@
 /*
  * Copyright (c) 2018, Joyent, Inc.  All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #include <sys/types.h>
@@ -38,6 +39,7 @@
 #include <mdb/mdb_ia32util.h>
 #include <mdb/mdb_target_impl.h>
 #include <mdb/mdb_kreg_impl.h>
+#include <mdb/mdb_stack.h>
 #include <mdb/mdb_debug.h>
 #include <mdb/mdb_modapi.h>
 #include <mdb/mdb_err.h>
@@ -424,41 +426,14 @@ mdb_ia32_next(mdb_tgt_t *t, uintptr_t *p, kreg_t pc, mdb_instr_t curinstr)
 }
 #endif
 
-/*ARGSUSED*/
 int
-mdb_ia32_kvm_frame(void *arglim, uintptr_t pc, uint_t argc, const long *largv,
+mdb_ia32_kvm_frame(void *argp, uintptr_t pc, uint_t argc, const long *argv,
     const mdb_tgt_gregset_t *gregs)
 {
-	const uint32_t *argv = (const uint32_t *)largv;
+	mdb_stack_frame_hdl_t *hdl = argp;
+	uint64_t bp;
 
-	argc = MIN(argc, (uintptr_t)arglim);
-	mdb_printf("%a(", pc);
-
-	if (argc != 0) {
-		mdb_printf("%lr", *argv++);
-		for (argc--; argc != 0; argc--)
-			mdb_printf(", %lr", *argv++);
-	}
-
-	mdb_printf(")\n");
-	return (0);
-}
-
-int
-mdb_ia32_kvm_framev(void *arglim, uintptr_t pc, uint_t argc, const long *largv,
-    const mdb_tgt_gregset_t *gregs)
-{
-	const uint32_t *argv = (const uint32_t *)largv;
-
-	argc = MIN(argc, (uintptr_t)arglim);
-	mdb_printf("%08lr %a(", gregs->kregs[KREG_EBP], pc);
-
-	if (argc != 0) {
-		mdb_printf("%lr", *argv++);
-		for (argc--; argc != 0; argc--)
-			mdb_printf(", %lr", *argv++);
-	}
-
-	mdb_printf(")\n");
+	bp = gregs->kregs[KREG_EBP];
+	mdb_stack_frame(hdl, pc, bp, argc, argv);
 	return (0);
 }

--- a/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.h
@@ -24,6 +24,7 @@
  */
 /*
  * Copyright (c) 2018, Joyent, Inc.  All rights reserved.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef _MDB_IA32UTIL_H
@@ -47,8 +48,6 @@ extern int mdb_ia32_kvm_stack_iter(mdb_tgt_t *, const mdb_tgt_gregset_t *,
     mdb_tgt_stack_f *, void *);
 
 extern int mdb_ia32_kvm_frame(void *, uintptr_t, uint_t, const long *,
-    const mdb_tgt_gregset_t *);
-extern int mdb_ia32_kvm_framev(void *, uintptr_t, uint_t, const long *,
     const mdb_tgt_gregset_t *);
 
 #ifdef __cplusplus

--- a/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_ia32util.h
@@ -49,6 +49,7 @@ extern int mdb_ia32_kvm_stack_iter(mdb_tgt_t *, const mdb_tgt_gregset_t *,
 
 extern int mdb_ia32_kvm_frame(void *, uintptr_t, uint_t, const long *,
     const mdb_tgt_gregset_t *);
+extern boolean_t mdb_ia32_prev_callcheck(uintptr_t);
 
 #ifdef __cplusplus
 }

--- a/usr/src/cmd/mdb/intel/mdb/mdb_isautil.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_isautil.h
@@ -49,6 +49,7 @@ typedef uchar_t mdb_instr_t;
 #define	mdb_isa_kvm_stack_iter	mdb_amd64_kvm_stack_iter
 
 #define	mdb_isa_kvm_frame	mdb_amd64_kvm_frame
+#define	mdb_isa_prev_callcheck	mdb_amd64_prev_callcheck
 
 #else
 #include <mdb/mdb_ia32util.h>
@@ -62,6 +63,7 @@ typedef uchar_t mdb_instr_t;
 #define	mdb_isa_kvm_stack_iter	mdb_ia32_kvm_stack_iter
 
 #define	mdb_isa_kvm_frame	mdb_ia32_kvm_frame
+#define	mdb_isa_prev_callcheck	mdb_ia32_prev_callcheck
 
 #endif
 

--- a/usr/src/cmd/mdb/intel/mdb/mdb_isautil.h
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_isautil.h
@@ -25,6 +25,7 @@
  */
 /*
  * Copyright (c) 2018, Joyent, Inc.  All rights reserved.
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef _MDB_ISAUTIL_H
@@ -48,7 +49,6 @@ typedef uchar_t mdb_instr_t;
 #define	mdb_isa_kvm_stack_iter	mdb_amd64_kvm_stack_iter
 
 #define	mdb_isa_kvm_frame	mdb_amd64_kvm_frame
-#define	mdb_isa_kvm_framev	mdb_amd64_kvm_framev
 
 #else
 #include <mdb/mdb_ia32util.h>
@@ -62,7 +62,6 @@ typedef uchar_t mdb_instr_t;
 #define	mdb_isa_kvm_stack_iter	mdb_ia32_kvm_stack_iter
 
 #define	mdb_isa_kvm_frame	mdb_ia32_kvm_frame
-#define	mdb_isa_kvm_framev	mdb_ia32_kvm_framev
 
 #endif
 

--- a/usr/src/common/crypto/ecc/ecp_192.c
+++ b/usr/src/common/crypto/ecc/ecp_192.c
@@ -170,8 +170,9 @@ ec_GFp_nistp192_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 					(r0b == 0xffffffff)) ) {
 			/* do a quick subtract */
 			MP_ADD_CARRY(r0a, 1, r0a, 0, carry);
-			r0b += carry;
-			r1a = r1b = r2a = r2b = 0;
+			MP_ADD_CARRY(r0b, 0, r0b, carry, carry);
+			r1a += 1 + carry;
+			r1b = r2a = r2b = 0;
 		}
 
 		/* set the lower words of r */
@@ -278,8 +279,9 @@ ec_GFp_nistp192_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		      ((r1 == MP_DIGIT_MAX) ||
 			((r1 == (MP_DIGIT_MAX-1)) && (r0 == MP_DIGIT_MAX))))) {
 			/* do a quick subtract */
-			r0++;
-			r1 = r2 = 0;
+			MP_ADD_CARRY(r0, 1, r0, 0, carry);
+			r1 += 1 + carry;
+			r2 = 0;
 		}
 		/* set the lower words of r */
 		if (a != r) {
@@ -292,6 +294,7 @@ ec_GFp_nistp192_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 #endif
 	}
 
+	s_mp_clamp(r);
   CLEANUP:
 	return res;
 }

--- a/usr/src/common/crypto/ecc/ecp_224.c
+++ b/usr/src/common/crypto/ecc/ecp_224.c
@@ -292,13 +292,15 @@ ec_GFp_nistp224_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 			r3b = (int)(r3 >>32);
 		}
 		/* check for final reduction */
-		/* now the only way we are over is if the top 4 words are all ones */
+		/* now the only way we are over is if the top 4 words are
+		 * all ones. Subtract the curve. (curve is 2^224 - 2^96 +1)
+		 */
 		if ((r3 == (MP_DIGIT_MAX >> 32)) && (r2 == MP_DIGIT_MAX)
 			&& ((r1 & MP_DIGIT_MAX << 32)== MP_DIGIT_MAX << 32) &&
 			 ((r1 != MP_DIGIT_MAX << 32 ) || (r0 != 0)) ) {
 			/* one last subraction */
 			MP_SUB_BORROW(r0, 1, r0, 0,     carry);
-			MP_SUB_BORROW(r1, 0, r1, carry, carry);
+			MP_SUB_BORROW(r1, MP_DIGIT_MAX << 32, r1, carry, carry);
 			r2 = r3 = 0;
 		}
 
@@ -315,6 +317,7 @@ ec_GFp_nistp224_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		MP_DIGIT(r, 0) = r0;
 #endif
 	}
+	s_mp_clamp(r);
 
   CLEANUP:
 	return res;

--- a/usr/src/common/crypto/ecc/ecp_521.c
+++ b/usr/src/common/crypto/ecc/ecp_521.c
@@ -101,6 +101,8 @@ ec_GFp_nistp521_mod(const mp_int *a, mp_int *r, const GFMethod *meth)
 		if (MP_DIGIT(r, FIRST_DIGIT) & 0x200) {
 			MP_CHECKOK(s_mp_add_d(r,1));
 			MP_DIGIT(r,FIRST_DIGIT) &=  0x1FF;
+		} else if (s_mp_cmp(r, &meth->irr) == 0) {
+			mp_zero(r);
 		}
 		s_mp_clamp(r);
 	}

--- a/usr/src/data/ucode/README.ucode
+++ b/usr/src/data/ucode/README.ucode
@@ -52,10 +52,6 @@ The script "update.amd" in this directory can be used to help automate
 the update by automatically checking out the latest upstream firmware and
 inserting it into the tree and package manifest. Be careful about new files.
 
-NOTE: If any microcode file is larger than 8KiB (8192 bytes), then the size of
-      the ucode_file_amd_t structure in uts/common/sys/ucode.h will need
-      increasing to cater for this.
-
 AMD - see:
     usr/src/pkg/manifests/system-microcode-amd.p5m
 for exact current version

--- a/usr/src/lib/libc/port/gen/localtime.c
+++ b/usr/src/lib/libc/port/gen/localtime.c
@@ -1428,7 +1428,6 @@ load_zoneinfo(const char *name, state_t *sp)
 	char	*bufp;
 	size_t	flen;
 	prev_t	*prevp;
-/* LINTED */
 	struct	tzhead *tzhp;
 	struct	stat64	stbuf;
 	ttinfo_t	*most_recent_alt = NULL;
@@ -1436,8 +1435,12 @@ load_zoneinfo(const char *name, state_t *sp)
 	ttinfo_t	*ttisp;
 
 
-	if (name == NULL && (name = TZDEFAULT) == NULL)
-		return (-1);
+	if (name == NULL) {
+		/* May TZDEFAULT be function call? */
+		name = TZDEFAULT;
+		if (name == NULL)
+			return (-1);
+	}
 
 	if ((name[0] == '/') || strstr(name, "../"))
 		return (-1);

--- a/usr/src/lib/libc/port/gen/ssp.c
+++ b/usr/src/lib/libc/port/gen/ssp.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2020 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 #include <upanic.h>
@@ -49,7 +49,7 @@ ssp_init(void)
 		 * off the ground.
 		 */
 		hrtime_t t = gethrtime();
-#ifdef	_LP32
+#ifdef	_ILP32
 		const uint16_t guard = '\n' << 8 | '\0';
 		__stack_chk_guard = guard  << 16 | (uint16_t)t;
 #else

--- a/usr/src/lib/libc/port/rt/mqueue.c
+++ b/usr/src/lib/libc/port/rt/mqueue.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 #include "lint.h"
@@ -385,7 +386,7 @@ mq_open(const char *path, int oflag, /* mode_t mode, mq_attr *attr */ ...)
 	ssize_t		maxmsg;
 	uint64_t	temp;
 	void		*ptr;
-	mqdes_t		*mqdp;
+	mqdes_t		*mqdp = NULL;
 	mqhdr_t		*mqhp;
 	struct mq_dn	*mqdnp;
 
@@ -483,7 +484,6 @@ mq_open(const char *path, int oflag, /* mode_t mode, mq_attr *attr */ ...)
 		errno = ENOMEM;
 		goto out;
 	}
-	cr_flag |= ALLOC_MEM;
 
 	if ((ptr = mmap64(NULL, total_size, PROT_READ|PROT_WRITE,
 	    MAP_SHARED, fd, (off64_t)0)) == MAP_FAILED)
@@ -554,8 +554,7 @@ out:
 		(void) __pos4obj_unlink(path, MQ_DATA_TYPE);
 	if ((cr_flag & PFILE_CREATE) != 0)
 		(void) __pos4obj_unlink(path, MQ_PERM_TYPE);
-	if ((cr_flag & ALLOC_MEM) != 0)
-		free((void *)mqdp);
+	free(mqdp);
 	if ((cr_flag & DFILE_MMAP) != 0)
 		(void) munmap((caddr_t)mqhp, (size_t)total_size);
 	if ((cr_flag & MQDNP_MMAP) != 0)

--- a/usr/src/lib/libc/port/rt/pos4obj.h
+++ b/usr/src/lib/libc/port/rt/pos4obj.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 #ifndef	_POS4OBJ_H
@@ -38,7 +39,7 @@ extern "C" {
 /* flags used to indicate current state of open */
 #define	DFILE_CREATE	0x01
 #define	DFILE_OPEN	0x02
-#define	ALLOC_MEM	0x04
+/* ALLOC_MEM 0x4 is deprecated, reuse this first */
 #define	DFILE_MMAP	0x08
 #define	PFILE_CREATE	0x10
 #define	NFILE_CREATE	0x20

--- a/usr/src/lib/libc/port/rt/sem.c
+++ b/usr/src/lib/libc/port/rt/sem.c
@@ -23,6 +23,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2024 Oxide Computer Company
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 #include "lint.h"
@@ -134,9 +135,7 @@ sem_open(const char *path, int oflag, /* mode_t mode, int value */ ...)
 		errno = ENOMEM;
 		goto out;
 	}
-	cr_flag |= ALLOC_MEM;
 
-	/* LINTED */
 	sem = (sem_t *)mmap64(NULL, sizeof (sem_t), PROT_READ|PROT_WRITE,
 	    MAP_SHARED, fd, (off64_t)0);
 	(void) __close_nc(fd);
@@ -172,8 +171,7 @@ out:
 		(void) __close_nc(fd);
 	if ((cr_flag & DFILE_CREATE) != 0)
 		(void) __pos4obj_unlink(path, SEM_DATA_TYPE);
-	if ((cr_flag & ALLOC_MEM) != 0)
-		free(next);
+	free(next);
 	if ((cr_flag & DFILE_MMAP) != 0)
 		(void) munmap((caddr_t)sem, sizeof (sem_t));
 	(void) __pos4obj_unlock(path, SEM_LOCK_TYPE);

--- a/usr/src/man/man1/mdb.1
+++ b/usr/src/man/man1/mdb.1
@@ -2,11 +2,11 @@
 .\" Copyright (c) 2005, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2019, Joyent, Inc. All Rights Reserved.
 .\" Copyright (c) 2014, 2017 by Delphix. All rights reserved.
-.\" Copyright 2024 Oxide Computer Company
+.\" Copyright 2025 Oxide Computer Company
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH MDB 1 "February 21, 2023"
+.TH MDB 1 "March 23, 2025"
 .SH NAME
 mdb \- modular debugger
 .SH SYNOPSIS
@@ -1665,16 +1665,71 @@ representative thread.
 .sp
 .ne 2
 .na
-\fB[ \fIaddress\fR ] \fB$C\fR [ \fIcount\fR ]\fR
+[ \fIaddress\fR ] \fB::stack\fR [-stv] [ \fIcount\fR ]
+.ad
+.br
+.na
+[ \fIaddress\fR ] \fB$c\fR [-stv] [ \fIcount\fR ]
+.ad
+.br
+.na
+[ \fIaddress\fR ] \fB$C\fR [-stv] [ \fIcount\fR ]
 .ad
 .sp .6
 .RS 4n
-Print a C stack backtrace, including stack frame pointer information. If the
-dcmd is preceded by an explicit \fIaddress\fR, a backtrace beginning at this
-virtual memory address is displayed. Otherwise the stack of the representative
-thread is displayed. If an optional count value is given as an argument, no
-more than \fIcount\fR arguments are displayed for each stack frame in the
-output.
+Print a C stack backtrace. If the dcmd is preceded by an explicit
+\fIaddress\fR, a backtrace beginning at this virtual memory address is
+displayed. Otherwise the stack of the representative thread is displayed. If an
+optional count value is given as an argument, no more than \fIcount\fR
+arguments are displayed for each stack frame in the output.
+This dcmd recognizes the following options:
+.sp
+.ne 2
+.na
+\fB-s\fR
+.ad
+.RS 17n
+Shows the difference in stack size between frames in square brackets to the
+left of each frame.
+.RE
+
+.ne 2
+.na
+\fB-t\fR
+.ad
+.RS 17n
+Where type information is available, show the function return type and the
+type of each argument. Some argument types, such as enums, are further
+decoded when possible.
+.RE
+
+.ne 2
+.na
+\fB-v\fR
+.ad
+.RS 17n
+Show stack frame pointer information. This option is enabled by default with
+the \fB$C\fR variant of this command.
+.RE
+
+In the following example output, the size of each stack frame is shown in
+the first column in square brackets, the frame pointer address is in the
+second column and the type information is displayed inline with the
+function name and arguments.
+.sp
+.in +2
+.nf
+> $C -st
+         fffffe004121cd10 void swtch+0x17f()
+  [  60] fffffe004121cd70 int cv_wait_sig+0x190(
+             (kcondvar_t *)fffffe2db1c002d2,
+             (kmutex_t *)fffffe2db1c002d8)
+  [  50] fffffe004121cdc0 int svc_wait+0xab((int)1)
+  [  e0] fffffe004121cea0 int nfssys+0x22d(
+             (enum nfssys_op)SVCPOOL_WAIT, (void *)fed21fa4)
+.fi
+.in -2
+
 .RE
 
 .sp
@@ -3367,24 +3422,6 @@ described under \fBSymbol Name Resolution\fR, above. The \fB::sizeof\fR dcmd
 can only be used with objects that contain symbolic debugging information
 designed for use with \fBmdb\fR. Refer to NOTES, \fBSymbolic Debugging
 Information\fR, below for more information.
-.RE
-
-.sp
-.ne 2
-.na
-\fB[ \fIaddress\fR ] \fB::stack \fR [ \fIcount\fR ]\fR
-.ad
-.br
-.na
-\fB[ \fI address\fR ] \fB$c\fR [ \fIcount\fR ]\fR
-.ad
-.sp .6
-.RS 4n
-Print a C stack backtrace. If the dcmd is preceded by an explicit
-\fIaddress\fR, a backtrace beginning at this virtual memory address is
-displayed. Otherwise the stack of the representative thread is displayed. If an
-optional count value is given as an argument, no more than \fIcount\fR
-arguments are displayed for each stack frame in the output.
 .RE
 
 .sp

--- a/usr/src/man/man3c/opendir.3c
+++ b/usr/src/man/man3c/opendir.3c
@@ -44,7 +44,7 @@
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright 2021 Oxide Computer Company
 .\"
-.Dd February 25, 2021
+.Dd April 15, 2025
 .Dt OPENDIR 3C
 .Os
 .Sh NAME
@@ -56,7 +56,7 @@
 .In dirent.h
 .Ft "DIR *"
 .Fo opendir
-.Fa "dirname"
+.Fa "const char *dirname"
 .Fc
 .Ft "DIR *"
 .Fo fdopendir
@@ -143,7 +143,7 @@ function will fail if:
 Search permission is denied for any component of the path prefix of
 .Fa dirname
 or read permission is denied for
-.Fa Idirname .
+.Fa dirname .
 .It Er ELOOP
 Too many symbolic links were encountered in resolving
 .Fa path .

--- a/usr/src/test/libc-tests/tests/stdbit.c
+++ b/usr/src/test/libc-tests/tests/stdbit.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 /*
@@ -1070,7 +1070,7 @@ stdbit_test_one(const stdbit_test_t *test, const stdbit_ops_t *ops)
 			ret = false;
 		}
 
-#ifdef	_LP32
+#ifdef	_ILP32
 		res = ops->so_ul(test->st_val);
 		if (res != comp) {
 			warnx("TEST FAILED: %s (0x%" PRIx64 ") 32-bit (ulong) "
@@ -1078,7 +1078,7 @@ stdbit_test_one(const stdbit_test_t *test, const stdbit_ops_t *ops)
 			    ops->so_name, test->st_val, res, comp);
 			ret = false;
 		}
-#endif	/* _LP32 */
+#endif	/* _ILP32 */
 
 		comp += ops->so_delta[2];
 	}
@@ -1262,7 +1262,7 @@ stdbit_1b_test_one(const stdbit_test_t *test)
 			ret = false;
 		}
 
-#ifdef	_LP32
+#ifdef	_ILP32
 		res = stdc_has_single_bit_ul(test->st_val);
 		if (res != comp) {
 			warnx("TEST FAILED: Single-bit (0x%" PRIx64 ") 32-bit "
@@ -1270,7 +1270,7 @@ stdbit_1b_test_one(const stdbit_test_t *test)
 			    res ? "true" : "false", comp ? "true" : "false");
 			ret = false;
 		}
-#endif	/* _LP32 */
+#endif	/* _ILP32 */
 	}
 
 	if ((test->st_types & STDBIT_TEST_U64) != 0) {
@@ -1495,7 +1495,7 @@ stdbit_fc_test_one(const stdbit_fc_test_t *test)
 			ret = false;
 		}
 
-#ifdef	_LP32
+#ifdef	_ILP32
 		res = stdc_bit_floor_ul(test->sfc_val);
 		if (res != test->sfc_floor) {
 			warnx("TEST FAILED: Bit Floor (0x%" PRIx64 ") 32-bit "
@@ -1511,7 +1511,7 @@ stdbit_fc_test_one(const stdbit_fc_test_t *test)
 			    PRIx64, test->sfc_val, res, test->sfc_ceil);
 			ret = false;
 		}
-#endif	/* _LP32 */
+#endif	/* _ILP32 */
 	}
 
 	if ((test->sfc_types & STDBIT_TEST_U64) != 0) {

--- a/usr/src/uts/common/sys/efi.h
+++ b/usr/src/uts/common/sys/efi.h
@@ -86,7 +86,7 @@ typedef uint64_t	EFI_PHYSICAL_ADDRESS;
 typedef uint64_t	EFI_VIRTUAL_ADDRESS;
 
 /*
- * EFI_MEMORY_TYPE enum is defined in UEFI v2.7 page 185.
+ * EFI_MEMORY_TYPE enum is defined in UEFI Specification, Version 2.9 page 167.
  */
 typedef enum {
 	EfiReservedMemoryType,
@@ -104,6 +104,7 @@ typedef enum {
 	EfiMemoryMappedIOPortSpace,
 	EfiPalCode,
 	EfiPersistentMemory,
+	EfiUnacceptedMemoryType,
 	EfiMaxMemoryType
 } EFI_MEMORY_TYPE;
 

--- a/usr/src/uts/i86pc/dboot/dboot_startkern.c
+++ b/usr/src/uts/i86pc/dboot/dboot_startkern.c
@@ -737,7 +737,13 @@ dboot_efi_to_smap_type(int index, uint32_t type)
 			return (1);
 	}
 
-	/* translate UEFI memory types to SMAP types */
+	/*
+	 * Translate UEFI memory types to SMAP types.
+	 * See "ACPI Specification Release 6.5 Errata A"
+	 * Table 15-6 (page 785), UEFI Memory Types and mapping to ACPI address
+	 * range types.
+	 */
+
 	switch (type) {
 	case EfiLoaderCode:
 	case EfiLoaderData:

--- a/usr/src/uts/intel/sys/ucode_amd.h
+++ b/usr/src/uts/intel/sys/ucode_amd.h
@@ -24,7 +24,7 @@
  *
  * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2022 Joyent, Inc.
- * Copyright 2023 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef	_SYS_UCODE_AMD_H
@@ -54,18 +54,21 @@ typedef struct ucode_header_amd {
 	uint32_t uh_match[8];
 } ucode_header_amd_t;
 
+/*
+ * This is the maximum size of a microcode blob that we are prepared to load
+ * in the kernel. AMD Turin microcode files are 14KiB and the size has been
+ * increasing with each generation. This value provides some margin for the
+ * future.
+ */
+#define	UCODE_AMD_MAXSIZE	(256 * 1024)
+
 typedef struct ucode_file_amd {
-	/*
-	 * The combined size of these fields adds up to 8KiB (8192 bytes).
-	 * If support is needed for larger update files, increase the size of
-	 * the uf_encr element.
-	 */
 	ucode_header_amd_t uf_header;
 	uint8_t uf_data[896];
 	uint8_t uf_resv[896];
 	uint8_t uf_code_present;
 	uint8_t uf_code[191];
-	uint8_t uf_encr[6144];
+	uint8_t uf_encr[];
 } ucode_file_amd_t;
 
 typedef struct ucode_eqtbl_amd {


### PR DESCRIPTION

## mail_msg

```

==== Nightly distributed build started:   Fri Apr 18 13:25:24 UTC 2025 ====
==== Nightly distributed build completed: Fri Apr 18 14:37:49 UTC 2025 ====

==== Total build time ====

real    1:12:24

==== Build environment ====

/usr/bin/uname
SunOS r151054 5.11 omnios-r151054-da6de07d63 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151054/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151054/14.2.0-il-1) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151054/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.14+7-omnios-151054"

/usr/bin/openssl
OpenSSL 3.5.0 8 Apr 2025 (Library: OpenSSL 3.5.0 8 Apr 2025)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   86

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-bpr54-31c56c502c3

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:36.5
user  4:18:38.1
sys   1:14:44.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:55.2
user  4:05:35.9
sys   1:15:06.7

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
