### PR TITLE
Upstream merge upstream_merge/2026020201

### DIFF
--- a/usr/src/boot/common/ls.c
+++ b/usr/src/boot/common/ls.c
@@ -57,95 +57,105 @@ COMMAND_SET(ls, "ls", "list files", command_ls);
 static int
 command_ls(int argc, char *argv[])
 {
-    int		fd;
-    struct stat	sb;
-    struct	dirent *d;
-    char	*buf, *path;
-    char	lbuf[128];		/* one line */
-    int		result, ch;
-    int		verbose;
+	int		fd;
+	struct stat	sb;
+	struct		dirent *d;
+	char		*buf, *path;
+	char		lbuf[128];		/* one line */
+	int		result, ch;
+	int		verbose;
 
-    result = CMD_OK;
-    fd = -1;
-    verbose = 0;
-    optind = 1;
-    optreset = 1;
-    while ((ch = getopt(argc, argv, "l")) != -1) {
-	switch (ch) {
-	case 'l':
-	    verbose = 1;
-	    break;
-	case '?':
-	default:
-	    /* getopt has already reported an error */
-	    return (CMD_OK);
-	}
-    }
-    argv += (optind - 1);
-    argc -= (optind - 1);
-
-    if (argc < 2) {
-	path = "";
-    } else {
-	path = argv[1];
-    }
-
-    if (stat(path, &sb) == 0 && !S_ISDIR(sb.st_mode)) {
-	if (verbose) {
-	    printf(" %c %8d %s\n",
-	    typestr[sb.st_mode >> 12],
-	    (int)sb.st_size, path);
-	} else {
-	    printf(" %c  %s\n",
-	    typestr[sb.st_mode >> 12], path);
-	}
-	return (CMD_OK);
-    }
-
-    fd = ls_getdir(&path);
-    if (fd == -1) {
-	result = CMD_ERROR;
-	goto out;
-    }
-    pager_open();
-    pager_output(path);
-    pager_output("\n");
-
-    while ((d = readdirfd(fd)) != NULL) {
-	if (strcmp(d->d_name, ".") && strcmp(d->d_name, "..")) {
-	    if (d->d_type == 0 || verbose) {
-		/* stat the file, if possible */
-		sb.st_size = 0;
-		sb.st_mode = 0;
-		buf = malloc(strlen(path) + strlen(d->d_name) + 2);
-		if (buf != NULL) {
-		    sprintf(buf, "%s/%s", path, d->d_name);
-		    /* ignore return, could be symlink, etc. */
-		    if (stat(buf, &sb)) {
-			sb.st_size = 0;
-			sb.st_mode = 0;
-		    }
-		    free(buf);
+	result = CMD_OK;
+	fd = -1;
+	verbose = 0;
+	optind = 1;
+	optreset = 1;
+	while ((ch = getopt(argc, argv, "l")) != -1) {
+		switch (ch) {
+		case 'l':
+			verbose = 1;
+			break;
+		case '?':
+		default:
+			/* getopt has already reported an error */
+			return (CMD_OK);
 		}
-	    }
-	    if (verbose) {
-		snprintf(lbuf, sizeof (lbuf), " %c %8d %s\n",
-		    typestr[d->d_type? d->d_type:sb.st_mode >> 12],
-		    (int)sb.st_size, d->d_name);
-	    } else {
-		snprintf(lbuf, sizeof (lbuf), " %c  %s\n",
-		    typestr[d->d_type? d->d_type:sb.st_mode >> 12], d->d_name);
-	    }
-	    if (pager_output(lbuf))
+	}
+	argv += (optind - 1);
+	argc -= (optind - 1);
+
+	if (argc < 2) {
+		path = "";
+	} else {
+		path = argv[1];
+	}
+
+	if (stat(path, &sb) == 0 && !S_ISDIR(sb.st_mode)) {
+		if (verbose) {
+			printf(" %c %8d %s\n",
+			    typestr[sb.st_mode >> 12],
+			    (int)sb.st_size, path);
+		} else {
+			printf(" %c  %s\n",
+			    typestr[sb.st_mode >> 12], path);
+		}
+		return (CMD_OK);
+	}
+
+	fd = ls_getdir(&path);
+	if (fd == -1) {
+		result = CMD_ERROR;
 		goto out;
 	}
-    }
- out:
-    pager_close();
-    if (fd != -1)
-	close(fd);
-    free(path);		/* ls_getdir() did allocate path */
-    return (result);
+	pager_open();
+	pager_output(path);
+	pager_output("\n");
+
+	while ((d = readdirfd(fd)) != NULL) {
+		if (strcmp(d->d_name, ".") && strcmp(d->d_name, "..")) {
+			if (d->d_type == 0 || verbose) {
+				/* stat the file, if possible */
+				sb.st_size = 0;
+				sb.st_mode = 0;
+				/* Avoid double '/' */
+				if (strcmp(path, "/") == 0) {
+					(void) asprintf(&buf, "/%s", d->d_name);
+				} else {
+					(void) asprintf(&buf, "%s/%s", path,
+					    d->d_name);
+				}
+
+				if (buf != NULL) {
+					/*
+					 * ignore return, could be symlink, etc.
+					 */
+					if (stat(buf, &sb) != 0) {
+						sb.st_size = 0;
+						sb.st_mode = 0;
+					}
+					free(buf);
+				}
+			}
+			if (verbose) {
+				snprintf(lbuf, sizeof (lbuf), " %c %8d %s\n",
+				    typestr[d->d_type ?
+				    d->d_type:sb.st_mode >> 12],
+				    (int)sb.st_size, d->d_name);
+			} else {
+				snprintf(lbuf, sizeof (lbuf), " %c  %s\n",
+				    typestr[d->d_type ?
+				    d->d_type:sb.st_mode >> 12], d->d_name);
+			}
+			if (pager_output(lbuf))
+				goto out;
+		}
+	}
+out:
+	pager_close();
+	if (fd != -1)
+		close(fd);
+	free(path);		/* ls_getdir() did allocate path */
+	return (result);
 }
 
 /*
@@ -155,58 +165,58 @@ command_ls(int argc, char *argv[])
 static int
 ls_getdir(char **pathp)
 {
-    struct stat	sb;
-    int		fd;
-    const char	*cp;
-    char	*path;
+	struct stat	sb;
+	int		fd;
+	const char	*cp;
+	char	*path;
 
-    fd = -1;
+	fd = -1;
 
-    /* one extra byte for a possible trailing slash required */
-    path = malloc(strlen(*pathp) + 2);
-    if (path == NULL) {
-	snprintf(command_errbuf, sizeof (command_errbuf),
-	    "out of memory");
-	goto out;
-    }
+	/* one extra byte for a possible trailing slash required */
+	path = malloc(strlen(*pathp) + 2);
+	if (path == NULL) {
+		snprintf(command_errbuf, sizeof (command_errbuf),
+		    "out of memory");
+		goto out;
+	}
 
-    strcpy(path, *pathp);
+	strcpy(path, *pathp);
 
-    /* Make sure the path is respectable to begin with */
-    if (archsw.arch_getdev(NULL, path, &cp)) {
-	snprintf(command_errbuf, sizeof (command_errbuf),
-	    "bad path '%s'", path);
-	goto out;
-    }
+	/* Make sure the path is respectable to begin with */
+	if (archsw.arch_getdev(NULL, path, &cp)) {
+		snprintf(command_errbuf, sizeof (command_errbuf),
+		    "bad path '%s'", path);
+		goto out;
+	}
 
-    /* If there's no path on the device, assume '/' */
-    if (*cp == 0)
-	strcat(path, "/");
+	/* If there's no path on the device, assume '/' */
+	if (*cp == 0)
+		strcat(path, "/");
 
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-	snprintf(command_errbuf, sizeof (command_errbuf),
-	    "open '%s' failed: %s", path, strerror(errno));
-	goto out;
-    }
-    if (fstat(fd, &sb) < 0) {
-	snprintf(command_errbuf, sizeof (command_errbuf),
-	    "stat failed: %s", strerror(errno));
-	goto out;
-    }
-    if (!S_ISDIR(sb.st_mode)) {
-	snprintf(command_errbuf, sizeof (command_errbuf),
-	    "%s: %s", path, strerror(ENOTDIR));
-	goto out;
-    }
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		snprintf(command_errbuf, sizeof (command_errbuf),
+		    "open '%s' failed: %s", path, strerror(errno));
+		goto out;
+	}
+	if (fstat(fd, &sb) < 0) {
+		snprintf(command_errbuf, sizeof (command_errbuf),
+		    "stat failed: %s", strerror(errno));
+		goto out;
+	}
+	if (!S_ISDIR(sb.st_mode)) {
+		snprintf(command_errbuf, sizeof (command_errbuf),
+		    "%s: %s", path, strerror(ENOTDIR));
+		goto out;
+	}
 
