### PR TITLE
Backport bpr54

### DIFF
--- a/usr/src/pkg/manifests/system-test-tztest.p5m
+++ b/usr/src/pkg/manifests/system-test-tztest.p5m
@@ -34,6 +34,9 @@ file path=opt/tz-tests/tests/tz_dump mode=0555
 file path=opt/tz-tests/tests/tzlist.64 mode=0555
 file path=opt/tz-tests/tests/tzload.32 mode=0555
 file path=opt/tz-tests/tests/tzload.64 mode=0555
+file path=opt/tz-tests/tests/tzname_17947 mode=0555
+file path=opt/tz-tests/tests/tznames.32 mode=0555
+file path=opt/tz-tests/tests/tznames.64 mode=0555
 file path=opt/tz-tests/tests/tzparams.64 mode=0555
 file path=opt/tz-tests/tests/zoneinfo_dump.32 mode=0555
 file path=opt/tz-tests/tests/zoneinfo_dump.64 mode=0555

--- a/usr/src/test/tz-tests/tests/Makefile
+++ b/usr/src/test/tz-tests/tests/Makefile
@@ -14,12 +14,14 @@
 #
 
 PROGS = \
+	tznames		\
 	tzload		\
 	zoneinfo_dump
 
 SCRIPTS = \
 	basic_tzs \
-	tz_dump
+	tz_dump \
+	tzname_17947
 
 PROGS32 = $(PROGS:%=%.32)
 PROGS64 = $(PROGS:%=%.64) \

--- a/usr/src/test/tz-tests/tests/tzname_17947.ksh
+++ b/usr/src/test/tz-tests/tests/tzname_17947.ksh
@@ -1,0 +1,65 @@
+#!/usr/bin/ksh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Oxide Computer Company
+#
+
+#
+# This test serves as a basic regression test for #17947 where we were
+# incorrectly determining the value of tzname[] for various POSIX-style
+# timezones due to how we had updated the data and incorrect assumptions made
+# around indexes that were thrown off with the addition of LMT.
+#
+
+unalias -a
+set -o pipefail
+export LANG=C.UTF-8
+
+tz_dir=$(dirname $0)
+tz_n32="$tz_dir/tznames.32"
+tz_n64="$tz_dir/tznames.64"
+tz_exit=0
+
+#
+# When there is no DST style time zone, then the following empty string is used.
+#
+tz_none="   "
+
+test_one()
+{
+	if ! $tz_n32 "$1" "$2" "$3"; then
+		tz_exit=1
+	fi
+
+	if ! $tz_n64 "$1" "$2" "$3"; then
+		tz_exit=1
+	fi
+}
+
+test_one UTC UTC "$tz_none"
+test_one UTC0UTC UTC UTC
+test_one GMT0GMT GMT GMT
+test_one FOO0BAR FOO BAR
+test_one America/New_York EST EDT
+test_one CET0 CET "$tz_none"
+test_one CET0CET CET CET
+test_one CET0CEST CET CEST
+test_one Asia/Tokyo JST JDT
+test_one Europe/Rome CET CEST
+test_one Australia/Brisbane AEST AEDT
+
+if (( tz_exit == 0 )); then
+	printf "All tests passed successfully!\n"
+fi
+
+exit $tz_exit

--- a/usr/src/test/tz-tests/tests/tznames.c
+++ b/usr/src/test/tz-tests/tests/tznames.c
@@ -1,0 +1,57 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Oxide Computer Company
+ */
+
+/*
+ * This file tests that the parsed tzname is equal to what was passed in as
+ * args. We use the arguments as TZ=arg0, name0=arg1, name1=arg2.
+ */
+
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+
+int
+main(int argc, char *argv[])
+{
+	int ret = EXIT_SUCCESS;
+
+	if (argc != 4) {
+		(void) fprintf(stderr, "Usage:  tznames <TZ> <tzname0> "
+		    "<tzname1>\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (setenv("TZ", argv[1], 1) != 0) {
+		err(EXIT_FAILURE, "failed to set TZ to %s", argv[1]);
+	}
+
+	tzset();
+
+	if (strcmp(tzname[0], argv[2]) != 0) {
+		warnx("TEST FAILED: TZ %s: found tzname[0] %s, expected %s",
+		    argv[1], tzname[0], argv[2]);
+		ret = EXIT_FAILURE;
+	}
+
+	if (strcmp(tzname[1], argv[3]) != 0) {
+		warnx("TEST FAILED: TZ %s: found tzname[1] %s, expected %s",
+		    argv[1], tzname[1], argv[3]);
+		ret = EXIT_FAILURE;
+	}
+
+	return (ret);
+}

--- a/usr/src/uts/common/io/nvme/nvme.c
+++ b/usr/src/uts/common/io/nvme/nvme.c
@@ -1213,8 +1213,6 @@ nvme_mgmt_bd_end(nvme_t *nvme)
  * blocked locks, and sending a DDI FMA impact. This is called from a precarious
  * place where locking is suspect. The only guarantee we have is that the nvme_t
  * is valid and won't disappear until we return.
- *
- * This should only be used after attach has been called.
  */
 static void
 nvme_ctrl_mark_dead(nvme_t *nvme, boolean_t removed)
@@ -4257,14 +4255,10 @@ nvme_init(nvme_t *nvme)
 	}
 
 	/*
-	 * Post an asynchronous event command to catch errors.
-	 * We assume the asynchronous events are supported as required by
-	 * specification (Figure 40 in section 5 of NVMe 1.2).
-	 * However, since at least qemu does not follow the specification,
-	 * we need a mechanism to protect ourselves.
+	 * Initialize the failure status we should use if we mark the controller
+	 * dead. Do this ahead of issuing any commands.
 	 */
