### PR TITLE
kern: Turn off FD_CLOFORK on exec

### DIFF
--- a/usr/src/test/os-tests/tests/oclo/oclo.c
+++ b/usr/src/test/os-tests/tests/oclo/oclo.c
@@ -1235,8 +1235,12 @@ oclo_exec(void)
 
 	argv[0] = file;
 	for (size_t i = 0; i < oclo_rtdata_next; i++) {
-		if (asprintf(&argv[i + 1], "0x%x", oclo_rtdata[i].crt_flags) ==
-		    -1) {
+		/*
+		 * https://austingroupbugs.net/view.php?id=1851
+		 * FD_CLOFORK should not be preserved across exec
+		 */
+		int flags = oclo_rtdata[i].crt_flags & ~FD_CLOFORK;
+		if (asprintf(&argv[i + 1], "0x%x", flags) == -1) {
 			err(EXIT_FAILURE, "TEST FAILED: failed to assemble "
 			    "exec argument %zu", i + 1);
 		}


### PR DESCRIPTION
Will test over the weekend but wanted to raise attention to the potential security implication of allowing FD_CLOFORK on exec():

- https://austingroupbugs.net/view.php?id=1851
- https://marc.info/?l=openbsd-tech&m=175054703914823&w=2

Hopefully fixes https://www.illumos.org/issues/17481
