### PR TITLE
Upstream merge/2026032801

### DIFF
--- a/usr/src/boot/Makefile.version
+++ b/usr/src/boot/Makefile.version
@@ -35,4 +35,4 @@ LOADER_VERSION = 1.1
 # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
 # The version is processed from left to right, the version number can only
 # be increased.
-BOOT_VERSION = $(LOADER_VERSION)-2026.02.20.1
+BOOT_VERSION = $(LOADER_VERSION)-2026.03.18.1

--- a/usr/src/boot/efi/loader/arch/amd64/trap.c
+++ b/usr/src/boot/efi/loader/arch/amd64/trap.c
@@ -85,14 +85,68 @@ struct frame {
 };
 
 void report_exc(struct trapframe *tf);
-void
-report_exc(struct trapframe *tf)
+
+static void
+stack_trace(struct frame *fp, uintptr_t pc)
 {
-	struct frame *fp;
-	uintptr_t pc, base;
+	uintptr_t base;
 	char buf[80];
 
 	base = (uintptr_t)boot_img->ImageBase;
+
+	printf("Stack trace:\n");
+	pager_open();
+	while (fp != NULL || pc != 0) {
+		struct frame *nfp;
+		char *source = "PC";
+
+		if (pc >= base && pc < base + boot_img->ImageSize) {
+			pc -= base;
+			source = "loader PC";
+		}
+		(void) snprintf(buf, sizeof (buf), "FP %016lx: %s 0x%016lx\n",
+		    (uintptr_t)fp, source, pc);
+		if (pager_output(buf))
+			break;
+
+		if (fp == NULL)
+			break;
+
+		nfp = fp->fr_savfp;
+		if (nfp != NULL && nfp <= fp) {
+			printf("FP %016lx: loop detected, stopping trace\n",
+			    (uintptr_t)nfp);
+			break;
+		}
+		fp = nfp;
+
+		if (fp != NULL)
+			pc = fp->fr_savpc;
+		else
+			pc = 0;
+	}
+	pager_close();
+}
+
+void
+panic_action(void)
+{
+	struct frame *fp;
+	uintptr_t rip;
+
+	__asm __volatile("movq %%rbp,%0" : "=r" (fp));
+	rip = fp->fr_savpc;
+
+	stack_trace(fp, rip);
+	printf("--> Press a key on the console to reboot <--\n");
+	getchar();
+	printf("Rebooting...\n");
+	exit(1);
+}
+
+void
+report_exc(struct trapframe *tf)
+{
 	/*
 	 * printf() depends on loader runtime and UEFI firmware health
 	 * to produce the console output, in case of exception, the
@@ -119,32 +173,8 @@ report_exc(struct trapframe *tf)
 	    tf->tf_r9, tf->tf_rax, tf->tf_rbx, tf->tf_rbp, tf->tf_r10,
 	    tf->tf_r11, tf->tf_r12, tf->tf_r13, tf->tf_r14, tf->tf_r15);
 
-	fp = (struct frame *)tf->tf_rbp;
-	pc = tf->tf_rip;
+	stack_trace((struct frame *)tf->tf_rbp, tf->tf_rip);
 
-	printf("Stack trace:\n");
-	pager_open();
-	while (fp != NULL || pc != 0) {
-		char *source = "PC";
-
-		if (pc >= base && pc < base + boot_img->ImageSize) {
-			pc -= base;
-			source = "loader PC";
-		}
-		(void) snprintf(buf, sizeof (buf), "FP %016lx: %s 0x%016lx\n",
-		    (uintptr_t)fp, source, pc);
-		if (pager_output(buf))
-			break;
-
-		if (fp != NULL)
-			fp = fp->fr_savfp;
-
-		if (fp != NULL)
-			pc = fp->fr_savpc;
-		else
-			pc = 0;
-	}
-	pager_close();
 	printf("Machine stopped.\n");
 }
 

--- a/usr/src/boot/libsa/sbrk.c
+++ b/usr/src/boot/libsa/sbrk.c
@@ -46,10 +46,10 @@ setheap(void *base, void *top)
 	maxheap = (char *)top - (char *)heapbase;
 }
 
-char *
-sbrk(int incr)
+void *
+sbrk(intptr_t incr)
 {
-	char	*ret;
+	void	*ret;
 
 	if (heapbase == NULL)
 		panic("No heap setup");
@@ -61,5 +61,5 @@ sbrk(int incr)
 		return (ret);
 	}
 	errno = ENOMEM;
-	return ((char *)-1);
+	return ((void *)-1);
 }

--- a/usr/src/boot/libsa/stand.h
+++ b/usr/src/boot/libsa/stand.h
@@ -265,7 +265,7 @@ static __inline int tolower(int c)
 
 /* sbrk emulation */
 extern void	setheap(void *base, void *top);
-extern char	*sbrk(int incr);
+extern void	*sbrk(intptr_t incr);
 
 extern void	mallocstats(void);
 

--- a/usr/src/cmd/bhyve/common/bhyverun.c
+++ b/usr/src/cmd/bhyve/common/bhyverun.c
@@ -38,7 +38,7 @@
  * Copyright 2015 Pluribus Networks Inc.
  * Copyright 2018 Joyent, Inc.
  * Copyright 2025 Oxide Computer Company
- * Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  */
 
 
@@ -584,6 +584,13 @@ do_open(const char *vmname)
 	ctx = vm_open(vmname);
 	if (ctx == NULL) {
 		perror("vm_open");
+#ifndef __FreeBSD__
+		if (errno == ENOENT) {
+			fprintf(stderr,
+			    "Does the VM already exist in the global or "
+			    "another zone?\n");
+		}
+#endif
 		exit(4);
 	}
 

--- a/usr/src/cmd/bhyve/common/mem.c
+++ b/usr/src/cmd/bhyve/common/mem.c
@@ -36,6 +36,7 @@
  * http://www.illumos.org/license/CDDL.
  *
  * Copyright 2020 Oxide Computer Company
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -58,6 +59,7 @@
 #include <vmmapi.h>
 
 #include "mem.h"
+#include "debug.h"
 
 struct mmio_rb_range {
 	RB_ENTRY(mmio_rb_range)	mr_link;	/* RB tree links */
@@ -109,29 +111,6 @@ mmio_rb_lookup(struct mmio_rb_tree *rbt, uint64_t addr,
 	return (ENOENT);
 }
 
-static int
-mmio_rb_add(struct mmio_rb_tree *rbt, struct mmio_rb_range *new)
-{
-	struct mmio_rb_range *overlap;
-
-	overlap = RB_INSERT(mmio_rb_tree, rbt, new);
-
-	if (overlap != NULL) {
-#ifdef RB_DEBUG
-		printf("overlap detected: new %lx:%lx, tree %lx:%lx, '%s' "
-		       "claims region already claimed for '%s'\n",
-		       new->mr_base, new->mr_end,
-		       overlap->mr_base, overlap->mr_end,
-		       new->mr_param.name, overlap->mr_param.name);
-#endif
-
-		return (EEXIST);
-	}
-
-	return (0);
-}
-
-#if 0
 static void
 mmio_rb_dump(struct mmio_rb_tree *rbt)
 {
@@ -140,13 +119,32 @@ mmio_rb_dump(struct mmio_rb_tree *rbt)
 
 	pthread_rwlock_rdlock(&mmio_rwlock);
 	RB_FOREACH(np, mmio_rb_tree, rbt) {
-		printf(" %lx:%lx, %s\n", np->mr_base, np->mr_end,
+		PRINTLN(" %lx:%lx, %s", np->mr_base, np->mr_end,
 		       np->mr_param.name);
 	}
 	perror = pthread_rwlock_unlock(&mmio_rwlock);
 	assert(perror == 0);
 }
-#endif
+
+static int
+mmio_rb_add(struct mmio_rb_tree *rbt, struct mmio_rb_range *new)
+{
+	struct mmio_rb_range *overlap;
+
+	overlap = RB_INSERT(mmio_rb_tree, rbt, new);
+
+	if (overlap != NULL) {
+		EPRINTLN("overlap detected: new %lx:%lx, tree %lx:%lx, '%s' "
+		       "claims region already claimed for '%s'",
+		       new->mr_base, new->mr_end,
+		       overlap->mr_base, overlap->mr_end,
+		       new->mr_param.name, overlap->mr_param.name);
+
+		return (EEXIST);
+	}
+
+	return (0);
+}
 
 RB_GENERATE(mmio_rb_tree, mmio_rb_range, mr_link, mmio_rb_range_compare);
 
@@ -321,7 +319,14 @@ register_mem_int(struct mmio_rb_tree *rbt, struct mem_range *memp)
 			free(mrp);
 #endif
 		perror = pthread_rwlock_unlock(&mmio_rwlock);
+#ifdef	__FreeBSD__
 		assert(perror == 0);
+#else
+		if (perror != 0) {
+			mmio_rb_dump(rbt);
+			exit(4);
+		}
+#endif
 		if (err)
 			free(mrp);
 	}

--- a/usr/src/cmd/diskinfo/diskinfo.c
+++ b/usr/src/cmd/diskinfo/diskinfo.c
@@ -15,6 +15,7 @@
  * Copyright 2021 Tintri by DDN, Inc. All rights reserved.
  * Copyright 2023 Oxide Computer Company
  * Copyright 2024 Sebastian Wiedenroth
+ * Copyright 2026 Jason King
  */
 
 #include <sys/types.h>
@@ -155,7 +156,8 @@ disk_walker(topo_hdl_t *hp, tnode_t *np, void *arg)
 		 * label higher up in the tree will not be appropriate.
 		 */
 		if ((strcmp(pname, BAY) == 0 || strcmp(pname, SLOT) == 0 ||
-		    strcmp(pname, USB_DEVICE) == 0) && consider_label) {
+		    strcmp(pname, USB_DEVICE) == 0 ||
+		    strcmp(pname, NVME) == 0) && consider_label) {
 			consider_label = B_FALSE;
 
 			if (topo_prop_get_string(pnp, TOPO_PGROUP_PROTOCOL,

--- a/usr/src/cmd/mv/Makefile
+++ b/usr/src/cmd/mv/Makefile
@@ -35,22 +35,20 @@ ROOTLINKS= $(ROOTBIN)/$(CPFILE) $(ROOTBIN)/$(LNFILE)
 ROOTXPG4LINKS= $(ROOTXPG4BIN)/$(CPFILE) $(ROOTXPG4BIN)/$(LNFILE)
 
 include ../Makefile.cmd
+include ../Makefile.ctf
 
 clean $(XPG4)	:= OBJS += values-xpg4.o
 
 CLOBBERFILES += $(CPFILE) $(LNFILE)
 CFLAGS	+=	$(CCVERBOSE)
-CERRWARN +=	-_gcc=-Wno-parentheses
-CERRWARN +=	-_gcc=-Wno-unused-variable
-CERRWARN +=	$(CNOWARN_UNINIT)
 $(XPG4) := CFLAGS += -DXPG4
-LINTFLAGS += -DXPG4 -u
 XGETFLAGS += -a -x mv.xcl
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -I $(SRC)/common/util
 
-lint :=	LDLIBS += -lcmdutils -lavl -lsec -lnvpair
 $(PROG) := LDLIBS += -lcmdutils -lavl -lsec -lnvpair
 $(XPG4) := LDLIBS += -lcmdutils -lavl -lsec -lnvpair
+
+CTF_MODE = link
 
 .KEEP_STATE:
 
@@ -97,7 +95,5 @@ $(ROOTXPG4LINKS):	$(ROOTXPG4PROG)
 
 clean:
 	$(RM) $(OBJS) $(XPG4OBJS)
-
-lint:	lint_SRCS
 
 include ../Makefile.targ

--- a/usr/src/cmd/mv/mv.c
+++ b/usr/src/cmd/mv/mv.c
@@ -230,7 +230,7 @@ main(int argc, char *argv[])
 	 * Determine command invoked (mv, cp, or ln)
 	 */
 
-	if (cmd = strrchr(argv[0], '/'))
+	if ((cmd = strrchr(argv[0], '/')) != NULL)
 		++cmd;
 	else
 		cmd = argv[0];
@@ -637,7 +637,6 @@ cpymve(const char *source, char *target)
 	int ret = 0;
 	int attret = 0;
 	int sattret = 0;
-	int errno_save;
 	int error = 0;
 
 	switch (chkfiles(source, &target)) {
@@ -749,7 +748,7 @@ cpymve(const char *source, char *target)
 			if (targetexists && ISDIR(s2)) {
 				/* existing target dir must be empty */
 				if (rmdir(target) < 0) {
-					errno_save = errno;
+					int errno_save = errno;
 					(void) fprintf(stderr,
 					    gettext("%s: cannot rmdir %s: "),
 					    cmd, target);

--- a/usr/src/data/zoneinfo/africa
+++ b/usr/src/data/zoneinfo/africa
@@ -4,9 +4,9 @@
 # 2009-05-17 by Arthur David Olson.
 
 # This file is by no means authoritative; if you think you know better,
-# go ahead and edit the file (and please send any changes to
-# tz@iana.org for general use in the future).  For more, please see
-# the file CONTRIBUTING in the tz distribution.
+# go ahead and edit the file, and please send any changes to
+# the public mailing list tz@iana.org for general use in the future.
+# For more, please see the file CONTRIBUTING in the tz distribution.
 
 # From Paul Eggert (2018-05-27):
 #
@@ -115,8 +115,9 @@ Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1912 Jan 01  2:00u # Praia
 			-1:00	-	%z
 
 # Chad
+# Fort-Lamy was renamed to N’Djamena on 1973-04-06.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Ndjamena	1:00:12 -	LMT	1912 Jan  1 # N'Djamena
+Zone	Africa/Ndjamena	1:00:12 -	LMT	1912 Jan  1 # Fort-Lamy
 			1:00	-	WAT	1979 Oct 14
 			1:00	1:00	WAST	1980 Mar  8
 			1:00	-	WAT

--- a/usr/src/data/zoneinfo/antarctica
+++ b/usr/src/data/zoneinfo/antarctica
@@ -3,13 +3,10 @@
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
-# From Paul Eggert (1999-11-15):
-# To keep things manageable, we list only locations occupied year-round; see
-# COMNAP - Stations and Bases
-# http://www.comnap.aq/comnap/comnap.nsf/P/Stations/
-# and
-# Summary of the Peri-Antarctic Islands (1998-07-23)
-# http://www.spri.cam.ac.uk/bob/periant.htm
+# From Paul Eggert (2025-08-16):
+# To keep things manageable, list only locations occupied year-round; see
+# Antarctic Facilities Information
+# https://www.comnap.aq/antarctic-facilities-information
 # for information.
 # Unless otherwise specified, we have no time zone information.
 
@@ -144,6 +141,7 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 # China - year-round bases
 # Great Wall, King George Island, -6213-05858, since 1985-02-20
 # Zhongshan, Larsemann Hills, Prydz Bay, -6922+07623, since 1989-02-26
+# Qinling, Inexpressible I, Terra Nova Bay, -7456+16343, since 2024-02-07
 
 # France - year-round bases (also see "France & Italy")
 #

--- a/usr/src/data/zoneinfo/asia
+++ b/usr/src/data/zoneinfo/asia
@@ -4,9 +4,9 @@
 # 2009-05-17 by Arthur David Olson.
 
 # This file is by no means authoritative; if you think you know better,
-# go ahead and edit the file (and please send any changes to
-# tz@iana.org for general use in the future).  For more, please see
-# the file CONTRIBUTING in the tz distribution.
+# go ahead and edit the file, and please send any changes to
+# the public mailing list tz@iana.org for general use in the future.
+# For more, please see the file CONTRIBUTING in the tz distribution.
 
 # From Paul Eggert (2019-07-11):
 #

--- a/usr/src/data/zoneinfo/australasia
+++ b/usr/src/data/zoneinfo/australasia
@@ -937,9 +937,9 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # NOTES
 
 # This file is by no means authoritative; if you think you know better,
-# go ahead and edit the file (and please send any changes to
-# tz@iana.org for general use in the future).  For more, please see
-# the file CONTRIBUTING in the tz distribution.
+# go ahead and edit the file, and please send any changes to
+# the public mailing list tz@iana.org for general use in the future.
+# For more, please see the file CONTRIBUTING in the tz distribution.
 
 # From Paul Eggert (2018-11-18):
 #
@@ -1988,6 +1988,7 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # From Paul Eggert (2018-11-19):
 # The 1921-01-15 introduction of standard time is in Shanks; it is also in
 # "Standard Time Throughout the World", US National Bureau of Standards (1935),
+# https://nvlpubs.nist.gov/nistpubs/Legacy/circ/nbscircular406.pdf
 # page 3, which does not give the UT offset.  In response to a comment by
 # Phake Nick I set the Nauru time of occupation by Japan to
 # 1942-08-29/1945-09-08 by using dates from:
@@ -2055,9 +2056,10 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # https://webspace.science.uu.nl/~gent0113/idl/idl_alaska_samoa.htm
 
 # Although Shanks & Pottenger says they both switched to UT -11:30
-# in 1911, and to -11 in 1950. many earlier sources give -11
+# in 1911, and to -11 in 1950, many earlier sources give -11
 # for American Samoa, e.g., the US National Bureau of Standards
 # circular "Standard Time Throughout the World", 1932.
+# https://nvlpubs.nist.gov/nistpubs/Legacy/circ/nbscircular399.pdf
 # Assume American Samoa switched to -11 in 1911, not 1950,
 # and that after 1950 they agreed until (western) Samoa skipped a
 # day in 2011.  Assume also that the Samoas follow the US and New

--- a/usr/src/data/zoneinfo/country.tab
+++ b/usr/src/data/zoneinfo/country.tab
@@ -3,22 +3,22 @@
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 #
-# From Paul Eggert (2023-09-06):
+# From Paul Eggert (2025-07-01):
 # This file contains a table of two-letter country codes.  Columns are
-# separated by a single tab.  Lines beginning with '#' are comments.
+# separated by a single tab.  Lines beginning with ‘#’ are comments.
 # All text uses UTF-8 encoding.  The columns of the table are as follows:
 #
 # 1.  ISO 3166-1 alpha-2 country code, current as of
-#     ISO/TC 46 N1108 (2023-04-05).  See: ISO/TC 46 Documents
+#     ISO/TC 46 N1127 (2024-02-29).  See: ISO/TC 46 Documents
 #     https://www.iso.org/committee/48750.html?view=documents
 # 2.  The usual English name for the coded region.  This sometimes
 #     departs from ISO-listed names, sometimes so that sorted subsets
-#     of names are useful (e.g., "Samoa (American)" and "Samoa
-#     (western)" rather than "American Samoa" and "Samoa"),
+#     of names are useful (e.g., “Samoa (American)” and “Samoa
+#     (western)” rather than “American Samoa” and “Samoa”),
 #     sometimes to avoid confusion among non-experts (e.g.,
-#     "Czech Republic" and "Turkey" rather than "Czechia" and "Türkiye"),
-#     and sometimes to omit needless detail or churn (e.g., "Netherlands"
-#     rather than "Netherlands (the)" or "Netherlands (Kingdom of the)").
+#     “Czech Republic” and “Turkey” rather than “Czechia” and “Türkiye”),
+#     and sometimes to omit needless detail or churn (e.g., “Netherlands”
+#     rather than “Netherlands (the)” or “Netherlands (Kingdom of the)”).
 #
 # The table is sorted by country code.
 #
@@ -71,7 +71,7 @@ CD	Congo (Dem. Rep.)
 CF	Central African Rep.
 CG	Congo (Rep.)
 CH	Switzerland
-CI	Côte d'Ivoire
+CI	Côte d’Ivoire
 CK	Cook Islands
 CL	Chile
 CM	Cameroon

--- a/usr/src/data/zoneinfo/etcetera
+++ b/usr/src/data/zoneinfo/etcetera
@@ -20,7 +20,8 @@
 # which load the "UTC" file to handle seconds properly.
 Zone	Etc/UTC		0	-	UTC
 
-# Functions like gmtime load the "GMT" file to handle leap seconds properly.
+# If leap second support is enabled, functions like gmtime
+# load the "GMT" file to handle leap seconds properly.
 # Vanguard section, which works with most .zi parsers.
 #Zone	GMT		0	-	GMT
 # Rearguard section, for TZUpdater 2.3.2 and earlier.

--- a/usr/src/data/zoneinfo/europe
+++ b/usr/src/data/zoneinfo/europe
@@ -4,9 +4,9 @@
 # 2009-05-17 by Arthur David Olson.
 
 # This file is by no means authoritative; if you think you know better,
-# go ahead and edit the file (and please send any changes to
-# tz@iana.org for general use in the future).  For more, please see
-# the file CONTRIBUTING in the tz distribution.
+# go ahead and edit the file, and please send any changes to
+# the public mailing list tz@iana.org for general use in the future.
+# For more, please see the file CONTRIBUTING in the tz distribution.
 
 # From Paul Eggert (2017-02-10):
 #
@@ -42,7 +42,7 @@
 #	<https://www.jstor.org/stable/1774359>.  He writes:
 #	"It is requested that corrections and additions to these tables
 #	may be sent to Mr. John Milne, Royal Geographical Society,
-#	Savile Row, London."  Nowadays please email them to tz@iana.org.
+#	Savile Row, London."  Nowadays please see the file CONTRIBUTING.
 #
 #	Byalokoz EL. New Counting of Time in Russia since July 1, 1919.
 #	This Russian-language source was consulted by Vladimir Karpinsky; see
@@ -54,7 +54,7 @@
 #	Десятая гос. тип., 1919.
 #	http://resolver.gpntb.ru/purl?docushare/dsweb/Get/Resource-2011/Byalokoz__E.L.__Novyy__schet__vremeni__v__techenie__sutok__izd__2(1).pdf
 #
-#	Brazil's Divisão Serviço da Hora (DSHO),
+#	Brazil's Divisão de Serviços da Hora (DISHO)
 #	History of Summer Time
 #	<http://pcdsh01.on.br/HISTHV.htm>
 #	(1998-09-21, in Portuguese)
@@ -914,7 +914,7 @@ Rule	Belgium	1922	1927	-	Oct	Sat>=1	23:00s	0	-
 Rule	Belgium	1923	only	-	Apr	21	23:00s	1:00	S
 Rule	Belgium	1924	only	-	Mar	29	23:00s	1:00	S
 Rule	Belgium	1925	only	-	Apr	 4	23:00s	1:00	S
-# DSH writes that a royal decree of 1926-02-22 specified the Sun following 3rd
+# DISHO writes that a royal decree of 1926-02-22 specified the Sun following 3rd
 # Sat in Apr (except if it's Easter, in which case it's one Sunday earlier),
 # to Sun following 1st Sat in Oct, and that a royal decree of 1928-09-15
 # changed the transition times to 02:00 GMT.
@@ -1041,9 +1041,19 @@ Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 
 # Greenland
 #
-# From Paul Eggert (2004-10-31):
+# From Paul Eggert (2026-01-22):
+# During World War II, Greenland was effectively independent of Denmark and
+# observed daylight saving time.  TIME, volume 37, page 23 (1941-04-21)
+# <https://time.com/archive/6770243/war-peace-greenlands-icy-mountains/> says,
+# "Penfield and West made their way to the U.S.'s most northerly consulate.
+# They were astonished to find that Greenlanders, with almost 24 hours of
+# sunlight a day during the summer, have daylight saving time."
+# As the details are unknown they are omitted from the data for now.
+#
 # During World War II, Germany maintained secret manned weather stations in
 # East Greenland and Franz Josef Land, but we don't know their time zones.
+# Also, they're likely out of scope for the database
+# as we lack resources to track every bit of military activity.
 # My source for this is Wilhelm Dege's book mentioned under Svalbard.
 #
 # From Paul Eggert (2017-12-10):
@@ -1310,6 +1320,13 @@ Zone	Europe/Helsinki	1:39:49 -	LMT	1878 May 31
 # France
 # Monaco
 
+# From Robert H. van Gent (2025-07-21):
+# The most recent issue of the Annuaire [par le Bureau des Longitudes]
+# on Gallica (2021) ... lists information for France
+# https://gallica.bnf.fr/ark:/12148/bpt6k9127672b/f52.item
+# From Paul Eggert (2025-07-21):
+# Go with the 2020 Annuaire (published 2021) except as noted below.
+
 # From Ciro Discepolo (2000-12-20):
 #
 # Henri Le Corre, Régimes horaires pour le monde entier, Éditions
@@ -1371,7 +1388,6 @@ Zone	Europe/Helsinki	1:39:49 -	LMT	1878 May 31
 # problems in Algiers, Monaco and Tunis.
 
 #
-# Shank & Pottenger seem to use '24:00' ambiguously; resolve it with Whitman.
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	France	1916	only	-	Jun	14	23:00s	1:00	S
 Rule	France	1916	1919	-	Oct	Sun>=1	23:00s	0	-
@@ -1383,9 +1399,25 @@ Rule	France	1920	only	-	Oct	23	23:00s	0	-
 Rule	France	1921	only	-	Mar	14	23:00s	1:00	S
 Rule	France	1921	only	-	Oct	25	23:00s	0	-
 Rule	France	1922	only	-	Mar	25	23:00s	1:00	S
-# DSH writes that a law of 1923-05-24 specified 3rd Sat in Apr at 23:00 to 1st
-# Sat in Oct at 24:00; and that in 1930, because of Easter, the transitions
-# were Apr 12 and Oct 5.  Go with Shanks & Pottenger.
+# From Robert H. van Gent (2025-07-22):
+# There is a curious history behind the erroneous date for the start of
+# daylight saving in France in 1923 as listed in the current issues of
+# the Annuaire du Bureau des Longitudes.  [See:]
+# https://lists.iana.org/hyperkitty/list/tz@iana.org/message/MYQEJMSXO2AIEZ3UIXZKMTTAIPY7KNT2/
+# From Brian Inglis (2025-07-23):
+# Légifrance JORF No. 0073 du 15 mars 1922
+# https://www.legifrance.gouv.fr/jorf/jo/id/JORFCONT000000008324
+# Légifrance JORF No. 0139 du 25 mai 1923
+# https://www.legifrance.gouv.fr/jorf/jo/id/JORFCONT000000008416
+# From Paul Eggert (2025-07-23):
+# The latter specifies March's last Saturday at 23:00 to October's first
+# Saturday at 24:00, except that if neighboring allies agree the dates
+# can be moved to April's third Saturday and September's third Saturday.
+# Apparently spring 1923 was tricky.  DISHO writes that in 1930,
+# because of Easter, the transitions were Apr 12 and Oct 5.
+# Use the 2020 Annuaire dates, except for spring 1923 where
+# Shanks & Pottenger's May 26 matches the dates given in the 1924 and
+# 1961-2001 issues of the Annuaire.
 Rule	France	1922	1938	-	Oct	Sat>=1	23:00s	0	-
 Rule	France	1923	only	-	May	26	23:00s	1:00	S
 Rule	France	1924	only	-	Mar	29	23:00s	1:00	S
@@ -1935,7 +1967,6 @@ Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2 # Valletta
 
 # From Stepan Golosunov (2016-03-07):
 # the act of the government of the Republic of Moldova Nr. 132 from 1990-05-04
-# http://lex.justice.md/viewdoc.php?action=view&view=doc&id=298782&lang=2
 # ... says that since 1990-05-06 on the territory of the Moldavian SSR
 # time would be calculated as the standard time of the second time belt
 # plus one hour of the "summer" time. To implement that clocks would be
@@ -1990,9 +2021,61 @@ Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2 # Valletta
 # says the 2014-03-30 spring-forward transition was at 02:00 local time.
 # Guess that since 1997 Moldova has switched one hour before the EU.
 
+# From Heitor David Pinto (2026-02-22):
+# Soviet Moldovan resolution 132 of 1990 defined the summer time period from
+# the last Sunday in March at 2:00 to the last Sunday in September at 3:00,
+# matching the dates used in most of Europe at the time:
+# https://web.archive.org/web/20211107050832/http://lex.justice.md/viewdoc.php?action=view&view=doc&id=298782&lang=1
+#
+# It seems that in 1996 Moldova changed the end date to October like most of
+# Europe, but kept the transitions at 2:00 and 3:00 rather than 1:00 UTC,
+# which would have been locally 3:00 and 4:00....
+#
+# The notices in the Moldovan government website and broadcaster showed the
+# transitions at 2:00 and 3:00 until 2021:
+# 2015 https://old.gov.md/en/node/7304
+# 2016 https://old.gov.md/en/node/12587
+# 2017 https://old.gov.md/en/node/20654
+# 2017 https://old.gov.md/en/content/moldova-upholds-winter-time-night-28-29-october
+# 2018 https://old.gov.md/en/content/moldova-switch-summer-time
+# 2018 https://old.gov.md/en/content/cabinet-ministers-informs-about-switch-winter-time-28-october
+# 2019 https://old.gov.md/en/content/moldova-switch-summer-time-31-march
+# 2019 https://old.gov.md/en/node/31122
+# 2020 https://old.gov.md/en/node/32771
+# 2020 https://old.gov.md/en/node/34497
+# 2021 https://trm.md/ro/social/moldova-trece-in-aceasta-noapte-la-ora-de-vara
+# 2021 https://trm.md/en/social/republica-moldova-trece-la-ora-de-iarna1
+#
+# However, since 2022, the notices showed the transitions at 3:00 and 4:00,
+# matching the EU rule at 1:00 UTC:
+# 2022 https://trm.md/en/social/in-acest-weekend-republica-moldova-trece-la-ora-de-vara
+# 2022 https://old.gov.md/en/content/moldova-switch-winter-time
+# 2023 https://moldova1.md/p/6587/ora-de-vara-2023-cum-schimbam-acele-ceasornicelor-si-cand-trecem-la-ora-de-vara
+# 2023 https://old.gov.md/en/node/46662
+# 2024 https://moldova1.md/p/26535/republica-moldova-trece-la-ora-de-vara-in-acest-weekend
+# 2024 https://moldova1.md/p/37768/republica-moldova-trece-in-aceasta-noapte-la-ora-de-iarna
+# 2025 https://moldova1.md/p/46349/republica-moldova-trece-la-ora-de-vara-pe-30-martie-cum-ne-afecteaza-si-ce-recomanda-medicii
+# 2025 https://moldova1.md/p/60469/republica-moldova-trece-la-ora-de-iarna-ceasurile-se-dau-inapoi-cu-o-ora
+#
+# It seems that the changes to the end date and transition times were just
+# done in practice without formally changing the resolution. In late 2025, the
+# government said that the Soviet resolution was still in force, and proposed
+# a new resolution to replace it and formally establish the EU rule:
+# ... based on the notices, it seems that in practice Moldova already
+# uses the EU rule since 2022. This was also the year when Moldova applied to
+# join the EU.
+#
+# From Robert Bastian (2026-02-26):
+# This has been approved and published in the government gazette:
+# https://monitorul.gov.md/ro/monitorul/view/pdf/3234/part/2#page=27
+#
+# From Paul Eggert (2026-02-24):
+# Also see Svetlana Rudenko, "Moldova abandons the 'Soviet era'", Logos Press,
+# 2026-02-21 <https://logos-pres.md/en/news/moldova-abandons-the-soviet-era/>.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Moldova	1997	max	-	Mar	lastSun	 2:00	1:00	S
-Rule	Moldova	1997	max	-	Oct	lastSun	 3:00	0	-
+Rule	Moldova	1997	2021	-	Mar	lastSun	 2:00	1:00	S
+Rule	Moldova	1997	2021	-	Oct	lastSun	 3:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Chisinau	1:55:20 -	LMT	1880
@@ -2005,7 +2088,8 @@ Zone	Europe/Chisinau	1:55:20 -	LMT	1880
 			2:00	Russia	EE%sT	1992
 			2:00	E-Eur	EE%sT	1997
 # See Romania commentary for the guessed 1997 transition to EU rules.
-			2:00	Moldova	EE%sT
+			2:00	Moldova	EE%sT	2022
+			2:00	EU	EE%sT
 
 # Poland
 
@@ -2096,12 +2180,10 @@ Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 # all clocks therefore having to be advanced or set back correspondingly ...
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-# From Tim Parenti (2024-07-01), per Paul Eggert (1999-01-30):
-# DSH writes in their history that Decreto 1469 of 1915-03-30 established
-# summer time and that, "despite" this, the change to the clocks was not done
-# every year, depending on what Spain did, because of railroad schedules.
-# In fact, that decree had nothing to do with DST; rather, it regulated the
-# sending of time signals.  But we do see linkage to Spain in the 1920s below.
+# From Tim Parenti (2024-07-01):
+# Decreto 1469 of 1915-03-30 ... had nothing to do with DST;
+# rather it regulated the sending of time signals.
+# But we do see linkage to Spain in the 1920s below.
 # https://dre.pt/dr/detalhe/decreto/1469-1915-285721
 # https://dre.pt/application/conteudo/285721
 #
@@ -2393,7 +2475,7 @@ Zone Atlantic/Madeira	-1:07:36 -	LMT	1884        # Funchal
 # Nine O'clock <http://www.nineoclock.ro/POL/1778pol.html>
 # (1998-10-23) reports that the switch occurred at
 # 04:00 local time in fall 1998.  For lack of better info,
-# assume that Romania and Moldova switched to EU rules in 1997,
+# assume that Romania switched to EU rules in 1997,
 # the same year as Bulgaria.
 #
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S

--- a/usr/src/data/zoneinfo/northamerica
+++ b/usr/src/data/zoneinfo/northamerica
@@ -6,9 +6,9 @@
 # also includes Central America and the Caribbean
 
 # This file is by no means authoritative; if you think you know better,
-# go ahead and edit the file (and please send any changes to
-# tz@iana.org for general use in the future).  For more, please see
-# the file CONTRIBUTING in the tz distribution.
+# go ahead and edit the file, and please send any changes to
+# the public mailing list tz@iana.org for general use in the future.
+# For more, please see the file CONTRIBUTING in the tz distribution.
 
 # From Paul Eggert (1999-03-22):
 # A reliable and entertaining source about time zones is
@@ -1217,6 +1217,16 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # see Mark Fineman, "An Isle Rich in Guano and Discord",
 # _Los Angeles Times_ (1998-11-10), A1, A10; it cites
 # Jimmy Skaggs, _The Great Guano Rush_ (1994).
+
+# From Rob van Gent (2025-07-23):
+# Another useful source for historical time zone information appears to be
+# a series of circulars with the title "Standard Time Throughout the World"
+# issued between 1925 and 1950 by the U.S. Bureau of Standards.
+# I found the following issues online:
+# https://nvlpubs.nist.gov/nistpubs/Legacy/circ/nbscircular280.pdf (1925)
+# https://nvlpubs.nist.gov/nistpubs/Legacy/circ/nbscircular399.pdf (1932)
+# https://nvlpubs.nist.gov/nistpubs/Legacy/circ/nbscircular406.pdf (1935)
+# https://nvlpubs.nist.gov/nistpubs/Legacy/circ/nbscircular496.pdf (1950)
 
 ################################################################################
 
@@ -2434,11 +2444,34 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # on the same dates or with a difference of one day.
 # So it may be easier to implement these changes as DST with rule CA
 # during this whole period.
+
+# From Alois Treindl (2025-07-29):
+# I did a quick newspaper archive research on https://hndm.iib.unam.mx/
+# and found that Periódico Oficial del Estado de Baja California Norte
+# (1973-04-20) states clearly that DST was observed from last Sunday
+# in April to last Sunday in October....  I have a few more data from the
+# official bulletin for DST begin or end in Baja California 1964 1967 1969
+# 1972 1973 (already sent) 1974 1975 1976 I do not know whether it is safe to
+# assume that it also applied in the years where I did not yet find proof.
+# The 1974 end of DST contains a reference to an Acuerdo of 1973-dec-20 which
+# I could not find....  One might assume that Baja California, which followed
+# US-CA in all these other yours, did the same.
 #
-# From Paul Eggert (2024-08-18):
-# For now, maintain the slightly-different history for Baja California,
+# From Paul Eggert (2025-08-04):
+# Assume that Tijuana agreed with San Diego from 1953 through 1996,
+# as this agrees with Alois Treindl's data and with Shanks.
+# For now, keep the slightly-different 1948/1952 history for Baja California,
 # as we have no information on whether 1948/1952 clocks in Tijuana followed
 # the decrees or followed San Diego.
+
+# From Mark Schapiro, writing in The Nation (2002-10-28):
+# https://www.thenation.com/article/archive/sowing-disaster/
+# When Mexican clocks were turned back for daylight saving time in the spring,
+# the Zapotecs refused to make the adjustment, insisting that they live in
+# "God's time," not in what they derisively call "Fox time," referring to
+# President Vicente Fox in far-off Mexico City.
+# From Paul Eggert (2025-08-04):
+# Unfortunately we have no data to track this informal practice.
 
 # From Alan Perry (1996-02-15):
 # A guy from our Mexico subsidiary finally found the Presidential Decree
@@ -2705,7 +2738,7 @@ Zone America/Mexico_City -6:36:36 -	LMT	1922 Jan  1  7:00u
 # Chihuahua (near US border - western side)
 # This includes the municipios of Janos, Ascensión, Juárez, Guadalupe, and
 # Práxedis G Guerrero.
-# http://gaceta.diputados.gob.mx/PDF/65/2a022/nov/20221124-VII.pdf
+# https://gaceta.diputados.gob.mx/PDF/65/2022/nov/20221124-VII.pdf
 Zone America/Ciudad_Juarez -7:05:56 -	LMT	1922 Jan  1  7:00u
 			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
@@ -2720,7 +2753,7 @@ Zone America/Ciudad_Juarez -7:05:56 -	LMT	1922 Jan  1  7:00u
 # Chihuahua (near US border - eastern side)
 # This includes the municipios of Coyame del Sotol, Ojinaga, and Manuel
 # Benavides.
-# http://gaceta.diputados.gob.mx/PDF/65/2a022/nov/20221124-VII.pdf
+# https://gaceta.diputados.gob.mx/PDF/65/2022/nov/20221124-VII.pdf
 Zone America/Ojinaga	-6:57:40 -	LMT	1922 Jan  1  7:00u
 			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
@@ -2817,9 +2850,7 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  7:00u
 			-8:00	1:00	PDT	1951 Sep 30  2:00
 			-8:00	-	PST	1952 Apr 27  2:00
 			-8:00	1:00	PDT	1952 Sep 28  2:00
-			-8:00	-	PST	1954
-			-8:00	CA	P%sT	1961
-			-8:00	-	PST	1976
+			-8:00	CA	P%sT	1967
 			-8:00	US	P%sT	1996
 			-8:00	Mexico	P%sT	2001
 			-8:00	US	P%sT	2002 Feb 20

--- a/usr/src/data/zoneinfo/southamerica
+++ b/usr/src/data/zoneinfo/southamerica
@@ -4,9 +4,9 @@
 # 2009-05-17 by Arthur David Olson.
 
 # This file is by no means authoritative; if you think you know better,
-# go ahead and edit the file (and please send any changes to
-# tz@iana.org for general use in the future).  For more, please see
-# the file CONTRIBUTING in the tz distribution.
+# go ahead and edit the file, and please send any changes to
+# the public mailing list tz@iana.org for general use in the future.
+# For more, please see the file CONTRIBUTING in the tz distribution.
 
 # From Paul Eggert (2016-12-05):
 #

--- a/usr/src/man/man1/cp.1
+++ b/usr/src/man/man1/cp.1
@@ -44,389 +44,436 @@
 .\" Copyright (c) 1992, X/Open Company Limited All Rights Reserved
 .\" Portions Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved
 .\" Copyright 2013 Nexenta Systems, Inc. All rights reserved.
-.\" Copyright 2024 Oxide Computer Company
+.\" Copyright 2026 Oxide Computer Company
 .\"
-.TH CP 1 "September 14, 2024"
-.SH NAME
-cp \- copy files
-.SH SYNOPSIS
-.nf
-\fB/usr/bin/cp\fR [\fB-afinp@/\fR] \fIsource_file\fR \fItarget_file\fR
-.fi
-
-.LP
-.nf
-\fB/usr/bin/cp\fR [\fB-afinp@/\fR] \fIsource_file\fR... \fItarget\fR
-.fi
-
-.LP
-.nf
-\fB/usr/bin/cp\fR [\fB-r\fR | \fB-R\fR [\fB-H\fR | \fB-L\fR | \fB-P\fR]] [\fB-afinp@/\fR] \fIsource_dir\fR... \fItarget\fR
-.fi
-
-.LP
-.nf
-\fB/usr/bin/cp\fR [\fB-R\fR | \fB-R\fR [\fB-H\fR | \fB-L\fR | \fB-P\fR]] [\fB-afinp@/\fR] \fIsource_dir\fR... \fItarget\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/cp\fR [\fB-afinp@/\fR] \fIsource_file\fR \fItarget_file\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/cp\fR [\fB-afinp@/\fR] \fIsource_file\fR... \fItarget\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/cp\fR [\fB-r\fR | \fB-R\fR [\fB-H\fR | \fB-L\fR | \fB-P\fR]] [\fB-afinp@/\fR] \fIsource_dir\fR... \fItarget\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/cp\fR [\fB-R\fR | \fB-R\fR [\fB-H\fR | \fB-L\fR | \fB-P\fR]] [\fB-afinp@/\fR] \fIsource_dir\fR... \fItarget\fR
-.fi
-
-.SH DESCRIPTION
-In the first synopsis form, neither \fIsource_file\fR nor \fItarget_file\fR are
-directory files, nor can they have the same name. The \fBcp\fR utility copies
-the contents of \fIsource_file\fR to the destination path named by
-\fItarget_file\fR. If \fItarget_file\fR exists, \fBcp\fR overwrites its
-contents, but the mode (and \fBACL\fR if applicable), owner, and group
-associated with it are not changed. The last modification time of
-\fItarget_file\fR and the last access time of \fIsource_file\fR are set to the
-time the copy was made. If \fItarget_file\fR does not exist, \fBcp\fR creates a
-new file named \fItarget_file\fR that has the same mode as \fIsource_file\fR
-except that the sticky bit is not set unless the user is super-user. In this
-case, the owner and group of \fItarget_file\fR are those of the user, unless
-the setgid bit is set on the directory containing the newly created file. If
-the directory's setgid bit is set, the newly created file has the group of the
-containing directory rather than of the creating user. If \fItarget_file\fR is
-a link to another file, \fBcp\fR overwrites the link destination with the
-contents of \fIsource_file\fR; the link(s) from \fItarget_file\fR remains.
-.sp
-.LP
-In the second synopsis form, one or more \fIsource_file\fRs are copied to the
-directory specified by \fItarget\fR. It is an error if any \fIsource_file\fR is
-a file of type directory, if \fItarget\fR either does not exist or is not a
-directory.
-.sp
-.LP
-In the third or fourth synopsis forms, one or more directories specified by
-\fIsource_dir\fR are copied to the directory specified by \fItarget\fR. Either
-the \fB-r\fR or \fB-R\fR must be specified. For each \fIsource_dir\fR, \fBcp\fR
+.Dd "March 22, 2026"
+.Dt CP 1
+.Os
+.Sh NAME
+.Nm cp
+.Nd copy files
+.Sh SYNOPSIS
+.Nm /usr/bin/cp
+.Op Fl afinp@/
+.Ar source_file
+.Ar target_file
+.Nm /usr/bin/cp
+.Op Fl afinp@/
+.Ar source_file Ns ...
+.Ar target
+.Nm /usr/bin/cp
+.Oo
+.Fl r | R
+.Op Fl H | L | P
+.Oc
+.Op Fl afinp@/
+.Ar source_dir Ns ...
+.Ar target
+.Pp
+.Nm /usr/xpg4/bin/cp
+.Op Fl afinp@/
+.Ar source_file
+.Ar target_file
+.Nm /usr/xpg4/bin/cp
+.Op Fl afinp@/
+.Ar source_file Ns ...
+.Ar target
+.Nm /usr/xpg4/bin/cp
+.Oo
+.Fl r | R
+.Op Fl H | L | P
+.Oc
+.Op Fl afinp@/
+.Ar source_dir Ns ...
+.Ar target
+.Sh DESCRIPTION
+In the first synopsis form, neither
+.Ar source_file
+nor
+.Ar target_file
+are directory files, nor can they have the same name.
+The
+.Nm
+utility copies the contents of
+.Ar source_file
+to the destination path named by
+.Ar target_file .
+If
+.Ar target_file
+exists,
+.Nm
+overwrites its
+contents, but the mode
+.Pq and ACL if applicable ,
+owner, and group associated with it are not changed.
+The last modification time of
+.Ar target_file
+and the last access time of
+.Ar source_file
+are set to the time the copy was made.
+If
+.Ar target_file
+does not exist,
+.Nm
+creates a new file named
+.Ar target_file
+that has the same mode as
+.Ar source_file
+except that the sticky bit is not set unless the user is super-user.
+In this case, the owner and group of
+.Ar target_file
+are those of the user, unless the setgid bit is set on the directory containing
+the newly created file.
+If the directory's setgid bit is set, the newly created file has the group of
+the containing directory rather than of the creating user.
+If
+.Ar target_file
+is a link to another file,
+.Nm
+overwrites the link destination with the contents of
+.Ar source_file ;
+the link(s) from
+.Ar target_file
+remains.
+.Pp
+In the second synopsis form, one or more
+.Ar source_file Ns s
+are copied to the directory specified by
+.Ar target .
+It is an error if any
+.Ar source_file
+is a file of type directory, if
+.Ar target
+either does not exist or is not a directory.
+.Pp
+In the third synopsis form, one or more directories specified by
+.Ar source_dir
+are copied to the directory specified by
+.Ar target .
+Either the
+.Fl r
+or
+.Fl R
+must be specified.
+For each
+.Ar source_dir ,
+.Nm
 copies all files and subdirectories.
-.SH OPTIONS
-The following options are supported for both \fB/usr/bin/cp\fR and
-\fB/usr/xpg4/bin/cp\fR:
-.sp
-.ne 2
-.na
-\fB\fB-a\fR\fR
-.ad
-.RS 6n
-Archive mode. Same as -RpP.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.RS 6n
-Unlink. If a file descriptor for a destination file cannot be obtained, this
-option attempts to unlink the destination file and proceed. If the \fB-n\fR
+.Sh OPTIONS
+The following options are supported for both
+.Pa /usr/bin/cp
+and
+.Pa /usr/xpg4/bin/cp :
+.Bl -tag -width Ds
+.It Fl a
+Archive mode.
+Same as
+.Fl RpP .
+.It Fl f
+Unlink.
+If a file descriptor for a destination file cannot be obtained, this option
+attempts to unlink the destination file and proceed.
+If the
+.Fl n
 option is specified then this option is ignored.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-H\fR\fR
-.ad
-.RS 6n
+.It Fl H
 Takes actions based on the type and contents of the file referenced by any
-symbolic link specified as a \fIsource_file\fR operand.
-.sp
-If the \fIsource_file\fR operand is a symbolic link, then \fBcp\fR copies the
-file referenced by the symbolic link for the \fIsource_file\fR operand. All
-other symbolic links encountered during traversal of a file hierarchy are
+symbolic link specified as a
+.Ar source_file
+operand.
+.Pp
+If the
+.Ar source_file
+operand is a symbolic link, then
+.Nm
+copies the file referenced by the symbolic link for the
+.Ar source_file
+operand.
+All other symbolic links encountered during traversal of a file hierarchy are
 preserved.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-i\fR\fR
-.ad
-.RS 6n
-Interactive. \fBcp\fR prompts for confirmation whenever the copy would
-overwrite an existing \fItarget\fR. An affirmative response means that the copy
-should proceed. Any other answer prevents \fBcp\fR from overwriting
-\fItarget\fR. If both the \fB-i\fR and \fB-n\fR options are specified, only the
-last one on the command line is honored.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-L\fR\fR
-.ad
-.RS 6n
+.It Fl i
+Interactive.
+.Nm
+prompts for confirmation whenever the copy would overwrite an existing
+.Ar target .
+An affirmative response means that the copy should proceed.
+Any other answer prevents
+.Nm
+from overwriting
+.Ar target .
+If both the
+.Fl i
+and
+.Fl n
+options are specified, only the last one on the command line is honored.
+.It Fl L
 Takes actions based on the type and contents of the file referenced by any
-symbolic link specified as a \fIsource_file\fR operand or any symbolic links
-encountered during traversal of a file hierarchy.
-.sp
-Copies files referenced by symbolic links. Symbolic links encountered during
-traversal of a file hierarchy are not preserved.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-n\fR\fR
-.ad
-.RS 6n
-No clobber. When \fBcp\fR encounters a target file that already exists, whether
-specified explicitly, the file is found in a directory, or as part of a
-recursive copy, do not overwrite the file. Files skipped this way are not
-considered errors.  If both the \fB-i\fR and \fB-n\fR options are specified,
-only the last one on the command line is honored.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-p\fR\fR
-.ad
-.RS 6n
-Preserve. The \fBcp\fR utility duplicates not only the contents of
-\fIsource_file\fR, but also attempts to preserve its ACL, access and
-modification times, extended attributes, extended system attributes, file mode,
-and owner and group ids.
-.sp
-If \fBcp\fR is unable to preserve the access and modification times, extended
-attributes, or the file mode, \fBcp\fR does not consider it a failure. If
-\fBcp\fR is unable to preserve the owner and group id, the copy does not fail,
-but \fBcp\fR silently clears the \fBS_ISUID\fR and \fBS_ISGID\fR bits from the
-file mode of the target. The copy fails if \fBcp\fR is unable to clear these
-bits. If \fBcp\fR is unable to preserve the ACL or extended system attributes,
-the copy fails. If the copy fails, then a diagnostic message is written to
-\fBstderr\fR and (after processing any remaining operands) \fBcp\fR exits with
-a \fBnon-zero\fR exit status.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-P\fR\fR
-.ad
-.RS 6n
-Takes actions on any symbolic link specified as a \fIsource_file\fR operand or
-any symbolic link encountered during traversal of a file hierarchy.
-.sp
-Copies symbolic links. Symbolic links encountered during traversal of a file
-hierarchy are preserved.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-r\fR\fR
-.ad
-.RS 6n
-Recursive. \fBcp\fR copies the directory and all its files, including any
-subdirectories and their files to \fItarget\fR. Unless the \fB-H\fR, \fB-L\fR,
-or \fB-P\fR option is specified, the \fB-L\fR option is used as the default
-mode.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-R\fR\fR
-.ad
-.RS 6n
-Same as \fB-r\fR, except pipes are replicated, not read from.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-@\fR\fR
-.ad
-.RS 6n
-Preserves extended attributes. \fBcp\fR attempts to copy all of the source
-file's extended attributes along with the file data to the destination file.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-/\fR\fR
-.ad
-.RS 6n
-Preserves extended attributes and extended system attributes. Along with the
-file's data, the \fBcp\fR utility attempts to copy extended attributes and
-extended system attributes from each source file, and extended system
-attributes associated with extended attributes to the destination file. If
-\fBcp\fR is unable to copy extended attributes or extended system attributes,
-then a diagnostic message is written to \fBstderr\fR and (after processing any
-remaining operands) exits with a \fBnon-zero\fR exit status.
-.RE
-
-.sp
-.LP
-Specifying more than one of the mutually-exclusive options \fB-H\fR, \fB-L\fR,
-and \fB-P\fR is not considered an error. The last option specified determines
-the behavior of the utility.
-.SS "/usr/bin/cp"
-If the \fB-p\fR option is specified with either the \fB-@\fR option or the
-\fB-/\fR option, \fB/usr/bin/cp\fR behaves as follows
-.RS +4
-.TP
-.ie t \(bu
-.el o
-When both \fB-p\fR and \fB-@\fR are specified in any order, the copy fails if
-extended attributes cannot be copied.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-When both \fB-p\fR and \fB-/\fR are specified in any order, the copy fails if
-extended system attributes cannot be copied.
-.RE
-.SS "/usr/xpg4/bin/cp"
-If the \fB-p\fR option is specified with either the \fB-@\fR option or the
-\fB-/\fR option, \fB/usr/xpg4/bin/cp\fR behaves as follows:
-.RS +4
-.TP
-.ie t \(bu
-.el o
-When both \fB-p\fR and \fB-@\fR are specified, the last option specified
-determines whether the copy fails if extended attributes cannot be preserved.
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
-When both \fB-p\fR and \fB-/\fR are specified, the last option specified
-determines whether the copy fails if extended system attributes cannot be
+symbolic link specified as a
+.Ar source_file
+operand or any symbolic links encountered during traversal of a file hierarchy.
+.Pp
+Copies files referenced by symbolic links.
+Symbolic links encountered during traversal of a file hierarchy are not
 preserved.
-.RE
-.SH OPERANDS
+.It Fl n
+No clobber.
+When
+.Nm
+encounters a target file that already exists, whether specified explicitly, the
+file is found in a directory, or as part of a recursive copy, do not overwrite
+the file.
+Files skipped this way are not considered errors.
+If both the
+.Fl i
+and
+.Fl n
+options are specified, only the last one on the command line is honored.
+.It Fl p
+Preserve.
+The
+.Nm
+utility duplicates not only the contents of
+.Ar source_file ,
+but also attempts to preserve its ACL, access and modification times, extended
+attributes, extended system attributes, file mode, and owner and group ids.
+.Pp
+If
+.Nm
+is unable to preserve the access and modification times, extended attributes, or
+the file mode,
+.Nm
+does not consider it a failure.
+If
+.Nm
+is unable to preserve the owner and group id, the copy does not fail, but
+.Nm
+silently clears the
+.Dv S_ISUID
+and
+.Dv S_ISGID
+bits from the file mode of the target.
+The copy fails if
+.Nm
+is unable to clear these bits.
+If
+.Nm cp
+is unable to preserve the ACL or extended system attributes, the copy fails.
+If the copy fails, then a diagnostic message is written to
+.Va stderr
+and
+.Pq after processing any remaining operands
+.Nm
+exits with a non-zero exit status.
+.It Fl P
+Takes actions on any symbolic link specified as a
+.Ar source_file
+operand or any symbolic link encountered during traversal of a file hierarchy.
+.Pp
+Copies symbolic links.
+Symbolic links encountered during traversal of a file hierarchy are preserved.
+.It Fl r
+Recursive.
+.Nm
+copies the directory and all its files, including any subdirectories and their
+files to
+.Ar target .
+Unless the
+.Fl H ,
+.Fl L ,
+or
+.Fl P
+option is specified, the
+.Fl L
+option is used as the default mode.
+.It Fl R
+Same as
+.Fl r ,
+except pipes are replicated, not read from.
+.It Fl @
+Preserves extended attributes.
+.Nm
+attempts to copy all of the source file's extended attributes along with the
+file data to the destination file.
+.It Fl /
+Preserves extended attributes and extended system attributes.
+Along with the file's data, the
+.Nm
+utility attempts to copy extended attributes and extended system attributes from
+each source file, and extended system attributes associated with extended
+attributes to the destination file.
+If
+.Nm
+is unable to copy extended attributes or extended system attributes, then a
+diagnostic message is written to
+.Va stderr
+and
+.Pq after processing any remaining operands
+exits with a non-zero exit status.
+.El
+.Pp
+Specifying more than one of the mutually-exclusive options
+.Fl H ,
+.Fl L ,
+and
+.Fl P
+is not considered an error.
+The last option specified determines the behavior of the utility.
+.Ss "/usr/bin/cp"
+If the
+.Fl p
+option is specified with either the
+.Fl @
+option or the
+.Fl /
+option,
+.Pa /usr/bin/cp
+behaves as follows:
+.Bl -bullet -offset indent
+.It
+When both
+.Fl p
+and
+.Fl @
+are specified in any order, the copy fails if extended attributes cannot be
+copied.
+.It
+When both
+.Fl p
+and
+.Fl /
+are specified in any order, the copy fails if extended system attributes cannot
+be copied.
+.El
+.Ss "/usr/xpg4/bin/cp"
+If the
+.Fl p
+option is specified with either the
+.Fl @
+option or the
+.Fl /
+option,
+.Pa /usr/xpg4/bin/cp
+behaves as follows:
+.Bl -bullet -offset indent
+.It
+When both
+.Fl p
+and
+.Fl @
+are specified, the last option specified determines whether the copy fails if
+extended attributes cannot be preserved.
+.It
+When both
+.Fl p
+and
+.Fl /
+are specified, the last option specified determines whether the copy fails if
+extended system attributes cannot be preserved.
+.El
+.Sh OPERANDS
 The following operands are supported:
-.sp
-.ne 2
-.na
-\fB\fIsource_file\fR\fR
-.ad
-.RS 15n
+.Bl -tag -width Ar
+.It Ar source_file
 A pathname of a regular file to be copied.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fIsource_dir\fR\fR
-.ad
-.RS 15n
+.It Ar source_dir
 A pathname of a directory to be copied.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fItarget_file\fR\fR
-.ad
-.RS 15n
+.It Ar target_file
 A pathname of an existing or non-existing file, used for the output when a
 single file is copied.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fItarget\fR\fR
-.ad
-.RS 15n
+.It Ar target
 A pathname of a directory to contain the copied files.
-.RE
-
-.SH USAGE
-See \fBlargefile\fR(7) for the description of the behavior of \fBcp\fR when
-encountering files greater than or equal to 2 Gbyte ( 2^31 bytes).
-.SH EXAMPLES
-\fBExample 1 \fRCopying a File
-.sp
-.LP
+.El
+.Sh USAGE
+See
+.Xr largefile 7
+for the description of the behavior of
+.Nm
+when encountering files greater than or equal to 2 Gbyte
+.Pq 2^31 bytes .
+.Sh ENVIRONMENT VARIABLES
+See
+.Xr environ 7
+for descriptions of the following environment variables that affect the
+execution of
+.Nm :
+.Ev LANG ,
+.Ev LC_ALL ,
+.Ev LC_COLLATE ,
+.Ev LC_CTYPE ,
+.Ev LC_MESSAGES ,
+and
+.Ev NLSPATH .
+.Pp
+Affirmative responses are processed using the extended regular expression
+defined for the
+.Sy yesexpr
+keyword in the
+.Ev LC_MESSAGES
+category of the user's locale.
+The locale specified in the
+.Ev LC_COLLATE
+category defines the behavior of ranges, equivalence classes, and
+multi-character collating elements used in the expression defined for
+.Sy yesexpr .
+The locale specified in
+.Ev LC_CTYPE
+determines the locale for interpretation of sequences of bytes of text data a
+characters, the behavior of character classes used in the expression defined for
+the
+.Sy yesexpr .
+See
+.Xr locale 7 .
+.Sh EXIT STATUS
+The following exit values are returned:
+.Bl -tag -width Ds
+.It Sy 0
+All files were copied successfully.
+.It Sy > 0
+An error occurred.
+.El
+.Sh EXAMPLES
+.Sy Example 1
+Copying a File
+.Pp
 The following example copies a file:
-
-.sp
-.in +2
-.nf
+.Bd -literal -offset indent
 example% cp goodies goodies.old
 
 example% ls goodies*
 goodies goodies.old
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 2 \fRCopying a List of Files
-.sp
-.LP
+.Ed
+.Pp
+.Sy Example 2
+Copying a List of Files
+.Pp
 The following example copies a list of files to a destination directory:
-
-.sp
-.in +2
-.nf
+.Bd -literal -offset indent
 example% cp ~/src/* /tmp
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 3 \fRCopying a Directory
-.sp
-.LP
+.Ed
+.Pp
+.Sy Example 3
+Copying a Directory
+.Pp
 The following example copies a directory, first to a new, and then to an
-existing destination directory
-
-.sp
-.in +2
-.nf
+existing destination directory:
+.Bd -literal -offset indent
 example% ls ~/bkup
 /usr/example/fred/bkup not found
-
-example% cp \fB-r\fR ~/src ~/bkup
-
-example% ls \fB-R\fR ~/bkup
+example% cp -r ~/src ~/bkup
+example% ls -R ~/bkup
 x.c y.c z.sh
-
-example% cp \fB-r\fR ~/src ~/bkup
-
-example% ls \fB-R\fR ~/bkup
+example% cp -r ~/src ~/bkup
+example% ls -R ~/bkup
 src x.c y.c z.sh
 src:
 x.c y.c z.s
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 4 \fRCopying Extended File System Attributes
-.sp
-.LP
+.Ed
+.Pp
+.Sy Example 4
+Copying Extended File System Attributes
+.Pp
 The following example copies extended file system attributes:
-
-.sp
-.in +2
-.nf
+.Bd -literal -offset indent
 $ ls -/ c file1
 -rw-r--r--   1 foo   staff          0 Oct 29 20:04 file1
                 {AH-----m--}
@@ -435,19 +482,13 @@ $ cp -/ file1 file2
 $ ls -/c file2
 -rw-r--r--   1 foo  staff          0 Oct 29 20:17 file2
                 {AH-----m--}
-.fi
-.in -2
-.sp
-
-.LP
-\fBExample 5 \fRFailing to Copy Extended System Attributes
-.sp
-.LP
+.Ed
+.Pp
+.Sy Example 5
+Failing to Copy Extended System Attributes
+.Pp
 The following example fails to copy extended system attributes:
-
-.sp
-.in +2
-.nf
+.Bd -literal -offset indent
 $ ls -/c file1
 -rw-r--r--   1 foo    staff          0 Oct 29 20:04 file1
                 {AH-----m--}
@@ -459,86 +500,30 @@ cp: Failed to copy extended system attributes from file1 to /tmp/file1
 $ ls -/c /tmp/file1
 -rw-r--r--   1 foo    staff          0 Oct 29 20:09 /tmp/file1
                 {}
-.fi
-.in -2
-.sp
-
-.SH ENVIRONMENT VARIABLES
-See \fBenviron\fR(7) for descriptions of the following environment variables
-that affect the execution of \fBcp\fR: \fBLANG\fR, \fBLC_ALL\fR,
-\fBLC_COLLATE\fR, \fBLC_CTYPE\fR, \fBLC_MESSAGES\fR, and \fBNLSPATH\fR.
-.sp
-.LP
-Affirmative responses are processed using the extended regular expression
-defined for the \fByesexpr\fR keyword in the \fBLC_MESSAGES\fR category of the
-user's locale. The locale specified in the \fBLC_COLLATE\fR category defines
-the behavior of ranges, equivalence classes, and multi-character collating
-elements used in the expression defined for \fByesexpr\fR. The locale specified
-in \fBLC_CTYPE\fR determines the locale for interpretation of sequences of
-bytes of text data a characters, the behavior of character classes used in the
-expression defined for the \fByesexpr\fR. See \fBlocale\fR(7).
-.SH EXIT STATUS
-The following exit values are returned:
-.sp
-.ne 2
-.na
-\fB\fB0\fR\fR
-.ad
-.RS 6n
-All files were copied successfully.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB>0\fR\fR
-.ad
-.RS 6n
-An error occurred.
-.RE
-
-.SH ATTRIBUTES
-See \fBattributes\fR(7) for descriptions of the following attributes:
-.SS "/usr/bin/cp"
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-_
-Interface Stability	Committed
-.TE
-
-.SS "/usr/xpg4/bin/cp"
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-_
-Interface Stability	Committed
-.TE
-
-.SH SEE ALSO
-.BR chmod (1),
-.BR chown (1),
-.BR setfacl (1),
-.BR utime (2),
-.BR fgetattr (3C),
-.BR attributes (7),
-.BR environ (7),
-.BR fsattr (7),
-.BR largefile (7),
-.BR locale (7),
-.BR standards (7)
-.SH NOTES
+.Ed
+.Sh INTERFACE STABILITY
+.Sy Committed
+.Sh CODE SET INDEPENDENCE
+.Sy Enabled
+.Sh SEE ALSO
+.Xr chmod 1 ,
+.Xr chown 1 ,
+.Xr setfacl 1 ,
+.Xr utime 2 ,
+.Xr fgetattr 3C ,
+.Xr attributes 7 ,
+.Xr environ 7 ,
+.Xr fsattr 7 ,
+.Xr largefile 7 ,
+.Xr locale 7 ,
+.Xr standards 7
+.Sh NOTES
 The permission modes of the source file are preserved in the copy.
-.sp
-.LP
-A \fB--\fR permits the user to mark the end of any command line options
-explicitly, thus allowing \fBcp\fR to recognize filename arguments that begin
-with a \fB-\fR.
+.Pp
+A
+.Fl Fl
+permits the user to mark the end of any command line options explicitly, thus
+allowing
+.Nm
+to recognize filename arguments that begin with a
+.Fl .

--- a/usr/src/man/man1/ln.1
+++ b/usr/src/man/man1/ln.1
@@ -43,273 +43,338 @@
 .\" Copyright 1989 AT&T
 .\" Portions Copyright (c) 1992, X/Open Company Limited  All Rights Reserved
 .\" Copyright (c) 2004, Sun Microsystems, Inc.  All Rights Reserved
-.\" Copyright 2024 Oxide Computer Company
+.\" Copyright 2026 Oxide Computer Company
 .\"
-.TH LN 1 "September 14, 2024"
-.SH NAME
-ln \- make hard or symbolic links to files
-.SH SYNOPSIS
-.nf
-\fB/usr/bin/ln\fR [\fB-fins\fR] \fIsource_file\fR [\fItarget\fR]
-.fi
-
-.LP
-.nf
-\fB/usr/bin/ln\fR [\fB-fins\fR] \fIsource_file\fR... \fItarget\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/ln\fR [\fB-fis\fR] \fIsource_file\fR [\fItarget\fR]
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/ln\fR [\fB-fis\fR] \fIsource_file\fR... \fItarget\fR
-.fi
-
-.SH DESCRIPTION
-In the first synopsis form, the \fBln\fR utility creates a new directory entry
-(link) for the file specified by \fIsource_file\fR, at the destination path
-specified by \fItarget\fR. If \fItarget\fR is not specified, the link is made
-in the current directory. This first synopsis form is assumed when the final
-operand does not name an existing directory; if more than two operands are
-specified and the final is not an existing directory, an error will result.
-.sp
-.LP
-In the second synopsis form, the \fBln\fR utility creates a new directory entry
-for each file specified by a \fIsource_file\fR operand, at a destination path
-in the existing directory named by \fItarget\fR.
-.sp
-.LP
-The \fBln\fR utility may be used to create both hard links and symbolic links.
+.Dd "March 22, 2026"
+.Dt LN 1
+.Os
+.Sh NAME
+.Nm ln
+.Nd make hard or symbolic links to files
+.Sh SYNOPSIS
+.Nm /usr/bin/ln
+.Op Fl fins
+.Ar source_file
+.Op Ar target
+.Nm /usr/bin/ln
+.Op Fl fins
+.Ar source_file Ns ...
+.Ar target
+.Pp
+.Nm /usr/xpg4/bin/ln
+.Op Fl fis
+.Ar source_file
+.Op Ar target
+.Nm /usr/xpg4/bin/ln
+.Op Fl fis
+.Ar source_file Ns ...
+.Ar target
+.Sh DESCRIPTION
+In the first synopsis form, the
+.Nm
+utility creates a new directory entry
+.Pq link
+for the file specified by
+.Ar source_file ,
+at the destination path specified by
+.Ar target .
+If
+.Ar target
+is not specified, the link is made in the current directory.
+This first synopsis form is assumed when the final operand does not name an
+existing directory; if more than two operands are specified and the final one is
+not an existing directory, an error will result.
+.Pp
+In the second synopsis form, the
+.Nm
+utility creates a new directory entry for each file specified by a
+.Ar source_file
+operand, at a destination path in the existing directory named by
+.Ar target .
+.Pp
+The
+.Nm
+utility may be used to create both hard links and symbolic links.
 A hard link is a pointer to a file and is indistinguishable from the original
-directory entry. Any changes to a file are effective independent of the name
-used to reference the file. Hard links may not span file systems and may not
-refer to directories.
-.sp
-.LP
-\fBln\fR by default creates hard links. \fIsource_file\fR is linked to
-\fItarget\fR. If \fItarget\fR is a directory, another file named
-\fIsource_file\fR is created in \fItarget\fR and linked to the original
-\fIsource_file\fR.
-.sp
-.LP
-If \fItarget\fR is an existing file and the \fB-f\fR option is not specified,
-\fBln\fR will write a diagnostic message to standard error, do nothing more
-with the current \fIsource_file\fR, and go on to any remaining
-\fIsource_file\fRs.
-.sp
-.LP
-A symbolic link is an indirect pointer to a file; its directory entry  contains
-the name of the file to which it is linked. Symbolic links may span file
-systems and may refer to directories.
-.sp
-.LP
-File permissions for \fItarget\fR may be different from those displayed with an
-\fB-l\fR listing of the \fBls\fR(1) command. To display the permissions of
-\fItarget\fR, use \fBls\fR \fB-lL\fR. See \fBstat\fR(2) for more information.
-.SS "/usr/bin/ln"
-If \fB/usr/bin/ln\fR determines that the mode of \fItarget\fR forbids writing,
-it prints the mode (see \fBchmod\fR(1)), asks for a response, and reads the
-standard input for one line. If the response is affirmative, the link occurs,
-if permissible. Otherwise, the command exits.
-.SS "/usr/xpg4/bin/ln"
+directory entry.
+Any changes to a file are effective independent of the name used to reference
+the file.
+Hard links may not span file systems and may not refer to directories.
+.Pp
+.Nm
+by default creates hard links.
+.Ar source_file
+is linked to
+.Ar target .
+If
+.Ar target
+is a directory, another file named
+.Ar source_file
+is created in
+.Ar target
+and linked to the original
+.Ar source_file .
+.Pp
+If
+.Ar target
+is an existing file and the
+.Fl f
+option is not specified,
+.Nm
+will write a diagnostic message to standard error, do nothing more with the
+current
+.Ar source_file ,
+and go on to any remaining
+.Ar source_file Ns s.
+.Pp
+A symbolic link is an indirect pointer to a file; its directory entry contains
+the name of the file to which it is linked.
+Symbolic links may span file systems and may refer to directories.
+.Pp
+File permissions for
+.Ar target
+may be different from those displayed with an
+.Fl l
+listing of the
+.Xr ls 1
+command.
+To display the permissions of
+.Ar target ,
+use
+.Nm ls
+.Fl lL .
+See
+.Xr stat 2
+for more information.
+.Ss "/usr/bin/ln"
+If
+.Pa /usr/bin/ln
+determines that the mode of
+.Ar target
+forbids writing, it prints the mode
+.Po
+see
+.Xr chmod 1
+.Pc ,
+asks for a response, and reads the standard input for one line.
+If the response is affirmative, the link occurs, if permissible.
+Otherwise, the command exits.
+.Ss "/usr/xpg4/bin/ln"
 When creating a hard link, and the source file is itself a symbolic link, the
 target will be a hard link to the file referenced by the symbolic link, not to
-the symbolic link object itself (\fIsource_file\fR).
-.SH OPTIONS
-The following options are supported for both \fB/usr/bin/ln\fR and
-\fB/usr/xpg4/bin/ln\fR:
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.RS 6n
-Links files without questioning the user, even if the mode of \fItarget\fR
-forbids writing. If both the \fB-f\fR and \fB-i\fR options are specified, only
-the last one on the command line is honored.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-i\fR\fR
-.ad
-.RS 6n
-Interactively prompt the user about how to proceed when \fItarget\fR already
-exists. An affirmative response means that \fItarget\fR should be removed so
-that a link can be created. Any other answer will prevent the overwriting.
-If both the \fB-f\fR and \fB-i\fR options are specified, only the last one on
-the command line is honored.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-s\fR\fR
-.ad
-.RS 6n
+the symbolic link object itself
+.Pq Ar source_file .
+.Sh OPTIONS
+The following options are supported for both
+.Pa /usr/bin/ln
+and
+.Pa /usr/xpg4/bin/ln :
+.Bl -tag -width Ds
+.It Fl f
+Links files without questioning the user, even if the mode of
+.Ar target
+forbids writing.
+If both the
+.Fl f
+and
+.Fl i
+options are specified, only the last one on the command line is honored.
+.It Fl i
+Interactively prompt the user about how to proceed when
+.Ar target
+already exists.
+An affirmative response means that
+.Ar target
+should be removed so that a link can be created.
+Any other answer will prevent the overwriting.
+If both the
+.Fl f
+and
+.Fl i
+options are specified, only the last one on the command line is honored.
+.It Fl s
 Creates a symbolic link.
-.sp
-If the \fB-s\fR option is used with two arguments, \fItarget\fR may be an
-existing directory or a non-existent file. If \fItarget\fR already exists and
-is not a directory, an error is returned. \fIsource_file\fR may be any path
-name and need not exist. If it exists, it may be a file or directory and may
-reside on a different file system from \fItarget\fR. If \fItarget\fR is an
-existing directory, a file is created in directory \fItarget\fR whose name is
-\fIsource_file\fR or the last component of \fIsource_file\fR. This file is a
-symbolic link that references \fIsource_file\fR. If \fItarget\fR does not
-exist, a file with name \fItarget\fR is created and it is a symbolic link that
-references \fIsource_file\fR.
-.sp
-If the \fB-s\fR option is used with more than two arguments, \fItarget\fR must
-be an existing directory or an error will be returned. For each
-\fIsource_file\fR, a link is created in \fItarget\fR whose name is the last
-component of \fIsource_file\fR. Each new \fIsource_file\fR is a symbolic link
-to the original \fIsource_file\fR. The files and \fItarget\fR may reside on
-different file systems.
-.RE
-
-.SS "/usr/bin/ln"
-The following option is supported for \fB/usr/bin/ln\fR only:
-.sp
-.ne 2
-.na
-\fB\fB-n\fR\fR
-.ad
-.RS 6n
-If \fItarget\fR is an existing file, writes a diagnostic message to stderr and
-goes on to any remaining \fIsource_file\fRs. The \fB-f\fR and \fB-i\fR options
-override this option. This is the default behavior for \fB/usr/bin/ln\fR and
-\fB/usr/xpg4/bin/ln\fR, and is silently ignored.
-.RE
-
-.SH OPERANDS
+.Pp
+If the
+.Fl s
+option is used with two arguments,
+.Ar target
+may be an existing directory or a non-existent file.
+If
+.Ar target
+already exists and is not a directory, an error is returned.
+.Ar source_file
+may be any path name and need not exist.
+If it exists, it may be a file or directory and may reside on a different file
+system from
+.Ar target .
+If
+.Ar target
+is an existing directory, a file is created in directory
+.Ar target
+whose name is
+.Ar source_file
+or the last component of
+.Ar source_file .
+This file is a symbolic link that references
+.Ar source_file .
+If
+.Ar target
+does not exist, a file with name
+.Ar target
+is created and it is a symbolic link that references
+.Ar source_file .
+.Pp
+If the
+.Fl s
+option is used with more than two arguments,
+.Ar target
+must be an existing directory or an error will be returned.
+For each
+.Ar source_file ,
+a link is created in
+.Ar target
+whose name is the last component of
+.Ar source_file .
+Each new
+.Ar source_file
+is a symbolic link to the original
+.Ar source_file .
+The files and
+.Ar target
+may reside on different file systems.
+.El
+.Ss "/usr/bin/ln"
+The following option is supported for
+.Pa /usr/bin/ln
+only:
+.Bl -tag -width Ds
+.It Fl n
+If
+.Ar target
+is an existing file, writes a diagnostic message to stderr and goes on to any
+remaining
+.Ar source_file Ns s.
+The
+.Fl f
+and
+.Fl i
+options override this option.
+This is the default behavior for
+.Pa /usr/bin/ln
+and
+.Pa /usr/xpg4/bin/ln
+and is silently ignored.
+.El
+.Sh OPERANDS
 The following operands are supported:
-.sp
-.ne 2
-.na
-\fB\fIsource_file\fR\fR
-.ad
-.RS 15n
-A path name of a file to be linked. This can be either a regular or special
-file. If the \fB-s\fR option is specified, \fIsource_file\fR can also be a
-directory.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fItarget\fR\fR
-.ad
-.RS 15n
+.Bl -tag -width Ar
+.It Ar source_file
+A path name of a file to be linked.
+This can be either a regular or special file.
+If the
+.Fl s
+option is specified,
+.Ar source_file
+can also be a directory.
+.It Ar target
 The path name of the new directory entry to be created, or of an existing
 directory in which the new directory entries are to be created.
-.RE
-
-.SH USAGE
-See \fBlargefile\fR(7) for the description of the behavior of \fBln\fR when
-encountering files greater than or equal to 2 Gbyte ( 2^31 bytes).
-.SH ENVIRONMENT VARIABLES
-See \fBenviron\fR(7) for descriptions of the following environment variables
-that affect the execution of \fBln\fR: \fBLANG\fR, \fBLC_ALL\fR,
-\fBLC_CTYPE\fR, \fBLC_MESSAGES\fR, and \fBNLSPATH\fR.
-.SH EXIT STATUS
+.El
+.Sh USAGE
+See
+.Xr largefile 7
+for the description of the behavior of
+.Nm
+when encountering files greater than or equal to 2 Gbyte
+.Pq 2^31 bytes .
+.Sh ENVIRONMENT VARIABLES
+See
+.Xr environ 7
+for descriptions of the following environment variables that affect the
+execution of
+.Nm :
+.Ev LANG ,
+.Ev LC_ALL ,
+.Ev LC_CTYPE ,
+.Ev LC_MESSAGES ,
+and
+.Ev NLSPATH .
+.Sh EXIT STATUS
 The following exit values are returned:
-.sp
-.ne 2
-.na
-\fB\fB0\fR\fR
-.ad
-.RS 6n
+.Bl -tag -width Ds
+.It Sy 0
 All the specified files were linked successfully
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB>0\fR\fR
-.ad
-.RS 6n
+.It Sy >0
 An error occurred.
-.RE
-
-.SH ATTRIBUTES
-See \fBattributes\fR(7) for descriptions of the following attributes:
-.SS "/usr/bin/ln"
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-.TE
-
-.SS "/usr/xpg4/bin/ln"
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-_
-Interface Stability	Standard
-.TE
-
-.SH SEE ALSO
-.BR chmod (1),
-.BR ls (1),
-.BR stat (2),
-.BR attributes (7),
-.BR environ (7),
-.BR largefile (7),
-.BR standards (7)
-.SH NOTES
+.El
+.Sh INTERFACE STABILITY
+.Sy Committed
+.Sh CODE SET INDEPENDENCE
+.Sy Enabled
+.Sh SEE ALSO
+.Xr chmod 1 ,
+.Xr ls 1 ,
+.Xr stat 2 ,
+.Xr attributes 7 ,
+.Xr environ 7 ,
+.Xr largefile 7 ,
+.Xr standards 7
+.Sh NOTES
 A symbolic link to a directory behaves differently than you might expect in
-certain cases. While an \fBls\fR(1) command on such a link displays the files
-in the pointed-to directory, entering \fBls\fR \fB-l\fR displays information
-about the link itself:
-.sp
-.in +2
-.nf
-example% \fBln -s dir link\fR
-example% \fBls link\fR
+certain cases.
+While an
+.Xr ls 1
+command on such a link displays the files in the pointed-to directory, entering
+.Nm ls
+.Fl l
+displays information about the link itself:
+.Bd -literal -offset indent
+example% ln -s dir link
+example% ls link
 file1 file2 file3 file4
-example% \fBls -l link\fR
+example% ls -l link
 lrwxrwxrwx  1 user            7 Jan 11 23:27 link -> dir
-.fi
-.in -2
-.sp
-
-.sp
-.LP
-When you change to a directory (see \fBcd\fR(1)) through a symbolic link, using
-\fB/usr/bin/sh\fR or \fB/usr/bin/csh\fR, you wind up in the pointed-to location
-within the file system. This means that the parent of the new working directory
-is not the parent of the symbolic link, but rather, the parent of the
-pointed-to directory. This will also happen when using \fBcd\fR with the
-\fB-P\fR option from \fB/usr/bin/ksh\fR or \fB/usr/xpg4/bin/sh\fR. For
-instance, in the following case, the final working directory is \fB/usr\fR and
-not \fB/home/user/linktest\fR.
-.sp
-.in +2
-.nf
-example% \fBpwd\fR
+.Ed
+.Pp
+When you change to a directory
+.Po
+see
+.Xr cd 1
+.Pc
+through a symbolic link, using
+.Pa /usr/bin/sh
+or
+.Pa /usr/bin/csh ,
+you wind up in the pointed-to location within the file system.
+This means that the parent of the new working directory is not the parent of the
+symbolic link, but rather, the parent of the pointed-to directory.
+This will also happen when using
+.Ic cd
+with the
+.Fl P
+option from
+.Pa /usr/bin/ksh
+or
+.Pa /usr/xpg4/bin/sh .
+For instance, in the following case, the final working directory is
+.Pa /usr
+and
+not
+.Pa /home/user/linktest .
+.Bd -literal -offset indent
+example% pwd
 /home/user/linktest
-example% \fBln -s /usr/tmp symlink\fR
-example% \fBcd symlink\fR
-example% \fBcd .\|.\fR
-example% \fBpwd\fR
+example% ln -s /usr/tmp symlink
+example% cd symlink
+example% cd ..
+example% pwd
 /usr
-.fi
-.in -2
-.sp
-
-.sp
-.LP
+.Ed
+.Pp
 C shell users can avoid any resulting navigation problems by using the
-\fBpushd\fR and \fBpopd\fR built-in commands instead of \fBcd\fR.
+.Ic pushd
+and
+.Ic popd
+built-in commands instead of
+.Ic cd .

--- a/usr/src/man/man1/mv.1
+++ b/usr/src/man/man1/mv.1
@@ -43,260 +43,299 @@
 .\" Copyright 1989 AT&T
 .\" Copyright (c) 1992, X/Open Company Limited  All Rights Reserved
 .\" Portions Copyright (c) 2007, Sun Microsystems, Inc.  All Rights Reserved
-.\" Copyright 2024 Oxide Computer Company
+.\" Copyright 2026 Oxide Computer Company
 .\"
-.TH MV 1 "September 14, 2024"
-.SH NAME
-mv \- move files
-.SH SYNOPSIS
-.nf
-\fB/usr/bin/mv\fR [\fB-fin\fR] \fIsource\fR \fItarget_file\fR
-.fi
-
-.LP
-.nf
-\fB/usr/bin/mv\fR [\fB-fin\fR] \fIsource\fR... \fItarget_dir\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/mv\fR [\fB-fin\fR] \fIsource\fR \fItarget_file\fR
-.fi
-
-.LP
-.nf
-\fB/usr/xpg4/bin/mv\fR [\fB-fin\fR] \fIsource\fR... \fItarget_dir\fR
-.fi
-
-.SH DESCRIPTION
-In the first synopsis form, the \fBmv\fR utility moves the file named by the
-\fIsource\fR operand to the destination specified by the \fItarget_file\fR.
-\fIsource\fR and \fItarget_file\fR can not have the same name. If
-\fItarget_file\fR does not exist, \fBmv\fR creates a file named
-\fItarget_file\fR. If \fItarget_file\fR exists, its contents are overwritten.
+.Dd "March 22, 2026"
+.Dt MV 1
+.Os
+.Sh NAME
+.Nm mv
+.Nd move files
+.Sh SYNOPSIS
+.Nm /usr/bin/mv
+.Op Fl fin
+.Ar source
+.Ar target_file
+.Nm /usr/bin/mv
+.Op Fl fin
+.Ar source Ns ...
+.Ar target_dir
+.Pp
+.Nm /usr/xpg4/bin/mv
+.Op Fl fin
+.Ar source
+.Ar target_file
+.Nm /usr/xpg4/bin/mv
+.Op Fl fin
+.Ar source Ns ...
+.Ar target_dir
+.Sh DESCRIPTION
+In the first synopsis form, the
+.Nm
+utility moves the file named by the
+.Ar source
+operand to the destination specified by the
+.Ar target_file .
+.Ar source
+and
+.Ar target_file
+can not have the same name.
+If
+.Ar target_file
+does not exist,
+.Nm
+creates a file named
+.Ar target_file .
+If
+.Ar target_file
+exists, its contents are overwritten.
 This first synopsis form is assumed when the final operand does not name an
 existing directory.
-.sp
-.LP
-In the second synopsis form, \fBmv\fR moves each file named by a \fIsource\fR
+.Pp
+In the second synopsis form,
+.Nm
+moves each file named by a
+.Ar source
 operand to a destination file in the existing directory named by the
-\fItarget_dir\fR operand. The destination path for each \fIsource\fR is the
-concatenation of the target directory, a single slash character (\fB/\fR), and
-the last path name component of the \fIsource\fR. This second form is assumed
-when the final operand names an existing directory.
-.sp
-.LP
-If \fBmv\fR determines that the mode of \fItarget_file\fR forbids writing, it
-prints the mode (see \fBchmod\fR(2)), ask for a response, and read the standard
-input for one line. If the response is affirmative, the \fBmv\fR occurs, if
-permissible; otherwise, the command exits. Notice that the mode displayed can
-not fully represent the access permission if \fItarget\fR is associated with an
-\fBACL\fR. When the parent directory of \fIsource\fR is writable and has the
-sticky bit set, one or more of the following conditions must be true:
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.Ar target_dir
+operand.
+The destination path for each
+.Ar source
+is the concatenation of the target directory, a single slash character
+.Pq Sq /
+and the last path name component of the
+.Ar source .
+This second form is assumed when the final operand names an existing directory.
+.Pp
+If
+.Nm
+determines that the mode of
+.Ar target_file
+forbids writing, it prints the mode
+.Po
+see
+.Xr chmod 2
+.Pc ,
+asks for a response, and reads the standard input for one line.
+If the response is affirmative, the
+.Nm
+occurs, if permissible; otherwise, the command exits.
+Notice that the mode displayed can not fully represent the access permission if
+.Ar target
+is associated with an ACL.
+When the parent directory of
+.Ar source
+is writable and has the sticky bit set, one or more of the following conditions
+must be true:
+.Bl -bullet -offset indent
+.It
 the user must own the file
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.It
 the user must own the directory
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.It
 the file must be writable by the user
-.RE
-.RS +4
-.TP
-.ie t \(bu
-.el o
+.It
 the user must be a privileged user
-.RE
-.sp
-.LP
-If \fIsource\fR is a file and \fItarget_file\fR is a link to another file with
-links, the other links remain and \fItarget_file\fR becomes a new file.
-.sp
-.LP
-If \fIsource\fR and \fItarget_file\fR/\fItarget_dir\fR are on different file
-systems, \fBmv\fR copies the source and deletes the original. Any hard links to
-other files are lost. \fBmv\fR attempts to duplicate the source file
-characteristics to the target, that is, the owner and group id, permission
-modes, modification and access times, \fBACL\fRs, and extended attributes, if
-applicable. For symbolic links, \fBmv\fR preserves only the owner and group of
-the link itself.
-.sp
-.LP
-If unable to preserve owner and group id, \fBmv\fR clears \fBS_ISUID\fR and
-\fBS_ISGID\fR bits in the target. \fBmv\fR prints a diagnostic message to
-stderr if unable to clear these bits, though the exit code is not affected.
-\fBmv\fR might be unable to preserve extended attributes if the target file
-system does not have extended attribute support. \fB/usr/xpg4/bin/mv\fR prints
-a diagnostic message to stderr for all other failed attempts to duplicate file
-characteristics. The exit code is not affected.
-.sp
-.LP
+.El
+.Pp
+If
+.Ar source
+is a file and
+.Ar target_file
+is a link to another file with links, the other links remain and
+.Ar target_file
+becomes a new file.
+.Pp
+If
+.Ar source
+and
+.Ar target_file Ns / Ns Ar target_dir
+are on different file systems,
+.Nm
+copies the source and deletes the original.
+Any hard links to other files are lost.
+.Nm
+attempts to duplicate the source file characteristics to the target, that is,
+the owner and group id, permission modes, modification and access times, ACLs,
+and extended attributes, if applicable.
+For symbolic links,
+.Nm
+preserves only the owner and group of the link itself.
+.Pp
+If unable to preserve owner and group id,
+.Nm
+clears
+.Dv S_ISUID
+and
+.Dv S_ISGID
+bits in the target.
+.Nm
+prints a diagnostic message to stderr if unable to clear these bits, though the
+exit code is not affected.
+.Nm
+might be unable to preserve extended attributes if the target file system does
+not have extended attribute support.
+.Pa /usr/xpg4/bin/mv
+prints a diagnostic message to stderr for all other failed attempts to duplicate
+file characteristics.
+The exit code is not affected.
+.Pp
 In order to preserve the source file characteristics, users must have the
-appropriate file access permissions. This includes being super-user or having
-the same owner id as the destination file.
-.SH OPTIONS
-The following options are supported:
-.sp
-.ne 2
-.na
-\fB\fB-f\fR\fR
-.ad
-.RS 6n
-\fBmv\fR moves the file(s) without prompting even if it is writing over an
-existing \fItarget\fR. Note that this is the default if the standard input is
-not a terminal. This overrides any \fB-i\fR and \fB-n\fR options already
-specified on the command line.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-i\fR\fR
-.ad
-.RS 6n
-\fBmv\fR prompts for confirmation whenever the move would overwrite an existing
-\fItarget\fR. An affirmative answer means that the move should proceed. Any
-other answer prevents \fBmv\fR from overwriting the \fItarget\fR. This overrides
-any \fB-n\fI options already specified on the command line. See the discussion
-of binary-specific behavior below for how \fB-i\fR and \fB-f\fR interact.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB-n\fR\fR
-.ad
-.RS 6n
-\fBmv\fR will not overwrite \fItarget\fR if it already exists, proceeding on to
-other sources. This does not generate an error. This overrides any \fB-i\fR or
-\fB-f\fR options already specified on the command line.
-.RE
-
-
-.SS "/usr/bin/mv"
-Specifying the \fB-f\fR the \fB-i\fR, and the \fB-n\fR options is not considered
-an error. The last option specified determines the behavior of \fBmv\fR with one
-exception: the \fB-f\fR option overrides all \fB-i\fR options, regardless of where
-they appear in the command line.
-.SS "/usr/xpg4/bin/mv"
-Specifying the \fB-f\fR the \fB-i\fR, and the \fB-n\fR options is not considered
-an error.  The last option specified determines the behavior of \fBmv\fR.
-.SH OPERANDS
+appropriate file access permissions.
+This includes being super-user or having the same owner id as the destination
+file.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl f
+.Nm
+moves the file(s) without prompting even if it is writing over an existing
+.Ar target .
+Note that this is the default if the standard input is not a terminal.
+This overrides any
+.Fl i
+and
+.Fl n
+options already specified on the command line.
+.It Fl i
+.Nm
+prompts for confirmation whenever the move would overwrite an existing
+.Ar target .
+An affirmative answer means that the move should proceed.
+Any other answer prevents
+.Nm
+from overwriting the
+.Ar target .
+This overrides any
+.Fl n
+options already specified on the command line.
+See the discussion of binary-specific behavior below for how
+.Fl i
+and
+.Fl f
+interact.
+.It Fl n
+.Nm
+will not overwrite
+.Ar target
+if it already exists, proceeding on to other sources.
+This does not generate an error.
+This overrides any
+.Fl i
+or
+.Fl f
+options already specified on the command line.
+.El
+.Ss "/usr/bin/mv"
+Specifying the
+.Fl f ,
+the
+.Fl i ,
+and the
+.Fl n
+options is not considered an error.
+The last option specified determines the behavior of
+.Nm
+with one exception: the
+.Fl f
+option overrides all
+.Fl i
+options, regardless of where they appear in the command line.
+.Ss "/usr/xpg4/bin/mv"
+Specifying the
+.Fl f ,
+the
+.Fl i ,
+and the
+.Fl n
+options is not considered an error.
+The last option specified determines the behavior of
+.Nm .
+.Sh OPERANDS
 The following operands are supported:
-.sp
-.ne 2
-.na
-\fB\fIsource\fR\fR
-.ad
-.RS 15n
+.Bl -tag -width Ar
+.It Ar source
 A path name of a file or directory to be moved.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fItarget_file\fR\fR
-.ad
-.RS 15n
+.It Ar target_file
 A new path name for the file or directory being moved.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fItarget_dir\fR\fR
-.ad
-.RS 15n
+.It Ar target_dir
 A path name of an existing directory into which to move the input files.
-.RE
-
-.SH USAGE
-See \fBlargefile\fR(7) for the description of the behavior of \fBmv\fR when
-encountering files greater than or equal to 2 Gbyte ( 2^31 bytes).
-.SH ENVIRONMENT VARIABLES
-See \fBenviron\fR(7) for descriptions of the following environment variables
-that affect the execution of \fBmv\fR: \fBLANG\fR, \fBLC_ALL\fR,
-\fBLC_COLLATE\fR, \fBLC_CTYPE\fR, \fBLC_MESSAGES\fR, and \fBNLSPATH\fR.
-.sp
-.LP
+.El
+.Sh USAGE
+See
+.Xr largefile 7
+for the description of the behavior of
+.Nm
+when encountering files greater than or equal to 2 Gbyte
+.Pq 2^31 bytes .
+.Sh ENVIRONMENT VARIABLES
+See
+.Xr environ 7
+for descriptions of the following environment variables that affect the
+execution of
+.Nm :
+.Ev LANG ,
+.Ev LC_ALL ,
+.Ev LC_COLLATE ,
+.Ev LC_CTYPE ,
+.Ev LC_MESSAGES ,
+and
+.Ev NLSPATH .
+.Pp
 Affirmative responses are processed using the extended regular expression
-defined for the \fByesexpr\fR keyword in the \fBLC_MESSAGES\fR category of the
-user's locale. The locale specified in the \fBLC_COLLATE\fR category defines
-the behavior of ranges, equivalence classes, and multi-character collating
-elements used in the expression defined for \fByesexpr\fR. The locale specified
-in \fBLC_CTYPE\fR determines the locale for interpretation of sequences of
-bytes of text data a characters, the behavior of character classes used in the
-expression defined for the \fByesexpr\fR. See \fBlocale\fR(7).
-.SH EXIT STATUS
+defined for the
+.Sy yesexpr
+keyword in the
+.Ev LC_MESSAGES
+category of the user's locale.
+The locale specified in the
+.Ev LC_COLLATE
+category defines the behavior of ranges, equivalence classes, and
+multi-character collating elements used in the expression defined for
+.Sy yesexpr .
+The locale specified in
+.Ev LC_CTYPE
+determines the locale for interpretation of sequences of bytes of text data a
+characters, the behavior of character classes used in the expression defined for
+the
+.Sy yesexpr .
+See
+.Xr locale 7 .
+.Sh EXIT STATUS
 The following exit values are returned:
-.sp
-.ne 2
-.na
-\fB\fB0\fR\fR
-.ad
-.RS 6n
+.Bl -tag -width Ds
+.It Sy 0
 All input files were moved successfully.
-.RE
-
-.sp
-.ne 2
-.na
-\fB\fB>0\fR\fR
-.ad
-.RS 6n
+.It Sy >0
 An error occurred.
-.RE
-
-.SH ATTRIBUTES
-See \fBattributes\fR(7) for descriptions of the following attributes:
-.SS "/usr/bin/mv"
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-_
-Interface Stability	Stable
-.TE
-
-.SS "/usr/xpg4/bin/mv"
-.TS
-box;
-c | c
-l | l .
-ATTRIBUTE TYPE	ATTRIBUTE VALUE
-_
-CSI	Enabled
-_
-Interface Stability	Standard
-.TE
-
-.SH SEE ALSO
-.BR cp (1),
-.BR cpio (1),
-.BR ln (1),
-.BR rm (1),
-.BR setfacl (1),
-.BR chmod (2),
-.BR attributes (7),
-.BR environ (7),
-.BR fsattr (7),
-.BR largefile (7),
-.BR standards (7)
-.SH NOTES
-A \fB--\fR permits the user to mark explicitly the end of any command line
-options, allowing \fBmv\fR to recognize filename arguments that begin with a
-\fB-\fR. As an aid to BSD migration, \fBmv\fR accepts \fB-\fR as a synonym for
-\fB--\fR. This migration aid might disappear in a future release.
+.El
+.Sh INTERFACE STABILITY
+.Sy Committed
+.Sh CODE SET INDEPENDENCE
+.Sy Enabled
+.Sh SEE ALSO
+.Xr cp 1 ,
+.Xr cpio 1 ,
+.Xr ln 1 ,
+.Xr rm 1 ,
+.Xr setfacl 1 ,
+.Xr chmod 2 ,
+.Xr attributes 7 ,
+.Xr environ 7 ,
+.Xr fsattr 7 ,
+.Xr largefile 7 ,
+.Xr standards 7
+.Sh NOTES
+A
+.Fl Fl
+permits the user to mark explicitly the end of any command line options,
+allowing
+.Nm
+to recognize filename arguments that begin with a
+.Fl .
+As an aid to BSD migration,
+.Nm
+accepts
+.Fl
+as a synonym for
+.Fl Fl .
+This migration aid might disappear in a future release.

--- a/usr/src/pkg/manifests/system-data-zoneinfo.p5m
+++ b/usr/src/pkg/manifests/system-data-zoneinfo.p5m
@@ -18,7 +18,7 @@
 #
 
 set name=pkg.fmri \
-    value=pkg:/system/data/zoneinfo@2025.2,$(PKGVERS_BUILTON)-$(PKGVERS_BRANCH)
+    value=pkg:/system/data/zoneinfo@2026.1,$(PKGVERS_BUILTON)-$(PKGVERS_BRANCH)
 set name=pkg.summary value="Timezone Information"
 set name=pkg.description value="timezone information"
 set name=info.classification value=org.opensolaris.category.2008:System/Core

--- a/usr/src/uts/common/io/ena/ena.c
+++ b/usr/src/uts/common/io/ena/ena.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 #include "ena_hw.h"
@@ -42,7 +42,6 @@
  *    o Rx DMA bind (loaned buffers)
  *    o TSO
  *    o RSS
- *    o Low Latency Queues (LLQ)
  *    o Support for different Tx completion policies
  *    o More controlled Tx recycling and Rx refill
  *
@@ -178,6 +177,113 @@
  * describing said TCB buffer. If and when we add more advanced
  * features like DMA binding of mblks and TSO, this 1:1 guarantee will
  * no longer hold.
+ *
+ * Low Latency Queues (LLQ)
+ * ------------------------
+ *
+ * The ENA device supports two placement policies for Tx submission
+ * queue descriptors: host memory (PLACEMENT_POLICY_HOST) and device
+ * memory (PLACEMENT_POLICY_DEV). With host placement, the driver
+ * writes descriptors to host memory and the device reads them via
+ * DMA. With device placement, the driver writes descriptors directly
+ * to a region of device memory mapped through PCI BAR 2. This is
+ * known as LLQ mode and reduces latency by eliminating the DMA read.
+ *
+ * Some device generations require LLQ. In particular, Nitro v5 and
+ * later instances will not attach without it. When the device
+ * supports LLQ, the driver negotiates LLQ parameters during attach
+ * via the ENA_ADMIN_LLQ feature. If the device does not support LLQ,
+ * the driver uses host placement. If the device supports LLQ but
+ * negotiation fails, the driver fails to attach.
+ *
+ * The following LLQ parameters are negotiated with the device
+ * during attach:
+ *
+ *    o Entry size: we honour the device's recommended entry size
+ *      if it is supported. If the device has no recommendation we
+ *      fall back to the lowest supported size. Each SQ entry is this
+ *      size, comprising descriptors followed by inline packet header
+ *      data. Larger entries allow more header to be inlined but
+ *      reduce the maximum queue depth since the LLQ memory is
+ *      fixed-size.
+ *
+ *    o Headers inline in the first entry: the packet header is
+ *      placed in the first SQ entry immediately after the
+ *      descriptors, using the remaining space in the entry.
+ *
+ *    o Descriptors before header: the number of descriptors that
+ *      precede the inline header in the first entry is negotiated
+ *      with the device, preferring 2, then 1, then 4, then 8. This
+ *      is the same order as other ena driver common code, with 2
+ *      being preferred over 1 as it maximises inline header space
+ *      while still allowing a meta + data descriptor pair.
+ *
+ *    o Stride control: prefers multiple descriptors per entry,
+ *      falling back to single descriptor per entry.
+ *
+ * The header location is fixed as inline, which is the only mode
+ * current ENA hardware supports. The negotiation fails attach if
+ * the device does not support any of the driver's choices for a
+ * given parameter.
+ *
+ * Accelerated LLQ
+ * ---------------
+ *
+ * Newer devices (Nitro v5/v6) additionally require accelerated LLQ
+ * mode, which the driver enables by setting two flags in the
+ * SET_FEATURE command:
+ *
+ *    o DISABLE_META_CACHING: the device will not cache Tx meta
+ *      descriptors, so the driver must include a meta descriptor
+ *      with every packet. This simplifies device state tracking
+ *      at the cost of additional descriptor space per packet.
+ *
+ *    o LIMIT_TX_BURST: the device specifies a maximum number of
+ *      LLQ entries that may be written between doorbells. The
+ *      driver tracks this per-queue and rings the doorbell when
+ *      the limit is reached, even if more packets are ready.
+ *
+ * LLQ Tx Path
+ * -----------
+ *
+ * In LLQ mode, the Tx path differs from the host placement path
+ * described above. Each queue has a bounce buffer -- a single
+ * staging area the size of one LLQ entry. For each packet the
+ * driver composes the complete LLQ entry in the bounce buffer:
+ *
+ *    +--------+------//------+---------------------------+
+ *    | meta   | data descs   | inline packet header      |
+ *    | 16B    | N x 16B      | remaining bytes           |
+ *    +--------+------//------+---------------------------+
+ *    |<------------- entry_size bytes ------------------>|
+ *
+ * The meta descriptor carries per-packet metadata (L3 header
+ * offset, MSS, etc.). The data descriptor(s) are the same as in
+ * host mode; N is the negotiated descs_before_header value. The
+ * inline header is copied from the packet's mblk chain and allows
+ * the device to begin processing before the full DMA payload
+ * arrives.
+ *
+ * Once the bounce buffer is complete, it is written to device
+ * memory using 64-bit stores. The bounce buffer approach ensures
+ * that the device sees a complete, consistent entry rather than
+ * a partial one that could result from writing fields individually.
+ *
+ * The LLQ BAR is mapped write-combining (DDI_STORECACHING_OK_ACC)
+ * so the CPU may merge and reorder stores within an entry. This
+ * is safe because the device does not poll its local memory for
+ * phase bit transitions the way a traditional NIC scans a
+ * host-memory descriptor ring; it only inspects LLQ entries
+ * after receiving a doorbell write. A membar_producer() before
+ * the doorbell guarantees that all prior stores to the LLQ entry
+ * are ordered before the doorbell, so there is no need to write
+ * phase bits in reverse order or otherwise arrange for the phase
+ * to be the last thing written.
+ *
+ * There is no DMA involved for the descriptors themselves; they
+ * reach the device via MMIO writes through the BAR. The packet
+ * payload beyond the inline header is still transferred by DMA
+ * and is synced separately (see ena_tcb_pull()).
  *
  * Rx Queue Workings
  * -----------------
@@ -333,18 +439,6 @@ CTASSERT(sizeof (enahw_tx_meta_desc_t) == sizeof (enahw_tx_desc_t));
 #error "ENA driver is little-endian only"
 #endif
 
-/*
- * These values are used to communicate the driver version to the AWS
- * hypervisor via the ena_set_host_info() function. We don't know what
- * exactly AWS does with this info, but it's fairly safe to assume
- * it's used solely for debug/informational purposes. The Linux driver
- * updates these values frequently as bugs are fixed and features are
- * added.
- */
-#define	ENA_DRV_VER_MAJOR	1
-#define	ENA_DRV_VER_MINOR	0
-#define	ENA_DRV_VER_SUBMINOR	0
-
 uint64_t ena_admin_cmd_timeout_ns = ENA_ADMIN_CMD_DEF_TIMEOUT_NS;
 
 /*
@@ -428,10 +522,14 @@ ena_is_feat_avail(ena_t *ena, const enahw_feature_id_t feat_id)
 
 	/*
 	 * The device attributes feature is always supported, as
-	 * indicated by the common code.
+	 * indicated by the common code. Host attributes must be sent
+	 * before querying device attributes, so the supported features
+	 * bitmask is not yet populated at that point.
 	 */
-	if (feat_id == ENAHW_FEAT_DEVICE_ATTRIBUTES)
+	if (feat_id == ENAHW_FEAT_DEVICE_ATTRIBUTES ||
+	    feat_id == ENAHW_FEAT_HOST_ATTR_CONFIG) {
 		return (true);
+	}
 
 	return ((ena->ena_supported_features & mask) != 0);
 }
@@ -579,41 +677,87 @@ ena_cleanup_regs_map(ena_t *ena, bool resetting)
 	ddi_regs_map_free(&ena->ena_reg_hdl);
 }
 
+/*
+ * Map a PCI BAR number (0-5) to a DDI register set number.
+ */
+static int
+ena_bar_to_rnumber(ena_t *ena, uint8_t bar)
+{
+	pci_regspec_t *regs;
+	uint_t bar_offset, regs_length, rcount;
+	int rnumber = -1;
+
+	if (bar > 5)
+		return (-1);
+
+	/*
+	 * PCI_CONF_BASE0 is 0x10; each BAR is 4 bytes apart.
+	 */
+	bar_offset = PCI_CONF_BASE0 + sizeof (uint32_t) * bar;
+
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, ena->ena_dip,
+	    DDI_PROP_DONTPASS, "reg", (int **)&regs, &regs_length) !=
+	    DDI_PROP_SUCCESS) {
+		return (-1);
+	}
+
+	rcount = regs_length * sizeof (int) / sizeof (pci_regspec_t);
+
+	for (int i = 0; i < rcount; i++) {
+		if (PCI_REG_REG_G(regs[i].pci_phys_hi) == bar_offset) {
+			rnumber = i;
+			break;
+		}
+	}
+
+	ddi_prop_free(regs);
+
+	return (rnumber);
+}
+
 static bool
 ena_attach_regs_map(ena_t *ena)
 {
+	ddi_device_acc_attr_t attr;
+	int rnumber;
 	int ret = 0;
 
-	if (ddi_dev_regsize(ena->ena_dip, ENA_REG_NUMBER, &ena->ena_reg_size) !=
+	rnumber = ena_bar_to_rnumber(ena, ENA_REG_BAR);
+	if (rnumber == -1) {
+		ena_err(ena, "failed to find rnumber for BAR %d", ENA_REG_BAR);
+		return (false);
+	}
+
+	if (ddi_dev_regsize(ena->ena_dip, rnumber, &ena->ena_reg_size) !=
 	    DDI_SUCCESS) {
-		ena_err(ena, "failed to get register set %d size",
-		    ENA_REG_NUMBER);
+		ena_err(ena, "failed to get register set %d size", rnumber);
 		return (false);
 	}
 
 	ena_dbg(ena, "register size: %ld", ena->ena_reg_size);
-	bzero(&ena->ena_reg_attr, sizeof (ena->ena_reg_attr));
-	ena->ena_reg_attr.devacc_attr_version = DDI_DEVICE_ATTR_V1;
-	ena->ena_reg_attr.devacc_attr_endian_flags = DDI_NEVERSWAP_ACC;
-	ena->ena_reg_attr.devacc_attr_dataorder = DDI_STRICTORDER_ACC;
+	bzero(&attr, sizeof (attr));
+	attr.devacc_attr_version = DDI_DEVICE_ATTR_V1;
+	attr.devacc_attr_endian_flags = DDI_NEVERSWAP_ACC;
+	attr.devacc_attr_dataorder = DDI_STRICTORDER_ACC;
+	attr.devacc_attr_access = DDI_DEFAULT_ACC;
 
 	/*
 	 * This function can return several different failure values,
 	 * so we make sure to capture its return value for the purpose
 	 * of logging.
 	 */
-	ret = ddi_regs_map_setup(ena->ena_dip, ENA_REG_NUMBER,
-	    &ena->ena_reg_base, 0, ena->ena_reg_size, &ena->ena_reg_attr,
+	ret = ddi_regs_map_setup(ena->ena_dip, rnumber,
+	    &ena->ena_reg_base, 0, ena->ena_reg_size, &attr,
 	    &ena->ena_reg_hdl);
 
 	if (ret != DDI_SUCCESS) {
-		ena_err(ena, "failed to map register set %d: %d",
-		    ENA_REG_NUMBER, ret);
+		ena_err(ena, "failed to map BAR %d (reg %d): %d",
+		    ENA_REG_BAR, rnumber, ret);
 		return (false);
 	}
 
-	ena_dbg(ena, "registers mapped to base: 0x%p",
-	    (void *)ena->ena_reg_base);
+	ena_dbg(ena, "registers BAR %d mapped to base: 0x%p size: %ld",
+	    ENA_REG_BAR, (void *)ena->ena_reg_base, ena->ena_reg_size);
 
 	return (true);
 }
@@ -950,7 +1094,7 @@ ena_get_link_config(ena_t *ena)
 	if (ena_get_feature(ena, &resp, ENAHW_FEAT_LINK_CONFIG,
 	    ENAHW_FEAT_LINK_CONFIG_VER) != 0) {
 		/*
-		 * Some ENA devices do no support this feature. In
+		 * Some ENA devices do not support this feature. In
 		 * those cases we report a 1Gbps link, full duplex.
 		 * For the most accurate information on bandwidth
 		 * limits see the official AWS documentation.
@@ -994,7 +1138,7 @@ ena_attach_read_conf(ena_t *ena)
 	 * CQ and SQ, but technically the device could return
 	 * different lengths. For now the driver locks them together.
 	 */
-	gcv = min(ena->ena_rx_max_sq_num_descs, ena->ena_rx_max_cq_num_descs);
+	gcv = MIN(ena->ena_rx_max_sq_num_descs, ena->ena_rx_max_cq_num_descs);
 	ASSERT3U(gcv, <=, INT_MAX);
 	ena->ena_rxq_num_descs = ena_get_prop(ena, ENA_PROP_RXQ_NUM_DESCS,
 	    ENA_PROP_RXQ_NUM_DESCS_MIN, gcv, gcv);
@@ -1003,7 +1147,7 @@ ena_attach_read_conf(ena_t *ena)
 	    ENA_PROP_RXQ_INTR_LIMIT_MIN, ENA_PROP_RXQ_INTR_LIMIT_MAX,
 	    ENA_PROP_RXQ_INTR_LIMIT_DEF);
 
-	gcv = min(ena->ena_tx_max_sq_num_descs, ena->ena_tx_max_cq_num_descs);
+	gcv = MIN(ena->ena_tx_max_sq_num_descs, ena->ena_tx_max_cq_num_descs);
 	ASSERT3U(gcv, <=, INT_MAX);
 	ena->ena_txq_num_descs = ena_get_prop(ena, ENA_PROP_TXQ_NUM_DESCS,
 	    ENA_PROP_TXQ_NUM_DESCS_MIN, gcv, gcv);
@@ -1113,6 +1257,11 @@ ena_cleanup_device_init(ena_t *ena, bool resetting)
 
 	VERIFY0(resetting);
 
+	if (ena->ena_llq_bar_mapped) {
+		ddi_regs_map_free(&ena->ena_llq_bar_hdl);
+		ena->ena_llq_bar_mapped = false;
+	}
+
 	ena_free_host_info(ena);
 	mutex_destroy(&aq->ea_sq_lock);
 	mutex_destroy(&aq->ea_cq_lock);
@@ -1127,6 +1276,280 @@ ena_cleanup_device_init(ena_t *ena, bool resetting)
 	ena_stat_device_basic_cleanup(ena);
 	ena_stat_device_extended_cleanup(ena);
 	ena_stat_aenq_cleanup(ena);
+}
+
+/*
+ * We explicitly disable hardware timestamping as a precaution.
+ * When enabled, the device uses (larger) extended completion descriptors to
+ * incorporate timestamp fields. Our completion processing assumes the base
+ * descriptor sizes.
+ */
+static bool
+ena_disable_hw_timestamp(ena_t *ena)
+{
+	enahw_cmd_desc_t cmd;
+	enahw_resp_desc_t resp;
+	enahw_feat_hw_timestamp_t *ts =
+	    &cmd.ecd_cmd.ecd_set_feat.ecsf_feat.ecsf_hw_timestamp;
+	int ret;
+
+	if (!ena_is_feat_avail(ena, ENAHW_FEAT_HW_TIMESTAMP))
+		return (true);
+
+	ena_dbg(ena, "Disabling HW timestamping");
+
+	bzero(&cmd, sizeof (cmd));
+	ts->efhwts_tx = ENAHW_HW_TIMESTAMP_NONE;
+	ts->efhwts_rx = ENAHW_HW_TIMESTAMP_NONE;
+
+	ret = ena_set_feature(ena, &cmd, &resp, ENAHW_FEAT_HW_TIMESTAMP,
+	    ENAHW_FEAT_HW_TIMESTAMP_VER);
+	if (ret != 0) {
+		ena_err(ena, "failed to disable HW timestamping: %d", ret);
+		return (false);
+	}
+
+	return (true);
+}
+
+/*
+ * Map the device memory BAR used for LLQ. This must be called before creating
+ * any LLQ submission queues.
+ */
+static bool
+ena_map_llq_mem_bar(ena_t *ena)
+{
+	ddi_device_acc_attr_t attr;
+	int rnumber, ret;
+
+	rnumber = ena_bar_to_rnumber(ena, ENA_LLQ_BAR);
+	if (rnumber == -1) {
+		ena_err(ena, "failed to find rnumber for BAR %d", ENA_LLQ_BAR);
+		return (false);
+	}
+
+	if (ddi_dev_regsize(ena->ena_dip, rnumber, &ena->ena_llq_bar_size) !=
+	    DDI_SUCCESS) {
+		ena_err(ena, "failed to get mem BAR %d size", ENA_LLQ_BAR);
+		return (false);
+	}
+
+	bzero(&attr, sizeof (attr));
+	attr.devacc_attr_version = DDI_DEVICE_ATTR_V1;
+	attr.devacc_attr_endian_flags = DDI_NEVERSWAP_ACC;
+	/*
+	 * See the "LLQ Tx Path" section of the big theory statement for why
+	 * it is safe to map the LLQ BAR with DDI_STORECACHING_OK_ACC.
+	 */
+	attr.devacc_attr_dataorder = DDI_STORECACHING_OK_ACC;
+	attr.devacc_attr_access = DDI_DEFAULT_ACC;
+
+	ret = ddi_regs_map_setup(ena->ena_dip, rnumber,
+	    &ena->ena_llq_bar_base, 0, ena->ena_llq_bar_size, &attr,
+	    &ena->ena_llq_bar_hdl);
+
+	if (ret != DDI_SUCCESS) {
+		ena_err(ena, "failed to map mem BAR %d (reg %d): %d",
+		    ENA_LLQ_BAR, rnumber, ret);
+		return (false);
+	}
+
+	ena->ena_llq_bar_mapped = true;
+	ena_dbg(ena, "LLQ BAR %d mapped to base: 0x%p size: %ld", ENA_LLQ_BAR,
+	    (void *)ena->ena_llq_bar_base, ena->ena_llq_bar_size);
+
+	return (true);
+}
+
+/*
+ * Negotiate LLQ parameters with the device and send SET_FEATURE to
+ * configure it. If the device does not advertise LLQ support we
+ * silently fall back to host placement. If the device does advertise
+ * LLQ but negotiation fails, we treat that as a fatal error rather
+ * than falling back. For newer instance types (Nitro v5 and later)
+ * it really is fatal, they require LLQ and do not support host
+ * placement at all.
+ */
+static bool
+ena_configure_llq(ena_t *ena)
+{
+	enahw_resp_desc_t resp;
+	enahw_feat_llq_t *llq_feat;
+	enahw_cmd_desc_t cmd;
+	enahw_feat_llq_t *llq_cmd;
+	enahw_llq_accel_mode_get_t accel_get;
+	uint16_t supported;
+	int ret;
+
+	/* Query the device's LLQ capabilities */
+	bzero(&resp, sizeof (resp));
+	ret = ena_get_feature(ena, &resp, ENAHW_FEAT_LLQ, ENAHW_FEAT_LLQ_VER);
+	if (ret == ENOTSUP) {
+		ena_dbg(ena, "LLQ not supported, using host placement");
+		return (true);
+	} else if (ret != 0) {
+		ena_err(ena, "failed to query LLQ feature: %d", ret);
+		return (false);
+	}
+
+	llq_feat = &resp.erd_resp.erd_get_feat.ergf_llq;
+
+	ena_dbg(ena, "LLQ max_num=%u max_depth=%u",
+	    llq_feat->efllq_max_llq_num, llq_feat->efllq_max_llq_depth);
+	ena_dbg(ena, "LLQ header_location supported=0x%x "
+	    "entry_size supported=0x%x recommended=%u",
+	    llq_feat->efllq_header_location_ctrl_supported,
+	    llq_feat->efllq_entry_size_ctrl_supported,
+	    llq_feat->efllq_entry_size_recommended);
+	ena_dbg(ena, "LLQ descs_before_header supported=0x%x "
+	    "stride supported=0x%x",
+	    llq_feat->efllq_desc_num_before_header_supported,
+	    llq_feat->efllq_descs_stride_ctrl_supported);
+	ena_dbg(ena, "LLQ accel_mode supported_flags=0x%x "
+	    "max_tx_burst_size=%u",
+	    llq_feat->efllq_accel_mode.eam_get.eamg_supported_flags,
+	    llq_feat->efllq_accel_mode.eam_get.eamg_max_tx_burst_size);
+
+	/*
+	 * Negotiate header location - we currently only support inline header,
+	 * which is advertised by all current devices.
+	 */
+	supported = llq_feat->efllq_header_location_ctrl_supported;
+	if (!(supported & ENAHW_LLQ_HEADER_INLINE)) {
+		ena_err(ena, "device does not support inline header "
+		    "LLQ (supported: 0x%x)", supported);
+		return (false);
+	}
+	ena->ena_llq_header_location = ENAHW_LLQ_HEADER_INLINE;
+
+	/* Negotiate stride control for inline header mode */
+	supported = llq_feat->efllq_descs_stride_ctrl_supported;
+	if (supported & ENAHW_LLQ_MULTIPLE_DESCS_PER_ENTRY) {
+		ena->ena_llq_stride_ctrl = ENAHW_LLQ_MULTIPLE_DESCS_PER_ENTRY;
+	} else if (supported & ENAHW_LLQ_SINGLE_DESC_PER_ENTRY) {
+		ena->ena_llq_stride_ctrl = ENAHW_LLQ_SINGLE_DESC_PER_ENTRY;
+	} else {
+		ena_err(ena, "no supported LLQ stride control (0x%x)",
+		    supported);
+		return (false);
+	}
+
+	/* Negotiate entry size */
+	supported = llq_feat->efllq_entry_size_ctrl_supported;
+	if (llq_feat->efllq_entry_size_recommended != 0 &&
+	    (supported & llq_feat->efllq_entry_size_recommended)) {
+		ena->ena_llq_entry_size =
+		    llq_feat->efllq_entry_size_recommended;
+	} else if (supported & ENAHW_LLQ_ENTRY_SIZE_128B) {
+		ena->ena_llq_entry_size = ENAHW_LLQ_ENTRY_SIZE_128B;
+	} else if (supported & ENAHW_LLQ_ENTRY_SIZE_192B) {
+		ena->ena_llq_entry_size = ENAHW_LLQ_ENTRY_SIZE_192B;
+	} else if (supported & ENAHW_LLQ_ENTRY_SIZE_256B) {
+		ena->ena_llq_entry_size = ENAHW_LLQ_ENTRY_SIZE_256B;
+	} else {
+		ena_err(ena, "no supported LLQ entry size (0x%x)", supported);
+		return (false);
+	}
+
+	switch (ena->ena_llq_entry_size) {
+	case ENAHW_LLQ_ENTRY_SIZE_128B:
+		ena->ena_llq_entry_size_bytes = 128;
+		break;
+	case ENAHW_LLQ_ENTRY_SIZE_192B:
+		ena->ena_llq_entry_size_bytes = 192;
+		break;
+	case ENAHW_LLQ_ENTRY_SIZE_256B:
+		ena->ena_llq_entry_size_bytes = 256;
+		break;
+	}
+
+	/*
+	 * Negotiate number of descriptors before header. Since we always
+	 * send both a meta and data descriptor in each LLQ entry we cannot
+	 * support ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_1.
+	 */
+	supported = llq_feat->efllq_desc_num_before_header_supported;
+	if (supported & ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_2) {
+		ena->ena_llq_num_descs_before_header =
+		    ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_2;
+	} else if (supported & ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_4) {
+		ena->ena_llq_num_descs_before_header =
+		    ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_4;
+	} else if (supported & ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_8) {
+		ena->ena_llq_num_descs_before_header =
+		    ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_8;
+	} else {
+		ena_err(ena, "no supported descs_before_header (0x%x)",
+		    supported);
+		return (false);
+	}
+
+	/* Check for accelerated LLQ mode support */
+	accel_get = llq_feat->efllq_accel_mode.eam_get;
+	const bool limit_tx_burst = (accel_get.eamg_supported_flags &
+	    ENAHW_LLQ_ACCEL_MODE_LIMIT_TX_BURST);
+
+	if (limit_tx_burst) {
+		ena->ena_llq_max_tx_burst_size =
+		    accel_get.eamg_max_tx_burst_size;
+	}
+
+	ena_dbg(ena, "LLQ negotiated: header_location=%u entry_size=%uB "
+	    "descs_before_header=%u stride=%u max_tx_burst=%u",
+	    ena->ena_llq_header_location,
+	    ena->ena_llq_entry_size_bytes,
+	    ena->ena_llq_num_descs_before_header,
+	    ena->ena_llq_stride_ctrl,
+	    ena->ena_llq_max_tx_burst_size);
+
+	/*
+	 * When LLQ is active the SQ lives in device memory rather
+	 * than host memory so max_tx_sq_depth does not apply;
+	 * replace it with max_llq_depth. For 256B entries the depth
+	 * is further reduced; the device may report a specific wide
+	 * depth, otherwise we halve the standard LLQ depth.
+	 */
+	ena->ena_tx_max_sq_num_descs = llq_feat->efllq_max_llq_depth;
+
+	if (ena->ena_llq_entry_size == ENAHW_LLQ_ENTRY_SIZE_256B) {
+		if (llq_feat->efllq_max_wide_llq_depth != 0) {
+			ena->ena_tx_max_sq_num_descs = MIN(
+			    ena->ena_tx_max_sq_num_descs,
+			    llq_feat->efllq_max_wide_llq_depth);
+		} else {
+			ena->ena_tx_max_sq_num_descs /= 2;
+		}
+	}
+
+	/* Send the LLQ configuration request */
+	bzero(&cmd, sizeof (cmd));
+	llq_cmd = &cmd.ecd_cmd.ecd_set_feat.ecsf_feat.ecsf_llq;
+
+	llq_cmd->efllq_header_location_ctrl_enabled =
+	    ena->ena_llq_header_location;
+	llq_cmd->efllq_entry_size_ctrl_enabled = ena->ena_llq_entry_size;
+	llq_cmd->efllq_desc_num_before_header_enabled =
+	    ena->ena_llq_num_descs_before_header;
+	llq_cmd->efllq_descs_stride_ctrl_enabled = ena->ena_llq_stride_ctrl;
+	llq_cmd->efllq_accel_mode.eam_set.eams_enabled_flags =
+	    ENAHW_LLQ_ACCEL_MODE_DISABLE_META_CACHING |
+	    (limit_tx_burst ? ENAHW_LLQ_ACCEL_MODE_LIMIT_TX_BURST : 0);
+
+	bzero(&resp, sizeof (resp));
+	ret = ena_set_feature(ena, &cmd, &resp, ENAHW_FEAT_LLQ,
+	    ENAHW_FEAT_LLQ_VER);
+	if (ret != 0) {
+		ena_err(ena, "failed to set LLQ feature: %d", ret);
+		return (false);
+	}
+
+	if (!ena_map_llq_mem_bar(ena))
+		return (false);
+
+	ena->ena_llq_enabled = true;
+	ena_dbg(ena, "LLQ enabled");
+
+	return (true);
 }
 
 static bool
@@ -1176,6 +1599,14 @@ ena_attach_device_init(ena_t *ena)
 		return (false);
 
 	if (!ena_aenq_init(ena))
+		return (false);
+
+	/*
+	 * The device will change the set of advertised features based on the
+	 * host info that we provide. We therefore need to send this here
+	 * before querying the features.
+	 */
+	if (!ena_init_host_info(ena))
 		return (false);
 
 	bzero(&resp, sizeof (resp));
@@ -1278,7 +1709,10 @@ ena_attach_device_init(ena_t *ena)
 	if (ena->ena_device_hints.eh_max_rx_sgl != 0)
 		ena->ena_rx_sgl_max_sz = ena->ena_device_hints.eh_max_rx_sgl;
 
-	if (!ena_init_host_info(ena))
+	if (!ena_disable_hw_timestamp(ena))
+		return (false);
+
+	if (!ena_configure_llq(ena))
 		return (false);
 
 	if (!ena_aenq_configure(ena))

--- a/usr/src/uts/common/io/ena/ena.h
+++ b/usr/src/uts/common/io/ena/ena.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 #ifndef	_ENA_H
@@ -55,8 +55,17 @@ extern "C" {
 #define	ENA_CTRL_MINOR_VSN_MIN		0
 #define	ENA_CTRL_SUBMINOR_VSN_MIN	1
 
+/*
+ * These values are used to communicate the driver version to the AWS
+ * hypervisor via the HOST_ATTR_CONFIG feature. We don't know what
+ * exactly AWS does with this info, but it's fairly safe to assume
+ * it's used solely for debug/informational purposes. The Linux driver
+ * updates these values frequently as bugs are fixed and features are
+ * added. Some instance types have minimum driver version requirements
+ * but they do not appear to check the version we pass.
+ */
 #define	ENA_MODULE_VER_MAJOR	1
-#define	ENA_MODULE_VER_MINOR	0
+#define	ENA_MODULE_VER_MINOR	1
 #define	ENA_MODULE_VER_SUBMINOR	0
 
 /*
@@ -71,8 +80,10 @@ extern "C" {
 #define	ENA_SPEC_VERSION_MINOR	0
 
 
-/* This represents BAR 0. */
-#define	ENA_REG_NUMBER	1
+/* PCI BAR index for the register BAR */
+#define	ENA_REG_BAR	0
+/* PCI BAR index for the LLQ memory BAR */
+#define	ENA_LLQ_BAR	2
 
 /*
  * A sentinel value passed as argument to ena_ring_rx() to indicate
@@ -441,6 +452,22 @@ typedef struct ena_txq {
 	uint32_t		*et_sq_db_addr; /* WO */
 
 	/*
+	 * LLQ state for this queue. When LLQ is active descriptors
+	 * are written to device memory at et_sq_llq_addr rather than
+	 * to host memory at et_sq_descs.
+	 *
+	 * The bounce buffer (et_sq_llq_buf) is used to stage a
+	 * complete LLQ entry before copying it to device memory.
+	 *
+	 * The burst counter (et_sq_llq_entries_left) tracks the
+	 * number of LLQ entries that may be written before the next
+	 * doorbell, for the LIMIT_TX_BURST acceleration feature.
+	 */
+	void			*et_sq_llq_addr; /* WO */
+	uint8_t			*et_sq_llq_buf; /* TM */
+	uint32_t		et_sq_llq_entries_left; /* TM */
+
+	/*
 	 * The TCBs track host Tx information, like a pointer to the
 	 * mblk being submitted. The TCBs currently available for use are
 	 * maintained in a free list.
@@ -694,13 +721,24 @@ typedef struct ena {
 	uint64_t		ena_watchdog_last_keepalive;
 
 	/*
-	 * PCI config space and BAR handle.
+	 * PCI config space handle
 	 */
 	ddi_acc_handle_t	ena_pci_hdl;
+
+	/*
+	 * Memory BAR for registers
+	 */
 	off_t			ena_reg_size;
 	caddr_t			ena_reg_base;
-	ddi_device_acc_attr_t	ena_reg_attr;
 	ddi_acc_handle_t	ena_reg_hdl;
+
+	/*
+	 * Memory BAR for LLQ device memory
+	 */
+	bool			ena_llq_bar_mapped;
+	off_t			ena_llq_bar_size;
+	caddr_t			ena_llq_bar_base;
+	ddi_acc_handle_t	ena_llq_bar_hdl;
 
 	/*
 	 * Vendor information.
@@ -806,6 +844,18 @@ typedef struct ena {
 	link_state_t		ena_link_state;
 	uint32_t		ena_aenq_supported_groups;
 	uint32_t		ena_aenq_enabled_groups;
+
+	/*
+	 * LLQ (Low Latency Queue) state. When ena_llq_enabled is true,
+	 * TX descriptors are written to device, rather than host, memory.
+	 */
+	bool					ena_llq_enabled;
+	enahw_llq_header_location_t		ena_llq_header_location;
+	enahw_llq_ring_entry_size_t		ena_llq_entry_size;
+	uint16_t				ena_llq_entry_size_bytes;
+	enahw_llq_num_descs_before_header_t	ena_llq_num_descs_before_header;
+	enahw_llq_stride_ctrl_t			ena_llq_stride_ctrl;
+	uint16_t				ena_llq_max_tx_burst_size;
 
 	uint32_t		ena_tx_max_sq_num;
 	uint32_t		ena_tx_max_sq_num_descs;
@@ -952,7 +1002,7 @@ extern int ena_create_cq(ena_t *, uint16_t, uint64_t, bool, uint32_t,
     uint16_t *, uint32_t **, uint32_t **);
 extern int ena_destroy_cq(ena_t *, uint16_t);
 extern int ena_create_sq(ena_t *, uint16_t, uint64_t, bool, uint16_t,
-    uint16_t *, uint32_t **);
+    uint16_t *, uint32_t **, void **);
 extern int ena_destroy_sq(ena_t *, uint16_t, bool);
 extern int ena_set_feature(ena_t *, enahw_cmd_desc_t *,
     enahw_resp_desc_t *, const enahw_feature_id_t, const uint8_t);

--- a/usr/src/uts/common/io/ena/ena_admin.c
+++ b/usr/src/uts/common/io/ena/ena_admin.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 /*
@@ -475,7 +475,9 @@ ena_create_cq(ena_t *ena, uint16_t num_descs, uint64_t phys_addr,
 	}
 
 	if ((ret = ena_admin_poll_for_resp(ena, ctx)) != 0) {
-		ena_err(ena, "failed to Create CQ: %d", ret);
+		ena_err(ena,
+		    "failed to Create CQ: %d (status %u ext_status %u)",
+		    ret, resp.erd_status, resp.erd_ext_status);
 		return (ret);
 	}
 
@@ -527,7 +529,8 @@ ena_destroy_cq(ena_t *ena, uint16_t hw_idx)
 
 int
 ena_create_sq(ena_t *ena, uint16_t num_descs, uint64_t phys_addr,
-    bool is_tx, uint16_t cq_index, uint16_t *hw_index, uint32_t **db_addr)
+    bool is_tx, uint16_t cq_index, uint16_t *hw_index, uint32_t **db_addr,
+    void **llq_descs_addrp)
 {
 	int ret;
 	enahw_cmd_desc_t cmd;
@@ -536,6 +539,7 @@ ena_create_sq(ena_t *ena, uint16_t num_descs, uint64_t phys_addr,
 	enahw_resp_create_sq_t *resp_sq = &resp.erd_resp.erd_create_sq;
 	enahw_sq_direction_t dir =
 	    is_tx ? ENAHW_SQ_DIRECTION_TX : ENAHW_SQ_DIRECTION_RX;
+	enahw_placement_policy_t placement = ENAHW_PLACEMENT_POLICY_HOST;
 	ena_cmd_ctx_t *ctx = NULL;
 
 	if (!ISP2(num_descs)) {
@@ -544,12 +548,18 @@ ena_create_sq(ena_t *ena, uint16_t num_descs, uint64_t phys_addr,
 		return (false);
 	}
 
+	/*
+	 * For Tx queues, use device placement (LLQ) when LLQ is
+	 * enabled. Rx queues always use host placement.
+	 */
+	if (is_tx && ena->ena_llq_enabled)
+		placement = ENAHW_PLACEMENT_POLICY_DEV;
+
 	bzero(&cmd, sizeof (cmd));
 	bzero(&resp, sizeof (resp));
 	cmd.ecd_opcode = ENAHW_CMD_CREATE_SQ;
 	ENAHW_CMD_CREATE_SQ_DIR(cmd_sq, dir);
-	ENAHW_CMD_CREATE_SQ_PLACEMENT_POLICY(cmd_sq,
-	    ENAHW_PLACEMENT_POLICY_HOST);
+	ENAHW_CMD_CREATE_SQ_PLACEMENT_POLICY(cmd_sq, placement);
 	ENAHW_CMD_CREATE_SQ_COMPLETION_POLICY(cmd_sq,
 	    ENAHW_COMPLETION_POLICY_DESC);
 	/*
@@ -561,11 +571,12 @@ ena_create_sq(ena_t *ena, uint16_t num_descs, uint64_t phys_addr,
 	cmd_sq->ecsq_num_descs = num_descs;
 
 	/*
-	 * If we ever use a non-host placement policy, then guard this
-	 * code against placement type (this value should not be set
-	 * for device placement).
+	 * For host placement, set the physical base address of the
+	 * descriptor ring. For device placement (LLQ), the base
+	 * address is not set as descriptors live in device memory.
 	 */
-	ena_set_dma_addr(ena, phys_addr, &cmd_sq->ecsq_base);
+	if (placement == ENAHW_PLACEMENT_POLICY_HOST)
+		ena_set_dma_addr(ena, phys_addr, &cmd_sq->ecsq_base);
 
 	if ((ret = ena_admin_submit_cmd(ena, &cmd, &resp, &ctx)) != 0) {
 		ena_err(ena, "failed to submit Create SQ command: %d", ret);
@@ -573,13 +584,27 @@ ena_create_sq(ena_t *ena, uint16_t num_descs, uint64_t phys_addr,
 	}
 
 	if ((ret = ena_admin_poll_for_resp(ena, ctx)) != 0) {
-		ena_err(ena, "failed to Create SQ: %d", ret);
+		ena_err(ena,
+		    "failed to Create SQ: %d (status %u ext_status %u)",
+		    ret, resp.erd_status, resp.erd_ext_status);
 		return (ret);
 	}
 
 	*hw_index = resp_sq->ersq_idx;
 	*db_addr = (uint32_t *)(ena->ena_reg_base +
 	    resp_sq->ersq_db_reg_offset);
+
+	/*
+	 * For device placement, the response contains the offset into
+	 * the memory BAR where this queue's descriptors should be
+	 * written.
+	 */
+	if (placement == ENAHW_PLACEMENT_POLICY_DEV &&
+	    llq_descs_addrp != NULL) {
+		*llq_descs_addrp = (void *)(ena->ena_llq_bar_base +
+		    resp_sq->ersq_llq_descs_reg_offset);
+	}
+
 	return (0);
 }
 
@@ -606,7 +631,9 @@ ena_destroy_sq(ena_t *ena, uint16_t hw_idx, bool is_tx)
 	}
 
 	if ((ret = ena_admin_poll_for_resp(ena, ctx)) != 0) {
-		ena_err(ena, "failed Destroy SQ: %d", ret);
+		ena_err(ena,
+		    "failed to Destroy SQ: %d (status %u ext_status %u)",
+		    ret, resp.erd_status, resp.erd_ext_status);
 		return (ret);
 	}
 

--- a/usr/src/uts/common/io/ena/ena_hw.h
+++ b/usr/src/uts/common/io/ena/ena_hw.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 /*
@@ -469,6 +469,214 @@ typedef struct enahw_feat_aenq {
 	uint32_t efa_enabled_groups;
 } enahw_feat_aenq_t;
 
+/*
+ * ENAHW_FEAT_HW_TIMESTAMP
+ *
+ * common: ena_admin_feature_hw_ts_desc
+ */
+typedef struct enahw_feat_hw_timestamp {
+	uint8_t efhwts_version;
+	uint8_t efhwts_tx;
+	uint8_t efhwts_rx;
+} enahw_feat_hw_timestamp_t;
+
+/*
+ * Values for efhwts_tx and efhwts_rx in the above struct.
+ *
+ * common: ena_admin_hw_timestamp_tx_support / ena_admin_hw_timestamp_rx_support
+ */
+#define	ENAHW_HW_TIMESTAMP_NONE		0
+#define	ENAHW_HW_TIMESTAMP_ALL_QUEUES	1
+
+/*
+ * LLQ Header Location.
+ *
+ * Describes where the packet header resides relative to the
+ * descriptor list entries in the Low Latency Queue.
+ *
+ * common: ena_admin_llq_header_location
+ */
+typedef enum enahw_llq_header_location {
+	/* Header is in-line within the descriptor list entry */
+	ENAHW_LLQ_HEADER_INLINE		= BIT(0),
+
+	/* Header is in a separate ring (implies 16B descriptor entries) */
+	ENAHW_LLQ_HEADER_SEPARATE_RING	= BIT(1),
+} enahw_llq_header_location_t;
+
+/*
+ * LLQ Ring Entry Size.
+ *
+ * The size of each entry in the LLQ descriptor list in device memory.
+ *
+ * common: ena_admin_llq_ring_entry_size
+ */
+typedef enum enahw_llq_ring_entry_size {
+	ENAHW_LLQ_ENTRY_SIZE_128B	= BIT(0),
+	ENAHW_LLQ_ENTRY_SIZE_192B	= BIT(1),
+	ENAHW_LLQ_ENTRY_SIZE_256B	= BIT(2),
+} enahw_llq_ring_entry_size_t;
+
+/*
+ * LLQ Number of Descriptors Before Header.
+ *
+ * When using inline header mode, the first entry contains some number
+ * of descriptors followed by the packet header. This enum specifies
+ * how many descriptors precede the header.
+ *
+ * common: ena_admin_llq_num_descs_before_header
+ */
+typedef enum enahw_llq_num_descs_before_header {
+	ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_0	= 0,
+	ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_1	= BIT(0),
+	ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_2	= BIT(1),
+	ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_4	= BIT(2),
+	ENAHW_LLQ_NUM_DESCS_BEFORE_HEADER_8	= BIT(3),
+} enahw_llq_num_descs_before_header_t;
+
+/*
+ * LLQ Descriptor Stride Control.
+ *
+ * Controls how descriptors beyond the first entry are laid out. With
+ * SINGLE_DESC_PER_ENTRY each subsequent entry holds one descriptor;
+ * with MULTIPLE_DESCS_PER_ENTRY they are packed contiguously.
+ * Only relevant for inline header mode.
+ *
+ * common: ena_admin_llq_stride_ctrl
+ */
+typedef enum enahw_llq_stride_ctrl {
+	ENAHW_LLQ_SINGLE_DESC_PER_ENTRY		= BIT(0),
+	ENAHW_LLQ_MULTIPLE_DESCS_PER_ENTRY	= BIT(1),
+} enahw_llq_stride_ctrl_t;
+
+/*
+ * LLQ Accelerated Mode Feature Flags.
+ *
+ * DISABLE_META_CACHING: The driver must send a meta descriptor with
+ * every packet rather than relying on the device caching meta
+ * information.
+ *
+ * LIMIT_TX_BURST: The device specifies a maximum burst size (in
+ * bytes) between doorbell writes. The driver must track how many
+ * bytes it has written and ring the doorbell before exceeding this
+ * limit.
+ *
+ * common: ena_admin_accel_mode_feat
+ */
+typedef enum enahw_llq_accel_mode_feat {
+	ENAHW_LLQ_ACCEL_MODE_DISABLE_META_CACHING	= BIT(0),
+	ENAHW_LLQ_ACCEL_MODE_LIMIT_TX_BURST		= BIT(1),
+} enahw_llq_accel_mode_feat_t;
+
+/*
+ * Accelerated LLQ mode - GET response.
+ *
+ * Returned by the device when querying the LLQ feature, indicating
+ * which accelerated mode features are supported and the maximum TX
+ * burst size.
+ *
+ * common: ena_admin_accel_mode_get
+ */
+typedef struct enahw_llq_accel_mode_get {
+	/* Bit field of enahw_llq_accel_mode_feat_t */
+	uint16_t eamg_supported_flags;
+
+	/* Max bytes the driver may write to device memory before a doorbell */
+	uint16_t eamg_max_tx_burst_size;
+} enahw_llq_accel_mode_get_t;
+
+/*
+ * Accelerated LLQ mode - SET request.
+ *
+ * Sent by the driver when configuring the LLQ feature, indicating
+ * which accelerated mode features to enable.
+ *
+ * common: ena_admin_accel_mode_set
+ */
+typedef struct enahw_llq_accel_mode_set {
+	/* Bit field of enahw_llq_accel_mode_feat_t */
+	uint16_t eams_enabled_flags;
+	uint16_t eams_rsvd;
+} enahw_llq_accel_mode_set_t;
+
+/*
+ * Accelerated LLQ mode request/response union.
+ *
+ * Used in both GET_FEATURE and SET_FEATURE for LLQ. The 'get' variant
+ * is populated in responses; the 'set' variant is populated in
+ * requests.
+ *
+ * common: ena_admin_accel_mode_req
+ */
+typedef union enahw_llq_accel_mode {
+	uint32_t			eam_raw[2];
+	enahw_llq_accel_mode_get_t	eam_get;
+	enahw_llq_accel_mode_set_t	eam_set;
+} enahw_llq_accel_mode_t;
+
+/*
+ * Response to ENAHW_FEAT_LLQ.
+ *
+ * Describes the Low Latency Queue capabilities of the device. The
+ * _supported fields are populated on GET responses; the _enabled
+ * fields are populated by the driver on SET requests.
+ *
+ * common: ena_admin_feature_llq_desc
+ */
+typedef struct enahw_feat_llq {
+	uint32_t efllq_max_llq_num;
+	uint32_t efllq_max_llq_depth;
+
+	/*
+	 * Bit field of enahw_llq_header_location_t. The locations the
+	 * device supports (GET) or the driver has selected (SET).
+	 */
+	uint16_t efllq_header_location_ctrl_supported;
+	uint16_t efllq_header_location_ctrl_enabled;
+
+	/*
+	 * Bit field of enahw_llq_ring_entry_size_t. The entry sizes
+	 * the device supports (GET) or the driver has selected (SET).
+	 */
+	uint16_t efllq_entry_size_ctrl_supported;
+	uint16_t efllq_entry_size_ctrl_enabled;
+
+	/*
+	 * Bit field of enahw_llq_num_descs_before_header_t. Valid
+	 * only for inline header mode. The number of descriptors
+	 * before the header the device supports (GET) or the driver
+	 * has selected (SET).
+	 */
+	uint16_t efllq_desc_num_before_header_supported;
+	uint16_t efllq_desc_num_before_header_enabled;
+
+	/*
+	 * Bit field of enahw_llq_stride_ctrl_t. Valid only for inline
+	 * header mode. The stride control the device supports (GET) or
+	 * the driver has selected (SET).
+	 */
+	uint16_t efllq_descs_stride_ctrl_supported;
+	uint16_t efllq_descs_stride_ctrl_enabled;
+
+	/* Feature version as reported by the device. */
+	uint8_t	 efllq_feature_version;
+
+	/*
+	 * The entry size recommended by the device, one of
+	 * enahw_llq_ring_entry_size_t. Only valid on GET.
+	 */
+	uint8_t	 efllq_entry_size_recommended;
+
+	/* Max depth of wide LLQ, or 0 if not applicable. */
+	uint16_t efllq_max_wide_llq_depth;
+
+	/*
+	 * Accelerated LLQ mode capabilities (GET) or requested
+	 * feature flags (SET). See enahw_llq_accel_mode_feat_t.
+	 */
+	enahw_llq_accel_mode_t efllq_accel_mode;
+} enahw_feat_llq_t;
+
 /* common: ena_admin_set_feat_cmd */
 typedef struct enahw_cmd_set_feat {
 	struct enahw_ctrl_buff		ecsf_ctrl_buf;
@@ -479,6 +687,8 @@ typedef struct enahw_cmd_set_feat {
 		enahw_feat_host_attr_t		ecsf_host_attr;
 		enahw_feat_mtu_t		ecsf_mtu;
 		enahw_feat_aenq_t		ecsf_aenq;
+		enahw_feat_hw_timestamp_t	ecsf_hw_timestamp;
+		enahw_feat_llq_t		ecsf_llq;
 	} ecsf_feat;
 } enahw_cmd_set_feat_t;
 
@@ -860,6 +1070,8 @@ typedef enum enahw_feature_id {
 	ENAHW_FEAT_LINK_CONFIG			= 27,
 	ENAHW_FEAT_HOST_ATTR_CONFIG		= 28,
 	ENAHW_FEAT_PHC_CONFIG			= 29,
+	ENAHW_FEAT_FLOW_STEERING_CONFIG		= 30,
+	ENAHW_FEAT_HW_TIMESTAMP			= 31,
 	ENAHW_FEAT_NUM				= 32,
 } enahw_feature_id_t;
 
@@ -887,7 +1099,7 @@ typedef enum enahw_capability_id {
 #define	ENAHW_FEAT_DEVICE_ATTRIBUTES_VER		0
 #define	ENAHW_FEAT_MAX_QUEUES_NUM_VER			0
 #define	ENAHW_FEAT_HW_HINTS_VER				0
-#define	ENAHW_FEAT_LLQ_VER				0
+#define	ENAHW_FEAT_LLQ_VER				1
 #define	ENAHW_FEAT_EXTRA_PROPERTIES_STRINGS_VER		0
 #define	ENAHW_FEAT_EXTRA_PROPERTIES_FLAGS_VER		0
 #define	ENAHW_FEAT_MAX_QUEUES_EXT_VER			1
@@ -900,6 +1112,7 @@ typedef enum enahw_capability_id {
 #define	ENAHW_FEAT_AENQ_CONFIG_VER			0
 #define	ENAHW_FEAT_LINK_CONFIG_VER			0
 #define	ENAHW_FEAT_HOST_ATTR_CONFIG_VER			0
+#define	ENAHW_FEAT_HW_TIMESTAMP_VER			0
 
 /* common: ena_admin_link_types */
 typedef enum enahw_link_speeds {
@@ -1208,6 +1421,7 @@ typedef union enahw_resp_get_feat {
 	enahw_feat_link_conf_t		ergf_link_conf;
 	enahw_feat_offload_t		ergf_offload;
 	enahw_device_hints_t		ergf_hints;
+	enahw_feat_llq_t		ergf_llq;
 } enahw_resp_get_feat_u;
 
 /*
@@ -1719,6 +1933,60 @@ typedef struct enahw_tx_meta_desc {
 	uint32_t etmd_word2;
 	uint32_t etmd_reserved;
 } enahw_tx_meta_desc_t;
+
+#define	ENAHW_TX_META_DESC_REQ_ID_LO_MASK	GENMASK(9, 0)
+#define	ENAHW_TX_META_DESC_EXT_VALID_SHIFT	14
+#define	ENAHW_TX_META_DESC_EXT_VALID_MASK	BIT(14)
+#define	ENAHW_TX_META_DESC_MSS_HI_SHIFT		16
+#define	ENAHW_TX_META_DESC_MSS_HI_MASK		GENMASK(19, 16)
+#define	ENAHW_TX_META_DESC_ETH_META_TYPE_SHIFT	20
+#define	ENAHW_TX_META_DESC_ETH_META_TYPE_MASK	BIT(20)
+#define	ENAHW_TX_META_DESC_META_STORE_SHIFT	21
+#define	ENAHW_TX_META_DESC_META_STORE_MASK	BIT(21)
+/* Bits 23-28 share positions with the data descriptor. */
+#define	ENAHW_TX_META_DESC_META_DESC_MASK	BIT(23)
+#define	ENAHW_TX_META_DESC_PHASE_SHIFT		24
+#define	ENAHW_TX_META_DESC_PHASE_MASK		BIT(24)
+#define	ENAHW_TX_META_DESC_FIRST_MASK		BIT(26)
+#define	ENAHW_TX_META_DESC_LAST_MASK		BIT(27)
+#define	ENAHW_TX_META_DESC_COMP_REQ_MASK	BIT(28)
+#define	ENAHW_TX_META_DESC_REQ_ID_HI_MASK	GENMASK(5, 0)
+
+#define	ENAHW_TX_META_DESC_L3_HDR_LEN_MASK	GENMASK(7, 0)
+#define	ENAHW_TX_META_DESC_L3_HDR_OFF_SHIFT	8
+#define	ENAHW_TX_META_DESC_L3_HDR_OFF_MASK	GENMASK(15, 8)
+#define	ENAHW_TX_META_DESC_L4_HDR_LEN_SHIFT	16
+#define	ENAHW_TX_META_DESC_L4_HDR_LEN_MASK	GENMASK(21, 16)
+#define	ENAHW_TX_META_DESC_MSS_LO_SHIFT		22
+#define	ENAHW_TX_META_DESC_MSS_LO_MASK		GENMASK(31, 22)
+
+#define	ENAHW_TX_META_DESC_META_DESC_ON(desc)			\
+	((desc)->etmd_len_ctrl |= ENAHW_TX_META_DESC_META_DESC_MASK)
+
+#define	ENAHW_TX_META_DESC_EXT_VALID_ON(desc)			\
+	((desc)->etmd_len_ctrl |= ENAHW_TX_META_DESC_EXT_VALID_MASK)
+
+#define	ENAHW_TX_META_DESC_ETH_META_TYPE_ON(desc)		\
+	((desc)->etmd_len_ctrl |= ENAHW_TX_META_DESC_ETH_META_TYPE_MASK)
+
+#define	ENAHW_TX_META_DESC_META_STORE_ON(desc)			\
+	((desc)->etmd_len_ctrl |= ENAHW_TX_META_DESC_META_STORE_MASK)
+
+#define	ENAHW_TX_META_DESC_PHASE(desc, phase)			\
+	((desc)->etmd_len_ctrl |=				\
+	    (((phase) << ENAHW_TX_META_DESC_PHASE_SHIFT) &	\
+	    ENAHW_TX_META_DESC_PHASE_MASK))
+
+#define	ENAHW_TX_META_DESC_FIRST_ON(desc)			\
+	((desc)->etmd_len_ctrl |= ENAHW_TX_META_DESC_FIRST_MASK)
+
+#define	ENAHW_TX_META_DESC_COMP_REQ_ON(desc)			\
+	((desc)->etmd_len_ctrl |= ENAHW_TX_META_DESC_COMP_REQ_MASK)
+
+#define	ENAHW_TX_META_DESC_L3_HDR_OFF(desc, off)		\
+	((desc)->etmd_word2 |=					\
+	    (((off) << ENAHW_TX_META_DESC_L3_HDR_OFF_SHIFT) &	\
+	    ENAHW_TX_META_DESC_L3_HDR_OFF_MASK))
 
 /* common: N/A */
 typedef union enahw_tx_desc {

--- a/usr/src/uts/common/io/ena/ena_rx.c
+++ b/usr/src/uts/common/io/ena/ena_rx.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 #include "ena.h"
@@ -208,7 +208,7 @@ ena_alloc_rxq(ena_rxq_t *rxq)
 	ASSERT3U(rxq->er_sq_num_descs, ==, rxq->er_cq_num_descs);
 	ret = ena_create_sq(ena, rxq->er_sq_num_descs,
 	    rxq->er_sq_dma.edb_cookie->dmac_laddress, false, cq_hw_idx,
-	    &sq_hw_idx, &sq_db_addr);
+	    &sq_hw_idx, &sq_db_addr, NULL);
 
 	if (ret != 0) {
 		ena_err(ena, "failed to create Rx SQ %u: %d", rxq->er_rxqs_idx,

--- a/usr/src/uts/common/io/ena/ena_tx.c
+++ b/usr/src/uts/common/io/ena/ena_tx.c
@@ -10,9 +10,10 @@
  */
 
 /*
- * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
+#include <sys/atomic.h>
 #include "ena.h"
 
 void
@@ -173,7 +174,7 @@ ena_alloc_txq(ena_txq_t *txq)
 
 	ret = ena_create_sq(ena, txq->et_sq_num_descs,
 	    txq->et_sq_dma.edb_cookie->dmac_laddress, true, cq_hw_idx,
-	    &sq_hw_idx, &sq_db_addr);
+	    &sq_hw_idx, &sq_db_addr, &txq->et_sq_llq_addr);
 
 	if (ret != 0) {
 		ena_err(ena, "failed to create Tx SQ %u: %d", txq->et_txqs_idx,
@@ -189,6 +190,17 @@ ena_alloc_txq(ena_txq_t *txq)
 	txq->et_blocked = false;
 	txq->et_stall_watchdog = 0;
 	txq->et_state |= ENA_TXQ_STATE_SQ_CREATED;
+
+	/*
+	 * Allocate the LLQ bounce buffer, used to stage a complete
+	 * LLQ entry before writing it to device memory.
+	 */
+	if (ena->ena_llq_enabled) {
+		txq->et_sq_llq_buf = kmem_zalloc(ena->ena_llq_entry_size_bytes,
+		    KM_SLEEP);
+		txq->et_sq_llq_entries_left = ena->ena_llq_max_tx_burst_size /
+		    ena->ena_llq_entry_size_bytes;
+	}
 
 	return (true);
 }
@@ -209,8 +221,15 @@ ena_cleanup_txq(ena_txq_t *txq, bool resetting)
 			}
 		}
 
+		if (txq->et_sq_llq_buf != NULL) {
+			kmem_free(txq->et_sq_llq_buf,
+			    ena->ena_llq_entry_size_bytes);
+			txq->et_sq_llq_buf = NULL;
+		}
+
 		txq->et_sq_hw_idx = 0;
 		txq->et_sq_db_addr = NULL;
+		txq->et_sq_llq_addr = NULL;
 		txq->et_sq_tail_idx = 0;
 		txq->et_sq_phase = 0;
 		txq->et_state &= ~ENA_TXQ_STATE_SQ_CREATED;
@@ -393,10 +412,70 @@ ena_fill_tx_data_desc(ena_txq_t *txq, ena_tx_control_block_t *tcb,
 	ENAHW_TX_DESC_L4_CSUM_PARTIAL_ON(desc);
 }
 
+/*
+ * Fill in a TX meta descriptor. With DISABLE_META_CACHING the device
+ * requires a meta descriptor for every packet. We don't use TSO so
+ * MSS is always zero; the meta descriptor carries header offset
+ * information.
+ */
+static void
+ena_fill_tx_meta_desc(enahw_tx_meta_desc_t *meta, uint8_t phase,
+    mac_ether_offload_info_t *meo)
+{
+	bzero(meta, sizeof (*meta));
+	ENAHW_TX_META_DESC_META_DESC_ON(meta);
+	ENAHW_TX_META_DESC_EXT_VALID_ON(meta);
+	ENAHW_TX_META_DESC_ETH_META_TYPE_ON(meta);
+	ENAHW_TX_META_DESC_META_STORE_ON(meta);
+	ENAHW_TX_META_DESC_PHASE(meta, phase);
+	ENAHW_TX_META_DESC_FIRST_ON(meta);
+	ENAHW_TX_META_DESC_COMP_REQ_ON(meta);
+	ENAHW_TX_META_DESC_L3_HDR_OFF(meta, meo->meoi_l2hlen);
+}
+
+/*
+ * Write a bounce buffer to LLQ device memory using 64-bit stores.
+ * See the "LLQ Tx Path" section of the big theory statement for
+ * discussion of write-combining safety and ordering.
+ */
+static void
+ena_llq_write_to_dev(ena_txq_t *txq, uint8_t *buf, uint16_t entry_size)
+{
+	const uint16_t modulo_mask = txq->et_sq_num_descs - 1;
+	uint32_t dst_offset;
+	volatile uint64_t *dst;
+	const uint64_t *src;
+	uint16_t count, i;
+
+	/*
+	 * The reference drivers place a write barrier here between
+	 * filling the bounce buffer and writing it to device memory.
+	 * The bounce buffer is only read back by this CPU so it is
+	 * not clear why this is needed, but we retain it for parity.
+	 */
+	membar_producer();
+
+	dst_offset = (txq->et_sq_tail_idx & modulo_mask) * entry_size;
+	dst = (volatile uint64_t *)((caddr_t)txq->et_sq_llq_addr + dst_offset);
+	src = (const uint64_t *)buf;
+	count = entry_size / sizeof (uint64_t);
+
+	for (i = 0; i < count; i++)
+		dst[i] = src[i];
+}
+
 static void
 ena_submit_tx(ena_txq_t *txq, uint16_t desc_idx)
 {
-	ena_hw_abs_write32(txq->et_ena, txq->et_sq_db_addr, desc_idx);
+	ena_t *ena = txq->et_ena;
+
+	ena_hw_abs_write32(ena, txq->et_sq_db_addr, desc_idx);
+
+	/* Reset the burst counter after each doorbell for LIMIT_TX_BURST */
+	if (ena->ena_llq_enabled) {
+		txq->et_sq_llq_entries_left = ena->ena_llq_max_tx_burst_size /
+		    ena->ena_llq_entry_size_bytes;
+	}
 }
 
 /*
@@ -467,11 +546,86 @@ ena_ring_tx(void *arg, mblk_t *mp)
 	ASSERT3P(tcb, !=, NULL);
 	ena_tcb_pull(txq, tcb, mp);
 
-	/* Fill in the Tx descriptor. */
-	tail_mod = txq->et_sq_tail_idx & modulo_mask;
-	desc = &txq->et_sq_descs[tail_mod].etd_data;
-	ena_fill_tx_data_desc(txq, tcb, tcb->etcb_id, txq->et_sq_phase, desc,
-	    &meo, meo.meoi_len);
+	if (ena->ena_llq_enabled) {
+		/*
+		 * LLQ: build the bounce buffer with a meta descriptor, data
+		 * descriptor, and inline packet header, then write the entire
+		 * entry to device memory.
+		 *
+		 * Layout in the bounce buffer (for 128B entry with
+		 * descs_before_header=2):
+		 *   [0..15]   meta descriptor
+		 *   [16..31]  data descriptor
+		 *   [32..127] inline packet header
+		 *
+		 * The data descriptor still references the DMA buffer for the
+		 * remaining packet payload; the inline header is an
+		 * optimisation that lets the device begin processing the
+		 * header immediately.
+		 */
+		uint8_t *buf = txq->et_sq_llq_buf;
+		enahw_tx_meta_desc_t *meta;
+		uint16_t hdr_off;
+		size_t hdr_space, hdr_copy;
+
+		bzero(buf, ena->ena_llq_entry_size_bytes);
+
+		/* Slot 0: meta descriptor */
+		meta = (enahw_tx_meta_desc_t *)buf;
+		ena_fill_tx_meta_desc(meta, txq->et_sq_phase, &meo);
+
+		/* Slot 1: data descriptor */
+		desc = (enahw_tx_data_desc_t *)(buf + sizeof (enahw_tx_desc_t));
+
+		/*
+		 * Copy the packet header into the bounce buffer after the
+		 * descriptor slots.
+		 */
+		hdr_off = ena->ena_llq_num_descs_before_header *
+		    sizeof (enahw_tx_desc_t);
+		hdr_space = ena->ena_llq_entry_size_bytes - hdr_off;
+		hdr_copy = MIN(meo.meoi_len, hdr_space);
+		bcopy(tcb->etcb_dma.edb_va, buf + hdr_off, hdr_copy);
+
+		/*
+		 * The data descriptor's address and length must skip past
+		 * the inline header bytes that are already in the LLQ
+		 * entry.
+		 */
+		ena_fill_tx_data_desc(txq, tcb, tcb->etcb_id,
+		    txq->et_sq_phase, desc, &meo,
+		    meo.meoi_len - hdr_copy);
+		ENAHW_TX_DESC_FIRST_OFF(desc);
+		ENAHW_TX_DESC_HEADER_LENGTH(desc, hdr_copy);
+		ENAHW_TX_DESC_ADDR_LO(desc,
+		    tcb->etcb_dma.edb_cookie->dmac_laddress + hdr_copy);
+		ENAHW_TX_DESC_ADDR_HI(desc,
+		    tcb->etcb_dma.edb_cookie->dmac_laddress + hdr_copy);
+
+		ena_llq_write_to_dev(txq, buf, ena->ena_llq_entry_size_bytes);
+		/*
+		 * Ensure the write-combining stores to the LLQ BAR are
+		 * ordered before the upcoming doorbell write.
+		 */
+		membar_producer();
+		/*
+		 * Since mac calls us with one packet at a time, we don't
+		 * actually do any batching and we never expect to run out
+		 * of llq entries.
+		 */
+		if (ena->ena_llq_max_tx_burst_size > 0) {
+			ASSERT3U(txq->et_sq_llq_entries_left, >, 0);
+			txq->et_sq_llq_entries_left--;
+		}
+	} else {
+		/* Host placement */
+		tail_mod = txq->et_sq_tail_idx & modulo_mask;
+		desc = &txq->et_sq_descs[tail_mod].etd_data;
+		ena_fill_tx_data_desc(txq, tcb, tcb->etcb_id,
+		    txq->et_sq_phase, desc, &meo, meo.meoi_len);
+		ENA_DMA_SYNC(txq->et_sq_dma, DDI_DMA_SYNC_FORDEV);
+	}
+
 	DTRACE_PROBE3(tx__submit, ena_tx_control_block_t *, tcb, uint16_t,
 	    tcb->etcb_id, enahw_tx_data_desc_t *, desc);
 

--- a/usr/src/uts/common/io/mac/mac.c
+++ b/usr/src/uts/common/io/mac/mac.c
@@ -2210,7 +2210,8 @@ mac_tx_client_unblock(mac_client_impl_t *mcip)
  * quiesce is done.
  */
 static void
-mac_srs_quiesce_wait(mac_soft_ring_set_t *srs, uint_t srs_flag)
+mac_srs_quiesce_wait(mac_soft_ring_set_t *srs,
+    const mac_soft_ring_set_state_t srs_flag)
 {
 	mutex_enter(&srs->srs_lock);
 	while (!(srs->srs_state & srs_flag))
@@ -2255,10 +2256,12 @@ mac_srs_quiesce_wait(mac_soft_ring_set_t *srs, uint_t srs_flag)
  * restart sequence.
  */
 void
-mac_rx_srs_quiesce(mac_soft_ring_set_t *srs, uint_t srs_quiesce_flag)
+mac_rx_srs_quiesce(mac_soft_ring_set_t *srs,
+    const mac_soft_ring_set_state_t srs_quiesce_flag)
 {
-	flow_entry_t	*flent = srs->srs_flent;
-	uint_t	mr_flag, srs_done_flag;
+	flow_entry_t *flent = srs->srs_flent;
+	uint_t mr_flag;
+	mac_soft_ring_set_state_t srs_done_flag;
 
 	VERIFY(mac_perim_held((mac_handle_t)FLENT_TO_MIP(flent)));
 	VERIFY0(srs->srs_type & SRST_TX);
@@ -2342,7 +2345,8 @@ mac_rx_srs_remove(mac_soft_ring_set_t *srs)
 }
 
 static void
-mac_srs_clear_flag(mac_soft_ring_set_t *srs, uint_t flag)
+mac_srs_clear_flag(mac_soft_ring_set_t *srs,
+    const mac_soft_ring_set_state_t flag)
 {
 	mutex_enter(&srs->srs_lock);
 	srs->srs_state &= ~flag;
@@ -2485,7 +2489,8 @@ mac_rx_client_restart(mac_client_handle_t mch)
  * future transmits in the mac before calling this function.
  */
 void
-mac_tx_srs_quiesce(mac_soft_ring_set_t *srs, uint_t srs_quiesce_flag)
+mac_tx_srs_quiesce(mac_soft_ring_set_t *srs,
+    const mac_soft_ring_set_state_t srs_quiesce_flag)
 {
 	mac_client_impl_t	*mcip = srs->srs_mcip;
 
@@ -2552,7 +2557,8 @@ mac_tx_flow_restart(flow_entry_t *flent, void *arg)
 }
 
 static void
-i_mac_tx_client_quiesce(mac_client_handle_t mch, uint_t srs_quiesce_flag)
+i_mac_tx_client_quiesce(mac_client_handle_t mch,
+    const mac_soft_ring_set_state_t srs_quiesce_flag)
 {
 	mac_client_impl_t	*mcip = (mac_client_impl_t *)mch;
 
@@ -5011,7 +5017,7 @@ i_mac_group_add_ring(mac_group_t *group, mac_ring_t *ring, int index)
 			VERIFY3S(flent->fe_rx_srs_cnt, >, 0);
 			mac_rx_srs_group_setup(mcip, flent, SRST_LINK);
 			mac_fanout_setup(mcip, flent, MCIP_RESOURCE_PROPS(mcip),
-			    mac_rx_deliver, mcip, NULL, NULL);
+			    mac_rx_deliver, mcip, NULL);
 		} else {
 			ring->mr_classify_type = MAC_SW_CLASSIFIER;
 		}
@@ -5065,7 +5071,7 @@ i_mac_group_add_ring(mac_group_t *group, mac_ring_t *ring, int index)
 			}
 			mac_tx_srs_add_ring(mac_srs, ring);
 			mac_fanout_setup(mcip, flent, MCIP_RESOURCE_PROPS(mcip),
-			    mac_rx_deliver, mcip, NULL, NULL);
+			    mac_rx_deliver, mcip, NULL);
 			mac_tx_client_restart((mac_client_handle_t)mcip);
 			mgcp = mgcp->mgc_next;
 		}
@@ -7550,8 +7556,7 @@ mac_rx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 	if (tgrp->mrg_state == MAC_GROUP_STATE_RESERVED) {
 		mac_rx_srs_group_setup(mcip, mcip->mci_flent, SRST_LINK);
 		mac_fanout_setup(mcip, mcip->mci_flent,
-		    MCIP_RESOURCE_PROPS(mcip), mac_rx_deliver, mcip, NULL,
-		    NULL);
+		    MCIP_RESOURCE_PROPS(mcip), mac_rx_deliver, mcip, NULL);
 		mac_rx_group_unmark(tgrp, MR_INCIPIENT);
 	} else {
 		mac_rx_switch_grp_to_sw(tgrp);
@@ -7905,7 +7910,7 @@ mac_tx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 				    SRST_LINK);
 				mac_fanout_setup(gmcip, gflent,
 				    MCIP_RESOURCE_PROPS(gmcip), mac_rx_deliver,
-				    gmcip, NULL, NULL);
+				    gmcip, NULL);
 
 				mac_tx_client_restart(
 				    (mac_client_handle_t)gmcip);
@@ -7966,7 +7971,7 @@ mac_tx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 			mac_tx_srs_group_setup(gmcip, gflent, SRST_LINK);
 			mac_fanout_setup(gmcip, gflent,
 			    MCIP_RESOURCE_PROPS(gmcip), mac_rx_deliver,
-			    gmcip, NULL, NULL);
+			    gmcip, NULL);
 
 			mac_tx_client_restart((mac_client_handle_t)gmcip);
 		}
@@ -7983,7 +7988,7 @@ mac_tx_switch_group(mac_client_impl_t *mcip, mac_group_t *fgrp,
 
 	mac_tx_srs_group_setup(mcip, flent, SRST_LINK);
 	mac_fanout_setup(mcip, flent, MCIP_RESOURCE_PROPS(mcip),
-	    mac_rx_deliver, mcip, NULL, NULL);
+	    mac_rx_deliver, mcip, NULL);
 }
 
 /*
@@ -8483,7 +8488,7 @@ mac_pool_link_update(mod_hash_key_t key, mod_hash_val_t *val, void *arg)
 				pool_lock();
 				cpupart = mac_pset_find(mrp, &use_default);
 				mac_fanout_setup(mcip, mcip->mci_flent, mrp,
-				    mac_rx_deliver, mcip, NULL, cpupart);
+				    mac_rx_deliver, mcip, cpupart);
 				mac_set_pool_effective(use_default, cpupart,
 				    mrp, emrp);
 				pool_unlock();
@@ -8501,7 +8506,7 @@ mac_pool_link_update(mod_hash_key_t key, mod_hash_val_t *val, void *arg)
 				emrp->mrp_mask &= ~MRP_POOL;
 				bzero(emrp->mrp_pool, MAXPATHLEN);
 				mac_fanout_setup(mcip, mcip->mci_flent, mrp,
-				    mac_rx_deliver, mcip, NULL, NULL);
+				    mac_rx_deliver, mcip, NULL);
 			}
 			mac_update_resources(mrp, MCIP_RESOURCE_PROPS(mcip),
 			    B_FALSE);

--- a/usr/src/uts/common/io/mac/mac_bcast.c
+++ b/usr/src/uts/common/io/mac/mac_bcast.c
@@ -22,6 +22,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2026 Oxide Computer Company
  */
 
 #include <sys/types.h>
