### PR TITLE
Upstream merge upstream_merge/2025070701

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from SmartOS
 
-Last illumos-joyent commit: acfd46c3541e20dbb036fab2d1b00a7a3d2f974a
+Last illumos-joyent commit: 1cf155e889a30d9fd364d72336d8f755bc2857f7
 
 

--- a/usr/src/cmd/dlmgmtd/Makefile
+++ b/usr/src/cmd/dlmgmtd/Makefile
@@ -35,7 +35,6 @@ CFGFILES=	datalink.conf
 include ../Makefile.cmd
 
 CSTD = $(CSTD_GNU99)
-C99LMODE = -Xc99=%all
 
 ROOTMANIFESTDIR=	$(ROOTSVCNETWORK)
 ROOTCFGDIR=		$(ROOTETC)/dladm

--- a/usr/src/cmd/hyperv/kvp/Makefile
+++ b/usr/src/cmd/hyperv/kvp/Makefile
@@ -33,8 +33,6 @@ HYPERV_LIB= ../../../uts/intel/io/hyperv
 INCS += -I$(HYPERV_LIB) -I$(HYPERV_LIB)/utilities
 
 CSTD=   $(CSTD_GNU99)
-C99MODE=    -xc99=%all
-C99LMODE=   -Xc99=%all
 
 CPPFLAGS += $(CCVERBOSE) $(INCS)
 $(NOT_RELEASE_BUILD)CPPFLAGS += -DDEBUG