-    *pathp = path;
-    return (fd);
+	*pathp = path;
+	return (fd);
 
- out:
-    free(path);
-    *pathp = NULL;
-    if (fd != -1)
-	close(fd);
-    return (-1);
+out:
+	free(path);
+	*pathp = NULL;
+	if (fd != -1)
+		close(fd);
+	return (-1);
 }

--- a/usr/src/boot/efi/loader/main.c
+++ b/usr/src/boot/efi/loader/main.c
@@ -416,8 +416,6 @@ find_currdev(EFI_LOADED_IMAGE_PROTOCOL *img)
 					return (true);
 			}
 		}
-	} else {
-		printf("Can't find device by handle\n");
 	}
 
 	/*

--- a/usr/src/cmd/bhyve/common/net_backends.h
+++ b/usr/src/cmd/bhyve/common/net_backends.h
@@ -73,28 +73,30 @@ int	netbe_get_mac(net_backend_t *, void *, size_t *);
  * Despite the name, these capabilities can be used by different frontends
  * (virtio-net, ptnet) and supported by different backends (netmap, tap, ...).
  */
-#define	VIRTIO_NET_F_CSUM	(1 <<  0) /* host handles partial cksum */
-#define	VIRTIO_NET_F_GUEST_CSUM	(1 <<  1) /* guest handles partial cksum */
-#define	VIRTIO_NET_F_MTU	(1 <<  3) /* initial MTU advice */
-#define	VIRTIO_NET_F_MAC	(1 <<  5) /* host supplies MAC */
-#define	VIRTIO_NET_F_GSO_DEPREC	(1 <<  6) /* deprecated: host handles GSO */
-#define	VIRTIO_NET_F_GUEST_TSO4	(1 <<  7) /* guest can rcv TSOv4 */
-#define	VIRTIO_NET_F_GUEST_TSO6	(1 <<  8) /* guest can rcv TSOv6 */
-#define	VIRTIO_NET_F_GUEST_ECN	(1 <<  9) /* guest can rcv TSO with ECN */
-#define	VIRTIO_NET_F_GUEST_UFO	(1 << 10) /* guest can rcv UFO */
-#define	VIRTIO_NET_F_HOST_TSO4	(1 << 11) /* host can rcv TSOv4 */
-#define	VIRTIO_NET_F_HOST_TSO6	(1 << 12) /* host can rcv TSOv6 */
-#define	VIRTIO_NET_F_HOST_ECN	(1 << 13) /* host can rcv TSO with ECN */
-#define	VIRTIO_NET_F_HOST_UFO	(1 << 14) /* host can rcv UFO */
-#define	VIRTIO_NET_F_MRG_RXBUF	(1 << 15) /* host can merge RX buffers */
-#define	VIRTIO_NET_F_STATUS	(1 << 16) /* config status field available */
-#define	VIRTIO_NET_F_CTRL_VQ	(1 << 17) /* control channel available */
-#define	VIRTIO_NET_F_CTRL_RX	(1 << 18) /* control channel RX mode support */
-#define	VIRTIO_NET_F_CTRL_VLAN	(1 << 19) /* control channel VLAN filtering */
+#define	VIRTIO_NET_F_CSUM	(1ULL <<  0) /* host handles partial cksum */
+#define	VIRTIO_NET_F_GUEST_CSUM	(1ULL <<  1) /* guest handles partial cksum */
+#define	VIRTIO_NET_F_MTU	(1ULL <<  3) /* initial MTU advice */
+#define	VIRTIO_NET_F_MAC	(1ULL <<  5) /* host supplies MAC */
+#define	VIRTIO_NET_F_GSO_DEPREC	(1ULL <<  6) /* deprecated: host handles GSO */
+#define	VIRTIO_NET_F_GUEST_TSO4	(1ULL <<  7) /* guest can rcv TSOv4 */
+#define	VIRTIO_NET_F_GUEST_TSO6	(1ULL <<  8) /* guest can rcv TSOv6 */
+#define	VIRTIO_NET_F_GUEST_ECN	(1ULL <<  9) /* guest can rcv TSO with ECN */
+#define	VIRTIO_NET_F_GUEST_UFO	(1ULL << 10) /* guest can rcv UFO */
+#define	VIRTIO_NET_F_HOST_TSO4	(1ULL << 11) /* host can rcv TSOv4 */
+#define	VIRTIO_NET_F_HOST_TSO6	(1ULL << 12) /* host can rcv TSOv6 */
+#define	VIRTIO_NET_F_HOST_ECN	(1ULL << 13) /* host can rcv TSO with ECN */
+#define	VIRTIO_NET_F_HOST_UFO	(1ULL << 14) /* host can rcv UFO */
+#define	VIRTIO_NET_F_MRG_RXBUF	(1ULL << 15) /* host can merge RX buffers */
+#define	VIRTIO_NET_F_STATUS	(1ULL << 16) /* config status field available */
+#define	VIRTIO_NET_F_CTRL_VQ	(1ULL << 17) /* control chan available */
+#define	VIRTIO_NET_F_CTRL_RX	(1ULL << 18) /* control chan RX mode support */
+#define	VIRTIO_NET_F_CTRL_VLAN	(1ULL << 19) /* control chan VLAN filtering */
 #define	VIRTIO_NET_F_GUEST_ANNOUNCE \
