### PR TITLE
Publish all packages from a build with a shared timestamp

### DIFF
--- a/usr/src/pkg/Makefile
+++ b/usr/src/pkg/Makefile
@@ -24,7 +24,7 @@
 # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2015 Igor Kozhukhov <ikozhukhov@gmail.com>
 # Copyright 2016 RackTop Systems.
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
 # Copyright 2020 Peter Tribble
 #
 
@@ -143,6 +143,16 @@ PKGVERS_BRANCH= $(ONNV_BUILDNUM).0
 PKGVERS= $(PKGVERS_COMPONENT),$(PKGVERS_BUILTON)-$(PKGVERS_BRANCH)
 
 #
+# All packages published by a single build share one timestamp so that
+# they carry a single version string. The value may be provided in the
+# environment so that separate make invocations can share it; by
+# default it is generated once per invocation. It is applied to
+# pkg.fmri by the final transforms, after dependency generation, so
+# that generated depend actions do not embed it.
+#
+PKGVERS_TIMESTAMP :sh= echo ${PKGVERS_TIMESTAMP:-`date -u +%Y%m%dT%H%M%SZ`}
+
+#
 # The ARCH32 and ARCH64 macros are used in the manifests to express
 # architecture-specific subdirectories in the installation paths
 # for isaexec'd commands.
@@ -165,7 +175,7 @@ i386_ARCH64= amd64
 #
 PM_TRANSFORMS= common_actions publish restart_fmri facets defaults \
 	extract_metadata
-PM_FINAL_TRANSFORMS= strip_dependinfo
+PM_FINAL_TRANSFORMS= strip_dependinfo timestamp
 PM_INC= transforms manifests
 
 JAVA_8_ONLY=
@@ -568,6 +578,7 @@ $(PDIR)/%.fin: $(PDIR)/%.res
 	$(PKGDEBUG)if [ -s $(<) ]; then \
 		print "Running final transforms for $(<F)"; \
 		$(PKGMOGRIFY) $(PKGMOG_VERBOSE) $(PM_INC:%= -I %) -O $(@) \
+		    -D PKGVERS_TIMESTAMP=$(PKGVERS_TIMESTAMP) \
 		    $(<) $(PM_FINAL_TRANSFORMS); \
 	else \
 		$(TOUCH) $(@); \
@@ -578,7 +589,8 @@ $(PDIR)/%.pub: $(PDIR)/%.fin
 	r=$${m#$(@F:%.pub=%.metadata.)+(?).}; \
 	if [ -s $(<) ]; then \
 		print "Publishing $(@F:%.pub=%) to $$r repository"; \
-		pkgsend -s file://$(PKGDEST)/repo.$$r publish \
+		pkgsend -D allow-timestamp \
+		    -s file://$(PKGDEST)/repo.$$r publish \
 		    -d $(PKGROOT) -d $(TOOLSROOT) \
 		    -d license_files -d $(PKGROOT)/licenses \
 		    --fmri-in-manifest --no-index --no-catalog $(<) \

--- a/usr/src/pkg/transforms/timestamp
+++ b/usr/src/pkg/transforms/timestamp
@@ -1,0 +1,24 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
+#
+
+#
+# Publish every package with an explicit timestamp, shared by all of
+# the packages from a single build, rather than letting the packaging
+# repository record the time at which each package's publication
+# transaction happened to open. Packages within a build already share
+# the rest of their version; with a shared timestamp the full version
+# string is identical across the build. That provides some optimisation
+# opportunities.
+#
+<transform set name=pkg.fmri -> edit value $ :$(PKGVERS_TIMESTAMP)>


### PR DESCRIPTION
Each package published by a build of illumos currently receives an
individual timestamp, recorded by the packaging repository at the
moment the package's publication transaction is opened. The packages
from one build already share the rest of their version string, so
these timestamps are the only thing distinguishing them, and they
show nothing more than the rate at which pkgsend walked the package
list (around ten packages per second, in alphabetical order).

Instead, generate a single timestamp when packaging begins and apply
it to every package's pkg.fmri via a new final publication transform;
pkgsend honours a timestamp that is already present in a published
manifest. Every package from one build then carries an identical
version string, including the timestamp.

This works with https://github.com/omniosorg/pkg5/pull/540 to improve catalogue sort performance.