--- a/usr/src/cmd/pcieadm/pcieadm_cfgspace.c
+++ b/usr/src/cmd/pcieadm/pcieadm_cfgspace.c
@@ -878,7 +878,7 @@ static const pcieadm_regdef_t pcieadm_regdef_status[] = {
  */
 static const pcieadm_regdef_t pcieadm_regdef_class[] = {
 	{ 16, 23, "class", "Class Code", PRDV_HEX },
-	{ 7, 15, "sclass", "Sub-Class Code", PRDV_HEX },
+	{ 8, 15, "sclass", "Sub-Class Code", PRDV_HEX },
 	{ 0, 7, "pi", "Programming Interface", PRDV_HEX },
 	{ -1, -1, NULL }
 };

--- a/usr/src/cmd/smbsrv/test-crypt/Makefile
+++ b/usr/src/cmd/smbsrv/test-crypt/Makefile
@@ -46,7 +46,6 @@ INCS +=	-I../../../uts/common/smbsrv
 INCS +=	-I../../../common/smbsrv
 
 CSTD=		$(CSTD_GNU99)
-C99LMODE=	-Xc99=%all
 
 CFLAGS += $(CCVERBOSE)
 CFLAGS64 += $(CCVERBOSE)

--- a/usr/src/man/man2/exec.2
+++ b/usr/src/man/man2/exec.2
@@ -45,9 +45,9 @@
 .\" Copyright (c) 2008, Sun Microsystems, Inc.  All Rights Reserved.
 .\" Copyright 2014 Garrett D'Amore <garrett@damore.org>
 .\" Copyright 2015, Joyent, Inc.
-.\" Copyright 2024 Oxide Computer Company
+.\" Copyright 2025 Oxide Computer Company
 .\"
-.Dd June 21, 2024
+.Dd June 25, 2025
 .Dt EXEC 2
 .Os
 .Sh NAME
@@ -302,12 +302,18 @@ alignment bytes are included in this total.
 File descriptors open in the calling process image remain open in the new
 process image, except for those whose close-on-exec flag
 .Dv FD_CLOEXEC
-is set; see
-.Xr fcntl 2 .
-For those file descriptors that remain open, all attributes of the open file
-description, including file locks and the disposition of the close-on-fork flag
-.Dv FD_CLOFORK ,
-remain unchanged.
+is set.
+For those file descriptors that remain open, most attributes of the open file
+descriptor, including file locks, remain unchanged; however, the close-on-fork
+flag
+.Dv FD_CLOFORK
+is cleared from all file descriptors.
+See
+.Xr fcntl 2
+for more information on
+.Dv FD_CLOEXEC
+and
+.Dv FD_CLOFORK .
 .Pp
 The preferred hardware address translation size
 .Po

--- a/usr/src/man/man3head/fcntl.h.3head
+++ b/usr/src/man/man3head/fcntl.h.3head
@@ -42,9 +42,9 @@
 .\"
 .\" Copyright 1989 AT&T
 .\" Copyright (c) 2008, Sun Microsystems, Inc.  All Rights Reserved.
-.\" Copyright 2024 Oxide Computer Company
+.\" Copyright 2025 Oxide Computer Company
 .\"
-.TH FCNTL.H 3HEAD "June 21, 2024"
+.TH FCNTL.H 3HEAD "June 25, 2025"
 .SH NAME
 fcntl.h, fcntl \- file control options
 .SH SYNOPSIS
@@ -305,6 +305,14 @@ Close the file descriptor upon execution of an \fBexec\fR function (see
 .RS 14n
 Close the file descriptor in any child process created with the \fBfork\fR(2)
 family functions.
+When a process executes an \fBexec\fR function (see \fBexec\fR(2)), this flag is
+not inherited by the new process image. All file descriptors with this flag set
+remain open (unless \fBFD_CLOEXEC\fR is specified) but have the
+\fBFD_CLOFORK\fR flag cleared.
+.sp
+While the majority of systems clear the \fBFD_CLOFORK\fR flag on execution of an
+\fBexec\fR family function, this is a deviation from the original POSIX 2024
+specification.
 .RE
 
 .sp

--- a/usr/src/uts/common/io/e1000g/e1000_osdep.h
+++ b/usr/src/uts/common/io/e1000g/e1000_osdep.h
@@ -50,6 +50,7 @@ extern "C" {
 #include <sys/note.h>
 #include <sys/mutex.h>
 #include <sys/pci_cap.h>
+#include <sys/stdbool.h>
 #include "e1000g_debug.h"
 
 #define	usec_delay(x)		drv_usecwait(x)
@@ -78,8 +79,6 @@ extern "C" {
 
 #define	OS_DEP(hw)		((struct e1000g_osdep *)((hw)->back))
 
-#define	false		0
-#define	true		1
 #define	FALSE		false
 #define	TRUE		true
 
@@ -112,9 +111,9 @@ extern "C" {
  * is used in the common code:
  *
  * if (cond)
- * 	E1000_WRITE_REG
+ *	E1000_WRITE_REG
  * else
- * 	...
+ *	...
  *
  * When the E1000_WRITE_REG macros was missing the do keyword, the compiler
  * would end up associating the outer brace of the block with the if statement
@@ -203,7 +202,6 @@ typedef	uint8_t		u8;
 typedef	uint16_t	u16;
 typedef	uint32_t	u32;
 typedef	uint64_t	u64;
-typedef boolean_t	bool;
 
 #define	__le16 u16
 #define	__le32 u32

--- a/usr/src/uts/common/io/e1000g/e1000g_main.c
+++ b/usr/src/uts/common/io/e1000g/e1000g_main.c
@@ -803,7 +803,7 @@ e1000g_set_driver_params(struct e1000g *Adapter)
 	hw = &Adapter->shared;
 
 	/* Set MAC type and initialize hardware functions */
-	if (e1000_setup_init_funcs(hw, B_TRUE) != E1000_SUCCESS) {
+	if (e1000_setup_init_funcs(hw, true) != E1000_SUCCESS) {
 		E1000G_DEBUGLOG_0(Adapter, CE_WARN,
 		    "Could not setup hardware functions");
 		return (DDI_FAILURE);
@@ -818,23 +818,23 @@ e1000g_set_driver_params(struct e1000g *Adapter)
 
 	e1000_read_pci_cfg(hw, PCI_COMMAND_REGISTER, &hw->bus.pci_cmd_word);
 
-	hw->mac.autoneg_failed = B_TRUE;
+	hw->mac.autoneg_failed = true;
 
 	/* Set the autoneg_wait_to_complete flag to B_FALSE */
-	hw->phy.autoneg_wait_to_complete = B_FALSE;
+	hw->phy.autoneg_wait_to_complete = false;
 
 	/* Adaptive IFS related changes */
-	hw->mac.adaptive_ifs = B_TRUE;
+	hw->mac.adaptive_ifs = true;
 
 	/* Enable phy init script for IGP phy of 82541/82547 */
 	if ((hw->mac.type == e1000_82547) ||
 	    (hw->mac.type == e1000_82541) ||
 	    (hw->mac.type == e1000_82547_rev_2) ||
 	    (hw->mac.type == e1000_82541_rev_2))
-		e1000_init_script_state_82541(hw, B_TRUE);
+		e1000_init_script_state_82541(hw, true);
 
 	/* Enable the TTL workaround for 82541/82547 */
-	e1000_set_ttl_workaround_state_82541(hw, B_TRUE);
+	e1000_set_ttl_workaround_state_82541(hw, true);
 
 #ifdef __sparc
 	Adapter->strip_crc = B_TRUE;
@@ -868,7 +868,7 @@ e1000g_set_driver_params(struct e1000g *Adapter)
 	/* copper options */
 	if (hw->phy.media_type == e1000_media_type_copper) {
 		hw->phy.mdix = 0;	/* AUTO_ALL_MODES */
-		hw->phy.disable_polarity_correction = B_FALSE;
+		hw->phy.disable_polarity_correction = false;
 		hw->phy.ms_type = e1000_ms_hw_default;	/* E1000_MASTER_SLAVE */
 	}
 
@@ -1460,7 +1460,7 @@ e1000g_init(struct e1000g *Adapter)
 	}
 
 	/* Set LAA state for 82571 chipset */
-	e1000_set_laa_state_82571(hw, B_TRUE);
+	e1000_set_laa_state_82571(hw, true);
 
 	/* Master Latency Timer implementation */
 	if (Adapter->master_latency_timer) {
@@ -1561,7 +1561,7 @@ e1000g_init(struct e1000g *Adapter)
 		hw->fc.pause_time = 0xFFFF;
 	else
 		hw->fc.pause_time = E1000_FC_PAUSE_TIME;
-	hw->fc.send_xon = B_TRUE;
+	hw->fc.send_xon = true;
 
 	/*
 	 * Reset the adapter hardware the second time.
@@ -2592,7 +2592,7 @@ e1000g_init_unicst(struct e1000g *Adapter)
 
 		/* Workaround for an erratum of 82571 chipst */
 		if ((hw->mac.type == e1000_82571) &&
-		    (e1000_get_laa_state_82571(hw) == B_TRUE))
+		    e1000_get_laa_state_82571(hw))
 			Adapter->unicst_total--;
 
 		/* VMware doesn't support multiple mac addresses properly */
@@ -2609,7 +2609,7 @@ e1000g_init_unicst(struct e1000g *Adapter)
 	} else {
 		/* Workaround for an erratum of 82571 chipst */
 		if ((hw->mac.type == e1000_82571) &&
-		    (e1000_get_laa_state_82571(hw) == B_TRUE))
+		    e1000_get_laa_state_82571(hw))
 			(void) e1000_rar_set(hw, hw->mac.addr, LAST_RAR_ENTRY);
 
 		/* Re-configure the RAR registers */
@@ -2664,7 +2664,7 @@ e1000g_unicst_set(struct e1000g *Adapter, const uint8_t *mac_addr,
 	/* Workaround for an erratum of 82571 chipst */
 	if (slot == 0) {
 		if ((hw->mac.type == e1000_82571) &&
-		    (e1000_get_laa_state_82571(hw) == B_TRUE))
+		    e1000_get_laa_state_82571(hw)) {
 			if (mac_addr == NULL) {
 				E1000_WRITE_REG_ARRAY(hw, E1000_RA,
 				    slot << 1, 0);
@@ -2676,6 +2676,7 @@ e1000g_unicst_set(struct e1000g *Adapter, const uint8_t *mac_addr,
 				(void) e1000_rar_set(hw, (uint8_t *)mac_addr,
 				    LAST_RAR_ENTRY);
 			}
+		}
 	}
 
 	/*
@@ -3469,7 +3470,7 @@ e1000g_m_setprop(void *arg, const char *pr_name, mac_prop_id_t pr_num,
 			Adapter->param_adv_autoneg = *(uint8_t *)pr_val;
 			goto reset;
 		case MAC_PROP_FLOWCTRL:
-			fc->send_xon = B_TRUE;
+			fc->send_xon = true;
 			bcopy(pr_val, &flowctrl, sizeof (flowctrl));
 
 			switch (flowctrl) {
@@ -4200,7 +4201,7 @@ e1000g_get_conf(struct e1000g *Adapter)
 	/*
 	 * FlowControl
 	 */
-	hw->fc.send_xon = B_TRUE;
+	hw->fc.send_xon = true;
 	(void) e1000g_get_prop(Adapter, "FlowControl",
 	    e1000_fc_none, 4, DEFAULT_FLOW_CONTROL, &propval);
 	hw->fc.requested_mode = propval;
@@ -4522,7 +4523,7 @@ e1000g_reset_link(struct e1000g *Adapter)
 		goto out;
 
 	if (Adapter->param_adv_autoneg == 1) {
-		mac->autoneg = B_TRUE;
+		mac->autoneg = true;
 		phy->autoneg_advertised = 0;
 
 		/*
@@ -4546,7 +4547,7 @@ e1000g_reset_link(struct e1000g *Adapter)
 		if (phy->autoneg_advertised == 0)
 			invalid = B_TRUE;
 	} else {
-		mac->autoneg = B_FALSE;
+		mac->autoneg = false;
 
 		/*
 		 * For Intel copper cards, 1000fdx and 1000hdx are not
@@ -4569,7 +4570,7 @@ e1000g_reset_link(struct e1000g *Adapter)
 		e1000g_log(Adapter, CE_WARN,
 		    "Invalid link settings. Setup link to "
 		    "support autonegotiation with all link capabilities.");
-		mac->autoneg = B_TRUE;
+		mac->autoneg = true;
 		phy->autoneg_advertised = AUTONEG_ADVERTISE_SPEED_DEFAULT;
 	}
 
@@ -4667,8 +4668,7 @@ e1000g_local_timer(void *ws)
 	 * be overwritten when there is a reset on the other port.
 	 * Detect this circumstance and correct it.
 	 */
-	if ((hw->mac.type == e1000_82571) &&
-	    (e1000_get_laa_state_82571(hw) == B_TRUE)) {
+	if ((hw->mac.type == e1000_82571) && e1000_get_laa_state_82571(hw)) {
 		ether_addr.reg.low = E1000_READ_REG_ARRAY(hw, E1000_RA, 0);
 		ether_addr.reg.high = E1000_READ_REG_ARRAY(hw, E1000_RA, 1);
 
@@ -4757,28 +4757,28 @@ e1000g_force_speed_duplex(struct e1000g *Adapter)
 		/*
 		 * Disable Auto Negotiation
 		 */
-		mac->autoneg = B_FALSE;
+		mac->autoneg = false;
 		mac->forced_speed_duplex = ADVERTISE_10_HALF;
 		break;
 	case GDIAG_10_FULL:
 		/*
 		 * Disable Auto Negotiation
 		 */
-		mac->autoneg = B_FALSE;
+		mac->autoneg = false;
 		mac->forced_speed_duplex = ADVERTISE_10_FULL;
 		break;
 	case GDIAG_100_HALF:
 		/*
 		 * Disable Auto Negotiation
 		 */
-		mac->autoneg = B_FALSE;
+		mac->autoneg = false;
 		mac->forced_speed_duplex = ADVERTISE_100_HALF;
 		break;
 	case GDIAG_100_FULL:
 		/*
 		 * Disable Auto Negotiation
 		 */
-		mac->autoneg = B_FALSE;
+		mac->autoneg = false;
 		mac->forced_speed_duplex = ADVERTISE_100_FULL;
 		break;
 	case GDIAG_1000_FULL:
@@ -4789,11 +4789,11 @@ e1000g_force_speed_duplex(struct e1000g *Adapter)
 		 * 1000Mbps.  This is different from 10/100 operation, where
 		 * we are allowed to link without any negotiation.
 		 */
-		mac->autoneg = B_TRUE;
+		mac->autoneg = true;
 		phy->autoneg_advertised = ADVERTISE_1000_FULL;
 		break;
 	default:	/* obey the setting of AutoNegAdvertised */
-		mac->autoneg = B_TRUE;
+		mac->autoneg = true;
 		(void) e1000g_get_prop(Adapter, "AutoNegAdvertised",
 		    0, AUTONEG_ADVERTISE_SPEED_DEFAULT,
 		    AUTONEG_ADVERTISE_SPEED_DEFAULT, &propval);
@@ -4866,7 +4866,7 @@ e1000g_pch_limits(struct e1000g *Adapter)
 
 	/* only applies to frames larger than ethernet default */
 	if (Adapter->max_frame_size > DEFAULT_FRAME_SIZE) {
-		hw->mac.autoneg = B_TRUE;
+		hw->mac.autoneg = true;
 		hw->phy.autoneg_advertised = ADVERTISE_1000_FULL;
 
 		Adapter->param_adv_autoneg = 1;
@@ -5588,9 +5588,9 @@ e1000g_set_loopback_mode(struct e1000g *Adapter, uint32_t mode)
 
 	if (mode == E1000G_LB_NONE) {
 		/* Reset the chip */
-		hw->phy.autoneg_wait_to_complete = B_TRUE;
+		hw->phy.autoneg_wait_to_complete = true;
 		(void) e1000g_reset_adapter(Adapter);
-		hw->phy.autoneg_wait_to_complete = B_FALSE;
+		hw->phy.autoneg_wait_to_complete = false;
 		return (B_TRUE);
 	}
 
@@ -5652,9 +5652,9 @@ again:
 		Adapter->loopback_mode = E1000G_LB_NONE;
 
 		/* Reset the chip */
-		hw->phy.autoneg_wait_to_complete = B_TRUE;
+		hw->phy.autoneg_wait_to_complete = true;
 		(void) e1000g_reset_adapter(Adapter);
-		hw->phy.autoneg_wait_to_complete = B_FALSE;
+		hw->phy.autoneg_wait_to_complete = false;
 
 		E1000G_DEBUGLOG_0(Adapter, E1000G_INFO_LEVEL,
 		    "Set loopback mode failed, reset to loopback none");

--- a/usr/src/uts/common/io/i40e/i40e_gld.c
+++ b/usr/src/uts/common/io/i40e/i40e_gld.c
@@ -15,7 +15,7 @@
  * Copyright 2017 Tegile Systems, Inc.  All rights reserved.
  * Copyright 2020 Ryan Zezeski
  * Copyright 2020 RackTop Systems, Inc.
- * Copyright 2023 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 /*
@@ -229,7 +229,7 @@ i40e_m_promisc(void *arg, boolean_t on)
 
 
 	ret = i40e_aq_set_vsi_unicast_promiscuous(hw, I40E_DEF_VSI_SEID(i40e),
-	    on, NULL, B_FALSE);
+	    on ? true : false, NULL, false);
 	if (ret != I40E_SUCCESS) {
 		i40e_error(i40e, "failed to %s unicast promiscuity on "
 		    "the default VSI: %d", on == B_TRUE ? "enable" : "disable",
@@ -259,7 +259,7 @@ i40e_m_promisc(void *arg, boolean_t on)
 		 * to be in.
 		 */
 		ret = i40e_aq_set_vsi_unicast_promiscuous(hw,
-		    I40E_DEF_VSI_SEID(i40e), !on, NULL, B_FALSE);
+		    I40E_DEF_VSI_SEID(i40e), !on, NULL, false);
 		if (ret != I40E_SUCCESS) {
 			i40e_error(i40e, "failed to %s unicast promiscuity on "
 			    "the default VSI after toggling multicast failed: "
@@ -295,7 +295,7 @@ i40e_multicast_add(i40e_t *i40e, const uint8_t *multicast_address)
 		if (i40e->i40e_mcast_promisc_count == 0 &&
 		    i40e->i40e_promisc_on == B_FALSE) {
 			ret = i40e_aq_set_vsi_multicast_promiscuous(hw,
-			    I40E_DEF_VSI_SEID(i40e), B_TRUE, NULL);
+			    I40E_DEF_VSI_SEID(i40e), true, NULL);
 			if (ret != I40E_SUCCESS) {
 				i40e_error(i40e, "failed to enable multicast "
 				    "promiscuous mode on VSI %d: %d",
@@ -382,7 +382,7 @@ i40e_multicast_remove(i40e_t *i40e, const uint8_t *multicast_address)
 		if (i40e->i40e_mcast_promisc_count == 1 &&
 		    i40e->i40e_promisc_on == B_FALSE) {
 			ret = i40e_aq_set_vsi_multicast_promiscuous(hw,
-			    I40E_DEF_VSI_SEID(i40e), B_FALSE, NULL);
+			    I40E_DEF_VSI_SEID(i40e), false, NULL);
 			if (ret != I40E_SUCCESS) {
 				i40e_error(i40e, "failed to disable "
 				    "multicast promiscuous mode on VSI %d: %d",
@@ -716,13 +716,13 @@ i40e_gld_led_set(void *arg, mac_led_mode_t mode, uint_t flags)
 		}
 		break;
 	case MAC_LED_IDENT:
-		i40e_led_set(hw, 0xf, B_TRUE);
+		i40e_led_set(hw, 0xf, true);
 		break;
 	case MAC_LED_OFF:
-		i40e_led_set(hw, 0x0, B_FALSE);
+		i40e_led_set(hw, 0x0, false);
 		break;
 	case MAC_LED_ON:
-		i40e_led_set(hw, 0xf, B_FALSE);
+		i40e_led_set(hw, 0xf, false);
 		break;
 	default:
 		return (ENOTSUP);
@@ -1009,7 +1009,7 @@ i40e_update_fec(i40e_t *i40e, link_fec_t fec)
 	if (fec != 0)
 		return (EINVAL);
 
-	if (i40e_aq_get_phy_capabilities(hw, B_FALSE, B_FALSE, &abilities,
+	if (i40e_aq_get_phy_capabilities(hw, false, false, &abilities,
 	    NULL) != I40E_SUCCESS)
 		return (EIO);
 
@@ -1465,6 +1465,26 @@ i40e_m_propinfo(void *arg, const char *pr_name, mac_prop_id_t pr_num,
 		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);
 		mac_prop_info_set_default_uint8(prh,
 		    (i40e->i40e_phy.link_speed & I40E_LINK_SPEED_1GB) != 0);
+		break;
+	case MAC_PROP_ADV_2500FDX_CAP:
+		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);
+		mac_prop_info_set_default_uint8(prh,
+		    (i40e->i40e_phy.link_speed & I40E_LINK_SPEED_2_5GB) != 0);
+		break;
+	case MAC_PROP_EN_2500FDX_CAP:
+		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);
+		mac_prop_info_set_default_uint8(prh,
+		    (i40e->i40e_phy.link_speed & I40E_LINK_SPEED_2_5GB) != 0);
+		break;
+	case MAC_PROP_ADV_5000FDX_CAP:
+		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);
+		mac_prop_info_set_default_uint8(prh,
+		    (i40e->i40e_phy.link_speed & I40E_LINK_SPEED_5GB) != 0);
+		break;
+	case MAC_PROP_EN_5000FDX_CAP:
+		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);
+		mac_prop_info_set_default_uint8(prh,
+		    (i40e->i40e_phy.link_speed & I40E_LINK_SPEED_5GB) != 0);
 		break;
 	case MAC_PROP_ADV_10GFDX_CAP:
 		mac_prop_info_set_perm(prh, MAC_PROP_PERM_READ);

--- a/usr/src/uts/common/io/i40e/i40e_main.c
+++ b/usr/src/uts/common/io/i40e/i40e_main.c
@@ -560,12 +560,12 @@ void
 i40e_link_check(i40e_t *i40e)
 {
 	i40e_hw_t *hw = &i40e->i40e_hw_space;
-	boolean_t ls;
+	bool ls;
 	int ret;
 
 	ASSERT(MUTEX_HELD(&i40e->i40e_general_lock));
 
-	hw->phy.get_link_info = B_TRUE;
+	hw->phy.get_link_info = true;
 	if ((ret = i40e_get_link_status(hw, &ls)) != I40E_SUCCESS) {
 		i40e->i40e_s_link_status_errs++;
 		i40e->i40e_s_link_status_lasterr = ret;
@@ -576,7 +576,7 @@ i40e_link_check(i40e_t *i40e)
 	 * Firmware abstracts all of the mac and phy information for us, so we
 	 * can use i40e_get_link_status to determine the current state.
 	 */
-	if (ls == B_TRUE) {
+	if (ls) {
 		enum i40e_aq_link_speed speed;
 
 		speed = i40e_get_link_speed(hw);
@@ -2004,14 +2004,14 @@ i40e_get_hw_state(i40e_t *i40e, i40e_hw_t *hw)
 	i40e_link_check(i40e);
 
 	/*
-	 * Try and determine our PHY. Note that we may have to retry to and
+	 * Try and determine our PHY. Note that we may have to retry and
 	 * delay to detect fiber correctly.
 	 */
-	rc = i40e_aq_get_phy_capabilities(hw, B_FALSE, B_TRUE, &i40e->i40e_phy,
+	rc = i40e_aq_get_phy_capabilities(hw, false, true, &i40e->i40e_phy,
 	    NULL);
 	if (rc == I40E_ERR_UNKNOWN_PHY) {
 		i40e_msec_delay(200);
-		rc = i40e_aq_get_phy_capabilities(hw, B_FALSE, B_TRUE,
+		rc = i40e_aq_get_phy_capabilities(hw, false, true,
 		    &i40e->i40e_phy, NULL);
 	}
 
@@ -2422,7 +2422,7 @@ i40e_config_rss_hlut(i40e_t *i40e, i40e_hw_t *hw)
 	if (i40e_is_x722(i40e)) {
 		enum i40e_status_code status;
 
-		status = i40e_aq_set_rss_lut(hw, 0, B_TRUE, (uint8_t *)hlut,
+		status = i40e_aq_set_rss_lut(hw, 0, true, (uint8_t *)hlut,
 		    I40E_HLUT_TABLE_SIZE);
 
 		if (status != I40E_SUCCESS) {
@@ -2521,7 +2521,7 @@ i40e_chip_start(i40e_t *i40e)
 
 	/* For now, we always disable Ethernet Flow Control. */
 	hw->fc.requested_mode = I40E_FC_NONE;
-	rc = i40e_set_fc(hw, &err, B_TRUE);
+	rc = i40e_set_fc(hw, &err, true);
 	if (rc != I40E_SUCCESS) {
 		i40e_error(i40e, "Setting flow control failed, returned %d"
 		    " with error: 0x%x", rc, err);
@@ -2563,7 +2563,7 @@ i40e_chip_start(i40e_t *i40e)
 	 * downlink port.
 	 */
 	rc = i40e_aq_add_veb(hw, i40e->i40e_mac_seid, I40E_DEF_VSI_SEID(i40e),
-	    0x1, B_TRUE, &i40e->i40e_veb_seid, B_FALSE, NULL);
+	    0x1, true, &i40e->i40e_veb_seid, false, NULL);
 	if (rc != I40E_SUCCESS) {
 		i40e_error(i40e, "i40e_aq_add_veb() failed %d: %d", rc,
 		    hw->aq.asq_last_status);
@@ -2635,7 +2635,7 @@ i40e_shutdown_tx_ring(i40e_trqpair_t *itrq)
 	/*
 	 * Step 2. Set the SET_QDIS flag for the queue.
 	 */
-	i40e_pre_tx_queue_cfg(hw, itrq->itrq_index, B_FALSE);
+	i40e_pre_tx_queue_cfg(hw, itrq->itrq_index, false);
 
 	/*
 	 * Step 3. Wait at least 400 usec.
@@ -2987,7 +2987,7 @@ i40e_setup_tx_ring(i40e_trqpair_t *itrq)
 	 * Step 1. Clear the queue disable flag and verify that the
 	 * index is set correctly.
 	 */
-	i40e_pre_tx_queue_cfg(hw, itrq->itrq_index, B_TRUE);
+	i40e_pre_tx_queue_cfg(hw, itrq->itrq_index, true);
 
 	/*
 	 * Step 2. Prepare the queue's FPM/HMC context.
@@ -3177,7 +3177,7 @@ i40e_start(i40e_t *i40e)
 	 * Enable broadcast traffic; however, do not enable multicast traffic.
 	 * That's handle exclusively through MAC's mc_multicst routines.
 	 */
-	err = i40e_aq_set_vsi_broadcast(hw, I40E_DEF_VSI_SEID(i40e), B_TRUE,
+	err = i40e_aq_set_vsi_broadcast(hw, I40E_DEF_VSI_SEID(i40e), true,
 	    NULL);
 	if (err != I40E_SUCCESS) {
 		i40e_error(i40e, "failed to set default VSI: %d", err);
@@ -3185,8 +3185,8 @@ i40e_start(i40e_t *i40e)
 		goto done;
 	}
 
-	err = i40e_aq_set_mac_config(hw, i40e->i40e_frame_max, B_TRUE, 0,
-	    B_FALSE, NULL);
+	err = i40e_aq_set_mac_config(hw, i40e->i40e_frame_max, true, 0,
+	    false, NULL);
 	if (err != I40E_SUCCESS) {
 		i40e_error(i40e, "failed to set MAC config: %d", err);
 		rc = B_FALSE;

--- a/usr/src/uts/common/io/i40e/i40e_osdep.h
+++ b/usr/src/uts/common/io/i40e/i40e_osdep.h
@@ -26,6 +26,7 @@ extern "C" {
 #include <sys/sunddi.h>
 #include <sys/pci_cap.h>
 #include <sys/sysmacros.h>
+#include <sys/stdbool.h>
 
 #define	DEBUGOUT(S)				i40e_debug(NULL, 0, S)
 #define	DEBUGOUT1(S, A)				i40e_debug(NULL, 0, S, A)
@@ -57,10 +58,8 @@ extern "C" {
  * the shared code will be upset.
  */
 #ifndef _I40E_MDB_DMOD
-#define	FALSE	B_FALSE
-#define	false	B_FALSE
-#define	TRUE	B_TRUE
-#define	true	B_TRUE
+#define	FALSE	false
+#define	TRUE	true
 #endif /* _I40E_MDB_DMOD */
 
 
@@ -84,10 +83,8 @@ extern "C" {
 
 #define	FIELD_SIZEOF(x, y) (sizeof (((x*)0)->y))
 
-#define	BIT(a) 		(1UL << (a))
-#define	BIT_ULL(a) 	(1ULL << (a))
-
-typedef boolean_t	bool;
+#define	BIT(a)		(1UL << (a))
+#define	BIT_ULL(a)	(1ULL << (a))
 
 typedef uint8_t		u8;
 typedef int8_t		s8;
@@ -124,8 +121,8 @@ struct i40e_spinlock {
 
 struct i40e_osdep {
 	off_t			ios_reg_size;
-	ddi_acc_handle_t 	ios_reg_handle;
-	ddi_acc_handle_t 	ios_cfg_handle;
+	ddi_acc_handle_t	ios_reg_handle;
+	ddi_acc_handle_t	ios_cfg_handle;
 	struct i40e		*ios_i40e;
 };
 
@@ -134,7 +131,7 @@ struct i40e_osdep {
  * cannot structure prefix it, even if we want to.
  */
 struct i40e_virt_mem {
-	void 	*va;
+	void	*va;
 	u32	size;
 };
 

--- a/usr/src/uts/common/io/igb/e1000_osdep.h
+++ b/usr/src/uts/common/io/igb/e1000_osdep.h
@@ -51,6 +51,7 @@ extern "C" {
 #include <sys/pci_cap.h>
 #include <sys/atomic.h>
 #include <sys/note.h>
+#include <sys/stdbool.h>
 #include "igb_debug.h"
 
 #define	usec_delay(x)		drv_usecwait(x)
@@ -71,8 +72,6 @@ extern "C" {
 
 #define	OS_DEP(hw)		((struct igb_osdep *)((hw)->back))
 
-#define	false			B_FALSE
-#define	true			B_TRUE
 #define	FALSE			false
 #define	TRUE			true
 
@@ -165,10 +164,9 @@ typedef	int16_t		s16;
 typedef	int32_t		s32;
 typedef	int64_t		s64;
 typedef uint8_t		u8;
-typedef	uint16_t 	u16;
+typedef	uint16_t	u16;
 typedef	uint32_t	u32;
 typedef	uint64_t	u64;
-typedef	boolean_t	bool;
 
 /*
  * igb only uses the first two of the ddi_acc_handle_t, the latter end up coming

--- a/usr/src/uts/common/io/igb/igb_main.c
+++ b/usr/src/uts/common/io/igb/igb_main.c
@@ -635,9 +635,9 @@ igb_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 	 * default.
 	 */
 	if (igb->hw.mac.type == e1000_i350)
-		(void) e1000_set_eee_i350(&igb->hw, B_FALSE, B_FALSE);
+		(void) e1000_set_eee_i350(&igb->hw, false, false);
 	else if (igb->hw.mac.type == e1000_i354)
-		(void) e1000_set_eee_i354(&igb->hw, B_FALSE, B_FALSE);
+		(void) e1000_set_eee_i354(&igb->hw, false, false);
 
 	return (DDI_SUCCESS);
 
@@ -1049,7 +1049,7 @@ igb_init_driver_settings(igb_t *igb)
 	/*
 	 * Initialize chipset specific hardware function pointers
 	 */
-	if (e1000_setup_init_funcs(hw, B_TRUE) != E1000_SUCCESS) {
+	if (e1000_setup_init_funcs(hw, true) != E1000_SUCCESS) {
 		return (IGB_FAILURE);
 	}
 
@@ -1458,7 +1458,7 @@ igb_init_adapter(igb_t *igb)
 	}
 
 	hw->fc.pause_time = E1000_FC_PAUSE_TIME;
-	hw->fc.send_xon = B_TRUE;
+	hw->fc.send_xon = true;
 
 	(void) e1000_validate_mdi_setting(hw);
 
@@ -1474,14 +1474,14 @@ igb_init_adapter(igb_t *igb)
 	/*
 	 * Don't wait for auto-negotiation to complete
 	 */
-	hw->phy.autoneg_wait_to_complete = B_FALSE;
+	hw->phy.autoneg_wait_to_complete = false;
 
 	/*
 	 * Copper options
 	 */
 	if (hw->phy.media_type == e1000_media_type_copper) {
 		hw->phy.mdix = 0;	/* AUTO_ALL_MODES */
-		hw->phy.disable_polarity_correction = B_FALSE;
+		hw->phy.disable_polarity_correction = false;
 		hw->phy.ms_type = e1000_ms_hw_default; /* E1000_MASTER_SLAVE */
 	}
 
@@ -1914,9 +1914,9 @@ igb_start(igb_t *igb, boolean_t alloc_buffer)
 		goto start_failure;
 
 	if (igb->hw.mac.type == e1000_i350)
-		(void) e1000_set_eee_i350(&igb->hw, B_FALSE, B_FALSE);
+		(void) e1000_set_eee_i350(&igb->hw, false, false);
 	else if (igb->hw.mac.type == e1000_i354)
-		(void) e1000_set_eee_i354(&igb->hw, B_FALSE, B_FALSE);
+		(void) e1000_set_eee_i354(&igb->hw, false, false);
 
 	for (i = igb->num_tx_rings - 1; i >= 0; i--)
 		mutex_exit(&igb->tx_rings[i].tx_lock);
@@ -3135,7 +3135,7 @@ igb_setup_link(igb_t *igb, boolean_t setup_hw)
 	invalid = B_FALSE;
 
 	if (igb->param_adv_autoneg_cap == 1) {
-		mac->autoneg = B_TRUE;
+		mac->autoneg = true;
 		phy->autoneg_advertised = 0;
 
 		/*
@@ -3159,7 +3159,7 @@ igb_setup_link(igb_t *igb, boolean_t setup_hw)
 		if (phy->autoneg_advertised == 0)
 			invalid = B_TRUE;
 	} else {
-		mac->autoneg = B_FALSE;
+		mac->autoneg = false;
 
 		/*
 		 * 1000fdx and 1000hdx are not supported for forced link
@@ -3179,7 +3179,7 @@ igb_setup_link(igb_t *igb, boolean_t setup_hw)
 	if (invalid) {
 		igb_log(igb, IGB_LOG_INFO, "Invalid link settings. Setup "
 		    "link to autonegotiation with full link capabilities.");
-		mac->autoneg = B_TRUE;
+		mac->autoneg = true;
 		phy->autoneg_advertised = ADVERTISE_1000_FULL |
 		    ADVERTISE_100_FULL | ADVERTISE_100_HALF |
 		    ADVERTISE_10_FULL | ADVERTISE_10_HALF;
@@ -3882,9 +3882,9 @@ igb_set_loopback_mode(igb_t *igb, uint32_t mode)
 
 	if (mode == IGB_LB_NONE) {
 		/* Reset the chip */
-		hw->phy.autoneg_wait_to_complete = B_TRUE;
+		hw->phy.autoneg_wait_to_complete = true;
 		(void) igb_reset(igb);
-		hw->phy.autoneg_wait_to_complete = B_FALSE;
+		hw->phy.autoneg_wait_to_complete = false;
 		return (B_TRUE);
 	}
 
@@ -3934,9 +3934,9 @@ igb_set_loopback_mode(igb_t *igb, uint32_t mode)
 			igb->loopback_mode = IGB_LB_NONE;
 
 			/* Reset the chip */
-			hw->phy.autoneg_wait_to_complete = B_TRUE;
+			hw->phy.autoneg_wait_to_complete = true;
 			(void) igb_reset(igb);
-			hw->phy.autoneg_wait_to_complete = B_FALSE;
+			hw->phy.autoneg_wait_to_complete = false;
 
 			igb_log(igb, IGB_LOG_INFO, "Set external loopback "
 			    "failed, reset to loopback none.");
@@ -4106,7 +4106,7 @@ igb_intr_link_work(igb_t *igb)
 	 * Because we got a link-status-change interrupt, force
 	 * e1000_check_for_link() to look at phy
 	 */
-	igb->hw.mac.get_link_status = B_TRUE;
+	igb->hw.mac.get_link_status = true;
 
 	/* igb_link_check takes care of link status change */
 	link_changed = igb_link_check(igb);
@@ -4189,7 +4189,7 @@ igb_intr_legacy(void *arg1, void *arg2)
 			 * Because we got a link-status-change interrupt, force
 			 * e1000_check_for_link() to look at phy
 			 */
-			igb->hw.mac.get_link_status = B_TRUE;
+			igb->hw.mac.get_link_status = true;
 
 			/* igb_link_check takes care of link status change */
 			link_changed = igb_link_check(igb);

--- a/usr/src/uts/common/io/ixgbe/ixgbe_main.c
+++ b/usr/src/uts/common/io/ixgbe/ixgbe_main.c
@@ -1484,7 +1484,7 @@ ixgbe_init(ixgbe_t *ixgbe)
 	hw->fc.high_water[0] = DEFAULT_FCRTH;
 	hw->fc.low_water[0] = DEFAULT_FCRTL;
 	hw->fc.pause_time = DEFAULT_FCPAUSE;
-	hw->fc.send_xon = B_TRUE;
+	hw->fc.send_xon = true;
 
 	/*
 	 * Initialize flow control
@@ -1646,7 +1646,7 @@ ixgbe_chip_stop(ixgbe_t *ixgbe)
 	/*
 	 * Stop interupt generation and disable Tx unit
 	 */
-	hw->adapter_stopped = B_FALSE;
+	hw->adapter_stopped = false;
 	(void) ixgbe_stop_adapter(hw);
 
 	/*
@@ -1664,13 +1664,13 @@ ixgbe_chip_stop(ixgbe_t *ixgbe)
 	 * the PHY while doing so. Else, just power down the PHY.
 	 */
 	if (hw->phy.ops.enter_lplu != NULL) {
-		hw->phy.reset_disable = B_TRUE;
+		hw->phy.reset_disable = true;
 		rv = hw->phy.ops.enter_lplu(hw);
 		if (rv != IXGBE_SUCCESS)
 			ixgbe_error(ixgbe, "Error while entering LPLU: %d", rv);
-		hw->phy.reset_disable = B_FALSE;
+		hw->phy.reset_disable = false;
 	} else {
-		(void) ixgbe_set_phy_power(hw, B_FALSE);
+		(void) ixgbe_set_phy_power(hw, false);
 	}
 
 	/*
@@ -3647,7 +3647,7 @@ ixgbe_init_params(ixgbe_t *ixgbe)
 {
 	struct ixgbe_hw *hw = &ixgbe->hw;
 	ixgbe_link_speed speeds_supported = 0;
-	boolean_t negotiate;
+	bool negotiate;
 
 	/*
 	 * Get a list of speeds the adapter supports. If the hw struct hasn't
@@ -3836,12 +3836,12 @@ ixgbe_driver_link_check(ixgbe_t *ixgbe)
 {
 	struct ixgbe_hw *hw = &ixgbe->hw;
 	ixgbe_link_speed speed = IXGBE_LINK_SPEED_UNKNOWN;
-	boolean_t link_up = B_FALSE;
+	bool link_up = false;
 	boolean_t link_changed = B_FALSE;
 
 	ASSERT(mutex_owned(&ixgbe->gen_lock));
 
-	(void) ixgbe_check_link(hw, &speed, &link_up, B_FALSE);
+	(void) ixgbe_check_link(hw, &speed, &link_up, false);
 	if (link_up) {
 		ixgbe->link_check_complete = B_TRUE;
 
@@ -3922,7 +3922,7 @@ ixgbe_sfp_check(void *arg)
 
 		/* if link up, do multispeed fiber setup */
 		(void) ixgbe_setup_link(hw, IXGBE_LINK_SPEED_82599_AUTONEG,
-		    B_TRUE);
+		    true);
 		ixgbe_driver_link_check(ixgbe);
 		ixgbe_get_hw_state(ixgbe);
 	} else if (eicr & IXGBE_EICR_GPI_SDP2_BY_MAC(hw)) {
@@ -3934,7 +3934,7 @@ ixgbe_sfp_check(void *arg)
 
 		/* do multispeed fiber setup */
 		(void) ixgbe_setup_link(hw, IXGBE_LINK_SPEED_82599_AUTONEG,
-		    B_TRUE);
+		    true);
 		ixgbe_driver_link_check(ixgbe);
 		ixgbe_get_hw_state(ixgbe);
 	}
@@ -3962,12 +3962,12 @@ ixgbe_overtemp_check(void *arg)
 	struct ixgbe_hw *hw = &ixgbe->hw;
 	uint32_t eicr = ixgbe->eicr;
 	ixgbe_link_speed speed;
-	boolean_t link_up;
+	bool link_up;
 
 	mutex_enter(&ixgbe->gen_lock);
 
 	/* make sure we know current state of link */
-	(void) ixgbe_check_link(hw, &speed, &link_up, B_FALSE);
+	(void) ixgbe_check_link(hw, &speed, &link_up, false);
 
 	/* check over-temp condition */
 	if (((eicr & IXGBE_EICR_GPI_SDP0_BY_MAC(hw)) && (!link_up)) ||
@@ -4638,7 +4638,7 @@ ixgbe_set_internal_mac_loopback(ixgbe_t *ixgbe)
 		IXGBE_WRITE_REG(&ixgbe->hw, IXGBE_AUTOC, reg);
 
 		(void) ixgbe_setup_link(&ixgbe->hw, IXGBE_LINK_SPEED_10GB_FULL,
-		    B_FALSE);
+		    false);
 		break;
 
 	default:
@@ -5934,7 +5934,7 @@ ixgbe_get_hw_state(ixgbe_t *ixgbe)
 {
 	struct ixgbe_hw *hw = &ixgbe->hw;
 	ixgbe_link_speed speed = 0;
-	boolean_t link_up = B_FALSE;
+	bool link_up = false;
 	uint32_t pcs1g_anlp = 0;
 
 	ASSERT(mutex_owned(&ixgbe->gen_lock));
@@ -5942,7 +5942,7 @@ ixgbe_get_hw_state(ixgbe_t *ixgbe)
 	ixgbe->param_lp_100fdx_cap  = 0;
 
 	/* check for link, don't wait */
-	(void) ixgbe_check_link(hw, &speed, &link_up, B_FALSE);
+	(void) ixgbe_check_link(hw, &speed, &link_up, false);
 	ixgbe->phys_supported = ixgbe_get_supported_physical_layer(hw);
 
 	/*
@@ -6508,7 +6508,7 @@ ixgbe_addvlan(mac_group_driver_t gdriver, uint16_t vid)
 	 * This logic is meant to reserve VLVF slots for use by
 	 * reserved groups: guaranteeing their use of HW filtering.
 	 */
-	ret = ixgbe_set_vfta(hw, vid, rx_group->index, B_TRUE, is_def_grp);
+	ret = ixgbe_set_vfta(hw, vid, rx_group->index, true, is_def_grp);
 
 	if (ret == IXGBE_SUCCESS) {
 		vlp = kmem_zalloc(sizeof (ixgbe_vlan_t), KM_SLEEP);
@@ -6588,7 +6588,7 @@ ixgbe_remvlan(mac_group_driver_t gdriver, uint16_t vid)
 	 * vlvf_bypass.
 	 */
 	if (vlp->ixvl_refs == 1) {
-		ret = ixgbe_set_vfta(hw, vid, rx_group->index, B_FALSE,
+		ret = ixgbe_set_vfta(hw, vid, rx_group->index, false,
 		    is_def_grp);
 	} else {
 		/*
@@ -6633,8 +6633,8 @@ ixgbe_remvlan(mac_group_driver_t gdriver, uint16_t vid)
 		vlp = ixgbe_find_vlan(defgrp, vid);
 		if (vlp != NULL) {
 			/* This shouldn't fail, but if it does return EIO. */
-			ret = ixgbe_set_vfta(hw, vid, rx_group->index, B_TRUE,
-			    B_TRUE);
+			ret = ixgbe_set_vfta(hw, vid, rx_group->index, true,
+			    true);
 			if (ret != IXGBE_SUCCESS) {
 				mutex_exit(&ixgbe->gen_lock);
 				return (EIO);

--- a/usr/src/uts/common/io/ixgbe/ixgbe_osdep.h
+++ b/usr/src/uts/common/io/ixgbe/ixgbe_osdep.h
@@ -56,6 +56,7 @@ extern "C" {
 #include <sys/pci.h>
 #include <sys/atomic.h>
 #include <sys/note.h>
+#include <sys/stdbool.h>
 #include "ixgbe_debug.h"
 
 /* Cheesy hack for EWARN() */
@@ -72,10 +73,8 @@ boolean_t ixgbe_removed(struct ixgbe_hw *);
 
 #define	OS_DEP(hw)		((struct ixgbe_osdep *)((hw)->back))
 
-#define	false		B_FALSE
-#define	true		B_TRUE
-#define	FALSE		B_FALSE
-#define	TRUE		B_TRUE
+#define	FALSE		false
+#define	TRUE		true
 
 #define	IXGBE_READ_PCIE_WORD	ixgbe_read_pci_cfg
 #define	IXGBE_WRITE_PCIE_WORD	ixgbe_write_pci_cfg
@@ -144,7 +143,6 @@ typedef	uint8_t		u8;
 typedef	uint16_t	u16;
 typedef	uint32_t	u32;
 typedef	uint64_t	u64;
-typedef	boolean_t	bool;
 
 /* shared code requires this */
 #define	__le16  u16


### PR DESCRIPTION
Weekly upstream for upstream_merge/2025070701

## Backports

_TBC_

## onu

```
_TBC_
```
## mail_msg

```

==== Nightly distributed build started:   Mon Jul  7 15:05:14 UTC 2025 ====
==== Nightly distributed build completed: Mon Jul  7 16:19:15 UTC 2025 ====

==== Total build time ====

real    1:14:01

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-16da17d43d5 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151055/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151055/14.3.0-il-1) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.15+6-omnios-151055"

/usr/bin/openssl
OpenSSL 3.5.0 8 Apr 2025 (Library: OpenSSL 3.5.0 8 Apr 2025)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   110

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-upstream_merge-2025070701-f9df02ece86

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    29:31.0
user  4:27:21.0
sys   1:24:34.4

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    27:06.1
user  4:06:22.2
sys   1:21:19.8

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
