### PR TITLE
18402 nvme panic with qemu which advertises namespace management support but rejects bcast nsid (r151058)

### DIFF
--- a/usr/src/uts/common/io/nvme/nvme.c
+++ b/usr/src/uts/common/io/nvme/nvme.c
@@ -3368,7 +3368,7 @@ nvme_get_logpage_int(nvme_t *nvme, boolean_t user, void **buf, size_t *bufsize,
 }
 
 static boolean_t
-nvme_identify(nvme_t *nvme, boolean_t user, nvme_ioctl_identify_t *ioc,
+nvme_identify(nvme_t *nvme, boolean_t dontpanic, nvme_ioctl_identify_t *ioc,
     void **buf)
 {
 	nvme_cmd_t *cmd = nvme_alloc_admin_cmd(nvme, KM_SLEEP);
@@ -3415,7 +3415,7 @@ nvme_identify(nvme_t *nvme, boolean_t user, nvme_ioctl_identify_t *ioc,
 		    cmd->nc_dma->nd_cookie.dmac_laddress;
 	}
 
-	if (user)
+	if (dontpanic)
 		cmd->nc_flags |= NVME_CMD_F_DONTPANIC;
 
 	nvme_admin_cmd(cmd, nvme_admin_cmd_timeout);
@@ -4407,6 +4407,7 @@ nvme_enable_host_behavior(nvme_t *nvme)
 static int
 nvme_init(nvme_t *nvme)
 {
+	nvme_ioctl_identify_t id = { 0 };
 	nvme_reg_cc_t cc = { 0 };
 	nvme_reg_aqa_t aqa = { 0 };
 	nvme_reg_asq_t asq = { 0 };
@@ -4729,11 +4730,29 @@ nvme_init(nvme_t *nvme)
 		nsid = 1;
 	}
 
-	if (!nvme_identify_int(nvme, nsid, NVME_IDENTIFY_NSID,
-	    (void **)&nvme->n_idcomns)) {
-		dev_err(nvme->n_dip, CE_WARN, "!failed to identify common "
-		    "namespace information");
-		goto fail;
+	/*
+	 * Some controllers may advertise namespace management support but still
+	 * reject an Identify Namespace command with the broadcast nsid.  Rather
+	 * than panic or fail we'll try to fall back to the data for nsid 1.
+	 */
+	id.nid_common.nioc_nsid = nsid;
+	id.nid_cns = NVME_IDENTIFY_NSID;
+	if (!nvme_identify(nvme, B_TRUE, &id, (void **)&nvme->n_idcomns)) {
+		if (nsid != NVME_NSID_BCAST) {
+			dev_err(nvme->n_dip, CE_WARN, "!failed to identify "
+			    "common namespace information");
+			goto fail;
+		}
+
+		dev_err(nvme->n_dip, CE_NOTE, "!failed to identify common with "
+		    "broadcast nsid, falling back to nsid 1");
+
+		if (!nvme_identify_int(nvme, 1, NVME_IDENTIFY_NSID,
+		    (void **)&nvme->n_idcomns)) {
+			dev_err(nvme->n_dip, CE_WARN, "!failed to identify "
+			    "common namespace information");
+			goto fail;
+		}
 	}
 
 	if (nvme_get_current_nqueues(nvme, &nq)) {


### PR DESCRIPTION
Backporting to help a [user on r151058](https://log.omnios.org/omnios/2026-09-10#1789041297-1240495) get up and running with their NVMe card that has this controller bug.
Not currently planning to actively push this into a weekly release and force a reboot, nor backport it to other versions, but I am providing a hotfix for r58 and we should ensure that does not regress should we ship an updated nvme module from r58 in the future.