@@ -64,30 +65,6 @@
  * hanging off the mac_impl_t. The broadcast group id's are
  * unique globally (tracked by mac_bcast_id).
  */
-
-/*
- * The same MAC client may be added for different <addr,vid> tuple,
- * we maintain a ref count for the number of times it has been added
- * to account for deleting the MAC client from the group.
- */
-typedef struct mac_bcast_grp_mcip_s {
-	mac_client_impl_t	*mgb_client;
-	int			mgb_client_ref;
-} mac_bcast_grp_mcip_t;
-
-typedef struct mac_bcast_grp_s {			/* Protected by */
-	struct mac_bcast_grp_s	*mbg_next;		/* SL */
-	void			*mbg_addr;		/* SL */
-	uint16_t		mbg_vid;		/* SL */
-	mac_impl_t		*mbg_mac_impl;		/* WO */
-	mac_addrtype_t		mbg_addrtype;		/* WO */
-	flow_entry_t		*mbg_flow_ent;		/* WO */
-	mac_bcast_grp_mcip_t	*mbg_clients;		/* mi_rw_lock */
-	uint_t			mbg_nclients;		/* mi_rw_lock */
-	uint_t			mbg_nclients_alloc;	/* SL */
-	uint64_t		mbg_clients_gen;	/* mi_rw_lock */
-	uint32_t		mbg_id;			/* atomic */
-} mac_bcast_grp_t;
 
 static kmem_cache_t *mac_bcast_grp_cache;
 static uint32_t mac_bcast_id = 0;
