### PR TITLE
17572 mdb should use CTF for `struct module` (r151054)

### DIFF
--- a/usr/src/cmd/mdb/common/mdb/mdb_ctf.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_ctf.c
@@ -1680,7 +1680,12 @@ mdb_ctf_vread(void *modbuf, const char *target_typename,
 	mdb_module_t *mod;
 	int ret;
 
-	if ((mod = mdb_get_module()) == NULL || (mfp = mod->mod_ctfp) == NULL) {
+	if ((mod = mdb_get_module()) == NULL) {
+		mdb_ctf_warn(flags, "could not get MDB module");
+		return (set_errno(EMDB_NOCTF));
+	}
+
+	if ((mfp = mod->mod_ctfp) == NULL) {
 		mdb_ctf_warn(flags, "no ctf data found for mdb module %s\n",
 		    mod->mod_name);
 		return (set_errno(EMDB_NOCTF));

--- a/usr/src/cmd/mdb/common/modules/dtrace/dtrace.c
+++ b/usr/src/cmd/mdb/common/modules/dtrace/dtrace.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright 2019 Joyent, Inc.
  * Copyright 2022 Racktop Systems, Inc.
+ * Copyright 2025 Oxide Computer Company
  */
 
 /*
@@ -35,6 +36,7 @@
 
 #include <mdb/mdb_param.h>
 #include <mdb/mdb_modapi.h>
+#include <mdb/mdb_ctf.h>
 #include <mdb/mdb_ks.h>
 #include <sys/dtrace_impl.h>
 #include <sys/vmem_impl.h>
@@ -765,15 +767,21 @@ dtracemdb_ioctl(void *varg, int cmd, void *arg)
 	}
 }
 
+struct dtrace_ctf_module {
+	char *text;
+	size_t text_size;
+};
+
 static int
 dtracemdb_modctl(uintptr_t addr, const struct modctl *m, dtracemdb_data_t *data)
 {
-	struct module mod;
+	struct dtrace_ctf_module mod;
 
 	if (m->mod_mp == NULL)
 		return (WALK_NEXT);
 
-	if (mdb_vread(&mod, sizeof (mod), (uintptr_t)m->mod_mp) == -1) {
+	if (mdb_ctf_vread(&mod, "struct module", "struct dtrace_ctf_module",
+	    (uintptr_t)m->mod_mp, 0) == -1) {
 		mdb_warn("couldn't read modctl %p's module", addr);
 		return (WALK_NEXT);
 	}

--- a/usr/src/cmd/mdb/common/modules/genunix/kmem.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/kmem.c
@@ -26,7 +26,7 @@
 /*
  * Copyright 2018 Joyent, Inc.  All rights reserved.
  * Copyright (c) 2012 by Delphix. All rights reserved.
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2025 Oxide Computer Company
  */
 
 #include <mdb/mdb_param.h>
@@ -2494,17 +2494,32 @@ whatis_modctl_match(mdb_whatis_t *w, const char *name,
 		mdb_whatis_report_address(w, cur, "in %s's %s\n", name, where);
 }
 
+struct kmem_ctf_module {
+	Shdr *symhdr;
+	char *symtbl;
+	unsigned int nsyms;
+	char *symspace;
+	size_t symsize;
+	char *text;
+	char *data;
+	uintptr_t bss;
+	size_t text_size;
+	size_t data_size;
+	size_t bss_size;
+};
+
 static int
 whatis_walk_modctl(uintptr_t addr, const struct modctl *m, mdb_whatis_t *w)
 {
 	char name[MODMAXNAMELEN];
-	struct module mod;
+	struct kmem_ctf_module mod;
 	Shdr shdr;
 
 	if (m->mod_mp == NULL)
 		return (WALK_NEXT);
 
-	if (mdb_vread(&mod, sizeof (mod), (uintptr_t)m->mod_mp) == -1) {
+	if (mdb_ctf_vread(&mod, "struct module", "struct kmem_ctf_module",
+	    (uintptr_t)m->mod_mp, 0) == -1) {
 		mdb_warn("couldn't read modctl %p's module", addr);
 		return (WALK_NEXT);
 	}


### PR DESCRIPTION
Needed so we can use mdb on crash dumps from kernels built from a different branch.