-				(1 << 21) /* guest can send gratuitous pkts */
-#define	VIRTIO_NET_F_MQ		(1 << 22) /* host supports multiple VQ pairs */
-#define	VIRTIO_F_CTRL_MAC_ADDR	(1 << 23) /* set MAC address through ctrlq */
+				(1ULL << 21) /* guest can send gratuit. pkts */
+#define	VIRTIO_NET_F_MQ		(1ULL << 22) /* host supp multiple VQ pairs */
+#define	VIRTIO_F_CTRL_MAC_ADDR	(1ULL << 23) /* set MAC address through ctrlq */
+#define	VIRTIO_NET_F_SPEED_DUPLEX \
+				(1ULL << 63) /* speed/duplex fields avail */
 
 /*
  * PCI config-space "registers"; device configuration fields.
@@ -104,10 +106,18 @@ struct virtio_net_config {
 	uint16_t vnc_status;
 	uint16_t vnc_max_qpair;
 	uint16_t vnc_mtu;
+	uint32_t vnc_speed;	/* Specified in Mb/s */
+	uint8_t vnc_duplex;
 } __packed;
 
-#define	VIRTIO_NET_S_LINK_UP	1
-#define	VIRTIO_NET_S_ANNOUNCE	2
+#define	VIRTIO_NET_S_LINK_UP		1
+#define	VIRTIO_NET_S_ANNOUNCE		2
+
+#define	VIRTIO_NET_SPEED_UNKNOWN	UINT32_MAX
+
+#define	VIRTIO_NET_DUPLEX_HALF		0
+#define	VIRTIO_NET_DUPLEX_FULL		1
+#define	VIRTIO_NET_DUPLEX_UNK		0xff
 
 /*
  * Fixed network header size

--- a/usr/src/cmd/mdb/common/modules/genunix/genunix.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/genunix.c
@@ -25,7 +25,7 @@
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright 2022 Garrett D'Amore
  * Copyright 2023 RackTop Systems, Inc.
- * Copyright 2025 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 #include <mdb/mdb_param.h>
@@ -4251,6 +4251,13 @@ static const mdb_dcmd_t dcmds[] = {
 	/* from fm.c */
 	{ "ereport", "[-v]", "print ereports logged in dump",
 	    ereport },
+
+	/* from pci.c */
+	{ "pcie_fatal_errors", "?[-v]",
+	    "display PCIe fabric scan info from fatal error",
+	    pcie_pf_impl_dcmd, pcie_pf_impl_help },
+	{ "bdf", ":", "decode a PCIe BDF (Bus/Device/Function) value and "
+	    "print it as b/d/f", pcie_bdf_dcmd },
 
 	/* from group.c */
 	{ "group", "?[-q]", "display a group", group},