-	nvme->n_async_event_supported = B_TRUE;
-	nvme_async_event(nvme);
+	nvme->n_dead_status = NVME_IOCTL_E_CTRL_DEAD;
 
 	/*
 	 * Identify Controller
@@ -4529,15 +4523,6 @@ nvme_init(nvme_t *nvme)
 			    "!unable to create I/O qpair %d", i);
 			goto fail;
 		}
-	}
-
-	/*
-	 * Post more asynchronous events commands to reduce event reporting
-	 * latency as suggested by the spec.
-	 */
-	if (nvme->n_async_event_supported) {
-		for (i = 1; i != nvme->n_async_event_limit; i++)
-			nvme_async_event(nvme);
 	}
 
 	return (DDI_SUCCESS);
@@ -5026,7 +5011,6 @@ nvme_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	nvme_mgmt_lock_init(&nvme->n_mgmt);
 	nvme_lock_init(&nvme->n_lock);
 	nvme->n_progress |= NVME_MGMT_INIT;
-	nvme->n_dead_status = NVME_IOCTL_E_CTRL_DEAD;
 
 	/*
 	 * Identify namespaces.
@@ -5082,6 +5066,12 @@ nvme_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		ns->ns_progress |= NVME_NS_MINOR;
 	}
 
+	/*
+	 * Indicate that namespace initialization is complete and therefore
+	 * marking the controller dead can evaluate every namespace lock.
+	 */
+	nvme->n_progress |= NVME_NS_INIT;
+
 	if (ddi_create_minor_node(dip, "devctl", S_IFCHR,
 	    NVME_MINOR(ddi_get_instance(dip), 0), DDI_NT_NVME_NEXUS, 0) !=
 	    DDI_SUCCESS) {
@@ -5114,6 +5104,29 @@ nvme_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	}
 
 	nvme_mgmt_unlock(nvme);
+
+	/*
+	 * As the last thing that we do, we finally go ahead and enable
+	 * asynchronous event notifications. Currently we rely upon whatever
+	 * defaults the device has for the events that we will receive. If we
+	 * enable this earlier, it's possible that we'll get events that we
+	 * cannot handle yet because all of our data structures are not valid.
+	 * The device will queue all asynchronous events on a per-log page basis
+	 * until we submit this. If the device is totally broken, it will have
+	 * likely failed our commands already. If we add support for configuring
+	 * which asynchronous events we would like to receive via the SET
+	 * FEATURES command, then we should do that as one of the first commands
+	 * we send in nvme_init().
+	 *
+	 * We start by assuming asynchronous events are supported. However, not
+	 * all devices (e.g. some versions of QEMU) support this, so we end up
+	 * tracking whether or not we think these actually work.
+	 */
+	nvme->n_async_event_supported = B_TRUE;
+	for (uint16_t i = 0; i < nvme->n_async_event_limit; i++) {
+		nvme_async_event(nvme);
+	}
+
 
 	return (DDI_SUCCESS);
 

--- a/usr/src/uts/common/io/nvme/nvme_var.h
+++ b/usr/src/uts/common/io/nvme/nvme_var.h
@@ -49,7 +49,8 @@ typedef enum {
 	NVME_UFM_INIT			= 1 << 6,
 	NVME_MUTEX_INIT			= 1 << 7,
 	NVME_MGMT_INIT			= 1 << 8,
-	NVME_STAT_INIT			= 1 << 9
+	NVME_STAT_INIT			= 1 << 9,
+	NVME_NS_INIT			= 1 << 10
 } nvme_progress_t;
 
 typedef enum {


### PR DESCRIPTION
Backport(s) for bpr54
## mail_msg

```

==== Nightly distributed build started:   Mon Jul 21 13:37:29 UTC 2025 ====
==== Nightly distributed build completed: Mon Jul 21 14:59:27 UTC 2025 ====

==== Total build time ====

real    1:21:57

==== Build environment ====

/usr/bin/uname
SunOS r151054 5.11 omnios-r151054-180b86b9dd i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151054/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151054/14.2.0-il-1) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/r151054/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.15+6-omnios-151054"

/usr/bin/openssl
OpenSSL 3.5.1 1 Jul 2025 (Library: OpenSSL 3.5.1 1 Jul 2025)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   114

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-bpr54-9e7a63b01a

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    33:31.1
user  5:06:07.4
sys   1:30:55.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    30:28.9
user  4:38:25.4
sys   1:28:13.9

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