@@ -258,7 +235,7 @@ int
 mac_bcast_add(mac_client_impl_t *mcip, const uint8_t *addr, uint16_t vid,
     mac_addrtype_t addrtype)
 {
-	mac_impl_t 		*mip = mcip->mci_mip;
+	mac_impl_t		*mip = mcip->mci_mip;
 	mac_bcast_grp_t		*grp = NULL, **last_grp;
 	size_t			addr_len = mip->mi_type->mt_addr_length;
 	int			rc = 0;

--- a/usr/src/uts/common/io/mac/mac_client.c
+++ b/usr/src/uts/common/io/mac/mac_client.c
@@ -3637,8 +3637,8 @@ mac_tx(mac_client_handle_t mch, mblk_t *mp_chain, uintptr_t hint,
 		obytes = (mp_chain->b_cont == NULL ? MBLKL(mp_chain) :
 		    msgdsize(mp_chain));
 
-		mp_chain = mac_provider_tx(mip, srs_tx->st_arg2, mp_chain,
-		    mcip);
+		mp_chain = mac_provider_tx(mip,
+		    (mac_ring_handle_t)srs_tx->st_arg2, mp_chain, mcip);
 
 		if (mp_chain == NULL) {
 			cookie = 0;

--- a/usr/src/uts/common/io/mac/mac_datapath_setup.c
+++ b/usr/src/uts/common/io/mac/mac_datapath_setup.c
@@ -47,11 +47,13 @@
 #include <sys/mac_flow_impl.h>
 #include <sys/mac_stat.h>
 
-static void mac_srs_soft_rings_signal(mac_soft_ring_set_t *, uint_t);
+static void mac_srs_soft_rings_signal(mac_soft_ring_set_t *,
+    const mac_soft_ring_state_t);
 static void mac_srs_update_fanout_list(mac_soft_ring_set_t *);
 static void mac_srs_poll_unbind(mac_soft_ring_set_t *);
 static void mac_srs_worker_unbind(mac_soft_ring_set_t *);
-static void mac_srs_soft_rings_quiesce(mac_soft_ring_set_t *, uint_t);
+static void mac_srs_soft_rings_quiesce(mac_soft_ring_set_t *,
+    const mac_soft_ring_state_t);
 
 static int mac_srs_cpu_setup(cpu_setup_t, int, void *);
 static void mac_srs_worker_bind(mac_soft_ring_set_t *, processorid_t);
@@ -660,8 +662,8 @@ mac_compute_soft_ring_count(flow_entry_t *flent, int rx_srs_cnt, int maxcpus)
 			srings = mac_rx_soft_ring_count;
 
 		/* Is this a 10Gig link? */
-		flent->fe_nic_speed = mac_client_stat_get(flent->fe_mcip,
-		    MAC_STAT_IFSPEED);
+		flent->fe_nic_speed = mac_client_stat_get(
+		    (mac_client_handle_t)flent->fe_mcip, MAC_STAT_IFSPEED);
 		/* convert to Mbps */
 		if (((flent->fe_nic_speed)/1000000) > 1000 &&
 		    mac_rx_soft_ring_10gig_count > 0) {
@@ -1572,8 +1574,11 @@ mac_tx_srs_update_bwlimit(mac_soft_ring_set_t *srs, mac_resource_props_t *mrp)
 	if (mrp->mrp_maxbw == MRP_MAXBW_RESETVAL) {
 		/* Reset bandwidth limit */
 		if (tx_mode == SRS_TX_BW) {
-			if (srs_tx->st_arg2 != NULL)
-				ring_info = mac_hwring_getinfo(srs_tx->st_arg2);
+			if (srs_tx->st_arg2 != NULL) {
+				mac_ring_handle_t mrh =
+				    (mac_ring_handle_t)srs_tx->st_arg2;
+				ring_info = mac_hwring_getinfo(mrh);
+			}
 			if (mac_tx_serialize ||
 			    (ring_info & MAC_RING_TX_SERIALIZE)) {
 				srs_tx->st_mode = SRS_TX_SERIALIZE;
@@ -1710,22 +1715,36 @@ mac_srs_update_fanout_list(mac_soft_ring_set_t *mac_srs)
 		mac_srs->srs_udp6_ring_count = 0;
 		mac_srs->srs_oth_ring_count = 0;
 		mac_srs->srs_tx_ring_count = 0;
+
+		/*
+		 * `SRST_NO_SOFT_RINGS` is a static property of Rx SRSes, and
+		 * determines their processing model. Adjust this only on Tx
+		 * SRSes, where its meaning is something of a vanity flag.
+		 */
+		if ((mac_srs->srs_type & SRST_TX) != 0) {
+			mac_srs->srs_type |= SRST_NO_SOFT_RINGS;
+		}
+
 		return;
 	}
 
+	if ((mac_srs->srs_type & SRST_TX) != 0) {
+		mac_srs->srs_type &= ~SRST_NO_SOFT_RINGS;
+	}
+
 	while (softring != NULL) {
-		if (softring->s_ring_type & ST_RING_TCP) {
+		if (softring->s_ring_state & ST_RING_TCP) {
 			mac_srs->srs_tcp_soft_rings[tcp_count++] = softring;
-		} else if (softring->s_ring_type & ST_RING_TCP6) {
+		} else if (softring->s_ring_state & ST_RING_TCP6) {
 			mac_srs->srs_tcp6_soft_rings[tcp6_count++] = softring;
-		} else if (softring->s_ring_type & ST_RING_UDP) {
+		} else if (softring->s_ring_state & ST_RING_UDP) {
 			mac_srs->srs_udp_soft_rings[udp_count++] = softring;
-		} else if (softring->s_ring_type & ST_RING_UDP6) {
+		} else if (softring->s_ring_state & ST_RING_UDP6) {
 			mac_srs->srs_udp6_soft_rings[udp6_count++] = softring;
-		} else if (softring->s_ring_type & ST_RING_OTH) {
+		} else if (softring->s_ring_state & ST_RING_OTH) {
 			mac_srs->srs_oth_soft_rings[oth_count++] = softring;
 		} else {
-			ASSERT(softring->s_ring_type & ST_RING_TX);
+			ASSERT(softring->s_ring_state & ST_RING_TX);
 			mac_srs->srs_tx_soft_rings[tx_count++] = softring;
 		}
 		softring = softring->s_ring_next;
@@ -1741,16 +1760,15 @@ mac_srs_update_fanout_list(mac_soft_ring_set_t *mac_srs)
 	mac_srs->srs_tx_ring_count = tx_count;
 }
 
-void
+static void
 mac_srs_create_proto_softrings(int id, pri_t pri, mac_client_impl_t *mcip,
     mac_soft_ring_set_t *mac_srs, processorid_t cpuid, mac_direct_rx_t rx_func,
-    void *x_arg1, mac_resource_handle_t x_arg2, boolean_t set_bypass)
+    void *x_arg1, boolean_t set_bypass)
 {
 	mac_soft_ring_t	*softring;
 
-	softring = mac_soft_ring_create(id, mac_soft_ring_worker_wait,
-	    ST_RING_TCP, pri, mcip, mac_srs, cpuid, rx_func, x_arg1, x_arg2);
-	softring->s_ring_rx_arg2 = NULL;
+	softring = mac_soft_ring_create_rx(id, mac_soft_ring_worker_wait,
+	    ST_RING_TCP, pri, mcip, mac_srs, cpuid, rx_func, x_arg1);
 
 	/*
 	 * TCP and UDP support DLS bypass. In addition TCP
@@ -1775,9 +1793,8 @@ mac_srs_create_proto_softrings(int id, pri_t pri, mac_client_impl_t *mcip,
 	 * rings. Now create the UDP softring and allow it to
 	 * bypass the DLS layer.
 	 */
-	softring = mac_soft_ring_create(id, mac_soft_ring_worker_wait,
-	    ST_RING_UDP, pri, mcip, mac_srs, cpuid, rx_func, x_arg1, x_arg2);
-	softring->s_ring_rx_arg2 = NULL;
+	softring = mac_soft_ring_create_rx(id, mac_soft_ring_worker_wait,
+	    ST_RING_UDP, pri, mcip, mac_srs, cpuid, rx_func, x_arg1);
 
 	if (set_bypass && mcip->mci_direct_rx.mdrx_v4 != NULL) {
 		mac_soft_ring_dls_bypass_enable(softring,
@@ -1786,9 +1803,8 @@ mac_srs_create_proto_softrings(int id, pri_t pri, mac_client_impl_t *mcip,
 	}
 
 	/* TCP for IPv6. */
-	softring = mac_soft_ring_create(id, mac_soft_ring_worker_wait,
-	    ST_RING_TCP6, pri, mcip, mac_srs, cpuid, rx_func, x_arg1, x_arg2);
-	softring->s_ring_rx_arg2 = NULL;
+	softring = mac_soft_ring_create_rx(id, mac_soft_ring_worker_wait,
+	    ST_RING_TCP6, pri, mcip, mac_srs, cpuid, rx_func, x_arg1);
 
 	if (set_bypass && mcip->mci_direct_rx.mdrx_v6 != NULL &&
 	    (mcip->mci_rcb6.mrc_arg != NULL)) {
@@ -1797,8 +1813,8 @@ mac_srs_create_proto_softrings(int id, pri_t pri, mac_client_impl_t *mcip,
 	}
 
 	/* UDP for IPv6. */
-	softring = mac_soft_ring_create(id, mac_soft_ring_worker_wait,
-	    ST_RING_UDP6, pri, mcip, mac_srs, cpuid, rx_func, x_arg1, x_arg2);
+	softring = mac_soft_ring_create_rx(id, mac_soft_ring_worker_wait,
+	    ST_RING_UDP6, pri, mcip, mac_srs, cpuid, rx_func, x_arg1);
 	softring->s_ring_rx_arg2 = NULL;
 
 	if (set_bypass && mcip->mci_direct_rx.mdrx_v6 != NULL) {
@@ -1808,9 +1824,8 @@ mac_srs_create_proto_softrings(int id, pri_t pri, mac_client_impl_t *mcip,
 	}
 
 	/* Create the Oth softrings which has to go through the DLS. */
-	softring = mac_soft_ring_create(id, mac_soft_ring_worker_wait,
-	    ST_RING_OTH, pri, mcip, mac_srs, cpuid, rx_func, x_arg1, x_arg2);
-	softring->s_ring_rx_arg2 = NULL;
+	softring = mac_soft_ring_create_rx(id, mac_soft_ring_worker_wait,
+	    ST_RING_OTH, pri, mcip, mac_srs, cpuid, rx_func, x_arg1);
 }
 
 /*
@@ -1823,8 +1838,8 @@ mac_srs_create_proto_softrings(int id, pri_t pri, mac_client_impl_t *mcip,
  */
 static void
 mac_srs_fanout_modify(mac_client_impl_t *mcip, mac_direct_rx_t rx_func,
-    void *x_arg1, mac_resource_handle_t x_arg2,
-    mac_soft_ring_set_t *mac_rx_srs, mac_soft_ring_set_t *mac_tx_srs)
+    void *x_arg1, mac_soft_ring_set_t *mac_rx_srs,
+    mac_soft_ring_set_t *mac_tx_srs)
 {
 	mac_soft_ring_t *softring;
 	processorid_t cpuid = -1;
@@ -1854,8 +1869,7 @@ mac_srs_fanout_modify(mac_client_impl_t *mcip, mac_direct_rx_t rx_func,
 			 * DLS bypass where possible.
 			 */
 			mac_srs_create_proto_softrings(i, mac_rx_srs->srs_pri,
-			    mcip, mac_rx_srs, cpuid, rx_func, x_arg1, x_arg2,
-			    B_TRUE);
+			    mcip, mac_rx_srs, cpuid, rx_func, x_arg1, B_TRUE);
 		}
 		mac_srs_update_fanout_list(mac_rx_srs);
 	} else if (new_fanout_cnt < srings_present) {
@@ -1940,9 +1954,8 @@ mac_srs_fanout_modify(mac_client_impl_t *mcip, mac_direct_rx_t rx_func,
  */
 void
 mac_srs_fanout_init(mac_client_impl_t *mcip, mac_resource_props_t *mrp,
-    mac_direct_rx_t rx_func, void *x_arg1, mac_resource_handle_t x_arg2,
-    mac_soft_ring_set_t *mac_rx_srs, mac_soft_ring_set_t *mac_tx_srs,
-    cpupart_t *cpupart)
+    mac_direct_rx_t rx_func, void *x_arg1, mac_soft_ring_set_t *mac_rx_srs,
+    mac_soft_ring_set_t *mac_tx_srs, cpupart_t *cpupart)
 {
 	int		i;
 	processorid_t	cpuid;
@@ -1975,8 +1988,7 @@ mac_srs_fanout_init(mac_client_impl_t *mcip, mac_resource_props_t *mrp,
 			cpuid = srs_cpu->mc_rx_fanout_cpus[i];
 			/* Create the protocol softrings */
 			mac_srs_create_proto_softrings(i, mac_rx_srs->srs_pri,
-			    mcip, mac_rx_srs, cpuid, rx_func, x_arg1, x_arg2,
-			    B_FALSE);
+			    mcip, mac_rx_srs, cpuid, rx_func, x_arg1, B_FALSE);
 		}
 		mac_srs_worker_bind(mac_rx_srs, srs_cpu->mc_rx_workerid);
 		mac_srs_poll_bind(mac_rx_srs, srs_cpu->mc_rx_pollid);
@@ -2020,7 +2032,7 @@ no_softrings:
 		cpuid = mac_next_bind_cpu(cpupart);
 		/* Create the protocol softrings */
 		mac_srs_create_proto_softrings(0, mac_rx_srs->srs_pri, mcip,
-		    mac_rx_srs, cpuid, rx_func, x_arg1, x_arg2, B_FALSE);
+		    mac_rx_srs, cpuid, rx_func, x_arg1, B_FALSE);
 		mutex_exit(&cpu_lock);
 	} else {
 		/*
@@ -2041,7 +2053,7 @@ no_softrings:
 void
 mac_fanout_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
     mac_resource_props_t *mrp, mac_direct_rx_t rx_func, void *x_arg1,
-    mac_resource_handle_t x_arg2, cpupart_t *cpupart)
+    cpupart_t *cpupart)
 {
 	mac_soft_ring_set_t *mac_rx_srs, *mac_tx_srs;
 	int i, rx_srs_cnt;
@@ -2067,8 +2079,7 @@ mac_fanout_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	/* No fanout for subflows */
 	if (flent->fe_type & FLOW_USER) {
 		mac_srs_fanout_init(mcip, mrp, rx_func,
-		    x_arg1, x_arg2, mac_rx_srs, mac_tx_srs,
-		    cpupart);
+		    x_arg1, mac_rx_srs, mac_tx_srs, cpupart);
 		return;
 	}
 
@@ -2089,16 +2100,15 @@ mac_fanout_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 			mac_tx_srs = NULL;
 		switch (mac_rx_srs->srs_fanout_state) {
 		case SRS_FANOUT_UNINIT:
-			mac_srs_fanout_init(mcip, mrp, rx_func,
-			    x_arg1, x_arg2, mac_rx_srs, mac_tx_srs,
-			    cpupart);
+			mac_srs_fanout_init(mcip, mrp, rx_func, x_arg1,
+			    mac_rx_srs, mac_tx_srs, cpupart);
 			break;
 		case SRS_FANOUT_INIT:
 			break;
 		case SRS_FANOUT_REINIT:
 			mac_rx_srs_quiesce(mac_rx_srs, SRS_QUIESCE);
-			mac_srs_fanout_modify(mcip, rx_func, x_arg1,
-			    x_arg2, mac_rx_srs, mac_tx_srs);
+			mac_srs_fanout_modify(mcip, rx_func, x_arg1, mac_rx_srs,
+			    mac_tx_srs);
 			mac_rx_srs_restart(mac_rx_srs);
 			break;
 		default:
@@ -2124,9 +2134,9 @@ mac_fanout_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
  *
  * mi_soft_ring_list_size, mi_soft_ring_size, etc need to disappear.
  */
-mac_soft_ring_set_t *
-mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
-    mac_direct_rx_t rx_func, void *x_arg1, mac_resource_handle_t x_arg2,
+static mac_soft_ring_set_t *
+mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent,
+    const mac_soft_ring_set_type_t srs_type, mac_direct_rx_t rx_func,
     mac_ring_t *ring)
 {
 	mac_soft_ring_set_t	*mac_srs;
@@ -2258,10 +2268,8 @@ mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
 		srs_rx->sr_poll_thres = mac_soft_ring_poll_thres <=
 		    (srs_rx->sr_lowat >> 1) ? mac_soft_ring_poll_thres :
 		    (srs_rx->sr_lowat >> 1);
-		if (mac_latency_optimize)
-			mac_srs->srs_state |= SRS_LATENCY_OPT;
-		else
-			mac_srs->srs_state |= SRS_SOFTRING_QUEUE;
+		mac_srs->srs_type |= mac_latency_optimize ?
+		    SRST_LATENCY_OPT : SRST_ENQUEUE;
 	}
 
 	/*
@@ -2281,8 +2289,8 @@ mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
 		srs_tx->st_hiwat =
 		    (mac_tx_srs_hiwat > mac_tx_srs_max_q_cnt) ?
 		    mac_tx_srs_max_q_cnt : mac_tx_srs_hiwat;
-		srs_tx->st_arg1 = x_arg1;
-		srs_tx->st_arg2 = x_arg2;
+		srs_tx->st_arg1 = mcip;
+		srs_tx->st_arg2 = NULL;
 		goto done;
 	}
 
@@ -2293,8 +2301,7 @@ mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
 		srs_rx->sr_lower_proc = mac_rx_srs_subflow_process;
 
 	srs_rx->sr_func = rx_func;
-	srs_rx->sr_arg1 = x_arg1;
-	srs_rx->sr_arg2 = x_arg2;
+	srs_rx->sr_arg1 = mcip;
 
 	if (ring != NULL) {
 		uint_t ring_info;
@@ -2324,8 +2331,9 @@ mac_srs_create(mac_client_impl_t *mcip, flow_entry_t *flent, uint32_t srs_type,
 		 * mode under backlog.
 		 */
 		ring_info = mac_hwring_getinfo((mac_ring_handle_t)ring);
-		if (ring_info & MAC_RING_RX_ENQUEUE)
-			mac_srs->srs_state |= SRS_SOFTRING_QUEUE;
+		if (ring_info & MAC_RING_RX_ENQUEUE) {
+			mac_srs->srs_type |= SRST_ENQUEUE;
+		}
 	}
 done:
 	mac_srs_stat_create(mac_srs);
@@ -2338,8 +2346,8 @@ done:
  * require us to do fanout for performance (based on mac_soft_ring_enable),
  * or user has specifically requested fanout.
  */
-static uint32_t
-mac_find_fanout(flow_entry_t *flent, uint32_t link_type)
+static mac_soft_ring_set_type_t
+mac_find_fanout(flow_entry_t *flent, const mac_soft_ring_set_type_t link_type)
 {
 	uint32_t			fanout_type;
 	mac_resource_props_t		*mrp = &flent->fe_effective_props;
@@ -2425,7 +2433,7 @@ mac_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	pool_lock();
 	cpupart = mac_pset_find(mrp, &use_default);
 	mac_fanout_setup(mcip, flent, MCIP_RESOURCE_PROPS(mcip),
-	    mac_rx_deliver, mcip, NULL, cpupart);
+	    mac_rx_deliver, mcip, cpupart);
 	mac_set_pool_effective(use_default, cpupart, mrp, emrp);
 	pool_unlock();
 }
@@ -2439,12 +2447,11 @@ mac_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
  */
 void
 mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
-    uint32_t link_type)
+    const mac_soft_ring_set_type_t link_type)
 {
 	mac_impl_t		*mip = mcip->mci_mip;
 	mac_soft_ring_set_t	*mac_srs;
 	mac_ring_t		*ring;
-	uint32_t		fanout_type;
 	mac_group_t		*rx_group = flent->fe_rx_ring_group;
 	boolean_t		no_unicast;
 
@@ -2471,14 +2478,15 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 	 */
 	ASSERT3U((mcip->mci_state_flags & MCIS_IS_AGGR_PORT), ==, 0);
 
-	fanout_type = mac_find_fanout(flent, link_type);
+	const mac_soft_ring_set_type_t fanout_type =
+	    mac_find_fanout(flent, link_type);
 	no_unicast = (mcip->mci_state_flags & MCIS_NO_UNICAST_ADDR) != 0;
 
 	/* Create the SRS for SW classification if none exists */
 	if (flent->fe_rx_srs[0] == NULL) {
 		ASSERT(flent->fe_rx_srs_cnt == 0);
 		mac_srs = mac_srs_create(mcip, flent, fanout_type | link_type,
-		    mac_rx_deliver, mcip, NULL, NULL);
+		    mac_rx_deliver, NULL);
 		mutex_enter(&flent->fe_lock);
 		flent->fe_cb_fn = (flow_fn_t)mac_srs->srs_rx.sr_lower_proc;
 		flent->fe_cb_arg1 = (void *)mip;
@@ -2527,7 +2535,7 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 				 */
 				mac_srs = mac_srs_create(mcip, flent,
 				    fanout_type | link_type,
-				    mac_rx_deliver, mcip, NULL, ring);
+				    mac_rx_deliver, ring);
 				break;
 			default:
 				cmn_err(CE_PANIC,
@@ -2557,7 +2565,7 @@ mac_rx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
  */
 void
 mac_tx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
-    uint32_t link_type)
+    const mac_soft_ring_set_type_t link_type)
 {
 	/*
 	 * If this is an exclusive client (e.g. an aggr port), then
@@ -2590,7 +2598,7 @@ mac_tx_srs_group_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 
 	if (flent->fe_tx_srs == NULL) {
 		(void) mac_srs_create(mcip, flent, SRST_TX | link_type,
-		    NULL, mcip, NULL, NULL);
+		    NULL, NULL);
 	}
 
 	mac_tx_srs_setup(mcip, flent);
@@ -2636,7 +2644,7 @@ mac_rx_srs_group_teardown(flow_entry_t *flent, boolean_t hwonly)
  */
 void
 mac_tx_srs_group_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
-    uint32_t link_type)
+    const mac_soft_ring_set_type_t link_type)
 {
 	mac_soft_ring_set_t	*tx_srs;
 	mac_srs_tx_t		*tx;
@@ -2933,7 +2941,7 @@ mac_group_next_state(mac_group_t *grp, mac_client_impl_t **group_only_mcip,
 
 int
 mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
-    uint32_t link_type)
+    const mac_soft_ring_set_type_t link_type)
 {
 	mac_impl_t		*mip = mcip->mci_mip;
 	mac_group_t		*rgroup = NULL;
@@ -3126,7 +3134,7 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 			goto setup_failed;
 
 		mcip->mci_unicast = mac_find_macaddr(mip, mac_addr);
-		VERIFY3P(mcip->mci_unicast, !=, NULL);
+		VERIFY(mcip->mci_unicast != NULL);
 
 		/*
 		 * Setup the Rx and Tx SRSes. If the client has a
@@ -3171,8 +3179,7 @@ mac_datapath_setup(mac_client_impl_t *mcip, flow_entry_t *flent,
 				mac_fanout_setup(group_only_mcip,
 				    group_only_mcip->mci_flent,
 				    MCIP_RESOURCE_PROPS(group_only_mcip),
-				    mac_rx_deliver, group_only_mcip, NULL,
-				    cpupart);
+				    mac_rx_deliver, group_only_mcip, cpupart);
 				mac_set_pool_effective(use_default, cpupart,
 				    mrp, emrp);
 				pool_unlock();
@@ -3212,7 +3219,7 @@ setup_failed:
 
 void
 mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
-    uint32_t link_type)
+    const mac_soft_ring_set_type_t link_type)
 {
 	mac_impl_t		*mip = mcip->mci_mip;
 	mac_group_t		*group = NULL;
@@ -3283,7 +3290,7 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 				/*
 				 * Only one client left on this RX group.
 				 */
-				VERIFY3P(grp_only_mcip, !=, NULL);
+				VERIFY(grp_only_mcip != NULL);
 				mac_set_group_state(group,
 				    MAC_GROUP_STATE_RESERVED);
 				group_only_flent = grp_only_mcip->mci_flent;
@@ -3298,7 +3305,7 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 				mac_fanout_setup(grp_only_mcip,
 				    group_only_flent,
 				    MCIP_RESOURCE_PROPS(grp_only_mcip),
-				    mac_rx_deliver, grp_only_mcip, NULL, NULL);
+				    mac_rx_deliver, grp_only_mcip, NULL);
 				mac_rx_group_unmark(group, MR_INCIPIENT);
 				mac_set_rings_effective(grp_only_mcip);
 			} else if (next_state == MAC_GROUP_STATE_REGISTERED) {
@@ -3416,7 +3423,7 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 		next_state = mac_group_next_state(default_group,
 		    &grp_only_mcip, default_group, B_TRUE);
 		if (next_state == MAC_GROUP_STATE_RESERVED) {
-			VERIFY3P(grp_only_mcip, !=, NULL);
+			VERIFY(grp_only_mcip != NULL);
 			VERIFY3U(mip->mi_nactiveclients, ==, 1);
 			mac_set_group_state(default_group,
 			    MAC_GROUP_STATE_RESERVED);
@@ -3425,7 +3432,7 @@ mac_datapath_teardown(mac_client_impl_t *mcip, flow_entry_t *flent,
 			mac_fanout_setup(grp_only_mcip,
 			    grp_only_mcip->mci_flent,
 			    MCIP_RESOURCE_PROPS(grp_only_mcip), mac_rx_deliver,
-			    grp_only_mcip, NULL, NULL);
+			    grp_only_mcip, NULL);
 			mac_rx_group_unmark(default_group, MR_INCIPIENT);
 			mac_set_rings_effective(grp_only_mcip);
 		}
@@ -3569,7 +3576,8 @@ mac_srs_free(mac_soft_ring_set_t *mac_srs)
 }
 
 static void