--- a/usr/src/cmd/mdb/common/modules/genunix/pci.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/pci.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2019, Joyent, Inc.
+ * Copyright 2026 Oxide Computer Company
  */
 
 /*
@@ -18,9 +19,11 @@
  */
 
 #include <mdb/mdb_modapi.h>
+#include <mdb/mdb_ctf.h>
 #include <sys/dditypes.h>
 #include <sys/ddi_impldefs.h>
 #include <sys/pcie_impl.h>
+#include <sys/stdbool.h>
 
 boolean_t
 pcie_bus_match(const struct dev_info *devi, uintptr_t *bus_p)
@@ -76,4 +79,376 @@ pcie_bus_walk_step(mdb_walk_state_t *wsp)
 	}
 
 	return (wsp->walk_callback(bus_addr, &bus, wsp->walk_cbdata));
+}
+
+/*
+ * Decode a BDF (Bus/Device/Function) value.
+ */
+
+/* The maximum size of a string produced by pcie_bdf() */
+#define	PCIE_BDF_BUFSZ	sizeof ("XX/XX/X")
+
+static const char *
+pcie_bdf(pcie_req_id_t bdf, char *buf, size_t len)
+{
+
+	if (bdf == PCIE_INVALID_BDF) {
+		(void) strlcpy(buf, "INVBDF", len);
+	} else {
+		uint_t bus, dev, func;
+
+		bus = (bdf & PCIE_REQ_ID_BUS_MASK) >> PCIE_REQ_ID_BUS_SHIFT;
+		dev = (bdf & PCIE_REQ_ID_DEV_MASK) >> PCIE_REQ_ID_DEV_SHIFT;
+		func = (bdf & PCIE_REQ_ID_FUNC_MASK) >> PCIE_REQ_ID_FUNC_SHIFT;
+
+		mdb_snprintf(buf, len, "%r/%r/%r", bus, dev, func);
+	}
+
+	return (buf);
+}
+
+static const mdb_bitmask_t pf_affected_bits[] = {
+	{ "ROOT", PF_AFFECTED_ROOT, PF_AFFECTED_ROOT },
+	{ "SELF", PF_AFFECTED_SELF, PF_AFFECTED_SELF },
+	{ "PARENT", PF_AFFECTED_PARENT, PF_AFFECTED_PARENT },
+	{ "CHILDREN", PF_AFFECTED_CHILDREN, PF_AFFECTED_CHILDREN },
+	{ "BDF", PF_AFFECTED_BDF, PF_AFFECTED_BDF },
+	{ "AER", PF_AFFECTED_AER, PF_AFFECTED_AER },
+	{ "SAER", PF_AFFECTED_SAER, PF_AFFECTED_SAER },
+	{ "ADDR", PF_AFFECTED_ADDR, PF_AFFECTED_ADDR },
+	{ NULL, 0, 0 }
+};
+
+static const mdb_bitmask_t pf_severity_bits[] = {
+	{ "NO_ERROR", PF_ERR_NO_ERROR, PF_ERR_NO_ERROR },
+	{ "CE", PF_ERR_CE, PF_ERR_CE },
+	{ "NO_PANIC", PF_ERR_NO_PANIC, PF_ERR_NO_PANIC },
+	{ "MATCHED_DEVICE", PF_ERR_MATCHED_DEVICE, PF_ERR_MATCHED_DEVICE },
+	{ "MATCHED_RC", PF_ERR_MATCHED_RC, PF_ERR_MATCHED_RC },
+	{ "MATCHED_PARENT", PF_ERR_MATCHED_PARENT, PF_ERR_MATCHED_PARENT },
+	{ "PANIC", PF_ERR_PANIC, PF_ERR_PANIC },
+	{ "PANIC_DEADLOCK", PF_ERR_PANIC_DEADLOCK, PF_ERR_PANIC_DEADLOCK },
+	{ "BAD_RESPONSE", PF_ERR_BAD_RESPONSE, PF_ERR_BAD_RESPONSE },
+	{ "MATCH_DOM", PF_ERR_MATCH_DOM, PF_ERR_MATCH_DOM },
+	{ NULL, 0, 0 }
+};
+
+static const mdb_bitmask_t pcie_devsts_bits[] = {
+	{ "CE", PCIE_DEVSTS_CE_DETECTED, PCIE_DEVSTS_CE_DETECTED },
+	{ "NFE", PCIE_DEVSTS_NFE_DETECTED, PCIE_DEVSTS_NFE_DETECTED },
+	{ "FE", PCIE_DEVSTS_FE_DETECTED, PCIE_DEVSTS_FE_DETECTED },
+	{ "UR", PCIE_DEVSTS_UR_DETECTED, PCIE_DEVSTS_UR_DETECTED },
+	{ NULL, 0, 0 }
+};
+
+static const mdb_bitmask_t pcie_aer_uce_bits[] = {
+	{ "TRAINING", PCIE_AER_UCE_TRAINING, PCIE_AER_UCE_TRAINING },
+	{ "DLP", PCIE_AER_UCE_DLP, PCIE_AER_UCE_DLP },
+	{ "SD", PCIE_AER_UCE_SD, PCIE_AER_UCE_SD },
+	{ "PTLP", PCIE_AER_UCE_PTLP, PCIE_AER_UCE_PTLP },
+	{ "FCP", PCIE_AER_UCE_FCP, PCIE_AER_UCE_FCP },
+	{ "TO", PCIE_AER_UCE_TO, PCIE_AER_UCE_TO },
+	{ "CA", PCIE_AER_UCE_CA, PCIE_AER_UCE_CA },
+	{ "UC", PCIE_AER_UCE_UC, PCIE_AER_UCE_UC },
+	{ "RO", PCIE_AER_UCE_RO, PCIE_AER_UCE_RO },
+	{ "MTLP", PCIE_AER_UCE_MTLP, PCIE_AER_UCE_MTLP },
+	{ "ECRC", PCIE_AER_UCE_ECRC, PCIE_AER_UCE_ECRC },
+	{ "UR", PCIE_AER_UCE_UR, PCIE_AER_UCE_UR },
+	{ NULL, 0, 0 }
+};
+
+static const mdb_bitmask_t pcie_aer_ce_bits[] = {
+	{ "RX_ERR", PCIE_AER_CE_RECEIVER_ERR, PCIE_AER_CE_RECEIVER_ERR },
+	{ "BAD_TLP", PCIE_AER_CE_BAD_TLP, PCIE_AER_CE_BAD_TLP },
+	{ "BAD_DLLP", PCIE_AER_CE_BAD_DLLP, PCIE_AER_CE_BAD_DLLP },
+	{ "REPLAY_RO", PCIE_AER_CE_REPLAY_ROLLOVER,
+	    PCIE_AER_CE_REPLAY_ROLLOVER },
+	{ "REPLAY_TO", PCIE_AER_CE_REPLAY_TO, PCIE_AER_CE_REPLAY_TO },
+	{ "AD_NFE", PCIE_AER_CE_AD_NFE, PCIE_AER_CE_AD_NFE },
+	{ NULL, 0, 0 }
+};
+
+/*
+ * Shadow structures for CTF reading. These contain only the fields we need
+ * from the target structures, allowing compatibility across kernel versions.
+ */
+typedef struct {
+	void		*pf_derr;
+	void		*pf_fault;
+	void		*pf_dq_head_p;
+	void		*pf_dq_tail_p;
+	uint32_t	pf_total;
+} mdb_pf_impl_t;
+
+typedef struct {
+	uint16_t	pcie_err_status;
+	void		*pcie_adv_regs;
+} mdb_pf_pcie_err_regs_t;
+
+typedef struct {
+	uint32_t	pcie_ue_status;
+	uint32_t	pcie_ce_status;
+} mdb_pf_pcie_adv_err_regs_t;
+
+typedef struct {
+	boolean_t	pe_valid;
+	uint32_t	pe_severity_flags;
+	uint32_t	pe_orig_severity_flags;
+	uint32_t	pe_severity_mask;
+	void		*pe_affected_dev;
+	void		*pe_bus_p;
+	union {
+		void	*pe_pcie_regs;
+	} pe_ext;
+	void		*pe_next;
+} mdb_pf_data_t;
+
+typedef struct {
+	pcie_req_id_t	scan_bdf;
+	uint64_t	scan_addr;
+	boolean_t	full_scan;
+} mdb_pf_root_fault_t;
+
+typedef struct {
+	pcie_req_id_t	bus_bdf;
+	uint16_t	bus_dev_type;
+	void		*bus_dip;
+	void		*bus_rp_dip;
+} mdb_pcie_bus_t;
+
+typedef struct {
+	uint16_t	pe_affected_flags;
+} mdb_pf_affected_dev_t;
+
+void
+pcie_pf_impl_help(void)
+{
+	mdb_printf(
+"Display PCIe fabric error scan results from a pf_impl_t structure.\n"
+"\n"
+"This dcmd is used to analyze PCIe fatal errors in crash dumps. It displays\n"
+"the error data queue and decoded PCIe error registers from a fabric scan.\n"
+"\n"
+"When called without an address, the dcmd uses the cached pcie_faulty_pf_impl\n"
+"global variable, which is automatically populated when pf_scan_fabric()\n"
+"detects a fatal error (PF_ERR_FATAL_FLAGS). This cache is specifically\n"
+"designed for post-mortem debugging, as ereports may be lost if errorq_dump\n"
+"overflows.\n"
+"\n"
+"When called with an address, the dcmd analyzes the pf_impl_t structure at\n"
+"that address. This is useful for examining old crash dumps where the address\n"
+"of the pf_impl_t is known, or for analyzing non-fatal error scenarios.\n"
+"\n"
+"%<b>OPTIONS%</b>\n"
+"  -v    Verbose mode. Display additional per-device information including\n"
+"        pe_valid status, original severity flags, severity mask, and device\n"
+"        info pointers.\n"
+"\n"
+"%<b>EXAMPLES%</b>\n"
+"  ::pcie_fatal_errors              Display cached fatal error info\n"
+"  ::pcie_fatal_errors -v           Display with verbose details\n"
+"  addr::pcie_fatal_errors          Analyze pf_impl_t at specific address\n");
+}
+
+int
+pcie_pf_impl_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+{
+	mdb_pf_impl_t impl;
+	mdb_pf_data_t pfd;
+	uintptr_t pfd_addr;
+	bool opt_v = false;
+	int count = 0;
+	char bdf[PCIE_BDF_BUFSZ];
+
+	if (mdb_getopts(argc, argv,
+	    'v', MDB_OPT_SETBITS, true, &opt_v,
+	    NULL) != argc) {
+		return (DCMD_USAGE);
+	}
+
+	/*
+	 * If no address is provided, use the cached global pcie_faulty_pf_impl
+	 */
+	if ((flags & DCMD_ADDRSPEC) == 0) {
+		GElf_Sym sym;
+
+		if (mdb_lookup_by_name("pcie_faulty_pf_impl", &sym) != 0) {
+			mdb_warn("failed to lookup pcie_faulty_pf_impl "
+			    "symbol");
+			return (DCMD_ERR);
+		}
+		addr = (uintptr_t)sym.st_value;
+	}
+
+	if ((flags & DCMD_PIPE_OUT) != 0) {
+		mdb_printf("%lr", addr);
+		return (DCMD_OK);
+	}
+
+	if (mdb_ctf_vread(&impl, "pf_impl_t", "mdb_pf_impl_t", addr, 0) == -1) {
+		mdb_warn("failed to read pf_impl_t at %p", addr);
+		return (DCMD_ERR);
+	}
+
+	/*
+	 * Check if the structure has been populated. If pf_dq_head_p is NULL,
+	 * no fatal error was recorded.
+	 */
+	if (impl.pf_dq_head_p == NULL && impl.pf_derr == NULL) {
+		mdb_printf("No fatal PCIe errors recorded.\n");
+		return (DCMD_OK);
+	}
+
+	mdb_printf("pf_impl_t (%p) summary:\n", addr);
+	mdb_printf("  pf_derr:       %p\n", impl.pf_derr);
+	mdb_printf("  pf_fault:      %p\n", impl.pf_fault);
+	mdb_printf("  pf_dq_head_p:  %p\n", impl.pf_dq_head_p);
+	mdb_printf("  pf_dq_tail_p:  %p\n", impl.pf_dq_tail_p);
+	mdb_printf("  pf_total:      %r\n", impl.pf_total);
+
+	if (impl.pf_fault != NULL) {
+		mdb_pf_root_fault_t fault;
+
+		if (mdb_ctf_vread(&fault,
+		    "pf_root_fault_t", "mdb_pf_root_fault_t",
+		    (uintptr_t)impl.pf_fault, 0) == -1) {
+			mdb_warn("failed to read pf_root_fault_t at %p",
+			    impl.pf_fault);
+		} else {
+			mdb_printf("\nRoot Fault Information:\n");
+			mdb_printf("  scan_bdf:      %04r (%s)\n",
+			    fault.scan_bdf,
+			    pcie_bdf(fault.scan_bdf, bdf, sizeof (bdf)));
+			mdb_printf("  scan_addr:     %016r\n",
+			    fault.scan_addr);
+			mdb_printf("  full_scan:     %s\n",
+			    fault.full_scan ? "true" : "false");
+		}
+	}
+
+	mdb_printf("\nError Data Queue:\n");
+	mdb_printf("%<u>%-4s %-16s %-17s %-7s %-16s %-16s%</u>\n",
+	    "#", "pf_data_t", "BDF", "DevType", "Severity", "Affected");
+
+	for (pfd_addr = (uintptr_t)impl.pf_dq_head_p; pfd_addr != 0;
+	    pfd_addr = (uintptr_t)pfd.pe_next) {
+		mdb_pf_affected_dev_t affected;
+		mdb_pcie_bus_t bus;
+		uint16_t affected_flags = 0;
+
+		if (mdb_ctf_vread(&pfd, "pf_data_t", "mdb_pf_data_t",
+		    pfd_addr, 0) == -1) {
+			mdb_warn("failed to read pf_data_t at %p", pfd_addr);
+			break;
+		}
+
+		if (pfd.pe_bus_p != NULL &&
+		    mdb_ctf_vread(&bus, "pcie_bus_t", "mdb_pcie_bus_t",
+		    (uintptr_t)pfd.pe_bus_p, 0) != -1) {
+			mdb_printf("%-4r %016p %05r (%8s) %8r ",
+			    count, pfd_addr, bus.bus_bdf,
+			    pcie_bdf(bus.bus_bdf, bdf, sizeof (bdf)),
+			    bus.bus_dev_type);
+		} else {
+			mdb_printf("%-4r %016p %-15s %-8s ",
+			    count, pfd_addr, "????", "????");
+		}
+		count++;
+
+		mdb_printf("%b ", pfd.pe_severity_flags, pf_severity_bits);
+
+		if (pfd.pe_affected_dev != NULL && mdb_ctf_vread(&affected,
+		    "pf_affected_dev_t", "mdb_pf_affected_dev_t",
+		    (uintptr_t)pfd.pe_affected_dev, 0) != -1) {
+			affected_flags = affected.pe_affected_flags;
+		}
+		mdb_printf("%hb\n", affected_flags, pf_affected_bits);
+
+		if (opt_v == 0)
+			continue;
+
+		if (pfd.pe_bus_p != NULL) {
+			mdb_printf("      pe_valid:          %s\n",
+			    pfd.pe_valid ? "true" : "false");
+			mdb_printf("      pe_affected:       %08r <%hb>\n",
+			    affected_flags, affected_flags, pf_affected_bits);
+			mdb_printf("      pe_severity:       %08r <%b>\n",
+			    pfd.pe_severity_flags,
+			    pfd.pe_severity_flags, pf_severity_bits);
+			mdb_printf("      pe_orig_severity:  %08r <%b>\n",
+			    pfd.pe_orig_severity_flags,
+			    pfd.pe_orig_severity_flags, pf_severity_bits);
+			mdb_printf("      pe_severity_mask:  %08r <%b>\n",
+			    pfd.pe_severity_mask,
+			    pfd.pe_severity_mask, pf_severity_bits);
+			mdb_printf("      bus_dip:           %p\n",
+			    bus.bus_dip);
+			mdb_printf("      bus_rp_dip:        %p\n",
+			    bus.bus_rp_dip);
+		}
+
+		/* Display PCIe-specific error information if available */
+		if (pfd.pe_ext.pe_pcie_regs != NULL) {
+			mdb_pf_pcie_err_regs_t pcie_regs;
+			mdb_pf_pcie_adv_err_regs_t adv_regs;
+
+			if (mdb_ctf_vread(&pcie_regs, "pf_pcie_err_regs_t",
+			    "mdb_pf_pcie_err_regs_t",
+			    (uintptr_t)pfd.pe_ext.pe_pcie_regs, 0) != -1) {
+				if (pcie_regs.pcie_err_status != 0) {
+					mdb_printf("      pcie_err_status: "
+					    "  %08r <%hb>\n",
+					    pcie_regs.pcie_err_status,
+					    pcie_regs.pcie_err_status,
+					    pcie_devsts_bits);
+				}
+
+				if (pcie_regs.pcie_adv_regs != NULL &&
+				    mdb_ctf_vread(&adv_regs,
+				    "pf_pcie_adv_err_regs_t",
+				    "mdb_pf_pcie_adv_err_regs_t",
+				    (uintptr_t)pcie_regs.pcie_adv_regs,
+				    0) != -1) {
+					if (adv_regs.pcie_ue_status != 0) {
+						mdb_printf("      AER UCE: "
+						    "          %08r <%b>\n",
+						    adv_regs.pcie_ue_status,
+						    adv_regs.pcie_ue_status,
+						    pcie_aer_uce_bits);
+					}
+					if (adv_regs.pcie_ce_status != 0) {
+						mdb_printf("      AER CE:  "
+						    "          %08r <%b>\n",
+						    adv_regs.pcie_ce_status,
+						    adv_regs.pcie_ce_status,
+						    pcie_aer_ce_bits);
+					}
+				}
+			}
+		}
+
+	}
+
+	mdb_printf("\nTotal errors in queue: %r\n", count);
+
+	return (DCMD_OK);
+}
+
+int
+pcie_bdf_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+{
+	char buf[PCIE_BDF_BUFSZ];
+
+	if ((flags & DCMD_ADDRSPEC) == 0)
+		return (DCMD_USAGE);
+
+	if (addr > UINT16_MAX) {
+		mdb_warn("bdf value too large, range [0,%r]\n",
+		    UINT16_MAX);
+		return (DCMD_ERR);
+	}
+
+	mdb_printf("%s\n", pcie_bdf((pcie_req_id_t)addr, buf, sizeof (buf)));
+
+	return (DCMD_OK);
 }

