### PR TITLE
Upstream merge/2025082801

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from SmartOS
 
-Last illumos-joyent commit: 73f55144a898b86fc96f9706c91174a68f2d7eba
+Last illumos-joyent commit: b38245598b9bd5a9557bddae5a7cb1cbfd6d2b5a
 
 

--- a/usr/src/cmd/bhyve/common/pci_virtio_console.c
+++ b/usr/src/cmd/bhyve/common/pci_virtio_console.c
@@ -32,6 +32,7 @@
 
 /*
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
  */
 
 
@@ -288,7 +289,11 @@ pci_vtcon_sock_add(struct pci_vtcon_softc *sc, const char *port_name,
 	const char *name, *path;
 	char *cp, *pathcopy;
 	long port;
+#ifdef __FreeBSD__
 	int s = -1, fd = -1, error = 0;
+#else
+	int s = -1, error = 0;
+#endif
 #ifndef WITHOUT_CAPSICUM
 	cap_rights_t rights;
 #endif
@@ -348,7 +353,7 @@ pci_vtcon_sock_add(struct pci_vtcon_softc *sc, const char *port_name,
 	pathcopy = (char *)path;
 	addr.sun_family = AF_UNIX;
 	(void) strlcpy(addr.sun_path, pathcopy, sizeof (addr.sun_path));
-	if (bind(fd, (struct sockaddr *)&addr, sizeof (addr)) < 0) {
+	if (bind(s, (struct sockaddr *)&addr, sizeof (addr)) < 0) {
 		error = -1;
 		goto out;
 	}
@@ -394,8 +399,10 @@ pci_vtcon_sock_add(struct pci_vtcon_softc *sc, const char *port_name,
 	}
 
 out:
+#ifdef __FreeBSD__
 	if (fd != -1)
 		close(fd);
+#endif
 
 	if (error != 0) {
 		if (s != -1)

--- a/usr/src/cmd/mdb/intel/mdb/mdb_bhyve.c
+++ b/usr/src/cmd/mdb/intel/mdb/mdb_bhyve.c
@@ -362,8 +362,12 @@ bhyve_stack_common(uintptr_t addr, uint_t flags, int argc,
 
 	mdb_tgt_gregset_t gregs;
 
-	if (vcpu == -1)
+	if (vcpu == -1) {
 		vcpu = bd->bd_curcpu;
+	} else if (vcpu >= vmm_ncpu(bd->bd_vmm)) {
+		mdb_warn("no such CPU\n");
+		return (DCMD_ERR);
+	}
 
 	if (flags & DCMD_ADDRSPEC) {
 		bzero(&gregs, sizeof (gregs));

--- a/usr/src/uts/common/brand/lx/procfs/lx_proc.h
+++ b/usr/src/uts/common/brand/lx/procfs/lx_proc.h
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  * Copyright 2019 Joyent, Inc.
  * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2025 Edgecast Cloud LLC.
  */
 
 #ifndef	_LX_PROC_H
@@ -238,9 +239,14 @@ typedef enum lxpr_nodetype {
 	LXPR_SYS_KERNEL_SHMMAX,		/* /proc/sys/kernel/shmmax	*/
 	LXPR_SYS_KERNEL_SHMMNI,		/* /proc/sys/kernel/shmmni	*/
 	LXPR_SYS_KERNEL_THREADS_MAX,	/* /proc/sys/kernel/threads-max */
+	LXPR_SYS_KERNEL_PANIC_ON_OOPS, /* /proc/sys/kernel/panic_on_oops */
 	LXPR_SYS_NETDIR,		/* /proc/sys/net		*/
 	LXPR_SYS_NET_COREDIR,		/* /proc/sys/net/core		*/
 	LXPR_SYS_NET_CORE_SOMAXCON,	/* /proc/sys/net/core/somaxconn	*/
+	LXPR_SYS_NET_CORE_WMEM_MAX,	/* /proc/sys/net/core/wmem_max	*/
+	LXPR_SYS_NET_CORE_WMEM_DEFAULT,
+	LXPR_SYS_NET_CORE_RMEM_MAX,	/* /proc/sys/net/core/rmem_max	*/
+	LXPR_SYS_NET_CORE_RMEM_DEFAULT,
 	LXPR_SYS_NET_IPV4DIR,		/* /proc/sys/net/ipv4		*/
 	LXPR_SYS_NET_IPV4_ICMP_EIB,	/* .../icmp_echo_ignore_broadcasts */
 	LXPR_SYS_NET_IPV4_IP_FORWARD,	/* .../net/ipv4/ip_forward */

--- a/usr/src/uts/common/io/cxgbe/t4nex/adapter.h
+++ b/usr/src/uts/common/io/cxgbe/t4nex/adapter.h
@@ -134,10 +134,12 @@ struct tx_desc {
 };
 
 struct tx_sdesc {
-	mblk_t *m;
+	mblk_t *mp_head;
+	mblk_t *mp_tail;
 	uint32_t txb_used;	/* # of bytes of tx copy buffer used */
 	uint16_t hdls_used;	/* # of dma handles used */
 	uint16_t desc_used;	/* # of hardware descriptors used */
+	uint64_t _pad;
 };
 
 typedef enum t4_iq_flags {
@@ -687,6 +689,9 @@ void t4_mac_rx(struct port_info *pi, struct sge_rxq *rxq, mblk_t *m);
 void t4_mac_tx_update(struct port_info *pi, struct sge_txq *txq);
 int t4_addmac(void *arg, const uint8_t *ucaddr);
 const char **t4_get_priv_props(struct port_info *, size_t *);
+uint8_t t4_choose_holdoff_timer(struct adapter *, uint_t);
+int8_t t4_choose_holdoff_pktcnt(struct adapter *, int);
+uint_t t4_choose_dbq_timer(struct adapter *, uint_t);
 
 /* t4_ioctl.c */
 int t4_ioctl(struct adapter *sc, int cmd, void *data, int mode);

--- a/usr/src/uts/common/io/cxgbe/t4nex/t4_mac.c
+++ b/usr/src/uts/common/io/cxgbe/t4nex/t4_mac.c
@@ -22,7 +22,7 @@
 
 /*
  * Copyright 2020 RackTop Systems, Inc.
- * Copyright 2023 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 #include <sys/ddi.h>
@@ -1935,7 +1935,7 @@ t4_getprop_priv(struct port_info *pi, const char *name, uint_t size, void *val)
 #define	ABS_DELTA(left, right)		\
 	(((left) > (right)) ? (left) - (right) : (right) - (left))
 
-static uint8_t
+uint8_t
 t4_choose_holdoff_timer(struct adapter *sc, uint_t target_us)
 {
 	const uint_t *timer_us = sc->props.holdoff_timer_us;
@@ -1955,7 +1955,7 @@ t4_choose_holdoff_timer(struct adapter *sc, uint_t target_us)
 	return (chosen_idx);
 }
 
-static int8_t
+int8_t
 t4_choose_holdoff_pktcnt(struct adapter *sc, int target_cnt)
 {
 	const uint_t *pkt_cnt = sc->props.holdoff_pktcnt;
@@ -1980,7 +1980,7 @@ t4_choose_holdoff_pktcnt(struct adapter *sc, int target_cnt)
 	return (chosen_idx);
 }
 
-static uint_t
+uint_t
 t4_choose_dbq_timer(struct adapter *sc, uint_t target_us)
 {
 	const uint16_t *dbq_us = sc->sge.dbq_timers;


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151055  omnios-upstream_merge-2025082801-b7d2e8c3df5    August 2025
illumos development build: 2025-Aug-28 [illumos-omnios]
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-upstream_merge-2025082801-b7d2e8c3df5 i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Thu Aug 28 15:12:46 UTC 2025 ====
==== Nightly distributed build completed: Thu Aug 28 15:48:37 UTC 2025 ====

==== Total build time ====

real    0:35:50

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-ee5eb697ca9 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 24

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151055/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151055/14.3.0-il-1) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.15+6-omnios-151055"

/usr/bin/openssl
OpenSSL 3.5.1 1 Jul 2025 (Library: OpenSSL 3.5.1 1 Jul 2025)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   241

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-upstream_merge-2025082801-b7d2e8c3df5

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    13:58.7
user  3:51:02.7
sys   1:18:16.7

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:03.4
user  3:37:09.6
sys   1:16:20.6

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```