-mac_srs_soft_rings_quiesce(mac_soft_ring_set_t *mac_srs, uint_t s_ring_flag)
+mac_srs_soft_rings_quiesce(mac_soft_ring_set_t *mac_srs,
+    const mac_soft_ring_state_t s_ring_flag)
 {
 	mac_soft_ring_t	*softring;
 
@@ -3609,19 +3617,14 @@ mac_srs_soft_rings_quiesce(mac_soft_ring_set_t *mac_srs, uint_t s_ring_flag)
 void
 mac_srs_worker_quiesce(mac_soft_ring_set_t *mac_srs)
 {
-	uint_t			s_ring_flag;
-	uint_t			srs_poll_wait_flag;
+	VERIFY(MUTEX_HELD(&mac_srs->srs_lock));
 
-	ASSERT(MUTEX_HELD(&mac_srs->srs_lock));
-	ASSERT(mac_srs->srs_state & (SRS_CONDEMNED | SRS_QUIESCE));
-
-	if (mac_srs->srs_state & SRS_CONDEMNED) {
-		s_ring_flag = S_RING_CONDEMNED;
-		srs_poll_wait_flag = SRS_POLL_THR_EXITED;
-	} else {
-		s_ring_flag = S_RING_QUIESCE;
-		srs_poll_wait_flag = SRS_POLL_THR_QUIESCED;
-	}
+	VERIFY((mac_srs->srs_state & (SRS_CONDEMNED | SRS_QUIESCE)) != 0);
+	const boolean_t condemn = (mac_srs->srs_state & SRS_CONDEMNED) != 0;
+	const mac_soft_ring_state_t s_ring_flag = condemn ?
+	    S_RING_CONDEMNED : S_RING_QUIESCE;
+	const mac_soft_ring_set_state_t srs_poll_wait_flag = condemn ?
+	    SRS_POLL_THR_EXITED : SRS_POLL_THR_QUIESCED;
 
 	/*
 	 * In the case of Rx SRS wait till the poll thread is done.
@@ -3644,7 +3647,7 @@ mac_srs_worker_quiesce(mac_soft_ring_set_t *mac_srs)
 	 */
 	mac_srs_soft_rings_quiesce(mac_srs, s_ring_flag);
 
-	if (mac_srs->srs_state & SRS_CONDEMNED)
+	if (condemn)
 		mac_srs->srs_state |= (SRS_QUIESCE_DONE | SRS_CONDEMNED_DONE);
 	else
 		mac_srs->srs_state |= SRS_QUIESCE_DONE;
@@ -3659,7 +3662,8 @@ mac_srs_worker_quiesce(mac_soft_ring_set_t *mac_srs)
  * higher level functions.
  */
 void
-mac_srs_signal(mac_soft_ring_set_t *mac_srs, uint_t srs_flag)
+mac_srs_signal(mac_soft_ring_set_t *mac_srs,
+    const mac_soft_ring_set_state_t srs_flag)
 {
 	mac_ring_t	*ring;
 
@@ -3696,7 +3700,8 @@ mac_srs_signal(mac_soft_ring_set_t *mac_srs, uint_t srs_flag)
  * Tx soft rings.
  */
 static void
-mac_srs_soft_rings_signal(mac_soft_ring_set_t *mac_srs, uint_t sr_flag)
+mac_srs_soft_rings_signal(mac_soft_ring_set_t *mac_srs,
+    const mac_soft_ring_state_t sr_flag)
 {
 	mac_soft_ring_t		*softring;
 
@@ -3876,16 +3881,15 @@ mac_tx_srs_add_ring(mac_soft_ring_set_t *mac_srs, mac_ring_t *tx_ring)
 	mac_client_impl_t *mcip = mac_srs->srs_mcip;
 	mac_soft_ring_t *soft_ring;
 	int count = mac_srs->srs_tx_ring_count;
-	uint32_t soft_ring_type = ST_RING_TX;
+	mac_soft_ring_state_t soft_ring_type = 0;
 	uint_t ring_info;
 
 	ASSERT(mac_srs->srs_state & SRS_QUIESCE);
 	ring_info = mac_hwring_getinfo((mac_ring_handle_t)tx_ring);
 	if (mac_tx_serialize || (ring_info & MAC_RING_TX_SERIALIZE))
 		soft_ring_type |= ST_RING_WORKER_ONLY;
-	soft_ring = mac_soft_ring_create(count, 0,
-	    soft_ring_type, maxclsyspri, mcip, mac_srs, -1,
-	    NULL, mcip, (mac_resource_handle_t)tx_ring);
+	soft_ring = mac_soft_ring_create_tx(count, 0, soft_ring_type,
+	    maxclsyspri, mcip, mac_srs, -1, tx_ring);
 	mac_srs->srs_tx_ring_count++;
 	mac_srs_update_fanout_list(mac_srs);
 	/*
@@ -3978,7 +3982,6 @@ mac_tx_srs_setup(mac_client_impl_t *mcip, flow_entry_t *flent)
 	mac_soft_ring_set_t	*tx_srs = flent->fe_tx_srs;
 	int			i;
 	int			tx_ring_count = 0;
-	uint32_t		soft_ring_type;
 	mac_group_t		*grp = NULL;
 	mac_ring_t		*ring;
 	mac_srs_tx_t		*tx = &tx_srs->srs_tx;
@@ -4025,7 +4028,6 @@ no_group:
 				}
 				break;
 			}
-			soft_ring_type = ST_RING_TX;
 			if (tx_srs->srs_type & SRST_BW_CONTROL) {
 				tx->st_mode = is_aggr ?
 				    SRS_TX_BW_AGGR : SRS_TX_BW_FANOUT;
@@ -4034,11 +4036,13 @@ no_group:
 				    SRS_TX_FANOUT;
 			}
 			for (i = 0; i < tx_ring_count; i++) {
-				ASSERT(ring != NULL);
+				VERIFY(ring != NULL);
+				mac_soft_ring_state_t soft_ring_type = 0;
+
 				switch (ring->mr_state) {
 				case MR_INUSE:
 				case MR_FREE:
-					ASSERT(ring->mr_srs == NULL);
+					VERIFY3P(ring->mr_srs, ==, NULL);
 
 					if (ring->mr_state != MR_INUSE)
 						(void) mac_start_ring(ring);
@@ -4049,10 +4053,9 @@ no_group:
 						soft_ring_type |=
 						    ST_RING_WORKER_ONLY;
 					}
-					(void) mac_soft_ring_create(i, 0,
+					(void) mac_soft_ring_create_tx(i, 0,
 					    soft_ring_type, maxclsyspri,
-					    mcip, tx_srs, -1, NULL, mcip,
-					    (mac_resource_handle_t)ring);
+					    mcip, tx_srs, -1, ring);
 					break;
 				default:
 					cmn_err(CE_PANIC,
@@ -4075,7 +4078,7 @@ no_group:
 		    MAC_CAPAB_AGGR, &tx->st_capab_aggr));
 	}
 	DTRACE_PROBE3(tx__srs___setup__return, mac_soft_ring_set_t *, tx_srs,
-	    int, tx->st_mode, int, tx_srs->srs_tx_ring_count);
+	    mac_tx_srs_mode_t, tx->st_mode, int, tx_srs->srs_tx_ring_count);
 }
 
 /*
@@ -4094,8 +4097,8 @@ mac_fanout_recompute_client(mac_client_impl_t *mcip, cpupart_t *cpupart)
 
 	ASSERT(MAC_PERIM_HELD((mac_handle_t)mcip->mci_mip));
 
-	link_speed = mac_client_stat_get(mcip->mci_flent->fe_mcip,
-	    MAC_STAT_IFSPEED);
+	link_speed = mac_client_stat_get(
+	    (mac_client_handle_t)mcip->mci_flent->fe_mcip, MAC_STAT_IFSPEED);
 
 	if ((link_speed != 0) &&
 	    (link_speed != mcip->mci_flent->fe_nic_speed)) {
@@ -4123,7 +4126,7 @@ mac_fanout_recompute_client(mac_client_impl_t *mcip, cpupart_t *cpupart)
 		srs_cpu = &rx_srs->srs_cpu;
 		if (soft_ring_count != srs_cpu->mc_rx_fanout_cnt) {
 			mac_fanout_setup(mcip, flent, mcip_mrp,
-			    mac_rx_deliver, mcip, NULL, cpupart);
+			    mac_rx_deliver, mcip, cpupart);
 		}
 	}
 }

--- a/usr/src/uts/common/io/mac/mac_flow.c
+++ b/usr/src/uts/common/io/mac/mac_flow.c
@@ -23,6 +23,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2018 Joyent, Inc.
+ * Copyright 2026 Oxide Computer Company
  */
 
 #include <sys/strsun.h>
@@ -114,7 +115,7 @@ flow_stat_update(kstat_t *ksp, int rw)
 
 	for (i = 0; i < fep->fe_rx_srs_cnt; i++) {
 		mac_srs = (mac_soft_ring_set_t *)fep->fe_rx_srs[i];
-		if (mac_srs == NULL) 		/* Multicast flow */
+		if (mac_srs == NULL)		/* Multicast flow */
 			break;
 		mac_rx_stat = &mac_srs->srs_rx.sr_stat;
 
@@ -128,7 +129,7 @@ flow_stat_update(kstat_t *ksp, int rw)
 	}
 
 	mac_srs = (mac_soft_ring_set_t *)fep->fe_tx_srs;
-	if (mac_srs == NULL) 		/* Multicast flow */
+	if (mac_srs == NULL)		/* Multicast flow */
 		goto done;
 	mac_tx_stat = &mac_srs->srs_tx.st_stat;
 
@@ -760,20 +761,19 @@ mac_flow_modify(flow_tab_t *ft, flow_entry_t *flent, mac_resource_props_t *mrp)
 		    !(changed_mask & MRP_CPUS) &&
 		    !(mcip_mrp->mrp_mask & MRP_CPUS_USERSPEC)) {
 			mac_fanout_setup(mcip, flent, mcip_mrp,
-			    mac_rx_deliver, mcip, NULL, NULL);
+			    mac_rx_deliver, mcip, NULL);
 		}
 	}
 	if (mrp->mrp_mask & MRP_PRIORITY)
 		mac_flow_update_priority(mcip, flent);
 
 	if (changed_mask & MRP_CPUS)
-		mac_fanout_setup(mcip, flent, mrp, mac_rx_deliver, mcip, NULL,
-		    NULL);
+		mac_fanout_setup(mcip, flent, mrp, mac_rx_deliver, mcip, NULL);
 
 	if (mrp->mrp_mask & MRP_POOL) {
 		pool_lock();
 		cpupart = mac_pset_find(mrp, &use_default);
-		mac_fanout_setup(mcip, flent, mrp, mac_rx_deliver, mcip, NULL,
+		mac_fanout_setup(mcip, flent, mrp, mac_rx_deliver, mcip,
 		    cpupart);
 		mac_set_pool_effective(use_default, cpupart, mrp, emrp);
 		pool_unlock();
@@ -1187,7 +1187,7 @@ mac_rename_flow(flow_entry_t *fep, const char *new_name)
 int
 mac_link_flow_init(mac_client_handle_t mch, flow_entry_t *sub_flow)
 {
-	mac_client_impl_t 	*mcip = (mac_client_impl_t *)mch;
+	mac_client_impl_t	*mcip = (mac_client_impl_t *)mch;
 	mac_impl_t		*mip = mcip->mci_mip;
 	int			err;
 
@@ -1321,7 +1321,7 @@ bail:
 void
 mac_link_flow_clean(mac_client_handle_t mch, flow_entry_t *sub_flow)
 {
-	mac_client_impl_t 	*mcip = (mac_client_impl_t *)mch;
+	mac_client_impl_t	*mcip = (mac_client_impl_t *)mch;
 	mac_impl_t		*mip = mcip->mci_mip;
 	boolean_t		last_subflow;
 
@@ -1439,7 +1439,7 @@ int
 mac_link_flow_modify(char *flow_name, mac_resource_props_t *mrp)
 {
 	flow_entry_t		*flent;
-	mac_client_impl_t 	*mcip;
+	mac_client_impl_t	*mcip;
 	int			err = 0;
 	mac_perim_handle_t	mph;
 	datalink_id_t		linkid;

--- a/usr/src/uts/common/io/mac/mac_sched.c
+++ b/usr/src/uts/common/io/mac/mac_sched.c
@@ -1262,7 +1262,7 @@ int mac_srs_worker_wakeup_ticks = 0;
 	ASSERT(MUTEX_HELD(&(mac_srs)->srs_lock));			\
 	if (!((mac_srs)->srs_state & SRS_PROC) &&			\
 		(mac_srs)->srs_tid == NULL) {				\
-		if (((mac_srs)->srs_state & SRS_LATENCY_OPT) ||		\
+		if (((mac_srs)->srs_type & SRST_LATENCY_OPT) ||		\
 			(mac_srs_worker_wakeup_ticks == 0))		\
 			cv_signal(&(mac_srs)->srs_async);		\
 		else							\
@@ -2435,7 +2435,7 @@ check_again:
 			 * is not running. Check to see if poll thread is
 			 * allowed to process.
 			 */
-			if (mac_srs->srs_state & SRS_LATENCY_OPT) {
+			if (mac_srs->srs_type & SRST_LATENCY_OPT) {
 				mac_srs->srs_drain_func(mac_srs, SRS_POLL_PROC);
 				if (!(mac_srs->srs_state & SRS_PAUSE) &&
 				    srs_rx->sr_poll_pkt_cnt <=
@@ -2640,7 +2640,8 @@ mac_srs_pick_chain(mac_soft_ring_set_t *mac_srs, mblk_t **chain_tail,
  * also apply to mac_rx_srs_drain_bw as well.
  */
 void
-mac_rx_srs_drain(mac_soft_ring_set_t *mac_srs, uint_t proc_type)
+mac_rx_srs_drain(mac_soft_ring_set_t *mac_srs,
+    const mac_soft_ring_set_state_t proc_type)
 {
 	mblk_t			*head;
 	mblk_t			*tail;
@@ -2652,17 +2653,12 @@ mac_rx_srs_drain(mac_soft_ring_set_t *mac_srs, uint_t proc_type)
 	ASSERT(MUTEX_HELD(&mac_srs->srs_lock));
 	ASSERT(!(mac_srs->srs_type & SRST_BW_CONTROL));
 
-	/* If we are blanked i.e. can't do upcalls, then we are done */
-	if (mac_srs->srs_state & (SRS_BLANK | SRS_PAUSE)) {
-		ASSERT((mac_srs->srs_type & SRST_NO_SOFT_RINGS) ||
-		    (mac_srs->srs_state & SRS_PAUSE));
+	if ((mac_srs->srs_state & SRS_PAUSE) != 0 ||
+	    mac_srs->srs_first == NULL) {
 		goto out;
 	}
 
-	if (mac_srs->srs_first == NULL)
-		goto out;
-
-	if (!(mac_srs->srs_state & SRS_LATENCY_OPT) &&
+	if (!(mac_srs->srs_type & SRST_LATENCY_OPT) &&
 	    (srs_rx->sr_poll_pkt_cnt <= srs_rx->sr_lowat)) {
 		/*
 		 * In the normal case, the SRS worker thread does no
@@ -2722,7 +2718,6 @@ again:
 	if (mac_srs->srs_type & SRST_NO_SOFT_RINGS) {
 		mac_direct_rx_t		proc;
 		void			*arg1;
-		mac_resource_handle_t	arg2;
 
 		/*
 		 * This is the case when a Rx is directly
@@ -2732,7 +2727,6 @@ again:
 		 */
 		proc = srs_rx->sr_func;
 		arg1 = srs_rx->sr_arg1;
-		arg2 = srs_rx->sr_arg2;
 
 		mac_srs->srs_state |= SRS_CLIENT_PROC;
 		mutex_exit(&mac_srs->srs_lock);
@@ -2741,15 +2735,14 @@ again:
 			tid = NULL;
 		}
 
-		proc(arg1, arg2, head, NULL);
+		proc(arg1, NULL, head, NULL);
 		/*
 		 * Decrement the size and count here itelf
 		 * since the packet has been processed.
 		 */
 		mutex_enter(&mac_srs->srs_lock);
 		MAC_UPDATE_SRS_COUNT_LOCKED(mac_srs, cnt);
-		if (mac_srs->srs_state & SRS_CLIENT_WAIT)
-			cv_signal(&mac_srs->srs_client_cv);
+
 		mac_srs->srs_state &= ~SRS_CLIENT_PROC;
 	} else {
 		/* Some kind of softrings based fanout is required */
@@ -2770,7 +2763,7 @@ again:
 		mutex_enter(&mac_srs->srs_lock);
 	}
 
-	if (!(mac_srs->srs_state & (SRS_BLANK|SRS_PAUSE)) &&
+	if (((mac_srs->srs_state & SRS_PAUSE) == 0) &&
 	    (mac_srs->srs_first != NULL)) {
 		/*
 		 * More packets arrived while we were clearing the
@@ -2877,7 +2870,8 @@ out:
  * also apply to mac_rx_srs_drain as well.
  */
 void
-mac_rx_srs_drain_bw(mac_soft_ring_set_t *mac_srs, uint_t proc_type)
+mac_rx_srs_drain_bw(mac_soft_ring_set_t *mac_srs,
+    const mac_soft_ring_set_state_t proc_type)
 {
 	mblk_t			*head;
 	mblk_t			*tail;
@@ -2910,10 +2904,7 @@ again:
 	}
 	mutex_exit(&mac_srs->srs_bw->mac_bw_lock);
 
-	/* If we are blanked i.e. can't do upcalls, then we are done */
-	if (mac_srs->srs_state & (SRS_BLANK | SRS_PAUSE)) {
-		ASSERT((mac_srs->srs_type & SRST_NO_SOFT_RINGS) ||
-		    (mac_srs->srs_state & SRS_PAUSE));
+	if ((mac_srs->srs_state & SRS_PAUSE) != 0) {
 		goto done;
 	}
 
@@ -3000,7 +2991,6 @@ again:
 	if (mac_srs->srs_type & SRST_NO_SOFT_RINGS) {
 		mac_direct_rx_t		proc;
 		void			*arg1;
-		mac_resource_handle_t	arg2;
 
 		/*
 		 * This is the case when a Rx is directly
@@ -3010,7 +3000,6 @@ again:
 		 */
 		proc = srs_rx->sr_func;
 		arg1 = srs_rx->sr_arg1;
-		arg2 = srs_rx->sr_arg2;
 
 		mac_srs->srs_state |= SRS_CLIENT_PROC;
 		mutex_exit(&mac_srs->srs_lock);
@@ -3019,7 +3008,7 @@ again:
 			tid = NULL;
 		}
 
-		proc(arg1, arg2, head, NULL);
+		proc(arg1, NULL, head, NULL);
 		/*
 		 * Decrement the size and count here itelf
 		 * since the packet has been processed.
@@ -3028,8 +3017,6 @@ again:
 		MAC_UPDATE_SRS_COUNT_LOCKED(mac_srs, cnt);
 		MAC_UPDATE_SRS_SIZE_LOCKED(mac_srs, sz);
 
-		if (mac_srs->srs_state & SRS_CLIENT_WAIT)
-			cv_signal(&mac_srs->srs_client_cv);
 		mac_srs->srs_state &= ~SRS_CLIENT_PROC;
 	} else {
 		/* Some kind of softrings based fanout is required */
@@ -3483,7 +3470,7 @@ mac_rx_srs_process(void *arg, mac_resource_handle_t srs, mblk_t *mp_chain,
 		 * latency, or if our stack is running deep, we should signal
 		 * the worker thread.
 		 */
-		if (loopback || !(mac_srs->srs_state & SRS_LATENCY_OPT)) {
+		if (loopback || !(mac_srs->srs_type & SRST_LATENCY_OPT)) {
 			/*
 			 * For loopback, We need to let the worker take
 			 * over as we don't want to continue in the same
@@ -4104,9 +4091,9 @@ mac_tx_invoke_callbacks(mac_client_impl_t *mcip, mac_tx_cookie_t cookie)
 	    &mcip->mci_tx_notify_cb_list);
 }
 
-/* ARGSUSED */
 void
-mac_tx_srs_drain(mac_soft_ring_set_t *mac_srs, uint_t proc_type)
+mac_tx_srs_drain(mac_soft_ring_set_t *mac_srs,
+    const mac_soft_ring_set_state_t proc_type __unused)
 {
 	mblk_t			*head, *tail;
 	size_t			sz;
@@ -4381,10 +4368,9 @@ mac_tx_classify(mac_impl_t *mip, mblk_t *mp)
 }
 
 mblk_t *
-mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
+mac_tx_send(mac_client_impl_t *src_mcip, mac_ring_t *ring, mblk_t *mp_chain,
     mac_tx_stats_t *stats)
 {
-	mac_client_impl_t *src_mcip = (mac_client_impl_t *)mch;
 	mac_impl_t *mip = src_mcip->mci_mip;
 	uint_t obytes = 0, opackets = 0, oerrors = 0;
 	mblk_t *mp = NULL, *next;
@@ -4395,7 +4381,7 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 		vid_check = MAC_VID_CHECK_NEEDED(src_mcip);
 		add_tag = MAC_TAG_NEEDED(src_mcip);
 		if (add_tag)
-			vid = mac_client_vid(mch);
+			vid = mac_client_vid((mac_client_handle_t)src_mcip);
 	} else {
 		ASSERT(mip->mi_nclients == 1);
 		vid_check = add_tag = B_FALSE;
@@ -4418,7 +4404,8 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 			    msgdsize(mp));
 
 			CHECK_VID_AND_ADD_TAG(mp);
-			mp = mac_provider_tx(mip, ring, mp, src_mcip);
+			mp = mac_provider_tx(mip, (mac_ring_handle_t)ring, mp,
+			    src_mcip);
 
 			/*
 			 * If the driver is out of descriptors and does a
@@ -4526,7 +4513,8 @@ mac_tx_send(mac_client_handle_t mch, mac_ring_handle_t ring, mblk_t *mp_chain,
 			 * Unknown destination, send via the underlying
 			 * NIC.
 			 */
-			mp = mac_provider_tx(mip, ring, mp, src_mcip);
+			mp = mac_provider_tx(mip, (mac_ring_handle_t)ring,
+			    mp, src_mcip);
 			if (mp != NULL) {
 				/*
 				 * Adjust for the last packet that
@@ -4602,8 +4590,9 @@ mac_tx_srs_get_soft_ring(mac_soft_ring_set_t *srs, mac_ring_t *tx_ring)
  * state field.
  */
 void
-mac_tx_srs_wakeup(mac_soft_ring_set_t *mac_srs, mac_ring_handle_t ring)
+mac_tx_srs_wakeup(mac_soft_ring_set_t *mac_srs, mac_ring_handle_t ring_h)
 {
+	mac_ring_t *ring = (mac_ring_t *)ring_h;
 	int i;
 	mac_soft_ring_t *sringp;
 	mac_srs_tx_t *srs_tx = &mac_srs->srs_tx;
@@ -4746,7 +4735,7 @@ mac_rx_soft_ring_process(mac_client_impl_t *mcip, mac_soft_ring_t *ringp,
 	ringp->s_ring_total_inpkt += cnt;
 	ringp->s_ring_total_rbytes += sz;
 	if ((mac_srs->srs_rx.sr_poll_pkt_cnt <= 1) &&
-	    !(ringp->s_ring_type & ST_RING_WORKER_ONLY)) {
+	    !(ringp->s_ring_state & ST_RING_WORKER_ONLY)) {
 		/* If on processor or blanking on, then enqueue and return */
 		if (ringp->s_ring_state & S_RING_BLANK ||
 		    ringp->s_ring_state & S_RING_PROC) {
@@ -4966,7 +4955,7 @@ mac_tx_soft_ring_process(mac_soft_ring_t *ringp, mblk_t *mp_chain,
 	    mac_srs->srs_tx.st_mode == SRS_TX_AGGR ||
 	    mac_srs->srs_tx.st_mode == SRS_TX_BW_AGGR);
 
-	if (ringp->s_ring_type & ST_RING_WORKER_ONLY) {
+	if (ringp->s_ring_state & ST_RING_WORKER_ONLY) {
 		/* Serialization mode */
 
 		mutex_enter(&ringp->s_ring_lock);

--- a/usr/src/uts/common/io/mac/mac_soft_ring.c
+++ b/usr/src/uts/common/io/mac/mac_soft_ring.c
@@ -142,19 +142,18 @@ mac_soft_ring_worker_wakeup(mac_soft_ring_t *ringp)
 }
 
 /*
- * mac_soft_ring_create
- *
  * Create a soft ring, do the necessary setup and bind the worker
  * thread to the assigned CPU.
  */
-mac_soft_ring_t *
-mac_soft_ring_create(int id, clock_t wait, uint16_t type,
+static mac_soft_ring_t *
+mac_soft_ring_create_i(int id, clock_t wait, const mac_soft_ring_state_t type,
     pri_t pri, mac_client_impl_t *mcip, mac_soft_ring_set_t *mac_srs,
-    processorid_t cpuid, mac_direct_rx_t rx_func, void *x_arg1,
-    mac_resource_handle_t x_arg2)
+    processorid_t cpuid)
 {
 	mac_soft_ring_t		*ringp;
 	char			name[S_RING_NAMELEN];
+
+	VERIFY3U(type & SR_STATE, ==, 0);
 
 	bzero(name, 64);
 	ringp = kmem_cache_alloc(mac_soft_ring_cache, KM_SLEEP);
@@ -186,7 +185,7 @@ mac_soft_ring_create(int id, clock_t wait, uint16_t type,
 	mutex_init(&ringp->s_ring_lock, NULL, MUTEX_DEFAULT, NULL);
 	ringp->s_ring_notify_cb_info.mcbi_lockp = &ringp->s_ring_lock;
 
-	ringp->s_ring_type = type;
+	ringp->s_ring_state = type;
 	ringp->s_ring_wait = MSEC_TO_TICK(wait);
 	ringp->s_ring_mcip = mcip;
 	ringp->s_ring_set = mac_srs;
@@ -206,32 +205,58 @@ mac_soft_ring_create(int id, clock_t wait, uint16_t type,
 	ringp->s_ring_cpuid = ringp->s_ring_cpuid_save = -1;
 	ringp->s_ring_worker = thread_create(NULL, 0,
 	    mac_soft_ring_worker, ringp, 0, &p0, TS_RUN, pri);
-	if (type & ST_RING_TX) {
-		ringp->s_ring_drain_func = mac_tx_soft_ring_drain;
-		ringp->s_ring_tx_arg1 = x_arg1;
-		ringp->s_ring_tx_arg2 = x_arg2;
-		ringp->s_ring_tx_max_q_cnt = mac_tx_soft_ring_max_q_cnt;
-		ringp->s_ring_tx_hiwat =
-		    (mac_tx_soft_ring_hiwat > mac_tx_soft_ring_max_q_cnt) ?
-		    mac_tx_soft_ring_max_q_cnt : mac_tx_soft_ring_hiwat;
-		if (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT) {
-			mac_srs_tx_t *tx = &mac_srs->srs_tx;
-
-			ASSERT(tx->st_soft_rings[
-			    ((mac_ring_t *)x_arg2)->mr_index] == NULL);
-			tx->st_soft_rings[((mac_ring_t *)x_arg2)->mr_index] =
-			    ringp;
-		}
-	} else {
-		ringp->s_ring_drain_func = mac_rx_soft_ring_drain;
-		ringp->s_ring_rx_func = rx_func;
-		ringp->s_ring_rx_arg1 = x_arg1;
-		ringp->s_ring_rx_arg2 = x_arg2;
-		if (mac_srs->srs_state & SRS_SOFTRING_QUEUE)
-			ringp->s_ring_type |= ST_RING_WORKER_ONLY;
-	}
 	if (cpuid != -1)
 		(void) mac_soft_ring_bind(ringp, cpuid);
+
+	return (ringp);
+}
+
+mac_soft_ring_t *
+mac_soft_ring_create_rx(int id, clock_t wait, const mac_soft_ring_state_t type,
+    pri_t pri, mac_client_impl_t *mcip, mac_soft_ring_set_t *mac_srs,
+    processorid_t cpuid, mac_direct_rx_t rx_func, void *x_arg1)
+{
+	VERIFY3U((type & ST_RING_TX), ==, 0);
+
+	mac_soft_ring_t *ringp = mac_soft_ring_create_i(id, wait, type, pri,
+	    mcip, mac_srs, cpuid);
+
+	ringp->s_ring_drain_func = mac_rx_soft_ring_drain;
+	ringp->s_ring_rx_func = rx_func;
+	ringp->s_ring_rx_arg1 = x_arg1;
+	ringp->s_ring_rx_arg2 = NULL;
+	if (mac_srs->srs_type & SRST_ENQUEUE) {
+		ringp->s_ring_state |= ST_RING_WORKER_ONLY;
+	}
+
+	mac_soft_ring_stat_create(ringp);
+
+	return (ringp);
+}
+
+mac_soft_ring_t *
+mac_soft_ring_create_tx(int id, clock_t wait, const mac_soft_ring_state_t type,
+    pri_t pri, mac_client_impl_t *mcip, mac_soft_ring_set_t *mac_srs,
+    processorid_t cpuid, mac_ring_t *ring)
+{
+	VERIFY3U((type & ST_RING_TX), ==, 0);
+	VERIFY(ring != NULL);
+
+	mac_soft_ring_t *ringp = mac_soft_ring_create_i(id, wait,
+	    type | ST_RING_TX, pri, mcip, mac_srs, cpuid);
+
+	ringp->s_ring_drain_func = mac_tx_soft_ring_drain;
+	ringp->s_ring_tx_arg1 = mcip;
+	ringp->s_ring_tx_arg2 = ring;
+	ringp->s_ring_tx_max_q_cnt = mac_tx_soft_ring_max_q_cnt;
+	ringp->s_ring_tx_hiwat =
+	    (mac_tx_soft_ring_hiwat > mac_tx_soft_ring_max_q_cnt) ?
+	    mac_tx_soft_ring_max_q_cnt : mac_tx_soft_ring_hiwat;
+	if (mcip->mci_state_flags & MCIS_IS_AGGR_CLIENT) {
+		mac_srs_tx_t *tx = &mac_srs->srs_tx;
+		VERIFY3P(tx->st_soft_rings[ring->mr_index], ==, NULL);
+		tx->st_soft_rings[ring->mr_index] = ringp;
+	}
 
 	mac_soft_ring_stat_create(ringp);
 
@@ -640,7 +665,7 @@ mac_soft_ring_poll_enable(mac_soft_ring_t *sr, mac_direct_rx_t drx,
 	mac_rx_fifo_t mrf;
 
 	/* Only TCP/IP clients are poll capable at the moment. */
-	VERIFY((sr->s_ring_type & (ST_RING_TCP | ST_RING_TCP6)) != 0);
+	VERIFY((sr->s_ring_state & (ST_RING_TCP | ST_RING_TCP6)) != 0);
 	/* The client resourse callback structure better be set. */
 	VERIFY3P(rcb->mrc_arg, !=, NULL);
 	/* Polling should be configured only once on a given softring. */
@@ -674,7 +699,7 @@ mac_soft_ring_poll_disable(mac_soft_ring_t *sr, mac_resource_cb_t *rcb,
     mac_client_impl_t *mcip)
 {
 	/* Only TCP/IP clients are poll capable at the moment. */
-	VERIFY((sr->s_ring_type & (ST_RING_TCP | ST_RING_TCP6)) != 0);
+	VERIFY((sr->s_ring_state & (ST_RING_TCP | ST_RING_TCP6)) != 0);
 
 	/*
 	 * Remove the IP ring if there is one associated with this
@@ -706,7 +731,8 @@ mac_soft_ring_poll_disable(mac_soft_ring_t *sr, mac_resource_cb_t *rcb,
  * Tx soft rings.
  */
 void
-mac_soft_ring_signal(mac_soft_ring_t *softring, uint_t sr_flag)
+mac_soft_ring_signal(mac_soft_ring_t *softring,
+    const mac_soft_ring_state_t sr_flag)
 {
 	mutex_enter(&softring->s_ring_lock);
 	softring->s_ring_state |= sr_flag;

--- a/usr/src/uts/common/io/mac/mac_stat.c
+++ b/usr/src/uts/common/io/mac/mac_stat.c
@@ -1104,7 +1104,7 @@ mac_soft_ring_stat_create(mac_soft_ring_t *ringp)
 {
 	mac_soft_ring_set_t	*mac_srs = ringp->s_ring_set;
 	flow_entry_t		*flent = ringp->s_ring_mcip->mci_flent;
-	mac_ring_t		*ring = (mac_ring_t *)ringp->s_ring_tx_arg2;
+	mac_ring_t		*ring = ringp->s_ring_tx_arg2;
 	boolean_t		is_tx_srs;
 	char			statname[MAXNAMELEN];
 
@@ -1125,7 +1125,7 @@ mac_soft_ring_stat_create(mac_soft_ring_t *ringp)
 		 * protocol softrings. That is, each set of (TCP/TCP6, UDP/UDP6,
 		 * OTH) softrings counts as a single lane.
 		 */
-		if (ringp->s_ring_type & ST_RING_TCP) {
+		if (ringp->s_ring_state & ST_RING_TCP) {
 			int			index;
 			int			fanout_lane;
 			mac_soft_ring_t		*softring;

--- a/usr/src/uts/common/klm/nlm_rpc_handle.c
+++ b/usr/src/uts/common/klm/nlm_rpc_handle.c
@@ -153,6 +153,37 @@ update_host_rpcbinding(struct nlm_host *hostp, int vers)
 }
 
 /*
+ * If we have a local (src) binding, use it.
+ * See similar in update_host_rpcbinding().
+ */
+static void
+set_bindsrcaddr(struct nlm_host *hostp, nlm_rpc_t *rpcp)
+{
+	struct netbuf *laddr_copy = (struct netbuf *)
+	    kmem_zalloc(sizeof (struct netbuf), KM_SLEEP);
+
+	clnt_dup_netbuf(&hostp->nh_laddr, laddr_copy);
+	struct sockaddr *saddr = (struct sockaddr *)
+	    laddr_copy->buf;
+	if (saddr->sa_family == AF_INET) {
+		struct sockaddr_in *in_addr;
+		in_addr = (struct sockaddr_in *)saddr;
+		in_addr->sin_port = 0;
+	} else if (saddr->sa_family == AF_INET6) {
+		struct sockaddr_in6 *in6_addr;
+		in6_addr = (struct sockaddr_in6 *)saddr;
+		in6_addr->sin6_port = 0;
+	}
+	if (!clnt_control(rpcp->nr_handle, CLSET_BINDSRCADDR,
+	    (char *)laddr_copy)) {
+		cmn_err(CE_WARN, "Unable to set "
+		    "CLSET_BINDSRCADDR\n");
+	}
+	clnt_free_netbuf(laddr_copy);
+	kmem_free(laddr_copy, sizeof (struct netbuf));
+}
+
+/*
  * Refresh RPC handle taken from host handles cache.
  * This function is called when an RPC handle is either
  * uninitialized or was initialized using a binding that's
@@ -185,38 +216,18 @@ refresh_nlm_rpc(struct nlm_host *hostp, nlm_rpc_t *rpcp)
 		    (char *)&clset) == FALSE) {
 			NLM_ERR("Unable to set CLSET_NODELAYONERR\n");
 		}
-		/*
-		 * If we have a local (src) binding, use it.
-		 * See similar in update_host_rpcbinding().
-		 */
-		if ((&hostp->nh_laddr)->buf != NULL) {
-			struct netbuf *laddr_copy = (struct netbuf *)
-			    kmem_zalloc(sizeof (struct netbuf), KM_SLEEP);
-			clnt_dup_netbuf(&hostp->nh_laddr, laddr_copy);
-			struct sockaddr *saddr = (struct sockaddr *)
-			    laddr_copy->buf;
-			if (saddr->sa_family == AF_INET) {
-				struct sockaddr_in *in_addr;
-				in_addr = (struct sockaddr_in *)saddr;
-				in_addr->sin_port = 0;
-			} else if (saddr->sa_family == AF_INET6) {
-				struct sockaddr_in6 *in6_addr;
-				in6_addr = (struct sockaddr_in6 *)saddr;
-				in6_addr->sin6_port = 0;
-			}
-			if (!clnt_control(rpcp->nr_handle, CLSET_BINDSRCADDR,
-			    (char *)laddr_copy)) {
-				cmn_err(CE_WARN, "Unable to set "
-				    "CLSET_BINDSRCADDR\n");
-			}
-			clnt_free_netbuf(laddr_copy);
-			kmem_free(laddr_copy, sizeof (struct netbuf));
+		if (hostp->nh_laddr.buf != NULL) {
+			set_bindsrcaddr(hostp, rpcp);
 		}
 	} else {
 		ret = clnt_tli_kinit(rpcp->nr_handle, &hostp->nh_knc,
 		    &hostp->nh_addr, 0, NLM_RPC_RETRIES, CRED());
 		if (ret == 0) {
 			enum clnt_stat stat;
+
+			if (hostp->nh_laddr.buf != NULL) {
+				set_bindsrcaddr(hostp, rpcp);
+			}
 
 			/*
 			 * Check whether host's RPC binding is still

--- a/usr/src/uts/common/mapfiles/ddi.mapfile
+++ b/usr/src/uts/common/mapfiles/ddi.mapfile
@@ -12,7 +12,7 @@
 #
 # Copyright 2020 Joyent, Inc.
 # Copyright 2020-2024 RackTop Systems, Inc.
-# Copyright 2025 Oxide Computer Company
+# Copyright 2026 Oxide Computer Company
 #
 
 #
@@ -232,6 +232,10 @@ SYMBOL_SCOPE {
 	list_next			{ FLAGS = EXTERN };
 	list_remove			{ FLAGS = EXTERN };
 	list_remove_head		{ FLAGS = EXTERN };
+	membar_consumer			{ FLAGS = EXTERN };
+	membar_enter			{ FLAGS = EXTERN };
+	membar_exit			{ FLAGS = EXTERN };
+	membar_producer			{ FLAGS = EXTERN };
 	memcpy				{ FLAGS = EXTERN };
 	memset				{ FLAGS = EXTERN };
 	miocack				{ FLAGS = EXTERN };

--- a/usr/src/uts/common/sys/mac_client.h
+++ b/usr/src/uts/common/sys/mac_client.h
@@ -23,7 +23,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2019 Joyent, Inc.
- * Copyright 2025 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 /*
@@ -156,7 +156,7 @@ extern mac_notify_handle_t mac_notify_add(mac_handle_t, mac_notify_t, void *);
 extern int mac_notify_remove(mac_notify_handle_t, boolean_t);
 extern void mac_notify_remove_wait(mac_handle_t);
 extern int mac_rename_primary(mac_handle_t, const char *);
-extern	char *mac_client_name(mac_client_handle_t);
+extern char *mac_client_name(mac_client_handle_t);
 
 extern int mac_open(const char *, mac_handle_t *);
 extern void mac_close(mac_handle_t);
@@ -185,8 +185,6 @@ extern mac_tx_notify_handle_t mac_client_tx_notify(mac_client_handle_t,
 extern int mac_client_set_resources(mac_client_handle_t,
     mac_resource_props_t *);
 extern void mac_client_get_resources(mac_client_handle_t,
-    mac_resource_props_t *);
-extern void mac_client_get_eff_resources(mac_client_handle_t,
     mac_resource_props_t *);
 
 /* bridging-related interfaces */

--- a/usr/src/uts/common/sys/mac_client_impl.h
+++ b/usr/src/uts/common/sys/mac_client_impl.h
@@ -58,11 +58,6 @@ typedef struct mac_unicast_impl_s {			/* Protected by */
 	uint16_t			mui_vid;	/* SL */
 } mac_unicast_impl_t;
 
-#define	MAC_CLIENT_FLAGS_PRIMARY		0x0001
-#define	MAC_CLIENT_FLAGS_VNIC_PRIMARY		0x0002
-#define	MAC_CLIENT_FLAGS_MULTI_PRIMARY		0x0004
-#define	MAC_CLIENT_FLAGS_PASSIVE_PRIMARY	0x0008
-
 /*
  * One of these is instantiated per MAC client promiscuous callback.
  *
@@ -100,6 +95,86 @@ typedef union mac_tx_percpu_s {
 #define	pcpu_tx_refcnt	pcpu_lr._pcpu_tx_refcnt
 
 /*
+ * MAC Client type
+ */
+typedef enum {
+	MAC_CLIENT_FLAGS_PRIMARY		= 1 << 0,
+	MAC_CLIENT_FLAGS_VNIC_PRIMARY		= 1 << 1,
+	MAC_CLIENT_FLAGS_MULTI_PRIMARY		= 1 << 2,
+	MAC_CLIENT_FLAGS_PASSIVE_PRIMARY	= 1 << 3,
+} mac_client_flags_t;
+
+/*
+ * MAC Client Implementation State
+ */
+typedef enum {
+	/*
+	 * The client is a VNIC.
+	 */
+	MCIS_IS_VNIC			= 1 << 0,
+	/*
+	 * The client has exclusive control over the MAC, such that it is
+	 * the sole client of the MAC.
+	 */
+	MCIS_EXCLUSIVE			= 1 << 1,
+	/*
+	 * MAC will not add VLAN tags to outgoing traffic. If this flag
+	 * is set it is up to the client to add the correct VLAN tag.
+	 */
+	MCIS_TAG_DISABLE		= 1 << 2,
+	/*
+	 * MAC will not strip the VLAN tags on incoming traffic before
+	 * passing it to mci_rx_fn. This only applies to non-bypass
+	 * traffic.
+	 */
+	MCIS_STRIP_DISABLE		= 1 << 3,
+	/*
+	 * The client represents a port on an aggr.
+	 */
+	MCIS_IS_AGGR_PORT		= 1 << 4,
+	/*
+	 * The client is capable of polling the Rx TCP softrings.
+	 */
+	MCIS_CLIENT_POLL_CAPABLE	= 1 << 5,
+	/*
+	 * This flag is set when the client's link info has been logged
+	 * by the mac_log_linkinfo() timer. This ensures that the
+	 * client's link info is only logged once.
+	 */
+	MCIS_DESC_LOGGED		= 1 << 6,
+	/*
+	 * This client has an HIO share bound to it.
+	 */
+	MCIS_SHARE_BOUND		= 1 << 7,
+	/*
+	 * MAC will not check the VID of the client's Tx traffic.
+	 */
+	MCIS_DISABLE_TX_VID_CHECK	= 1 << 8,
+	/*
+	 * The client is using the same name as its underlying MAC. This
+	 * happens when dlmgmtd is unreachable during client creation.
+	 */
+	MCIS_USE_DATALINK_NAME		= 1 << 9,
+	/*
+	 * The client requires MAC address hardware classification. This
+	 * is only used by sun4v vsw.
+	 */
+	MCIS_UNICAST_HW			= 1 << 10,
+	/*
+	 * The client sits atop an aggr.
+	 */
+	MCIS_IS_AGGR_CLIENT		= 1 << 11,
+	/*
+	 * Do not allow the client to enable DLS bypass.
+	 */
+	MCIS_RX_BYPASS_DISABLE		= 1 << 12,
+	/*
+	 * This client has no MAC unicast addresss associated with it.
+	 */
+	MCIS_NO_UNICAST_ADDR		= 1 << 13,
+} mac_client_state_t;
+
+/*
  * One of these is instantiated for each MAC client.
  */
 struct mac_client_impl_s {			/* Protected by */
@@ -119,7 +194,7 @@ struct mac_client_impl_s {			/* Protected by */
 	 */
 	struct mac_impl_s	*mci_upper_mip;		/* WO */
 
-	uint32_t		mci_state_flags;	/* WO */
+	mac_client_state_t	mci_state_flags;	/* WO */
 	mac_rx_t		mci_rx_fn;		/* Rx Quiescence */
 	void			*mci_rx_arg;		/* Rx Quiescence */
 	mac_direct_rxs_t	mci_direct_rx;		/* SL */
@@ -130,7 +205,7 @@ struct mac_client_impl_s {			/* Protected by */
 	mac_cb_t		*mci_promisc_list;	/* mi_promisc_lock */
 
 	mac_address_t		*mci_unicast;
-	uint32_t		mci_flags;		/* SL */
+	mac_client_flags_t	mci_flags;		/* SL */
 	krwlock_t		mci_rw_lock;
 	mac_unicast_impl_t	*mci_unicast_list;	/* mci_rw_lock */
 
@@ -323,90 +398,6 @@ extern	int	mac_tx_percpu_cnt;
 #define	MAC_TAG_NEEDED(mcip)						\
 	(((mcip)->mci_state_flags & MCIS_TAG_DISABLE) == 0 &&		\
 	(mcip)->mci_nvids == 1)						\
-
-/*
- * MAC Client Implementation State (mci_state_flags)
- *
- * MCIS_IS_VNIC
- *
- *	The client is a VNIC.
- *
- * MCIS_EXCLUSIVE
- *
- *	The client has exclusive control over the MAC, such that it is
- *	the sole client of the MAC.
- *
- * MCIS_TAG_DISABLE
- *
- *	MAC will not add VLAN tags to outgoing traffic. If this flag
- *	is set it is up to the client to add the correct VLAN tag.
- *
- * MCIS_STRIP_DISABLE
- *
- *	MAC will not strip the VLAN tags on incoming traffic before
- *	passing it to mci_rx_fn. This only applies to non-bypass
- *	traffic.
- *
- * MCIS_IS_AGGR_PORT
- *
- *	The client represents a port on an aggr.
- *
- * MCIS_CLIENT_POLL_CAPABLE
- *
- *	The client is capable of polling the Rx TCP/UDP softrings.
- *
- * MCIS_DESC_LOGGED
- *
- *	This flag is set when the client's link info has been logged
- *	by the mac_log_linkinfo() timer. This ensures that the
- *	client's link info is only logged once.
- *
- * MCIS_SHARE_BOUND
- *
- *	This client has an HIO share bound to it.
- *
- * MCIS_DISABLE_TX_VID_CHECK
- *
- *	MAC will not check the VID of the client's Tx traffic.
- *
- * MCIS_USE_DATALINK_NAME
- *
- *	The client is using the same name as its underlying MAC. This
- *	happens when dlmgmtd is unreachable during client creation.
- *
- * MCIS_UNICAST_HW
- *
- *	The client requires MAC address hardware classification. This
- *	is only used by sun4v vsw.
- *
- * MCIS_IS_AGGR_CLIENT
- *
- *	The client sits atop an aggr.
- *
- * MCIS_RX_BYPASS_DISABLE
- *
- *	Do not allow the client to enable DLS bypass.
- *
- * MCIS_NO_UNICAST_ADDR
- *
- *	This client has no MAC unicast addresss associated with it.
- *
- */
-/* MCI state flags */
-#define	MCIS_IS_VNIC			0x0001
-#define	MCIS_EXCLUSIVE			0x0002
-#define	MCIS_TAG_DISABLE		0x0004
-#define	MCIS_STRIP_DISABLE		0x0008
-#define	MCIS_IS_AGGR_PORT		0x0010
-#define	MCIS_CLIENT_POLL_CAPABLE	0x0020
-#define	MCIS_DESC_LOGGED		0x0040
-#define	MCIS_SHARE_BOUND		0x0080
-#define	MCIS_DISABLE_TX_VID_CHECK	0x0100
-#define	MCIS_USE_DATALINK_NAME		0x0200
-#define	MCIS_UNICAST_HW			0x0400
-#define	MCIS_IS_AGGR_CLIENT		0x0800
-#define	MCIS_RX_BYPASS_DISABLE		0x1000
-#define	MCIS_NO_UNICAST_ADDR		0x2000
 
 /* Mac protection flags */
 #define	MPT_FLAG_V6_LOCAL_ADDR_SET	0x0001

--- a/usr/src/uts/common/sys/mac_flow_impl.h
+++ b/usr/src/uts/common/sys/mac_flow_impl.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2026 Oxide Computer Company
  */
 
 #ifndef	_MAC_FLOW_IMPL_H
@@ -155,9 +156,12 @@ extern "C" {
 
 typedef struct flow_entry_s		flow_entry_t;
 typedef struct flow_tab_s		flow_tab_t;
-typedef struct flow_state_s 		flow_state_t;
+typedef struct flow_state_s		flow_state_t;
 struct mac_impl_s;
 struct mac_client_impl_s;
+struct mac_soft_ring_set_s;
+struct mac_group_s;
+struct mac_bcast_grp_s;
 
 /*
  * Classification flags used to lookup the flow.
@@ -180,24 +184,41 @@ typedef enum {
 typedef boolean_t	(*flow_match_fn_t)(flow_tab_t *, flow_entry_t *,
 			    flow_state_t *);
 
-/* fe_flags */
-#define	FE_QUIESCE		0x01	/* Quiesce the flow */
-#define	FE_WAITER		0x02	/* Flow has a waiter */
-#define	FE_FLOW_TAB		0x04	/* Flow is in the flow tab list */
-#define	FE_G_FLOW_HASH		0x08	/* Flow is in the global flow hash */
-#define	FE_INCIPIENT		0x10	/* Being setup */
-#define	FE_CONDEMNED		0x20	/* Being deleted */
-#define	FE_UF_NO_DATAPATH	0x40	/* No datapath setup for User flow */
-#define	FE_MC_NO_DATAPATH	0x80	/* No datapath setup for mac client */
+typedef enum {
+	/* Quiesce the flow */
+	FE_QUIESCE		= 0x01,
+	/* Flow has a waiter */
+	FE_WAITER		= 0x02,
+	/* Flow is in the flow tab list */
+	FE_FLOW_TAB		= 0x04,
+	/* Flow is in the global flow hash */
+	FE_G_FLOW_HASH		= 0x08,
+	/* Being setup */
+	FE_INCIPIENT		= 0x10,
+	/* Being deleted */
+	FE_CONDEMNED		= 0x20,
+	/* No datapath setup for User flow */
+	FE_UF_NO_DATAPATH	= 0x40,
+	/* No datapath setup for mac client */
+	FE_MC_NO_DATAPATH	= 0x80,
+} flow_entry_flags_t;
 
-/* fe_type */
-#define	FLOW_PRIMARY_MAC	0x01 	/* NIC primary MAC address */
-#define	FLOW_VNIC_MAC		0x02	/* VNIC flow */
-#define	FLOW_MCAST		0x04	/* Multicast (and broadcast) */
-#define	FLOW_OTHER		0x08	/* Other flows configured */
-#define	FLOW_USER		0x10	/* User defined flow */
+typedef enum {
+	/* NIC primary MAC address */
+	FLOW_PRIMARY_MAC	= 0x01,
+	/* VNIC flow */
+	FLOW_VNIC_MAC		= 0x02,
+	/* Multicast (and broadcast) */
+	FLOW_MCAST		= 0x04,
+	/* Other flows configured */
+	FLOW_OTHER		= 0x08,
+	/* User defined flow */
+	FLOW_USER		= 0x10,
+	/* Don't create stats for the flow */
+	FLOW_NO_STATS		= 0x20,
+} flow_entry_type_t;
+
 #define	FLOW_VNIC		FLOW_VNIC_MAC
-#define	FLOW_NO_STATS		0x20	/* Don't create stats for the flow */
 
 /*
  * Shared Bandwidth control counters between the soft ring set and its
@@ -228,7 +249,7 @@ typedef struct mac_bw_ctl_s {
 } mac_bw_ctl_t;
 
 struct flow_entry_s {					/* Protected by */
-	struct flow_entry_s	*fe_next;		/* ft_lock */
+	flow_entry_t		*fe_next;		/* ft_lock */
 
 	datalink_id_t		fe_link_id;		/* WO */
 
@@ -264,7 +285,7 @@ struct flow_entry_s {					/* Protected by */
 	 * has refs.
 	 */
 	uint32_t		fe_user_refcnt;		/* fe_lock */
-	uint_t			fe_flags;		/* fe_lock */
+	flow_entry_flags_t	fe_flags;		/* fe_lock */
 
 	/*
 	 * Function/args to invoke for delivering matching packets
@@ -273,33 +294,34 @@ struct flow_entry_s {					/* Protected by */
 	 * be changed.
 	 */
 	flow_fn_t		fe_cb_fn;		/* fe_lock */
-	void 			*fe_cb_arg1;		/* fe_lock */
+	void			*fe_cb_arg1;		/* fe_lock */
 	void			*fe_cb_arg2;		/* fe_lock */
 
 	void			*fe_client_cookie;	/* WO */
-	void			*fe_rx_ring_group;	/* SL */
-	void			*fe_rx_srs[MAX_RINGS_PER_GROUP]; /* fe_lock */
-	int			fe_rx_srs_cnt;		/* fe_lock */
-	void			*fe_tx_ring_group;
-	void			*fe_tx_srs;		/* WO */
-	int			fe_tx_ring_cnt;
+	struct mac_group_s	*fe_rx_ring_group;	/* SL */
+
+							/* fe_lock */
+	struct mac_soft_ring_set_s	*fe_rx_srs[MAX_RINGS_PER_GROUP];
+	uint32_t			fe_rx_srs_cnt;		/* fe_lock */
+	struct mac_group_s		*fe_tx_ring_group;
+	struct mac_soft_ring_set_s	*fe_tx_srs;		/* WO */
 
 	/*
 	 * This is a unicast flow, and is a mac_client_impl_t
 	 */
-	void			*fe_mcip; 		/* WO */
+	struct mac_client_impl_s	*fe_mcip;		/* WO */
 
 	/*
 	 * Used by mci_flent_list of mac_client_impl_t to track flows sharing
 	 * the same mac_client_impl_t.
 	 */
-	struct flow_entry_s	*fe_client_next;
+	flow_entry_t		*fe_client_next;
 
 	/*
 	 * This is a broadcast or multicast flow and is a mac_bcast_grp_t
 	 */
-	void			*fe_mbg;		/* WO */
-	uint_t			fe_type;		/* WO */
+	struct mac_bcast_grp_s	*fe_mbg;		/* WO */
+	flow_entry_type_t	fe_type;		/* WO */
 
 	/*
 	 * BW control info.
@@ -526,15 +548,12 @@ extern void	*mac_flow_get_client_cookie(flow_entry_t *);
 
 extern uint32_t	mac_flow_modify_props(flow_entry_t *, mac_resource_props_t *);
 
-extern int	mac_flow_update(flow_tab_t *, flow_entry_t *, flow_desc_t *);
 extern void	mac_flow_get_desc(flow_entry_t *, flow_desc_t *);
 extern void	mac_flow_set_desc(flow_entry_t *, flow_desc_t *);
 
 extern void	mac_flow_remove(flow_tab_t *, flow_entry_t *, boolean_t);
 extern void	mac_flow_hash_remove(flow_entry_t *);
 extern void	mac_flow_wait(flow_entry_t *, mac_flow_state_t);
-extern void	mac_flow_quiesce(flow_entry_t *);
-extern void	mac_flow_restart(flow_entry_t *);
 extern void	mac_flow_cleanup(flow_entry_t *);
 extern void	mac_flow_destroy(flow_entry_t *);
 
@@ -542,7 +561,6 @@ extern void	mac_flow_tab_create(flow_ops_t *, flow_mask_t, uint_t,
 		    struct mac_impl_s *, flow_tab_t **);
 extern void	mac_flow_l2tab_create(struct mac_impl_s *, flow_tab_t **);
 extern void	mac_flow_tab_destroy(flow_tab_t *);
-extern void	mac_flow_drop(void *, void *, mblk_t *);
 extern void	flow_stat_destroy(flow_entry_t *);
 
 #ifdef	__cplusplus

--- a/usr/src/uts/common/sys/mac_impl.h
+++ b/usr/src/uts/common/sys/mac_impl.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2019 Joyent, Inc.
- * Copyright 2025 Oxide Computer Company
+ * Copyright 2026 Oxide Computer Company
  */
 
 #ifndef	_SYS_MAC_IMPL_H
@@ -676,6 +676,8 @@ typedef struct mac_prop_info_state_s {
 
 typedef struct mac_client_impl_s mac_client_impl_t;
 
+typedef enum mac_soft_ring_set_type mac_soft_ring_set_type_t;
+
 extern void	mac_init(void);
 extern int	mac_fini(void);
 
@@ -696,7 +698,6 @@ extern boolean_t mac_ip_hdr_length_v6(ip6_t *, uint8_t *, uint16_t *,
     uint8_t *, ip6_frag_t **);
 
 extern mblk_t *mac_copymsgchain_cksum(mblk_t *);
-extern void mac_packet_print(mac_handle_t, mblk_t *);
 extern void mac_rx_deliver(void *, mac_resource_handle_t, mblk_t *,
     mac_header_info_t *);
 extern void mac_tx_notify(mac_impl_t *);
@@ -733,8 +734,6 @@ extern int mac_group_addmac(mac_group_t *, const uint8_t *);
 extern int mac_group_remmac(mac_group_t *, const uint8_t *);
 extern int mac_group_addvlan(mac_group_t *, uint16_t);
 extern int mac_group_remvlan(mac_group_t *, uint16_t);
-extern int mac_rx_group_add_flow(mac_client_impl_t *, flow_entry_t *,
-    mac_group_t *);
 extern mblk_t *mac_hwring_tx(mac_ring_handle_t, mblk_t *);
 extern mblk_t *mac_bridge_tx(mac_impl_t *, mac_ring_handle_t, mblk_t *);
 extern mac_group_t *mac_reserve_rx_group(mac_client_impl_t *, uint8_t *,
@@ -753,11 +752,9 @@ extern void mac_rx_switch_grp_to_sw(mac_group_t *);
  * MAC address functions are used internally by MAC layer.
  */
 extern mac_address_t *mac_find_macaddr(mac_impl_t *, uint8_t *);
-extern mac_address_t *mac_find_macaddr_vlan(mac_impl_t *, uint8_t *, uint16_t);
 extern boolean_t mac_check_macaddr_shared(mac_address_t *);
 extern int mac_update_macaddr(mac_address_t *, uint8_t *);
 extern void mac_freshen_macaddr(mac_address_t *, uint8_t *);
-extern void mac_retrieve_macaddr(mac_address_t *, uint8_t *);
 extern void mac_init_macaddr(mac_impl_t *);
 extern void mac_fini_macaddr(mac_impl_t *);
 
@@ -780,16 +777,17 @@ extern void mac_fanout_recompute(mac_impl_t *);
  * add/remove/update flows associated with a mac_impl_t. They should
  * never be used directly by MAC clients.
  */
-extern int mac_datapath_setup(mac_client_impl_t *, flow_entry_t *, uint32_t);
+extern int mac_datapath_setup(mac_client_impl_t *, flow_entry_t *,
+    const mac_soft_ring_set_type_t);
 extern void mac_datapath_teardown(mac_client_impl_t *, flow_entry_t *,
-    uint32_t);
+    const mac_soft_ring_set_type_t);
 extern void mac_rx_srs_group_setup(mac_client_impl_t *, flow_entry_t *,
-    uint32_t);
+    const mac_soft_ring_set_type_t);
 extern void mac_tx_srs_group_setup(mac_client_impl_t *, flow_entry_t *,
-    uint32_t);
+    const mac_soft_ring_set_type_t);
 extern void mac_rx_srs_group_teardown(flow_entry_t *, boolean_t);
 extern void mac_tx_srs_group_teardown(mac_client_impl_t *, flow_entry_t *,
-	    uint32_t);
+    const mac_soft_ring_set_type_t);
 extern int mac_rx_classify_flow_quiesce(flow_entry_t *, void *);
 extern int mac_rx_classify_flow_restart(flow_entry_t *, void *);
 extern void mac_client_quiesce(mac_client_impl_t *);
@@ -914,6 +912,34 @@ typedef struct mac_direct_rxs_s {
 	void		*mdrx_arg_v4;
 	void		*mdrx_arg_v6;
 } mac_direct_rxs_t;
+
+/*
+ * Struct definitions for mac_bcast.c
+ */
+
+/*
+ * The same MAC client may be added for different <addr,vid> tuple,
+ * we maintain a ref count for the number of times it has been added
+ * to account for deleting the MAC client from the group.
+ */
+typedef struct mac_bcast_grp_mcip_s {
+	mac_client_impl_t	*mgb_client;
+	int			mgb_client_ref;
+} mac_bcast_grp_mcip_t;
+
+typedef struct mac_bcast_grp_s {			/* Protected by */
+	struct mac_bcast_grp_s	*mbg_next;		/* SL */
+	void			*mbg_addr;		/* SL */
+	uint16_t		mbg_vid;		/* SL */
+	mac_impl_t		*mbg_mac_impl;		/* WO */
+	mac_addrtype_t		mbg_addrtype;		/* WO */
+	flow_entry_t		*mbg_flow_ent;		/* WO */
+	mac_bcast_grp_mcip_t	*mbg_clients;		/* mi_rw_lock */
+	uint_t			mbg_nclients;		/* mi_rw_lock */
+	uint_t			mbg_nclients_alloc;	/* SL */
+	uint64_t		mbg_clients_gen;	/* mi_rw_lock */
+	uint32_t		mbg_id;			/* atomic */
+} mac_bcast_grp_t;
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/sys/mac_soft_ring.h
+++ b/usr/src/uts/common/sys/mac_soft_ring.h
@@ -57,7 +57,6 @@ typedef void (*mac_soft_ring_drain_func_t)(mac_soft_ring_t *);
 typedef mac_tx_cookie_t (*mac_tx_func_t)(mac_soft_ring_set_t *, mblk_t *,
     uintptr_t, uint16_t, mblk_t **);
 
-
 /* Tx notify callback */
 typedef struct mac_tx_notify_cb_s {
 	mac_cb_t		mtnf_link;	/* Linked list of callbacks */
@@ -65,16 +64,181 @@ typedef struct mac_tx_notify_cb_s {
 	void			*mtnf_arg;	/* Callback function argument */
 } mac_tx_notify_cb_t;
 
+/*
+ * Flagset of immutable and datapath-altered aspects of a softring.
+ *
+ * Flags prefixed by `ST_` identify static characteristics of how a ring should
+ * process packets, whereas those prefixed `S_RING` reflect the current state
+ * of datapath processing.
+ *
+ * Gaps in flag allocation correspond to former flag definitions (such that
+ * existing flags mapped to their historic values). New flags can be placed in
+ * these gaps without issue. See issue 17920.
+ */
+typedef enum {
+	/*
+	 * Packets may only be drained from this softring by its own worker
+	 * thread, and cannot be handled inline by the SRS or its caller..
+	 *
+	 * Immutable.
+	 */
+	ST_RING_WORKER_ONLY	= 1 << 0,
+	/*
+	 * This softring is dedicated to handling TCP/IPv4 traffic when DLS
+	 * bypass is configured.
+	 *
+	 * Immutable.
+	 */
+	ST_RING_TCP		= 1 << 2,
+	/*
+	 * This softring is dedicated to handling UDP/IPv4 traffic when DLS
+	 * bypass is configured.
+	 *
+	 * Immutable.
+	 */
+	ST_RING_UDP		= 1 << 3,
+	/*
+	 * This softring handles all traffic which is ineligible for DLS bypass.
+	 *
+	 * Immutable.
+	 */
+	ST_RING_OTH		= 1 << 4,
+	/*
+	 * If set, this is a transmit softring. Packets will be directed via
+	 * `mac_tx_send` to an underlying provider's ring.
+	 *
+	 * If absent, this is a receive softring. Packets will be delivered to a
+	 * client via `s_ring_rx_func`.
+	 *
+	 * Immutable.
+	 */
+	ST_RING_TX		= 1 << 6,
+	/*
+	 * This softring is dedicated to handling TCP/IPv6 traffic when DLS
+	 * bypass is configured.
+	 *
+	 * Immutable.
+	 */
+	ST_RING_TCP6		= 1 << 7,
+	/*
+	 * This softring is dedicated to handling UDP/IPv6 traffic when DLS
+	 * bypass is configured.
+	 *
+	 * Immutable.
+	 */
+	ST_RING_UDP6		= 1 << 8,
+	/*
+	 * A thread is currently processing packets from this softring, and has
+	 * relinquished its hold on `s_ring_lock` to allow more packets to be
+	 * enqueued while it does so.
+	 *
+	 * Rx/Tx process methods will always enqueue packets if set, with the
+	 * expectation that whoever is draining the thread will continue to
+	 * do so.
+	 */
+	S_RING_PROC		= 1 << 16,
+	/*
+	 * The worker thread of this softring has been bound to a specific CPU.
+	 */
+	S_RING_BOUND		= 1 << 17,
+	/*
+	 * This softring is a TX softring and has run out of descriptors on the
+	 * underlying ring/NIC.
+	 *
+	 * Any outbound packets will be queued until the underlying provider
+	 * marks more descriptors as available via `mac_tx_ring_update`.
+	 */
+	S_RING_BLOCK		= 1 << 18,
+	/*
+	 * This softring is a TX softring and is flow controlled: more than
+	 * `s_ring_tx_hiwat` packets are currently enqueued.
+	 *
+	 * Any outbound packets will be enqueued, and drained by the softring
+	 * worker. Senders will receive a cookie -- they will be informed when
+	 * any cookie is no longer flow controlled if they have registered a
+	 * callback via `mac_client_tx_notify`.
+	 */
+	S_RING_TX_HIWAT		= 1 << 19,
+	/*
+	 * This softring is a TX softring and has returned a cookie to at least
+	 * one sender who has set `MAC_TX_NO_ENQUEUE` regardless of watermark
+	 * state.
+	 *
+	 * When the softring is drained, notify the client via its
+	 * `mac_client_tx_notify` callback that it may send.
+	 */
+	S_RING_WAKEUP_CLIENT	= 1 << 20,
+	/*
+	 * This RX softring is client pollable and its client has called
+	 * `mac_soft_ring_intr_disble` to stop MAC from delivering frames via
+	 * `s_ring_rx_func`.
+	 *
+	 * Packets may _only_ be delivered by client polling. The client may
+	 * undo this using `mac_soft_ring_intr_enable`.
+	 */
+	S_RING_BLANK		= 1 << 21,
+	/*
+	 * Request the thread processing packets to notify a waiting client when
+	 * it is safe to alter the `s_ring_rx_func` callback and its arguments.
+	 */
+	S_RING_CLIENT_WAIT	= 1 << 22,
+	/*
+	 * This softring is marked for deletion.
+	 *
+	 * No further packets can be admitted into the softring, and enqueued
+	 * packets must not be processed.
+	 */
+	S_RING_CONDEMNED	= 1 << 24,
+	/*
+	 * The softring worker has completed any teardown in response to
+	 * `S_RING_CONDEMNED`.
+	 *
+	 * Requires `S_RING_QUIESCE_DONE`.
+	 */
+	S_RING_CONDEMNED_DONE	= 1 << 25,
+	/*
+	 * This softring has been signalled to stop processing any packets.
+	 *
+	 * The presence of this flag implies that the parent SRS has
+	 * *also* been asked to quiesce. It will not enqueue any packets here.
+	 */
+	S_RING_QUIESCE		= 1 << 26,
+	/*
+	 * The softring has ceased processing any enqueued/arriving packets, and
+	 * is awaiting a signal of either `S_RING_CONDEMNED` or `S_RING_RESTART`
+	 * to wake up.
+	 */
+	S_RING_QUIESCE_DONE	= 1 << 27,
+	/*
+	 * The softring has been signalled to resume processing traffic.
+	 *
+	 * The worker thread should unset this and any `QUIESCE` flags and
+	 * resume processing packets.
+	 */
+	S_RING_RESTART		= 1 << 28,
+	/*
+	 * This TX softring has packets enqueued, which the worker thread is
+	 * responsible for draining.
+	 */
+	S_RING_ENQUEUED		= 1 << 29,
+} mac_soft_ring_state_t;
+
+/*
+ * Used to verify whether a given value is allowed to be used as the
+ * `type` of a softring during creation.
+ */
+#define	SR_STATE	0xffff0000
+
 struct mac_soft_ring_s {
 	/* Keep the most used members 64bytes cache aligned */
 	kmutex_t	s_ring_lock;	/* lock before using any member */
-	uint16_t	s_ring_type;	/* processing model of the sq */
-	uint16_t	s_ring_state;	/* state flags and message count */
-	int		s_ring_count;	/* # of mblocks in mac_soft_ring */
+	mac_soft_ring_state_t	s_ring_state;	/* processing model and state */
+	uint32_t	s_ring_count;	/* # of mblocks in mac_soft_ring */
 	size_t		s_ring_size;	/* Size of data queued */
 	mblk_t		*s_ring_first;	/* first mblk chain or NULL */
 	mblk_t		*s_ring_last;	/* last mblk chain or NULL */
 
+	/* Protected by s_ring_lock + !S_RING_PROC */
 	mac_direct_rx_t		s_ring_rx_func;
 	void			*s_ring_rx_arg1;
 	mac_resource_handle_t	s_ring_rx_arg2;
@@ -83,16 +247,17 @@ struct mac_soft_ring_s {
 	 * Threshold after which packets get dropped.
 	 * Is always greater than s_ring_tx_hiwat
 	 */
-	int		s_ring_tx_max_q_cnt;
+	uint32_t	s_ring_tx_max_q_cnt;
 	/* # of mblocks after which to apply flow control */
-	int		s_ring_tx_hiwat;
+	uint32_t	s_ring_tx_hiwat;
 	/* # of mblocks after which to relieve flow control */
-	int		s_ring_tx_lowat;
+	uint32_t	s_ring_tx_lowat;
 	boolean_t	s_ring_tx_woken_up;
 	uint32_t	s_ring_hiwat_cnt;	/* times blocked for Tx descs */
 
-	void		*s_ring_tx_arg1;
-	void		*s_ring_tx_arg2;
+	/* Arguments for `mac_tx_send`, called by `mac_tx_soft_ring_drain` */
+	mac_client_impl_t	*s_ring_tx_arg1;
+	mac_ring_t		*s_ring_tx_arg2;
 
 	/* Tx notify callback */
 	mac_cb_info_t	s_ring_notify_cb_info;		/* cb list info */
@@ -111,7 +276,7 @@ struct mac_soft_ring_s {
 	uint64_t	s_ring_total_inpkt;
 	uint64_t	s_ring_total_rbytes;
 	uint64_t	s_ring_drops;
-	struct mac_client_impl_s *s_ring_mcip;
+	mac_client_impl_t *s_ring_mcip;
 	kstat_t		*s_ring_ksp;
 
 	/* Teardown, poll disable control ops */
@@ -125,15 +290,29 @@ struct mac_soft_ring_s {
 	mac_tx_stats_t	s_st_stat;
 };
 
-typedef void (*mac_srs_drain_proc_t)(mac_soft_ring_set_t *, uint_t);
+/*
+ * soft ring set (SRS) Tx modes
+ */
+typedef enum {
+	SRS_TX_DEFAULT = 0,
+	SRS_TX_SERIALIZE,
+	SRS_TX_FANOUT,
+	SRS_TX_BW,
+	SRS_TX_BW_FANOUT,
+	SRS_TX_AGGR,
+	SRS_TX_BW_AGGR
+} mac_tx_srs_mode_t;
 
 /* Transmit side Soft Ring Set */
 typedef struct mac_srs_tx_s {
-	/* Members for Tx size processing */
-	uint32_t	st_mode;
-	mac_tx_func_t	st_func;
-	void		*st_arg1;
-	void		*st_arg2;
+	/* Members for Tx-side processing */
+	mac_tx_srs_mode_t		st_mode;
+	mac_tx_func_t			st_func;
+
+	/* Arguments for `mac_tx_send` when called within `st_func` */
+	mac_client_impl_t	*st_arg1;
+	mac_ring_t		*st_arg2;
+
 	mac_group_t	*st_group;	/* TX group for share */
 	boolean_t	st_woken_up;
 
@@ -175,16 +354,18 @@ typedef struct mac_srs_tx_s {
 /* Receive side Soft Ring Set */
 typedef struct mac_srs_rx_s {
 	/*
-	 * Upcall Function for fanout, Rx processing etc. Perhaps
-	 * the same 3 members below can be used for Tx
-	 * processing, but looking around, mac_rx_func_t has
-	 * proliferated too much into various files at different
-	 * places. I am leaving the consolidation battle for
-	 * another day.
+	 * Upcall function for Rx processing when `SRST_NO_SOFT_RINGS` is set.
+	 * Rx softring callbacks for non-bypass traffic should use the same
+	 * function and initial argument.
+	 * Argument 2 of `sr_func` would be a client-provided handle, but is
+	 * always `NULL` in this context as SRSes themselves cannot be used as
+	 * part of client polling.
+	 *
+	 * Protected by srs_lock + !SRS_PROC.
 	 */
-	mac_direct_rx_t		sr_func;	/* srs_lock */
-	void			*sr_arg1;	/* srs_lock */
-	mac_resource_handle_t	sr_arg2;	/* srs_lock */
+	mac_direct_rx_t		sr_func;
+	void			*sr_arg1;
+
 	mac_rx_func_t		sr_lower_proc;	/* Atomically changed */
 	uint32_t		sr_poll_pkt_cnt;
 	uint32_t		sr_poll_thres;
@@ -249,6 +430,358 @@ typedef struct mac_srs_rx_s {
 } mac_srs_rx_t;
 
 /*
+ * Flagset of immutable and slowly-varying aspects of a softring set (SRS).
+ *
+ * These identify mainly static characteristics (Tx/Rx, whether the SRS
+ * corresponds to the entrypoint on a MAC client) as well as state on an
+ * administrative timescale (fanout behaviour, bandwidth control).
+ *
+ * See the commentary on `mac_soft_ring_state_t` for commentary on gaps in the
+ * numbering of flags for this type.
+ */
+enum mac_soft_ring_set_type {
+	/*
+	 * The flow entry underpinning this SRS belongs to a MAC client for
+	 * a link.
+	 *
+	 * Immutable.
+	 */
+	SRST_LINK			= 1 << 0,
+	/*
+	 * The flow entry underpinning this SRS belongs to a flow classifier
+	 * attached to a given MAC client.
+	 *
+	 * Immutable.
+	 */
+	SRST_FLOW			= 1 << 1,
+	/*
+	 * This SRS does not have any softrings assigned.
+	 *
+	 * A Tx SRS has no rings and will send packets directly to the NIC,
+	 * and an Rx SRS will handle packets inline via `sr_func`.
+	 *
+	 * Mutable for Tx SRSes.
+	 */
+	SRST_NO_SOFT_RINGS		= 1 << 2,
+	/*
+	 * Set on all Rx SRSes when the tunable `mac_latency_optimize` is
+	 * `true`.
+	 *
+	 * If set, packets may be processed inline by any caller who arrives
+	 * with more packets to enqueue if there is no existing backlog.
+	 * The worker thread will share a CPU binding with the poll thread.
+	 * Wakeups sent to worker threads will be instantaneous (loopback,
+	 * teardown, and bandwidth-controlled cases).
+	 *
+	 * If unset on an Rx SRS, packets may only be moved to softrings by the
+	 * worker thread. `SRST_ENQUEUE` will also be set in this case.
+	 *
+	 * Immutable. Requires !`SRST_TX`.
+	 */
+	SRST_LATENCY_OPT		= 1 << 3,
+	/*
+	 * This Rx SRS has softrings assigned, and has at least one per traffic
+	 * class. Traffic must move to a softring for processing, but may still
+	 * drain inline if the SRS is quiet.
+	 *
+	 * Immutable. Requires !`SRST_TX`. Mutually exclusive with
+	 * `SRST_NO_SOFT_RINGS`.
+	 */
+	SRST_FANOUT_PROTO		= 1 << 4,
+	/*
+	 * This receive SRS has more than one softring for each traffic class,
+	 * and must hash/round-robin received packets amongst a class's rings.
+	 *
+	 * Mutable. Requires !`SRST_TX`.
+	 */
+	SRST_FANOUT_SRC_IP		= 1 << 5,
+	/*
+	 * All softrings will be initialised with `ST_RING_WORKER_ONLY`.
+	 *
+	 * Set when `SRST_LATENCY_OPT` is disabled, or when the underlying ring
+	 * requires `MAC_RING_RX_ENQUEUE` (sun4v).
+	 *
+	 * Immutable. Requires !`SRST_TX`.
+	 */
+	SRST_ENQUEUE			= 1 << 6,
+	/*
+	 * The SRS's client is placed on the default group (either due to
+	 * oversubscription, or the device admits only one group).
+	 *
+	 * A hardware classified ring of this type will receive additional
+	 * traffic when moved into full or all-multicast promiscuous mode.
+	 *
+	 * Mutable. Requires !`SRST_TX`.
+	 */
+	SRST_DEFAULT_GRP		= 1 << 7,
+	/*
+	 * If present, this is a transmit SRS. Otherwise it is a receive SRS.
+	 *
+	 * Transmit SRSes use softrings as mappings to underlying Tx rings
+	 * from the hardware.
+	 *
+	 * The validity of `srs_tx`/`srs_rx` are gated on this flag, as are the
+	 * choice of drain functions, enqueue behaviours, etc.
+	 *
+	 * Immutable.
+	 */
+	SRST_TX				= 1 << 8,
+	/*
+	 * `srs_bw` is enabled, and the queue size and egress rate of this SRS
+	 * are limited accordingly.
+	 *
+	 * Mutable.
+	 */
+	SRST_BW_CONTROL			= 1 << 9,
+	/*
+	 * The SRS's MAC client has had a callback plumbed from IP to allow
+	 * matching IPv4 packets to bypass DLS.
+	 *
+	 * When set, `ST_RING_TCP` and `ST_RING_UDP` must make use of this
+	 * callback. The Rx path will send eligible traffic to these softrings
+	 * in this case.
+	 *
+	 * Mutable under quiescence. Requires !`SRST_TX`.
+	 */
+	SRST_DLS_BYPASS_V4		= 1 << 12,
+	/*
+	 * The SRS's MAC client has had a callback plumbed from IP to allow
+	 * matching IPv6 packets to bypass DLS.
+	 *
+	 * When set, `ST_RING_TCP6` and `ST_RING_UDP6` must make use of this
+	 * callback. The Rx path will send eligible traffic to these softrings
+	 * in this case.
+	 *
+	 * Mutable under quiescence. Requires !`SRST_TX`.
+	 */
+	SRST_DLS_BYPASS_V6		= 1 << 13,
+	/*
+	 * The underlying MAC client has had a `mac_resource_cb_t` plumbed down
+	 * from IP for TCP/IPv4 classified traffic. MAC must inform IP of the
+	 * addition, removal, and other state changes to any `ST_RING_TCP`
+	 * softrings.
+	 *
+	 * Mutable under quiescence. Requires !`SRST_TX`.
+	 */
+	SRST_CLIENT_POLL_V4		= 1 << 14,
+	/*
+	 * The underlying MAC client has had a `mac_resource_cb_t` plumbed down
+	 * from IP for TCP/IPv6 classified traffic. MAC must inform IP of the
+	 * addition, removal, and other state changes to any `ST_RING_TCP6`
+	 * softrings.
+	 *
+	 * Mutable under quiescence. Requires !`SRST_TX`.
+	 */
+	SRST_CLIENT_POLL_V6		= 1 << 15,
+};
+
+/*
+ * Flagset reflecting the current state of datapath processing for a given SRS.
+ *
+ * See the commentary on `mac_soft_ring_state_t` for commentary on gaps in the
+ * numbering of flags for this type.
+ */
+typedef enum {
+	/*
+	 * This SRS's worker thread is explicitly bound to a single CPU.
+	 */
+	SRS_WORKER_BOUND	= 1 << 1,
+	/*
+	 * This Rx SRS's poll thread is explicitly bound to a single CPU.
+	 */
+	SRS_POLL_BOUND		= 1 << 2,
+	/*
+	 * This Rx SRS is created on top of (and has exclusive
+	 * use of) a dedicated ring. When under sufficient load, MAC will
+	 * disable interrupts and pull packets into the SRS by polling the
+	 * NIC/ring, and will set `SRS_POLLING` when this is the case.
+	 *
+	 * This flag may be added/removed as SRSes move between
+	 * hardware/software classification (e.g., if groups must be shared).
+	 */
+	SRS_POLLING_CAPAB	= 1 << 3,
+	/*
+	 * A thread is currently processing packets from this SRS, and
+	 * has relinquished its hold on `srs_lock` to allow more packets to be
+	 * enqueued while it does so.
+	 *
+	 * SRS processing will always enqueue packets if set, with the
+	 * expectation that whoever is draining the thread will continue to
+	 * do so.
+	 *
+	 * Requires qualification of what thread is doing the processing: either
+	 * `SRS_WORKER`, `SRS_PROC_FAST`, or `SRS_POLL_PROC`.
+	 */
+	SRS_PROC		= 1 << 4,
+	/*
+	 * The Rx poll thread should request more packets from the underlying
+	 * device.
+	 *
+	 * Requires `SRS_POLLING`.
+	 */
+	SRS_GET_PKTS		= 1 << 5,
+	/*
+	 * This Rx SRS has been moved into poll mode. Interrupts from
+	 * the underlying device are disabled, and the poll thread is
+	 * exclusively responsible for moving packets into the SRS.
+	 *
+	 * Requires `SRS_POLLING_CAPAB`.
+	 */
+	SRS_POLLING		= 1 << 6,
+	/*
+	 * The SRS worker thread currently holds `SRS_PROC`.
+	 *
+	 * Requires `SRS_PROC`.
+	 */
+	SRS_WORKER		= 1 << 8,
+	/*
+	 * Packets have been enqueued on this TX SRS due to either flow control
+	 * or a lack of Tx descriptors on the NIC.
+	 */
+	SRS_ENQUEUED		= 1 << 9,
+	/*
+	 * `SRS_PROC` is held by the caller of `mac_rx_srs_process` (typically
+	 * the interrupt context) and packets are being processed inline.
+	 *
+	 * Requires `SRS_PROC`.
+	 */
+	SRS_PROC_FAST		= 1 << 11,
+	/*
+	 * The Rx SRS poll thread currently holds `SRS_PROC`.
+	 *
+	 * Requires `SRS_PROC`.
+	 */
+	SRS_POLL_PROC		= 1 << 12,
+	/*
+	 * This Tx SRS has run out of descriptors on the underlying NIC.
+	 *
+	 * Any outbound packets will be queued until the underlying provider
+	 * marks more descriptors as available via `mac_tx_ring_update`.
+	 */
+	SRS_TX_BLOCKED		= 1 << 13,
+	/*
+	 * This Tx SRS is flow controlled: more than `st_hiwat` packets are
+	 * currently enqueued.
+	 *
+	 * Any outbound packets will be enqueued, and drained by the SRS
+	 * worker. Senders will receive a cookie -- they will be informed when
+	 * any cookie is no longer flow controlled if they have registered a
+	 * callback via `mac_client_tx_notify`.
+	 */
+	SRS_TX_HIWAT		= 1 << 14,
+	/*
+	 * This Tx SRS has returned a cookie to at least one sender who has set
+	 * `MAC_TX_NO_ENQUEUE` regardless of watermark state.
+	 *
+	 * When the SRS is drained, notify the client via its
+	 * `mac_client_tx_notify` callback that it may send.
+	 */
+	SRS_TX_WAKEUP_CLIENT	= 1 << 15,
+	/*
+	 * `SRS_PROC` is held by the SRS drain function, which is handling
+	 * packets inline because it is of type `SRST_NO_SOFT_RINGS`.
+	 *
+	 * Requires `SRS_PROC`.
+	 */
+	SRS_CLIENT_PROC		= 1 << 16,
+	/*
+	 * This SRS has been signalled to stop processing any packets.
+	 *
+	 * Downstack entrypoints (rings, flows) which can call into this SRS
+	 * should be quiesced such that no more packets will be enqueued while
+	 * this is set.
+	 *
+	 * The SRS worker thread will propagate the request to any softrings.
+	 */
+	SRS_QUIESCE		= 1 << 18,
+	/*
+	 * The SRS has ceased processing any enqueued packets, the worker thread
+	 * has finished quiescing any softrings and is awaiting a signal
+	 * of either `SRS_CONDEMNED` or `SRS_RESTART` to wake up.
+	 */
+	SRS_QUIESCE_DONE	= 1 << 19,
+	/*
+	 * This SRS is marked for deletion.
+	 *
+	 * Downstack entrypoints (rings, flows) which can call into this SRS
+	 * should be quiesced such that no more packets will be enqueued while
+	 * this is set.
+	 *
+	 * The SRS worker thread will propagate the request to any softrings.
+	 */
+	SRS_CONDEMNED		= 1 << 20,
+	/*
+	 * The SRS worker has completed any teardown in response to
+	 * `SRS_CONDEMNED`.
+	 *
+	 * Requires `SRS_CONDEMNED_DONE`.
+	 */
+	SRS_CONDEMNED_DONE	= 1 << 21,
+	/*
+	 * This Rx SRS's poll thread has quiesced in response to `SRS_QUIESCE`.
+	 */
+	SRS_POLL_THR_QUIESCED	= 1 << 22,
+	/*
+	 * The SRS has been signalled to resume processing traffic.
+	 *
+	 * The worker thread should unset this and any `QUIESCE` flags,
+	 * propagate the request to softrings and the poll thread, and
+	 * resume processing packets.
+	 */
+	SRS_RESTART		= 1 << 23,
+	/*
+	 * The SRS has successfully restarted all of its softrings and poll
+	 * thread, if present.
+	 */
+	SRS_RESTART_DONE	= 1 << 24,
+	/*
+	 * This Rx SRS's worker thread has signalled the poll thread to resume
+	 * in response to `SRS_RESTART`.
+	 */
+	SRS_POLL_THR_RESTART	= 1 << 25,
+	/*
+	 * This SRS is part of the global list `mac_srs_g_list`. Its siblings
+	 * are accessed via `srs_next` and `srs_prev`.
+	 */
+	SRS_IN_GLIST		= 1 << 26,
+	/*
+	 * This Rx SRS's poll thread has terminated in response to
+	 * `SRS_CONDEMN`.
+	 */
+	SRS_POLL_THR_EXITED	= 1 << 27,
+	/*
+	 * This SRS is semi-permanently quiesced, and should not accept
+	 * `SRS_RESTART` requests.
+	 */
+	SRS_QUIESCE_PERM	= 1 << 28,
+} mac_soft_ring_set_state_t;
+
+/*
+ * SRS fanout states.
+ *
+ * These are set during SRS initialisation and by the flow CPU init methods to
+ * indicate whether any work is needing done to adjust the softrings.
+ */
+typedef enum {
+	/*
+	 * This is a new SRS. Softrings have not yet been created.
+	 */
+	SRS_FANOUT_UNINIT = 0,
+	/*
+	 * The SRS's bindings and fanout count match the underlying CPU spec.
+	 */
+	SRS_FANOUT_INIT,
+	/*
+	 * CPU count and/or bindings have changed and the SRS needs to be
+	 * modified accordingly.
+	 */
+	SRS_FANOUT_REINIT
+} mac_srs_fanout_state_t;
+
+typedef void (*mac_srs_drain_proc_t)(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
+
+/*
  * mac_soft_ring_set_s:
  * This is used both for Tx and Rx side. The srs_type identifies Rx or
  * Tx type.
@@ -295,21 +828,25 @@ typedef struct mac_srs_rx_s {
  * a hint passed in mac_tx_srs_process(). Each soft ring, in turn, will
  * be associated with a distinct h/w Tx ring.
  */
-
 struct mac_soft_ring_set_s {
 	/*
 	 * Common elements, common to both Rx and Tx SRS type.
 	 * The following block of fields are protected by srs_lock
 	 */
 	kmutex_t	srs_lock;
-	uint32_t	srs_type;
-	uint32_t	srs_state;	/* state flags */
-	uint32_t	srs_count;
+	mac_soft_ring_set_type_t	srs_type;
+	mac_soft_ring_set_state_t	srs_state;
+
+	/*
+	 * The SRS's packet queue.
+	 */
 	mblk_t		*srs_first;	/* first mblk chain or NULL */
 	mblk_t		*srs_last;	/* last mblk chain or NULL */
+	size_t		srs_size;	/* Size of packets queued in bytes */
+	uint32_t	srs_count;
+
 	kcondvar_t	srs_async;	/* cv for worker thread */
 	kcondvar_t	srs_cv;		/* cv for poll thread */
-	kcondvar_t	srs_quiesce_done_cv;	/* cv for removal */
 	timeout_id_t	srs_tid;	/* timeout id for pending timeout */
 
 	/*
@@ -323,21 +860,24 @@ struct mac_soft_ring_set_s {
 	int		srs_soft_ring_count;
 	int		srs_soft_ring_quiesced_count;
 	int		srs_soft_ring_condemned_count;
+
+	kcondvar_t	srs_quiesce_done_cv;	/* cv for removal */
+
 	mac_soft_ring_t	**srs_tcp_soft_rings;
-	int		srs_tcp_ring_count;
 	mac_soft_ring_t	**srs_udp_soft_rings;
-	int		srs_udp_ring_count;
 	mac_soft_ring_t	**srs_tcp6_soft_rings;
-	int		srs_tcp6_ring_count;
 	mac_soft_ring_t	**srs_udp6_soft_rings;
-	int		srs_udp6_ring_count;
 	mac_soft_ring_t	**srs_oth_soft_rings;
-	int		srs_oth_ring_count;
 	/*
 	 * srs_tx_soft_rings is used by tx_srs in
 	 * when operating in multi tx ring mode.
 	 */
 	mac_soft_ring_t	**srs_tx_soft_rings;
+	int		srs_tcp_ring_count;
+	int		srs_udp_ring_count;
+	int		srs_tcp6_ring_count;
+	int		srs_udp6_ring_count;
+	int		srs_oth_ring_count;
 	int		srs_tx_ring_count;
 
 	/*
@@ -346,7 +886,6 @@ struct mac_soft_ring_set_s {
 	 * Following protected by srs_lock
 	 */
 	mac_bw_ctl_t	*srs_bw;
-	size_t		srs_size;	/* Size of packets queued in bytes */
 	pri_t		srs_pri;
 
 	mac_soft_ring_set_t	*srs_next;	/* mac_srs_g_lock */
@@ -365,12 +904,9 @@ struct mac_soft_ring_set_s {
 	 * The following blocks are write once (WO) and valid for the life
 	 * of the SRS
 	 */
-	struct mac_client_impl_s *srs_mcip;	/* back ptr to mac client */
-	void			*srs_flent;	/* back ptr to flent */
-	mac_ring_t		*srs_ring;	/*  Ring Descriptor */
-
-	/* Teardown, disable control ops */
-	kcondvar_t	srs_client_cv;	/* Client wait for the control op */
+	mac_client_impl_t *srs_mcip;	/* back ptr to mac client */
+	flow_entry_t	*srs_flent;	/* back ptr to flent */
+	mac_ring_t	*srs_ring;	/*  Ring Descriptor */
 
 	kthread_t	*srs_worker;	/* WO, worker thread */
 	kthread_t	*srs_poll_thr;	/* WO, poll thread */
@@ -380,7 +916,7 @@ struct mac_soft_ring_set_s {
 	processorid_t	srs_worker_cpuid_save;	/* saved cpuid during offline */
 	processorid_t	srs_poll_cpuid;		/* processor to bind to */
 	processorid_t	srs_poll_cpuid_save;	/* saved cpuid during offline */
-	uint_t		srs_fanout_state;
+	mac_srs_fanout_state_t	srs_fanout_state;
 	mac_cpus_t	srs_cpu;
 
 	mac_srs_rx_t	srs_rx;
@@ -389,110 +925,28 @@ struct mac_soft_ring_set_s {
 };
 
 /*
- * type flags - combination allowed to process and drain the queue
- */
-#define	ST_RING_WORKER_ONLY	0x0001	/* Worker thread only */
-#define	ST_RING_ANY		0x0002	/* Any thread can process the queue */
-#define	ST_RING_TCP		0x0004
-#define	ST_RING_UDP		0x0008
-#define	ST_RING_OTH		0x0010
-#define	ST_RING_TX		0x0040
-
-#define	ST_RING_TCP6		0x0080
-#define	ST_RING_UDP6		0x0100
-
-/*
  * The total number of softring protocol lanes: TCP, TCP6, UDP, UDP6, OTH.
  */
 #define	ST_RING_NUM_PROTO	5
-
-/*
- * State flags.
- */
-#define	S_RING_PROC		0x0001	/* being processed */
-#define	S_RING_BOUND		0x0002	/* Worker thread is bound to a cpu */
-#define	S_RING_BLOCK		0x0004	/* No Tx descs */
-#define	S_RING_TX_HIWAT		0x0008	/* Tx high watermark reached */
-
-#define	S_RING_WAKEUP_CLIENT	0x0010	/* flow ctrl, client wakeup needed */
-#define	S_RING_BLANK		0x0020	/* Has been put into polling mode */
-#define	S_RING_CLIENT_WAIT	0x0040	/* Client waiting for control op */
-
-#define	S_RING_CONDEMNED	0x0100	/* Being torn down */
-#define	S_RING_CONDEMNED_DONE	0x0200	/* Being torn down */
-#define	S_RING_QUIESCE		0x0400	/* No traffic flow, transient flag */
-#define	S_RING_QUIESCE_DONE	0x0800	/* No traffic flow, transient flag */
-
-#define	S_RING_RESTART		0x1000	/* Go back to normal traffic flow */
-#define	S_RING_ENQUEUED		0x2000	/* Pkts enqueued in Tx soft ring */
 
 /*
  * arguments for processors to bind to
  */
 #define	S_RING_BIND_NONE	-1
 
-#define	SRST_LINK		0x00000001
-#define	SRST_FLOW		0x00000002
-#define	SRST_NO_SOFT_RINGS	0x00000004
-#define	SRST_TCP_ONLY		0x00000008
-
-#define	SRST_FANOUT_PROTO	0x00000010
-#define	SRST_FANOUT_SRC_IP	0x00000020
-#define	SRST_FANOUT_OTH		0x00000040
-#define	SRST_DEFAULT_GRP	0x00000080
-
-#define	SRST_TX			0x00000100
-#define	SRST_BW_CONTROL		0x00000200
-#define	SRST_DIRECT_POLL	0x00000400
-
-#define	SRST_DLS_BYPASS_V4	0x00001000
-#define	SRST_DLS_BYPASS_V6	0x00002000
-#define	SRST_CLIENT_POLL_V4	0x00004000
-#define	SRST_CLIENT_POLL_V6	0x00008000
-
 /*
  * soft ring set flags. These bits are dynamic in nature and get
  * applied to srs_state. They reflect the state of SRS at any
  * point of time
  */
-#define	SRS_BLANK		0x00000001
-#define	SRS_WORKER_BOUND	0x00000002
-#define	SRS_POLL_BOUND		0x00000004
-#define	SRS_POLLING_CAPAB	0x00000008
 
-#define	SRS_PROC		0x00000010
-#define	SRS_GET_PKTS		0x00000020
-#define	SRS_POLLING		0x00000040
-#define	SRS_BW_ENFORCED		0x00000080
-
-#define	SRS_WORKER		0x00000100
-#define	SRS_ENQUEUED		0x00000200
-#define	SRS_ANY_PROCESS		0x00000400
-#define	SRS_PROC_FAST		0x00000800
-
-#define	SRS_POLL_PROC		0x00001000
-#define	SRS_TX_BLOCKED		0x00002000	/* out of Tx descs */
-#define	SRS_TX_HIWAT		0x00004000	/* Tx count exceeds hiwat */
-#define	SRS_TX_WAKEUP_CLIENT	0x00008000	/* Flow-ctl: wakeup client */
-
-#define	SRS_CLIENT_PROC		0x00010000
-#define	SRS_CLIENT_WAIT		0x00020000
-#define	SRS_QUIESCE		0x00040000
-#define	SRS_QUIESCE_DONE	0x00080000
-
-#define	SRS_CONDEMNED		0x00100000
-#define	SRS_CONDEMNED_DONE	0x00200000
-#define	SRS_POLL_THR_QUIESCED	0x00400000
-#define	SRS_RESTART		0x00800000
-
-#define	SRS_RESTART_DONE	0x01000000
-#define	SRS_POLL_THR_RESTART	0x02000000
-#define	SRS_IN_GLIST		0x04000000
-#define	SRS_POLL_THR_EXITED	0x08000000
-
-#define	SRS_QUIESCE_PERM	0x10000000
-#define	SRS_LATENCY_OPT		0x20000000
-#define	SRS_SOFTRING_QUEUE	0x40000000
+/*
+ * This flag pertains to `mac_bw_ctl_t` (mac_flow_impl.h), and should not live
+ * here.
+ *
+ * See illumos#17917.
+ */
+#define	SRS_BW_ENFORCED		1
 
 #define	SRS_QUIESCED(srs)	(srs->srs_state & SRS_QUIESCE_DONE)
 
@@ -501,28 +955,6 @@ struct mac_soft_ring_set_s {
  * able to be restarted.
  */
 #define	SRS_QUIESCED_PERMANENT(srs)	(srs->srs_state & SRS_QUIESCE_PERM)
-
-/*
- * soft ring set (SRS) Tx modes
- */
-typedef enum {
-	SRS_TX_DEFAULT = 0,
-	SRS_TX_SERIALIZE,
-	SRS_TX_FANOUT,
-	SRS_TX_BW,
-	SRS_TX_BW_FANOUT,
-	SRS_TX_AGGR,
-	SRS_TX_BW_AGGR
-} mac_tx_srs_mode_t;
-
-/*
- * SRS fanout states
- */
-typedef enum {
-	SRS_FANOUT_UNINIT = 0,
-	SRS_FANOUT_INIT,
-	SRS_FANOUT_REINIT
-} mac_srs_fanout_state_t;
 
 /*
  * Structure for dls statistics
@@ -642,13 +1074,10 @@ extern struct dls_kstats dls_kstat;
 extern void mac_soft_ring_init(void);
 extern void mac_soft_ring_finish(void);
 extern void mac_fanout_setup(mac_client_impl_t *, flow_entry_t *,
-    mac_resource_props_t *, mac_direct_rx_t, void *, mac_resource_handle_t,
-    cpupart_t *);
+    mac_resource_props_t *, mac_direct_rx_t, void *, cpupart_t *);
 
 extern void mac_soft_ring_worker_wakeup(mac_soft_ring_t *);
-extern void mac_soft_ring_blank(void *, time_t, uint_t, int);
 extern mblk_t *mac_soft_ring_poll(mac_soft_ring_t *, size_t);
-extern void mac_soft_ring_destroy(mac_soft_ring_t *);
 extern void mac_soft_ring_dls_bypass_enable(mac_soft_ring_t *, mac_direct_rx_t,
     void *);
 extern void mac_soft_ring_dls_bypass_disable(mac_soft_ring_t *,
@@ -658,36 +1087,33 @@ extern void mac_soft_ring_poll_enable(mac_soft_ring_t *, mac_direct_rx_t,
 extern void mac_soft_ring_poll_disable(mac_soft_ring_t *, mac_resource_cb_t *,
     mac_client_impl_t *);
 
-/* Rx SRS */
-extern mac_soft_ring_set_t *mac_srs_create(struct mac_client_impl_s *,
-    flow_entry_t *, uint32_t, mac_direct_rx_t, void *, mac_resource_handle_t,
-    mac_ring_t *);
+/* SRS */
 extern void mac_srs_free(mac_soft_ring_set_t *);
-extern void mac_srs_signal(mac_soft_ring_set_t *, uint_t);
-extern cpu_t *mac_srs_bind(mac_soft_ring_set_t *, processorid_t);
+extern void mac_srs_signal(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
+
 extern void mac_rx_srs_retarget_intr(mac_soft_ring_set_t *, processorid_t);
 extern void mac_tx_srs_retarget_intr(mac_soft_ring_set_t *);
 
-extern void mac_srs_quiesce_initiate(mac_soft_ring_set_t *);
-extern void mac_srs_client_poll_enable(struct mac_client_impl_s *,
+extern void mac_srs_client_poll_enable(mac_client_impl_t *,
     mac_soft_ring_set_t *, boolean_t);
-extern void mac_srs_client_poll_disable(struct mac_client_impl_s *,
+extern void mac_srs_client_poll_disable(mac_client_impl_t *,
     mac_soft_ring_set_t *, boolean_t);
-extern void mac_srs_client_poll_quiesce(struct mac_client_impl_s *,
+extern void mac_srs_client_poll_quiesce(mac_client_impl_t *,
     mac_soft_ring_set_t *);
-extern void mac_srs_client_poll_restart(struct mac_client_impl_s *,
+extern void mac_srs_client_poll_restart(mac_client_impl_t *,
     mac_soft_ring_set_t *);
-extern void mac_rx_srs_quiesce(mac_soft_ring_set_t *, uint_t);
+extern void mac_rx_srs_quiesce(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
 extern void mac_rx_srs_restart(mac_soft_ring_set_t *);
-extern void mac_rx_srs_subflow_process(void *, mac_resource_handle_t, mblk_t *,
-    boolean_t);
-extern void mac_tx_srs_quiesce(mac_soft_ring_set_t *, uint_t);
+extern void mac_tx_srs_quiesce(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
 
 /* Tx SRS, Tx softring */
 extern void mac_tx_srs_wakeup(mac_soft_ring_set_t *, mac_ring_handle_t);
-extern void mac_tx_srs_setup(struct mac_client_impl_s *, flow_entry_t *);
+extern void mac_tx_srs_setup(mac_client_impl_t *, flow_entry_t *);
 extern mac_tx_func_t mac_tx_get_func(uint32_t);
-extern mblk_t *mac_tx_send(mac_client_handle_t, mac_ring_handle_t, mblk_t *,
+extern mblk_t *mac_tx_send(mac_client_impl_t *, mac_ring_t *, mblk_t *,
     mac_tx_stats_t *);
 extern boolean_t mac_tx_srs_ring_present(mac_soft_ring_set_t *, mac_ring_t *);
 extern mac_soft_ring_t *mac_tx_srs_get_soft_ring(mac_soft_ring_set_t *,
@@ -698,39 +1124,44 @@ extern mac_tx_cookie_t mac_tx_srs_no_desc(mac_soft_ring_set_t *, mblk_t *,
     uint16_t, mblk_t **);
 
 /* Subflow specific stuff */
-extern int mac_srs_flow_create(struct mac_client_impl_s *, flow_entry_t *,
-    mac_resource_props_t *, int, int, mac_direct_rxs_t *);
 extern void mac_srs_update_bwlimit(flow_entry_t *, mac_resource_props_t *);
-extern void mac_srs_adjust_subflow_bwlimit(struct mac_client_impl_s *);
-extern void mac_srs_update_drv(struct mac_client_impl_s *);
 extern void mac_update_srs_priority(mac_soft_ring_set_t *, pri_t);
 extern void mac_client_update_classifier(mac_client_impl_t *, boolean_t);
+extern void mac_rx_srs_subflow_process(void *, mac_resource_handle_t, mblk_t *,
+    boolean_t);
 
+/* Resource callbacks for clients */
 extern int mac_soft_ring_intr_enable(void *);
 extern boolean_t mac_soft_ring_intr_disable(void *);
-extern mac_soft_ring_t *mac_soft_ring_create(int, clock_t, uint16_t,
-    pri_t, mac_client_impl_t *, mac_soft_ring_set_t *,
-    processorid_t, mac_direct_rx_t, void *, mac_resource_handle_t);
 extern cpu_t *mac_soft_ring_bind(mac_soft_ring_t *, processorid_t);
-	extern void mac_soft_ring_unbind(mac_soft_ring_t *);
+extern void mac_soft_ring_unbind(mac_soft_ring_t *);
+
+extern mac_soft_ring_t *mac_soft_ring_create_rx(int, clock_t,
+    const mac_soft_ring_state_t, pri_t, mac_client_impl_t *,
+    mac_soft_ring_set_t *, processorid_t, mac_direct_rx_t, void *);
+extern mac_soft_ring_t *mac_soft_ring_create_tx(int, clock_t,
+    const mac_soft_ring_state_t, pri_t, mac_client_impl_t *,
+    mac_soft_ring_set_t *, processorid_t, mac_ring_t *);
 extern void mac_soft_ring_free(mac_soft_ring_t *);
-extern void mac_soft_ring_signal(mac_soft_ring_t *, uint_t);
+extern void mac_soft_ring_signal(mac_soft_ring_t *,
+    const mac_soft_ring_state_t);
 extern void mac_rx_soft_ring_process(mac_client_impl_t *, mac_soft_ring_t *,
     mblk_t *, mblk_t *, int, size_t);
 extern mac_tx_cookie_t mac_tx_soft_ring_process(mac_soft_ring_t *,
     mblk_t *, uint16_t, mblk_t **);
 extern void mac_srs_worker_quiesce(mac_soft_ring_set_t *);
 extern void mac_srs_worker_restart(mac_soft_ring_set_t *);
-extern void mac_rx_attach_flow_srs(mac_impl_t *, flow_entry_t *,
-    mac_soft_ring_set_t *, mac_ring_t *, mac_classify_type_t);
 
-extern void mac_rx_srs_drain_bw(mac_soft_ring_set_t *, uint_t);
-extern void mac_rx_srs_drain(mac_soft_ring_set_t *, uint_t);
+extern void mac_rx_srs_drain_bw(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
+extern void mac_rx_srs_drain(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
 extern void mac_rx_srs_process(void *, mac_resource_handle_t, mblk_t *,
     boolean_t);
 extern void mac_srs_worker(mac_soft_ring_set_t *);
 extern void mac_rx_srs_poll_ring(mac_soft_ring_set_t *);
-extern void mac_tx_srs_drain(mac_soft_ring_set_t *, uint_t);
+extern void mac_tx_srs_drain(mac_soft_ring_set_t *,
+    const mac_soft_ring_set_state_t);
 
 extern void mac_tx_srs_restart(mac_soft_ring_set_t *);
 extern void mac_rx_srs_remove(mac_soft_ring_set_t *);

--- a/usr/src/uts/i86pc/os/fakebop.c
+++ b/usr/src/uts/i86pc/os/fakebop.c
@@ -28,6 +28,7 @@
  *
  * Copyright 2020 Joyent, Inc.
  * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 Edgecast Cloud LLC.
  */
 
 /*
@@ -1319,7 +1320,7 @@ static struct bop_blacklist {
 	int bl_name_len;
 } bop_prop_blacklist[] = {
 	{ "ISADIR", sizeof ("ISADIR") },
-	{ "acpi", sizeof ("acpi") },
+	{ "acpi.", sizeof ("acpi.") },
 	{ "autoboot_delay", sizeof ("autoboot_delay") },
 	{ "beansi_", sizeof ("beansi_") },
 	{ "beastie", sizeof ("beastie") },
@@ -1344,7 +1345,7 @@ static struct bop_blacklist {
 	{ "optionstoggled_", sizeof ("optionstoggled_") },
 	{ "pcibios", sizeof ("pcibios") },
 	{ "prompt", sizeof ("prompt") },
-	{ "smbios", sizeof ("smbios") },
+	{ "smbios.", sizeof ("smbios.") },
 	{ "tem", sizeof ("tem") },
 	{ "twiddle_divisor", sizeof ("twiddle_divisor") },
 	{ "zfs_be", sizeof ("zfs_be") },
@@ -1450,6 +1451,27 @@ process_boot_environment(struct boot_modules *benv)
 		}
 		if (strcmp(name, "boot.nfsroot.path") == 0) {
 			bsetprops(BP_SERVER_PATH, value);
+			continue;
+		}
+
+		if (strcmp(name, "acpi-root-tab") == 0) {
+			uint64_t i64;
+			if (parse_value(value, &i64) == 0)
+				bsetprop64(name, i64);
+			continue;
+		}
+
+		if (strcmp(name, "smbios-address") == 0) {
+			uint64_t i64;
+			if (parse_value(value, &i64) == 0)
+				bsetprop64(name, i64);
+			continue;
+		}
+
+		if (strcmp(name, "efi-systab") == 0) {
+			uint64_t i64;
+			if (parse_value(value, &i64) == 0)
+				bsetprop64(name, i64);
 			continue;
 		}
 
@@ -2919,20 +2941,25 @@ build_firmware_properties(struct xboot_info *xbp)
 
 #ifndef __xpv
 	if (xbp->bi_uefi_arch == XBI_UEFI_ARCH_64) {
-		bsetprops("efi-systype", "64");
-		bsetprop64("efi-systab",
-		    (uint64_t)(uintptr_t)xbp->bi_uefi_systab);
+		if (do_bsys_getproplen(NULL, "efi-systype") == -1)
+			bsetprops("efi-systype", "64");
+		if (do_bsys_getproplen(NULL, "efi-systab") == -1)
+			bsetprop64("efi-systab",
+			    (uint64_t)(uintptr_t)xbp->bi_uefi_systab);
 		if (kbm_debug)
 			bop_printf(NULL, "64-bit UEFI detected.\n");
 	} else if (xbp->bi_uefi_arch == XBI_UEFI_ARCH_32) {
-		bsetprops("efi-systype", "32");
-		bsetprop64("efi-systab",
-		    (uint64_t)(uintptr_t)xbp->bi_uefi_systab);
+		if (do_bsys_getproplen(NULL, "efi-systype") == -1)
+			bsetprops("efi-systype", "32");
+		if (do_bsys_getproplen(NULL, "efi-systab") == -1)
+			bsetprop64("efi-systab",
+			    (uint64_t)(uintptr_t)xbp->bi_uefi_systab);
 		if (kbm_debug)
 			bop_printf(NULL, "32-bit UEFI detected.\n");
 	}
 
-	if (xbp->bi_smbios != NULL) {
+	if (xbp->bi_smbios != NULL &&
+	    do_bsys_getproplen(NULL, "smbios-address") == -1) {
 		bsetprop64("smbios-address",
 		    (uint64_t)(uintptr_t)xbp->bi_smbios);
 	}


### PR DESCRIPTION
Weekly merge from illumos-gate

## Backports

* none

## onu

```
OmniOS r151057  omnios-upstream_merge-2026032801-f5f97319e7a    March 2026
illumos development build: 2026-Mar-28 [illumos-omnios]
hadfl@nemesis:~$ uname -a
SunOS nemesis 5.11 omnios-upstream_merge-2026032801-f5f97319e7a i86pc i386 i86pc
```

## mail_msg
```
==== Nightly distributed build started:   Sat Mar 28 13:28:31 UTC 2026 ====
==== Nightly distributed build completed: Sat Mar 28 14:05:19 UTC 2026 ====

==== Total build time ====

real    0:36:47

==== Build environment ====

/usr/bin/uname
SunOS nemesis 5.11 omnios-master-4c3af994d63 i86pc i386 i86pc

/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 24

cw version 10.0
primary: /opt/gcc-10/bin/gcc
gcc (OmniOS 151057/10.5.0-il-2) 10.5.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /opt/gcc-14/bin/gcc
gcc (OmniOS 151057/14.3.0-il-1) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /build/illumos-omnios/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/usr/jdk/openjdk17.0/bin/javac
openjdk full version "17.0.17+10-omnios-151057"

/usr/bin/openssl
OpenSSL 3.6.1 27 Jan 2026 (Library: OpenSSL 3.6.1 27 Jan 2026)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   135

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

omnios-upstream_merge-2026032801-f5f97319e7a

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real    14:29.9
user  3:53:09.4
sys   1:21:21.8

==== Build noise differences (non-DEBUG) ====


==== package build errors (non-DEBUG) ====


==== Build errors (DEBUG) ====


==== Build warnings (DEBUG) ====


==== Elapsed build time (DEBUG) ====

real    13:18.5
user  3:38:53.0
sys   1:18:18.2

==== Build noise differences (DEBUG) ====


==== package build errors (DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====


==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====
```