--- a/usr/src/cmd/mdb/common/modules/genunix/pci.h
+++ b/usr/src/cmd/mdb/common/modules/genunix/pci.h
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2019, Joyent, Inc.
+ * Copyright 2026 Oxide Computer Company
  */
 
 #ifndef _MDB_PCI_H
@@ -32,6 +33,10 @@ extern int pcie_bus_walk_init(mdb_walk_state_t *);
 extern int pcie_bus_walk_step(mdb_walk_state_t *);
 
 extern boolean_t pcie_bus_match(const struct dev_info *, uintptr_t *);
+
+extern int pcie_pf_impl_dcmd(uintptr_t, uint_t, int, const mdb_arg_t *);
+extern void pcie_pf_impl_help(void);
+extern int pcie_bdf_dcmd(uintptr_t, uint_t, int, const mdb_arg_t *);
 
 #ifdef __cplusplus
 }

--- a/usr/src/head/memory.h
+++ b/usr/src/head/memory.h
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2026 Gordon Ross <gordon.w.ross@gmail.com>
  * Copyright 2014 Garrett D'Amore <garrett@damore.org>
  */
 /*	Copyright (c) 1988 AT&T	*/
@@ -35,28 +36,46 @@ extern "C" {
 #endif
 
 extern void *memccpy(void *, const void *, int, size_t);
+
 #if __cplusplus >= 199711L
 namespace std {
+#endif
+
+extern int memcmp(const void *, const void *, size_t);
+extern void *memcpy(void *_RESTRICT_KYWD, const void *_RESTRICT_KYWD, size_t);
+extern void *memset(void *, int, size_t);
+
+/* See similar in string_iso.h */
+#if __cplusplus >= 199711L
 extern const void *memchr(const void *, int, size_t);
-#ifndef _MEMCHR_INLINE
+#ifndef	_MEMCHR_INLINE
 #define	_MEMCHR_INLINE
 extern "C++" {
 	inline void *memchr(void * __s, int __c, size_t __n) {
-		return (void*)memchr((const void *) __s, __c, __n);
+		return (void *)memchr((const void *)__s, __c, __n);
 	}
 }
-#endif /* _MEMCHR_INLINE */
-} /* end of namespace std */
-using std::memchr;
-#else
+#endif	/* _MEMCHR_INLINE */
+
+#else	/* __cplusplus >= 199711L */
+
 extern void *memchr(const void *, int, size_t);
-#endif
-extern void *memcpy(void *, const void *, size_t);
-extern void *memset(void *, int, size_t);
-extern int memcmp(const void *, const void *, size_t);
+
+#endif	/* __cplusplus >= 199711L */
+
+#if __cplusplus >= 199711L
+}	/* end of namespace std */
+#endif	/* __cplusplus >= 199711L */
 
 #ifdef	__cplusplus
 }
 #endif
