### PR TITLE
Upstream merge upstream_merge/2025083101

### DIFF
--- a/README.OmniOS
+++ b/README.OmniOS
@@ -1,5 +1,5 @@
 This README is here to keep track of merges from SmartOS
 
-Last illumos-joyent commit: b38245598b9bd5a9557bddae5a7cb1cbfd6d2b5a
+Last illumos-joyent commit: 312a77c51fe51438253703406f0daee63ac951e5
 
 

--- a/usr/src/pkg/manifests/driver-network-rge.p5m
+++ b/usr/src/pkg/manifests/driver-network-rge.p5m
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2025 Oxide Computer Company
 #
 
 #
@@ -43,11 +44,11 @@ dir  path=usr/share/man
 dir  path=usr/share/man/man4d
 file path=usr/share/man/man4d/rge.4d
 driver name=rge perms="* 0666 root sys" clone_perms="rge 0666 root sys" \
-    alias=pci10ec,8136 \
-    alias=pci10ec,8167 \
-    alias=pci10ec,8168 \
-    alias=pci10ec,8169 \
-    alias=pci16ec,116 \
+    alias=pci10ec,8136,p \
+    alias=pci10ec,8167,p \
+    alias=pci10ec,8168,p \
+    alias=pci10ec,8169,p \
+    alias=pci16ec,116,p \
     alias=pciex10ec,8136 \
     alias=pciex10ec,8168 \
     alias=pciex10ec,8169

--- a/usr/src/uts/common/sys/types.h
+++ b/usr/src/uts/common/sys/types.h
@@ -28,7 +28,7 @@
  *
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 Joyent, Inc.
- * Copyright 2023 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 #ifndef _SYS_TYPES_H
@@ -49,11 +49,11 @@
  * required by any standard but constitute a useful, general purpose set
  * of type definitions which is namespace clean with respect to all standards.
  */
-#ifdef	_KERNEL
+#if defined(_KERNEL) || defined(_BOOT)
 #include <sys/inttypes.h>
-#else	/* _KERNEL */
+#else
 #include <sys/int_types.h>
-#endif	/* _KERNEL */
+#endif
 
 #if defined(_KERNEL) || defined(_SYSCALL32)
 #include <sys/types32.h>

--- a/usr/src/uts/i86pc/boot/boot_console.c
+++ b/usr/src/uts/i86pc/boot/boot_console.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2012 Gary Mills
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2025 Oxide Computer Company
  *
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
@@ -579,9 +580,20 @@ boot_fb(struct xboot_info *xbi, int console)
 	if (xbi_fb_init(xbi, &bcons_dev) == B_FALSE)
 		return (console);
 
-	/* FB address is not set, fall back to serial terminal. */
+	/*
+	 * The framebuffer address is not set; fall back to the serial console.
+	 */
 	if (fb_info.paddr == 0)
 		return (CONS_TTY);
+
+#if defined(_BOOT)
+	/*
+	 * If the firmware placed the framebuffer mapping above the 32-bit
+	 * boundary, we cannot use it from dboot.
+	 */
+	if (fb_info.paddr >= UINTPTR_MAX)
+		return (CONS_TTY);
+#endif
 
 	fb_info.terminal.x = VGA_TEXT_COLS;
 	fb_info.terminal.y = VGA_TEXT_ROWS;


### PR DESCRIPTION
Weekly upstream for upstream_merge/2025083101

## Backports

_TBC_

## onu

```
_TBC_
```
## mail_msg

```

==== Nightly distributed build started:   Sun Aug 31 10:01:49 UTC 2025 ====
==== Nightly distributed build completed: Sun Aug 31 11:14:22 UTC 2025 ====

==== Total build time ====

real    1:12:32

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-ee5eb697ca9 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151055/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151055/14.3.0-il-1) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.15+6-omnios-151055"

/usr/bin/openssl
OpenSSL 3.5.1 1 Jul 2025 (Library: OpenSSL 3.5.1 1 Jul 2025)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   100

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-upstream_merge-2025083101-166aa909bb8

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    28:45.9
user  4:25:07.6
sys   1:18:06.3

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    26:28.8
user  4:03:55.1
sys   1:16:30.3

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