+
+#if __cplusplus >= 199711L
+using std::memcmp;
+using std::memcpy;
+using std::memset;
+using std::memchr;
+#endif	/* __cplusplus >= 199711L */
 
 #endif	/* _MEMORY_H */

--- a/usr/src/man/man5/bhyve_config.5
+++ b/usr/src/man/man5/bhyve_config.5
@@ -26,7 +26,7 @@
 .\" Portions Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
 .\" Portions Copyright 2026 Oxide Computer Company
 .\"
-.Dd January 9, 2026
+.Dd January 28, 2026
 .Dt BHYVE_CONFIG 5
 .Os
 .Sh NAME
@@ -477,6 +477,10 @@ Note that most guests will allocate memory for all permitted queues, regardless
 of whether they are actively used.
 The default of 8 queue pairs results in 8 RX and 8 TX queues for network packet
 transfer, plus one control queue.
+.It speed Ta integer Ta 1000 Ta
+Specify speed of the virtual network device as advertised to the guest.
+This value is specified as a number of megabits per second
+.Pq Mb/s .
 .El
 .Pp
 Viona network devices have the ability to lend out their TX buffers, which

--- a/usr/src/man/man8/bhyve.8
+++ b/usr/src/man/man8/bhyve.8
@@ -25,7 +25,7 @@
 .\" Portions Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 .\" Copyright 2026 Oxide Computer Company
 .\"
-.Dd January 9, 2026
+.Dd January 28, 2026
 .Dt BHYVE 8
 .Os
 .Sh NAME
@@ -476,6 +476,12 @@ Note that most guests will allocate memory for all permitted queues,
 regardless of whether they are actively used.
 The default of 8 queue pairs results in 8 RX and 8 TX queues for network packet
 transfer, plus one control queue.
+.It Cm speed Ns = Ns Ar link_speed
+Specify speed of the virtual network device as advertised to the guest.
+This value is specified as a number of megabits per second
+.Pq Mb/s
+and defaults to 1000
+.Pq 1Gb/s .
 .El
 .Pp
 .Sy Other Network Backends :

--- a/usr/src/uts/common/io/virtio/virtio_main.c
+++ b/usr/src/uts/common/io/virtio/virtio_main.c
@@ -964,7 +964,7 @@ virtio_queue_alloc(virtio_t *vio, uint16_t qidx, const char *name,
 	membar_producer();
 	VIRTQ_DMA_SYNC_FORDEV(viq);
 
-	const uint32_t pa = virtio_dma_cookie_pa(&viq->viq_dma, 0);
+	const uint64_t pa = virtio_dma_cookie_pa(&viq->viq_dma, 0);
 	vio->vio_ops->vop_queue_addr_set(vio, qidx,
 	    pa, pa + sz_descs, pa + sz_driver);
 


### PR DESCRIPTION
Weekly upstream for upstream_merge/2026020201

## Backports

None

## onu

```
OmniOS r151057 Version omnios-upstream_merge-2026020201-e404c9efd3f 64-bit
Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
Copyright (c) 2017-2026 OmniOS Community Edition (OmniOSce) Association.
DEBUG enabled
Hostname: bloody

bloody console login: root
Password:
Last login: Thu Jan 29 23:15:00 2026 on console
OmniOS r151057  omnios-upstream_merge-2026020201-e404c9efd3f    February 2026
illumos development build: 2026-Feb-02 [illumos]
You have new mail.
root@bloody:~# uname -a
SunOS bloody 5.11 omnios-upstream_merge-2026020201-e404c9efd3f i86pc i386 i86pc
```
## mail_msg

```

==== Nightly distributed build started:   Mon Feb  2 13:01:23 UTC 2026 ====
==== Nightly distributed build completed: Mon Feb  2 13:57:05 UTC 2026 ====

==== Total build time ====

real    0:55:42

==== Build environment ====

/usr/bin/uname
SunOS bloody 5.11 omnios-master-1e99cf27658 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 8

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151057/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151057/14.3.0-il-1) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /data/omnios-build/omniosorg/bloody/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.17+10-omnios-151057"

/usr/bin/openssl
OpenSSL 3.6.1 27 Jan 2026 (Library: OpenSSL 3.6.1 27 Jan 2026)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   89

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-upstream_merge-2026020201-e404c9efd3f

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    22:37.4
user  3:02:53.2
sys   1:19:29.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    21:20.1
user  2:51:20.8
sys   1:18:43.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====

usr/bin/latencytop: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/amd64/libpthread.so.1; unused dependency of /usr/lib/64/libpcre2-8.so.0	<remove lib or -zignore?>
usr/bin/latencytop: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/amd64/libpthread.so.1	<remove lib or -zignore?>
usr/bin/rmmount: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/bin/volcheck: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/bin/volrmmount: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-is-caller-privileged: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-is-caller-privileged: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-cleanup-all-mountpoints: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-cleanup-all-mountpoints: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-cleanup-mountpoint: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-cleanup-mountpoint: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-closetray: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-closetray: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-eject: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-eject: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-mount: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-mount: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-unmount: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-unmount: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-zpool-export: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-zpool-export: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hal-storage-zpool-import: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hal-storage-zpool-import: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hald: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hald-addon-acpi: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hald-addon-acpi: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hald-addon-cpufreq: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hald-addon-network-discovery: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hald-probe-acpi: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/hal/hald-probe-acpi: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/hal/hald-runner: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/libpolkit.so.0.0.0: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/lib/libpolkit.so.0.0.0: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>
usr/lib/rmvolmgr: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/sbin/lshal: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/sbin/polkit-is-privileged: unreferenced object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1; unused dependency of /usr/lib/libpcre2-8.so.0	<remove lib or -zignore?>
usr/sbin/polkit-is-privileged: unused object=/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib/libpthread.so.1	<remove lib or -zignore?>

==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```
